### PR TITLE
Clean up some junction related code

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -125,11 +125,8 @@ fn create_junction(target: &Path, path: &Path) -> std::io::Result<()> {
                 )
             ) =>
         {
-            // Broken reparse point. Once junction::delete strips the reparse data, only an empty
-            // directory shell remains.
-            if junction::delete(path).is_ok() {
-                let _ = fs_err::remove_dir(path);
-            }
+            // Broken reparse point.
+            let _ = fs_err::remove_dir(path);
             Err(create_result.err().unwrap_or(err))
         }
         Err(err) => Err(create_result.err().unwrap_or(err)),
@@ -175,12 +172,8 @@ pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io:
 #[cfg(windows)]
 fn replace_with_junction(src: &Path, dst: &Path) -> std::io::Result<()> {
     // Remove the existing junction, if any.
-    match junction::delete(dunce::simplified(dst)) {
-        Ok(()) => match fs_err::remove_dir_all(dst) {
-            Ok(()) => {}
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => return Err(err),
-        },
+    match fs_err::remove_dir(dst) {
+        Ok(()) => {}
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
         Err(err) => return Err(err),
     }
@@ -319,7 +312,10 @@ mod tests {
 
         let err = create_junction(&target, &link).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidFilename);
-        assert!(!link.exists());
+        assert!(matches!(
+            fs_err::symlink_metadata(&link),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound
+        ));
         Ok(())
     }
 }

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -200,25 +200,6 @@ fn replace_with_symlink_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
     fs_err::os::windows::fs::symlink_dir(dunce::simplified(src), dunce::simplified(dst))
 }
 
-/// Read the target of a directory link created by [`create_symlink`] or
-/// [`replace_symlink`].
-///
-/// On Windows, uv normally creates junctions for directory links, but creates
-/// directory symbolic links under Wine. This function reads the appropriate link
-/// type for the current environment. For junctions, this uses the `junction`
-/// crate, which handles the `\??\` prefix that Windows uses internally for
-/// junction targets.
-#[cfg(windows)]
-pub fn read_link(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
-    let path = path.as_ref();
-
-    if uv_windows::is_wine() {
-        fs_err::read_link(path)
-    } else {
-        junction::get_target(dunce::simplified(path))
-    }
-}
-
 /// Create a symlink at `dst` pointing to `src`, replacing any existing symlink if necessary.
 ///
 /// On Unix, this method creates a temporary file, then moves it into place.
@@ -281,10 +262,12 @@ pub fn create_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::
 
 #[cfg(all(test, windows))]
 mod tests {
+    use std::os::windows::ffi::OsStrExt;
+
     use super::*;
 
     #[test]
-    fn read_link_reads_created_directory_link() -> std::io::Result<()> {
+    fn fs_err_read_link_reads_created_directory_link() -> std::io::Result<()> {
         let tempdir = tempfile::tempdir()?;
         let target = tempdir.path().join("target");
         fs_err::create_dir(&target)?;
@@ -292,7 +275,27 @@ mod tests {
 
         create_symlink(&target, &link)?;
 
-        assert_eq!(read_link(&link)?, dunce::simplified(&target));
+        assert_eq!(
+            verbatim_path(&fs_err::read_link(&link)?),
+            verbatim_path(&target)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn fs_err_read_link_reads_long_junction_target() -> std::io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let mut target = tempdir.path().join("target");
+        while target.as_os_str().encode_wide().count() < 257 {
+            target.push("long-path-component");
+        }
+        fs_err::create_dir_all(&target)?;
+        let link = tempdir.path().join("link");
+
+        create_symlink(&target, &link)?;
+
+        let link_target = fs_err::read_link(&link)?;
+        assert_eq!(verbatim_path(&link_target), verbatim_path(&target));
         Ok(())
     }
 

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -15,6 +15,8 @@ use tracing::{debug, warn};
 #[cfg(windows)]
 use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
 
+#[cfg(windows)]
+use uv_fs::verbatim_path;
 use uv_fs::{
     LockedFile, LockedFileError, LockedFileMode, Simplified, normalize_absolute_path,
     replace_symlink, symlink_or_copy_file,
@@ -843,9 +845,9 @@ impl PythonMinorVersionLink {
                     // is a symlink or junction.
                     (metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0) != 0
                 })
-                && self
-                    .read_target()
-                    .is_some_and(|target| target == self.target_directory)
+                && self.read_target().is_some_and(|target| {
+                    verbatim_path(&target) == verbatim_path(&self.target_directory)
+                })
         }
     }
 
@@ -860,7 +862,7 @@ impl PythonMinorVersionLink {
         }
         #[cfg(windows)]
         {
-            uv_fs::read_link(&self.symlink_directory).ok()
+            fs_err::read_link(&self.symlink_directory).ok()
         }
     }
 }

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -15,11 +15,9 @@ use tracing::{debug, warn};
 #[cfg(windows)]
 use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
 
-#[cfg(windows)]
-use uv_fs::verbatim_path;
 use uv_fs::{
     LockedFile, LockedFileError, LockedFileMode, Simplified, normalize_absolute_path,
-    replace_symlink, symlink_or_copy_file,
+    replace_symlink, symlink_or_copy_file, verbatim_path,
 };
 use uv_platform::{Error as PlatformError, Os};
 use uv_platform::{LibcDetectionError, Platform};
@@ -827,14 +825,17 @@ impl PythonMinorVersionLink {
     /// may exist but point to a different installation (e.g., after an upgrade), in which
     /// case we should not use the link for the current installation.
     pub fn exists(&self) -> bool {
+        let points_to_target = || {
+            fs_err::read_link(&self.symlink_directory)
+                .is_ok_and(|target| verbatim_path(&target) == verbatim_path(&self.target_directory))
+        };
+
         #[cfg(unix)]
         {
             self.symlink_directory
                 .symlink_metadata()
                 .is_ok_and(|metadata| metadata.file_type().is_symlink())
-                && self
-                    .read_target()
-                    .is_some_and(|target| target == self.target_directory)
+                && points_to_target()
         }
         #[cfg(windows)]
         {
@@ -845,24 +846,7 @@ impl PythonMinorVersionLink {
                     // is a symlink or junction.
                     (metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0) != 0
                 })
-                && self.read_target().is_some_and(|target| {
-                    verbatim_path(&target) == verbatim_path(&self.target_directory)
-                })
-        }
-    }
-
-    /// Read the target of the minor version link.
-    ///
-    /// On Unix, this reads the symlink target. On Windows, this reads the directory link
-    /// target, whether uv created it as a junction or as a directory symlink under Wine.
-    fn read_target(&self) -> Option<PathBuf> {
-        #[cfg(unix)]
-        {
-            self.symlink_directory.read_link().ok()
-        }
-        #[cfg(windows)]
-        {
-            fs_err::read_link(&self.symlink_directory).ok()
+                && points_to_target()
         }
     }
 }


### PR DESCRIPTION
## Summary

While centralising the whole environment, I noticed that this code was unnecessarily complicated so I deleted it.

Using `remove_dir` instead of `junction::delete` also fixes a bug of sorts if we were to actually encounter a regular directory symlink on windows.

`junction::get_target` has this weird quirk where it will produce non-verbatim long paths. This means that prefix comparisons will work assuming the prefix isn't a verbatim path (so actually this is a bug disguised as a feature).

To avoid the opposite issue in this case, it's necessary to verbatim both paths.

## Test Plan

Existing coverage, some augmentations, and a targeted test for a verbatim_path idiom.