### PR TITLE
Add `TY` and `RUFF` env vars for providing paths of binaries used by `format` and `check`

### DIFF
--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -714,6 +714,8 @@ impl EnvFlag {
 /// the CLI level, however there are limited semantics in that context.
 #[derive(Debug, Clone)]
 pub struct EnvironmentOptions {
+    pub ruff_path: Option<PathBuf>,
+    pub ty_path: Option<PathBuf>,
     pub skip_wheel_filename_check: Option<bool>,
     pub hide_build_output: Option<bool>,
     pub python_install_bin: Option<bool>,
@@ -788,6 +790,8 @@ impl EnvironmentOptions {
         .map(Duration::from_secs);
 
         Ok(Self {
+            ruff_path: parse_path_environment_variable(EnvVars::RUFF),
+            ty_path: parse_path_environment_variable(EnvVars::TY),
             skip_wheel_filename_check: parse_boolish_environment_variable(
                 EnvVars::UV_SKIP_WHEEL_FILENAME_CHECK,
             )?,
@@ -1037,7 +1041,6 @@ where
     }
 }
 
-#[cfg(feature = "tracing-durations-export")]
 /// Parse a path environment variable.
 fn parse_path_environment_variable(name: &'static str) -> Option<PathBuf> {
     let value = std::env::var_os(name)?;

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -19,6 +19,14 @@ impl EnvVars {
     #[attr_added_in("0.6.0")]
     pub const UV: &'static str = "UV";
 
+    /// The path to the Ruff binary used by `uv format`.
+    #[attr_added_in("next release")]
+    pub const RUFF: &'static str = "RUFF";
+
+    /// The path to the ty binary used by `uv check`.
+    #[attr_added_in("next release")]
+    pub const TY: &'static str = "TY";
+
     /// Equivalent to the `--offline` command-line argument. If set, uv will disable network access.
     #[attr_added_in("0.5.9")]
     pub const UV_OFFLINE: &'static str = "UV_OFFLINE";

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use tracing::debug;
@@ -38,6 +38,7 @@ mod ty;
 #[expect(clippy::fn_params_excessive_bools)]
 pub(crate) async fn check(
     project_dir: &Path,
+    ty_path: Option<PathBuf>,
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
     no_sync: bool,
@@ -381,6 +382,7 @@ pub(crate) async fn check(
 
     ty::run(
         ty_version,
+        ty_path,
         &target_dir,
         venv_path.as_deref(),
         workspace_metadata,

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -11,7 +11,6 @@ use tracing::debug;
 use uv_bin_install::{BinVersion, Binary, ResolvedVersion, bin_install, find_matching_version};
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
-use uv_static::EnvVars;
 
 use crate::child::run_to_completion;
 use crate::commands::ExitStatus;
@@ -38,6 +37,7 @@ async fn write_workspace_metadata(mut stdin: ChildStdin, workspace_metadata: Str
 /// Run a type check powered by ty.
 pub(super) async fn run(
     version: Option<String>,
+    ty_path: Option<PathBuf>,
     target_dir: &Path,
     venv_path: Option<&Path>,
     workspace_metadata: Option<String>,
@@ -46,10 +46,19 @@ pub(super) async fn run(
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    let ty_path = if let Some(ty_path) =
-        std::env::var_os(EnvVars::TY).filter(|path| !path.is_empty())
-    {
-        PathBuf::from(ty_path)
+    let ty_path = if let Some(ty_path) = ty_path {
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let output = Command::new(&ty_path)
+                .arg("--version")
+                .output()
+                .await
+                .context("Failed to query ty version")?;
+            if !output.status.success() {
+                anyhow::bail!("Failed to query ty version");
+            }
+            debug!("Using `{}`", String::from_utf8_lossy(&output.stdout).trim());
+        }
+        ty_path
     } else {
         let retry_policy = client_builder.retry_policy();
         let ty_client = client_builder.clone().retries(0).build()?;

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str::FromStr;
 use std::time::Duration;
@@ -11,6 +11,7 @@ use tracing::debug;
 use uv_bin_install::{BinVersion, Binary, ResolvedVersion, bin_install, find_matching_version};
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
+use uv_static::EnvVars;
 
 use crate::child::run_to_completion;
 use crate::commands::ExitStatus;
@@ -45,74 +46,85 @@ pub(super) async fn run(
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    let retry_policy = client_builder.retry_policy();
-    let ty_client = client_builder.clone().retries(0).build()?;
+    let ty_path = if let Some(ty_path) =
+        std::env::var_os(EnvVars::TY).filter(|path| !path.is_empty())
+    {
+        PathBuf::from(ty_path)
+    } else {
+        let retry_policy = client_builder.retry_policy();
+        let ty_client = client_builder.clone().retries(0).build()?;
 
-    let reporter = BinaryDownloadReporter::single(printer);
-    let bin_version = version
-        .as_deref()
-        .map(BinVersion::from_str)
-        .transpose()?
-        .unwrap_or(BinVersion::Default);
+        let reporter = BinaryDownloadReporter::single(printer);
+        let bin_version = version
+            .as_deref()
+            .map(BinVersion::from_str)
+            .transpose()?
+            .unwrap_or(BinVersion::Default);
 
-    let resolved = match bin_version {
-        BinVersion::Default => {
-            let constraints = Binary::Ty.default_constraints();
-            let resolved = find_matching_version(
-                Binary::Ty,
-                Some(&constraints),
-                exclude_newer,
-                &ty_client,
-                &retry_policy,
-            )
-            .await
-            .with_context(|| {
-                format!("Failed to find ty version matching default constraints: {constraints}")
-            })?;
-            debug!("Resolved `ty@{constraints}` to `ty=={}`", resolved.version);
-            resolved
-        }
-        BinVersion::Pinned(version) => {
-            if exclude_newer.is_some() {
-                debug!("`--exclude-newer` is ignored for pinned version `{version}`");
+        let resolved = match bin_version {
+            BinVersion::Default => {
+                let constraints = Binary::Ty.default_constraints();
+                let resolved = find_matching_version(
+                    Binary::Ty,
+                    Some(&constraints),
+                    exclude_newer,
+                    &ty_client,
+                    &retry_policy,
+                )
+                .await
+                .with_context(|| {
+                    format!("Failed to find ty version matching default constraints: {constraints}")
+                })?;
+                debug!("Resolved `ty@{constraints}` to `ty=={}`", resolved.version);
+                resolved
             }
-            let resolved = ResolvedVersion::from_version(Binary::Ty, version)?;
-            debug!("Using `ty=={}`", resolved.version);
-            resolved
-        }
-        BinVersion::Latest => {
-            let resolved =
-                find_matching_version(Binary::Ty, None, exclude_newer, &ty_client, &retry_policy)
-                    .await
-                    .with_context(|| "Failed to find latest ty version")?;
-            debug!("Resolved `ty@latest` to `ty=={}`", resolved.version);
-            resolved
-        }
-        BinVersion::Constraint(constraints) => {
-            let resolved = find_matching_version(
-                Binary::Ty,
-                Some(&constraints),
-                exclude_newer,
-                &ty_client,
-                &retry_policy,
-            )
-            .await
-            .with_context(|| format!("Failed to find ty version matching: {constraints}"))?;
-            debug!("Resolved `ty@{constraints}` to `ty=={}`", resolved.version);
-            resolved
-        }
-    };
+            BinVersion::Pinned(version) => {
+                if exclude_newer.is_some() {
+                    debug!("`--exclude-newer` is ignored for pinned version `{version}`");
+                }
+                let resolved = ResolvedVersion::from_version(Binary::Ty, version)?;
+                debug!("Using `ty=={}`", resolved.version);
+                resolved
+            }
+            BinVersion::Latest => {
+                let resolved = find_matching_version(
+                    Binary::Ty,
+                    None,
+                    exclude_newer,
+                    &ty_client,
+                    &retry_policy,
+                )
+                .await
+                .with_context(|| "Failed to find latest ty version")?;
+                debug!("Resolved `ty@latest` to `ty=={}`", resolved.version);
+                resolved
+            }
+            BinVersion::Constraint(constraints) => {
+                let resolved = find_matching_version(
+                    Binary::Ty,
+                    Some(&constraints),
+                    exclude_newer,
+                    &ty_client,
+                    &retry_policy,
+                )
+                .await
+                .with_context(|| format!("Failed to find ty version matching: {constraints}"))?;
+                debug!("Resolved `ty@{constraints}` to `ty=={}`", resolved.version);
+                resolved
+            }
+        };
 
-    let ty_path = bin_install(
-        Binary::Ty,
-        &resolved,
-        &ty_client,
-        &retry_policy,
-        cache,
-        &reporter,
-    )
-    .await
-    .with_context(|| format!("Failed to install ty {}", resolved.version))?;
+        bin_install(
+            Binary::Ty,
+            &resolved,
+            &ty_client,
+            &retry_policy,
+            cache,
+            &reporter,
+        )
+        .await
+        .with_context(|| format!("Failed to install ty {}", resolved.version))?
+    };
 
     let mut command = Command::new(&ty_path);
     command.current_dir(target_dir);

--- a/crates/uv/src/commands/project/format.rs
+++ b/crates/uv/src/commands/project/format.rs
@@ -1,5 +1,5 @@
 use std::fmt::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
@@ -10,6 +10,7 @@ use uv_bin_install::{BinVersion, Binary, ResolvedVersion, bin_install, find_matc
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_preview::{Preview, PreviewFeature};
+use uv_static::EnvVars;
 use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceErrorKind};
 
@@ -74,89 +75,102 @@ pub(crate) async fn format(
         }
     };
 
-    let retry_policy = client_builder.retry_policy();
-    // Python downloads are performing their own retries to catch stream errors, disable the
-    // default retries to avoid the middleware from performing uncontrolled retries.
-    let client = client_builder.retries(0).build()?;
-
     // Determine the version to use and get the path to Ruff.
-    let reporter = BinaryDownloadReporter::single(printer);
-    let bin_version = version
-        .as_deref()
-        .map(BinVersion::from_str)
-        .transpose()?
-        .unwrap_or(BinVersion::Default);
+    let ruff_path = if let Some(ruff_path) =
+        std::env::var_os(EnvVars::RUFF).filter(|path| !path.is_empty())
+    {
+        PathBuf::from(ruff_path)
+    } else {
+        let retry_policy = client_builder.retry_policy();
+        // Python downloads are performing their own retries to catch stream errors, disable the
+        // default retries to avoid the middleware from performing uncontrolled retries.
+        let client = client_builder.retries(0).build()?;
 
-    let resolved = match bin_version {
-        BinVersion::Default => {
-            // Find the best version matching the default constraints
-            let constraints = Binary::Ruff.default_constraints();
-            let resolved = find_matching_version(
-                Binary::Ruff,
-                Some(&constraints),
-                exclude_newer,
-                &client,
-                &retry_policy,
-            )
-            .await
-            .with_context(|| {
-                format!("Failed to find ruff version matching default constraints: {constraints}")
-            })?;
-            debug!(
-                "Resolved `ruff@{constraints}` to `ruff=={}`",
-                resolved.version
-            );
-            resolved
-        }
-        BinVersion::Pinned(version) => {
-            // Use the exact version directly without manifest lookup.
-            if exclude_newer.is_some() {
-                debug!("`--exclude-newer` is ignored for pinned version `{version}`");
+        let reporter = BinaryDownloadReporter::single(printer);
+        let bin_version = version
+            .as_deref()
+            .map(BinVersion::from_str)
+            .transpose()?
+            .unwrap_or(BinVersion::Default);
+
+        let resolved = match bin_version {
+            BinVersion::Default => {
+                // Find the best version matching the default constraints
+                let constraints = Binary::Ruff.default_constraints();
+                let resolved = find_matching_version(
+                    Binary::Ruff,
+                    Some(&constraints),
+                    exclude_newer,
+                    &client,
+                    &retry_policy,
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to find ruff version matching default constraints: {constraints}"
+                    )
+                })?;
+                debug!(
+                    "Resolved `ruff@{constraints}` to `ruff=={}`",
+                    resolved.version
+                );
+                resolved
             }
-            ResolvedVersion::from_version(Binary::Ruff, version)?
+            BinVersion::Pinned(version) => {
+                // Use the exact version directly without manifest lookup.
+                if exclude_newer.is_some() {
+                    debug!("`--exclude-newer` is ignored for pinned version `{version}`");
+                }
+                ResolvedVersion::from_version(Binary::Ruff, version)?
+            }
+            BinVersion::Latest => {
+                // Fetch the latest version from the manifest
+                let resolved = find_matching_version(
+                    Binary::Ruff,
+                    None,
+                    exclude_newer,
+                    &client,
+                    &retry_policy,
+                )
+                .await
+                .with_context(|| "Failed to find latest ruff version")?;
+                debug!("Resolved `ruff@latest` to `ruff=={}`", resolved.version);
+                resolved
+            }
+            BinVersion::Constraint(constraints) => {
+                // Find the best version matching the constraints
+                let resolved = find_matching_version(
+                    Binary::Ruff,
+                    Some(&constraints),
+                    exclude_newer,
+                    &client,
+                    &retry_policy,
+                )
+                .await
+                .with_context(|| format!("Failed to find ruff version matching: {constraints}"))?;
+                debug!(
+                    "Resolved `ruff@{constraints}` to `ruff=={}`",
+                    resolved.version
+                );
+                resolved
+            }
+        };
+
+        if show_version {
+            writeln!(printer.stderr(), "ruff {}", resolved.version)?;
         }
-        BinVersion::Latest => {
-            // Fetch the latest version from the manifest
-            let resolved =
-                find_matching_version(Binary::Ruff, None, exclude_newer, &client, &retry_policy)
-                    .await
-                    .with_context(|| "Failed to find latest ruff version")?;
-            debug!("Resolved `ruff@latest` to `ruff=={}`", resolved.version);
-            resolved
-        }
-        BinVersion::Constraint(constraints) => {
-            // Find the best version matching the constraints
-            let resolved = find_matching_version(
-                Binary::Ruff,
-                Some(&constraints),
-                exclude_newer,
-                &client,
-                &retry_policy,
-            )
-            .await
-            .with_context(|| format!("Failed to find ruff version matching: {constraints}"))?;
-            debug!(
-                "Resolved `ruff@{constraints}` to `ruff=={}`",
-                resolved.version
-            );
-            resolved
-        }
+
+        bin_install(
+            Binary::Ruff,
+            &resolved,
+            &client,
+            &retry_policy,
+            &cache,
+            &reporter,
+        )
+        .await
+        .with_context(|| format!("Failed to install ruff {}", resolved.version))?
     };
-
-    if show_version {
-        writeln!(printer.stderr(), "ruff {}", resolved.version)?;
-    }
-
-    let ruff_path = bin_install(
-        Binary::Ruff,
-        &resolved,
-        &client,
-        &retry_policy,
-        &cache,
-        &reporter,
-    )
-    .await
-    .with_context(|| format!("Failed to install ruff {}", resolved.version))?;
 
     let mut command = Command::new(&ruff_path);
     command.current_dir(target_dir);

--- a/crates/uv/src/commands/project/format.rs
+++ b/crates/uv/src/commands/project/format.rs
@@ -10,7 +10,6 @@ use uv_bin_install::{BinVersion, Binary, ResolvedVersion, bin_install, find_matc
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_preview::{Preview, PreviewFeature};
-use uv_static::EnvVars;
 use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceErrorKind};
 
@@ -23,6 +22,7 @@ use crate::printer::Printer;
 #[expect(clippy::fn_params_excessive_bools)]
 pub(crate) async fn format(
     project_dir: &Path,
+    ruff_path: Option<PathBuf>,
     check: bool,
     diff: bool,
     extra_args: Vec<String>,
@@ -76,10 +76,23 @@ pub(crate) async fn format(
     };
 
     // Determine the version to use and get the path to Ruff.
-    let ruff_path = if let Some(ruff_path) =
-        std::env::var_os(EnvVars::RUFF).filter(|path| !path.is_empty())
-    {
-        PathBuf::from(ruff_path)
+    let ruff_path = if let Some(ruff_path) = ruff_path {
+        if show_version {
+            let output = Command::new(&ruff_path)
+                .arg("--version")
+                .output()
+                .await
+                .context("Failed to query Ruff version")?;
+            if !output.status.success() {
+                anyhow::bail!("Failed to query Ruff version");
+            }
+            write!(
+                printer.stderr(),
+                "{}",
+                String::from_utf8_lossy(&output.stdout)
+            )?;
+        }
+        ruff_path
     } else {
         let retry_policy = client_builder.retry_policy();
         // Python downloads are performing their own retries to catch stream errors, disable the

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2736,7 +2736,7 @@ async fn run_project(
         }
         ProjectCommand::Format(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let args = settings::FormatSettings::resolve(args, filesystem);
+            let args = settings::FormatSettings::resolve(args, filesystem, environment);
             show_settings!(args);
 
             // Initialize the cache.
@@ -2744,6 +2744,7 @@ async fn run_project(
 
             Box::pin(commands::format(
                 project_dir,
+                args.ruff_path,
                 args.check,
                 args.diff,
                 args.extra_args,
@@ -2777,6 +2778,7 @@ async fn run_project(
 
             Box::pin(commands::check(
                 project_dir,
+                args.ty_path,
                 args.lock_check,
                 args.frozen,
                 args.no_sync,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2916,6 +2916,7 @@ impl ExportSettings {
 /// The resolved settings to use for a `format` invocation.
 #[derive(Debug, Clone)]
 pub(crate) struct FormatSettings {
+    pub(crate) ruff_path: Option<PathBuf>,
     pub(crate) check: bool,
     pub(crate) diff: bool,
     pub(crate) extra_args: Vec<String>,
@@ -2927,7 +2928,11 @@ pub(crate) struct FormatSettings {
 
 impl FormatSettings {
     /// Resolve the [`FormatSettings`] from the CLI and filesystem configuration.
-    pub(crate) fn resolve(args: FormatArgs, _filesystem: Option<FilesystemOptions>) -> Self {
+    pub(crate) fn resolve(
+        args: FormatArgs,
+        _filesystem: Option<FilesystemOptions>,
+        environment: EnvironmentOptions,
+    ) -> Self {
         let FormatArgs {
             check,
             diff,
@@ -2939,6 +2944,7 @@ impl FormatSettings {
         } = args;
 
         Self {
+            ruff_path: environment.ruff_path,
             check,
             diff,
             extra_args,
@@ -2953,6 +2959,7 @@ impl FormatSettings {
 /// The resolved settings to use for a `check` invocation.
 #[derive(Debug, Clone)]
 pub(crate) struct CheckSettings {
+    pub(crate) ty_path: Option<PathBuf>,
     pub(crate) extras: ExtrasSpecification,
     pub(crate) groups: DependencyGroups,
     pub(crate) lock_check: LockCheck,
@@ -3027,6 +3034,7 @@ impl CheckSettings {
         let malware_settings = MalwareCheckSettings::from(&environment);
 
         Self {
+            ty_path: environment.ty_path,
             extras: ExtrasSpecification::from_args(
                 extra.unwrap_or_default(),
                 no_extra,

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
+#[cfg(feature = "test-pypi")]
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::indoc;
@@ -38,46 +39,43 @@ fn check_project() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "test-pypi")]
 fn check_uses_ty_from_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
+    let tool_dir = context.root.child("tools");
+    let bin_dir = context.root.child("tool-bin");
 
     context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(indoc! {r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = []
-    "#})?;
-    context.temp_dir.child("main.py").write_str("x: int = 1")?;
-    context
-        .temp_dir
-        .child("check")
-        .write_str("print('custom ty')")?;
+        .tool_install()
+        .arg("ty==0.0.17")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::UV_EXCLUDE_NEWER, "2026-02-15T00:00:00Z")
+        .assert()
+        .success();
 
-    let python = context
-        .python_versions
-        .first()
-        .map(|(_, path)| path)
-        .context("Expected a Python interpreter")?;
+    let ty = bin_dir.child(format!("ty{}", std::env::consts::EXE_SUFFIX));
+    context.temp_dir.child("main.py").write_str("x = 1")?;
 
     uv_snapshot!(
         context.filters(),
         context
             .check()
+            .arg("--no-project")
             .arg("--ty-version")
             .arg(">=999.0.0")
-            .env(EnvVars::TY, python),
+            .arg("--verbose")
+            .env(EnvVars::RUST_LOG, "uv::commands::project::check::ty=debug")
+            .env(EnvVars::TY, ty.as_os_str()),
         @"
     success: true
     exit_code: 0
     ----- stdout -----
-    custom ty
+    All checks passed!
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    DEBUG Using `ty 0.0.17 (8cec85718 2026-02-13)`
     "
     );
 

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -41,7 +41,8 @@ fn check_project() -> Result<()> {
 #[test]
 #[cfg(feature = "test-pypi")]
 fn check_uses_ty_from_environment() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"ty 0\.0\.17(?: \([^)]*\))?", "ty 0.0.17"));
     let tool_dir = context.root.child("tools");
     let bin_dir = context.root.child("tool-bin");
 
@@ -75,7 +76,7 @@ fn check_uses_ty_from_environment() -> Result<()> {
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    DEBUG Using `ty 0.0.17 (8cec85718 2026-02-13)`
+    DEBUG Using `ty 0.0.17`
     "
     );
 

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::indoc;
@@ -33,6 +33,53 @@ fn check_project() -> Result<()> {
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     ");
+
+    Ok(())
+}
+
+#[test]
+fn check_uses_ty_from_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+    context.temp_dir.child("main.py").write_str("x: int = 1")?;
+    context
+        .temp_dir
+        .child("check")
+        .write_str("print('custom ty')")?;
+
+    let python = context
+        .python_versions
+        .first()
+        .map(|(_, path)| path)
+        .context("Expected a Python interpreter")?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--ty-version")
+            .arg(">=999.0.0")
+            .env(EnvVars::TY, python),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    custom ty
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/project/format.rs
+++ b/crates/uv/tests/project/format.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use assert_fs::prelude::*;
 use indoc::indoc;
 use insta::assert_snapshot;
 
+use uv_static::EnvVars;
 use uv_test::uv_snapshot;
 
 #[test]
@@ -37,6 +38,52 @@ fn format_project() -> Result<()> {
     // Check that the file was formatted
     let formatted_content = fs_err::read_to_string(&main_py)?;
     assert_snapshot!(formatted_content, @"x = 1");
+
+    Ok(())
+}
+
+#[test]
+fn format_uses_ruff_from_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+    context
+        .temp_dir
+        .child("format")
+        .write_str("print('custom ruff')")?;
+
+    let python = context
+        .python_versions
+        .first()
+        .map(|(_, path)| path)
+        .context("Expected a Python interpreter")?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .format()
+            .arg("--version")
+            .arg(">=999.0.0")
+            .env(EnvVars::RUFF, python),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    custom ruff
+
+    ----- stderr -----
+    warning: `uv format` is experimental and may change without warning. Pass `--preview-features format-command` to disable this warning.
+    "
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/project/format.rs
+++ b/crates/uv/tests/project/format.rs
@@ -1,8 +1,11 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
+#[cfg(feature = "test-pypi")]
+use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::indoc;
 use insta::assert_snapshot;
 
+#[cfg(feature = "test-pypi")]
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
 
@@ -43,29 +46,23 @@ fn format_project() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "test-pypi")]
 fn format_uses_ruff_from_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
+    let tool_dir = context.root.child("tools");
+    let bin_dir = context.root.child("tool-bin");
 
     context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(indoc! {r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = []
-    "#})?;
-    context
-        .temp_dir
-        .child("format")
-        .write_str("print('custom ruff')")?;
+        .tool_install()
+        .arg("ruff==0.3.4")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
 
-    let python = context
-        .python_versions
-        .first()
-        .map(|(_, path)| path)
-        .context("Expected a Python interpreter")?;
+    let main_py = context.temp_dir.child("main.py");
+    main_py.write_str("x    = 1")?;
+    let ruff = bin_dir.child(format!("ruff{}", std::env::consts::EXE_SUFFIX));
 
     uv_snapshot!(
         context.filters(),
@@ -73,17 +70,21 @@ fn format_uses_ruff_from_environment() -> Result<()> {
             .format()
             .arg("--version")
             .arg(">=999.0.0")
-            .env(EnvVars::RUFF, python),
+            .arg("--show-version")
+            .env(EnvVars::RUFF, ruff.as_os_str()),
         @"
     success: true
     exit_code: 0
     ----- stdout -----
-    custom ruff
+    1 file reformatted
 
     ----- stderr -----
     warning: `uv format` is experimental and may change without warning. Pass `--preview-features format-command` to disable this warning.
+    ruff 0.3.4
     "
     );
+
+    assert_snapshot!(fs_err::read_to_string(&main_py)?, @"x = 1");
 
     Ok(())
 }


### PR DESCRIPTION
This should be useful for local integration testing while developing cross-tool functionality.