### PR TITLE
Show installed versions for `uv tool list --show-with` dependencies

### DIFF
--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -11,9 +11,11 @@ use uv_cache_info::Timestamp;
 use uv_client::{BaseClientBuilder, RegistryClientBuilder};
 use uv_configuration::Concurrency;
 use uv_distribution_filename::DistFilename;
-use uv_distribution_types::{IndexCapabilities, RequiresPython};
+use uv_distribution_types::{IndexCapabilities, InstalledDist, Requirement, RequiresPython};
 use uv_fs::Simplified;
+use uv_installer::SitePackages;
 use uv_normalize::PackageName;
+use uv_pep440::{Operator, Version};
 use uv_python::LenientImplementationName;
 use uv_settings::{Combine, ResolverInstallerOptions};
 use uv_tool::InstalledTools;
@@ -238,18 +240,24 @@ pub(crate) async fn list(
             String::new()
         };
 
-        let with_requirements = show_with
-            .then(|| {
+        let site_packages = if show_with {
+            Some(SitePackages::from_environment(tool_env.environment())?)
+        } else {
+            None
+        };
+
+        let with_requirements = site_packages
+            .as_ref()
+            .map(|site_packages| {
                 tool.requirements()
                     .iter()
                     .filter(|req| req.name != name)
+                    .map(|req| format_with_requirement(req, site_packages))
                     .peekable()
             })
             .take_if(|requirements| requirements.peek().is_some())
-            .map(|requirements| {
-                let requirements = requirements
-                    .map(|req| format!("{}{}", req.name, req.source))
-                    .join(", ");
+            .map(|mut requirements| {
+                let requirements = requirements.join(", ");
                 format!(" [with: {requirements}]")
             })
             .unwrap_or_default();
@@ -296,4 +304,39 @@ pub(crate) async fn list(
     }
 
     Ok(ExitStatus::Success)
+}
+
+fn format_with_requirement(requirement: &Requirement, site_packages: &SitePackages) -> String {
+    let source = requirement.source.to_string();
+
+    let Some(version) = site_packages
+        .get_packages(&requirement.name)
+        .into_iter()
+        .next()
+        .map(InstalledDist::version)
+    else {
+        return format!("{}{}", requirement.name, source);
+    };
+
+    if source.is_empty() || is_exact_version(requirement, version) {
+        format!("{}=={}", requirement.name, version)
+    } else {
+        format!("{}{} (installed: {})", requirement.name, source, version)
+    }
+}
+
+fn is_exact_version(requirement: &Requirement, version: &Version) -> bool {
+    let Some(specifiers) = requirement.source.version_specifiers() else {
+        return false;
+    };
+
+    let mut specifiers = specifiers.iter();
+
+    let Some(specifier) = specifiers.next() else {
+        return false;
+    };
+
+    specifiers.next().is_none()
+        && *specifier.operator() == Operator::Equal
+        && specifier.version() == version
 }

--- a/crates/uv/tests/tool/tool_list.rs
+++ b/crates/uv/tests/tool/tool_list.rs
@@ -521,7 +521,7 @@ fn tool_list_show_with() {
         .tool_install()
         .arg("ruff==0.3.4")
         .arg("--with")
-        .arg("requests")
+        .arg("requests>=2")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .assert()
@@ -537,9 +537,9 @@ fn tool_list_show_with() {
     black v24.2.0
     - black
     - blackd
-    flask v3.0.2 [with: requests, black==24.2.0]
+    flask v3.0.2 [with: requests==2.31.0, black==24.2.0]
     - flask
-    ruff v0.3.4 [with: requests]
+    ruff v0.3.4 [with: requests>=2 (installed: 2.31.0)]
     - ruff
 
     ----- stderr -----
@@ -555,9 +555,9 @@ fn tool_list_show_with() {
     black v24.2.0 ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
-    flask v3.0.2 [with: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
+    flask v3.0.2 [with: requests==2.31.0, black==24.2.0] ([TEMP_DIR]/tools/flask)
     - flask ([TEMP_DIR]/bin/flask)
-    ruff v0.3.4 [with: requests] ([TEMP_DIR]/tools/ruff)
+    ruff v0.3.4 [with: requests>=2 (installed: 2.31.0)] ([TEMP_DIR]/tools/ruff)
     - ruff ([TEMP_DIR]/bin/ruff)
 
     ----- stderr -----
@@ -573,9 +573,9 @@ fn tool_list_show_with() {
     black v24.2.0 [required: ==24.2.0]
     - black
     - blackd
-    flask v3.0.2 [with: requests, black==24.2.0]
+    flask v3.0.2 [with: requests==2.31.0, black==24.2.0]
     - flask
-    ruff v0.3.4 [required: ==0.3.4] [with: requests]
+    ruff v0.3.4 [required: ==0.3.4] [with: requests>=2 (installed: 2.31.0)]
     - ruff
 
     ----- stderr -----
@@ -594,9 +594,9 @@ fn tool_list_show_with() {
     black v24.2.0 [required: ==24.2.0] ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
-    flask v3.0.2 [with: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
+    flask v3.0.2 [with: requests==2.31.0, black==24.2.0] ([TEMP_DIR]/tools/flask)
     - flask ([TEMP_DIR]/bin/flask)
-    ruff v0.3.4 [required: ==0.3.4] [with: requests] ([TEMP_DIR]/tools/ruff)
+    ruff v0.3.4 [required: ==0.3.4] [with: requests>=2 (installed: 2.31.0)] ([TEMP_DIR]/tools/ruff)
     - ruff ([TEMP_DIR]/bin/ruff)
 
     ----- stderr -----
@@ -655,7 +655,7 @@ fn tool_list_show_extras() {
     black v24.2.0
     - black
     - blackd
-    flask v3.0.2 [extras: async, dotenv] [with: requests]
+    flask v3.0.2 [extras: async, dotenv] [with: requests==2.31.0]
     - flask
 
     ----- stderr -----
@@ -707,7 +707,7 @@ fn tool_list_show_extras() {
     black v24.2.0 [required: ==24.2.0] ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
-    flask v3.0.2 [extras: async, dotenv] [with: requests] ([TEMP_DIR]/tools/flask)
+    flask v3.0.2 [extras: async, dotenv] [with: requests==2.31.0] ([TEMP_DIR]/tools/flask)
     - flask ([TEMP_DIR]/bin/flask)
 
     ----- stderr -----
@@ -785,7 +785,7 @@ fn tool_list_show_all() {
     black v24.2.0 [required: ==24.2.0] [CPython 3.12.[X]] ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
-    flask v3.0.2 [extras: async, dotenv] [with: requests] [CPython 3.12.[X]] ([TEMP_DIR]/tools/flask)
+    flask v3.0.2 [extras: async, dotenv] [with: requests==2.31.0] [CPython 3.12.[X]] ([TEMP_DIR]/tools/flask)
     - flask ([TEMP_DIR]/bin/flask)
 
     ----- stderr -----


### PR DESCRIPTION
Resolves #19930

This diff updates `uv tool list --show-with` to include the installed version for packages injected with
`--with`. Bare `--with` requirements are shown as exact resolved versions, while constrained requirements keep the requested specifier and append the installed version.
