### PR TITLE
Allow uv upgrade to target dependency patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5679,6 +5679,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "futures",
+ "glob",
  "http",
  "http-body-util",
  "hyper",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4278,9 +4278,12 @@ pub struct LockArgs {
 
 #[derive(Args)]
 pub struct UpgradeArgs {
-    /// The package to upgrade.
+    /// The dependency patterns to upgrade.
+    ///
+    /// Supports package names and glob patterns. If omitted, upgrades every eligible direct
+    /// dependency in the selected package.
     #[arg(value_hint = ValueHint::Other)]
-    pub package: PackageName,
+    pub patterns: Vec<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -77,6 +77,7 @@ axoupdater = { workspace = true, features = [
 ], optional = true }
 clap = { workspace = true, features = ["derive", "string", "wrap_help"] }
 console = { workspace = true }
+glob = { workspace = true }
 ctrlc = { workspace = true }
 diskus = { workspace = true }
 dotenvy = { workspace = true }

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result, anyhow, bail};
 use uv_cache::{Cache, Refresh};
 use uv_client::BaseClientBuilder;
-use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun};
+use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun, Upgrade};
 use uv_distribution::{ArchiveMetadata, Metadata};
 use uv_distribution_types::Identifier;
 use uv_normalize::PackageName;
@@ -34,6 +34,179 @@ use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 
 pub(crate) async fn upgrade(
+    project_dir: &Path,
+    patterns: Vec<String>,
+    install_mirrors: PythonInstallMirrors,
+    settings: ResolverSettings,
+    client_builder: BaseClientBuilder<'_>,
+    python_preference: PythonPreference,
+    python_downloads: PythonDownloads,
+    concurrency: Concurrency,
+    no_config: bool,
+    cache: &Cache,
+    workspace_cache: &WorkspaceCache,
+    printer: Printer,
+    preview: Preview,
+) -> Result<ExitStatus> {
+    if let [pattern] = patterns.as_slice()
+        && !contains_glob_meta(pattern)
+        && let Ok(package) = PackageName::from_str(pattern)
+    {
+        let mut settings = settings;
+        settings.upgrade = Upgrade::package(package.clone());
+        return Box::pin(upgrade_one(
+            project_dir,
+            package,
+            install_mirrors,
+            settings,
+            client_builder,
+            python_preference,
+            python_downloads,
+            concurrency,
+            no_config,
+            cache,
+            workspace_cache,
+            printer,
+            preview,
+        ))
+        .await;
+    }
+
+    let packages = selected_packages(project_dir, &patterns, cache, workspace_cache).await?;
+    if packages.is_empty() {
+        bail!("No dependencies matched the requested upgrade patterns");
+    }
+
+    let mut blocked = false;
+    for package in packages {
+        let package_workspace_cache = WorkspaceCache::default();
+        let project = discover_project(project_dir, cache, &package_workspace_cache).await?;
+        if let Err(err) = select_requirement(&project, &package) {
+            writeln!(printer.stderr(), "Skipped {package}: {err}")?;
+            continue;
+        }
+        let pyproject_path = project.project_root().join("pyproject.toml");
+        let before = fs_err::read_to_string(&pyproject_path)?;
+        let mut package_settings = settings.clone();
+        package_settings.upgrade = Upgrade::package(package.clone());
+        match Box::pin(upgrade_one(
+            project_dir,
+            package.clone(),
+            install_mirrors.clone(),
+            package_settings,
+            client_builder.clone(),
+            python_preference,
+            python_downloads,
+            concurrency.clone(),
+            no_config,
+            cache,
+            &package_workspace_cache,
+            printer,
+            preview,
+        ))
+        .await
+        {
+            Ok(ExitStatus::Success) => {
+                let after = fs_err::read_to_string(&pyproject_path)?;
+                let outcome = if before == after {
+                    "Unchanged"
+                } else {
+                    "Changed"
+                };
+                writeln!(printer.stderr(), "{outcome} {package}")?;
+            }
+            Ok(ExitStatus::Failure | ExitStatus::Error | ExitStatus::External(_)) => {
+                blocked = true;
+                writeln!(printer.stderr(), "Blocked {package}")?;
+            }
+            Err(err) => {
+                blocked = true;
+                writeln!(printer.stderr(), "Blocked {package}: {err}")?;
+            }
+        }
+    }
+
+    Ok(if blocked {
+        ExitStatus::Failure
+    } else {
+        ExitStatus::Success
+    })
+}
+
+async fn discover_project(
+    project_dir: &Path,
+    cache: &Cache,
+    workspace_cache: &WorkspaceCache,
+) -> Result<ProjectWorkspace> {
+    match VirtualProject::discover(
+        project_dir,
+        &DiscoveryOptions::default(),
+        cache,
+        workspace_cache,
+    )
+    .await
+    {
+        Ok(VirtualProject::Project(project)) => Ok(project),
+        Ok(VirtualProject::NonProject(_)) => {
+            bail!("`uv upgrade` requires a project with a `[project]` table")
+        }
+        Err(err)
+            if matches!(
+                err.as_ref(),
+                WorkspaceErrorKind::MissingPyprojectToml | WorkspaceErrorKind::MissingProject(_)
+            ) =>
+        {
+            bail!("`uv upgrade` requires a project with a `[project]` table");
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+async fn selected_packages(
+    project_dir: &Path,
+    patterns: &[String],
+    cache: &Cache,
+    workspace_cache: &WorkspaceCache,
+) -> Result<Vec<PackageName>> {
+    let project = discover_project(project_dir, cache, workspace_cache).await?;
+    if project.workspace().packages().len() != 1 {
+        bail!("`uv upgrade` does not support workspaces with multiple members yet");
+    }
+    let patterns = patterns
+        .iter()
+        .map(|pattern| {
+            glob::Pattern::new(pattern)
+                .with_context(|| format!("Invalid dependency pattern `{pattern}`"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut packages = BTreeSet::new();
+    for dependency in project
+        .current_project()
+        .project()
+        .dependencies
+        .as_deref()
+        .unwrap_or_default()
+    {
+        let requirement =
+            Requirement::<VerbatimParsedUrl>::from_str(dependency).with_context(|| {
+                format!("Failed to parse dependency `{dependency}` from `project.dependencies`")
+            })?;
+        if patterns.is_empty()
+            || patterns
+                .iter()
+                .any(|pattern| pattern.matches(requirement.name.as_str()))
+        {
+            packages.insert(requirement.name);
+        }
+    }
+    Ok(packages.into_iter().collect())
+}
+
+fn contains_glob_meta(pattern: &str) -> bool {
+    pattern.contains(['*', '?', '['])
+}
+
+async fn upgrade_one(
     project_dir: &Path,
     package: PackageName,
     install_mirrors: PythonInstallMirrors,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2392,7 +2392,7 @@ async fn run_project(
 
             Box::pin(commands::upgrade(
                 project_dir,
-                args.package,
+                args.patterns,
                 args.install_mirrors,
                 args.settings,
                 client_builder.subcommand(vec!["upgrade".to_owned()]),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2044,7 +2044,7 @@ impl LockSettings {
 /// The resolved settings to use for an `upgrade` invocation.
 #[derive(Debug, Clone)]
 pub(crate) struct UpgradeSettings {
-    pub(crate) package: PackageName,
+    pub(crate) patterns: Vec<String>,
     pub(crate) install_mirrors: PythonInstallMirrors,
     pub(crate) settings: ResolverSettings,
 }
@@ -2060,13 +2060,12 @@ impl UpgradeSettings {
             .clone()
             .map(|fs| fs.install_mirrors.clone())
             .unwrap_or_default();
-        let package = args.package;
-        let mut settings =
+        let patterns = args.patterns;
+        let settings =
             ResolverSettings::combine(ResolverOptions::default(), filesystem, &environment);
-        settings.upgrade = Upgrade::package(package.clone());
 
         Self {
-            package,
+            patterns,
             install_mirrors: environment
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
@@ -5115,19 +5114,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn upgrade_settings_target_only_requested_package() -> anyhow::Result<()> {
-        let package = PackageName::from_str("anyio")?;
+    fn upgrade_settings_preserve_requested_patterns() -> anyhow::Result<()> {
         let settings = UpgradeSettings::resolve(
             UpgradeArgs {
-                package: package.clone(),
+                patterns: vec!["a*".to_string(), "idna".to_string()],
             },
             None,
             EnvironmentOptions::new()?,
         );
-        let expected = FxHashSet::from_iter([package]);
 
-        assert!(!settings.settings.upgrade.is_all());
-        assert_eq!(settings.settings.upgrade.packages(), Some(&expected));
+        assert_eq!(settings.patterns, ["a*", "idna"]);
+        assert!(settings.settings.upgrade.is_none());
         Ok(())
     }
 }

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -65,10 +65,10 @@ fn upgrade_help() {
     ----- stdout -----
     Upgrade a dependency in the project
 
-    Usage: uv upgrade [OPTIONS] <PACKAGE>
+    Usage: uv upgrade [OPTIONS] [PATTERNS]...
 
     Arguments:
-      <PACKAGE>  The package to upgrade
+      [PATTERNS]...  The dependency patterns to upgrade
 
     Cache options:
       -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary
@@ -111,6 +111,98 @@ fn upgrade_help() {
     ----- stderr -----
     "#
     );
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn upgrade_reports_independent_mixed_outcomes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio<=2", "idna==9999", "project", "sniffio"]
+
+        [tool.uv]
+        exclude-newer = "2024-03-25T00:00:00Z"
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(context.filters(), context.upgrade(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because there is no version of idna==9999 and your project depends on idna==9999, we can conclude that your project's requirements are unsatisfiable.
+    Blocked anyio
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    Add idna v3.6
+    Updated requirement: `idna==9999` -> `idna==3.6`
+    Changed idna
+    Skipped project: Dependency `project` refers to the current project and cannot be upgraded
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    Add sniffio v1.3.1
+    Unchanged sniffio
+    ");
+
+    let pyproject = fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?;
+    assert!(pyproject.contains("idna==3.6"), "{pyproject}");
+    assert!(pyproject.contains("anyio<=2"), "{pyproject}");
+    assert!(pyproject.contains("project"), "{pyproject}");
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn upgrade_accepts_multiple_dependency_patterns() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio<=2", "idna"]
+
+        [tool.uv]
+        exclude-newer = "2024-03-25T00:00:00Z"
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(context.filters(), context.upgrade().arg("a*").arg("i*"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    Add anyio v4.3.0
+    Updated requirement: `anyio<=2` -> `anyio<=4.3.0`
+    Changed anyio
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    Add idna v3.6
+    Unchanged idna
+    ");
+
+    let pyproject = fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?;
+    assert!(pyproject.contains("anyio<=4.3.0"), "{pyproject}");
+    assert!(pyproject.contains("idna"), "{pyproject}");
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`uv upgrade` currently accepts exactly one package, which makes coordinated dependency upgrades repetitive and prevents users from expressing an "upgrade everything eligible" operation.

This change:

- accepts zero or more package-name or glob patterns;
- treats no patterns as selecting every eligible direct dependency in the current project;
- preserves the existing single-package path for an exact package name; and
- processes selected dependencies independently, reporting changed, unchanged, blocked, and skipped outcomes.

The command continues after one selected dependency is blocked, allowing other eligible dependencies to upgrade successfully.

## Test Plan

- `cargo fmt --check`
- `cargo check -p uv`
- `cargo clippy -p uv`
- `cargo test -p uv --test it upgrade_ --features test-pypi`
- `git diff --check`
