### PR TITLE
fix: fix relock failure with exclude-newer and multiple indexes

### DIFF
--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -317,11 +317,38 @@ impl CandidateSelector {
                 }
             }
 
-            // Check for a remote distribution that matches the preferred version
-            if let Some((version_map, file)) = version_maps
-                .iter()
-                .find_map(|version_map| version_map.get(version).map(|dist| (version_map, dist)))
-            {
+            // Find the preferred version on a remote index. The same version may be
+            // available from several indexes (e.g. with `unsafe-best-match`); prefer
+            // one whose distribution isn't filtered by `exclude-newer`, but fall back
+            // to the first match so an otherwise-unsatisfiable preference is still
+            // surfaced (e.g. in the resolver error).
+            let mut fallback = None;
+            let mut preferred = None;
+            for version_map in version_maps {
+                let Some(dist) = version_map.get(version) else {
+                    continue;
+                };
+                if fallback.is_none() {
+                    fallback = Some((version_map, dist));
+                }
+                let exclude_newer_incompatible = matches!(
+                    Candidate::new(package_name, version, dist, VersionChoiceKind::Preference)
+                        .dist(),
+                    CandidateDist::Incompatible {
+                        incompatible_dist: IncompatibleDist::Source(
+                            IncompatibleSource::ExcludeNewer(_)
+                        ) | IncompatibleDist::Wheel(
+                            IncompatibleWheel::ExcludeNewer(_)
+                        ),
+                        ..
+                    }
+                );
+                if !exclude_newer_incompatible {
+                    preferred = Some((version_map, dist));
+                    break;
+                }
+            }
+            if let Some((version_map, file)) = preferred.or(fallback) {
                 // If the preferred version has a local variant, prefer that.
                 if version_map.local() {
                     for local in version_map

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -20747,6 +20747,75 @@ fn lock_default_index() -> Result<()> {
     Ok(())
 }
 
+/// Re-locking must not fail when a preferred (locked) version is available on
+/// multiple indexes and the higher-priority index's distribution is filtered by
+/// `exclude-newer`.
+///
+/// `jinja2==3.1.3` exists on both the PyTorch mirror and PyPI. Under the test
+/// harness's default `exclude-newer` of `2024-03-25`, PyPI's wheel (uploaded
+/// 2024-01) is kept, but the mirror's copy (whose wheels are all stamped
+/// `2025-01-29`) is filtered out. The initial lock resolves `jinja2` from PyPI and
+/// records it as a preference; re-locking feeds that version back, and the
+/// preferred-version selection must skip the filtered mirror entry and fall back
+/// to PyPI rather than failing with "was published after the exclude newer time".
+#[test]
+fn lock_preference_exclude_newer_across_indexes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["jinja2==3.1.3"]
+
+        [tool.uv]
+        index-strategy = "unsafe-best-match"
+
+        [[tool.uv.index]]
+        name = "pytorch"
+        url = "https://astral-sh.github.io/pytorch-mirror/whl/cu121"
+        "#,
+    )?;
+
+    // The initial lock succeeds, pinning `jinja2` to PyPI's copy and seeding it as
+    // a preference for subsequent resolutions.
+    context.lock().assert().success();
+
+    // Introduce an unrelated dependency to force a re-resolution that carries the
+    // locked `jinja2==3.1.3` forward as a preference.
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["jinja2==3.1.3", "iniconfig"]
+
+        [tool.uv]
+        index-strategy = "unsafe-best-match"
+
+        [[tool.uv.index]]
+        name = "pytorch"
+        url = "https://astral-sh.github.io/pytorch-mirror/whl/cu121"
+        "#,
+    )?;
+
+    // Re-locking previously failed because the preferred `jinja2==3.1.3` bound to
+    // the exclude-newer-filtered mirror entry; it must now fall back to PyPI.
+    context.lock().assert().success();
+
+    let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock"))?;
+    assert!(
+        !lock.contains("download.pytorch.org"),
+        "jinja2 should resolve from PyPI, not the exclude-newer-filtered mirror:\n{lock}"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn lock_named_index_cli() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");


### PR DESCRIPTION
## Summary

Fix relocking with `exclude-newer` when the same locked version exists on multiple indexes.

The issue shows up with `index-strategy = "unsafe-best-match"`. A locked version can exist on both the PyTorch index and PyPI. If the copy from the higher-priority index is filtered by `exclude-newer`, relocking could fail with something like:

```text
Because jinja2==3.1.3 was published after the exclude newer time … unsatisfiable
```

The problem was in the preference path. Locked versions are fed back into the resolver as preferences, and `get_preferred` picked the first distribution for that version without checking whether it was actually usable. So it could bind to a filtered file from the PyTorch index and stop there, instead of falling back to the valid PyPI copy.

A fresh resolve already handled this correctly because `select_candidate` skips incompatible candidates. This makes the preference path do the same.

## Test Plan

Reproduced with:

```toml
[project]
name = "project"
version = "0.1.0"
requires-python = ">=3.12"
dependencies = ["jinja2==3.1.3"]

[tool.uv]
exclude-newer = "2024-03-25T00:00:00Z"
index-strategy = "unsafe-best-match"

[[tool.uv.index]]
name = "pytorch"
url = "https://astral-sh.github.io/pytorch-mirror/whl/cu121"
```

`uv lock` succeeds. Then after adding another dependency:

```toml
dependencies = ["jinja2==3.1.3", "iniconfig"]
```

relocking fails on `main`.

Covered by `lock_preference_exclude_newer_across_indexes` in `crates/uv/tests/lock/lock.rs`.