### PR TITLE
Allow disabling `exclude-newer`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -29,7 +29,7 @@ use uv_pypi_types::VerbatimParsedUrl;
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_redacted::DisplaySafeUrl;
 use uv_resolver::{
-    AnnotationStyle, ExcludeNewerPackageEntry, ExcludeNewerValue, ForkStrategy, PrereleaseMode,
+    AnnotationStyle, ExcludeNewerOverride, ExcludeNewerPackageEntry, ForkStrategy, PrereleaseMode,
     ResolutionMode,
 };
 use uv_settings::PythonInstallMirrors;
@@ -3284,8 +3284,10 @@ pub struct VenvArgs {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Use `false` to disable `exclude-newer`.
     #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER)]
-    pub exclude_newer: Option<ExcludeNewerValue>,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
 
     /// Limit candidate packages for a specific package to those that were uploaded prior to the
     /// given date.
@@ -5205,8 +5207,10 @@ pub struct FormatArgs {
     /// Accepts a superset of [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339.html) (e.g.,
     /// `2006-12-02T02:07:43Z`) or local date in the same format (e.g. `2006-12-02`), as well as
     /// durations relative to "now" (e.g., `-1 week`).
+    ///
+    /// Use `false` to disable `exclude-newer`.
     #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER)]
-    pub exclude_newer: Option<ExcludeNewerValue>,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
 
     /// Additional arguments to pass to Ruff.
     ///
@@ -6110,8 +6114,10 @@ pub struct ToolListArgs {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Use `false` to disable `exclude-newer`.
     #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    pub exclude_newer: Option<ExcludeNewerValue>,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
 
     // Hide unused global Python options.
     #[arg(long, hide = true)]
@@ -6373,8 +6379,10 @@ pub struct ToolUpgradeArgs {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Use `false` to disable `exclude-newer`.
     #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    pub exclude_newer: Option<ExcludeNewerValue>,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
 
     /// Limit candidate packages for specific packages to those that were uploaded prior to the
     /// given date.
@@ -7444,8 +7452,10 @@ pub struct InstallerArgs {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Use `false` to disable `exclude-newer`.
     #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    exclude_newer: Option<ExcludeNewerValue>,
+    exclude_newer: Option<ExcludeNewerOverride>,
 
     /// Limit candidate packages for specific packages to those that were uploaded prior to the
     /// given date.
@@ -7691,8 +7701,10 @@ pub struct ResolverArgs {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Use `false` to disable `exclude-newer`.
     #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    exclude_newer: Option<ExcludeNewerValue>,
+    exclude_newer: Option<ExcludeNewerOverride>,
 
     /// Limit candidate packages for specific packages to those that were uploaded prior to the
     /// given date.
@@ -7936,13 +7948,15 @@ pub struct ResolverInstallerArgs {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Use `false` to disable `exclude-newer`.
     #[arg(
         long,
         env = EnvVars::UV_EXCLUDE_NEWER,
         help_heading = "Resolver options",
         value_hint = ValueHint::Other,
     )]
-    pub exclude_newer: Option<ExcludeNewerValue>,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
 
     /// Limit candidate packages for specific packages to those that were uploaded prior to the
     /// given date.
@@ -8071,8 +8085,10 @@ pub struct FetchArgs {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Use `false` to disable `exclude-newer`.
     #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    exclude_newer: Option<ExcludeNewerValue>,
+    exclude_newer: Option<ExcludeNewerOverride>,
 }
 
 #[derive(Args)]

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -5,7 +5,7 @@ use anstream::eprintln;
 use uv_cache::Refresh;
 use uv_configuration::{BuildIsolation, Reinstall, Upgrade};
 use uv_distribution_types::{ConfigSettings, Index, PackageConfigSettings, Requirement};
-use uv_resolver::{ExcludeNewer, ExcludeNewerPackage, PrereleaseMode};
+use uv_resolver::{ExcludeNewerPackage, PrereleaseMode};
 use uv_settings::{Combine, EnvFlag, PipOptions, ResolverInstallerOptions, ResolverOptions};
 use uv_warnings::owo_colors::OwoColorize;
 
@@ -584,10 +584,8 @@ pub fn resolver_options(
         ),
         extra_build_dependencies: None,
         extra_build_variables: None,
-        exclude_newer: ExcludeNewer::from_args(
-            exclude_newer,
-            exclude_newer_package.unwrap_or_default(),
-        ),
+        exclude_newer,
+        exclude_newer_package: exclude_newer_package.map(ExcludeNewerPackage::from_iter),
         link_mode,
         torch_backend: None,
         no_build: flag(no_build, build, "build"),

--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -380,7 +380,7 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerOverride {
             {
                 ExcludeNewerValue::from_str(v)
                     .map(ExcludeNewerOverride::from)
-                    .map_err(|e| E::custom(format!("failed to parse exclude-newer value: {e}")))
+                    .map_err(E::custom)
             }
 
             fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>

--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -309,6 +309,34 @@ pub enum ExcludeNewerOverride {
     Enabled(Box<ExcludeNewerValue>),
 }
 
+impl ExcludeNewerOverride {
+    /// Return the configured cutoff, or `None` if `exclude-newer` is disabled.
+    pub fn into_value(self) -> Option<ExcludeNewerValue> {
+        match self {
+            Self::Disabled => None,
+            Self::Enabled(value) => Some(*value),
+        }
+    }
+}
+
+impl From<ExcludeNewerValue> for ExcludeNewerOverride {
+    fn from(value: ExcludeNewerValue) -> Self {
+        Self::Enabled(Box::new(value))
+    }
+}
+
+impl FromStr for ExcludeNewerOverride {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if input == "false" {
+            Ok(Self::Disabled)
+        } else {
+            ExcludeNewerValue::from_str(input).map(Self::from)
+        }
+    }
+}
+
 #[cfg(feature = "schemars")]
 impl schemars::JsonSchema for ExcludeNewerOverride {
     fn schema_name() -> Cow<'static, str> {
@@ -351,7 +379,7 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerOverride {
                 E: serde::de::Error,
             {
                 ExcludeNewerValue::from_str(v)
-                    .map(|ts| ExcludeNewerOverride::Enabled(Box::new(ts)))
+                    .map(ExcludeNewerOverride::from)
                     .map_err(|e| E::custom(format!("failed to parse exclude-newer value: {e}")))
             }
 

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -433,9 +433,10 @@ impl ExcludeNewer {
 
     /// Create from CLI arguments.
     pub fn from_args(
-        global: Option<ExcludeNewerValue>,
+        global: Option<ExcludeNewerOverride>,
         package: Vec<ExcludeNewerPackageEntry>,
     ) -> Self {
+        let global = global.and_then(ExcludeNewerOverride::into_value);
         let package: ExcludeNewerPackage = package.into_iter().collect();
 
         Self { global, package }

--- a/crates/uv-settings/src/combine.rs
+++ b/crates/uv-settings/src/combine.rs
@@ -16,8 +16,8 @@ use uv_pypi_types::{SchemaConflicts, SupportedEnvironments};
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_redacted::DisplaySafeUrl;
 use uv_resolver::{
-    AnnotationStyle, ExcludeNewer, ExcludeNewerPackage, ExcludeNewerValue, ForkStrategy,
-    PrereleaseMode, ResolutionMode,
+    AnnotationStyle, ExcludeNewer, ExcludeNewerOverride, ExcludeNewerPackage, ExcludeNewerValue,
+    ForkStrategy, PrereleaseMode, ResolutionMode,
 };
 use uv_torch::TorchMode;
 use uv_workspace::pyproject::ExtraBuildDependencies;
@@ -94,6 +94,7 @@ macro_rules! impl_combine_or {
 impl_combine_or!(AddBoundsKind);
 impl_combine_or!(AnnotationStyle);
 impl_combine_or!(ExcludeNewer);
+impl_combine_or!(ExcludeNewerOverride);
 impl_combine_or!(ExcludeNewerValue);
 impl_combine_or!(ExportFormat);
 impl_combine_or!(ForkStrategy);

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -22,8 +22,9 @@ use uv_pypi_types::{SupportedEnvironments, VerbatimParsedUrl};
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_redacted::DisplaySafeUrl;
 use uv_resolver::{
-    AnnotationStyle, ExcludeNewer, ExcludeNewerPackage, ExcludeNewerSpan, ExcludeNewerValue,
-    ForkStrategy, PrereleaseMode, ResolutionMode, serialize_exclude_newer_package_with_spans,
+    AnnotationStyle, ExcludeNewerOverride, ExcludeNewerPackage, ExcludeNewerSpan,
+    ExcludeNewerValue, ForkStrategy, PrereleaseMode, ResolutionMode,
+    serialize_exclude_newer_package_with_spans,
 };
 use uv_torch::TorchMode;
 use uv_workspace::pyproject::ExtraBuildDependencies;
@@ -518,7 +519,7 @@ pub struct InstallerOptions {
     index_strategy: Option<IndexStrategy>,
     keyring_provider: Option<KeyringProviderType>,
     config_settings: Option<ConfigSettings>,
-    exclude_newer: Option<ExcludeNewerValue>,
+    exclude_newer: Option<ExcludeNewerOverride>,
     link_mode: Option<LinkMode>,
     compile_bytecode: Option<bool>,
     reinstall: Option<Reinstall>,
@@ -547,7 +548,8 @@ pub struct ResolverOptions {
     pub dependency_metadata: Option<Vec<StaticMetadata>>,
     pub config_settings: Option<ConfigSettings>,
     pub config_settings_package: Option<PackageConfigSettings>,
-    pub exclude_newer: ExcludeNewer,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
+    pub exclude_newer_package: Option<ExcludeNewerPackage>,
     pub link_mode: Option<LinkMode>,
     pub torch_backend: Option<TorchMode>,
     pub upgrade: Option<Upgrade>,
@@ -582,7 +584,7 @@ pub struct ResolverInstallerOptions {
     pub build_isolation: Option<BuildIsolation>,
     pub extra_build_dependencies: Option<ExtraBuildDependencies>,
     pub extra_build_variables: Option<ExtraBuildVariables>,
-    pub exclude_newer: Option<ExcludeNewerValue>,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
     pub exclude_newer_package: Option<ExcludeNewerPackage>,
     pub link_mode: Option<LinkMode>,
     pub torch_backend: Option<TorchMode>,
@@ -1003,14 +1005,16 @@ pub struct ResolverInstallerSchema {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Set to `false` to disable `exclude-newer`.
     #[option(
         default = "None",
-        value_type = "str",
+        value_type = "str | false",
         example = r#"
             exclude-newer = "2006-12-02T02:07:43Z"
         "#
     )]
-    pub exclude_newer: Option<ExcludeNewerValue>,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
     /// Limit candidate packages for specific packages to those that were uploaded prior to the
     /// given date.
     ///
@@ -1815,14 +1819,16 @@ pub struct PipOptions {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Set to `false` to disable `exclude-newer`.
     #[option(
         default = "None",
-        value_type = "str",
+        value_type = "str | false",
         example = r#"
             exclude-newer = "2006-12-02T02:07:43Z"
         "#
     )]
-    pub exclude_newer: Option<ExcludeNewerValue>,
+    pub exclude_newer: Option<ExcludeNewerOverride>,
     /// Limit candidate packages for specific packages to those that were uploaded prior to the given date.
     ///
     /// Accepts a dictionary format of `PACKAGE = "DATE"` pairs, where `DATE` is an RFC 3339
@@ -2124,15 +2130,8 @@ impl From<ResolverInstallerSchema> for ResolverOptions {
             dependency_metadata: value.dependency_metadata,
             config_settings: value.config_settings,
             config_settings_package: value.config_settings_package,
-            exclude_newer: ExcludeNewer::from_args(
-                value.exclude_newer,
-                value
-                    .exclude_newer_package
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
-            ),
+            exclude_newer: value.exclude_newer,
+            exclude_newer_package: value.exclude_newer_package,
             link_mode: value.link_mode,
             upgrade: Upgrade::from_args(
                 value.upgrade,
@@ -2172,16 +2171,7 @@ impl From<ResolverInstallerSchema> for InstallerOptions {
             index_strategy: value.index_strategy,
             keyring_provider: value.keyring_provider,
             config_settings: value.config_settings,
-            exclude_newer: ExcludeNewer::from_args(
-                value.exclude_newer,
-                value
-                    .exclude_newer_package
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
-            )
-            .global,
+            exclude_newer: value.exclude_newer,
             link_mode: value.link_mode,
             compile_bytecode: value.compile_bytecode,
             reinstall: Reinstall::from_args(
@@ -2228,7 +2218,7 @@ pub struct ToolOptions {
     build_isolation: Option<BuildIsolation>,
     extra_build_dependencies: Option<ExtraBuildDependencies>,
     extra_build_variables: Option<ExtraBuildVariables>,
-    exclude_newer: Option<ExcludeNewerValue>,
+    exclude_newer: Option<ExcludeNewerOverride>,
     exclude_newer_package: Option<ExcludeNewerPackage>,
     link_mode: Option<LinkMode>,
     compile_bytecode: Option<bool>,
@@ -2261,7 +2251,7 @@ pub struct ToolOptionsWire {
     build_isolation: Option<BuildIsolation>,
     extra_build_dependencies: Option<ExtraBuildDependencies>,
     extra_build_variables: Option<ExtraBuildVariables>,
-    exclude_newer: Option<ExcludeNewerValue>,
+    exclude_newer: Option<ExcludeNewerOverride>,
     exclude_newer_span: Option<ExcludeNewerSpan>,
     #[serde(serialize_with = "serialize_exclude_newer_package_with_spans")]
     exclude_newer_package: Option<ExcludeNewerPackage>,
@@ -2317,15 +2307,21 @@ impl From<ResolverInstallerOptions> for ToolOptions {
 
 impl From<ToolOptionsWire> for ToolOptions {
     fn from(value: ToolOptionsWire) -> Self {
-        let exclude_newer = value.exclude_newer.map(|exclude_newer| {
-            if let Some(span) = value.exclude_newer_span
-                && exclude_newer.span().is_none()
-            {
-                ExcludeNewerValue::relative(span)
-            } else {
-                exclude_newer
-            }
-        });
+        let exclude_newer = value
+            .exclude_newer
+            .map(|exclude_newer| match exclude_newer {
+                ExcludeNewerOverride::Disabled => ExcludeNewerOverride::Disabled,
+                ExcludeNewerOverride::Enabled(exclude_newer) => {
+                    let exclude_newer = *exclude_newer;
+                    if let Some(span) = value.exclude_newer_span
+                        && exclude_newer.span().is_none()
+                    {
+                        ExcludeNewerValue::relative(span).into()
+                    } else {
+                        exclude_newer.into()
+                    }
+                }
+            });
 
         Self {
             index: value.index,
@@ -2362,11 +2358,16 @@ impl From<ToolOptionsWire> for ToolOptions {
 impl From<ToolOptions> for ToolOptionsWire {
     fn from(value: ToolOptions) -> Self {
         let (exclude_newer, exclude_newer_span) = match &value.exclude_newer {
-            Some(value @ ExcludeNewerValue::Absolute(_)) => (Some(value.clone()), None),
-            Some(value @ ExcludeNewerValue::Relative(span)) => (
-                Some(ExcludeNewerValue::absolute(value.timestamp())),
-                Some(*span),
-            ),
+            Some(ExcludeNewerOverride::Disabled) => (Some(ExcludeNewerOverride::Disabled), None),
+            Some(ExcludeNewerOverride::Enabled(value)) => match value.as_ref() {
+                ExcludeNewerValue::Absolute(_) => {
+                    (Some(ExcludeNewerOverride::Enabled(value.clone())), None)
+                }
+                ExcludeNewerValue::Relative(span) => (
+                    Some(ExcludeNewerValue::absolute(value.timestamp()).into()),
+                    Some(*span),
+                ),
+            },
             None => (None, None),
         };
 
@@ -2483,7 +2484,7 @@ struct OptionsWire {
     no_build_isolation_package: Option<Vec<PackageName>>,
     extra_build_dependencies: Option<ExtraBuildDependencies>,
     extra_build_variables: Option<ExtraBuildVariables>,
-    exclude_newer: Option<ExcludeNewerValue>,
+    exclude_newer: Option<ExcludeNewerOverride>,
     exclude_newer_package: Option<ExcludeNewerPackage>,
     link_mode: Option<LinkMode>,
     compile_bytecode: Option<bool>,

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -205,7 +205,8 @@ impl EnvVars {
     pub const UV_ISOLATED: &'static str = "UV_ISOLATED";
 
     /// Equivalent to the `--exclude-newer` command-line argument. If set, uv will
-    /// exclude distributions published after the specified date.
+    /// exclude distributions published after the specified date. Set to `false` to disable
+    /// `exclude-newer`.
     #[attr_added_in("0.2.12")]
     pub const UV_EXCLUDE_NEWER: &'static str = "UV_EXCLUDE_NEWER";
 

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -52,8 +52,8 @@ use uv_pypi_types::SupportedEnvironments;
 use uv_python::{Prefix, PythonDownloads, PythonPreference, PythonVersion, Target};
 use uv_redacted::DisplaySafeUrl;
 use uv_resolver::{
-    AnnotationStyle, DependencyMode, ExcludeNewer, ExcludeNewerPackage, ForkStrategy,
-    PrereleaseMode, ResolutionMode,
+    AnnotationStyle, DependencyMode, ExcludeNewer, ExcludeNewerOverride, ExcludeNewerPackage,
+    ForkStrategy, PrereleaseMode, ResolutionMode,
 };
 use uv_settings::{
     Combine, EnvironmentOptions, FilesystemOptions, MalwareCheckSettings, Options, PipOptions,
@@ -2968,7 +2968,9 @@ impl FormatSettings {
             diff,
             extra_args,
             version,
-            exclude_newer: exclude_newer.map(|v| v.timestamp()),
+            exclude_newer: exclude_newer
+                .and_then(ExcludeNewerOverride::into_value)
+                .map(|value| value.timestamp()),
             no_project,
             show_version,
         }
@@ -4367,7 +4369,15 @@ impl From<ResolverOptions> for ResolverSettings {
             build_isolation: value.build_isolation.unwrap_or_default(),
             extra_build_dependencies: value.extra_build_dependencies.unwrap_or_default(),
             extra_build_variables: value.extra_build_variables.unwrap_or_default(),
-            exclude_newer: value.exclude_newer,
+            exclude_newer: ExcludeNewer::from_args(
+                value.exclude_newer,
+                value
+                    .exclude_newer_package
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            ),
             link_mode: value.link_mode.unwrap_or_default(),
             torch_backend: value.torch_backend,
             cuda_driver_version: None,

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -34078,6 +34078,152 @@ fn test_tilde_equals_python_version() -> Result<()> {
     Ok(())
 }
 
+/// Test that a configured exclude-newer value can be disabled via the CLI.
+#[test]
+fn lock_exclude_newer_disable_cli() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        exclude-newer = "2022-04-04T12:00:00Z"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--exclude-newer")
+        .arg("false"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        "#);
+    });
+
+    Ok(())
+}
+
+/// Test that a configured exclude-newer value can be disabled via the environment.
+#[test]
+fn lock_exclude_newer_disable_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        exclude-newer = "2022-04-04T12:00:00Z"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env(EnvVars::UV_EXCLUDE_NEWER, "false"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        "#);
+    });
+
+    Ok(())
+}
+
+/// Test that exclude-newer can be disabled in configuration.
+#[test]
+fn lock_exclude_newer_disable_config() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        exclude-newer = false
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        "#);
+    });
+
+    Ok(())
+}
+
 /// Test that exclude-newer-package can be disabled for specific packages using `false`.
 #[test]
 fn lock_exclude_newer_package_disable() -> Result<()> {

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -715,6 +715,10 @@ This option is also supported in the `pyproject.toml`, e.g.:
 exclude-newer = "2006-12-02T02:07:43Z"
 ```
 
+To disable a global cutoff from a lower-priority configuration source, pass `--exclude-newer false`,
+set `UV_EXCLUDE_NEWER=false`, or set `exclude-newer = false` in a higher-priority configuration
+file.
+
 When specified in persistent configuration, local date times are not allowed.
 
 Values may also be specified for specific packages, e.g.,

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -185,10 +185,10 @@
       }
     },
     "exclude-newer": {
-      "description": "Limit candidate packages to those that were uploaded prior to the given date.\n\nThe date is compared against the upload time of each individual distribution artifact\n(i.e., when each file was uploaded to the package index), not the release date of the\npackage version.\n\nAccepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g.,\n`24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.",
+      "description": "Limit candidate packages to those that were uploaded prior to the given date.\n\nThe date is compared against the upload time of each individual distribution artifact\n(i.e., when each file was uploaded to the package index), not the release date of the\npackage version.\n\nAccepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g.,\n`24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.\n\nSet to `false` to disable `exclude-newer`.",
       "anyOf": [
         {
-          "$ref": "#/definitions/ExcludeNewerValue"
+          "$ref": "#/definitions/ExcludeNewerOverride"
         },
         {
           "type": "null"
@@ -1278,10 +1278,10 @@
           "type": ["boolean", "null"]
         },
         "exclude-newer": {
-          "description": "Limit candidate packages to those that were uploaded prior to a given point in time.\n\nThe date is compared against the upload time of each individual distribution artifact\n(i.e., when each file was uploaded to the package index), not the release date of the\npackage version.\n\nAccepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g.,\n`24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.",
+          "description": "Limit candidate packages to those that were uploaded prior to a given point in time.\n\nThe date is compared against the upload time of each individual distribution artifact\n(i.e., when each file was uploaded to the package index), not the release date of the\npackage version.\n\nAccepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g.,\n`24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.\n\nSet to `false` to disable `exclude-newer`.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ExcludeNewerValue"
+              "$ref": "#/definitions/ExcludeNewerOverride"
             },
             {
               "type": "null"


### PR DESCRIPTION
## Summary

Prior to this change, `--exclude-newer` and `UV_EXCLUDE_NEWER` accepted only a date or duration. This meant a cutoff configured in `pyproject.toml` or `uv.toml` could be replaced with another cutoff, but could not be disabled from a higher-priority CLI or environment setting.

This treats the global setting as an explicit enabled-or-disabled override until configuration precedence has been resolved. `--exclude-newer false`, `UV_EXCLUDE_NEWER=false`, and `exclude-newer = false` now remove the global cutoff while preserving package- and index-specific overrides. Tool receipts retain the disabled state, and the configuration schema and documentation reflect the new value.

The regression coverage verifies CLI, environment, and TOML overrides and ensures the resulting lockfile omits the global `exclude-newer` option.

Closes https://github.com/astral-sh/uv/issues/19929.
