### PR TITLE
Bump version to 0.11.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 <!-- prettier-ignore-start -->
 
 
+## 0.11.20
+
+Released on 2026-06-10.
+
+### Enhancements
+
+- Add `--emit-index-url` and `--emit-find-links` to `uv export` ([#18370](https://github.com/astral-sh/uv/pull/18370))
+- Add `--find-links` support for `uv pip list` ([#16103](https://github.com/astral-sh/uv/pull/16103))
+- Group executable install errors during `uv python install` ([#19691](https://github.com/astral-sh/uv/pull/19691))
+- Use ICF in macOS release builds to reduce binary sizes ([#19615](https://github.com/astral-sh/uv/pull/19615))
+
+### Preview features
+
+- Add initial hidden `uv upgrade` command ([#19678](https://github.com/astral-sh/uv/pull/19678))
+- Reject Git revisions in `uv upgrade` ([#19742](https://github.com/astral-sh/uv/pull/19742))
+
+### Configuration
+
+- Recognize `UV_NO_INSTALL_PROJECT`, `UV_NO_INSTALL_WORKSPACE`, `UV_NO_INSTALL_LOCAL` ([#19323](https://github.com/astral-sh/uv/pull/19323))
+
+### Performance
+
+- Speed up discovery of large workspaces ([#18311](https://github.com/astral-sh/uv/pull/18311))
+
+### Bug fixes
+
+- Allow unknown preview flags with a warning again ([#19669](https://github.com/astral-sh/uv/pull/19669))
+- Apply dependency exclusions to direct requirements ([#19699](https://github.com/astral-sh/uv/pull/19699))
+- Avoid following external symlinks during cache clean ([#19682](https://github.com/astral-sh/uv/pull/19682))
+- Avoid following symlinks during cache prune ([#19543](https://github.com/astral-sh/uv/pull/19543))
+- Fix Git cache keys for worktrees and packed refs ([#19706](https://github.com/astral-sh/uv/pull/19706))
+- Make resolver error handling iterative to avoid stack overflows ([#19695](https://github.com/astral-sh/uv/pull/19695))
+- Pass `VIRTUAL_ENV` through `cygpath` inside `fish` on Windows ([#19703](https://github.com/astral-sh/uv/pull/19703))
+- Rebuild explicit local directory tool installs ([#19591](https://github.com/astral-sh/uv/pull/19591))
+- Validate egg top-level entries as identifiers ([#19679](https://github.com/astral-sh/uv/pull/19679))
+
+### Documentation
+
+- Document `--find-links` caching behavior ([#19585](https://github.com/astral-sh/uv/pull/19585))
+- Add a small section for malware checks ([#19680](https://github.com/astral-sh/uv/pull/19680))
+
 ## 0.11.19
 
 Released on 2026-06-03.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "uv"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anstream",
  "anyhow",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "uv-audit"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "astral-reqwest-middleware",
  "clap",
@@ -5811,7 +5811,7 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "uv-bench"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "uv-bin-install"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "uv-build"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anstream",
  "anyhow",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "astral-tokio-tar",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "fs-err",
@@ -6019,7 +6019,7 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "clap",
  "fs-err",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "hex",
  "memchr",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "uv-cli"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "clap",
@@ -6212,14 +6212,14 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dev"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6273,7 +6273,7 @@ dependencies = [
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "assert_fs",
  "etcetera",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "futures",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -6371,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "insta",
  "memchr",
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -6429,7 +6429,7 @@ dependencies = [
 
 [[package]]
 name = "uv-errors"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -6473,7 +6473,7 @@ dependencies = [
 
 [[package]]
 name = "uv-fastid"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "fastrand",
  "rand 0.9.4",
@@ -6483,14 +6483,14 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "backon",
  "clap",
@@ -6521,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -6547,7 +6547,7 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "percent-encoding",
  "serde",
@@ -6561,7 +6561,7 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "fs-err",
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6675,7 +6675,7 @@ dependencies = [
 
 [[package]]
 name = "uv-logging"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "jiff",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "uv-netrc"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "fs-err",
  "shellexpand",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "rkyv",
  "schemars",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "dashmap",
  "futures",
@@ -6741,14 +6741,14 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "astral-version-ranges",
  "indoc",
@@ -6762,7 +6762,7 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -6792,7 +6792,7 @@ dependencies = [
 
 [[package]]
 name = "uv-performance-memory-allocator"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "mimalloc",
  "tikv-jemallocator",
@@ -6800,7 +6800,7 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "fs-err",
  "goblin",
@@ -6821,7 +6821,7 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "bitflags",
  "insta",
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -6846,7 +6846,7 @@ dependencies = [
 
 [[package]]
 name = "uv-publish"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "ambient-id",
  "anstream",
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -6922,7 +6922,7 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "ref-cast",
  "schemars",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "configparser",
@@ -7030,7 +7030,7 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -7130,7 +7130,7 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "fs-err",
  "indoc",
@@ -7155,7 +7155,7 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "clap",
  "fs-err",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -7209,7 +7209,7 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -7219,7 +7219,7 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "tempfile",
  "uv-dirs",
@@ -7227,7 +7227,7 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "thiserror",
  "uv-macros",
@@ -7235,7 +7235,7 @@ dependencies = [
 
 [[package]]
 name = "uv-test"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7278,7 +7278,7 @@ dependencies = [
 
 [[package]]
 name = "uv-toml"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "toml_datetime",
  "toml_parser",
@@ -7286,7 +7286,7 @@ dependencies = [
 
 [[package]]
 name = "uv-tool"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "fs-err",
  "owo-colors",
@@ -7315,7 +7315,7 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "clap",
  "either",
@@ -7335,7 +7335,7 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7354,7 +7354,7 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -7377,7 +7377,7 @@ dependencies = [
 
 [[package]]
 name = "uv-unix"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "nix 0.31.3",
  "thiserror",
@@ -7385,11 +7385,11 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.19"
+version = "0.11.20"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "console",
  "fs-err",
@@ -7411,7 +7411,7 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anstream",
  "anyhow",
@@ -7423,7 +7423,7 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "arrayvec",
  "windows",
@@ -7431,7 +7431,7 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,81 +16,81 @@ authors = ["uv"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-uv-audit = { version = "0.0.52", path = "crates/uv-audit" }
-uv-auth = { version = "0.0.52", path = "crates/uv-auth" }
-uv-bin-install = { version = "0.0.52", path = "crates/uv-bin-install" }
-uv-build-backend = { version = "0.0.52", path = "crates/uv-build-backend" }
-uv-build-frontend = { version = "0.0.52", path = "crates/uv-build-frontend" }
-uv-cache = { version = "0.0.52", path = "crates/uv-cache" }
-uv-cache-info = { version = "0.0.52", path = "crates/uv-cache-info" }
-uv-cache-key = { version = "0.0.52", path = "crates/uv-cache-key" }
-uv-cli = { version = "0.0.52", path = "crates/uv-cli" }
-uv-client = { version = "0.0.52", path = "crates/uv-client" }
-uv-configuration = { version = "0.0.52", path = "crates/uv-configuration" }
-uv-console = { version = "0.0.52", path = "crates/uv-console" }
-uv-dirs = { version = "0.0.52", path = "crates/uv-dirs" }
-uv-dispatch = { version = "0.0.52", path = "crates/uv-dispatch" }
-uv-distribution = { version = "0.0.52", path = "crates/uv-distribution" }
-uv-distribution-filename = { version = "0.0.52", path = "crates/uv-distribution-filename" }
-uv-distribution-types = { version = "0.0.52", path = "crates/uv-distribution-types" }
-uv-errors = { version = "0.0.52", path = "crates/uv-errors" }
-uv-extract = { version = "0.0.52", path = "crates/uv-extract" }
-uv-fastid = { version = "0.0.52", path = "crates/uv-fastid" }
-uv-flags = { version = "0.0.52", path = "crates/uv-flags" }
-uv-fs = { version = "0.0.52", path = "crates/uv-fs", features = [
+uv-audit = { version = "0.0.53", path = "crates/uv-audit" }
+uv-auth = { version = "0.0.53", path = "crates/uv-auth" }
+uv-bin-install = { version = "0.0.53", path = "crates/uv-bin-install" }
+uv-build-backend = { version = "0.0.53", path = "crates/uv-build-backend" }
+uv-build-frontend = { version = "0.0.53", path = "crates/uv-build-frontend" }
+uv-cache = { version = "0.0.53", path = "crates/uv-cache" }
+uv-cache-info = { version = "0.0.53", path = "crates/uv-cache-info" }
+uv-cache-key = { version = "0.0.53", path = "crates/uv-cache-key" }
+uv-cli = { version = "0.0.53", path = "crates/uv-cli" }
+uv-client = { version = "0.0.53", path = "crates/uv-client" }
+uv-configuration = { version = "0.0.53", path = "crates/uv-configuration" }
+uv-console = { version = "0.0.53", path = "crates/uv-console" }
+uv-dirs = { version = "0.0.53", path = "crates/uv-dirs" }
+uv-dispatch = { version = "0.0.53", path = "crates/uv-dispatch" }
+uv-distribution = { version = "0.0.53", path = "crates/uv-distribution" }
+uv-distribution-filename = { version = "0.0.53", path = "crates/uv-distribution-filename" }
+uv-distribution-types = { version = "0.0.53", path = "crates/uv-distribution-types" }
+uv-errors = { version = "0.0.53", path = "crates/uv-errors" }
+uv-extract = { version = "0.0.53", path = "crates/uv-extract" }
+uv-fastid = { version = "0.0.53", path = "crates/uv-fastid" }
+uv-flags = { version = "0.0.53", path = "crates/uv-flags" }
+uv-fs = { version = "0.0.53", path = "crates/uv-fs", features = [
   "serde",
   "tokio",
 ] }
-uv-git = { version = "0.0.52", path = "crates/uv-git" }
-uv-git-types = { version = "0.0.52", path = "crates/uv-git-types" }
-uv-globfilter = { version = "0.0.52", path = "crates/uv-globfilter" }
-uv-install-wheel = { version = "0.0.52", path = "crates/uv-install-wheel", default-features = false }
-uv-installer = { version = "0.0.52", path = "crates/uv-installer" }
-uv-keyring = { version = "0.0.52", path = "crates/uv-keyring" }
-uv-logging = { version = "0.0.52", path = "crates/uv-logging" }
-uv-macros = { version = "0.0.52", path = "crates/uv-macros" }
-uv-metadata = { version = "0.0.52", path = "crates/uv-metadata" }
-uv-netrc = { version = "0.0.52", path = "crates/uv-netrc" }
-uv-normalize = { version = "0.0.52", path = "crates/uv-normalize" }
-uv-once-map = { version = "0.0.52", path = "crates/uv-once-map" }
-uv-options-metadata = { version = "0.0.52", path = "crates/uv-options-metadata" }
-uv-performance-memory-allocator = { version = "0.0.52", path = "crates/uv-performance-memory-allocator" }
-uv-pep440 = { version = "0.0.52", path = "crates/uv-pep440", features = [
+uv-git = { version = "0.0.53", path = "crates/uv-git" }
+uv-git-types = { version = "0.0.53", path = "crates/uv-git-types" }
+uv-globfilter = { version = "0.0.53", path = "crates/uv-globfilter" }
+uv-install-wheel = { version = "0.0.53", path = "crates/uv-install-wheel", default-features = false }
+uv-installer = { version = "0.0.53", path = "crates/uv-installer" }
+uv-keyring = { version = "0.0.53", path = "crates/uv-keyring" }
+uv-logging = { version = "0.0.53", path = "crates/uv-logging" }
+uv-macros = { version = "0.0.53", path = "crates/uv-macros" }
+uv-metadata = { version = "0.0.53", path = "crates/uv-metadata" }
+uv-netrc = { version = "0.0.53", path = "crates/uv-netrc" }
+uv-normalize = { version = "0.0.53", path = "crates/uv-normalize" }
+uv-once-map = { version = "0.0.53", path = "crates/uv-once-map" }
+uv-options-metadata = { version = "0.0.53", path = "crates/uv-options-metadata" }
+uv-performance-memory-allocator = { version = "0.0.53", path = "crates/uv-performance-memory-allocator" }
+uv-pep440 = { version = "0.0.53", path = "crates/uv-pep440", features = [
   "tracing",
   "rkyv",
   "version-ranges",
 ] }
-uv-pep508 = { version = "0.0.52", path = "crates/uv-pep508", features = [
+uv-pep508 = { version = "0.0.53", path = "crates/uv-pep508", features = [
   "non-pep508-extensions",
 ] }
-uv-platform = { version = "0.0.52", path = "crates/uv-platform" }
-uv-platform-tags = { version = "0.0.52", path = "crates/uv-platform-tags" }
-uv-preview = { version = "0.0.52", path = "crates/uv-preview" }
-uv-publish = { version = "0.0.52", path = "crates/uv-publish" }
-uv-pypi-types = { version = "0.0.52", path = "crates/uv-pypi-types" }
-uv-python = { version = "0.0.52", path = "crates/uv-python" }
-uv-redacted = { version = "0.0.52", path = "crates/uv-redacted" }
-uv-requirements = { version = "0.0.52", path = "crates/uv-requirements" }
-uv-requirements-txt = { version = "0.0.52", path = "crates/uv-requirements-txt" }
-uv-resolver = { version = "0.0.52", path = "crates/uv-resolver" }
-uv-scripts = { version = "0.0.52", path = "crates/uv-scripts" }
-uv-settings = { version = "0.0.52", path = "crates/uv-settings" }
-uv-shell = { version = "0.0.52", path = "crates/uv-shell" }
-uv-small-str = { version = "0.0.52", path = "crates/uv-small-str" }
-uv-state = { version = "0.0.52", path = "crates/uv-state" }
-uv-static = { version = "0.0.52", path = "crates/uv-static" }
-uv-test = { version = "0.0.52", path = "crates/uv-test" }
-uv-toml = { version = "0.0.52", path = "crates/uv-toml" }
-uv-tool = { version = "0.0.52", path = "crates/uv-tool" }
-uv-torch = { version = "0.0.52", path = "crates/uv-torch" }
-uv-trampoline-builder = { version = "0.0.52", path = "crates/uv-trampoline-builder" }
-uv-types = { version = "0.0.52", path = "crates/uv-types" }
-uv-unix = { version = "0.0.52", path = "crates/uv-unix" }
-uv-version = { version = "0.11.19", path = "crates/uv-version" }
-uv-virtualenv = { version = "0.0.52", path = "crates/uv-virtualenv" }
-uv-warnings = { version = "0.0.52", path = "crates/uv-warnings" }
-uv-windows = { version = "0.0.52", path = "crates/uv-windows" }
-uv-workspace = { version = "0.0.52", path = "crates/uv-workspace" }
+uv-platform = { version = "0.0.53", path = "crates/uv-platform" }
+uv-platform-tags = { version = "0.0.53", path = "crates/uv-platform-tags" }
+uv-preview = { version = "0.0.53", path = "crates/uv-preview" }
+uv-publish = { version = "0.0.53", path = "crates/uv-publish" }
+uv-pypi-types = { version = "0.0.53", path = "crates/uv-pypi-types" }
+uv-python = { version = "0.0.53", path = "crates/uv-python" }
+uv-redacted = { version = "0.0.53", path = "crates/uv-redacted" }
+uv-requirements = { version = "0.0.53", path = "crates/uv-requirements" }
+uv-requirements-txt = { version = "0.0.53", path = "crates/uv-requirements-txt" }
+uv-resolver = { version = "0.0.53", path = "crates/uv-resolver" }
+uv-scripts = { version = "0.0.53", path = "crates/uv-scripts" }
+uv-settings = { version = "0.0.53", path = "crates/uv-settings" }
+uv-shell = { version = "0.0.53", path = "crates/uv-shell" }
+uv-small-str = { version = "0.0.53", path = "crates/uv-small-str" }
+uv-state = { version = "0.0.53", path = "crates/uv-state" }
+uv-static = { version = "0.0.53", path = "crates/uv-static" }
+uv-test = { version = "0.0.53", path = "crates/uv-test" }
+uv-toml = { version = "0.0.53", path = "crates/uv-toml" }
+uv-tool = { version = "0.0.53", path = "crates/uv-tool" }
+uv-torch = { version = "0.0.53", path = "crates/uv-torch" }
+uv-trampoline-builder = { version = "0.0.53", path = "crates/uv-trampoline-builder" }
+uv-types = { version = "0.0.53", path = "crates/uv-types" }
+uv-unix = { version = "0.0.53", path = "crates/uv-unix" }
+uv-version = { version = "0.11.20", path = "crates/uv-version" }
+uv-virtualenv = { version = "0.0.53", path = "crates/uv-virtualenv" }
+uv-warnings = { version = "0.0.53", path = "crates/uv-warnings" }
+uv-windows = { version = "0.0.53", path = "crates/uv-windows" }
+uv-workspace = { version = "0.0.53", path = "crates/uv-workspace" }
 
 ambient-id = { version = "0.0.11", default-features = false, features = [
   "reqwest-middleware",

--- a/crates/uv-audit/Cargo.toml
+++ b/crates/uv-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-audit"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/uv-audit/README.md
+++ b/crates/uv-audit/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-audit).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-audit).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-auth"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-auth/README.md
+++ b/crates/uv-auth/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-auth).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-auth).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-bench"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 publish = false
 authors = { workspace = true }

--- a/crates/uv-bench/README.md
+++ b/crates/uv-bench/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-bench).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-bench).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-bin-install/Cargo.toml
+++ b/crates/uv-bin-install/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-bin-install"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-bin-install/README.md
+++ b/crates/uv-bin-install/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-bin-install).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-bin-install).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-build-backend"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-build-backend/README.md
+++ b/crates/uv-build-backend/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-build-backend).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-build-backend).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-build-frontend/Cargo.toml
+++ b/crates/uv-build-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-build-frontend"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-build-frontend/README.md
+++ b/crates/uv-build-frontend/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-build-frontend).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-build-frontend).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-build"
-version = "0.11.19"
+version = "0.11.20"
 description = "A Python build backend"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-build/pyproject.toml
+++ b/crates/uv-build/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uv-build"
-version = "0.11.19"
+version = "0.11.20"
 description = "The uv build backend"
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 requires-python = ">=3.8"

--- a/crates/uv-cache-info/Cargo.toml
+++ b/crates/uv-cache-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-cache-info"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-cache-info/README.md
+++ b/crates/uv-cache-info/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-cache-info).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-cache-info).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-cache-key/Cargo.toml
+++ b/crates/uv-cache-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-cache-key"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-cache-key/README.md
+++ b/crates/uv-cache-key/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-cache-key).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-cache-key).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-cache"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-cache/README.md
+++ b/crates/uv-cache/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-cache).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-cache).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-cli/Cargo.toml
+++ b/crates/uv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-cli"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-cli/README.md
+++ b/crates/uv-cli/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-cli).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-cli).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-client"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-client/README.md
+++ b/crates/uv-client/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-client).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-client).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-configuration"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-configuration/README.md
+++ b/crates/uv-configuration/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-configuration).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-configuration).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-console/Cargo.toml
+++ b/crates/uv-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-console"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-console/README.md
+++ b/crates/uv-console/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-console).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-console).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-dev"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 publish = false
 

--- a/crates/uv-dev/README.md
+++ b/crates/uv-dev/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-dev).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-dev).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-dirs/Cargo.toml
+++ b/crates/uv-dirs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-dirs"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-dirs/README.md
+++ b/crates/uv-dirs/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-dirs).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-dirs).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-dispatch/Cargo.toml
+++ b/crates/uv-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-dispatch"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-dispatch/README.md
+++ b/crates/uv-dispatch/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-dispatch).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-dispatch).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-distribution-filename/Cargo.toml
+++ b/crates/uv-distribution-filename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-distribution-filename"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-distribution-filename/README.md
+++ b/crates/uv-distribution-filename/README.md
@@ -5,9 +5,9 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
 source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-distribution-filename).
+[here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-distribution-filename).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-distribution-types"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-distribution-types/README.md
+++ b/crates/uv-distribution-types/README.md
@@ -5,9 +5,9 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
 source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-distribution-types).
+[here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-distribution-types).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-distribution"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-distribution/README.md
+++ b/crates/uv-distribution/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-distribution).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-distribution).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-errors/Cargo.toml
+++ b/crates/uv-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-errors"
-version = "0.0.52"
+version = "0.0.53"
 description = "Common error traits for uv."
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-errors/README.md
+++ b/crates/uv-errors/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-errors).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-errors).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-extract"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-extract/README.md
+++ b/crates/uv-extract/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-extract).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-extract).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-fastid/Cargo.toml
+++ b/crates/uv-fastid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uv-fastid"
 description = "This is an internal component crate of uv"
-version = "0.0.52"
+version = "0.0.53"
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/uv-fastid/README.md
+++ b/crates/uv-fastid/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-fastid).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-fastid).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-flags/Cargo.toml
+++ b/crates/uv-flags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-flags"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-flags/README.md
+++ b/crates/uv-flags/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-flags).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-flags).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-fs"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-fs/README.md
+++ b/crates/uv-fs/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-fs).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-fs).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-git-types/Cargo.toml
+++ b/crates/uv-git-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-git-types"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-git-types/README.md
+++ b/crates/uv-git-types/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-git-types).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-git-types).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-git/Cargo.toml
+++ b/crates/uv-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-git"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-git/README.md
+++ b/crates/uv-git/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-git).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-git).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-globfilter/Cargo.toml
+++ b/crates/uv-globfilter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-globfilter"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 readme = "README.md"
 edition = { workspace = true }

--- a/crates/uv-install-wheel/Cargo.toml
+++ b/crates/uv-install-wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-install-wheel"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 keywords = ["wheel", "python"]
 

--- a/crates/uv-install-wheel/README.md
+++ b/crates/uv-install-wheel/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-install-wheel).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-install-wheel).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-installer/Cargo.toml
+++ b/crates/uv-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-installer"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-installer/README.md
+++ b/crates/uv-installer/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-installer).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-installer).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-keyring/Cargo.toml
+++ b/crates/uv-keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-keyring"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-logging/Cargo.toml
+++ b/crates/uv-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-logging"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-logging/README.md
+++ b/crates/uv-logging/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-logging).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-logging).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-macros/Cargo.toml
+++ b/crates/uv-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-macros"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-macros/README.md
+++ b/crates/uv-macros/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-macros).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-macros).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-metadata/Cargo.toml
+++ b/crates/uv-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-metadata"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-metadata/README.md
+++ b/crates/uv-metadata/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-metadata).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-metadata).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-netrc/Cargo.toml
+++ b/crates/uv-netrc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-netrc"
-version = "0.0.52"
+version = "0.0.53"
 description = "A vendored netrc parser for uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-normalize/Cargo.toml
+++ b/crates/uv-normalize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-normalize"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-normalize/README.md
+++ b/crates/uv-normalize/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-normalize).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-normalize).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-once-map/Cargo.toml
+++ b/crates/uv-once-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-once-map"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-once-map/README.md
+++ b/crates/uv-once-map/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-once-map).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-once-map).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-options-metadata/Cargo.toml
+++ b/crates/uv-options-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-options-metadata"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-options-metadata/README.md
+++ b/crates/uv-options-metadata/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-options-metadata).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-options-metadata).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-pep440/Cargo.toml
+++ b/crates/uv-pep440/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-pep440"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 license = "Apache-2.0 OR BSD-2-Clause"
 include = ["/src", "Changelog.md", "License-Apache", "License-BSD", "Readme.md", "pyproject.toml"]

--- a/crates/uv-pep440/README.md
+++ b/crates/uv-pep440/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-pep440).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-pep440).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-pep508"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 include = ["/src", "Changelog.md", "License-Apache", "License-BSD", "Readme.md", "pyproject.toml"]
 license = "Apache-2.0 OR BSD-2-Clause"

--- a/crates/uv-pep508/README.md
+++ b/crates/uv-pep508/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-pep508).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-pep508).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-performance-memory-allocator/Cargo.toml
+++ b/crates/uv-performance-memory-allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-performance-memory-allocator"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-performance-memory-allocator/README.md
+++ b/crates/uv-performance-memory-allocator/README.md
@@ -5,9 +5,9 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
 source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-performance-memory-allocator).
+[here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-performance-memory-allocator).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-platform-tags/Cargo.toml
+++ b/crates/uv-platform-tags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-platform-tags"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-platform-tags/README.md
+++ b/crates/uv-platform-tags/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-platform-tags).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-platform-tags).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-platform/Cargo.toml
+++ b/crates/uv-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-platform"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-platform/README.md
+++ b/crates/uv-platform/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-platform).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-platform).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-preview/Cargo.toml
+++ b/crates/uv-preview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-preview"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-preview/README.md
+++ b/crates/uv-preview/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-preview).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-preview).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-publish/Cargo.toml
+++ b/crates/uv-publish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-publish"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-publish/README.md
+++ b/crates/uv-publish/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-publish).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-publish).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-pypi-types"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-pypi-types/README.md
+++ b/crates/uv-pypi-types/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-pypi-types).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-pypi-types).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-python"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-python/README.md
+++ b/crates/uv-python/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-python).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-python).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-redacted/Cargo.toml
+++ b/crates/uv-redacted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-redacted"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-redacted/README.md
+++ b/crates/uv-redacted/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-redacted).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-redacted).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-requirements-txt/Cargo.toml
+++ b/crates/uv-requirements-txt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-requirements-txt"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-requirements-txt/README.md
+++ b/crates/uv-requirements-txt/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-requirements-txt).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-requirements-txt).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-requirements/Cargo.toml
+++ b/crates/uv-requirements/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-requirements"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-requirements/README.md
+++ b/crates/uv-requirements/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-requirements).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-requirements).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-resolver"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-resolver/README.md
+++ b/crates/uv-resolver/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-resolver).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-resolver).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-scripts/Cargo.toml
+++ b/crates/uv-scripts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-scripts"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-scripts/README.md
+++ b/crates/uv-scripts/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-scripts).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-scripts).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-settings"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-settings/README.md
+++ b/crates/uv-settings/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-settings).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-settings).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-shell/Cargo.toml
+++ b/crates/uv-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-shell"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-shell/README.md
+++ b/crates/uv-shell/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-shell).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-shell).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-small-str/Cargo.toml
+++ b/crates/uv-small-str/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-small-str"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-small-str/README.md
+++ b/crates/uv-small-str/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-small-str).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-small-str).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-state/Cargo.toml
+++ b/crates/uv-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-state"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-state/README.md
+++ b/crates/uv-state/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-state).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-state).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-static/Cargo.toml
+++ b/crates/uv-static/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-static"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-static/README.md
+++ b/crates/uv-static/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-static).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-static).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -262,34 +262,34 @@ impl EnvVars {
 
     /// Equivalent to the `--no-install-project` command-line argument. If set, uv will
     /// install the project's dependencies but not the project itself.
-    #[attr_added_in("next release")]
+    #[attr_added_in("0.11.20")]
     pub const UV_NO_INSTALL_PROJECT: &'static str = "UV_NO_INSTALL_PROJECT";
 
     /// Equivalent to the `--no-install-workspace` command-line argument. If set, uv will
     /// install workspace dependencies but not workspace members (including the current
     /// project).
-    #[attr_added_in("next release")]
+    #[attr_added_in("0.11.20")]
     pub const UV_NO_INSTALL_WORKSPACE: &'static str = "UV_NO_INSTALL_WORKSPACE";
 
     /// Equivalent to the `--no-install-local` command-line argument. If set, uv will skip
     /// the current project, workspace members, and any other local (path or editable)
     /// packages, installing only remote dependencies.
-    #[attr_added_in("next release")]
+    #[attr_added_in("0.11.20")]
     pub const UV_NO_INSTALL_LOCAL: &'static str = "UV_NO_INSTALL_LOCAL";
 
     /// Equivalent to the hidden `--only-install-project` command-line argument.
     #[attr_hidden]
-    #[attr_added_in("next release")]
+    #[attr_added_in("0.11.20")]
     pub const UV_ONLY_INSTALL_PROJECT: &'static str = "UV_ONLY_INSTALL_PROJECT";
 
     /// Equivalent to the hidden `--only-install-workspace` command-line argument.
     #[attr_hidden]
-    #[attr_added_in("next release")]
+    #[attr_added_in("0.11.20")]
     pub const UV_ONLY_INSTALL_WORKSPACE: &'static str = "UV_ONLY_INSTALL_WORKSPACE";
 
     /// Equivalent to the hidden `--only-install-local` command-line argument.
     #[attr_hidden]
-    #[attr_added_in("next release")]
+    #[attr_added_in("0.11.20")]
     pub const UV_ONLY_INSTALL_LOCAL: &'static str = "UV_ONLY_INSTALL_LOCAL";
 
     /// Equivalent to the `--no-binary` command-line argument. If set, uv will install

--- a/crates/uv-test/Cargo.toml
+++ b/crates/uv-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-test"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-test/README.md
+++ b/crates/uv-test/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-test).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-test).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-toml/Cargo.toml
+++ b/crates/uv-toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-toml"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-toml/README.md
+++ b/crates/uv-toml/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-toml).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-toml).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-tool"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-tool/README.md
+++ b/crates/uv-tool/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-tool).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-tool).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-torch/Cargo.toml
+++ b/crates/uv-torch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-torch"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-torch/README.md
+++ b/crates/uv-torch/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-torch).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-torch).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-trampoline-builder/Cargo.toml
+++ b/crates/uv-trampoline-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-trampoline-builder"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 
 edition = { workspace = true }

--- a/crates/uv-trampoline-builder/README.md
+++ b/crates/uv-trampoline-builder/README.md
@@ -5,9 +5,9 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
 source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-trampoline-builder).
+[here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-trampoline-builder).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-trampoline/Cargo.lock
+++ b/crates/uv-trampoline/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "uv-macros"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "thiserror",
  "uv-macros",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "windows",
 ]

--- a/crates/uv-types/Cargo.toml
+++ b/crates/uv-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-types"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-types/README.md
+++ b/crates/uv-types/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-types).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-types).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-unix/Cargo.toml
+++ b/crates/uv-unix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-unix"
-version = "0.0.52"
+version = "0.0.53"
 description = "Unix-specific functionality for uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-unix/README.md
+++ b/crates/uv-unix/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-unix).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-unix).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-version/Cargo.toml
+++ b/crates/uv-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-version"
-version = "0.11.19"
+version = "0.11.20"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-version/README.md
+++ b/crates/uv-version/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.11.19) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-version).
+This version (0.11.20) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-version).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-virtualenv"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 keywords = ["virtualenv", "venv", "python"]
 

--- a/crates/uv-warnings/Cargo.toml
+++ b/crates/uv-warnings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-warnings"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-warnings/README.md
+++ b/crates/uv-warnings/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-warnings).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-warnings).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-windows/Cargo.toml
+++ b/crates/uv-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-windows"
-version = "0.0.52"
+version = "0.0.53"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }

--- a/crates/uv-windows/README.md
+++ b/crates/uv-windows/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-windows).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-windows).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-workspace"
-version = "0.0.52"
+version = "0.0.53"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-workspace/README.md
+++ b/crates/uv-workspace/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.52) is a component of [uv 0.11.19](https://crates.io/crates/uv/0.11.19). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv-workspace).
+This version (0.0.53) is a component of [uv 0.11.20](https://crates.io/crates/uv/0.11.20). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv-workspace).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv"
-version = "0.11.19"
+version = "0.11.20"
 description = "A Python package and project manager"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv/README.md
+++ b/crates/uv/README.md
@@ -10,8 +10,8 @@ for more information.
 This crate is the entry point to the uv command-line interface. The Rust API exposed here is not
 considered public interface.
 
-This is version 0.11.19. The source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.19/crates/uv).
+This is version 0.11.20. The source can be found
+[here](https://github.com/astral-sh/uv/blob/0.11.20/crates/uv).
 
 The following uv workspace members are also available:
 

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -31,7 +31,7 @@ To use uv as a build backend in an existing project, add `uv_build` to the
 
 ```toml title="pyproject.toml"
 [build-system]
-requires = ["uv_build>=0.11.19,<0.12"]
+requires = ["uv_build>=0.11.20,<0.12"]
 build-backend = "uv_build"
 ```
 

--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -113,7 +113,7 @@ dependencies = []
 example-pkg = "example_pkg:main"
 
 [build-system]
-requires = ["uv_build>=0.11.19,<0.12"]
+requires = ["uv_build>=0.11.20,<0.12"]
 build-backend = "uv_build"
 ```
 
@@ -136,7 +136,7 @@ dependencies = []
 example-pkg = "example_pkg:main"
 
 [build-system]
-requires = ["uv_build>=0.11.19,<0.12"]
+requires = ["uv_build>=0.11.20,<0.12"]
 build-backend = "uv_build"
 ```
 
@@ -197,7 +197,7 @@ requires-python = ">=3.11"
 dependencies = []
 
 [build-system]
-requires = ["uv_build>=0.11.19,<0.12"]
+requires = ["uv_build>=0.11.20,<0.12"]
 build-backend = "uv_build"
 ```
 

--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -75,7 +75,7 @@ bird-feeder = { workspace = true }
 members = ["packages/*"]
 
 [build-system]
-requires = ["uv_build>=0.11.19,<0.12"]
+requires = ["uv_build>=0.11.20,<0.12"]
 build-backend = "uv_build"
 ```
 
@@ -106,7 +106,7 @@ tqdm = { git = "https://github.com/tqdm/tqdm" }
 members = ["packages/*"]
 
 [build-system]
-requires = ["uv_build>=0.11.19,<0.12"]
+requires = ["uv_build>=0.11.20,<0.12"]
 build-backend = "uv_build"
 ```
 
@@ -188,7 +188,7 @@ dependencies = ["bird-feeder", "tqdm>=4,<5"]
 bird-feeder = { path = "packages/bird-feeder" }
 
 [build-system]
-requires = ["uv_build>=0.11.19,<0.12"]
+requires = ["uv_build>=0.11.20,<0.12"]
 build-backend = "uv_build"
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ uv provides a standalone installer to download and install uv:
     Request a specific version by including it in the URL:
 
     ```console
-    $ curl -LsSf https://astral.sh/uv/0.11.19/install.sh | sh
+    $ curl -LsSf https://astral.sh/uv/0.11.20/install.sh | sh
     ```
 
 === "Windows"
@@ -41,7 +41,7 @@ uv provides a standalone installer to download and install uv:
     Request a specific version by including it in the URL:
 
     ```pwsh-session
-    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.11.19/install.ps1 | iex"
+    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.11.20/install.ps1 | iex"
     ```
 
 !!! tip

--- a/docs/guides/integration/aws-lambda.md
+++ b/docs/guides/integration/aws-lambda.md
@@ -92,7 +92,7 @@ the second stage, we'll copy this directory over to the final image, omitting th
 other unnecessary files.
 
 ```dockerfile title="Dockerfile"
-FROM ghcr.io/astral-sh/uv:0.11.19 AS uv
+FROM ghcr.io/astral-sh/uv:0.11.20 AS uv
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder
@@ -334,7 +334,7 @@ And confirm that opening http://127.0.0.1:8000/ in a web browser displays, "Hell
 Finally, we'll update the Dockerfile to include the local library in the deployment package:
 
 ```dockerfile title="Dockerfile"
-FROM ghcr.io/astral-sh/uv:0.11.19 AS uv
+FROM ghcr.io/astral-sh/uv:0.11.20 AS uv
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -31,7 +31,7 @@ $ docker run --rm -it ghcr.io/astral-sh/uv:debian uv --help
 The following distroless images are available:
 
 - `ghcr.io/astral-sh/uv:latest`
-- `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/uv:0.11.19`
+- `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/uv:0.11.20`
 - `ghcr.io/astral-sh/uv:{major}.{minor}`, e.g., `ghcr.io/astral-sh/uv:0.8` (the latest patch
   version)
 
@@ -92,7 +92,7 @@ And the following derived images are available:
 
 As with the distroless image, each derived image is published with uv version tags as
 `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}-{base}` and
-`ghcr.io/astral-sh/uv:{major}.{minor}-{base}`, e.g., `ghcr.io/astral-sh/uv:0.11.19-alpine`.
+`ghcr.io/astral-sh/uv:{major}.{minor}-{base}`, e.g., `ghcr.io/astral-sh/uv:0.11.20-alpine`.
 
 In addition, starting with `0.8` each derived image also sets `UV_TOOL_BIN_DIR` to `/usr/local/bin`
 to allow `uv tool install` to work as expected with the default user.
@@ -133,7 +133,7 @@ Note this requires `curl` to be available.
 In either case, it is best practice to pin to a specific uv version, e.g., with:
 
 ```dockerfile
-COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.20 /uv /uvx /bin/
 ```
 
 !!! tip
@@ -151,7 +151,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
 Or, with the installer:
 
 ```dockerfile
-ADD https://astral.sh/uv/0.11.19/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.11.20/install.sh /uv-installer.sh
 ```
 
 ### Installing a project
@@ -619,5 +619,5 @@ Verified OK
 !!! tip
 
     These examples use `latest`, but best practice is to verify the attestation for a specific
-    version tag, e.g., `ghcr.io/astral-sh/uv:0.11.19`, or (even better) the specific image digest,
+    version tag, e.g., `ghcr.io/astral-sh/uv:0.11.20`, or (even better) the specific image digest,
     such as `ghcr.io/astral-sh/uv:0.5.27@sha256:5adf09a5a526f380237408032a9308000d14d5947eafa687ad6c6a2476787b4f`.

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -47,7 +47,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           # Install a specific version of uv.
-          version: "0.11.19"
+          version: "0.11.20"
 ```
 
 ## Setting up Python

--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -13,7 +13,7 @@ Select a variant that is suitable for your workflow.
 
 ```yaml title=".gitlab-ci.yml"
 variables:
-  UV_VERSION: "0.11.19"
+  UV_VERSION: "0.11.20"
   PYTHON_VERSION: "3.12"
   BASE_LAYER: trixie-slim
   # GitLab CI creates a separate mountpoint for the build directory,

--- a/docs/guides/integration/pre-commit.md
+++ b/docs/guides/integration/pre-commit.md
@@ -19,7 +19,7 @@ To make sure your `uv.lock` file is up to date even if your `pyproject.toml` fil
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.19
+    rev: 0.11.20
     hooks:
       - id: uv-lock
 ```
@@ -30,7 +30,7 @@ To keep a `requirements.txt` file in sync with your `uv.lock` file:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.19
+    rev: 0.11.20
     hooks:
       - id: uv-export
 ```
@@ -41,7 +41,7 @@ To compile requirements files:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.19
+    rev: 0.11.20
     hooks:
       # Compile requirements
       - id: pip-compile
@@ -54,7 +54,7 @@ To compile alternative requirements files, modify `args` and `files`:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.19
+    rev: 0.11.20
     hooks:
       # Compile requirements
       - id: pip-compile
@@ -68,7 +68,7 @@ To run the hook over multiple files at the same time, add additional entries:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.19
+    rev: 0.11.20
     hooks:
       # Compile requirements
       - id: pip-compile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "uv"
-version = "0.11.19"
+version = "0.11.20"
 description = "An extremely fast Python package and project manager, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 requires-python = ">=3.8"

--- a/uv.lock
+++ b/uv.lock
@@ -6,7 +6,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-
 [[package]]
 name = "babel"
 version = "2.18.0"
@@ -973,7 +972,7 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.11.19"
+version = "0.11.20"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Released on 2026-06-10.

### Enhancements

- Add `--emit-index-url` and `--emit-find-links` to `uv export` ([#18370](https://github.com/astral-sh/uv/pull/18370))
- Add `--find-links` support for `uv pip list` ([#16103](https://github.com/astral-sh/uv/pull/16103))
- Group executable install errors during `uv python install` ([#19691](https://github.com/astral-sh/uv/pull/19691))
- Use ICF in macOS release builds to reduce binary sizes ([#19615](https://github.com/astral-sh/uv/pull/19615))

### Preview features

- Add initial hidden `uv upgrade` command ([#19678](https://github.com/astral-sh/uv/pull/19678))
- Reject Git revisions in `uv upgrade` ([#19742](https://github.com/astral-sh/uv/pull/19742))

### Configuration

- Recognize `UV_NO_INSTALL_PROJECT`, `UV_NO_INSTALL_WORKSPACE`, `UV_NO_INSTALL_LOCAL` ([#19323](https://github.com/astral-sh/uv/pull/19323))

### Performance

- Speed up discovery of large workspaces ([#18311](https://github.com/astral-sh/uv/pull/18311))

### Bug fixes

- Allow unknown preview flags with a warning again ([#19669](https://github.com/astral-sh/uv/pull/19669))
- Apply dependency exclusions to direct requirements ([#19699](https://github.com/astral-sh/uv/pull/19699))
- Avoid following external symlinks during cache clean ([#19682](https://github.com/astral-sh/uv/pull/19682))
- Avoid following symlinks during cache prune ([#19543](https://github.com/astral-sh/uv/pull/19543))
- Fix Git cache keys for worktrees and packed refs ([#19706](https://github.com/astral-sh/uv/pull/19706))
- Make resolver error handling iterative to avoid stack overflows ([#19695](https://github.com/astral-sh/uv/pull/19695))
- Pass `VIRTUAL_ENV` through `cygpath` inside `fish` on Windows ([#19703](https://github.com/astral-sh/uv/pull/19703))
- Rebuild explicit local directory tool installs ([#19591](https://github.com/astral-sh/uv/pull/19591))
- Validate egg top-level entries as identifiers ([#19679](https://github.com/astral-sh/uv/pull/19679))

### Documentation

- Document `--find-links` caching behavior ([#19585](https://github.com/astral-sh/uv/pull/19585))
- Add a small section for malware checks ([#19680](https://github.com/astral-sh/uv/pull/19680))