### PR TITLE
Avoid archive id collisions

### DIFF
--- a/crates/uv-cache/src/archive.rs
+++ b/crates/uv-cache/src/archive.rs
@@ -19,7 +19,7 @@ impl Default for ArchiveId {
 impl ArchiveId {
     /// Generate a new unique identifier for an archive.
     pub(crate) fn new() -> Self {
-        Self(uv_fastid::Id::insecure().to_string())
+        Self(uv_fastid::Id::secure().to_string())
     }
 }
 

--- a/crates/uv-distribution/src/source/revision.rs
+++ b/crates/uv-distribution/src/source/revision.rs
@@ -65,7 +65,7 @@ pub(crate) struct RevisionId(String);
 impl RevisionId {
     /// Generate a new unique identifier for an archive.
     fn new() -> Self {
-        Self(uv_fastid::Id::insecure().to_string())
+        Self(uv_fastid::Id::secure().to_string())
     }
 
     pub(crate) fn as_str(&self) -> &str {


### PR DESCRIPTION

We observed what appears to be a collision between `ArchiveIds` in https://github.com/astral-sh/ruff/actions/runs/27950213732/job/82705000710?pr=26198. This may happen if two processes installing the same package are started at exactly the same time, which is plausible in the ruff test suite. Using a secure RNG prevents this.