### PR TITLE
Update string marker ordering semantics

### DIFF
--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -218,7 +218,7 @@ impl InternerGuard<'_> {
             //
             // Note that in the presence of the `in` operator, we may not be able to simplify
             // some marker trees to a constant `true` or `false`. For example, it is not trivial to
-            // detect that `os_name > 'z' and os_name in 'Linux'` is unsatisfiable.
+            // detect that `os_name == 'Windows' and os_name in 'Linux'` is unsatisfiable.
             MarkerExpression::String {
                 key,
                 operator: MarkerOperator::In,
@@ -313,7 +313,10 @@ impl InternerGuard<'_> {
                     ),
                     _ => (key.into(), value),
                 };
-                (Variable::String(key), Edges::from_string(operator, value))
+                (
+                    Variable::String(key),
+                    Edges::from_string(key, operator, value),
+                )
             }
             MarkerExpression::List { pair, operator } => (
                 Variable::List(pair),
@@ -1225,15 +1228,47 @@ impl Edges {
     ///
     /// This function will panic for the `In` and `Contains` marker operators, which
     /// should be represented as separate boolean variables.
-    fn from_string(operator: MarkerOperator, value: ArcStr) -> Self {
-        let range: Ranges<ArcStr> = match operator {
-            MarkerOperator::Equal => Ranges::singleton(value),
-            MarkerOperator::NotEqual => Ranges::singleton(value).complement(),
-            MarkerOperator::GreaterThan => Ranges::strictly_higher_than(value),
-            MarkerOperator::GreaterEqual => Ranges::higher_than(value),
-            MarkerOperator::LessThan => Ranges::strictly_lower_than(value),
-            MarkerOperator::LessEqual => Ranges::lower_than(value),
-            MarkerOperator::TildeEqual => unreachable!("string comparisons with ~= are ignored"),
+    fn from_string(
+        key: CanonicalMarkerValueString,
+        operator: MarkerOperator,
+        value: ArcStr,
+    ) -> Self {
+        let range: Ranges<ArcStr> = match (key, operator) {
+            // `platform_release` and `platform_version` are `Version | String` fields. Preserve
+            // their existing lexicographic behavior here; their version-aware semantics are
+            // outside the pure string field behavior handled by this change.
+            (
+                CanonicalMarkerValueString::PlatformRelease
+                | CanonicalMarkerValueString::PlatformVersion,
+                MarkerOperator::GreaterThan,
+            ) => Ranges::strictly_higher_than(value),
+            (
+                CanonicalMarkerValueString::PlatformRelease
+                | CanonicalMarkerValueString::PlatformVersion,
+                MarkerOperator::GreaterEqual,
+            ) => Ranges::higher_than(value),
+            (
+                CanonicalMarkerValueString::PlatformRelease
+                | CanonicalMarkerValueString::PlatformVersion,
+                MarkerOperator::LessThan,
+            ) => Ranges::strictly_lower_than(value),
+            (
+                CanonicalMarkerValueString::PlatformRelease
+                | CanonicalMarkerValueString::PlatformVersion,
+                MarkerOperator::LessEqual,
+            ) => Ranges::lower_than(value),
+            (_, MarkerOperator::Equal) => Ranges::singleton(value),
+            (_, MarkerOperator::NotEqual) => Ranges::singleton(value).complement(),
+            // The marker specification defines strict ordering comparisons for string-valued
+            // fields as always false, while inclusive ordering comparisons are equivalent to
+            // equality.
+            (_, MarkerOperator::GreaterThan | MarkerOperator::LessThan) => Ranges::empty(),
+            (_, MarkerOperator::GreaterEqual | MarkerOperator::LessEqual) => {
+                Ranges::singleton(value)
+            }
+            (_, MarkerOperator::TildeEqual) => {
+                unreachable!("string comparisons with ~= are ignored")
+            }
             _ => unreachable!("`in` and `contains` are treated as boolean variables"),
         };
 
@@ -1784,15 +1819,17 @@ mod tests {
         assert!(m().or(extra_foo, extra_not_foo).is_true());
 
         let os_geq_bar = expr("os_name >= 'bar'");
-        assert!(!os_geq_bar.is_false());
+        assert_eq!(os_geq_bar, expr("os_name == 'bar'"));
 
-        let os_le_bar = expr("os_name < 'bar'");
-        assert!(m().and(os_geq_bar, os_le_bar).is_false());
-        assert!(m().or(os_geq_bar, os_le_bar).is_true());
+        let os_lt_bar = expr("os_name < 'bar'");
+        assert!(os_lt_bar.is_false());
+        assert!(m().and(os_geq_bar, os_lt_bar).is_false());
+        assert_eq!(m().or(os_geq_bar, os_lt_bar), os_geq_bar);
 
         let os_leq_bar = expr("os_name <= 'bar'");
-        assert!(!m().and(os_geq_bar, os_leq_bar).is_false());
-        assert!(m().or(os_geq_bar, os_leq_bar).is_true());
+        assert_eq!(os_leq_bar, os_geq_bar);
+        assert_eq!(m().and(os_geq_bar, os_leq_bar), os_geq_bar);
+        assert_eq!(m().or(os_geq_bar, os_leq_bar), os_geq_bar);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1046,7 +1046,12 @@ impl MarkerTree {
                 for (range, tree) in marker.children() {
                     let l_string = env.get_string(marker.key());
 
-                    if range.as_singleton().is_none() {
+                    if matches!(
+                        marker.key(),
+                        CanonicalMarkerValueString::PlatformRelease
+                            | CanonicalMarkerValueString::PlatformVersion
+                    ) && range.as_singleton().is_none()
+                    {
                         if let Some((start, end)) = range.bounding_range() {
                             if let Bound::Included(value) | Bound::Excluded(value) = start {
                                 reporter.report(
@@ -1989,6 +1994,62 @@ mod test {
     }
 
     #[test]
+    fn test_string_ordering_comparisons() {
+        let env = MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
+            implementation_name: "cpython",
+            implementation_version: "3.13",
+            os_name: "posix",
+            platform_machine: "x86_64",
+            platform_python_implementation: "CPython",
+            platform_release: "10",
+            platform_system: "Plan9",
+            platform_version: "10",
+            python_full_version: "3.13",
+            python_version: "3.13",
+            sys_platform: "plan9",
+        })
+        .unwrap();
+
+        for (key, value) in [
+            ("implementation_name", "cpython"),
+            ("os_name", "posix"),
+            ("platform_machine", "x86_64"),
+            ("platform_python_implementation", "CPython"),
+            ("platform_system", "Plan9"),
+            ("sys_platform", "plan9"),
+        ] {
+            for operator in [">", "<"] {
+                let marker = m(&format!("{key} {operator} '{value}'"));
+                assert!(marker.is_false(), "{marker:?}");
+                assert!(!marker.evaluate(&env, &[]));
+
+                let marker = m(&format!("'{value}' {operator} {key}"));
+                assert!(marker.is_false(), "{marker:?}");
+                assert!(!marker.evaluate(&env, &[]));
+            }
+
+            for operator in [">=", "<="] {
+                let marker = m(&format!("{key} {operator} '{value}'"));
+                assert_eq!(marker, m(&format!("{key} == '{value}'")));
+                assert!(marker.evaluate(&env, &[]));
+
+                let marker = m(&format!("{key} {operator} 'different'"));
+                assert_eq!(marker, m(&format!("{key} == 'different'")));
+                assert!(!marker.evaluate(&env, &[]));
+
+                let marker = m(&format!("'{value}' {operator} {key}"));
+                assert_eq!(marker, m(&format!("{key} == '{value}'")));
+                assert!(marker.evaluate(&env, &[]));
+            }
+        }
+
+        // `platform_release` and `platform_version` are `Version | String` fields, not pure
+        // strings. Preserve their existing ordering behavior in this change.
+        assert!(m("platform_release < '2'").evaluate(&env, &[]));
+        assert!(m("platform_version <= '2'").evaluate(&env, &[]));
+    }
+
+    #[test]
     fn test_version_in_evaluation() {
         let env27 = MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
             implementation_name: "",
@@ -2107,7 +2168,6 @@ mod test {
                 "WARN warnings4: uv_pep508: platform.python_implementation is deprecated in favor of platform_python_implementation",
                 "WARN warnings4: uv_pep508: platform.version is deprecated in favor of platform_version",
                 "WARN warnings4: uv_pep508: sys.platform is deprecated in favor of sys_platform",
-                "WARN warnings4: uv_pep508: Comparing linux and posix lexicographically",
             ];
             if lines == expected {
                 Ok(())
@@ -2115,6 +2175,16 @@ mod test {
                 Err(format!("{lines:#?}"))
             }
         });
+    }
+
+    #[test]
+    #[cfg(feature = "tracing")]
+    #[tracing_test::traced_test]
+    fn warnings5() {
+        let env = env37().with_platform_release("10");
+        let marker = MarkerTree::from_str("platform_release < '2'").unwrap();
+        assert!(marker.evaluate(&env, &[]));
+        logs_contain("Comparing 10 and 2 lexicographically");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prior to this change, we used lexicographic ordering for pure string-valued environment markers. For example, with `os_name = "posix"`, both `os_name > "nt"` and `os_name >= "nt"` evaluated to true.

The [current dependency specification](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#marker-comparisons), updated by [pypa/packaging.python.org#1988](https://github.com/pypa/packaging.python.org/pull/1988), defines strict string comparisons (`>` and `<`) as always false, while inclusive comparisons (`>=` and `<=`) are equivalent to equality. This applies those rules to every pure String marker field, including reversed operand forms.

`platform_release` and `platform_version` remain on their existing comparison path because the specification types them as `Version | String` rather than pure strings.
