### PR TITLE
fix(pep440): make `Version` hash consistent with its `Eq`

### DIFF
--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -2794,18 +2794,21 @@ pub(crate) fn compare_release(this: &[u64], other: &[u64]) -> Ordering {
 /// implementation
 ///
 /// [pep440-suffix-ordering]: https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering
-fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, LocalVersionSlice<'_>) {
-    // If the version is a "max" version, use a post version larger than any possible post version.
-    let post = if version.max().is_some() {
+fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, LocalVersionSlice<'_>, bool) {
+    // A "max" version reuses the post-release bucket of its base version (`post = u64::MAX`) so it
+    // sorts above every real version in that bucket. The trailing `is_max` flag keeps it distinct
+    // from — and just above — a real `post == u64::MAX`, which would otherwise compare equal.
+    let is_max = version.max().is_some();
+    let post = if is_max {
         Some(u64::MAX)
     } else {
         version.post()
     };
     match (version.pre(), post, version.dev(), version.min()) {
         // min release
-        (_pre, post, _dev, Some(n)) => (0, 0, post, n, version.local()),
+        (_pre, post, _dev, Some(n)) => (0, 0, post, n, version.local(), is_max),
         // dev release
-        (None, None, Some(n), None) => (1, 0, None, n, version.local()),
+        (None, None, Some(n), None) => (1, 0, None, n, version.local(), is_max),
         // alpha release
         (
             Some(Prerelease {
@@ -2815,7 +2818,7 @@ fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, LocalVersio
             post,
             dev,
             None,
-        ) => (2, n, post, dev.unwrap_or(u64::MAX), version.local()),
+        ) => (2, n, post, dev.unwrap_or(u64::MAX), version.local(), is_max),
         // beta release
         (
             Some(Prerelease {
@@ -2825,8 +2828,8 @@ fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, LocalVersio
             post,
             dev,
             None,
-        ) => (3, n, post, dev.unwrap_or(u64::MAX), version.local()),
-        // alpha release
+        ) => (3, n, post, dev.unwrap_or(u64::MAX), version.local(), is_max),
+        // rc release
         (
             Some(Prerelease {
                 kind: PrereleaseKind::Rc,
@@ -2835,13 +2838,18 @@ fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, LocalVersio
             post,
             dev,
             None,
-        ) => (4, n, post, dev.unwrap_or(u64::MAX), version.local()),
+        ) => (4, n, post, dev.unwrap_or(u64::MAX), version.local(), is_max),
         // final release
-        (None, None, None, None) => (5, 0, None, 0, version.local()),
+        (None, None, None, None) => (5, 0, None, 0, version.local(), is_max),
         // post release
-        (None, Some(post), dev, None) => {
-            (6, 0, Some(post), dev.unwrap_or(u64::MAX), version.local())
-        }
+        (None, Some(post), dev, None) => (
+            6,
+            0,
+            Some(post),
+            dev.unwrap_or(u64::MAX),
+            version.local(),
+            is_max,
+        ),
     }
 }
 
@@ -2924,6 +2932,13 @@ mod tests {
         let b = Version::new([1u64, 2]).with_min(Some(0));
         assert_eq!(a, b);
         assert_eq!(hash_of(&a), hash_of(&b));
+
+        // The `max` sentinel sorts above every real version, so it must stay distinct from a
+        // real `post == u64::MAX` rather than comparing equal to it.
+        let max = Version::new([1u64]).with_max(Some(0));
+        let post_max = Version::new([1u64]).with_post(Some(u64::MAX));
+        assert_ne!(max, post_max);
+        assert!(max > post_max);
     }
 
     /// <https://github.com/pypa/packaging/blob/237ff3aa348486cf835a980592af3a59fccd6101/tests/test_version.py#L24-L81>

--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -975,10 +975,18 @@ impl Hash for Version {
         for i in self.release().iter().rev().skip_while(|x| **x == 0) {
             i.hash(state);
         }
-        self.pre().hash(state);
-        self.dev().hash(state);
-        self.post().hash(state);
-        self.local().hash(state);
+        // The `min`/`max` sentinels make `pre`/`dev`/`post` irrelevant to equality (see
+        // `sortable_tuple`), so hashing those fields directly would let two equal versions hash
+        // differently. Hash the comparison key for sentinels; regular versions keep hashing their
+        // fields directly so existing hashes are unaffected.
+        if self.min().is_some() || self.max().is_some() {
+            sortable_tuple(self).hash(state);
+        } else {
+            self.pre().hash(state);
+            self.dev().hash(state);
+            self.post().hash(state);
+            self.local().hash(state);
+        }
     }
 }
 
@@ -2890,6 +2898,33 @@ mod tests {
     use crate::VersionSpecifier;
 
     use super::*;
+
+    #[test]
+    fn hash_matches_eq() {
+        use std::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        // Normal zero-padding equality still hashes consistently.
+        let v1 = Version::new([1u64, 0, 0]);
+        let v2 = Version::new([1u64]);
+        assert_eq!(v1, v2);
+        assert_eq!(hash_of(&v1), hash_of(&v2));
+
+        // The `min` sentinel makes pre/dev irrelevant to equality, so these compare equal,
+        // and the hash must agree.
+        let a = Version::new([1u64, 2])
+            .with_min(Some(0))
+            .with_pre(Some(Prerelease {
+                kind: PrereleaseKind::Alpha,
+                number: 1,
+            }));
+        let b = Version::new([1u64, 2]).with_min(Some(0));
+        assert_eq!(a, b);
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
 
     /// <https://github.com/pypa/packaging/blob/237ff3aa348486cf835a980592af3a59fccd6101/tests/test_version.py#L24-L81>
     #[test]


### PR DESCRIPTION
`Version`'s `Hash` mixes in `pre`/`dev`/`post` directly, but `Ord`/`PartialEq` compare through `sortable_tuple`, which treats the `min`/`max` sentinels specially — when `min` is set, `pre`/`dev` are irrelevant to equality. Two equal versions can therefore hash differently, breaking the `Hash`/`Eq` contract (and any `HashMap`/`HashSet<Version>` that holds such a version).

Hash the same `sortable_tuple` key the comparison uses. Added a regression test (fails before, passes after).