### PR TITLE
Reject registry lock packages without versions

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3785,6 +3785,10 @@ impl PackageWire {
         requires_python: &RequiresPython,
         unambiguous_package_ids: &FxHashMap<PackageName, PackageId>,
     ) -> Result<Package, LockError> {
+        if matches!(&self.id.source, Source::Registry(_)) && self.id.version.is_none() {
+            return Err(LockErrorKind::MissingPackageVersion { name: self.id.name }.into());
+        }
+
         // Consistency check
         if !uv_flags::contains(uv_flags::EnvironmentFlags::SKIP_WHEEL_FILENAME_CHECK) {
             if let Some(version) = &self.id.version {
@@ -6541,6 +6545,12 @@ enum LockErrorKind {
     #[error("Dependency `{name}` has missing `version` field but has more than one matching package", name = name.cyan())]
     MissingDependencyVersion {
         /// The name of the dependency that is missing a `version` field.
+        name: PackageName,
+    },
+    /// An error that occurs when a package sourced from a registry is missing a `version` field.
+    #[error("Package `{name}` has missing `version` field but is sourced from a registry", name = name.cyan())]
+    MissingPackageVersion {
+        /// The name of the package that is missing a `version` field.
         name: PackageName,
     },
     /// An error that occurs when an ambiguous `package.dependency` is

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -5437,6 +5437,51 @@ fn sync_ignore_extras_check_when_no_provides_extras() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for: <https://github.com/astral-sh/uv/issues/19854>
+#[test]
+fn sync_frozen_rejects_registry_package_missing_version() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio"]
+        "#,
+    )?;
+
+    context.temp_dir.child("uv.lock").write_str(indoc! {r#"
+        version = 1
+        revision = 1
+        requires-python = ">=3.12"
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { editable = "." }
+        dependencies = [{ name = "anyio" }]
+
+        [[package]]
+        name = "anyio"
+        source = { registry = "https://example.invalid/simple" }
+        sdist = { url = "https://example.invalid/anyio-4.0.0.tar.gz", hash = "sha256:0000000000000000000000000000000000000000000000000000000000000000", size = 1 }
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--offline"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to parse `uv.lock`
+      Caused by: Package `anyio` has missing `version` field but is sourced from a registry
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn sync_workspace_members_with_transitive_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
﻿## Summary

Fixes #19854.

This rejects lockfile registry packages that are missing a `version` field during lockfile parsing, instead of allowing them to reach later code paths that expect registry sources to always have a version.

## Details

- Adds a `MissingPackageVersion` lockfile error for registry-sourced package entries without versions.
- Keeps source-tree packages unchanged, since dynamic source trees can intentionally omit versions.
- Adds a regression test for `uv sync --frozen --offline` with a malformed registry package in `uv.lock`.

## Validation

- `cargo +stable fmt --check`
- `git diff --check`
- `cargo +stable test -p uv --test sync sync_frozen_rejects_registry_package_missing_version -- --nocapture`
- `cargo +stable check -p uv-resolver`
