### PR TITLE
Don't capture secrets in tracing

### DIFF
--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -122,7 +122,7 @@ impl KeyringProvider {
     }
 
     /// Store credentials to the system keyring.
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(service = ?service, username = ?username))]
     async fn store_native(
         &self,
         service: &str,

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1131,7 +1131,7 @@ impl ManagedPythonDownload {
     /// For CPython without a user-configured mirror, the default Astral mirror is tried first.
     /// Each attempt tries all URLs in sequence without backoff between them; backoff is only
     /// applied after all URLs have been exhausted.
-    #[instrument(skip(client, installation_dir, scratch_dir, reporter), fields(download = % self.key()))]
+    #[instrument(skip_all, fields(download = % self.key()))]
     pub async fn fetch_with_retry(
         &self,
         client: &BaseClient,


### PR DESCRIPTION
These fields aren't logged in uv release builds, but we shouldn't capture them in the first place.