### PR TITLE
Error on a registry uv.lock package without a version instead of panicking

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3804,6 +3804,15 @@ impl PackageWire {
             }
         }
 
+        // A registry-source package must carry a version; downstream conversions
+        // (e.g. `to_source_dist`, `satisfies`) rely on it.
+        if matches!(self.id.source, Source::Registry(_)) && self.id.version.is_none() {
+            return Err(LockErrorKind::MissingPackageVersion {
+                name: self.id.name.clone(),
+            }
+            .into());
+        }
+
         let unwire_deps = |deps: Vec<DependencyWire>| -> Result<Vec<Dependency>, LockError> {
             deps.into_iter()
                 .map(|dep| dep.unwire(requires_python, unambiguous_package_ids))
@@ -6543,6 +6552,13 @@ enum LockErrorKind {
         /// The name of the dependency that is missing a `version` field.
         name: PackageName,
     },
+    /// An error that occurs when a registry-source package is missing a
+    /// `version` field.
+    #[error("Package `{name}` from a registry source has a missing `version` field", name = name.cyan())]
+    MissingPackageVersion {
+        /// The name of the package that is missing a `version` field.
+        name: PackageName,
+    },
     /// An error that occurs when an ambiguous `package.dependency` is
     /// missing a `source` field.
     #[error("Dependency `{name}` has missing `source` field but has more than one matching package", name = name.cyan())]
@@ -7144,6 +7160,21 @@ source = { registry = "https://pypi.org/simple" }
 "#;
         let result = toml::from_str::<Lock>(data).unwrap_err();
         assert_stripped_snapshot!(result, @"Dependency `a` has missing `version` field but has more than one matching package");
+    }
+
+    #[test]
+    fn missing_package_version_registry() {
+        let data = r#"
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "a"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://example.com", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 0 }
+"#;
+        let result = toml::from_str::<Lock>(data).unwrap_err();
+        assert_stripped_snapshot!(result, @"Package `a` from a registry source has a missing `version` field");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #19854.

A registry-source `[[package]]` in `uv.lock` may omit the `version` field. `PackageId.version` is `Option<Version>` and nothing validated it for registry sources during deserialization, so the value is later `.expect()`-ed and `uv sync --frozen` panics:

    thread 'main2' panicked at crates/uv-resolver/src/lock/mod.rs:3304:
    version for registry source

(Reached via `Package::to_source_dist`; the same `.expect("version for registry source")` is also in `Lock::satisfies`.)

This rejects such a package in `PackageWire::unwire` with a `LockError` (`MissingPackageVersion`), mirroring the existing dependency-level `MissingDependencyVersion`, so a malformed lockfile is a graceful parse error instead of a panic:

    error: Failed to parse `uv.lock`
      Caused by: Package `anyio` from a registry source has a missing `version` field

## Test Plan

Added a unit regression test `missing_package_version_registry` in `crates/uv-resolver/src/lock/mod.rs`: `toml::from_str::<Lock>` of a registry package without a `version` now returns the new error (inline insta snapshot).

Manual check: a project whose `uv.lock` has a registry package with an `sdist` but no `version` previously panicked on `uv sync --frozen` (exit 101); it now reports `error: Failed to parse uv.lock: Package ... has a missing version field` and exits 2.
