### PR TITLE
Downgrade to Rust 1.95

### DIFF
--- a/crates/uv-build/rust-toolchain.toml
+++ b/crates/uv-build/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.95.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.95.0"


### PR DESCRIPTION
## Summary

1.96 currently has a bug (in `cargo`) that causes transient/in-protocol errors to surface as fatal errors rather than being retried. This is especially painful in the context of GitHub Actions, which seems to be uniquely/abnormally unreliable in terms of HTTP/2 connections.

We can re-bump once 1.96.1 or 1.97 is released.

Context: https://github.com/rust-lang/cargo/pull/16903 

Context: [#t-infra > CI failing because of curl?](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/CI.20failing.20because.20of.20curl.3F/with/605849316)

## Test Plan

NFC, internal/toolchain only.

