### PR TITLE
Avoid evaluating virtual environment prompts

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -98,8 +98,8 @@ _OLD_VIRTUAL_PATH="$PATH"
 PATH="$VIRTUAL_ENV/{{ BIN_NAME }}:$PATH"
 export PATH
 
-if [ "x{{ VIRTUAL_PROMPT }}" != x ] ; then
-    VIRTUAL_ENV_PROMPT="{{ VIRTUAL_PROMPT }}"
+if [ "x"{{ VIRTUAL_PROMPT }} != x ] ; then
+    VIRTUAL_ENV_PROMPT={{ VIRTUAL_PROMPT }}
 else
     VIRTUAL_ENV_PROMPT=$(basename "$VIRTUAL_ENV")
 fi

--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -113,7 +113,11 @@ fi
 
 if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
     _OLD_VIRTUAL_PS1="${PS1-}"
-    PS1="(${VIRTUAL_ENV_PROMPT}) ${PS1-}"
+    if [ -n "${BASH_VERSION-}" ] ; then
+        PS1='(${VIRTUAL_ENV_PROMPT}) '"${PS1-}"
+    else
+        PS1="(${VIRTUAL_ENV_PROMPT}) ${PS1-}"
+    fi
     export PS1
 fi
 

--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -66,6 +66,11 @@ deactivate () {
         export PS1
         unset _OLD_VIRTUAL_PS1
     fi
+    if [ -n "${ZSH_VERSION-}" ] && [ -n "${_VIRTUAL_ENV_PROMPT_PSVAR_INDEX-}" ] ; then
+        # Keep zsh array syntax opaque to POSIX parsers; the evaluated text is constant.
+        eval 'psvar[$_VIRTUAL_ENV_PROMPT_PSVAR_INDEX]=()'
+        unset _VIRTUAL_ENV_PROMPT_PSVAR_INDEX
+    fi
 
     unset VIRTUAL_ENV
     unset VIRTUAL_ENV_PROMPT
@@ -113,7 +118,15 @@ fi
 
 if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
     _OLD_VIRTUAL_PS1="${PS1-}"
-    if [ -n "${BASH_VERSION-}" ] ; then
+    # With PROMPT_SUBST, zsh re-evaluates command substitutions stored directly in PS1.
+    # `%Nv` renders psvar[N] without another substitution pass. Append a temporary value
+    # so deactivation can remove it without changing the user's existing entries.
+    if [ -n "${ZSH_VERSION-}" ] ; then
+        _VIRTUAL_ENV_PROMPT_PSVAR_INDEX=$((${#psvar} + 1))
+        # Keep zsh array syntax opaque to POSIX parsers; the evaluated text is constant.
+        eval 'psvar+=("$VIRTUAL_ENV_PROMPT")'
+        PS1="(%${_VIRTUAL_ENV_PROMPT_PSVAR_INDEX}v) ${PS1-}"
+    elif [ -n "${BASH_VERSION-}" ] ; then
         PS1='(${VIRTUAL_ENV_PROMPT}) '"${PS1-}"
     else
         PS1="(${VIRTUAL_ENV_PROMPT}) ${PS1-}"

--- a/crates/uv-virtualenv/src/activator/activate.fish
+++ b/crates/uv-virtualenv/src/activator/activate.fish
@@ -94,8 +94,8 @@ set -gx PATH "$VIRTUAL_ENV"'/{{ BIN_NAME }}' $PATH
 
 # Prompt override provided?
 # If not, just use the environment name.
-if test -n '{{ VIRTUAL_PROMPT }}'
-    set -gx VIRTUAL_ENV_PROMPT '{{ VIRTUAL_PROMPT }}'
+if test -n {{ VIRTUAL_PROMPT }}
+    set -gx VIRTUAL_ENV_PROMPT {{ VIRTUAL_PROMPT }}
 else
     set -gx VIRTUAL_ENV_PROMPT (basename "$VIRTUAL_ENV")
 end

--- a/crates/uv-virtualenv/src/activator/activate.ps1
+++ b/crates/uv-virtualenv/src/activator/activate.ps1
@@ -58,8 +58,8 @@ deactivate -nondestructive
 $VIRTUAL_ENV = $BASE_DIR
 $env:VIRTUAL_ENV = $VIRTUAL_ENV
 
-if ("{{ VIRTUAL_PROMPT }}" -ne "") {
-    $env:VIRTUAL_ENV_PROMPT = "{{ VIRTUAL_PROMPT }}"
+if ({{ VIRTUAL_PROMPT }} -ne "") {
+    $env:VIRTUAL_ENV_PROMPT = {{ VIRTUAL_PROMPT }}
 }
 else {
     $env:VIRTUAL_ENV_PROMPT = $( Split-Path $env:VIRTUAL_ENV -Leaf )

--- a/crates/uv-virtualenv/src/activator/activate_this.py
+++ b/crates/uv-virtualenv/src/activator/activate_this.py
@@ -46,7 +46,7 @@ base = bin_dir[: -len("{{ BIN_NAME }}") - 1]  # strip away the bin part from the
 # prepend bin to PATH (this file is inside the bin directory)
 os.environ["PATH"] = os.pathsep.join([bin_dir, *os.environ.get("PATH", "").split(os.pathsep)])
 os.environ["VIRTUAL_ENV"] = base  # virtual env is right above bin directory
-os.environ["VIRTUAL_ENV_PROMPT"] = "{{ VIRTUAL_PROMPT }}" or os.path.basename(base)  # noqa: SIM222
+os.environ["VIRTUAL_ENV_PROMPT"] = {{ VIRTUAL_PROMPT }} or os.path.basename(base)  # noqa: SIM222
 
 # add the virtual environments libraries to the host python import mechanism
 prev_length = len(sys.path)

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -38,7 +38,11 @@ const ACTIVATE_TEMPLATES: &[(&str, &str, Option<PromptQuoting>)] = &[
         Some(PromptQuoting::Fish),
     ),
     ("activate.nu", include_str!("activator/activate.nu"), None),
-    ("activate.ps1", include_str!("activator/activate.ps1"), None),
+    (
+        "activate.ps1",
+        include_str!("activator/activate.ps1"),
+        Some(PromptQuoting::PowerShell),
+    ),
     ("activate.bat", include_str!("activator/activate.bat"), None),
     (
         "deactivate.bat",
@@ -58,6 +62,7 @@ const VIRTUALENV_PATCH: &str = include_str!("_virtualenv.py");
 enum PromptQuoting {
     Posix,
     Fish,
+    PowerShell,
 }
 
 impl PromptQuoting {
@@ -69,6 +74,15 @@ impl PromptQuoting {
                 let value = value.replace('\\', r"\\").replace('\'', r"\'");
                 format!("'{value}'")
             }
+            Self::PowerShell => format!(
+                "'{}'",
+                value
+                    .replace('\'', "''")
+                    .replace('‘', "‘‘")
+                    .replace('’', "’’")
+                    .replace('‚', "‚‚")
+                    .replace('‛', "‛‛")
+            ),
         }
     }
 }

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -1,6 +1,7 @@
 //! Create a virtual environment.
 
 use std::env::consts::EXE_SUFFIX;
+use std::fmt::Write as _;
 use std::io;
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -53,7 +54,7 @@ const ACTIVATE_TEMPLATES: &[(&str, &str, Option<PromptQuoting>)] = &[
     (
         "activate_this.py",
         include_str!("activator/activate_this.py"),
-        None,
+        Some(PromptQuoting::Python),
     ),
 ];
 const VIRTUALENV_PATCH: &str = include_str!("_virtualenv.py");
@@ -63,6 +64,7 @@ enum PromptQuoting {
     Posix,
     Fish,
     PowerShell,
+    Python,
 }
 
 impl PromptQuoting {
@@ -83,8 +85,30 @@ impl PromptQuoting {
                     .replace('‚', "‚‚")
                     .replace('‛', "‛‛")
             ),
+            Self::Python => quote_python(value),
         }
     }
+}
+
+fn quote_python(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for character in value.chars() {
+        match character {
+            '\\' => quoted.push_str(r"\\"),
+            '"' => quoted.push_str(r#"\""#),
+            '\n' => quoted.push_str(r"\n"),
+            '\r' => quoted.push_str(r"\r"),
+            '\t' => quoted.push_str(r"\t"),
+            character if character.is_control() => {
+                write!(quoted, r"\u{:04x}", u32::from(character))
+                    .expect("writing to a string cannot fail");
+            }
+            _ => quoted.push(character),
+        }
+    }
+    quoted.push('"');
+    quoted
 }
 
 /// Very basic `.cfg` file format writer.

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -25,21 +25,47 @@ use uv_version::version;
 use uv_warnings::warn_user_once;
 
 /// Activation scripts for the environment, with dependent paths templated out.
-const ACTIVATE_TEMPLATES: &[(&str, &str)] = &[
-    ("activate", include_str!("activator/activate")),
-    ("activate.csh", include_str!("activator/activate.csh")),
-    ("activate.fish", include_str!("activator/activate.fish")),
-    ("activate.nu", include_str!("activator/activate.nu")),
-    ("activate.ps1", include_str!("activator/activate.ps1")),
-    ("activate.bat", include_str!("activator/activate.bat")),
-    ("deactivate.bat", include_str!("activator/deactivate.bat")),
-    ("pydoc.bat", include_str!("activator/pydoc.bat")),
+const ACTIVATE_TEMPLATES: &[(&str, &str, Option<PromptQuoting>)] = &[
+    (
+        "activate",
+        include_str!("activator/activate"),
+        Some(PromptQuoting::Posix),
+    ),
+    ("activate.csh", include_str!("activator/activate.csh"), None),
+    (
+        "activate.fish",
+        include_str!("activator/activate.fish"),
+        None,
+    ),
+    ("activate.nu", include_str!("activator/activate.nu"), None),
+    ("activate.ps1", include_str!("activator/activate.ps1"), None),
+    ("activate.bat", include_str!("activator/activate.bat"), None),
+    (
+        "deactivate.bat",
+        include_str!("activator/deactivate.bat"),
+        None,
+    ),
+    ("pydoc.bat", include_str!("activator/pydoc.bat"), None),
     (
         "activate_this.py",
         include_str!("activator/activate_this.py"),
+        None,
     ),
 ];
 const VIRTUALENV_PATCH: &str = include_str!("_virtualenv.py");
+
+#[derive(Clone, Copy)]
+enum PromptQuoting {
+    Posix,
+}
+
+impl PromptQuoting {
+    fn quote(self, value: &str) -> String {
+        match self {
+            Self::Posix => format!("'{}'", escape_posix_for_single_quotes(value)),
+        }
+    }
+}
 
 /// Very basic `.cfg` file format writer.
 fn write_cfg(f: &mut impl Write, data: &[(String, String)]) -> io::Result<()> {
@@ -459,11 +485,11 @@ pub(crate) fn create(
     }
 
     // Add all the activate scripts for different shells
-    for (name, template) in ACTIVATE_TEMPLATES {
+    for &(name, template, prompt_quoting) in ACTIVATE_TEMPLATES {
         // csh has no way to determine its own script location, so a relocatable
         // activate.csh is not possible. Skip it entirely instead of generating a
         // non-functional script.
-        if relocatable && *name == "activate.csh" {
+        if relocatable && name == "activate.csh" {
             continue;
         }
 
@@ -482,7 +508,7 @@ pub(crate) fn create(
         .map(|path| path.simplified().to_str().unwrap().replace('\\', "\\\\"))
         .join(path_sep);
 
-        let virtual_env_dir = match (relocatable, name.to_owned()) {
+        let virtual_env_dir = match (relocatable, name) {
             (true, "activate") => {
                 r#"'"$(dirname -- "$(dirname -- "$(realpath -- "$SCRIPT_PATH")")")"'"#.to_string()
             }
@@ -501,16 +527,18 @@ pub(crate) fn create(
             _ => escape_posix_for_single_quotes(location.simplified().to_str().unwrap()),
         };
 
-        let activator = template
+        let prompt = prompt.as_deref().unwrap_or_default();
+        let virtual_prompt = prompt_quoting
+            .map(|quoting| quoting.quote(prompt))
+            .unwrap_or_else(|| prompt.to_string());
+
+        let contents = template
             .replace("{{ VIRTUAL_ENV_DIR }}", &virtual_env_dir)
             .replace("{{ BIN_NAME }}", bin_name)
-            .replace(
-                "{{ VIRTUAL_PROMPT }}",
-                prompt.as_deref().unwrap_or_default(),
-            )
+            .replace("{{ VIRTUAL_PROMPT }}", &virtual_prompt)
             .replace("{{ PATH_SEP }}", path_sep)
             .replace("{{ RELATIVE_SITE_PACKAGES }}", &relative_site_packages);
-        fs_err::write(scripts.join(name), activator)?;
+        fs_err::write(scripts.join(name), contents)?;
     }
 
     let mut pyvenv_cfg_data: Vec<(String, String)> = vec![

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -35,7 +35,7 @@ const ACTIVATE_TEMPLATES: &[(&str, &str, Option<PromptQuoting>)] = &[
     (
         "activate.fish",
         include_str!("activator/activate.fish"),
-        None,
+        Some(PromptQuoting::Fish),
     ),
     ("activate.nu", include_str!("activator/activate.nu"), None),
     ("activate.ps1", include_str!("activator/activate.ps1"), None),
@@ -57,12 +57,18 @@ const VIRTUALENV_PATCH: &str = include_str!("_virtualenv.py");
 #[derive(Clone, Copy)]
 enum PromptQuoting {
     Posix,
+    Fish,
 }
 
 impl PromptQuoting {
     fn quote(self, value: &str) -> String {
         match self {
             Self::Posix => format!("'{}'", escape_posix_for_single_quotes(value)),
+            Self::Fish => {
+                // Fish interprets backslashes inside single quotes, unlike POSIX shells.
+                let value = value.replace('\\', r"\\").replace('\'', r"\'");
+                format!("'{value}'")
+            }
         }
     }
 }

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -131,6 +131,36 @@ fn custom_prompt_is_escaped() {
     marker.assert(predicates::path::missing());
 }
 
+/// Bash must not evaluate custom prompts when rendering `PS1`.
+#[test]
+#[cfg(unix)]
+fn custom_prompt_is_not_evaluated_by_bash() {
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+    let marker = context.temp_dir.child("injected");
+    let prompt = r#"$(touch "$INJECTION_MARKER")"#;
+
+    create_venv_with_prompt(&context, prompt);
+
+    let activation = context.venv.child("bin").child("activate");
+    Command::new("bash")
+        .arg("--noprofile")
+        .arg("--norc")
+        .arg("-i")
+        .env("ACTIVATION", activation.path())
+        .env("EXPECTED_PROMPT", prompt)
+        .env("INJECTION_MARKER", marker.path())
+        .write_stdin(indoc! {r#"
+            . "$ACTIVATION"
+            test "$VIRTUAL_ENV_PROMPT" = "$EXPECTED_PROMPT" || exit 2
+            true
+            exit
+        "#})
+        .assert()
+        .success();
+
+    marker.assert(predicates::path::missing());
+}
+
 #[test]
 fn create_venv_project_environment() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.12"]);

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -161,6 +161,42 @@ fn custom_prompt_is_not_evaluated_by_bash() {
     marker.assert(predicates::path::missing());
 }
 
+/// Custom prompts are treated as data when the PowerShell activation script is executed.
+#[test]
+fn custom_prompt_is_escaped_in_powershell() {
+    #[cfg(windows)]
+    let powershell = "powershell";
+    #[cfg(unix)]
+    let Ok(powershell) = which::which("pwsh") else {
+        return;
+    };
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+    let marker = context.temp_dir.child("injected");
+    let prompt = "safe’ + $(New-Item -ItemType File -Force -Path $env:INJECTION_MARKER) + ‘‚ + $(New-Item -ItemType File -Force -Path $env:INJECTION_MARKER) + ‛";
+
+    create_venv_with_prompt(&context, prompt);
+
+    let scripts = context
+        .venv
+        .child(if cfg!(windows) { "Scripts" } else { "bin" });
+    let activation = scripts.child("activate.ps1");
+    Command::new(powershell)
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .args(["-ExecutionPolicy", "Bypass"])
+        .arg("-Command")
+        .arg(
+            "& $env:ACTIVATE_PS1; if ($env:VIRTUAL_ENV_PROMPT -ne $env:EXPECTED_PROMPT) { exit 1 }",
+        )
+        .env("ACTIVATE_PS1", activation.path())
+        .env("EXPECTED_PROMPT", prompt)
+        .env("INJECTION_MARKER", marker.path())
+        .assert()
+        .success();
+
+    marker.assert(predicates::path::missing());
+}
+
 #[test]
 fn create_venv_project_environment() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.12"]);

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -4,6 +4,7 @@ use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use indoc::indoc;
 use predicates::prelude::*;
+use std::env::consts::EXE_SUFFIX;
 use uv_python::{PYTHON_VERSION_FILENAME, PYTHON_VERSIONS_FILENAME};
 use uv_static::EnvVars;
 
@@ -189,6 +190,39 @@ fn custom_prompt_is_escaped_in_powershell() {
             "& $env:ACTIVATE_PS1; if ($env:VIRTUAL_ENV_PROMPT -ne $env:EXPECTED_PROMPT) { exit 1 }",
         )
         .env("ACTIVATE_PS1", activation.path())
+        .env("EXPECTED_PROMPT", prompt)
+        .env("INJECTION_MARKER", marker.path())
+        .assert()
+        .success();
+
+    marker.assert(predicates::path::missing());
+}
+
+/// Custom prompts are treated as data when the Python activation script is executed.
+#[test]
+fn custom_prompt_is_escaped_in_activate_this() {
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+    let marker = context.temp_dir.child("injected");
+    let prompt = r#"safe"; __import__("pathlib").Path(__import__("os").environ["INJECTION_MARKER"]).touch(); #"#;
+
+    create_venv_with_prompt(&context, prompt);
+
+    let scripts = context
+        .venv
+        .child(if cfg!(windows) { "Scripts" } else { "bin" });
+    let activation = scripts.child("activate_this.py");
+    let python = scripts.child(format!("python{EXE_SUFFIX}"));
+    Command::new(python.path())
+        .arg("-c")
+        .arg(indoc! {r#"
+            import os
+            import runpy
+            import sys
+
+            runpy.run_path(sys.argv[1])
+            assert os.environ["VIRTUAL_ENV_PROMPT"] == os.environ["EXPECTED_PROMPT"]
+        "#})
+        .arg(activation.path())
         .env("EXPECTED_PROMPT", prompt)
         .env("INJECTION_MARKER", marker.path())
         .assert()

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use assert_cmd::Command;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use indoc::indoc;
@@ -10,6 +11,18 @@ use uv_static::EnvVars;
 use fs_err::os::unix::fs::symlink;
 
 use uv_test::uv_snapshot;
+
+fn create_venv_with_prompt(context: &uv_test::TestContext, prompt: &str) {
+    context
+        .venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.12")
+        .arg("--prompt")
+        .arg(prompt)
+        .assert()
+        .success();
+}
 
 #[test]
 fn create_venv() {
@@ -92,6 +105,30 @@ fn create_venv_313() {
     );
 
     context.venv.assert(predicates::path::is_dir());
+}
+
+/// Custom prompts are treated as data when the activation script is sourced.
+#[test]
+#[cfg(unix)]
+fn custom_prompt_is_escaped() {
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+    let marker = context.temp_dir.child("injected");
+    let prompt = r#"safe'"; touch "$INJECTION_MARKER"; echo "'"#;
+
+    create_venv_with_prompt(&context, prompt);
+
+    let activation = context.venv.child("bin").child("activate");
+    Command::new("sh")
+        .arg("-c")
+        .arg(r#". "$1" && test "$VIRTUAL_ENV_PROMPT" = "$EXPECTED_PROMPT""#)
+        .arg("sh")
+        .arg(activation.path())
+        .env("EXPECTED_PROMPT", prompt)
+        .env("INJECTION_MARKER", marker.path())
+        .assert()
+        .success();
+
+    marker.assert(predicates::path::missing());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Prior to this change, `uv venv --prompt` interpolated the prompt directly into activation scripts. A prompt containing syntax for the target language could therefore be evaluated when the script was sourced; Bash and zsh could also evaluate prompt contents later while rendering `PS1`.

This serializes prompts as literals for the POSIX, Fish, PowerShell, and Python activation scripts. Bash keeps the prompt value indirect in `PS1`, while zsh renders it through a temporary `psvar` entry that is removed during deactivation without disturbing existing entries.

The change adds focused regression coverage for POSIX sourcing, Bash prompt rendering, PowerShell execution, and `activate_this.py`. Csh/Tcsh, Nushell, and cmd.exe activators remain unchanged, and no dedicated ksh prompt-rendering implementation is added.

## Test plan

- `cargo test --package uv --test python -- 'venv::custom_prompt_is_'`
- `cargo clippy --package uv --test python --locked -- -D warnings`
- `cargo xwin clippy --package uv --test python --target x86_64-pc-windows-msvc --locked -- -D warnings`
- Source generated activators in Dash, Fish, and zsh and confirm the prompt round-trips without creating the injection marker; for zsh, also confirm `PROMPT_SUBST` rendering and `psvar` restoration.
