### PR TITLE
docs: add minimal Flask app to running commands example

### DIFF
--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -214,6 +214,23 @@ For example, to use `flask`:
 
 ```console
 $ uv add flask
+```
+
+Then, create a minimal Flask application:
+
+```python title="app.py"
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route("/")
+def home():
+    return "Hello, Flask!"
+```
+
+And run it:
+
+```console
 $ uv run -- flask run -p 3000
 ```
 


### PR DESCRIPTION
## Problem

The Flask example in the [Running commands](https://docs.astral.sh/uv/guides/projects/#running-commands) section assumes a Flask application already exists. Following the guide literally on a fresh `uv init` project produces:

```
Error: Could not locate a Flask application. Use the 'flask --app' option,
'FLASK_APP' environment variable, or a 'wsgi.py' or 'app.py' file in the
current directory.
```

This is confusing because uv itself works correctly -- the error comes from Flask, not uv. But a newcomer following the guide to learn uv hits a Flask error that looks like uv did something wrong.

## Solution

Add a minimal `app.py` between `uv add flask` and `uv run -- flask run` so the example is self-contained and works out of the box.

## Verification

```console
$ uv init test-flask && cd test-flask
$ uv add flask
$ # create app.py as shown in the updated docs
$ uv run -- flask run -p 3000
# opens http://127.0.0.1:3000 successfully
```

Fixes #19835