### PR TITLE
Ignore reversed string compatible-release markers

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -1458,6 +1458,13 @@ mod tests {
     }
 
     #[test]
+    fn reversed_compatible_release_string_marker() {
+        let requirement = Requirement::<Url>::from_str(r#"foo; "3" ~= sys_platform"#).unwrap();
+
+        assert_eq!(requirement.to_string(), "foo");
+    }
+
+    #[test]
     fn error_marker_incomplete1() {
         assert_snapshot!(
             parse_pep508_err(r"numpy; sys_platform"),

--- a/crates/uv-pep508/src/marker/parse.rs
+++ b/crates/uv-pep508/src/marker/parse.rs
@@ -282,12 +282,23 @@ pub(crate) fn parse_marker_key_op_value<T: Pep508Url>(
                     parse_inverted_version_expr(&l_string, operator, key, reporter)
                 }
                 // '...' == <env key>
-                MarkerValue::MarkerEnvString(key) => Some(MarkerExpression::String {
-                    key,
-                    // Invert the operator to normalize the expression order.
-                    operator: operator.invert(),
-                    value: l_string,
-                }),
+                MarkerValue::MarkerEnvString(key) => {
+                    if operator == MarkerOperator::TildeEqual {
+                        reporter.report(
+                            MarkerWarningKind::LexicographicComparison,
+                            "Can't compare strings with `~=`, will be ignored".to_string(),
+                        );
+
+                        return Ok(None);
+                    }
+
+                    Some(MarkerExpression::String {
+                        key,
+                        // Invert the operator to normalize the expression order.
+                        operator: operator.invert(),
+                        value: l_string,
+                    })
+                }
                 // `"test" in extras` or `"dev" in dependency_groups`
                 MarkerValue::MarkerEnvList(key) => {
                     let operator =


### PR DESCRIPTION
## Summary

Prior to this change, a reversed compatible-release comparison against a string marker reached an `unreachable!()` in marker algebra:

```text
foo; "3" ~= sys_platform
```

The normal-order form, `sys_platform ~= "3"`, was already ignored with a warning because `~=` is not meaningful for strings. The reversed form bypassed that guard and constructed the invalid string expression.

This PR applies the same guard to reversed string comparisons before normalizing the operator. The marker is now ignored with the existing warning instead of panicking.
