### PR TITLE
Reject colliding normalized extra names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7287,6 +7287,7 @@ dependencies = [
 name = "uv-toml"
 version = "0.0.54"
 dependencies = [
+ "serde",
  "toml_datetime",
  "toml_parser",
 ]
@@ -7475,6 +7476,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-redacted",
  "uv-static",
+ "uv-toml",
  "uv-warnings",
 ]
 

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -23,6 +23,7 @@ use uv_pep508::{
 use uv_pypi_types::{
     Identifier, IdentifierParseError, Keywords, Metadata23, ProjectUrls, VerbatimParsedUrl,
 };
+use uv_toml::deserialize_unique_map;
 
 use crate::serde_verbatim::SerdeVerbatim;
 use crate::{BuildBackendSettings, Error, error_on_venv};
@@ -41,43 +42,10 @@ where
     D: Deserializer<'de>,
     V: Deserialize<'de>,
 {
-    struct Visitor<V>(std::marker::PhantomData<V>);
-
-    impl<'de, V> serde::de::Visitor<'de> for Visitor<V>
-    where
-        V: Deserialize<'de>,
-    {
-        type Value = Option<BTreeMap<ExtraName, V>>;
-
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str("a map with unique normalized extra names")
-        }
-
-        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
-        where
-            M: serde::de::MapAccess<'de>,
-        {
-            use std::collections::btree_map::Entry;
-
-            let mut optional_dependencies = BTreeMap::new();
-            while let Some((extra, requirements)) = access.next_entry::<ExtraName, V>()? {
-                match optional_dependencies.entry(extra) {
-                    Entry::Occupied(entry) => {
-                        return Err(serde::de::Error::custom(format!(
-                            "duplicate normalized extra name `{}`",
-                            entry.key()
-                        )));
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(requirements);
-                    }
-                }
-            }
-            Ok(Some(optional_dependencies))
-        }
-    }
-
-    deserializer.deserialize_map(Visitor(std::marker::PhantomData))
+    deserialize_unique_map(deserializer, |key: &ExtraName| {
+        format!("duplicate normalized extra name `{key}`")
+    })
+    .map(Some)
 }
 
 #[derive(Debug, Error)]

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -34,6 +34,52 @@ pub(crate) const DEFAULT_EXCLUDES: &[&str] = &["__pycache__", "*.pyc", "*.pyo"];
 /// the fast path for them too.
 const COMPATIBLE_VERSIONS: &[&str] = &["0.9.30", "0.10.12"];
 
+fn deserialize_optional_dependencies<'de, D, V>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<ExtraName, V>>, D::Error>
+where
+    D: Deserializer<'de>,
+    V: Deserialize<'de>,
+{
+    struct Visitor<V>(std::marker::PhantomData<V>);
+
+    impl<'de, V> serde::de::Visitor<'de> for Visitor<V>
+    where
+        V: Deserialize<'de>,
+    {
+        type Value = Option<BTreeMap<ExtraName, V>>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map with unique normalized extra names")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: serde::de::MapAccess<'de>,
+        {
+            use std::collections::btree_map::Entry;
+
+            let mut optional_dependencies = BTreeMap::new();
+            while let Some((extra, requirements)) = access.next_entry::<ExtraName, V>()? {
+                match optional_dependencies.entry(extra) {
+                    Entry::Occupied(entry) => {
+                        return Err(serde::de::Error::custom(format!(
+                            "duplicate normalized extra name `{}`",
+                            entry.key()
+                        )));
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(requirements);
+                    }
+                }
+            }
+            Ok(Some(optional_dependencies))
+        }
+    }
+
+    deserializer.deserialize_map(Visitor(std::marker::PhantomData))
+}
+
 #[derive(Debug, Error)]
 pub enum ValidationError {
     /// The spec isn't clear about what the values in that field would be, and we only support the
@@ -984,6 +1030,7 @@ struct Project {
     /// The dependencies of the project.
     dependencies: Option<Vec<Requirement>>,
     /// The optional dependencies of the project.
+    #[serde(default, deserialize_with = "deserialize_optional_dependencies")]
     optional_dependencies: Option<BTreeMap<ExtraName, Vec<Requirement>>>,
     /// Import names exclusively provided by the project.
     ///
@@ -1806,6 +1853,24 @@ mod tests {
         Name: hello-world
         Version: 0.1.0
         ");
+    }
+
+    #[test]
+    fn reject_colliding_optional_dependency_names() {
+        let contents = extend_project(indoc! {r#"
+            [project.optional-dependencies]
+            foo-bar = ["anyio"]
+            foo_bar = ["iniconfig"]
+        "#});
+
+        let err = toml::from_str::<PyProjectToml>(&contents).unwrap_err();
+        assert_snapshot!(err.to_string(), @r#"
+        TOML parse error at line 4, column 1
+          |
+        4 | [project.optional-dependencies]
+          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        duplicate normalized extra name `foo-bar`
+        "#);
     }
 
     #[test]

--- a/crates/uv-toml/Cargo.toml
+++ b/crates/uv-toml/Cargo.toml
@@ -16,5 +16,6 @@ doctest = false
 workspace = true
 
 [dependencies]
+serde = { workspace = true }
 toml_datetime = { workspace = true }
 toml_parser = { workspace = true }

--- a/crates/uv-toml/src/lib.rs
+++ b/crates/uv-toml/src/lib.rs
@@ -1,8 +1,60 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Deserializer};
 use toml_datetime::Datetime;
 use toml_parser::decoder::Encoding;
 use toml_parser::lexer::Token;
 use toml_parser::parser::{EventReceiver, parse_document};
 use toml_parser::{ErrorSink, Source, Span};
+
+/// Deserialize a map while ensuring all keys are unique.
+pub fn deserialize_unique_map<'de, D, K, V, F>(
+    deserializer: D,
+    error_msg: F,
+) -> Result<BTreeMap<K, V>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: Deserialize<'de> + Ord,
+    V: Deserialize<'de>,
+    F: FnOnce(&K) -> String,
+{
+    struct Visitor<K, V, F>(F, std::marker::PhantomData<(K, V)>);
+
+    impl<'de, K, V, F> serde::de::Visitor<'de> for Visitor<K, V, F>
+    where
+        K: Deserialize<'de> + Ord,
+        V: Deserialize<'de>,
+        F: FnOnce(&K) -> String,
+    {
+        type Value = BTreeMap<K, V>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map with unique keys")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: serde::de::MapAccess<'de>,
+        {
+            use std::collections::btree_map::Entry;
+
+            let mut map = BTreeMap::new();
+            while let Some((key, value)) = access.next_entry::<K, V>()? {
+                match map.entry(key) {
+                    Entry::Occupied(entry) => {
+                        return Err(serde::de::Error::custom((self.0)(entry.key())));
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(value);
+                    }
+                }
+            }
+            Ok(map)
+        }
+    }
+
+    deserializer.deserialize_map(Visitor(error_msg, std::marker::PhantomData))
+}
 
 /// Detect TOML 1.1 specific features in a TOML document.
 ///

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -33,6 +33,7 @@ uv-pep508 = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-redacted = { workspace = true }
 uv-static = { workspace = true }
+uv-toml = { workspace = true }
 uv-warnings = { workspace = true }
 
 clap = { workspace = true, optional = true }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -105,6 +105,19 @@ where
     deserializer.deserialize_map(Visitor(error_msg, std::marker::PhantomData))
 }
 
+fn deserialize_optional_dependencies<'de, D, V>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<ExtraName, V>>, D::Error>
+where
+    D: Deserializer<'de>,
+    V: Deserialize<'de>,
+{
+    deserialize_unique_map(deserializer, |key: &ExtraName| {
+        format!("duplicate normalized extra name `{key}`")
+    })
+    .map(Some)
+}
+
 /// A `pyproject.toml` as specified in PEP 517.
 #[derive(Deserialize, Debug, Clone)]
 #[cfg_attr(test, derive(Serialize))]
@@ -248,6 +261,7 @@ struct ProjectWire {
     dynamic: Option<Vec<String>>,
     requires_python: Option<VersionSpecifiers>,
     dependencies: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_optional_dependencies")]
     optional_dependencies: Option<BTreeMap<ExtraName, Vec<String>>>,
     gui_scripts: Option<serde::de::IgnoredAny>,
     scripts: Option<serde::de::IgnoredAny>,

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -35,6 +35,7 @@ use uv_pypi_types::{
     VerbatimParsedUrl,
 };
 use uv_redacted::DisplaySafeUrl;
+use uv_toml::deserialize_unique_map;
 
 #[derive(Error, Debug)]
 pub enum PyprojectTomlError {
@@ -54,55 +55,6 @@ pub enum PyprojectTomlError {
         "`pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list"
     )]
     MissingVersion,
-}
-
-/// Helper function to deserialize a map while ensuring all keys are unique.
-fn deserialize_unique_map<'de, D, K, V, F>(
-    deserializer: D,
-    error_msg: F,
-) -> Result<BTreeMap<K, V>, D::Error>
-where
-    D: Deserializer<'de>,
-    K: Deserialize<'de> + Ord + std::fmt::Display,
-    V: Deserialize<'de>,
-    F: FnOnce(&K) -> String,
-{
-    struct Visitor<K, V, F>(F, std::marker::PhantomData<(K, V)>);
-
-    impl<'de, K, V, F> serde::de::Visitor<'de> for Visitor<K, V, F>
-    where
-        K: Deserialize<'de> + Ord + std::fmt::Display,
-        V: Deserialize<'de>,
-        F: FnOnce(&K) -> String,
-    {
-        type Value = BTreeMap<K, V>;
-
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str("a map with unique keys")
-        }
-
-        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
-        where
-            M: serde::de::MapAccess<'de>,
-        {
-            use std::collections::btree_map::Entry;
-
-            let mut map = BTreeMap::new();
-            while let Some((key, value)) = access.next_entry::<K, V>()? {
-                match map.entry(key) {
-                    Entry::Occupied(entry) => {
-                        return Err(serde::de::Error::custom((self.0)(entry.key())));
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(value);
-                    }
-                }
-            }
-            Ok(map)
-        }
-    }
-
-    deserializer.deserialize_map(Visitor(error_msg, std::marker::PhantomData))
 }
 
 fn deserialize_optional_dependencies<'de, D, V>(

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -3274,6 +3274,32 @@ bar = ["b"]
         );
     }
 
+    #[test]
+    fn reject_colliding_optional_dependency_names() {
+        let err = PyProjectToml::from_string(
+            r#"
+[project]
+name = "example"
+version = "1.0.0"
+
+[project.optional-dependencies]
+foo-bar = ["anyio"]
+foo_bar = ["iniconfig"]
+"#
+            .to_string(),
+            "pyproject.toml",
+        )
+        .unwrap_err();
+
+        assert_snapshot!(err.to_string(), @r#"
+        TOML parse error at line 6, column 1
+          |
+        6 | [project.optional-dependencies]
+          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        duplicate normalized extra name `foo-bar`
+        "#);
+    }
+
     #[tokio::test]
     async fn nested_workspace() -> Result<()> {
         let root = tempfile::TempDir::new()?;


### PR DESCRIPTION
## Summary

PEP 685 requires tools to reject extra names that collide after normalization. Both the workspace parser and uv-build previously parsed `project.optional-dependencies` directly into maps keyed by `ExtraName`, so entries such as `foo-bar` and `foo_bar` silently overwrote one another.

Detect duplicate normalized extra names during deserialization in both paths and report a TOML parse error instead. The regression coverage exercises both workspace and build-backend parsing.
