### PR TITLE
Prototype: version-aware, file-sourced denylist

### DIFF
--- a/crates/uv-configuration/src/excludes.rs
+++ b/crates/uv-configuration/src/excludes.rs
@@ -1,20 +1,63 @@
-use rustc_hash::FxHashSet;
+use rustc_hash::FxHashMap;
 
 use uv_normalize::PackageName;
+use uv_pep440::{Version, VersionSpecifiers};
+use uv_pep508::Requirement;
 
-/// A set of packages to exclude from resolution.
+
 #[derive(Debug, Default, Clone)]
-pub struct Excludes(FxHashSet<PackageName>);
+pub struct Excludes(FxHashMap<PackageName, VersionSpecifiers>);
 
 impl Excludes {
-    /// Check if a package is excluded.
+
     pub fn contains(&self, name: &PackageName) -> bool {
-        self.0.contains(name)
+        matches!(self.0.get(name), Some(specifiers) if specifiers.is_empty())
+    }
+
+    pub fn is_excluded(&self, name: &PackageName, version: &Version) -> bool {
+        match self.0.get(name) {
+            // Name is excluded for all versions.
+            Some(specifiers) if specifiers.is_empty() => true,
+            // Name is excluded only for matching versions.
+            Some(specifiers) => specifiers.contains(version),
+            None => false,
+        }
+    }
+
+    pub fn names(&self) -> impl Iterator<Item = &PackageName> {
+        self.0.keys()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 
+/// Build name-only exclusions (every version excluded). Preserves the legacy behavior of
+/// `tool.uv.exclude-dependencies = ["werkzeug"]`.
 impl FromIterator<PackageName> for Excludes {
     fn from_iter<I: IntoIterator<Item = PackageName>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+        Self(
+            iter.into_iter()
+                .map(|name| (name, VersionSpecifiers::empty()))
+                .collect(),
+        )
+    }
+}
+
+impl<T: uv_pep508::Pep508Url> FromIterator<Requirement<T>> for Excludes {
+    fn from_iter<I: IntoIterator<Item = Requirement<T>>>(iter: I) -> Self {
+        let mut map: FxHashMap<PackageName, VersionSpecifiers> = FxHashMap::default();
+        for requirement in iter {
+            let specifiers = match requirement.version_or_url {
+                Some(uv_pep508::VersionOrUrl::VersionSpecifier(specifiers)) => specifiers,
+                // A URL or bare name excludes every version.
+                _ => VersionSpecifiers::empty(),
+            };
+            // PROTOTYPE: duplicate entries for the same name simply overwrite. A real
+            // implementation should union the specifier sets.
+            map.insert(requirement.name, specifiers);
+        }
+        Self(map)
     }
 }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -511,6 +511,31 @@ pub struct ToolUv {
     )]
     pub(crate) exclude_dependencies: Option<Vec<PackageName>>,
 
+    /// PROTOTYPE: a constraints-style file whose entries describe version-aware exclusions.
+    ///
+    /// Each line uses the standard requirements.txt syntax (`requests<2.31`, `numpy==1.24.0`,
+    /// `left-pad`); matching versions are silently dropped during resolution. A bare name
+    /// excludes every version, identical to listing it in `exclude-dependencies`.
+    ///
+    /// This lets a project source a large, externally-generated deny-list from a standalone
+    /// file instead of inlining every entry here. The path is resolved relative to the
+    /// workspace-root `pyproject.toml`.
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(
+            with = "Option<String>",
+            description = "Path to a constraints-style file of version-aware exclusions."
+        )
+    )]
+    #[option(
+        default = "null",
+        value_type = "str",
+        example = r#"
+            exclude-dependencies-file = "banned.txt"
+        "#
+    )]
+    pub(crate) exclude_dependencies_file: Option<std::path::PathBuf>,
+
     /// Constraints to apply when resolving the project's dependencies.
     ///
     /// Constraints are used to restrict the versions of dependencies that are selected during

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -785,6 +785,14 @@ impl Workspace {
         };
         excludes.clone()
     }
+    pub fn exclude_dependencies_file(&self) -> Option<std::path::PathBuf> {
+        self.pyproject_toml
+            .tool
+            .as_ref()
+            .and_then(|tool| tool.uv.as_ref())
+            .and_then(|uv| uv.exclude_dependencies_file.as_ref())
+            .map(|path| self.install_path.join(path))
+    }
 
     /// Returns the set of constraints for the workspace.
     pub fn constraints(&self) -> Vec<uv_pep508::Requirement<VerbatimParsedUrl>> {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use owo_colors::OwoColorize;
@@ -26,7 +27,7 @@ use uv_git_types::GitOid;
 use uv_normalize::{GroupName, PackageName};
 use uv_pep440::Version;
 use uv_preview::{Preview, PreviewFeature};
-use uv_pypi_types::{ConflictKind, Conflicts, SupportedEnvironments};
+use uv_pypi_types::{ConflictKind, Conflicts, SupportedEnvironments, VerbatimParsedUrl};
 use uv_python::{Interpreter, PythonDownloads, PythonEnvironment, PythonPreference, PythonRequest};
 use uv_requirements::{ExtrasResolver, LockedRequirements, read_lock_requirements};
 use uv_resolver::{
@@ -515,6 +516,23 @@ async fn do_lock(
     let requirements = target.requirements();
     let overrides = target.overrides();
     let excludes = target.exclude_dependencies();
+
+    let file_excludes: uv_configuration::Excludes = match target.exclude_dependencies_file() {
+        Some(path) => {
+            let contents = fs_err::read_to_string(&path)?;
+            let requirements = contents
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                .map(uv_pep508::Requirement::<VerbatimParsedUrl>::from_str)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| ProjectError::Anyhow(anyhow::anyhow!(err)))?;
+            requirements.into_iter().collect()
+        }
+        None => excludes.iter().cloned().collect(),
+    };
+    let _ = &file_excludes; // TODO: thread `file_excludes` into the resolver in place of `excludes`.
+
     let constraints = target.constraints();
     let build_constraints = target.build_constraints();
     let dependency_groups = target.dependency_groups()?;

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -79,6 +79,13 @@ impl<'lock> LockTarget<'lock> {
                 .collect(),
         }
     }
+    
+    pub(crate) fn exclude_dependencies_file(self) -> Option<std::path::PathBuf> {
+        match self {
+            Self::Workspace(workspace) => workspace.exclude_dependencies_file(),
+            Self::Script(_) => None,
+        }
+    }
 
     /// Returns the set of constraints for the [`LockTarget`].
     pub(crate) fn constraints(self) -> Vec<uv_pep508::Requirement<VerbatimParsedUrl>> {


### PR DESCRIPTION
## Summary

This is only a draft/prototype to supplement discussion in #19932 

The purpose of this is to add a denylist that isn't inlined, but based off a file in the workspace (perhaps globally). This solves the enterprise problem of a python index being a proxy, and the real index being in CI.

## Test Plan

It's not! It's a really rough prototype to assist decision making.
