### PR TITLE
Validate pylock.toml package Python requirements

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -45,6 +45,8 @@ use crate::{Installable, LockError, ResolverOutput};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PylockTomlErrorKind {
+    #[error("Package `{0}` requires Python {2}, but the target Python version is {1}")]
+    IncompatibleRequiresPython(PackageName, Version, RequiresPython),
     #[error(
         "Package `{0}` includes both a registry (`packages.wheels`) and a directory source (`packages.directory`)"
     )]
@@ -1043,6 +1045,17 @@ impl<'lock> PylockToml {
             // Omit packages that aren't relevant to the current environment.
             if !package.marker.evaluate_pep751(markers, extras, groups) {
                 continue;
+            }
+
+            if let Some(requires_python) = package.requires_python.as_ref()
+                && !requires_python.contains(&markers.python_full_version().version)
+            {
+                return Err(PylockTomlErrorKind::IncompatibleRequiresPython(
+                    package.name.clone(),
+                    markers.python_full_version().version.clone(),
+                    requires_python.clone(),
+                )
+                .into());
             }
 
             match (

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13394,6 +13394,66 @@ requires_python = "==3.13.*"
 }
 
 #[test]
+fn pep_751_package_requires_python() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+    pylock_toml.write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "example"
+        marker = "python_version < '3.0'"
+        requires-python = ">=99"
+        directory = { path = "." }
+        "#,
+    )?;
+
+    // Skip the Python requirement for packages excluded by their marker.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("-r")
+        .arg("pylock.toml"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Checked in [TIME]
+    "#
+    );
+
+    pylock_toml.write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "example"
+        requires-python = ">=99"
+        directory = { path = "." }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("-r")
+        .arg("pylock.toml"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Package `example` requires Python >=99, but the target Python version is 3.12.[X]
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_requires_python() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.12", "3.13"]);
 


### PR DESCRIPTION
## Summary

Prior to this change, uv parsed `packages.requires-python` from `pylock.toml` files but did not enforce it. A package selected for installation could therefore require a different Python version than the target environment.

This checks each selected package's Python requirement immediately after evaluating its marker. Packages excluded by their marker remain skipped, while a selected package with an incompatible requirement now produces a direct error before its source is processed.

The regression coverage verifies both the skipped-marker case and the incompatible selected-package case.
