### PR TITLE
Validate GraalPy ABI suffixes

### DIFF
--- a/crates/uv-platform-tags/src/abi_tag.rs
+++ b/crates/uv-platform-tags/src/abi_tag.rs
@@ -366,12 +366,18 @@ impl FromStr for AbiTag {
                         tag: s.to_string(),
                     })?;
             let (impl_major, impl_minor) = parse_impl_version(impl_ver_str, "GraalPy", s)?;
-            let (py_ver_str, _) =
+            let (py_ver_str, suffix) =
                 rest.split_once('_')
                     .ok_or_else(|| ParseAbiTagError::InvalidFormat {
                         implementation: "GraalPy",
                         tag: s.to_string(),
                     })?;
+            if suffix != "native" {
+                return Err(ParseAbiTagError::InvalidFormat {
+                    implementation: "GraalPy",
+                    tag: s.to_string(),
+                });
+            }
             let (major, minor) = parse_python_version(py_ver_str, "GraalPy", s)?;
             Ok(Self::GraalPy {
                 python_version: (major, minor),
@@ -587,6 +593,20 @@ mod tests {
             Err(ParseAbiTagError::InvalidFormat {
                 implementation: "GraalPy",
                 tag: "graalpy310_graalpyXY".to_string()
+            })
+        );
+        assert_eq!(
+            AbiTag::from_str("graalpy240_310_wrong"),
+            Err(ParseAbiTagError::InvalidFormat {
+                implementation: "GraalPy",
+                tag: "graalpy240_310_wrong".to_string()
+            })
+        );
+        assert_eq!(
+            AbiTag::from_str("graalpy240_310_native_extra"),
+            Err(ParseAbiTagError::InvalidFormat {
+                implementation: "GraalPy",
+                tag: "graalpy240_310_native_extra".to_string()
             })
         );
     }


### PR DESCRIPTION
## Summary

Prior to this change, the GraalPy ABI parser discarded the final tag segment, so an invalid tag like `graalpy240_310_wrong` was accepted and normalized to `graalpy240_310_native`.

This requires GraalPy ABI tags to end in exactly `_native` and rejects unexpected or additional suffixes. It adds regression coverage for both forms.
