### PR TITLE
Added flag for whether to fail on invalid environments during project interpreter discovery

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -298,6 +298,7 @@ pub(crate) async fn add(
                 active,
                 cache,
                 printer,
+                true,
             )
             .await?
             .into_interpreter();

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -152,6 +152,7 @@ pub(crate) async fn audit(
                     Some(false),
                     &cache,
                     printer,
+                    true,
                 )
                 .await?
                 .into_interpreter()

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -191,6 +191,7 @@ pub(crate) async fn export(
                     Some(false),
                     cache,
                     printer,
+                    true,
                 )
                 .await?
                 .into_interpreter()

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -168,6 +168,7 @@ pub(crate) async fn lock(
                     Some(false),
                     cache,
                     printer,
+                    false,
                 )
                 .await?
                 .into_interpreter()

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1022,6 +1022,7 @@ impl ProjectInterpreter {
         active: Option<bool>,
         cache: &Cache,
         printer: Printer,
+        fail_on_invalid_environment: bool,
     ) -> Result<Self, ProjectError> {
         let WorkspacePython {
             source,
@@ -1055,7 +1056,10 @@ impl ProjectInterpreter {
                 }
             }
             Err(uv_python::Error::MissingEnvironment(_)) => {}
-            Err(uv_python::Error::InvalidEnvironment(inner)) => {
+            Err(uv_python::Error::InvalidEnvironment(inner)) => 'invalid_environment: {
+                if !fail_on_invalid_environment {
+                    break 'invalid_environment;
+                }
                 // If there's an invalid environment with existing content, we error instead of
                 // deleting it later on
                 match inner.kind {
@@ -1482,6 +1486,7 @@ impl ProjectEnvironment {
             active,
             cache,
             printer,
+            true,
         )
         .await?
         {

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -245,6 +245,7 @@ pub(crate) async fn remove(
                     active,
                     cache,
                     printer,
+                    true,
                 )
                 .await?
                 .into_interpreter();

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -127,6 +127,7 @@ pub(crate) async fn tree(
                     Some(false),
                     cache,
                     printer,
+                    true,
                 )
                 .await?
                 .into_interpreter()

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -132,6 +132,7 @@ pub(crate) async fn upgrade(
         Some(false),
         cache,
         printer,
+        true,
     )
     .await?
     .into_interpreter();

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -514,6 +514,7 @@ async fn print_frozen_version(
         active,
         cache,
         printer,
+        true,
     )
     .await?
     .into_interpreter();
@@ -632,6 +633,7 @@ async fn lock_and_sync(
             active,
             cache,
             printer,
+            true,
         )
         .await?
         .into_interpreter();

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -95,6 +95,7 @@ pub(crate) async fn metadata(
             Some(false),
             cache,
             printer,
+            true,
         )
         .await?
         .into_interpreter();


### PR DESCRIPTION
Closes #19832.

## Summary

An environment (active or existing) is not required for `uv lock`. The discovery of the environment should fall back to the global or managed python installation should the environment be invalid instead of returning an error. To avoid the error, the `InvalidEnvironment` handler in `ProjectInterpreter::discover` is now conditioned with a `fail_on_invalid_environment` flag. Only `uv lock` sets this flag to `false`. The behavior of all other commands remains unchanged.

## Test Plan

There are two kinds of `InvalidEnvironment` errors that may return from `ProjectInterpreter::discover`: `NotDirectory` and `MissingExecutable` (`Empty` is already ignored). These errors should no longer return when executing `uv lock`.

First, create the following example project. The project should only have the `pyproject.toml` file with the following contents.

```toml
# pyproject.toml
[project]
name = "example"
version = "0"
requires-python = ">=3"
```

Now, run the following two tests.

1. Create the file `.venv` and run `uv lock` (without a virtual environment active). This should no longer fail, so the `uv.lock` should be generated.
2. Create the non-empty folder `.venv/` and run `uv lock` (without a virtual environment active). This should no longer fail, so the `uv.lock` should be generated.

## Related Issues

Relates to #13235. However, `uv lock` does not have a `--no-sync` flag, and by definition, it does not modify the active environment.