### PR TITLE
Improve mirror error for custom Python download URLs

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -107,7 +107,7 @@ pub enum Error {
     InvalidRequestPlatform(#[from] platform::Error),
     #[error("No download found for request: {}", _0.green())]
     NoDownloadFound(PythonDownloadRequest),
-    #[error("A mirror was provided via `{0}`, but the URL does not match the expected format: {0}")]
+    #[error("A mirror was provided via `{0}`, but the URL does not match the expected format: {1}")]
     Mirror(&'static str, String),
     #[error("Failed to determine the libc used on the current platform")]
     LibcDetection(#[from] platform::LibcDetectionError),

--- a/crates/uv/tests/python/python_list.rs
+++ b/crates/uv/tests/python/python_list.rs
@@ -669,6 +669,24 @@ async fn python_list_remote_python_downloads_json_url() -> Result<()> {
     ----- stderr -----
     ");
 
+    // Test showing custom download metadata with a CPython mirror configured
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(EnvVars::UV_PYTHON_INSTALL_MIRROR, "https://mirror.example.com")
+        .arg("--all-versions")
+        .arg("--all-platforms")
+        .arg("--all-arches")
+        .arg("--show-urls")
+        .arg("--python-downloads-json-url").arg(server.uri()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: A mirror was provided via `UV_PYTHON_INSTALL_MIRROR`, but the URL does not match the expected format: https://custom.com/cpython-3.14.0-darwin-aarch64-none.tar.gz
+    ");
+
     // test invalid URL path
     uv_snapshot!(context.filters(), context
         .python_list()


### PR DESCRIPTION
### Summary

This improves the error emitted when a configured CPython install mirror is applied to a download URL that does not match uv's expected `python-build-standalone` URL prefix.

Previously the message repeated the environment variable name:

```text
error: A mirror was provided via `UV_PYTHON_INSTALL_MIRROR`, but the URL does not match the expected format: UV_PYTHON_INSTALL_MIRROR
```

With this change, the message includes the offending URL instead:

```text
error: A mirror was provided via `UV_PYTHON_INSTALL_MIRROR`, but the URL does not match the expected format: https://custom.com/cpython-3.14.0-darwin-aarch64-none.tar.gz
```

The PR also adds integration coverage for the intersection of:

- `--python-downloads-json-url` with custom CPython download metadata
- `UV_PYTHON_INSTALL_MIRROR`
- `uv python list --show-urls`

This intentionally keeps the behavior unchanged. The custom download URL still errors when a CPython mirror is configured and the URL does not match the canonical prefix. The change only makes the failure actionable and covers the reported path.

Fixes #19893.

### Test Plan

```shell
cargo fmt --check
cargo test --package uv --test python -- python_list_remote_python_downloads_json_url -- --exact
cargo test --package uv-python test_cpython
```
