### PR TITLE
Encode hashes in file paths

### DIFF
--- a/crates/uv-pep508/src/unnamed.rs
+++ b/crates/uv-pep508/src/unnamed.rs
@@ -41,11 +41,11 @@ impl UnnamedRequirementUrl for VerbatimUrl {
         path: impl AsRef<Path>,
         working_dir: impl AsRef<Path>,
     ) -> Result<Self, VerbatimUrlError> {
-        Self::from_path(path, working_dir)
+        Self::from_path_with_fragment(path, working_dir)
     }
 
     fn parse_absolute_path(path: impl AsRef<Path>) -> Result<Self, Self::Err> {
-        Self::from_absolute_path(path)
+        Self::from_absolute_path_with_fragment(path)
     }
 
     fn parse_unnamed_url(given: impl AsRef<str>) -> Result<Self, Self::Err> {

--- a/crates/uv-pep508/src/unnamed.rs
+++ b/crates/uv-pep508/src/unnamed.rs
@@ -41,11 +41,11 @@ impl UnnamedRequirementUrl for VerbatimUrl {
         path: impl AsRef<Path>,
         working_dir: impl AsRef<Path>,
     ) -> Result<Self, VerbatimUrlError> {
-        Self::from_path_with_fragment(path, working_dir)
+        Self::from_path_with_fragment(path, Some(working_dir.as_ref()))
     }
 
     fn parse_absolute_path(path: impl AsRef<Path>) -> Result<Self, Self::Err> {
-        Self::from_absolute_path_with_fragment(path)
+        Self::from_path_with_fragment(path, None)
     }
 
     fn parse_unnamed_url(given: impl AsRef<str>) -> Result<Self, Self::Err> {

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -94,12 +94,12 @@ impl VerbatimUrl {
                     None => {
                         // Ex) `C:\Users\user\index`
                         if let Some(root_dir) = root_dir {
-                            Self::from_path_with_fragment(input, root_dir)?
+                            Self::from_path_with_fragment(input, Some(root_dir))?
                         } else {
                             let absolute_path = std::path::absolute(input).map_err(|err| {
                                 VerbatimUrlError::Absolute(input.to_string(), err)
                             })?;
-                            Self::from_absolute_path_with_fragment(absolute_path)?
+                            Self::from_path_with_fragment(absolute_path, None)?
                         }
                     }
                 }
@@ -107,11 +107,11 @@ impl VerbatimUrl {
             None => {
                 // Ex) `/Users/user/index`
                 if let Some(root_dir) = root_dir {
-                    Self::from_path_with_fragment(input, root_dir)?
+                    Self::from_path_with_fragment(input, Some(root_dir))?
                 } else {
                     let absolute_path = std::path::absolute(input)
                         .map_err(|err| VerbatimUrlError::Absolute(input.to_string(), err))?;
-                    Self::from_absolute_path_with_fragment(absolute_path)?
+                    Self::from_path_with_fragment(absolute_path, None)?
                 }
             }
         };
@@ -152,10 +152,15 @@ impl VerbatimUrl {
     #[cfg(feature = "non-pep508-extensions")]
     pub(crate) fn from_path_with_fragment(
         path: impl AsRef<Path>,
-        base_dir: impl AsRef<Path>,
+        base_dir: Option<&Path>,
     ) -> Result<Self, VerbatimUrlError> {
         let (path, fragment) = split_fragment(path.as_ref());
-        Ok(Self::from_path(path, base_dir)?.with_url_fragment(fragment))
+        let url = if let Some(base_dir) = base_dir {
+            Self::from_path(path, base_dir)?
+        } else {
+            Self::from_absolute_path(path)?
+        };
+        Ok(url.with_url_fragment(fragment))
     }
 
     /// Parse a URL from an absolute path.
@@ -182,15 +187,6 @@ impl VerbatimUrl {
             given: None,
             expanded: false,
         })
-    }
-
-    /// Parse a URL from an absolute path, including a URL fragment.
-    #[cfg(feature = "non-pep508-extensions")]
-    pub(crate) fn from_absolute_path_with_fragment(
-        path: impl AsRef<Path>,
-    ) -> Result<Self, VerbatimUrlError> {
-        let (path, fragment) = split_fragment(path.as_ref());
-        Ok(Self::from_absolute_path(path)?.with_url_fragment(fragment))
     }
 
     /// Parse a URL from a normalized path.
@@ -428,18 +424,11 @@ impl Pep508Url for VerbatimUrl {
                 _ => {
                     #[cfg(feature = "non-pep508-extensions")]
                     {
-                        if let Some(working_dir) = working_dir {
-                            return Ok(Self::from_path_with_fragment(
-                                expanded.as_ref(),
-                                working_dir,
-                            )?
-                            .with_given(url)
-                            .with_expanded(vars_expanded));
-                        }
-
-                        Ok(Self::from_absolute_path_with_fragment(expanded.as_ref())?
-                            .with_given(url)
-                            .with_expanded(vars_expanded))
+                        Ok(
+                            Self::from_path_with_fragment(expanded.as_ref(), working_dir)?
+                                .with_given(url)
+                                .with_expanded(vars_expanded),
+                        )
                     }
                     #[cfg(not(feature = "non-pep508-extensions"))]
                     Err(Self::Err::NotAUrl(expanded.to_string()))
@@ -449,17 +438,11 @@ impl Pep508Url for VerbatimUrl {
             // Ex) `../editable/`
             #[cfg(feature = "non-pep508-extensions")]
             {
-                if let Some(working_dir) = working_dir {
-                    return Ok(
-                        Self::from_path_with_fragment(expanded.as_ref(), working_dir)?
-                            .with_given(url)
-                            .with_expanded(vars_expanded),
-                    );
-                }
-
-                Ok(Self::from_absolute_path_with_fragment(expanded.as_ref())?
-                    .with_given(url)
-                    .with_expanded(vars_expanded))
+                Ok(
+                    Self::from_path_with_fragment(expanded.as_ref(), working_dir)?
+                        .with_given(url)
+                        .with_expanded(vars_expanded),
+                )
             }
 
             #[cfg(not(feature = "non-pep508-extensions"))]
@@ -607,7 +590,7 @@ pub fn looks_like_git_repository(url: &Url) -> bool {
 ///
 /// For example, given `file:///home/ferris/project/scripts#hash=somehash`, returns
 /// `("/home/ferris/project/scripts", Some("hash=somehash"))`.
-#[cfg_attr(not(feature = "non-pep508-extensions"), allow(dead_code))]
+#[cfg(feature = "non-pep508-extensions")]
 fn split_fragment(path: &Path) -> (Cow<'_, Path>, Option<&str>) {
     let Some(s) = path.to_str() else {
         return (Cow::Borrowed(path), None);
@@ -756,6 +739,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "non-pep508-extensions")]
     fn fragment() {
         assert_eq!(
             split_fragment(Path::new(
@@ -794,30 +778,26 @@ mod tests {
     }
 
     #[test]
-    fn fragment_in_path() {
+    fn hash_in_path() {
+        let assert_path = |url: VerbatimUrl, path: &Path| {
+            assert_eq!(url.fragment(), None);
+            assert_eq!(url.to_file_path().unwrap(), path);
+            assert!(url.as_str().ends_with("scripts%23hash=somehash"));
+        };
+
         let path = std::path::absolute("scripts#hash=somehash").unwrap();
+        assert_path(VerbatimUrl::from_absolute_path(&path).unwrap(), &path);
+        assert_path(VerbatimUrl::from_normalized_path(&path).unwrap(), &path);
 
-        let url = VerbatimUrl::from_absolute_path(&path).unwrap();
-        assert_eq!(url.fragment(), None);
-        assert_eq!(url.to_file_path().unwrap(), path);
-        assert!(url.as_str().ends_with("scripts%23hash=somehash"));
-
-        let url = VerbatimUrl::from_normalized_path(&path).unwrap();
-        assert_eq!(url.fragment(), None);
-        assert_eq!(url.to_file_path().unwrap(), path);
-        assert!(url.as_str().ends_with("scripts%23hash=somehash"));
-    }
-
-    #[test]
-    #[cfg(feature = "non-pep508-extensions")]
-    fn fragment_in_relative_path() {
-        let base_dir = std::env::current_dir().unwrap();
-        let path = base_dir.join("scripts#hash=somehash");
-
-        let url = VerbatimUrl::from_path("scripts#hash=somehash", base_dir).unwrap();
-        assert_eq!(url.fragment(), None);
-        assert_eq!(url.to_file_path().unwrap(), path);
-        assert!(url.as_str().ends_with("scripts%23hash=somehash"));
+        #[cfg(feature = "non-pep508-extensions")]
+        {
+            let base_dir = std::env::current_dir().unwrap();
+            let path = base_dir.join("scripts#hash=somehash");
+            assert_path(
+                VerbatimUrl::from_path("scripts#hash=somehash", base_dir).unwrap(),
+                &path,
+            );
+        }
     }
 
     #[test]

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -150,7 +150,7 @@ impl VerbatimUrl {
 
     /// Parse a URL from an absolute or relative path, including a URL fragment.
     #[cfg(feature = "non-pep508-extensions")]
-    fn from_path_with_fragment(
+    pub(crate) fn from_path_with_fragment(
         path: impl AsRef<Path>,
         base_dir: impl AsRef<Path>,
     ) -> Result<Self, VerbatimUrlError> {
@@ -186,7 +186,9 @@ impl VerbatimUrl {
 
     /// Parse a URL from an absolute path, including a URL fragment.
     #[cfg(feature = "non-pep508-extensions")]
-    fn from_absolute_path_with_fragment(path: impl AsRef<Path>) -> Result<Self, VerbatimUrlError> {
+    pub(crate) fn from_absolute_path_with_fragment(
+        path: impl AsRef<Path>,
+    ) -> Result<Self, VerbatimUrlError> {
         let (path, fragment) = split_fragment(path.as_ref());
         Ok(Self::from_absolute_path(path)?.with_url_fragment(fragment))
     }

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -94,12 +94,12 @@ impl VerbatimUrl {
                     None => {
                         // Ex) `C:\Users\user\index`
                         if let Some(root_dir) = root_dir {
-                            Self::from_path(input, root_dir)?
+                            Self::from_path_with_fragment(input, root_dir)?
                         } else {
                             let absolute_path = std::path::absolute(input).map_err(|err| {
                                 VerbatimUrlError::Absolute(input.to_string(), err)
                             })?;
-                            Self::from_absolute_path(absolute_path)?
+                            Self::from_absolute_path_with_fragment(absolute_path)?
                         }
                     }
                 }
@@ -107,11 +107,11 @@ impl VerbatimUrl {
             None => {
                 // Ex) `/Users/user/index`
                 if let Some(root_dir) = root_dir {
-                    Self::from_path(input, root_dir)?
+                    Self::from_path_with_fragment(input, root_dir)?
                 } else {
                     let absolute_path = std::path::absolute(input)
                         .map_err(|err| VerbatimUrlError::Absolute(input.to_string(), err))?;
-                    Self::from_absolute_path(absolute_path)?
+                    Self::from_absolute_path_with_fragment(absolute_path)?
                 }
             }
         };
@@ -137,23 +137,25 @@ impl VerbatimUrl {
         let path = normalize_absolute_path(&path)
             .map_err(|err| VerbatimUrlError::Normalization(path.to_path_buf(), err))?;
 
-        // Extract the fragment, if it exists.
-        let (path, fragment) = split_fragment(&path);
-
         // Convert to a URL.
-        let mut url = DisplaySafeUrl::from_file_path(path.clone())
-            .map_err(|()| VerbatimUrlError::UrlConversion(path.to_path_buf()))?;
-
-        // Set the fragment, if it exists.
-        if let Some(fragment) = fragment {
-            url.set_fragment(Some(fragment));
-        }
+        let url = DisplaySafeUrl::from_file_path(path.clone())
+            .map_err(|()| VerbatimUrlError::UrlConversion(path.clone()))?;
 
         Ok(Self {
             url,
             given: None,
             expanded: false,
         })
+    }
+
+    /// Parse a URL from an absolute or relative path, including a URL fragment.
+    #[cfg(feature = "non-pep508-extensions")]
+    fn from_path_with_fragment(
+        path: impl AsRef<Path>,
+        base_dir: impl AsRef<Path>,
+    ) -> Result<Self, VerbatimUrlError> {
+        let (path, fragment) = split_fragment(path.as_ref());
+        Ok(Self::from_path(path, base_dir)?.with_url_fragment(fragment))
     }
 
     /// Parse a URL from an absolute path.
@@ -171,23 +173,22 @@ impl VerbatimUrl {
         let path = normalize_absolute_path(path)
             .map_err(|err| VerbatimUrlError::Normalization(path.to_path_buf(), err))?;
 
-        // Extract the fragment, if it exists.
-        let (path, fragment) = split_fragment(&path);
-
         // Convert to a URL.
-        let mut url = DisplaySafeUrl::from_file_path(path.clone())
+        let url = DisplaySafeUrl::from_file_path(path.clone())
             .unwrap_or_else(|()| panic!("path is absolute: {}", path.display()));
-
-        // Set the fragment, if it exists.
-        if let Some(fragment) = fragment {
-            url.set_fragment(Some(fragment));
-        }
 
         Ok(Self {
             url,
             given: None,
             expanded: false,
         })
+    }
+
+    /// Parse a URL from an absolute path, including a URL fragment.
+    #[cfg(feature = "non-pep508-extensions")]
+    fn from_absolute_path_with_fragment(path: impl AsRef<Path>) -> Result<Self, VerbatimUrlError> {
+        let (path, fragment) = split_fragment(path.as_ref());
+        Ok(Self::from_absolute_path(path)?.with_url_fragment(fragment))
     }
 
     /// Parse a URL from a normalized path.
@@ -203,23 +204,25 @@ impl VerbatimUrl {
             return Err(VerbatimUrlError::WorkingDirectory(path.to_path_buf()));
         };
 
-        // Extract the fragment, if it exists.
-        let (path, fragment) = split_fragment(path);
-
         // Convert to a URL.
-        let mut url = DisplaySafeUrl::from_file_path(path.clone())
+        let url = DisplaySafeUrl::from_file_path(path)
             .unwrap_or_else(|()| panic!("path is absolute: {}", path.display()));
-
-        // Set the fragment, if it exists.
-        if let Some(fragment) = fragment {
-            url.set_fragment(Some(fragment));
-        }
 
         Ok(Self {
             url,
             given: None,
             expanded: false,
         })
+    }
+
+    /// Set a fragment that was provided as part of a URL.
+    #[must_use]
+    #[cfg(feature = "non-pep508-extensions")]
+    fn with_url_fragment(mut self, fragment: Option<&str>) -> Self {
+        if let Some(fragment) = fragment {
+            self.url.set_fragment(Some(fragment));
+        }
+        self
     }
 
     /// Set the verbatim representation of the URL.
@@ -388,17 +391,22 @@ impl Pep508Url for VerbatimUrl {
                     // Transform, e.g., `/C:/Users/ferris/wheel-0.42.0.tar.gz` to `C:\Users\ferris\wheel-0.42.0.tar.gz`.
                     #[cfg(feature = "non-pep508-extensions")]
                     {
+                        let (path, fragment) = path
+                            .split_once('#')
+                            .map_or((path, None), |(path, fragment)| (path, Some(fragment)));
                         let path = strip_host(path);
 
                         let path = normalize_url_path(path);
 
                         if let Some(working_dir) = working_dir {
                             return Ok(Self::from_path(path.as_ref(), working_dir)?
+                                .with_url_fragment(fragment)
                                 .with_given(url)
                                 .with_expanded(vars_expanded));
                         }
 
                         Ok(Self::from_absolute_path(path.as_ref())?
+                            .with_url_fragment(fragment)
                             .with_given(url)
                             .with_expanded(vars_expanded))
                     }
@@ -419,12 +427,15 @@ impl Pep508Url for VerbatimUrl {
                     #[cfg(feature = "non-pep508-extensions")]
                     {
                         if let Some(working_dir) = working_dir {
-                            return Ok(Self::from_path(expanded.as_ref(), working_dir)?
-                                .with_given(url)
-                                .with_expanded(vars_expanded));
+                            return Ok(Self::from_path_with_fragment(
+                                expanded.as_ref(),
+                                working_dir,
+                            )?
+                            .with_given(url)
+                            .with_expanded(vars_expanded));
                         }
 
-                        Ok(Self::from_absolute_path(expanded.as_ref())?
+                        Ok(Self::from_absolute_path_with_fragment(expanded.as_ref())?
                             .with_given(url)
                             .with_expanded(vars_expanded))
                     }
@@ -437,12 +448,14 @@ impl Pep508Url for VerbatimUrl {
             #[cfg(feature = "non-pep508-extensions")]
             {
                 if let Some(working_dir) = working_dir {
-                    return Ok(Self::from_path(expanded.as_ref(), working_dir)?
-                        .with_given(url)
-                        .with_expanded(vars_expanded));
+                    return Ok(
+                        Self::from_path_with_fragment(expanded.as_ref(), working_dir)?
+                            .with_given(url)
+                            .with_expanded(vars_expanded),
+                    );
                 }
 
-                Ok(Self::from_absolute_path(expanded.as_ref())?
+                Ok(Self::from_absolute_path_with_fragment(expanded.as_ref())?
                     .with_given(url)
                     .with_expanded(vars_expanded))
             }
@@ -592,6 +605,7 @@ pub fn looks_like_git_repository(url: &Url) -> bool {
 ///
 /// For example, given `file:///home/ferris/project/scripts#hash=somehash`, returns
 /// `("/home/ferris/project/scripts", Some("hash=somehash"))`.
+#[cfg_attr(not(feature = "non-pep508-extensions"), allow(dead_code))]
 fn split_fragment(path: &Path) -> (Cow<'_, Path>, Option<&str>) {
     let Some(s) = path.to_str() else {
         return (Cow::Borrowed(path), None);
@@ -775,6 +789,33 @@ mod tests {
             split_fragment(Path::new("")),
             (Cow::Borrowed(Path::new("")), None)
         );
+    }
+
+    #[test]
+    fn fragment_in_path() {
+        let path = std::path::absolute("scripts#hash=somehash").unwrap();
+
+        let url = VerbatimUrl::from_absolute_path(&path).unwrap();
+        assert_eq!(url.fragment(), None);
+        assert_eq!(url.to_file_path().unwrap(), path);
+        assert!(url.as_str().ends_with("scripts%23hash=somehash"));
+
+        let url = VerbatimUrl::from_normalized_path(&path).unwrap();
+        assert_eq!(url.fragment(), None);
+        assert_eq!(url.to_file_path().unwrap(), path);
+        assert!(url.as_str().ends_with("scripts%23hash=somehash"));
+    }
+
+    #[test]
+    #[cfg(feature = "non-pep508-extensions")]
+    fn fragment_in_relative_path() {
+        let base_dir = std::env::current_dir().unwrap();
+        let path = base_dir.join("scripts#hash=somehash");
+
+        let url = VerbatimUrl::from_path("scripts#hash=somehash", base_dir).unwrap();
+        assert_eq!(url.fragment(), None);
+        assert_eq!(url.to_file_path().unwrap(), path);
+        assert!(url.as_str().ends_with("scripts%23hash=somehash"));
     }
 
     #[test]

--- a/crates/uv-pypi-types/src/parsed_url.rs
+++ b/crates/uv-pypi-types/src/parsed_url.rs
@@ -80,7 +80,7 @@ impl UnnamedRequirementUrl for VerbatimParsedUrl {
         path: impl AsRef<Path>,
         working_dir: impl AsRef<Path>,
     ) -> Result<Self, Self::Err> {
-        let verbatim = VerbatimUrl::from_path(&path, &working_dir)?;
+        let verbatim = <VerbatimUrl as UnnamedRequirementUrl>::parse_path(&path, &working_dir)?;
         let verbatim_path = verbatim.as_path()?;
         let is_dir = if let Ok(metadata) = verbatim_path.metadata() {
             metadata.is_dir()
@@ -112,7 +112,7 @@ impl UnnamedRequirementUrl for VerbatimParsedUrl {
     }
 
     fn parse_absolute_path(path: impl AsRef<Path>) -> Result<Self, Self::Err> {
-        let verbatim = VerbatimUrl::from_absolute_path(&path)?;
+        let verbatim = <VerbatimUrl as UnnamedRequirementUrl>::parse_absolute_path(&path)?;
         let verbatim_path = verbatim.as_path()?;
         let is_dir = if let Ok(metadata) = verbatim_path.metadata() {
             metadata.is_dir()

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -10861,6 +10861,88 @@ fn lock_peer_member() -> Result<()> {
     Ok(())
 }
 
+/// Lock a workspace with a member whose directory contains a URL fragment delimiter.
+#[test]
+fn lock_workspace_member_with_fragment_delimiter() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["member"]
+
+        [tool.uv.workspace]
+        members = ["member#x"]
+
+        [tool.uv.sources]
+        member = { workspace = true }
+        "#,
+    )?;
+
+    context
+        .temp_dir
+        .child("member#x")
+        .child("pyproject.toml")
+        .write_str(
+            r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#,
+        )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "member",
+            "project",
+        ]
+
+        [[package]]
+        name = "member"
+        version = "0.1.0"
+        source = { editable = "member#x" }
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "member" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "member", editable = "member#x" }]
+        "#);
+    });
+
+    Ok(())
+}
+
 /// Lock a workspace in which a member defines an explicit index that requires authentication.
 #[tokio::test]
 async fn lock_index_workspace_member() -> Result<()> {


### PR DESCRIPTION
## Summary

Prior to this change, we treated `#` in every filesystem path as a URL fragment delimiter. A workspace member directory like `member#x` was discovered from disk, but its file URL pointed at `member` with fragment `x`, so locking failed.

This separates filesystem path construction from requirement-string parsing. Literal `#` characters in paths are now percent-encoded as `%23`, while user-provided requirement strings continue to support explicit URL fragments such as `#hash=...`.
