### PR TITLE
Clean up ImplementationName

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1840,8 +1840,9 @@ impl PythonRequest {
 
         // the prefix of e.g. `python312` and the empty prefix of bare versions, e.g. `312`
         let abstract_version_prefixes = ["python", ""];
-        let all_implementation_names =
-            ImplementationName::long_names().chain(ImplementationName::short_names());
+        let all_implementation_names = ImplementationName::iter_all().flat_map(|implementation| {
+            std::iter::once(implementation.long_name()).chain(implementation.short_name())
+        });
         // Abstract versions like `python@312`, `python312`, or `312`, plus implementations and
         // implementation versions like `pypy`, `pypy@312` or `pypy312`.
         if let Ok(Some(request)) = Self::parse_versions_and_implementations(
@@ -1932,7 +1933,7 @@ impl PythonRequest {
         }
         Self::parse_versions_and_implementations(
             abstract_version_prefixes.iter().copied(),
-            ImplementationName::long_names(),
+            ImplementationName::iter_all().map(ImplementationName::long_name),
             lowercase_value,
         )
     }
@@ -1948,7 +1949,7 @@ impl PythonRequest {
     fn parse_versions_and_implementations<'a>(
         // typically "python", possibly also "pythonw" or "" (for bare versions)
         abstract_version_prefixes: impl IntoIterator<Item = &'a str>,
-        // expected to be either long_names() or all names
+        // expected to be either long names or all names
         implementation_names: impl IntoIterator<Item = &'a str>,
         // the string to parse
         lowercase_value: &str,
@@ -2141,12 +2142,12 @@ impl PythonRequest {
             }
             Self::Implementation(implementation) => interpreter
                 .implementation_name()
-                .eq_ignore_ascii_case(implementation.into()),
+                .eq_ignore_ascii_case(implementation.long_name()),
             Self::ImplementationVersion(implementation, version) => {
                 version.matches_interpreter(interpreter)
                     && interpreter
                         .implementation_name()
-                        .eq_ignore_ascii_case(implementation.into())
+                        .eq_ignore_ascii_case(implementation.long_name())
             }
             Self::Key(request) => request.satisfied_by_interpreter(interpreter),
         }

--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -28,12 +28,24 @@ pub enum LenientImplementationName {
 }
 
 impl ImplementationName {
-    pub(crate) fn short_names() -> impl Iterator<Item = &'static str> {
-        ["cp", "pp", "gp"].into_iter()
+    /// Return the full implementation name.
+    pub(crate) const fn long_name(self) -> &'static str {
+        match self {
+            Self::CPython => "cpython",
+            Self::PyPy => "pypy",
+            Self::GraalPy => "graalpy",
+            Self::Pyodide => "pyodide",
+        }
     }
 
-    pub(crate) fn long_names() -> impl Iterator<Item = &'static str> {
-        ["cpython", "pypy", "graalpy", "pyodide"].into_iter()
+    /// Return the abbreviated implementation name, if one exists.
+    pub(crate) const fn short_name(self) -> Option<&'static str> {
+        match self {
+            Self::CPython => Some("cp"),
+            Self::PyPy => Some("pp"),
+            Self::GraalPy => Some("gp"),
+            Self::Pyodide => None,
+        }
     }
 
     pub(crate) fn iter_all() -> impl Iterator<Item = Self> {
@@ -53,7 +65,7 @@ impl ImplementationName {
     pub(crate) fn executable_name(self) -> &'static str {
         match self {
             Self::CPython | Self::Pyodide => "python",
-            Self::PyPy | Self::GraalPy => self.into(),
+            Self::PyPy | Self::GraalPy => self.long_name(),
         }
     }
 
@@ -70,7 +82,7 @@ impl ImplementationName {
             Self::Pyodide => interpreter.os().is_emscripten(),
             _ => interpreter
                 .implementation_name()
-                .eq_ignore_ascii_case(self.into()),
+                .eq_ignore_ascii_case(self.long_name()),
         }
     }
 }
@@ -91,27 +103,10 @@ impl LenientImplementationName {
     }
 }
 
-impl From<&ImplementationName> for &'static str {
-    fn from(value: &ImplementationName) -> &'static str {
-        match value {
-            ImplementationName::CPython => "cpython",
-            ImplementationName::PyPy => "pypy",
-            ImplementationName::GraalPy => "graalpy",
-            ImplementationName::Pyodide => "pyodide",
-        }
-    }
-}
-
-impl From<ImplementationName> for &'static str {
-    fn from(value: ImplementationName) -> &'static str {
-        (&value).into()
-    }
-}
-
 impl<'a> From<&'a LenientImplementationName> for &'a str {
     fn from(value: &'a LenientImplementationName) -> &'a str {
         match value {
-            LenientImplementationName::Known(implementation) => implementation.into(),
+            LenientImplementationName::Known(implementation) => implementation.long_name(),
             LenientImplementationName::Unknown(name) => name,
         }
     }
@@ -124,19 +119,20 @@ impl FromStr for ImplementationName {
     ///
     /// Supports the full name and the platform compatibility tag style name.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "cpython" | "cp" => Ok(Self::CPython),
-            "pypy" | "pp" => Ok(Self::PyPy),
-            "graalpy" | "gp" => Ok(Self::GraalPy),
-            "pyodide" => Ok(Self::Pyodide),
-            _ => Err(Error::UnknownImplementation(s.to_string())),
-        }
+        Self::iter_all()
+            .find(|implementation| {
+                s.eq_ignore_ascii_case(implementation.long_name())
+                    || implementation
+                        .short_name()
+                        .is_some_and(|name| s.eq_ignore_ascii_case(name))
+            })
+            .ok_or_else(|| Error::UnknownImplementation(s.to_string()))
     }
 }
 
 impl Display for ImplementationName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.into())
+        f.write_str(self.long_name())
     }
 }
 

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -411,7 +411,7 @@ mod tests {
                     &format!("{}.{}", version.major(), version.minor()),
                 )
                 .replace("{FREE_THREADED}", &free_threaded.to_string())
-                .replace("{IMPLEMENTATION}", (&implementation).into());
+                .replace("{IMPLEMENTATION}", implementation.long_name());
 
             fs_err::create_dir_all(path.parent().unwrap())?;
             fs_err::write(


### PR DESCRIPTION
## Summary

This is a refactor of `uv_python::implementation::ImplementationName`. It gets rid of the From impls in favour of just having functions which returns the long and short names for an implementation. I think this is just strictly cleaner at the call sites, and is less code. It gets rid of the `long_names` and `short_names` functions in favour of using the existing `iter_all`. It uses these changes to centralise a bunch of the information so the short and long names aren't duplicated in various locations anymore.

The PR becomes most useful for the centralised environments PR but the refactor seemed helpful stand-alone and is completely isolated from that PR.

## Test Plan

Relies on existing coverage.