### PR TITLE
Support centralised environments in `uv venv`

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1098,7 +1098,7 @@ fn discover_project_environment(
 }
 
 /// Return whether to use centralized project environments for this invocation.
-fn centralized_environments_enabled(
+pub(crate) fn centralized_environments_enabled(
     selection: &ProjectEnvironmentSelection,
     cache: &Cache,
 ) -> bool {
@@ -1115,7 +1115,7 @@ fn centralized_environments_enabled(
 }
 
 /// Return whether `path` is a link into the current cache's environment bucket.
-fn is_centralized_environment_link(path: &Path, cache: &Cache) -> bool {
+pub(crate) fn is_centralized_environment_link(path: &Path, cache: &Cache) -> bool {
     let Ok(target) = fs_err::read_link(path) else {
         return false;
     };
@@ -1139,7 +1139,7 @@ fn is_centralized_environment_link(path: &Path, cache: &Cache) -> bool {
 }
 
 /// Return the centralized environment path for a given workspace and interpreter.
-fn centralized_environment_root(
+pub(crate) fn centralized_environment_root(
     workspace: &Workspace,
     interpreter: &Interpreter,
     upgradeable: bool,
@@ -1203,11 +1203,11 @@ pub(crate) enum LinkErrorReporting {
 }
 
 /// Point the workspace's `.venv` to the centralized environment.
-fn update_project_environment_link(
+pub(crate) fn update_project_environment_link(
     environment: &PythonEnvironment,
     workspace: &Workspace,
     link_error_reporting: LinkErrorReporting,
-) {
+) -> bool {
     let link = workspace.install_path().join(".venv");
     let report_error = |message: &str, err: &std::io::Error| match link_error_reporting {
         LinkErrorReporting::User => {
@@ -1220,22 +1220,26 @@ fn update_project_environment_link(
         if uv_fs::is_virtualenv_base(&link) {
             if let Err(err) = uv_fs::remove_virtualenv(&link) {
                 report_error("Failed to remove existing local virtual environment", &err);
-                return;
+                return false;
             }
         } else {
             // On Windows, copying a junction can produce an empty directory.
             #[cfg(windows)]
             if let Err(err) = fs_err::remove_dir(&link) {
                 report_error("Failed to create link to project environment", &err);
-                return;
+                return false;
             }
         }
     }
 
     // TODO(tk): When directory links are unavailable, write `.venv` as a file containing the
     // environment path.
-    if let Err(err) = uv_fs::replace_symlink(environment.root(), &link) {
-        report_error("Failed to create link to project environment", &err);
+    match uv_fs::replace_symlink(environment.root(), &link) {
+        Ok(()) => true,
+        Err(err) => {
+            report_error("Failed to create link to project environment", &err);
+            false
+        }
     }
 }
 

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -146,18 +146,6 @@ pub(crate) async fn venv(
         );
     }
 
-    // Determine the default path; either the virtual environment for the project or `.venv`.
-    let path = path.unwrap_or_else(|| {
-        project_environment_selection.map_or_else(
-            || PathBuf::from(".venv"),
-            |selection| {
-                selection
-                    .explicit_path()
-                    .map_or_else(|| project_dir.join(".venv"), Path::to_path_buf)
-            },
-        )
-    });
-
     let reporter = PythonDownloadReporter::single(printer);
 
     // If the default dependency-groups demand a higher requires-python
@@ -199,6 +187,22 @@ pub(crate) async fn venv(
         python.into_interpreter()
     };
 
+    let upgradeable = python_request
+        .as_ref()
+        .is_none_or(|request| !request.includes_patch());
+
+    // Determine the default path; either the virtual environment for the project or `.venv`.
+    let path = path.unwrap_or_else(|| {
+        project_environment_selection.map_or_else(
+            || PathBuf::from(".venv"),
+            |selection| {
+                selection
+                    .explicit_path()
+                    .map_or_else(|| project_dir.join(".venv"), Path::to_path_buf)
+            },
+        )
+    });
+
     // Check if the discovered Python version is incompatible with the current workspace
     if let Some(requires_python) = requires_python {
         match validate_project_requires_python(
@@ -221,10 +225,6 @@ pub(crate) async fn venv(
         if seed { "with seed packages " } else { "" },
         path.user_display().cyan()
     )?;
-
-    let upgradeable = python_request
-        .as_ref()
-        .is_none_or(|request| !request.includes_patch());
 
     // Lock the project environment to avoid synchronization issues.
     let _lock = if let Some(workspace) = project_environment {

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -22,7 +22,7 @@ use uv_distribution_types::{
 use uv_fs::Simplified;
 use uv_install_wheel::LinkMode;
 use uv_normalize::DefaultGroups;
-use uv_preview::{Preview, PreviewFeature};
+use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference, PythonRequest,
 };
@@ -32,18 +32,17 @@ use uv_shell::{Shell, shlex_posix, shlex_windows};
 use uv_types::{
     AnyErrorBuild, BuildContext, BuildIsolation, BuildStack, HashStrategy, SourceTreeEditablePolicy,
 };
-use uv_virtualenv::OnExisting;
+use uv_virtualenv::{OnExisting, RemovalReason};
 use uv_warnings::warn_user;
-use uv_workspace::{
-    DiscoveryOptions, ProjectEnvironmentSelection, VirtualProject, WorkspaceCache,
-    WorkspaceErrorKind,
-};
+use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceErrorKind};
 
 use crate::commands::ExitStatus;
 use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
 use crate::commands::pip::operations::{Changelog, report_interpreter};
 use crate::commands::project::{
-    WorkspacePython, lock_project_environment, validate_project_requires_python,
+    LinkErrorReporting, WorkspacePython, centralized_environment_root,
+    centralized_environments_enabled, is_centralized_environment_link, lock_project_environment,
+    update_project_environment_link, validate_project_requires_python,
 };
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::printer::Printer;
@@ -131,20 +130,13 @@ pub(crate) async fn venv(
     let project_environment = project
         .as_ref()
         .map(VirtualProject::workspace)
-        .filter(|workspace| path.is_none() && workspace.install_path() == project_dir);
+        .filter(|workspace| path.is_none() && workspace.install_path() == project_dir)
+        .map(|workspace| (workspace, workspace.environment_selection(Some(false))));
 
-    let project_environment_selection =
-        project_environment.map(|workspace| workspace.environment_selection(Some(false)));
-
-    if project_environment_selection
+    let centralized_workspace = project_environment
         .as_ref()
-        .is_some_and(ProjectEnvironmentSelection::is_default)
-        && preview.is_enabled(PreviewFeature::CentralizedProjectEnvs)
-    {
-        warn_user!(
-            "The `centralized-project-envs` preview feature currently has no effect on `uv venv`"
-        );
-    }
+        .filter(|(_, selection)| centralized_environments_enabled(selection, cache))
+        .map(|(workspace, _)| *workspace);
 
     let reporter = PythonDownloadReporter::single(printer);
 
@@ -191,17 +183,19 @@ pub(crate) async fn venv(
         .as_ref()
         .is_none_or(|request| !request.includes_patch());
 
-    // Determine the default path; either the virtual environment for the project or `.venv`.
-    let path = path.unwrap_or_else(|| {
-        project_environment_selection.map_or_else(
-            || PathBuf::from(".venv"),
-            |selection| {
+    // Determine the default path.
+    let path = if let Some(workspace) = centralized_workspace {
+        centralized_environment_root(workspace, &interpreter, upgradeable, cache)
+    } else {
+        path.or_else(|| {
+            project_environment.as_ref().map(|(_, selection)| {
                 selection
                     .explicit_path()
                     .map_or_else(|| project_dir.join(".venv"), Path::to_path_buf)
-            },
-        )
-    });
+            })
+        })
+        .unwrap_or_else(|| PathBuf::from(".venv"))
+    };
 
     // Check if the discovered Python version is incompatible with the current workspace
     if let Some(requires_python) = requires_python {
@@ -219,15 +213,26 @@ pub(crate) async fn venv(
         }
     }
 
-    writeln!(
-        printer.stderr(),
-        "Creating virtual environment {}at: {}",
-        if seed { "with seed packages " } else { "" },
-        path.user_display().cyan()
-    )?;
+    let with_seed = if seed { " with seed packages" } else { "" };
+    if centralized_workspace.is_some() {
+        writeln!(
+            printer.stderr(),
+            "Creating virtual environment `{}`{with_seed}",
+            path.file_name()
+                .unwrap_or(path.as_os_str())
+                .to_string_lossy()
+                .cyan(),
+        )?;
+    } else {
+        writeln!(
+            printer.stderr(),
+            "Creating virtual environment{with_seed} at: {}",
+            path.user_display().cyan()
+        )?;
+    }
 
     // Lock the project environment to avoid synchronization issues.
-    let _lock = if let Some(workspace) = project_environment {
+    let _lock = if let Some((workspace, _)) = project_environment.as_ref() {
         lock_project_environment(workspace)
             .await
             .inspect_err(|err| {
@@ -236,6 +241,21 @@ pub(crate) async fn venv(
             .ok()
     } else {
         None
+    };
+
+    let on_existing = match on_existing {
+        OnExisting::Prompt | OnExisting::Remove(_) if centralized_workspace.is_some() => {
+            // Centralized environments are managed by uv, so replace them without prompting.
+            OnExisting::Remove(RemovalReason::ManagedEnvironment)
+        }
+        OnExisting::Prompt | OnExisting::Remove(_)
+            if is_centralized_environment_link(&path, cache) =>
+        {
+            // Remove `.venv` without following it into the cache.
+            uv_fs::remove_symlink(&path).map_err(|err| VenvError::Creation(err.into()))?;
+            on_existing
+        }
+        _ => on_existing,
     };
 
     // Create the virtual environment.
@@ -355,30 +375,36 @@ pub(crate) async fn venv(
         DefaultInstallLogger.on_complete(&changelog, printer, DryRun::Disabled)?;
     }
 
+    // Determine the appropriate environment path.
+    let scripts = if let Some(workspace) = centralized_workspace
+        && update_project_environment_link(&venv, workspace, LinkErrorReporting::User)
+        && let Ok(suffix) = venv.scripts().strip_prefix(&path)
+    {
+        workspace.install_path().join(".venv").join(suffix)
+    } else {
+        venv.scripts().to_path_buf()
+    };
+
     // Determine the appropriate activation command.
     let activation = match Shell::from_env() {
         None => None,
-        Some(Shell::Bash | Shell::Zsh | Shell::Ksh) => Some(format!(
-            "source {}",
-            shlex_posix(venv.scripts().join("activate"))
-        )),
+        Some(Shell::Bash | Shell::Zsh | Shell::Ksh) => {
+            Some(format!("source {}", shlex_posix(scripts.join("activate"))))
+        }
         Some(Shell::Fish) => Some(format!(
             "source {}",
-            shlex_posix(venv.scripts().join("activate.fish"))
+            shlex_posix(scripts.join("activate.fish"))
         )),
         Some(Shell::Nushell) => Some(format!(
             "overlay use {}",
-            shlex_posix(venv.scripts().join("activate.nu"))
+            shlex_posix(scripts.join("activate.nu"))
         )),
         Some(Shell::Csh) => Some(format!(
             "source {}",
-            shlex_posix(venv.scripts().join("activate.csh"))
+            shlex_posix(scripts.join("activate.csh"))
         )),
-        Some(Shell::Powershell) => Some(shlex_windows(
-            venv.scripts().join("activate"),
-            Shell::Powershell,
-        )),
-        Some(Shell::Cmd) => Some(shlex_windows(venv.scripts().join("activate"), Shell::Cmd)),
+        Some(Shell::Powershell) => Some(shlex_windows(scripts.join("activate"), Shell::Powershell)),
+        Some(Shell::Cmd) => Some(shlex_windows(scripts.join("activate"), Shell::Cmd)),
     };
     if let Some(act) = activation {
         writeln!(printer.stderr(), "Activate with: {}", act.green())?;

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -75,15 +75,13 @@ fn create_venv() {
 }
 
 #[test]
-fn create_venv_centralized_project_envs_warning() -> Result<()> {
+fn create_centralized_project_environment_bypasses() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.12"]);
 
-    // The feature is project-scoped, so it does not warn outside a project.
+    // Centralized environments are only enabled for projects.
     uv_snapshot!(context.filters(), context.venv()
         .arg("--preview-features")
-        .arg("centralized-project-envs")
-        .arg("--python")
-        .arg("3.12"), @"
+        .arg("centralized-project-envs"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -94,6 +92,8 @@ fn create_venv_centralized_project_envs_warning() -> Result<()> {
     Activate with: source .venv/[BIN]/activate
     "
     );
+    context.venv.assert(predicates::path::is_dir());
+    assert!(fs_err::read_link(context.venv.path()).is_err());
 
     fs_err::remove_dir_all(&context.venv)?;
     context
@@ -105,29 +105,11 @@ fn create_venv_centralized_project_envs_warning() -> Result<()> {
         version = "0.1.0"
     "#})?;
 
-    uv_snapshot!(context.filters(), context.venv()
-        .arg("--preview-features")
-        .arg("centralized-project-envs")
-        .arg("--python")
-        .arg("3.12"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    warning: The `centralized-project-envs` preview feature currently has no effect on `uv venv`
-    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtual environment at: .venv
-    Activate with: source .venv/[BIN]/activate
-    "
-    );
-
+    // Explicit project environment paths are not centralized.
     uv_snapshot!(context.filters(), context.venv()
         .env(EnvVars::UV_PROJECT_ENVIRONMENT, "explicit")
         .arg("--preview-features")
-        .arg("centralized-project-envs")
-        .arg("--python")
-        .arg("3.12"), @"
+        .arg("centralized-project-envs"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -138,7 +120,23 @@ fn create_venv_centralized_project_envs_warning() -> Result<()> {
     Activate with: source explicit/[BIN]/activate
     "
     );
+    let explicit = context.temp_dir.child("explicit");
+    explicit.assert(predicates::path::is_dir());
+    assert!(fs_err::read_link(explicit.path()).is_err());
 
+    // Pathless invocations outside the project root are not centralized.
+    let child = context.temp_dir.child("child");
+    child.create_dir_all()?;
+    context
+        .venv()
+        .current_dir(child.path())
+        .arg("--preview-features")
+        .arg("centralized-project-envs")
+        .assert()
+        .success();
+    let environment = child.child(".venv");
+    environment.assert(predicates::path::is_dir());
+    assert!(fs_err::read_link(environment.path()).is_err());
     Ok(())
 }
 
@@ -329,6 +327,273 @@ async fn create_venv_project_environment_lock() -> Result<()> {
         .child("foo")
         .assert(predicates::path::is_dir());
 
+    Ok(())
+}
+
+#[test]
+fn create_centralized_project_environment() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.12"])
+        .with_filtered_centralized_environment_hashes();
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    // Explicit paths remain local; expose one through a directory link.
+    let external = context.temp_dir.child("external");
+    context
+        .venv()
+        .arg(external.path())
+        .arg("--preview-features")
+        .arg("centralized-project-envs")
+        .assert()
+        .success();
+    external.child("marker").touch()?;
+    uv_fs::create_symlink(external.path(), context.temp_dir.child(".venv").path())?;
+
+    // Migrate to centralized storage without removing the linked environment.
+    uv_snapshot!(context.filters(), context.venv()
+        .arg("--preview-features")
+        .arg("centralized-project-envs"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment `project-cp3.12.[X]-[HASH]`
+    Activate with: source .venv/[BIN]/activate
+    "#);
+
+    let target = fs_err::read_link(context.temp_dir.child(".venv").path())?;
+    assert_eq!(
+        target.parent(),
+        Some(context.cache_dir.child("environments-v2").path())
+    );
+    assert!(target.join("pyvenv.cfg").is_file());
+    assert!(external.child("marker").is_file());
+
+    let marker = context.temp_dir.child(".venv").child("marker");
+    marker.touch()?;
+
+    // `--allow-existing` preserves the contents of the centralized environment.
+    context
+        .venv()
+        .arg("--allow-existing")
+        .arg("--preview-features")
+        .arg("centralized-project-envs")
+        .assert()
+        .success();
+    assert_eq!(
+        target,
+        fs_err::read_link(context.temp_dir.child(".venv").path())?
+    );
+    assert!(marker.exists());
+
+    // Preserve an existing centralized environment with `--no-clear`.
+    uv_snapshot!(context.filters(), context.venv()
+        .arg("--no-clear")
+        .arg("--preview-features")
+        .arg("centralized-project-envs"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment `project-cp3.12.[X]-[HASH]`
+    error: Failed to create virtual environment
+      Caused by: A virtual environment already exists at: [CACHE_DIR]/environments-v2/project-cp3.12.[X]-[HASH]
+
+    hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
+    "#);
+
+    assert_eq!(
+        target,
+        fs_err::read_link(context.temp_dir.child(".venv").path())?
+    );
+    assert!(marker.exists());
+
+    let environment = context.temp_dir.child(".venv");
+    let cache_marker = target.join("marker");
+    assert!(cache_marker.is_file());
+
+    // Without the preview, `--allow-existing` operates on the environment through the link.
+    context.venv().arg("--allow-existing").assert().success();
+    assert_eq!(target, fs_err::read_link(environment.path())?);
+    assert!(cache_marker.is_file());
+
+    // Without the preview, `.venv` is replaced locally without clearing its cached target.
+    context.venv().assert().success();
+
+    assert!(fs_err::read_link(environment.path()).is_err());
+    assert!(cache_marker.is_file());
+    let local_marker = environment.child("local-marker");
+    local_marker.touch()?;
+
+    // With the preview, `--allow-existing` operates on the cached environment.
+    context
+        .venv()
+        .arg("--allow-existing")
+        .arg("--preview-features")
+        .arg("centralized-project-envs")
+        .assert()
+        .success();
+
+    assert_eq!(target, fs_err::read_link(environment.path())?);
+    assert!(!local_marker.exists());
+    assert!(cache_marker.is_file());
+
+    // A plain invocation recreates the centralized environment without prompting.
+    uv_snapshot!(context.filters(), context.venv()
+        .arg("--preview-features")
+        .arg("centralized-project-envs"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment `project-cp3.12.[X]-[HASH]`
+    Activate with: source .venv/[BIN]/activate
+    "#);
+
+    assert_eq!(target, fs_err::read_link(environment.path())?);
+    assert!(!cache_marker.exists());
+    Ok(())
+}
+
+#[test]
+fn create_centralized_project_environment_link_failure() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.12"])
+        .with_filtered_centralized_environment_hashes()
+        .with_filter((
+            r"(?m)^(warning: Failed to create link to project environment at `[^`]+`): .*$",
+            "$1: [ERR]",
+        ));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+    let environment = context.temp_dir.child(".venv");
+    environment.create_dir_all()?;
+    environment.child("keep").touch()?;
+
+    uv_snapshot!(context.filters(), context.venv()
+        .arg("--preview-features")
+        .arg("centralized-project-envs"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment `project-cp3.12.[X]-[HASH]`
+    warning: Failed to create link to project environment at `.venv`: [ERR]
+    Activate with: source [CACHE_DIR]/environments-v2/project-cp3.12.[X]-[HASH]/[BIN]/activate
+    "#);
+
+    assert!(environment.child("keep").is_file());
+    Ok(())
+}
+
+#[test]
+fn create_centralized_project_environment_no_cache() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.venv()
+        .arg("--no-cache")
+        .arg("--preview-features")
+        .arg("centralized-project-envs"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: The `centralized-project-envs` feature has no effect when `--no-cache` is enabled
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    Activate with: source .venv/[BIN]/activate
+    "#);
+
+    assert!(context.temp_dir.child(".venv").is_dir());
+    assert!(fs_err::read_link(context.temp_dir.child(".venv").path()).is_err());
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn create_centralized_project_environment_with_seed_packages() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.12"])
+        .with_filtered_centralized_environment_hashes();
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.venv()
+        .arg("--seed")
+        .arg("--preview-features")
+        .arg("centralized-project-envs"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment `project-cp3.12.[X]-[HASH]` with seed packages
+     + pip==24.0
+    Activate with: source .venv/[BIN]/activate
+    "#);
+
+    let target = fs_err::read_link(context.temp_dir.child(".venv").path())?;
+    assert!(target.join("pyvenv.cfg").is_file());
+
+    // Seed the existing environment without clearing its contents.
+    let marker = target.join("marker");
+    fs_err::write(&marker, "")?;
+    context
+        .venv()
+        .arg("--seed")
+        .arg("--allow-existing")
+        .arg("--preview-features")
+        .arg("centralized-project-envs")
+        .assert()
+        .success();
+
+    assert_eq!(
+        target,
+        fs_err::read_link(context.temp_dir.child(".venv").path())?
+    );
+    assert!(marker.is_file());
     Ok(())
 }
 

--- a/docs/concepts/projects/layout.md
+++ b/docs/concepts/projects/layout.md
@@ -69,6 +69,8 @@ discover it. Switching interpreters selects separate cached environments and can
 Explicit project environment paths, including `UV_PROJECT_ENVIRONMENT` and environments selected
 with `--active`, are not centralized. The feature has no effect when `--no-cache` is enabled.
 
+The feature also applies to pathless `uv venv` invocations from a project or workspace root.
+
 ## The lockfile
 
 uv creates a `uv.lock` file next to the `pyproject.toml`.


### PR DESCRIPTION
## Summary

With the centralised project environments preview feature enabled, `uv venv` invoked with no path and `UV_PROJECT_ENVIRONMENT` unset  will now use the environment cache bucket as the backing store for the environment. The key selection logic is the same as for centralised project environments. 

There's are some cases of note:

* With the feature enabled:
  * Unless you explicitly pass `--no-clear`, existing environments will be clobbered without prompting
  * If you pass `--allow-existing` this will avoid clearing the _centralised_ environment, before re-using it, but will still clobber local environments when creating the link. This might sound weird, but the alternatives are:
    * Disable the feature if `.venv` exists, but if `.venv` doesn't exist, instead operate on any "existing" environment in the cache (this gets more confusing the more you think about it)
    * Don't touch `.venv` if it exists, but otherwise operate on any "existing" environment in the cache
    * Complain if `.venv` exists but is not referencing the cache (somewhat sane sounding... except also somewhat heavy and still weird)
* With the feature disabled:
  * Whenever we would normally clear an environment, if it's a link to the cache, we just delete the link (we would normally clear the target of the link). I consider this not to be breaking because a `.venv` that is a link into the cache should never have been a thing prior to the feature.
  * The user is not prompted to remove links to the cache.

See also #18214.

## Test Plan

A range of new tests covering a variety of normal and corner cases.