### PR TITLE
Use byte offsets when peeking over requirements

### DIFF
--- a/crates/uv-pep508/src/cursor.rs
+++ b/crates/uv-pep508/src/cursor.rs
@@ -88,7 +88,10 @@ impl<'a> Cursor<'a> {
     pub(crate) fn peek_while(&mut self, condition: impl Fn(char) -> bool) -> (usize, usize) {
         let peeker = self.chars.clone();
         let start = self.pos();
-        let len = peeker.take_while(|c| condition(*c)).count();
+        let len = peeker
+            .take_while(|c| condition(*c))
+            .map(char::len_utf8)
+            .sum();
         (start, len)
     }
 

--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -1680,6 +1680,17 @@ mod tests {
     }
 
     #[test]
+    fn error_non_ascii_after_marker() {
+        assert_snapshot!(
+            Requirement::<VerbatimUrl>::from_str(r#"foo; python_version == "3.12" α"#)
+                .unwrap_err()
+                .message
+                .to_string(),
+            @"Unexpected character 'α', expected 'and', 'or' or end of input"
+        );
+    }
+
+    #[test]
     fn error_markers_inpython_version() {
         assert_snapshot!(
             parse_pep508_err("name; '3.6'inpython_version"),


### PR DESCRIPTION
## Summary

Prior to this change, non-ASCII input after an otherwise complete marker could panic the requirement parser:

```text
foo; python_version == "3.12" α
```

Cursor positions and slice lengths are byte offsets, but `peek_while` returned a character count. For `α`, the resulting one-byte slice ended in the middle of a two-byte UTF-8 character.

This PR makes `peek_while` return a byte length, matching the rest of the cursor API, and adds regression coverage for the input above.
