### PR TITLE
Use UTF-8 lengths for requirement errors

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -617,7 +617,7 @@ fn parse_extras_cursor<T: Pep508Url>(
                         "Expected either `,` (separating extras) or `]` (ending the extras section), found `{other}`"
                     )),
                     start: pos,
-                    len: 1,
+                    len: other.len_utf8(),
                     input: cursor.to_string(),
                 });
             }
@@ -1316,6 +1316,18 @@ mod tests {
         Invalid character in extras name, expected an alphanumeric character, `-`, `_`, `.`, `,` or `]`, found `ü`
         black[jüpyter]
                ^
+        "
+        );
+    }
+
+    #[test]
+    fn error_unicode_after_extra() {
+        assert_snapshot!(
+            parse_pep508_err("foo[bar α]"),
+            @"
+        Expected either `,` (separating extras) or `]` (ending the extras section), found `α`
+        foo[bar α]
+                ^
         "
         );
     }


### PR DESCRIPTION
## Summary

Prior to this change, formatting the parse error for a Unicode character after an extra could itself panic:

```text
foo[bar α]
```

The parser found the intended error, but recorded `α` with a length of one. Error formatting treats spans as byte offsets, so it attempted to slice through the middle of the two-byte UTF-8 character.

This PR records the character's UTF-8 byte length instead. The input now produces the intended positioned parse error, with a snapshot covering the complete diagnostic.
