### PR TITLE
Add `--depends-on` to `uv workspace list`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -8330,6 +8330,14 @@ pub struct WorkspaceListArgs {
     /// Show paths instead of names.
     #[arg(long)]
     pub paths: bool,
+
+    /// Only list workspace members that depend on the given package.
+    ///
+    /// Includes direct and transitive dependencies from production dependencies, optional
+    /// dependencies, and dependency groups under at least one valid marker environment. The query
+    /// reads the existing `uv.lock` without updating it.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub depends_on: Option<PackageName>,
 }
 
 /// See [PEP 517](https://peps.python.org/pep-0517/) and

--- a/crates/uv-resolver/src/lock/dependents.rs
+++ b/crates/uv-resolver/src/lock/dependents.rs
@@ -1,0 +1,121 @@
+use std::collections::{BTreeSet, VecDeque};
+
+use rustc_hash::FxHashSet;
+use uv_normalize::{ExtraName, PackageName};
+use uv_pep508::MarkerTree;
+
+use crate::lock::{Dependency, Lock, Package, PackageId};
+use crate::{ConflictMarker, UniversalMarker};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TraversalState<'lock> {
+    package_id: &'lock PackageId,
+    extras: BTreeSet<&'lock ExtraName>,
+    marker: UniversalMarker,
+}
+
+impl Lock {
+    /// Return the workspace members that depend on `target` in at least one valid environment.
+    ///
+    /// The traversal considers every production dependency, optional dependency, and dependency
+    /// group on each member as a root context. Once it leaves the member, it follows production
+    /// dependencies and explicitly activated extras, but not dependency groups owned by transitive
+    /// workspace packages.
+    ///
+    /// Returns `None` if `target` does not occur in the lockfile.
+    pub fn workspace_members_depending_on(
+        &self,
+        target: &PackageName,
+    ) -> Option<BTreeSet<PackageName>> {
+        if !self
+            .packages
+            .iter()
+            .any(|package| &package.id.name == target)
+        {
+            return None;
+        }
+
+        let members: BTreeSet<&PackageId> = if self.members().is_empty() {
+            self.root().into_iter().map(|package| &package.id).collect()
+        } else {
+            self.packages
+                .iter()
+                .filter(|package| self.members().contains(&package.id.name))
+                .map(|package| &package.id)
+                .collect()
+        };
+        let conflict_marker = UniversalMarker::new(
+            MarkerTree::TRUE,
+            ConflictMarker::from_conflicts(self.conflicts()),
+        );
+
+        Some(
+            members
+                .into_iter()
+                .filter(|package_id| &package_id.name != target)
+                .filter(|package_id| {
+                    self.package_depends_on(self.find_by_id(package_id), target, conflict_marker)
+                })
+                .map(|package_id| package_id.name.clone())
+                .collect(),
+        )
+    }
+
+    fn package_depends_on(
+        &self,
+        member: &Package,
+        target: &PackageName,
+        conflict_marker: UniversalMarker,
+    ) -> bool {
+        let mut queue = VecDeque::new();
+        let mut visited = FxHashSet::default();
+
+        for dependency in member
+            .dependencies
+            .iter()
+            .chain(member.optional_dependencies.values().flatten())
+            .chain(member.dependency_groups.values().flatten())
+        {
+            enqueue(&mut queue, dependency, conflict_marker);
+        }
+
+        while let Some(state) = queue.pop_front() {
+            if &state.package_id.name == target {
+                return true;
+            }
+            if !visited.insert(state.clone()) {
+                continue;
+            }
+
+            let package = self.find_by_id(state.package_id);
+            for dependency in &package.dependencies {
+                enqueue(&mut queue, dependency, state.marker);
+            }
+            for extra in &state.extras {
+                if let Some(dependencies) = package.optional_dependencies.get(*extra) {
+                    for dependency in dependencies {
+                        enqueue(&mut queue, dependency, state.marker);
+                    }
+                }
+            }
+        }
+
+        false
+    }
+}
+
+fn enqueue<'lock>(
+    queue: &mut VecDeque<TraversalState<'lock>>,
+    dependency: &'lock Dependency,
+    mut marker: UniversalMarker,
+) {
+    marker.and(dependency.complexified_marker);
+    if marker.is_false() {
+        return;
+    }
+    queue.push_back(TraversalState {
+        package_id: &dependency.package_id,
+        extras: dependency.extra.iter().collect(),
+        marker,
+    });
+}

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -73,6 +73,7 @@ use crate::{
     InMemoryIndex, MetadataResponse, PrereleaseMode, ResolutionMode, ResolverOutput,
 };
 
+mod dependents;
 pub(crate) mod export;
 mod installable;
 mod map;

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -1,20 +1,23 @@
 use std::fmt::Write;
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 
 use owo_colors::OwoColorize;
 use uv_cache::Cache;
 use uv_fs::Simplified;
+use uv_normalize::PackageName;
 use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
 
 use crate::commands::ExitStatus;
+use crate::commands::project::lock_target::LockTarget;
 use crate::printer::Printer;
 
 /// List workspace members
 pub(crate) async fn list(
     project_dir: &Path,
     paths: bool,
+    depends_on: Option<PackageName>,
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     printer: Printer,
@@ -27,7 +30,35 @@ pub(crate) async fn list(
     )
     .await?;
 
+    let dependents = if let Some(target) = depends_on {
+        let lock_path = workspace.install_path().join("uv.lock");
+        let lock = LockTarget::from(workspace.as_ref())
+            .read()
+            .await?
+            .with_context(|| {
+                format!(
+                    "No `{}` found; run `uv lock` to create it",
+                    lock_path.simplified_display()
+                )
+            })?;
+        let Some(dependents) = lock.workspace_members_depending_on(&target) else {
+            bail!(
+                "Package `{target}` was not found in `{}`",
+                lock_path.simplified_display()
+            );
+        };
+        Some(dependents)
+    } else {
+        None
+    };
+
     for (name, member) in workspace.packages() {
+        if dependents
+            .as_ref()
+            .is_some_and(|dependents| !dependents.contains(name))
+        {
+            continue;
+        }
         if paths {
             writeln!(
                 printer.stdout(),

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2029,7 +2029,15 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .await
             }
             WorkspaceCommand::List(args) => {
-                commands::list(&project_dir, args.paths, &cache, &workspace_cache, printer).await
+                commands::list(
+                    &project_dir,
+                    args.paths,
+                    args.depends_on,
+                    &cache,
+                    &workspace_cache,
+                    printer,
+                )
+                .await
             }
         },
         Commands::BuildBackend { command } => spawn_blocking(move || match command {

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
-use assert_fs::fixture::PathChild;
+use assert_fs::fixture::{FileWriteStr, PathChild};
 
 use uv_test::{copy_dir_ignore, uv_snapshot};
 
@@ -231,4 +231,280 @@ fn workspace_list_no_project() {
     error: No `pyproject.toml` found in current directory or any parent directory
     "
     );
+}
+
+#[test]
+fn workspace_list_depends_on() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [tool.uv.workspace]
+        members = ["packages/*"]
+        "#,
+    )?;
+
+    let package_a = context.temp_dir.child("packages/package-a");
+    package_a.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-b"]
+
+        [tool.uv.sources]
+        package-b = { workspace = true }
+        "#,
+    )?;
+
+    let package_b = context.temp_dir.child("packages/package-b");
+    package_b.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-x"]
+
+        [tool.uv.sources]
+        package-x = { workspace = true }
+        "#,
+    )?;
+
+    let package_c = context.temp_dir.child("packages/package-c");
+    package_c.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-c"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    let package_x = context.temp_dir.child("packages/package-x");
+    package_x.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-x"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    // The query is deliberately lock-backed and does not mutate the project.
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--depends-on")
+        .arg("package-x"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No `[TEMP_DIR]/uv.lock` found; run `uv lock` to create it
+    ");
+
+    context.lock().assert().success();
+
+    // Both direct and transitive dependents are included; the target itself and unrelated members
+    // are not.
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--depends-on")
+        .arg("package-x"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    package-a
+    package-b
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--depends-on")
+        .arg("package-x")
+        .arg("--paths"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/packages/package-a
+    [TEMP_DIR]/packages/package-b
+
+    ----- stderr -----
+    ");
+
+    // A known target with no dependents produces an empty successful result.
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--depends-on")
+        .arg("package-c"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    // Unknown package names fail instead of silently producing an empty CI matrix.
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--depends-on")
+        .arg("missing"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Package `missing` was not found in `[TEMP_DIR]/uv.lock`
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn workspace_list_depends_on_preserves_context() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [tool.uv.workspace]
+        members = ["packages/*"]
+        "#,
+    )?;
+
+    let package_p = context.temp_dir.child("packages/package-p");
+    package_p.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-p"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["package-x; sys_platform == 'linux'"]
+
+        [tool.uv.sources]
+        package-x = { workspace = true }
+        "#,
+    )?;
+
+    let package_a = context.temp_dir.child("packages/package-a");
+    package_a.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-p[feature]; sys_platform == 'linux'"]
+
+        [tool.uv.sources]
+        package-p = { workspace = true }
+        "#,
+    )?;
+
+    let package_b = context.temp_dir.child("packages/package-b");
+    package_b.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-p"]
+
+        [tool.uv.sources]
+        package-p = { workspace = true }
+        "#,
+    )?;
+
+    let package_c = context.temp_dir.child("packages/package-c");
+    package_c.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-c"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-p[feature]; sys_platform == 'win32'"]
+
+        [tool.uv.sources]
+        package-p = { workspace = true }
+        "#,
+    )?;
+
+    let package_x = context.temp_dir.child("packages/package-x");
+    package_x.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-x"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    let package_g = context.temp_dir.child("packages/package-g");
+    package_g.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-g"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [dependency-groups]
+        dev = ["package-y"]
+
+        [tool.uv.sources]
+        package-y = { workspace = true }
+        "#,
+    )?;
+
+    let package_h = context.temp_dir.child("packages/package-h");
+    package_h.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-h"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-g"]
+
+        [tool.uv.sources]
+        package-g = { workspace = true }
+        "#,
+    )?;
+
+    let package_y = context.temp_dir.child("packages/package-y");
+    package_y.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-y"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    context.lock().assert().success();
+
+    // Optional dependencies only propagate to consumers that activate the extra under a
+    // compatible marker. The package that declares the extra is itself a possible dependent.
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--depends-on")
+        .arg("package-x"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    package-a
+    package-p
+
+    ----- stderr -----
+    ");
+
+    // A member's dependency groups do not become dependencies of packages that consume it.
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--depends-on")
+        .arg("package-y"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    package-g
+
+    ----- stderr -----
+    ");
+
+    Ok(())
 }


### PR DESCRIPTION
Alternative to #19901 

## Summary

Add `--depends-on <PACKAGE>` to `uv workspace list`.

The query reads the existing `uv.lock` without modifying it and lists every current workspace member with a satisfiable direct or transitive dependency path to the target package. Each member's production dependencies, optional dependencies, and dependency groups are considered as root contexts; transitive packages only activate explicitly requested extras, and dependency groups do not leak through packages that consume another workspace member.

The target itself is excluded. A known package with no workspace dependents produces an empty successful result, while a missing lockfile or unknown package name is an error. `--paths` composes with the filter.

## Test Plan

- Workspace-list integration snapshots for direct and transitive dependents, path output, empty matches, missing lockfiles, and unknown targets
- Context-preservation snapshots for activated and unactivated extras, compatible and incompatible markers, and dependency-group ownership
- `RUST_LOG=off cargo +stable test --package uv --test workspace 'workspace_list::'`
- Clippy for `uv-resolver`, `uv-cli`, and the `uv` workspace integration target with warnings denied
- `cargo +stable fmt --all -- --check`
- `git diff --check`
