### PR TITLE
Fix musllinux tag priority

### DIFF
--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -586,12 +586,16 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
             platform_tags
         }
         (Os::Musllinux { major, minor }, _) => {
-            let mut platform_tags = vec![PlatformTag::Linux { arch }];
-            platform_tags.extend((0..=*minor).map(|minor| PlatformTag::Musllinux {
-                major: *major,
-                minor,
-                arch,
-            }));
+            let mut platform_tags = (0..=*minor)
+                .rev()
+                .map(|minor| PlatformTag::Musllinux {
+                    major: *major,
+                    minor,
+                    arch,
+                })
+                .collect::<Vec<_>>();
+            // Non-musllinux is given lowest priority.
+            platform_tags.push(PlatformTag::Linux { arch });
             platform_tags
         }
         (Os::Macos { major, minor }, Arch::X86_64) => {
@@ -1181,6 +1185,27 @@ mod tests {
             "manylinux_2_6_x86_64",
             "manylinux_2_5_x86_64",
             "manylinux1_x86_64",
+            "linux_x86_64",
+        ]
+        "#
+        );
+    }
+
+    #[test]
+    fn test_platform_tags_musllinux() {
+        let tags = compatible_tags(&Platform::new(
+            Os::Musllinux { major: 1, minor: 2 },
+            Arch::X86_64,
+        ))
+        .unwrap();
+        let tags = tags.iter().map(ToString::to_string).collect::<Vec<_>>();
+        assert_debug_snapshot!(
+            tags,
+            @r#"
+        [
+            "musllinux_1_2_x86_64",
+            "musllinux_1_1_x86_64",
+            "musllinux_1_0_x86_64",
             "linux_x86_64",
         ]
         "#


### PR DESCRIPTION
## Summary

Prior to this change, uv generated compatible musllinux platform tags in ascending version order and put the generic `linux` tag first. Since wheel tags are ordered from most to least preferred, this made older musllinux wheels and the generic Linux fallback outrank the current musllinux version.

This generates musllinux tags from the detected version down to 1.0, then appends the generic Linux fallback last. It adds snapshot coverage for musllinux 1.2 on x86-64.
