### PR TITLE
Fix relocatable `activate.fish` and broaden Fish version support

### DIFF
--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -488,7 +488,7 @@ pub(crate) fn create(
             }
             (true, "activate.bat") => r"%~dp0..".to_string(),
             (true, "activate.fish") => {
-                r#"'"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"'"#.to_string()
+                r"'(dirname -- (dirname -- (realpath -- (status -f))))'".to_string()
             }
             (true, "activate.nu") => r"(path self | path dirname | path dirname)".to_string(),
             (false, "activate.nu") => {

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1391,7 +1391,9 @@ fn verify_pyvenv_cfg_relocatable() {
 
     let activate_fish = scripts.child("activate.fish");
     activate_fish.assert(predicates::path::is_file());
-    activate_fish.assert(predicates::str::contains(r#"set -gx VIRTUAL_ENV ''"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"''"#));
+    activate_fish.assert(predicates::str::contains(
+        r"set -gx VIRTUAL_ENV ''(dirname -- (dirname -- (realpath -- (status -f))))''",
+    ));
     activate_fish.assert(predicates::str::contains(
         "if string match -qr 'CYGWIN|MSYS|MINGW' (uname); and command -s cygpath >/dev/null",
     ));


### PR DESCRIPTION
## Summary

For relocatable virtual environments, the generated `activate.fish` derived
`VIRTUAL_ENV` using Bash-style `$(...)` command substitution:

    set -gx VIRTUAL_ENV ''"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"''

This had two problems on Fish:

1. **Syntax error on Fish before 3.4.** Fish only added `$(...)` command substitution in 3.4. On older releases — which the rest of the activation script still supports via its `FISH_VERSION < 3` guards. This makes `uv venv --relocatable` unusable under Fish < 3.4: the script can't even be parsed.

2. **Sourcing changed the caller's working directory.** Unlike Bash, Fish's `(...)` / `$(...)` substitution does not run in a subshell, so the `cd` in the expression changed the directory of the shell that sourced the script.

Both are fixed by switching to Fish-native `(...)` substitution and using `realpath` instead of the `cd` trick, which works across all supported Fish versions and leaves the caller's directory untouched:

## Test plan

Updated `verify_pyvenv_cfg_relocatable` to assert the new Fish-native form is generated. Verified end-to-end on Fish 3.3.1 that, with the fix, `uv venv
--relocatable` produces an `activate.fish` that:
- sources cleanly (previously a hard syntax error),
- resolves `VIRTUAL_ENV` to the venv root, including after relocating the venv directory, and
- no longer changes the sourcing shell's working directory.