### PR TITLE
Reset stale index settings when replacing URLs

### DIFF
--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -486,6 +486,22 @@ impl PyProjectTomlMut {
             .cloned()
             .unwrap_or_default();
 
+        let same_name = index.name.as_deref().is_some_and(|index| {
+            table
+                .get("name")
+                .and_then(|name| name.as_str())
+                .is_some_and(|name| name == index)
+        });
+        let same_url = table
+            .get("url")
+            .and_then(|item| item.as_str())
+            .and_then(|url| DisplaySafeUrl::parse(url).ok())
+            .is_some_and(|url| CanonicalUrl::new(&url) == CanonicalUrl::new(index.url.url()));
+
+        if same_name && !same_url {
+            table = Table::new();
+        }
+
         // If necessary, update the name.
         if let Some(index) = index.name.as_deref() {
             if table

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -11250,6 +11250,70 @@ fn add_index_without_trailing_slash() -> Result<()> {
     Ok(())
 }
 
+/// Replacing an index by name should not retain settings from the previous URL.
+#[test]
+fn add_index_replaces_stale_settings() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "index"
+        url = "https://example.com/flat"
+        format = "flat"
+    "#})?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .add()
+            .arg("iniconfig>=2.0.0")
+            .arg("--index")
+            .arg("index=https://pypi.org/simple")
+            .arg("--frozen"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+
+    let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig>=2.0.0",
+        ]
+
+        [[tool.uv.index]]
+        name = "index"
+        url = "https://pypi.org/simple"
+
+        [tool.uv.sources]
+        iniconfig = { index = "index" }
+        "#
+        );
+    });
+
+    Ok(())
+}
+
 /// Add an index with an existing relative path.
 #[test]
 fn add_index_with_existing_relative_path_index() -> Result<()> {


### PR DESCRIPTION
## Problem

`uv add --index name=url` can reuse an existing `[[tool.uv.index]]` table with the same name while keeping settings from the old URL. For example, replacing a flat index with a Simple API URL can leave `format = "flat"` behind and break later resolution.

## Fix

When an index is matched by name and the URL changes, reset the table before writing the new index fields. Matching by the same URL still preserves the existing table so bump-to-top behavior keeps its settings.

## Test

- `cargo test --package uv --test project add_index_replaces_stale_settings --features test-python,test-pypi`
- `cargo test --package uv --test project edit::add_index --features test-python,test-pypi`
- `cargo fmt --all`
- `git diff --check`

## Risk

Low. The change is limited to `pyproject.toml` mutation for command-line indexes. The main behavior change is intentional: settings attached to a previous URL are not carried to a different URL with the same name.

Fixes #19759
