### PR TITLE
Enforce wheels-before-sdists when publishing

### DIFF
--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -104,6 +104,8 @@ pub(crate) async fn publish(
     };
 
     let mut groups = group_files_for_publishing(paths, no_attestations)?;
+    // Sort by filename first so the stable type sort preserves filename order within each type.
+    groups.sort_by(|left, right| left.raw_filename.cmp(&right.raw_filename));
     // Sort by distribution type, with wheels before source distributions.
     groups.sort_by_key(|group| matches!(&group.filename, DistFilename::SourceDistFilename(_)));
     match groups.len() {

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -12,6 +12,7 @@ use uv_client::{
     AuthIntegration, BaseClient, BaseClientBuilder, RedirectPolicy, RegistryClientBuilder,
 };
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
+use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{IndexCapabilities, IndexLocations, IndexUrl};
 use uv_errors::{ErrorOptions, write_error_chain_with_options};
 use uv_preview::{Preview, PreviewFeature};
@@ -102,7 +103,9 @@ pub(crate) async fn publish(
         (publish_url, check_url)
     };
 
-    let groups = group_files_for_publishing(paths, no_attestations)?;
+    let mut groups = group_files_for_publishing(paths, no_attestations)?;
+    // Sort by distribution type, with source distributions before wheels.
+    groups.sort_by_key(|group| matches!(&group.filename, DistFilename::WheelFilename(_)));
     match groups.len() {
         0 => bail!("No files found to publish"),
         1 => {

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -104,8 +104,8 @@ pub(crate) async fn publish(
     };
 
     let mut groups = group_files_for_publishing(paths, no_attestations)?;
-    // Sort by distribution type, with source distributions before wheels.
-    groups.sort_by_key(|group| matches!(&group.filename, DistFilename::WheelFilename(_)));
+    // Sort by distribution type, with wheels before source distributions.
+    groups.sort_by_key(|group| matches!(&group.filename, DistFilename::SourceDistFilename(_)));
     match groups.len() {
         0 => bail!("No files found to publish"),
         1 => {

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -227,7 +227,7 @@ fn dubious_filenames() {
 }
 
 #[tokio::test]
-async fn publish_sdist_before_wheel() {
+async fn publish_wheel_before_sdist() {
     let context = uv_test::test_context!("3.12");
     let server = MockServer::start().await;
     let sdist = basic_package_sdist();
@@ -241,9 +241,9 @@ async fn publish_sdist_before_wheel() {
         .await;
 
     uv_snapshot!(context.filters(), context.publish()
-        // Pass the wheel first to ensure distribution type determines the upload order.
-        .arg(wheel)
+        // Pass the source distribution first to ensure type determines the upload order.
         .arg(sdist)
+        .arg(wheel)
         .arg("--username")
         .arg("dummy")
         .arg("--password")
@@ -256,10 +256,10 @@ async fn publish_sdist_before_wheel() {
 
     ----- stderr -----
     Publishing 2 files to http://[LOCALHOST]/upload
-    Hashing basic_package-0.1.0.tar.gz ([SIZE])
-    Uploading basic_package-0.1.0.tar.gz ([SIZE])
     Hashing basic_package-0.1.0-py3-none-any.whl ([SIZE])
     Uploading basic_package-0.1.0-py3-none-any.whl ([SIZE])
+    Hashing basic_package-0.1.0.tar.gz ([SIZE])
+    Uploading basic_package-0.1.0.tar.gz ([SIZE])
     "
     );
 }

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -12,13 +12,26 @@ use uv_test::{uv_snapshot, venv_bin_path};
 use wiremock::matchers::{basic_auth, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn dummy_wheel() -> PathBuf {
+fn test_link(filename: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
         .parent()
         .unwrap()
-        .join("test/links/ok-1.0.0-py3-none-any.whl")
+        .join("test/links")
+        .join(filename)
+}
+
+fn dummy_wheel() -> PathBuf {
+    test_link("ok-1.0.0-py3-none-any.whl")
+}
+
+fn basic_package_sdist() -> PathBuf {
+    test_link("basic_package-0.1.0.tar.gz")
+}
+
+fn basic_package_wheel() -> PathBuf {
+    test_link("basic_package-0.1.0-py3-none-any.whl")
 }
 
 #[test]
@@ -209,6 +222,44 @@ fn dubious_filenames() {
     warning: Skipping file that looks like a distribution, but is not a valid distribution filename: `[TEMP_DIR]/not-a-wheel.whl`
     warning: Skipping file that looks like a distribution, but is not a valid distribution filename: `[TEMP_DIR]/not-sdist-1-2-3-asdf.zip`
     error: No files found to publish
+    "
+    );
+}
+
+#[tokio::test]
+async fn publish_sdist_before_wheel() {
+    let context = uv_test::test_context!("3.12");
+    let server = MockServer::start().await;
+    let sdist = basic_package_sdist();
+    let wheel = basic_package_wheel();
+
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        // Pass the wheel first to ensure distribution type determines the upload order.
+        .arg(wheel)
+        .arg(sdist)
+        .arg("--username")
+        .arg("dummy")
+        .arg("--password")
+        .arg("dummy")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri())), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 2 files to http://[LOCALHOST]/upload
+    Hashing basic_package-0.1.0.tar.gz ([SIZE])
+    Uploading basic_package-0.1.0.tar.gz ([SIZE])
+    Hashing basic_package-0.1.0-py3-none-any.whl ([SIZE])
+    Uploading basic_package-0.1.0-py3-none-any.whl ([SIZE])
     "
     );
 }

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -26,6 +26,10 @@ fn dummy_wheel() -> PathBuf {
     test_link("ok-1.0.0-py3-none-any.whl")
 }
 
+fn basic_app_wheel() -> PathBuf {
+    test_link("basic_app-0.1.0-py3-none-any.whl")
+}
+
 fn basic_package_sdist() -> PathBuf {
     test_link("basic_package-0.1.0.tar.gz")
 }
@@ -227,23 +231,25 @@ fn dubious_filenames() {
 }
 
 #[tokio::test]
-async fn publish_wheel_before_sdist() {
+async fn publish_wheels_before_sdist_in_filename_order() {
     let context = uv_test::test_context!("3.12");
     let server = MockServer::start().await;
+    let app_wheel = basic_app_wheel();
     let sdist = basic_package_sdist();
-    let wheel = basic_package_wheel();
+    let package_wheel = basic_package_wheel();
 
     Mock::given(method("POST"))
         .and(path("/upload"))
         .respond_with(ResponseTemplate::new(200))
-        .expect(2)
+        .expect(3)
         .mount(&server)
         .await;
 
     uv_snapshot!(context.filters(), context.publish()
-        // Pass the source distribution first to ensure type determines the upload order.
+        // Pass the source distribution first and the wheels in reverse filename order.
         .arg(sdist)
-        .arg(wheel)
+        .arg(package_wheel)
+        .arg(app_wheel)
         .arg("--username")
         .arg("dummy")
         .arg("--password")
@@ -255,7 +261,9 @@ async fn publish_wheel_before_sdist() {
     ----- stdout -----
 
     ----- stderr -----
-    Publishing 2 files to http://[LOCALHOST]/upload
+    Publishing 3 files to http://[LOCALHOST]/upload
+    Hashing basic_app-0.1.0-py3-none-any.whl ([SIZE])
+    Uploading basic_app-0.1.0-py3-none-any.whl ([SIZE])
     Hashing basic_package-0.1.0-py3-none-any.whl ([SIZE])
     Uploading basic_package-0.1.0-py3-none-any.whl ([SIZE])
     Hashing basic_package-0.1.0.tar.gz ([SIZE])


### PR DESCRIPTION
## Summary

This addresses a small papercut: high-activity projects that publish to PyPI generally prefer to have their wheels published first, so that installations degrade gracefully (falling back to an older release) rather than failing because the sdist fails to build.

This matches twine's behavior.

## Test Plan

One line change, added a test demonstrating upload order.