### PR TITLE
Modernize predicate checks with `is_some_and` and `is_none_or`

### DIFF
--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -204,7 +204,7 @@ impl KeyringProvider {
             "Should only use keyring for URLs without a password"
         );
         debug_assert!(
-            !username.map(str::is_empty).unwrap_or(false),
+            username.is_none_or(|username| !username.is_empty()),
             "Should only use keyring with a non-empty username"
         );
 

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -905,8 +905,7 @@ impl PyProjectToml {
         if !group
             .chars()
             .next()
-            .map(|c| c.is_alphanumeric() || c == '_')
-            .unwrap_or(false)
+            .is_some_and(|c| c.is_alphanumeric() || c == '_')
             || !group
                 .chars()
                 .all(|c| c.is_alphanumeric() || c == '.' || c == '_')
@@ -1228,8 +1227,7 @@ impl BuildSystem {
                 }
                 Ranges::from(specifier.clone())
                     .bounding_range()
-                    .map(|bounding_range| bounding_range.1 != Bound::Unbounded)
-                    .unwrap_or(false)
+                    .is_some_and(|bounding_range| bounding_range.1 != Bound::Unbounded)
             }
         };
 

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -630,8 +630,7 @@ impl SourceBuild {
                 .tool
                 .as_ref()
                 .and_then(|tool| tool.uv.as_ref())
-                .map(|uv| uv.build_backend.is_some())
-                .unwrap_or(false)
+                .is_some_and(|uv| uv.build_backend.is_some())
             && build_backend != Some("uv_build")
             && let Some(package_name) =
                 package_name.or(pyproject_toml.project.as_ref().map(|project| &project.name))

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -863,8 +863,7 @@ fn path_source(
                     .ok()
                     .and_then(|contents| PyProjectToml::from_string(contents, pyproject_path).ok())
                     // We don't require a build system for path dependencies
-                    .map(|pyproject_toml| pyproject_toml.is_package(false))
-                    .unwrap_or(true)
+                    .is_none_or(|pyproject_toml| pyproject_toml.is_package(false))
             });
 
             // If the project is not a package, treat it as a virtual dependency.

--- a/crates/uv-fs/src/which.rs
+++ b/crates/uv-fs/src/which.rs
@@ -51,8 +51,7 @@ pub fn is_executable(path: &Path) -> bool {
         use std::os::unix::fs::PermissionsExt;
 
         if !fs_err::metadata(path)
-            .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
-            .unwrap_or(false)
+            .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
         {
             return false;
         }

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -425,8 +425,7 @@ impl Tags {
     pub fn is_compatible_abi(&self, python_tag: LanguageTag, abi_tag: AbiTag) -> bool {
         self.map
             .get(&python_tag)
-            .map(|abis| abis.contains_key(&abi_tag))
-            .unwrap_or(false)
+            .is_some_and(|abis| abis.contains_key(&abi_tag))
     }
 
     pub fn python_platform(&self) -> &Platform {

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -228,8 +228,7 @@ impl ManagedPythonInstallations {
             .filter(|path| {
                 path.file_name()
                     .and_then(OsStr::to_str)
-                    .map(|name| !name.starts_with('.'))
-                    .unwrap_or(true)
+                    .is_none_or(|name| !name.starts_with('.'))
             })
             .filter_map(|path| {
                 ManagedPythonInstallation::from_path(path)

--- a/crates/uv-python/src/version_files.rs
+++ b/crates/uv-python/src/version_files.rs
@@ -137,8 +137,7 @@ impl PythonVersionFile {
                 options
                     .stop_discovery_at
                     .and_then(Path::parent)
-                    .map(|stop_discovery_at| stop_discovery_at != *path)
-                    .unwrap_or(true)
+                    .is_none_or(|stop_discovery_at| stop_discovery_at != *path)
             })
             .find_map(|path| Self::find_in_directory(path, options))
     }

--- a/crates/uv-redacted/src/lib.rs
+++ b/crates/uv-redacted/src/lib.rs
@@ -123,10 +123,7 @@ impl DisplaySafeUrl {
 
         // Check for the suspicious pattern.
         if !has_credential_like_pattern(url.path())
-            && !url
-                .fragment()
-                .map(has_credential_like_pattern)
-                .unwrap_or(false)
+            && !url.fragment().is_some_and(has_credential_like_pattern)
         {
             return Ok(());
         }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3878,7 +3878,7 @@ impl PackageId {
     fn to_toml(&self, dist_count_by_name: Option<&FxHashMap<PackageName, u64>>, table: &mut Table) {
         let count = dist_count_by_name.and_then(|map| map.get(&self.name).copied());
         table.insert("name", value(self.name.to_string()));
-        if count.map(|count| count > 1).unwrap_or(true) {
+        if count.is_none_or(|count| count > 1) {
             if let Some(version) = &self.version {
                 table.insert("version", value(version.to_string()));
             }

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -117,8 +117,7 @@ impl PubGrubDependency {
     ) -> impl Iterator<Item = Self> + 'a {
         let parent_name = parent_package.and_then(|package| package.name_no_root());
         let is_normal_parent = parent_package
-            .map(|pp| pp.extra().is_none() && pp.group().is_none())
-            .unwrap_or(false);
+            .is_some_and(|parent| parent.extra().is_none() && parent.group().is_none());
         let iter = if !requirement.extras.is_empty() {
             // This is crazy subtle, but if any of the extras in the
             // requirement are part of a declared conflict, then we

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -970,12 +970,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         request_sink: &Sender<Request>,
     ) -> Result<(), ResolveError> {
         // Ignore unresolved URL packages, i.e., packages that use a direct URL in some forks.
-        if url.is_none()
-            && package
-                .name()
-                .map(|name| self.urls.any_url(name))
-                .unwrap_or(true)
-        {
+        if url.is_none() && package.name().is_none_or(|name| self.urls.any_url(name)) {
             return Ok(());
         }
 
@@ -3030,8 +3025,7 @@ impl ForkState {
                 // Warn the user if a direct dependency lacks a lower bound in `--lowest` resolution.
                 let missing_lower_bound = version
                     .bounding_range()
-                    .map(|(lowest, _highest)| lowest == Bound::Unbounded)
-                    .unwrap_or(true);
+                    .is_none_or(|(lowest, _highest)| lowest == Bound::Unbounded);
                 let strategy_lowest = matches!(
                     resolution_strategy,
                     ResolutionStrategy::Lowest | ResolutionStrategy::LowestDirect(..)
@@ -3050,8 +3044,7 @@ impl ForkState {
                             && !other
                                 .version
                                 .bounding_range()
-                                .map(|(lowest, _highest)| lowest == Bound::Unbounded)
-                                .unwrap_or(true)
+                                .is_none_or(|(lowest, _highest)| lowest == Bound::Unbounded)
                     });
 
                     if !bound_on_other_package {

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -1182,8 +1182,7 @@ impl Workspace {
                             // If the directory is hidden, skip it.
                             if member_root
                                 .file_name()
-                                .map(|name| name.as_encoded_bytes().starts_with(b"."))
-                                .unwrap_or(false)
+                                .is_some_and(|name| name.as_encoded_bytes().starts_with(b"."))
                             {
                                 debug!(
                                     "Ignoring hidden workspace member: `{}`",
@@ -1467,8 +1466,7 @@ impl ProjectWorkspace {
                     .stop_discovery_at
                     .as_deref()
                     .and_then(Path::parent)
-                    .map(|stop_discovery_at| stop_discovery_at != *path)
-                    .unwrap_or(true)
+                    .is_none_or(|stop_discovery_at| stop_discovery_at != *path)
             })
             .find(|path| path.join("pyproject.toml").is_file())
             .ok_or_else(|| WorkspaceErrorKind::MissingPyprojectToml)?;
@@ -1762,8 +1760,7 @@ async fn find_workspace(
                 .stop_discovery_at
                 .as_deref()
                 .and_then(Path::parent)
-                .map(|stop_discovery_at| stop_discovery_at != *path)
-                .unwrap_or(true)
+                .is_none_or(|stop_discovery_at| stop_discovery_at != *path)
         })
         .skip(1)
     {
@@ -1962,8 +1959,7 @@ impl VirtualProject {
                     .stop_discovery_at
                     .as_deref()
                     .and_then(Path::parent)
-                    .map(|stop_discovery_at| stop_discovery_at != *path)
-                    .unwrap_or(true)
+                    .is_none_or(|stop_discovery_at| stop_discovery_at != *path)
             })
             .find(|path| path.join("pyproject.toml").is_file())
             .ok_or(WorkspaceErrorKind::MissingPyprojectToml)?;

--- a/crates/uv/src/commands/auth/helper.rs
+++ b/crates/uv/src/commands/auth/helper.rs
@@ -72,8 +72,7 @@ async fn credentials_for_url(
     let username = url_credentials.as_ref().and_then(|c| c.username());
     if url_credentials
         .as_ref()
-        .map(|c| c.password().is_some())
-        .unwrap_or(false)
+        .is_some_and(|credentials| credentials.password().is_some())
     {
         debug!("URL '{url}' contain a password; ignoring");
     }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -616,9 +616,7 @@ pub(crate) fn validate_project_requires_python(
         .flatten()
         .filter(|(.., requires)| !requires.contains(interpreter.python_version()))
         .collect::<RequiresPythonSources>();
-    let workspace_non_trivial = workspace
-        .map(|workspace| workspace.packages().len() > 1)
-        .unwrap_or(false);
+    let workspace_non_trivial = workspace.is_some_and(|workspace| workspace.packages().len() > 1);
 
     match source {
         PythonRequestSource::UserRequest => {

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -552,10 +552,7 @@ async fn execute_official_installer(
     }
 
     let result = command.output().await;
-    let failed = result
-        .as_ref()
-        .map(|output| !output.status.success())
-        .unwrap_or(true);
+    let failed = !result.as_ref().is_ok_and(|output| output.status.success());
 
     if let Some((previous_path, old_path)) = to_restore.as_ref() {
         if failed {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -500,11 +500,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .break_words(false)
                 .word_separator(textwrap::WordSeparator::AsciiSpace)
                 .word_splitter(textwrap::WordSplitter::NoHyphenation)
-                .wrap_lines(
-                    std::env::var(EnvVars::UV_NO_WRAP)
-                        .map(|_| false)
-                        .unwrap_or(true),
-                )
+                .wrap_lines(std::env::var(EnvVars::UV_NO_WRAP).is_err())
                 .build(),
         )
     }))?;

--- a/crates/uv/tests/it/self_update.rs
+++ b/crates/uv/tests/it/self_update.rs
@@ -20,10 +20,7 @@ fn check_self_update() {
     // To maximally emulate behaviour in practice, this test actually modifies CARGO_HOME
     // and therefore should only be run in CI by default, where it can't hurt developers.
     // We use the "CI" env-var that CI machines tend to run
-    if std::env::var(EnvVars::CI)
-        .map(|s| s.is_empty())
-        .unwrap_or(true)
-    {
+    if !std::env::var(EnvVars::CI).is_ok_and(|value| !value.is_empty()) {
         return;
     }
 


### PR DESCRIPTION
Now that uv’s MSRV is Rust 1.94, use clearer `Option` and `Result` predicate helpers where it makes sense.

This replaces `map(...).unwrap_or(...)` probes with APIs such as `is_some_and`, `is_none_or`, and `is_ok_and`, preserving existing ownership and `None`/`Err` behavior.