### PR TITLE
Update cargo publish nightly to 2026-06-12

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -30,9 +30,9 @@ jobs:
         # Nightly is required for the unstable `-Zpublish-timeout` flag, which lets us
         # raise the per-crate wait above the 60s default. crates.io indexing has been
         # known to lag long enough to exceed that during workspace publishes.
-        run: rustup toolchain install nightly-2026-06-09 --profile minimal --no-self-update
+        run: rustup toolchain install nightly-2026-06-12 --profile minimal --no-self-update
       - name: Publish workspace crates
         # Note `--no-verify` is safe because we do a publish dry-run elsewhere in CI
-        run: python3 scripts/publish-crates.py --cargo cargo +nightly-2026-06-09 --no-verify -- -Zpublish-timeout --config 'publish.timeout=600'
+        run: python3 scripts/publish-crates.py --cargo cargo +nightly-2026-06-12 --no-verify -- -Zpublish-timeout --config 'publish.timeout=600'
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -30,9 +30,9 @@ jobs:
         # Nightly is required for the unstable `-Zpublish-timeout` flag, which lets us
         # raise the per-crate wait above the 60s default. crates.io indexing has been
         # known to lag long enough to exceed that during workspace publishes.
-        run: rustup toolchain install nightly-2026-04-15 --profile minimal --no-self-update
+        run: rustup toolchain install nightly-2026-06-09 --profile minimal --no-self-update
       - name: Publish workspace crates
         # Note `--no-verify` is safe because we do a publish dry-run elsewhere in CI
-        run: python3 scripts/publish-crates.py --cargo cargo +nightly-2026-04-15 --no-verify -- -Zpublish-timeout --config 'publish.timeout=600'
+        run: python3 scripts/publish-crates.py --cargo cargo +nightly-2026-06-09 --no-verify -- -Zpublish-timeout --config 'publish.timeout=600'
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Fixes the crates.io publishing error from [https://github.com/rust-lang/cargo/issues/17093](https://github.com/rust-lang/cargo/issues/17093)