### PR TITLE
docs: note that the Running commands Flask example requires an app

### DIFF
--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -217,6 +217,12 @@ $ uv add flask
 $ uv run -- flask run -p 3000
 ```
 
+!!! note
+
+    This example assumes a Flask application is defined in the project (for example, an `app.py`).
+    See the [`uv-flask-example`](https://github.com/astral-sh/uv-flask-example) repository for a
+    complete example.
+
 Or, to run a script:
 
 ```python title="example.py"


### PR DESCRIPTION
## Summary

The "Running commands" guide shows `uv add flask` followed by
`uv run -- flask run -p 3000`, but on a fresh project this fails with
"Could not locate a Flask application", since no app has been created
yet. This adds a short note clarifying that the example assumes a Flask
application is already defined in the project, and points readers to the
uv-flask-example repository for a complete, working setup.

Closes #19835
