### PR TITLE
Reject unsupported macOS protected keychain target

### DIFF
--- a/crates/uv-keyring/src/macos.rs
+++ b/crates/uv-keyring/src/macos.rs
@@ -238,7 +238,11 @@ impl CredentialBuilderApi for MacCredentialBuilder {
     /// the User keychain is selected.
     fn build(&self, target: Option<&str>, service: &str, user: &str) -> Result<Box<Credential>> {
         let domain: MacKeychainDomain = if let Some(target) = target {
-            target.parse().unwrap_or(MacKeychainDomain::User)
+            match target.parse() {
+                Ok(domain) => domain,
+                Err(err) if MacKeychainDomain::is_protected_target(target) => return Err(err),
+                Err(_) => MacKeychainDomain::User,
+            }
         } else {
             MacKeychainDomain::User
         };
@@ -292,13 +296,24 @@ impl std::str::FromStr for MacKeychainDomain {
             "system" => Ok(Self::System),
             "common" => Ok(Self::Common),
             "dynamic" => Ok(Self::Dynamic),
-            "protected" => Ok(Self::Protected),
-            "data protection" => Ok(Self::Protected),
+            "protected" | "data protection" => Err(ErrorCode::Invalid(
+                "target".to_string(),
+                format!("'{s}' is not a keychain domain on macOS"),
+            )),
             _ => Err(ErrorCode::Invalid(
                 "target".to_string(),
-                format!("'{s}' is not User, System, Common, Dynamic, or Protected"),
+                format!("'{s}' is not User, System, Common, or Dynamic"),
             )),
         }
+    }
+}
+
+impl MacKeychainDomain {
+    fn is_protected_target(target: &str) -> bool {
+        matches!(
+            target.to_ascii_lowercase().as_str(),
+            "protected" | "data protection"
+        )
     }
 }
 
@@ -308,7 +323,12 @@ fn get_keychain(domain: MacKeychainDomain) -> Result<SecKeychain> {
         MacKeychainDomain::System => SecPreferencesDomain::System,
         MacKeychainDomain::Common => SecPreferencesDomain::Common,
         MacKeychainDomain::Dynamic => SecPreferencesDomain::Dynamic,
-        MacKeychainDomain::Protected => panic!("Protected is not a keychain domain on macOS"),
+        MacKeychainDomain::Protected => {
+            return Err(ErrorCode::Invalid(
+                "target".to_string(),
+                "Protected is not a keychain domain on macOS".to_string(),
+            ));
+        }
     };
     match SecKeychain::default_for_domain(domain) {
         Ok(keychain) => Ok(keychain),
@@ -446,5 +466,24 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_protected_keychain_rejected() {
+        for target in ["protected", "data protection", "Protected"] {
+            let credential = Entry::new_with_target(target, "service", "user");
+            assert!(
+                matches!(credential, Err(Error::Invalid(_, _))),
+                "Created credential with unsupported target {target:?}"
+            );
+        }
+
+        assert!(
+            matches!(
+                super::get_keychain(super::MacKeychainDomain::Protected),
+                Err(Error::Invalid(_, _))
+            ),
+            "Protected target should return an error"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Reject `protected` and `data protection` as unsupported macOS keychain targets during entry creation.
- Return `Error::Invalid` if `MacKeychainDomain::Protected` reaches keychain lookup directly, instead of panicking.
- Add regression coverage for the protected target path.

## Test plan

- `cargo fmt --check --package uv-keyring`
- `cargo test -p uv-keyring --features native-auth test_protected_keychain_rejected`
- `cargo test -p uv-keyring --features native-auth test_select_keychain`
- `cargo check -p uv-keyring --features native-auth --all-targets`
- `cargo clippy -p uv-keyring --features native-auth --all-targets -- -D warnings`