### PR TITLE
Add `--flatten` to `uv tree`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4736,6 +4736,10 @@ pub struct TreeArgs {
     #[arg(long)]
     pub universal: bool,
 
+    /// Display each package once, without dependency relationships.
+    #[arg(long, conflicts_with_all = ["depth", "no_dedupe"])]
+    pub flatten: bool,
+
     #[command(flatten)]
     pub tree: DisplayTreeArgs,
 

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -11,7 +11,7 @@ pub use fork_strategy::ForkStrategy;
 pub use lock::{
     Installable, Lock, LockError, LockVersion, Metadata, Package, PackageMap, PylockToml,
     PylockTomlError, PylockTomlErrorKind, RequirementsTxtExport, ResolverManifest, SatisfiesResult,
-    TreeDisplay, VERSION, cyclonedx_json,
+    TreeDisplay, TreeDisplayMode, VERSION, cyclonedx_json,
 };
 pub use manifest::Manifest;
 pub use options::{Flexibility, Options, OptionsBuilder};

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -65,7 +65,7 @@ pub use crate::lock::export::{
 };
 pub use crate::lock::installable::Installable;
 pub use crate::lock::map::PackageMap;
-pub use crate::lock::tree::TreeDisplay;
+pub use crate::lock::tree::{TreeDisplay, TreeDisplayMode};
 use crate::resolution::{AnnotatedDist, ResolutionGraphNode};
 use crate::universal_marker::{ConflictMarker, UniversalMarker};
 use crate::{

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -19,6 +19,15 @@ use uv_pypi_types::ResolverMarkerEnvironment;
 use crate::lock::{Package, PackageId};
 use crate::{Lock, PackageMap};
 
+/// The structure used to render a dependency graph.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum TreeDisplayMode {
+    /// Render dependency relationships as a tree.
+    Tree,
+    /// Render each reachable package once, without dependency relationships.
+    Flattened,
+}
+
 #[derive(Debug)]
 pub struct TreeDisplay<'env> {
     /// The constructed dependency graph.
@@ -37,6 +46,8 @@ pub struct TreeDisplay<'env> {
     lock: &'env Lock,
     /// Whether to show sizes in the rendered output.
     show_sizes: bool,
+    /// The structure used to render the selected graph.
+    mode: TreeDisplayMode,
 }
 
 impl<'env> TreeDisplay<'env> {
@@ -52,6 +63,7 @@ impl<'env> TreeDisplay<'env> {
         no_dedupe: bool,
         invert: bool,
         show_sizes: bool,
+        mode: TreeDisplayMode,
     ) -> Self {
         // Identify any workspace members.
         //
@@ -415,7 +427,97 @@ impl<'env> TreeDisplay<'env> {
             invert,
             lock,
             show_sizes,
+            mode,
         }
+    }
+
+    /// Traverse the selected graph and return each reachable package exactly once.
+    fn render_flattened(&'env self) -> Vec<String> {
+        let mut packages = BTreeSet::new();
+        let mut visited = FxHashSet::default();
+        let mut queue = VecDeque::new();
+
+        for node in &self.roots {
+            match self.graph[*node] {
+                Node::Root => {
+                    queue.extend(
+                        self.graph
+                            .edges_directed(*node, Direction::Outgoing)
+                            .map(|edge| Cursor::new(edge.target(), edge.id())),
+                    );
+                }
+                Node::Package(_) => queue.push_back(Cursor::root(*node)),
+            }
+        }
+
+        while let Some(cursor) = queue.pop_front() {
+            let Node::Package(package_id) = self.graph[cursor.node()] else {
+                continue;
+            };
+            let package = self.lock.find_by_id(package_id);
+            let edge = cursor.edge().map(|edge_id| &self.graph[edge_id]);
+            let expanded_extras = self.expanded_extras(package, edge);
+
+            packages.insert(package_id);
+            if !visited.insert(VisitedNode {
+                package_id,
+                expanded_extras: expanded_extras.clone(),
+            }) {
+                continue;
+            }
+
+            queue.extend(
+                self.graph
+                    .edges_directed(cursor.node(), Direction::Outgoing)
+                    .filter_map(|edge| match self.graph[edge.target()] {
+                        Node::Root => None,
+                        Node::Package(_) => {
+                            if !self.invert
+                                && let Edge::Optional(required_extra, _) = &self.graph[edge.id()]
+                                && !expanded_extras.contains(required_extra)
+                            {
+                                return None;
+                            }
+                            Some(Cursor::new(edge.target(), edge.id()))
+                        }
+                    }),
+            );
+        }
+
+        let mut package_counts = FxHashMap::default();
+        for package_id in &packages {
+            *package_counts
+                .entry((&package_id.name, package_id.version.as_ref()))
+                .or_insert(0usize) += 1;
+        }
+
+        packages
+            .into_iter()
+            .map(|package_id| {
+                let mut line = format!("{}", package_id.name);
+                if let Some(version) = package_id.version.as_ref() {
+                    let _ = write!(line, " v{version}");
+                }
+                if package_counts[&(&package_id.name, package_id.version.as_ref())] > 1 {
+                    let _ = write!(line, " @ {}", package_id.source);
+                }
+                if let Some(version) = self.latest.get(package_id) {
+                    let _ = write!(line, " {}", format!("(latest: v{version})").bold().cyan());
+                }
+                if self.show_sizes
+                    && let Some(size_bytes) = self
+                        .lock
+                        .find_by_id(package_id)
+                        .wheels
+                        .iter()
+                        .find_map(|wheel| wheel.size)
+                {
+                    let (bytes, unit) = human_readable_bytes(size_bytes);
+                    let _ = write!(line, " {}", format!("({bytes:.1}{unit})").dimmed());
+                }
+                line
+            })
+            .collect()
     }
 
     /// Perform a depth-first traversal of the given package and its dependencies.
@@ -724,6 +826,13 @@ impl Cursor {
 impl std::fmt::Display for TreeDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use owo_colors::OwoColorize;
+
+        if self.mode == TreeDisplayMode::Flattened {
+            for line in self.render_flattened() {
+                writeln!(f, "{line}")?;
+            }
+            return Ok(());
+        }
 
         let mut deduped = false;
         for line in self.render() {

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -12,7 +12,7 @@ use uv_normalize::DefaultGroups;
 use uv_normalize::PackageName;
 use uv_preview::Preview;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion};
-use uv_resolver::{PackageMap, TreeDisplay};
+use uv_resolver::{PackageMap, TreeDisplay, TreeDisplayMode};
 use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
 use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
@@ -41,6 +41,7 @@ pub(crate) async fn tree(
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
     universal: bool,
+    flatten: bool,
     depth: u8,
     prune: Vec<PackageName>,
     package: Vec<PackageName>,
@@ -302,6 +303,11 @@ pub(crate) async fn tree(
         no_dedupe,
         invert,
         show_sizes,
+        if flatten {
+            TreeDisplayMode::Flattened
+        } else {
+            TreeDisplayMode::Tree
+        },
     );
 
     print!("{tree}");

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2667,6 +2667,7 @@ async fn run_project(
                 args.lock_check,
                 args.frozen,
                 args.universal,
+                args.flatten,
                 args.depth,
                 args.prune,
                 args.package,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2645,6 +2645,7 @@ pub(crate) struct TreeSettings {
     pub(crate) lock_check: LockCheck,
     pub(crate) frozen: Option<FrozenSource>,
     pub(crate) universal: bool,
+    pub(crate) flatten: bool,
     pub(crate) depth: u8,
     pub(crate) prune: Vec<PackageName>,
     pub(crate) package: Vec<PackageName>,
@@ -2671,6 +2672,7 @@ impl TreeSettings {
         let TreeArgs {
             tree,
             universal,
+            flatten,
             dev,
             only_dev,
             no_dev,
@@ -2728,6 +2730,7 @@ impl TreeSettings {
             lock_check: resolve_lock_check(locked),
             frozen: resolve_frozen(frozen),
             universal,
+            flatten,
             depth: tree.depth,
             prune: tree.prune,
             package: tree.package,

--- a/crates/uv/tests/project/tree.rs
+++ b/crates/uv/tests/project/tree.rs
@@ -42,11 +42,76 @@ fn nested_dependencies() -> Result<()> {
     "
     );
 
+    // Flattening emits a deterministic set and omits the repeated path to `numpy`.
+    uv_snapshot!(context.filters(), context.tree().arg("--universal").arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    joblib v1.3.2
+    numpy v1.26.4
+    project v0.1.0
+    scikit-learn v1.4.1.post1
+    scipy v1.12.0
+    threadpoolctl v3.4.0
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
+    // Selection and pruning happen before flattening.
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--universal")
+        .arg("--package").arg("scikit-learn")
+        .arg("--prune").arg("scipy")
+        .arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    joblib v1.3.2
+    numpy v1.26.4
+    scikit-learn v1.4.1.post1
+    threadpoolctl v3.4.0
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
     // `uv tree` should update the lockfile
     let lock = context.read("uv.lock");
     assert!(!lock.is_empty());
 
     Ok(())
+}
+
+#[test]
+fn flatten_conflicts_with_hierarchical_options() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.tree().arg("--flatten").arg("--depth").arg("1"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--flatten' cannot be used with '--depth <DEPTH>'
+
+    Usage: uv tree --cache-dir [CACHE_DIR] --flatten --exclude-newer <EXCLUDE_NEWER>
+
+    For more information, try '--help'.
+    "###);
+
+    uv_snapshot!(context.filters(), context.tree().arg("--flatten").arg("--no-dedupe"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--flatten' cannot be used with '--no-dedupe'
+
+    Usage: uv tree --cache-dir [CACHE_DIR] --flatten --exclude-newer <EXCLUDE_NEWER>
+
+    For more information, try '--help'.
+    "###);
 }
 
 #[test]
@@ -175,6 +240,22 @@ fn invert() -> Result<()> {
     "
     );
 
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--invert")
+        .arg("--package").arg("numpy")
+        .arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    numpy v1.26.4
+    project v0.1.0
+    scikit-learn v1.4.1.post1
+    scipy v1.12.0
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
     Ok(())
 }
 
@@ -268,6 +349,19 @@ fn outdated() -> Result<()> {
     Resolved 4 packages in [TIME]
     "
     );
+
+    uv_snapshot!(context.filters(), context.tree().arg("--outdated").arg("--universal").arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    anyio v3.0.0 (latest: v4.3.0)
+    idna v3.6
+    project v0.1.0
+    sniffio v1.3.1
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
 
     Ok(())
 }
@@ -497,6 +591,21 @@ fn repeated_dependencies() -> Result<()> {
     "
     );
 
+    uv_snapshot!(context.filters(), context.tree().arg("--universal").arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    anyio v1.4.0
+    anyio v4.3.0
+    async-generator v1.10
+    idna v3.6
+    project v0.1.0
+    sniffio v1.3.1
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
     // `uv tree` should update the lockfile
     let lock = context.read("uv.lock");
     assert!(!lock.is_empty());
@@ -574,6 +683,66 @@ fn repeated_version() -> Result<()> {
     // `uv tree` should update the lockfile
     let lock = context.read("uv.lock");
     assert!(!lock.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn flatten_distinguishes_sources() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#,
+    )?;
+    context.temp_dir.child("uv.lock").write_str(
+        r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [[package]]
+        name = "dep"
+        version = "1.0.0"
+        source = { registry = "https://one.example/simple" }
+
+        [[package]]
+        name = "dep"
+        version = "1.0.0"
+        source = { registry = "https://two.example/simple" }
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { editable = "." }
+        dependencies = [
+            { name = "dep", version = "1.0.0", source = { registry = "https://one.example/simple" } },
+            { name = "dep", version = "1.0.0", source = { registry = "https://two.example/simple" } },
+        ]
+
+        [package.metadata]
+        requires-dist = []
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--frozen")
+        .arg("--universal")
+        .arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dep v1.0.0 @ registry+https://one.example/simple
+    dep v1.0.0 @ registry+https://two.example/simple
+    project v0.1.0
+
+    ----- stderr -----
+    ");
 
     Ok(())
 }
@@ -731,6 +900,30 @@ fn optional_dependencies() -> Result<()> {
     Resolved 14 packages in [TIME]
     "
     );
+
+    // Flattened traversal still activates both workspace extras and requested package extras.
+    uv_snapshot!(context.filters(), context.tree().arg("--universal").arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    anyio v4.3.0
+    blinker v1.7.0
+    click v8.1.7
+    colorama v0.4.6
+    flask v3.0.2
+    idna v3.6
+    iniconfig v2.0.0
+    itsdangerous v2.1.2
+    jinja2 v3.1.3
+    markupsafe v2.1.5
+    project v0.1.0
+    python-dotenv v1.0.1
+    sniffio v1.3.1
+    werkzeug v3.0.1
+
+    ----- stderr -----
+    Resolved 14 packages in [TIME]
+    ");
 
     // `uv tree` should update the lockfile
     let lock = context.read("uv.lock");
@@ -1294,6 +1487,26 @@ fn cycle() -> Result<()> {
     Resolved 11 packages in [TIME]
     "
     );
+
+    uv_snapshot!(context.filters(), context.tree().arg("--universal").arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    argparse v1.4.0
+    extras v1.0.0
+    fixtures v3.0.0
+    linecache2 v1.0.0
+    pbr v6.0.0
+    project v0.1.0
+    python-mimeparse v1.6.0
+    six v1.16.0
+    testtools v2.3.0
+    traceback2 v1.4.0
+    unittest2 v1.1.0
+
+    ----- stderr -----
+    Resolved 11 packages in [TIME]
+    ");
 
     // `uv tree` should update the lockfile
     let lock = context.read("uv.lock");
@@ -2257,6 +2470,17 @@ fn show_sizes() -> Result<()> {
     Resolved 2 packages in [TIME]
     "
     );
+
+    uv_snapshot!(context.filters(), context.tree().arg("--show-sizes").arg("--universal").arg("--flatten"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    iniconfig v2.0.0 ([SIZE])
+    project v0.1.0
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Add `--flatten` to project `uv tree` output.

Flattened output traverses the same selected dependency graph as the hierarchical display, including package selection, pruning, inversion, groups, markers, and activated extras, then emits every reachable package identity once in deterministic order. Packages with the same name and version from different sources receive source qualifiers so the resulting lines remain unambiguous.

The option composes with `--package`, `--prune`, `--invert`, `--outdated`, and `--show-sizes`. It conflicts with the hierarchy-specific `--depth` and `--no-dedupe` options. `uv pip tree` is unchanged.

## Test Plan

- Integration snapshots for forward and inverted flattening, selection and pruning, extras and groups, cycles, multiple versions and sources, outdated annotations, sizes, and CLI conflicts
- `cargo +stable clippy --package uv --package uv-cli --package uv-resolver --all-targets --locked -- -D warnings`
- `cargo +stable fmt --all -- --check`
- `git diff --check`
