### PR TITLE
Handle non-file editable URLs in pip list

### DIFF
--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -17,8 +17,7 @@ use uv_client::{BaseClientBuilder, RegistryClientBuilder};
 use uv_configuration::{Concurrency, IndexStrategy, KeyringProviderType};
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{
-    DependencyMetadata, Diagnostic, IndexCapabilities, IndexLocations, InstalledDist, Name,
-    RequiresPython,
+    DependencyMetadata, Diagnostic, IndexCapabilities, IndexLocations, Name, RequiresPython,
 };
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
@@ -195,7 +194,8 @@ pub(crate) async fn pip_list(
                         .map(FileType::from),
                     editable_project_location: dist
                         .as_editable()
-                        .map(|url| url.to_file_path().unwrap().simplified_display().to_string()),
+                        .and_then(|url| url.to_file_path().ok())
+                        .map(|path| path.simplified_display().to_string()),
                 })
                 .collect_vec();
             let output = serde_json::to_string(&rows)?;
@@ -255,18 +255,20 @@ pub(crate) async fn pip_list(
                 });
             }
 
-            // Editable column is only displayed if at least one editable package is found.
-            if results.iter().copied().any(InstalledDist::is_editable) {
+            // Editable column is only displayed if at least one editable path is found.
+            if results.iter().any(|dist| {
+                dist.as_editable()
+                    .is_some_and(|url| url.to_file_path().is_ok())
+            }) {
                 columns.push(Column {
                     header: String::from("Editable project location"),
                     rows: results
                         .iter()
                         .map(|dist| dist.as_editable())
                         .map(|url| {
-                            url.map(|url| {
-                                url.to_file_path().unwrap().simplified_display().to_string()
-                            })
-                            .unwrap_or_default()
+                            url.and_then(|url| url.to_file_path().ok())
+                                .map(|path| path.simplified_display().to_string())
+                                .unwrap_or_default()
                         })
                         .collect_vec(),
                 });

--- a/crates/uv/tests/pip/pip_list.rs
+++ b/crates/uv/tests/pip/pip_list.rs
@@ -58,6 +58,42 @@ fn list_empty_json() {
 }
 
 #[test]
+fn list_editable_non_file_url() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let dist_info = ChildPath::new(context.site_packages()).child("project-1.0.0.dist-info");
+    dist_info.create_dir_all()?;
+    dist_info
+        .child("METADATA")
+        .write_str("Metadata-Version: 2.1\nName: project\nVersion: 1.0.0\n")?;
+    dist_info
+        .child("direct_url.json")
+        .write_str(r#"{"url":"https://example.com/project","dir_info":{"editable":true}}"#)?;
+
+    uv_snapshot!(context.pip_list(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Package Version
+    ------- -------
+    project 1.0.0
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.pip_list().arg("--format=json"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [{"name":"project","version":"1.0.0"}]
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "test-pypi")]
 fn list_single_no_editable() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

Prior to this change, `uv pip list` assumed that every installed editable direct URL could be converted to a local file path. An editable `direct_url.json` containing a non-file URL caused both the columns and JSON output formats to panic.

This handles the URL-to-path conversion fallibly and omits the editable project location when the URL does not identify a local path, matching `uv pip show`.

The regression test constructs the installed metadata directly and verifies both output formats.
