### PR TITLE
Consolidate Python discovery strategies

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -3720,11 +3720,12 @@ fn split_wheel_tag_release_version(version: Version) -> Version {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, str::FromStr};
+    use std::{cell::Cell, path::PathBuf, str::FromStr};
 
     use assert_fs::{TempDir, prelude::*};
     use target_lexicon::{Aarch64Architecture, Architecture};
     use test_log::test;
+    use uv_cache::Cache;
     use uv_distribution_types::RequiresPython;
     use uv_pep440::{Prerelease, PrereleaseKind, Version, VersionSpecifiers};
 
@@ -3736,8 +3737,32 @@ mod tests {
     use uv_platform::{Arch, Libc, Os};
 
     use super::{
-        DiscoveryPreferences, EnvironmentPreference, Error, PythonPreference, PythonVariant,
+        DiscoveryPreferences, EnvironmentPreference, Error, PythonPreference, PythonSource,
+        PythonVariant, QueryStrategy, python_installations_from_executables,
     };
+
+    #[test]
+    fn sequential_query_strategy_does_not_prefetch_executables() -> anyhow::Result<()> {
+        let cache = Cache::temp()?;
+        let pulls = Cell::new(0);
+        let executables = (0..2).map(|_| {
+            pulls.set(pulls.get() + 1);
+            Err::<(PythonSource, PathBuf), _>(Error::SourceNotAllowed(
+                PythonRequest::Default,
+                PythonSource::SearchPath,
+                PythonPreference::OnlyManaged,
+            ))
+        });
+
+        let mut installations =
+            python_installations_from_executables(executables, &cache, QueryStrategy::Sequential);
+
+        assert_eq!(pulls.get(), 0);
+        assert!(installations.next().is_some_and(|result| result.is_err()));
+        assert_eq!(pulls.get(), 1);
+
+        Ok(())
+    }
 
     #[test]
     fn interpreter_request_from_str() {

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -739,7 +739,16 @@ fn find_all_minor(
     }
 }
 
-/// Lazily iterate over all discoverable Python interpreters.
+/// How to query discovered Python executables.
+#[derive(Debug, Clone, Copy)]
+enum QueryStrategy {
+    /// Query each executable as it is requested by the consumer.
+    Sequential,
+    /// Query all executables concurrently before yielding results.
+    Parallel,
+}
+
+/// Iterate over all discoverable Python interpreters.
 ///
 /// Note interpreters may be excluded by the given [`EnvironmentPreference`], [`PythonPreference`],
 /// [`VersionRequest`], or [`PlatformRequest`].
@@ -755,22 +764,25 @@ fn python_installations<'a>(
     environments: EnvironmentPreference,
     preference: PythonPreference,
     cache: &'a Cache,
-) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
-    iter_python_installations_from_executables(
-        // Perform filtering on the discovered executables based on their source. This avoids
-        // unnecessary interpreter queries, which are generally expensive. We'll filter again
-        // with `PythonInstallation::satisfies_preferences` after querying.
-        python_executables(version, implementation, platform, environments, preference).filter_ok(
-            move |(source, path)| {
-                source_satisfies_environment_preference(*source, path, environments)
-            },
-        ),
-        cache,
+    strategy: QueryStrategy,
+) -> Box<dyn Iterator<Item = Result<PythonInstallation, Error>> + 'a> {
+    Box::new(
+        python_installations_from_executables(
+            // Perform filtering on the discovered executables based on their source. This avoids
+            // unnecessary interpreter queries, which are generally expensive. We'll filter again
+            // with `PythonInstallation::satisfies_preferences` after querying.
+            python_executables(version, implementation, platform, environments, preference)
+                .filter_ok(move |(source, path)| {
+                    source_satisfies_environment_preference(*source, path, environments)
+                }),
+            cache,
+            strategy,
+        )
+        .filter_ok(move |installation| {
+            installation.satisfies_preferences(version, environments, preference)
+        })
+        .map_ok(PythonInstallation::maybe_with_test_source),
     )
-    .filter_ok(move |installation| {
-        installation.satisfies_preferences(version, environments, preference)
-    })
-    .map_ok(PythonInstallation::maybe_with_test_source)
 }
 
 /// Query a single Python executable, returning a [`PythonInstallation`] on success.
@@ -795,71 +807,29 @@ fn python_installation_from_executable(
         .inspect_err(|err| debug!("{err}"))
 }
 
-/// Lazily convert Python executables into installations.
-fn iter_python_installations_from_executables<'a>(
+/// Convert Python executables into installations using the given query strategy.
+fn python_installations_from_executables<'a>(
     executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>> + 'a,
     cache: &'a Cache,
-) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
-    executables.map(move |result| match result {
-        Ok((source, path)) => python_installation_from_executable(source, path, cache),
-        Err(err) => Err(err),
-    })
-}
-
-/// Collect queried Python installations from executables, dropping non-critical discovery
-/// errors.
-///
-/// See [`iter_python_installations_from_executables`] for a lazy, sequential alternative.
-fn collect_python_installations_from_executables(
-    executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>>,
-    cache: &Cache,
-) -> Result<Vec<PythonInstallation>, Error> {
-    let items: Vec<Result<(PythonSource, PathBuf), Error>> = executables.collect();
-    let results: Vec<Result<PythonInstallation, Error>> = items
-        .into_par_iter()
-        .map(|result| match result {
+    strategy: QueryStrategy,
+) -> Box<dyn Iterator<Item = Result<PythonInstallation, Error>> + 'a> {
+    match strategy {
+        QueryStrategy::Sequential => Box::new(executables.map(move |result| match result {
             Ok((source, path)) => python_installation_from_executable(source, path, cache),
             Err(err) => Err(err),
-        })
-        .collect();
-
-    let mut installations = Vec::with_capacity(results.len());
-    for result in results {
-        match result {
-            Ok(installation) => installations.push(installation),
-            Err(err) if err.is_critical() => return Err(err),
-            Err(_) => {}
+        })),
+        QueryStrategy::Parallel => {
+            let items: Vec<Result<(PythonSource, PathBuf), Error>> = executables.collect();
+            let results: Vec<Result<PythonInstallation, Error>> = items
+                .into_par_iter()
+                .map(|result| match result {
+                    Ok((source, path)) => python_installation_from_executable(source, path, cache),
+                    Err(err) => Err(err),
+                })
+                .collect();
+            Box::new(results.into_iter())
         }
     }
-    Ok(installations)
-}
-
-/// Find all Python installations that satisfy the standard discovery filters, querying
-/// interpreters concurrently.
-fn find_all_matching_python_installations(
-    version: &VersionRequest,
-    implementation: Option<&ImplementationName>,
-    platform: PlatformRequest,
-    environments: EnvironmentPreference,
-    preference: PythonPreference,
-    cache: &Cache,
-) -> Result<Vec<PythonInstallation>, Error> {
-    let executables =
-        python_executables(version, implementation, platform, environments, preference).filter_ok(
-            move |(source, path)| {
-                source_satisfies_environment_preference(*source, path, environments)
-            },
-        );
-
-    let mut installations = collect_python_installations_from_executables(executables, cache)?;
-    installations.retain(|installation| {
-        installation.satisfies_preferences(version, environments, preference)
-    });
-    let installations = installations
-        .into_iter()
-        .map(PythonInstallation::maybe_with_test_source)
-        .collect();
-    Ok(installations)
 }
 
 /// Whether a [`Interpreter`] matches the [`EnvironmentPreference`].
@@ -1056,8 +1026,9 @@ fn python_executables_with_name(
 fn python_installations_with_name<'a>(
     name: &'a str,
     cache: &'a Cache,
-) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
-    iter_python_installations_from_executables(python_executables_with_name(name), cache)
+    strategy: QueryStrategy,
+) -> Box<dyn Iterator<Item = Result<PythonInstallation, Error>> + 'a> {
+    python_installations_from_executables(python_executables_with_name(name), cache, strategy)
 }
 
 /// Iterate over all Python installations that satisfy the given request.
@@ -1066,6 +1037,24 @@ pub fn find_python_installations<'a>(
     environments: EnvironmentPreference,
     preference: PythonPreference,
     cache: &'a Cache,
+) -> Box<dyn Iterator<Item = Result<FindPythonResult, Error>> + 'a> {
+    find_python_installations_with_strategy(
+        request,
+        environments,
+        preference,
+        cache,
+        QueryStrategy::Sequential,
+    )
+}
+
+/// Iterate over all Python installations that satisfy the given request using the given query
+/// strategy.
+fn find_python_installations_with_strategy<'a>(
+    request: &'a PythonRequest,
+    environments: EnvironmentPreference,
+    preference: PythonPreference,
+    cache: &'a Cache,
+    strategy: QueryStrategy,
 ) -> Box<dyn Iterator<Item = Result<FindPythonResult, Error>> + 'a> {
     let sources = DiscoveryPreferences {
         python_preference: preference,
@@ -1133,7 +1122,7 @@ pub fn find_python_installations<'a>(
             if preference.allows_source(PythonSource::SearchPath) {
                 debug!("Searching for Python interpreter with {request}");
                 Box::new(
-                    python_installations_with_name(name, cache)
+                    python_installations_with_name(name, cache, strategy)
                         .filter_ok(move |installation| {
                             environments.allows_installation(installation)
                         })
@@ -1156,6 +1145,7 @@ pub fn find_python_installations<'a>(
                 environments,
                 preference,
                 cache,
+                strategy,
             )
             .map_ok(Ok)
         }),
@@ -1168,6 +1158,7 @@ pub fn find_python_installations<'a>(
                 environments,
                 preference,
                 cache,
+                strategy,
             )
             .map_ok(Ok)
         }),
@@ -1184,6 +1175,7 @@ pub fn find_python_installations<'a>(
                     environments,
                     preference,
                     cache,
+                    strategy,
                 )
                 .map_ok(Ok)
             })
@@ -1197,6 +1189,7 @@ pub fn find_python_installations<'a>(
                 environments,
                 preference,
                 cache,
+                strategy,
             )
             .filter_ok(|installation| implementation.matches_interpreter(&installation.interpreter))
             .map_ok(Ok)
@@ -1214,6 +1207,7 @@ pub fn find_python_installations<'a>(
                     environments,
                     preference,
                     cache,
+                    strategy,
                 )
                 .filter_ok(|installation| {
                     implementation.matches_interpreter(&installation.interpreter)
@@ -1237,6 +1231,7 @@ pub fn find_python_installations<'a>(
                     environments,
                     preference,
                     cache,
+                    strategy,
                 )
                 .filter_ok(move |installation| {
                     request.satisfied_by_interpreter(&installation.interpreter)
@@ -1252,147 +1247,30 @@ pub fn find_python_installations<'a>(
 ///
 /// Unlike [`find_python_installations`], this eagerly collects matching installations instead of
 /// returning a lazy iterator. Non-critical discovery errors are dropped, while critical errors are
-/// propagated immediately.
+/// propagated in discovery order.
 pub fn find_all_python_installations(
     request: &PythonRequest,
     environments: EnvironmentPreference,
     preference: PythonPreference,
     cache: &Cache,
 ) -> Result<Vec<PythonInstallation>, Error> {
-    let sources = DiscoveryPreferences {
-        python_preference: preference,
-        environment_preference: environments,
-    }
-    .sources(request);
-
-    match request {
-        PythonRequest::File(path) => {
-            preference.check_allows_request_source(request, PythonSource::ProvidedPath)?;
-            debug!("Checking for Python interpreter at {request}");
-            match Interpreter::query(path, cache) {
-                Ok(interpreter) => Ok(vec![PythonInstallation {
-                    source: PythonSource::ProvidedPath,
-                    interpreter,
-                }]),
-                Err(err) => {
-                    let err = Error::Query(Box::new(err), path.clone(), PythonSource::ProvidedPath);
-                    if err.is_critical() {
-                        Err(err)
-                    } else {
-                        Ok(vec![])
-                    }
-                }
-            }
-        }
-        PythonRequest::Directory(path) => {
-            preference.check_allows_request_source(request, PythonSource::ProvidedPath)?;
-            debug!("Checking for Python interpreter in {request}");
-            match python_installation_from_directory(path, cache) {
-                Ok(installation) => Ok(vec![installation]),
-                Err(err) => {
-                    let err = Error::Query(Box::new(err), path.clone(), PythonSource::ProvidedPath);
-                    if err.is_critical() {
-                        Err(err)
-                    } else {
-                        Ok(vec![])
-                    }
-                }
-            }
-        }
-        PythonRequest::ExecutableName(name) => {
-            preference.check_allows_request_source(request, PythonSource::SearchPath)?;
-            debug!("Searching for Python interpreter with {request}");
-            let mut installations = collect_python_installations_from_executables(
-                python_executables_with_name(name),
-                cache,
-            )?;
-            installations.retain(|installation| environments.allows_installation(installation));
-            Ok(installations)
-        }
-        PythonRequest::Any => {
-            debug!("Searching for any Python interpreter in {sources}");
-            find_all_matching_python_installations(
-                &VersionRequest::Any,
-                None,
-                PlatformRequest::default(),
-                environments,
-                preference,
-                cache,
-            )
-        }
-        PythonRequest::Default => {
-            debug!("Searching for default Python interpreter in {sources}");
-            find_all_matching_python_installations(
-                &VersionRequest::Default,
-                None,
-                PlatformRequest::default(),
-                environments,
-                preference,
-                cache,
-            )
-        }
-        PythonRequest::Version(version) => {
-            if let Err(err) = version.check_supported() {
-                return Err(Error::InvalidVersionRequest(err));
-            }
-            debug!("Searching for {request} in {sources}");
-            find_all_matching_python_installations(
-                version,
-                None,
-                PlatformRequest::default(),
-                environments,
-                preference,
-                cache,
-            )
-        }
-        PythonRequest::Implementation(implementation) => {
-            debug!("Searching for a {request} interpreter in {sources}");
-            let mut installations = find_all_matching_python_installations(
-                &VersionRequest::Default,
-                Some(implementation),
-                PlatformRequest::default(),
-                environments,
-                preference,
-                cache,
-            )?;
-            installations.retain(|inst| implementation.matches_interpreter(&inst.interpreter));
-            Ok(installations)
-        }
-        PythonRequest::ImplementationVersion(implementation, version) => {
-            if let Err(err) = version.check_supported() {
-                return Err(Error::InvalidVersionRequest(err));
-            }
-            debug!("Searching for {request} in {sources}");
-            let mut installations = find_all_matching_python_installations(
-                version,
-                Some(implementation),
-                PlatformRequest::default(),
-                environments,
-                preference,
-                cache,
-            )?;
-            installations.retain(|inst| implementation.matches_interpreter(&inst.interpreter));
-            Ok(installations)
-        }
-        PythonRequest::Key(request) => {
-            if let Some(version) = request.version() {
-                if let Err(err) = version.check_supported() {
-                    return Err(Error::InvalidVersionRequest(err));
-                }
-            }
-            debug!("Searching for {request} in {sources}");
-            let mut installations = find_all_matching_python_installations(
-                request.version().unwrap_or(&VersionRequest::Default),
-                request.implementation(),
-                request.platform(),
-                environments,
-                preference,
-                cache,
-            )?;
-            installations.retain(|inst| request.satisfied_by_interpreter(&inst.interpreter));
-            Ok(installations)
+    let results = find_python_installations_with_strategy(
+        request,
+        environments,
+        preference,
+        cache,
+        QueryStrategy::Parallel,
+    );
+    let mut installations = Vec::new();
+    for result in results {
+        match result {
+            Ok(Ok(installation)) => installations.push(installation),
+            Ok(Err(_)) => {}
+            Err(err) if err.is_critical() => return Err(err),
+            Err(_) => {}
         }
     }
+    Ok(installations)
 }
 
 /// Find a Python installation that satisfies the given request.
@@ -2529,19 +2407,6 @@ impl PythonPreference {
             Self::OnlySystem => {
                 matches!(source, PythonSource::SearchPath | PythonSource::Registry)
             }
-        }
-    }
-
-    /// Check that this preference allows the given source, returning an error if not.
-    fn check_allows_request_source(
-        self,
-        request: &PythonRequest,
-        source: PythonSource,
-    ) -> Result<(), Error> {
-        if self.allows_source(source) {
-            Ok(())
-        } else {
-            Err(Error::SourceNotAllowed(request.clone(), source, self))
         }
     }
 

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -221,6 +221,7 @@ mod tests {
 
     use crate::{
         PythonDownloads, PythonNotFound, PythonRequest, PythonSource, PythonVersion,
+        find_all_python_installations, find_python_installations,
         implementation::ImplementationName, installation::PythonInstallation,
         managed::ManagedPythonInstallations, virtualenv::virtualenv_python_executable,
     };
@@ -847,6 +848,149 @@ mod tests {
             "We should skip the bad executables in favor of the good one; got {python:?}"
         );
         assert_eq!(python.interpreter().sys_executable(), python_path);
+
+        Ok(())
+    }
+
+    #[test]
+    fn find_all_python_installations_matches_sequential_discovery() -> Result<()> {
+        let mut context = TestContext::new()?;
+        let sequential_cache = Cache::temp()?;
+        let parallel_cache = Cache::temp()?;
+
+        let broken_directory = context.new_search_path_directory("broken")?;
+        let broken = broken_directory.join(format!("python{}", env::consts::EXE_SUFFIX));
+        fs_err::write(
+            &broken,
+            formatdoc! {r"
+                #!/bin/sh
+                echo 'not interpreter metadata'
+            "},
+        )?;
+        fs_err::set_permissions(&broken, std::os::unix::fs::PermissionsExt::from_mode(0o770))?;
+
+        let cpython_311_directory = context.new_search_path_directory("cpython-3.11")?;
+        let cpython_311 = cpython_311_directory.join(format!("python{}", env::consts::EXE_SUFFIX));
+        TestContext::create_mock_interpreter(
+            &cpython_311,
+            &PythonVersion::from_str("3.11.9").expect("Test uses a valid Python version"),
+            ImplementationName::CPython,
+            true,
+            false,
+        )?;
+        let cpython_311_target =
+            cpython_311_directory.join(format!("python-real{}", env::consts::EXE_SUFFIX));
+        fs_err::rename(&cpython_311, &cpython_311_target)?;
+        fs_err::write(
+            &cpython_311,
+            formatdoc! {r#"
+                #!/bin/sh
+                sleep 1
+                exec "{target}" "$@"
+            "#,
+            target = cpython_311_target.display()},
+        )?;
+        fs_err::set_permissions(
+            &cpython_311,
+            std::os::unix::fs::PermissionsExt::from_mode(0o770),
+        )?;
+
+        let cpython_312_directory = context.new_search_path_directory("cpython-3.12")?;
+        let cpython_312 = cpython_312_directory.join(format!("python{}", env::consts::EXE_SUFFIX));
+        TestContext::create_mock_interpreter(
+            &cpython_312,
+            &PythonVersion::from_str("3.12.1").expect("Test uses a valid Python version"),
+            ImplementationName::CPython,
+            true,
+            false,
+        )?;
+
+        let pypy_directory = context.new_search_path_directory("pypy-3.10")?;
+        let pypy = pypy_directory.join(format!("pypy{}", env::consts::EXE_SUFFIX));
+        TestContext::create_mock_interpreter(
+            &pypy,
+            &PythonVersion::from_str("3.10.14").expect("Test uses a valid Python version"),
+            ImplementationName::PyPy,
+            true,
+            false,
+        )?;
+
+        let virtual_environment = context.tempdir.child("virtual-environment");
+        TestContext::mock_venv(&virtual_environment, "3.12.1")?;
+
+        let key = context
+            .run(|| {
+                find_python_installation(
+                    &PythonRequest::File(cpython_312.clone()),
+                    EnvironmentPreference::OnlySystem,
+                    PythonPreference::OnlySystem,
+                    &context.cache,
+                )
+            })??
+            .key()
+            .to_string();
+        let key_request = PythonRequest::parse(&key);
+        assert!(
+            matches!(key_request, PythonRequest::Key(_)),
+            "Expected an installation key request, got {key_request:?}"
+        );
+
+        let requests = [
+            PythonRequest::Any,
+            PythonRequest::Default,
+            PythonRequest::parse("3.12"),
+            PythonRequest::parse("cpython"),
+            PythonRequest::parse("pypy@3.10"),
+            PythonRequest::ExecutableName(format!("pypy{}", env::consts::EXE_SUFFIX)),
+            PythonRequest::File(cpython_312),
+            PythonRequest::Directory(virtual_environment.to_path_buf()),
+            key_request,
+        ];
+
+        for request in requests {
+            let (sequential, parallel) = context.run(|| {
+                let mut sequential = Vec::new();
+                for result in find_python_installations(
+                    &request,
+                    EnvironmentPreference::OnlySystem,
+                    PythonPreference::OnlySystem,
+                    &sequential_cache,
+                ) {
+                    match result {
+                        Ok(Ok(installation)) => sequential.push(installation),
+                        Ok(Err(_)) => {}
+                        Err(err) if err.is_critical() => return Err(err),
+                        Err(_) => {}
+                    }
+                }
+
+                let parallel = find_all_python_installations(
+                    &request,
+                    EnvironmentPreference::OnlySystem,
+                    PythonPreference::OnlySystem,
+                    &parallel_cache,
+                )?;
+                Ok::<_, discovery::Error>((sequential, parallel))
+            })?;
+
+            let identifiers = |installations: Vec<PythonInstallation>| {
+                installations
+                    .into_iter()
+                    .map(|installation| {
+                        (
+                            *installation.source(),
+                            installation.interpreter().sys_executable().to_path_buf(),
+                            installation.key().to_string(),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(
+                identifiers(sequential),
+                identifiers(parallel),
+                "Sequential and parallel discovery differ for {request}"
+            );
+        }
 
         Ok(())
     }

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -853,6 +853,120 @@ mod tests {
     }
 
     #[test]
+    fn find_python_installations_discovers_search_path_lazily() -> Result<()> {
+        let context = TestContext::new()?;
+        let first_directory = context.tempdir.child("first");
+        let second_directory = context.tempdir.child("second");
+
+        let python = first_directory.join(format!("python{}", env::consts::EXE_SUFFIX));
+        let second = second_directory.join(format!("python{}", env::consts::EXE_SUFFIX));
+
+        let installation = context.run(|| -> Result<_> {
+            let mut installations = find_python_installations(
+                &PythonRequest::Default,
+                EnvironmentPreference::OnlySystem,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            );
+
+            TestContext::create_mock_interpreter(
+                &python,
+                &PythonVersion::from_str("3.12.1").expect("Test uses a valid Python version"),
+                ImplementationName::CPython,
+                true,
+                false,
+            )?;
+
+            let search_path = env::join_paths([first_directory.path(), second_directory.path()])?;
+            with_vars(
+                [(EnvVars::PATH, Some(search_path.as_os_str()))],
+                || -> Result<_> {
+                    let installation = installations
+                        .next()
+                        .expect("Deferred search path should contain an interpreter")??;
+
+                    TestContext::create_mock_interpreter(
+                        &second,
+                        &PythonVersion::from_str("3.11.9")
+                            .expect("Test uses a valid Python version"),
+                        ImplementationName::CPython,
+                        true,
+                        false,
+                    )?;
+                    let second_installation = installations
+                        .next()
+                        .expect("Later search path directory should be discovered")??;
+                    assert_eq!(second_installation.interpreter().sys_executable(), second);
+
+                    Ok(installation)
+                },
+            )
+        })?;
+
+        assert_eq!(installation.interpreter().sys_executable(), python);
+
+        Ok(())
+    }
+
+    #[test]
+    fn find_python_installation_queries_lazily() -> Result<()> {
+        let mut context = TestContext::new()?;
+        let first_directory = context.new_search_path_directory("first")?;
+        let second_directory = context.new_search_path_directory("second")?;
+
+        let first = first_directory.join(format!("python{}", env::consts::EXE_SUFFIX));
+        TestContext::create_mock_interpreter(
+            &first,
+            &PythonVersion::from_str("3.12.1").expect("Test uses a valid Python version"),
+            ImplementationName::CPython,
+            true,
+            false,
+        )?;
+
+        let second = second_directory.join(format!("python{}", env::consts::EXE_SUFFIX));
+        TestContext::create_mock_interpreter(
+            &second,
+            &PythonVersion::from_str("3.11.9").expect("Test uses a valid Python version"),
+            ImplementationName::CPython,
+            true,
+            false,
+        )?;
+        let second_target =
+            second_directory.join(format!("python-real{}", env::consts::EXE_SUFFIX));
+        fs_err::rename(&second, &second_target)?;
+
+        let marker = context.tempdir.child("second-was-queried");
+        fs_err::write(
+            &second,
+            formatdoc! {r#"
+                #!/bin/sh
+                : > "{marker}"
+                exec "{target}" "$@"
+            "#,
+            marker = marker.path().display(),
+            target = second_target.display()},
+        )?;
+        fs_err::set_permissions(&second, std::os::unix::fs::PermissionsExt::from_mode(0o770))?;
+
+        let installation = context.run(|| {
+            find_python_installation(
+                &PythonRequest::Default,
+                EnvironmentPreference::OnlySystem,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })??;
+
+        assert_eq!(installation.interpreter().sys_executable(), first);
+        assert!(
+            !marker.path().exists(),
+            "Sequential discovery should not query candidates after finding a match"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn find_all_python_installations_matches_sequential_discovery() -> Result<()> {
         let mut context = TestContext::new()?;
         let sequential_cache = Cache::temp()?;


### PR DESCRIPTION
## Summary

Consolidate the sequential and parallel Python discovery paths introduced in #18684.

Both modes now share a single `PythonRequest` dispatcher and executable-to-installation pipeline. A private `QueryStrategy` selects either lazy sequential querying or eager parallel querying while preserving the existing filtering, ordering, and error-handling behavior.

No prefetching is introduced here. Sequential discovery still defers reading and traversing `PATH`, advances candidate executables one at a time, and stops querying after finding an acceptable installation. The pre-existing eager behavior for explicit file, directory, and executable-name requests is unchanged.

## Test Plan

- Added parity coverage across every `PythonRequest` variant, using independent caches and out-of-order query completion to verify ordered results and non-critical error handling.
- Added regression coverage proving sequential strategy construction pulls no candidates, one iteration pulls exactly one candidate, later `PATH` directories are not inspected early, and later interpreters are not queried after a match.
- Mutation-checked the laziness tests against candidate collection, eager interpreter querying, and eager `PATH` directory filtering.
- `cargo test -p uv-python`
- `cargo test -p uv --test python python_list --no-fail-fast`
- `cargo test -p uv --test python python_find --no-fail-fast`
- `cargo +stable clippy -p uv-python --tests --no-deps --locked -- -D warnings`
- `cargo +stable fmt --all -- --check`
