### PR TITLE
Unify registry clients on `IndexLocations`

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -22,7 +22,7 @@ use uv_configuration::KeyringProviderType;
 use uv_distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
 use uv_distribution_types::{
     BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-    IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, IndexUrls, Name,
+    IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
 };
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
@@ -164,49 +164,30 @@ impl<'a> RegistryClientBuilder<'a> {
         Ok(())
     }
 
-    pub fn build(mut self) -> Result<RegistryClient, ClientBuildError> {
-        self.cache_index_credentials()?;
-        let index_urls = self.index_locations.index_urls();
-
-        // Build a base client
-        let builder = self
-            .base_client_builder
-            .indexes(Indexes::from(&self.index_locations));
-
-        let client = builder.build()?;
-
-        let read_timeout = client.read_timeout();
-        let connectivity = client.connectivity();
-
-        // Wrap in the cache middleware.
-        let client = CachedClient::new(client);
-
-        Ok(RegistryClient {
-            index_urls,
-            index_strategy: self.index_strategy,
-            torch_backend: self.torch_backend,
-            cache: self.cache,
-            connectivity,
-            client,
-            read_timeout,
-            flat_indexes: Arc::default(),
-            pyx_token_store: PyxTokenStore::from_settings().ok(),
-        })
+    pub fn build(self) -> Result<RegistryClient, ClientBuildError> {
+        self.build_inner(None)
     }
 
     /// Share the underlying client between two different middleware configurations.
-    pub fn wrap_existing(
+    pub fn wrap_existing(self, existing: &BaseClient) -> Result<RegistryClient, ClientBuildError> {
+        self.build_inner(Some(existing))
+    }
+
+    fn build_inner(
         mut self,
-        existing: &BaseClient,
+        existing: Option<&BaseClient>,
     ) -> Result<RegistryClient, ClientBuildError> {
         self.cache_index_credentials()?;
-        let index_urls = self.index_locations.index_urls();
 
         // Wrap in any relevant middleware and handle connectivity.
-        let client = self
+        let builder = self
             .base_client_builder
-            .indexes(Indexes::from(&self.index_locations))
-            .wrap_existing(existing);
+            .indexes(Indexes::from(&self.index_locations));
+        let client = if let Some(existing) = existing {
+            builder.wrap_existing(existing)
+        } else {
+            builder.build()?
+        };
 
         let read_timeout = client.read_timeout();
         let connectivity = client.connectivity();
@@ -215,7 +196,7 @@ impl<'a> RegistryClientBuilder<'a> {
         let client = CachedClient::new(client);
 
         Ok(RegistryClient {
-            index_urls,
+            index_locations: self.index_locations,
             index_strategy: self.index_strategy,
             torch_backend: self.torch_backend,
             cache: self.cache,
@@ -231,8 +212,8 @@ impl<'a> RegistryClientBuilder<'a> {
 /// A client for fetching packages from a `PyPI`-compatible index.
 #[derive(Debug, Clone)]
 pub struct RegistryClient {
-    /// The index URLs to use for fetching packages.
-    index_urls: IndexUrls,
+    /// The index locations to use for fetching packages.
+    index_locations: IndexLocations,
     /// The strategy to use when fetching across multiple indexes.
     index_strategy: IndexStrategy,
     /// The strategy to use when selecting a PyTorch backend, if any.
@@ -305,7 +286,13 @@ impl RegistryClient {
                     .map(|indexes| indexes.map(IndexMetadataRef::from))
             })
             .map(Either::Left)
-            .unwrap_or_else(|| Either::Right(self.index_urls.indexes().map(IndexMetadataRef::from)))
+            .unwrap_or_else(|| {
+                Either::Right(
+                    self.index_locations
+                        .fetch_indexes()
+                        .map(IndexMetadataRef::from),
+                )
+            })
     }
 
     /// Return the appropriate [`IndexStrategy`] for the given [`PackageName`].
@@ -337,7 +324,7 @@ impl RegistryClient {
     ) -> Result<Vec<(&'index IndexUrl, MetadataFormat)>, Error> {
         // If `--no-index` is specified, avoid fetching regardless of whether the index is implicit,
         // explicit, etc.
-        if self.index_urls.no_index() {
+        if self.index_locations.no_index() {
             return Err(ErrorKind::NoIndex(package_name.to_string()).into());
         }
 
@@ -357,7 +344,7 @@ impl RegistryClient {
                     match index.format {
                         IndexFormat::Simple => {
                             let status_code_strategy =
-                                self.index_urls.status_code_strategy_for(index.url);
+                                self.index_locations.status_code_strategy_for(index.url);
                             match self
                                 .simple_detail_single_index(
                                     package_name,
@@ -455,7 +442,7 @@ impl RegistryClient {
         package_name: &PackageName,
         download_concurrency: &Semaphore,
     ) -> Result<Vec<FlatIndexEntry>, Error> {
-        Ok(futures::stream::iter(self.index_urls.flat_indexes())
+        Ok(futures::stream::iter(self.index_locations.flat_indexes())
             .map(async |index| {
                 let _permit = download_concurrency.acquire().await;
                 self.flat_single_index(package_name, index.url()).await
@@ -545,7 +532,7 @@ impl RegistryClient {
         );
         let cache_control = match self.connectivity {
             Connectivity::Online => {
-                if let Some(header) = self.index_urls.simple_api_cache_control_for(index) {
+                if let Some(header) = self.index_locations.simple_api_cache_control_for(index) {
                     CacheControl::Override(header)
                 } else {
                     CacheControl::from(
@@ -805,7 +792,7 @@ impl RegistryClient {
         );
         let cache_control = match self.connectivity {
             Connectivity::Online => {
-                if let Some(header) = self.index_urls.simple_api_cache_control_for(index) {
+                if let Some(header) = self.index_locations.simple_api_cache_control_for(index) {
                     CacheControl::Override(header)
                 } else {
                     CacheControl::from(
@@ -1091,7 +1078,7 @@ impl RegistryClient {
             );
             let cache_control = match self.connectivity {
                 Connectivity::Online => {
-                    if let Some(header) = self.index_urls.artifact_cache_control_for(index) {
+                    if let Some(header) = self.index_locations.artifact_cache_control_for(index) {
                         CacheControl::Override(header)
                     } else {
                         CacheControl::from(
@@ -1168,7 +1155,7 @@ impl RegistryClient {
         let cache_control = match self.connectivity {
             Connectivity::Online => {
                 if let Some(index) = index {
-                    if let Some(header) = self.index_urls.artifact_cache_control_for(index) {
+                    if let Some(header) = self.index_locations.artifact_cache_control_for(index) {
                         CacheControl::Override(header)
                     } else {
                         CacheControl::from(
@@ -1760,6 +1747,34 @@ mod tests {
                 .index_locations(IndexLocations::new(vec![], flat_indexes, true))
                 .build()?,
         )
+    }
+
+    #[test]
+    fn build_and_wrap_existing_preserve_index_locations() -> Result<(), Error> {
+        let url = IndexUrl::from_str("https://index.example.com/simple")?;
+        let first = Index::from(url.clone());
+        let mut second = Index::from(url);
+        second.default = true;
+        let flat = Index::from_find_links(IndexUrl::from_str("https://index.example.com/flat")?);
+        let locations = IndexLocations::new(vec![first, second], vec![flat], false);
+
+        let built = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations.clone())
+            .build()?;
+
+        let base_client = BaseClientBuilder::default().build()?;
+        let wrapped = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations)
+            .wrap_existing(&base_client)?;
+
+        for client in [&built, &wrapped] {
+            assert_eq!(client.index_locations.indexes().count(), 2);
+            assert_eq!(client.index_locations.fetch_indexes().count(), 1);
+            assert_eq!(client.index_locations.flat_indexes().count(), 1);
+            assert!(!client.index_locations.no_index());
+        }
+
+        Ok(())
     }
 
     async fn assert_no_index(

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -196,7 +196,7 @@ impl<'a> RegistryClientBuilder<'a> {
         let client = CachedClient::new(client);
 
         Ok(RegistryClient {
-            index_locations: self.index_locations,
+            indexes: self.index_locations,
             index_strategy: self.index_strategy,
             torch_backend: self.torch_backend,
             cache: self.cache,
@@ -212,8 +212,8 @@ impl<'a> RegistryClientBuilder<'a> {
 /// A client for fetching packages from a `PyPI`-compatible index.
 #[derive(Debug, Clone)]
 pub struct RegistryClient {
-    /// The index locations to use for fetching packages.
-    index_locations: IndexLocations,
+    /// The indexes to use for fetching packages.
+    indexes: IndexLocations,
     /// The strategy to use when fetching across multiple indexes.
     index_strategy: IndexStrategy,
     /// The strategy to use when selecting a PyTorch backend, if any.
@@ -287,11 +287,7 @@ impl RegistryClient {
             })
             .map(Either::Left)
             .unwrap_or_else(|| {
-                Either::Right(
-                    self.index_locations
-                        .fetch_indexes()
-                        .map(IndexMetadataRef::from),
-                )
+                Either::Right(self.indexes.fetch_indexes().map(IndexMetadataRef::from))
             })
     }
 
@@ -324,7 +320,7 @@ impl RegistryClient {
     ) -> Result<Vec<(&'index IndexUrl, MetadataFormat)>, Error> {
         // If `--no-index` is specified, avoid fetching regardless of whether the index is implicit,
         // explicit, etc.
-        if self.index_locations.no_index() {
+        if self.indexes.no_index() {
             return Err(ErrorKind::NoIndex(package_name.to_string()).into());
         }
 
@@ -344,7 +340,7 @@ impl RegistryClient {
                     match index.format {
                         IndexFormat::Simple => {
                             let status_code_strategy =
-                                self.index_locations.status_code_strategy_for(index.url);
+                                self.indexes.status_code_strategy_for(index.url);
                             match self
                                 .simple_detail_single_index(
                                     package_name,
@@ -442,7 +438,7 @@ impl RegistryClient {
         package_name: &PackageName,
         download_concurrency: &Semaphore,
     ) -> Result<Vec<FlatIndexEntry>, Error> {
-        Ok(futures::stream::iter(self.index_locations.flat_indexes())
+        Ok(futures::stream::iter(self.indexes.flat_indexes())
             .map(async |index| {
                 let _permit = download_concurrency.acquire().await;
                 self.flat_single_index(package_name, index.url()).await
@@ -532,7 +528,7 @@ impl RegistryClient {
         );
         let cache_control = match self.connectivity {
             Connectivity::Online => {
-                if let Some(header) = self.index_locations.simple_api_cache_control_for(index) {
+                if let Some(header) = self.indexes.simple_api_cache_control_for(index) {
                     CacheControl::Override(header)
                 } else {
                     CacheControl::from(
@@ -792,7 +788,7 @@ impl RegistryClient {
         );
         let cache_control = match self.connectivity {
             Connectivity::Online => {
-                if let Some(header) = self.index_locations.simple_api_cache_control_for(index) {
+                if let Some(header) = self.indexes.simple_api_cache_control_for(index) {
                     CacheControl::Override(header)
                 } else {
                     CacheControl::from(
@@ -1078,7 +1074,7 @@ impl RegistryClient {
             );
             let cache_control = match self.connectivity {
                 Connectivity::Online => {
-                    if let Some(header) = self.index_locations.artifact_cache_control_for(index) {
+                    if let Some(header) = self.indexes.artifact_cache_control_for(index) {
                         CacheControl::Override(header)
                     } else {
                         CacheControl::from(
@@ -1155,7 +1151,7 @@ impl RegistryClient {
         let cache_control = match self.connectivity {
             Connectivity::Online => {
                 if let Some(index) = index {
-                    if let Some(header) = self.index_locations.artifact_cache_control_for(index) {
+                    if let Some(header) = self.indexes.artifact_cache_control_for(index) {
                         CacheControl::Override(header)
                     } else {
                         CacheControl::from(
@@ -1747,34 +1743,6 @@ mod tests {
                 .index_locations(IndexLocations::new(vec![], flat_indexes, true))
                 .build()?,
         )
-    }
-
-    #[test]
-    fn build_and_wrap_existing_preserve_index_locations() -> Result<(), Error> {
-        let url = IndexUrl::from_str("https://index.example.com/simple")?;
-        let first = Index::from(url.clone());
-        let mut second = Index::from(url);
-        second.default = true;
-        let flat = Index::from_find_links(IndexUrl::from_str("https://index.example.com/flat")?);
-        let locations = IndexLocations::new(vec![first, second], vec![flat], false);
-
-        let built = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
-            .index_locations(locations.clone())
-            .build()?;
-
-        let base_client = BaseClientBuilder::default().build()?;
-        let wrapped = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
-            .index_locations(locations)
-            .wrap_existing(&base_client)?;
-
-        for client in [&built, &wrapped] {
-            assert_eq!(client.index_locations.indexes().count(), 2);
-            assert_eq!(client.index_locations.fetch_indexes().count(), 1);
-            assert_eq!(client.index_locations.flat_indexes().count(), 1);
-            assert!(!client.index_locations.no_index());
-        }
-
-        Ok(())
     }
 
     async fn assert_no_index(

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -365,6 +365,15 @@ impl<'a> IndexLocations {
             .filter(|index| !index.explicit)
     }
 
+    /// Return an iterator over all [`Index`] entries to fetch in order.
+    ///
+    /// Unlike [`IndexLocations::indexes`], indexes with duplicate raw URLs are excluded.
+    pub fn fetch_indexes(&'a self) -> impl Iterator<Item = &'a Index> + 'a {
+        let mut seen = FxHashSet::default();
+        self.indexes()
+            .filter(move |index| seen.insert(index.raw_url()))
+    }
+
     /// Return an iterator over all simple [`Index`] entries in order.
     ///
     /// If `no_index` was enabled, then this always returns an empty iterator.
@@ -389,15 +398,6 @@ impl<'a> IndexLocations {
     /// Return the `--no-index` flag.
     pub fn no_index(&self) -> bool {
         self.no_index
-    }
-
-    /// Clone the index locations into a [`IndexUrls`] instance.
-    pub fn index_urls(&'a self) -> IndexUrls {
-        IndexUrls {
-            indexes: self.indexes.clone(),
-            flat_indexes: self.flat_index.clone(),
-            no_index: self.no_index,
-        }
     }
 
     /// Return a vector containing all allowed [`Index`] entries.
@@ -457,140 +457,15 @@ impl<'a> IndexLocations {
         }
     }
 
-    /// Return the Simple API cache control header for an [`IndexUrl`], if configured.
-    pub fn simple_api_cache_control_for(&self, url: &IndexUrl) -> Option<http::HeaderValue> {
-        for index in &self.indexes {
-            if is_same_index(index.url(), url) {
-                return index.simple_api_cache_control();
-            }
-        }
-        None
-    }
-
-    /// Return the artifact cache control header for an [`IndexUrl`], if configured.
-    pub fn artifact_cache_control_for(&self, url: &IndexUrl) -> Option<http::HeaderValue> {
-        for index in &self.indexes {
-            if is_same_index(index.url(), url) {
-                return index.artifact_cache_control();
-            }
-        }
-        None
-    }
-
-    /// Return the `exclude-newer` setting for a given index, if the index is configured.
-    pub fn exclude_newer_for(&self, url: &IndexUrl) -> Option<&ExcludeNewerOverride> {
-        for index in &self.indexes {
-            if is_same_index(index.url(), url) {
-                return index.exclude_newer();
-            }
-        }
-        None
-    }
-}
-
-impl From<&IndexLocations> for uv_auth::Indexes {
-    fn from(index_locations: &IndexLocations) -> Self {
-        Self::from_indexes(index_locations.allowed_indexes().into_iter().map(|index| {
-            let mut url = index.url().url().clone();
-            url.set_username("").ok();
-            url.set_password(None).ok();
-            let mut root_url = index.url().root().unwrap_or_else(|| url.clone());
-            root_url.set_username("").ok();
-            root_url.set_password(None).ok();
-            uv_auth::Index {
-                url,
-                root_url,
-                auth_policy: index.authenticate,
-            }
-        }))
-    }
-}
-
-/// The index URLs to use for fetching packages.
-///
-/// This type merges the legacy `--index-url` and `--extra-index-url` options, along with the
-/// uv-specific `--index` and `--default-index`.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub struct IndexUrls {
-    indexes: Vec<Index>,
-    flat_indexes: Vec<Index>,
-    no_index: bool,
-}
-
-impl<'a> IndexUrls {
-    pub fn from_indexes(indexes: Vec<Index>) -> Self {
-        Self {
-            indexes,
-            flat_indexes: Vec::new(),
-            no_index: false,
-        }
-    }
-
-    /// Return an iterator over the configured flat-index locations.
-    pub fn flat_indexes(&'a self) -> impl Iterator<Item = &'a Index> + 'a {
-        self.flat_indexes.iter()
-    }
-
-    /// Return the default [`Index`] entry.
-    ///
-    /// If `--no-index` is set, return `None`.
-    ///
-    /// If no index is provided, use the `PyPI` index.
-    fn default_index(&'a self) -> Option<&'a Index> {
-        if self.no_index {
-            None
-        } else {
-            let mut seen = FxHashSet::default();
-            self.indexes
-                .iter()
-                .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
-                .find(|index| index.default)
-                .or_else(|| Some(&DEFAULT_INDEX))
-        }
-    }
-
-    /// Return an iterator over the implicit [`Index`] entries.
-    ///
-    /// Default and explicit indexes are excluded.
-    fn implicit_indexes(&'a self) -> impl Iterator<Item = &'a Index> + 'a {
-        if self.no_index {
-            Either::Left(std::iter::empty())
-        } else {
-            let mut seen = FxHashSet::default();
-            Either::Right(
-                self.indexes
-                    .iter()
-                    .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
-                    .filter(|index| !index.default && !index.explicit),
-            )
-        }
-    }
-
-    /// Return an iterator over all [`IndexUrl`] entries in order.
-    ///
-    /// Prioritizes the `[tool.uv.index]` definitions over the `--extra-index-url` definitions
-    /// over the `--index-url` definition.
-    ///
-    /// If `no_index` was enabled, then this always returns an empty
-    /// iterator.
-    pub fn indexes(&'a self) -> impl Iterator<Item = &'a Index> + 'a {
-        let mut seen = FxHashSet::default();
-        self.implicit_indexes()
-            .chain(self.default_index())
-            .filter(|index| !index.explicit)
-            .filter(move |index| seen.insert(index.raw_url())) // Filter out redundant raw URLs
-    }
-
     /// Return an iterator over all user-defined [`Index`] entries in order.
     ///
     /// Prioritizes the `[tool.uv.index]` definitions over the `--extra-index-url` definitions
     /// over the `--index-url` definition.
     ///
-    /// Unlike [`IndexUrl::indexes`], this includes explicit indexes and does _not_ insert PyPI
-    /// as a fallback default.
+    /// Unlike [`IndexLocations::indexes`], this includes explicit indexes and does _not_ insert
+    /// PyPI as a fallback default.
     ///
-    /// If `no_index` was enabled, then this always returns an empty
-    /// iterator.
+    /// If `no_index` was enabled, then this always returns an empty iterator.
     pub fn defined_indexes(&'a self) -> impl Iterator<Item = &'a Index> + 'a {
         if self.no_index {
             return Either::Left(std::iter::empty());
@@ -612,39 +487,54 @@ impl<'a> IndexUrls {
         Either::Right(non_default.into_iter().chain(default))
     }
 
-    /// Return the `--no-index` flag.
-    pub fn no_index(&self) -> bool {
-        self.no_index
+    /// Return the configured index matching the given URL.
+    fn index_for_url(&self, url: &IndexUrl) -> Option<&Index> {
+        self.indexes
+            .iter()
+            .find(|index| is_same_index(index.url(), url))
     }
 
     /// Return the [`IndexStatusCodeStrategy`] for an [`IndexUrl`].
     pub fn status_code_strategy_for(&self, url: &IndexUrl) -> IndexStatusCodeStrategy {
-        for index in &self.indexes {
-            if is_same_index(index.url(), url) {
-                return index.status_code_strategy();
-            }
-        }
-        IndexStatusCodeStrategy::Default
+        self.index_for_url(url).map_or(
+            IndexStatusCodeStrategy::Default,
+            Index::status_code_strategy,
+        )
     }
 
     /// Return the Simple API cache control header for an [`IndexUrl`], if configured.
     pub fn simple_api_cache_control_for(&self, url: &IndexUrl) -> Option<http::HeaderValue> {
-        for index in &self.indexes {
-            if is_same_index(index.url(), url) {
-                return index.simple_api_cache_control();
-            }
-        }
-        None
+        self.index_for_url(url)
+            .and_then(Index::simple_api_cache_control)
     }
 
     /// Return the artifact cache control header for an [`IndexUrl`], if configured.
     pub fn artifact_cache_control_for(&self, url: &IndexUrl) -> Option<http::HeaderValue> {
-        for index in &self.indexes {
-            if is_same_index(index.url(), url) {
-                return index.artifact_cache_control();
+        self.index_for_url(url)
+            .and_then(Index::artifact_cache_control)
+    }
+
+    /// Return the `exclude-newer` setting for a given index, if the index is configured.
+    pub fn exclude_newer_for(&self, url: &IndexUrl) -> Option<&ExcludeNewerOverride> {
+        self.index_for_url(url).and_then(Index::exclude_newer)
+    }
+}
+
+impl From<&IndexLocations> for uv_auth::Indexes {
+    fn from(index_locations: &IndexLocations) -> Self {
+        Self::from_indexes(index_locations.allowed_indexes().into_iter().map(|index| {
+            let mut url = index.url().url().clone();
+            url.set_username("").ok();
+            url.set_password(None).ok();
+            let mut root_url = index.url().root().unwrap_or_else(|| url.clone());
+            root_url.set_username("").ok();
+            root_url.set_password(None).ok();
+            uv_auth::Index {
+                url,
+                root_url,
+                auth_policy: index.authenticate,
             }
-        }
-        None
+        }))
     }
 }
 
@@ -768,6 +658,20 @@ mod tests {
     }
 
     #[test]
+    fn fetch_indexes_deduplicates_raw_urls() {
+        let url = IndexUrl::from_str("https://index.example.com/simple").unwrap();
+        let mut first = Index::from(url.clone());
+        first.name = Some(IndexName::from_str("first").unwrap());
+        let mut second = Index::from(url);
+        second.name = Some(IndexName::from_str("second").unwrap());
+        second.default = true;
+        let locations = IndexLocations::new(vec![first, second], Vec::new(), false);
+
+        assert_eq!(locations.indexes().count(), 2);
+        assert_eq!(locations.fetch_indexes().count(), 1);
+    }
+
+    #[test]
     fn test_cache_control_lookup() {
         use std::str::FromStr;
 
@@ -806,25 +710,25 @@ mod tests {
             },
         ];
 
-        let index_urls = IndexUrls::from_indexes(indexes);
+        let index_locations = IndexLocations::new(indexes, Vec::new(), false);
 
         let url1 = IndexUrl::from_str("https://index1.example.com/simple").unwrap();
         assert_eq!(
-            index_urls.simple_api_cache_control_for(&url1),
+            index_locations.simple_api_cache_control_for(&url1),
             Some(HeaderValue::from_static("max-age=300"))
         );
         assert_eq!(
-            index_urls.artifact_cache_control_for(&url1),
+            index_locations.artifact_cache_control_for(&url1),
             Some(HeaderValue::from_static("max-age=1800"))
         );
 
         let url2 = IndexUrl::from_str("https://index2.example.com/simple").unwrap();
-        assert_eq!(index_urls.simple_api_cache_control_for(&url2), None);
-        assert_eq!(index_urls.artifact_cache_control_for(&url2), None);
+        assert_eq!(index_locations.simple_api_cache_control_for(&url2), None);
+        assert_eq!(index_locations.artifact_cache_control_for(&url2), None);
 
         let url3 = IndexUrl::from_str("https://index3.example.com/simple").unwrap();
-        assert_eq!(index_urls.simple_api_cache_control_for(&url3), None);
-        assert_eq!(index_urls.artifact_cache_control_for(&url3), None);
+        assert_eq!(index_locations.simple_api_cache_control_for(&url3), None);
+        assert_eq!(index_locations.artifact_cache_control_for(&url3), None);
     }
 
     #[test]
@@ -844,21 +748,10 @@ mod tests {
             exclude_newer: None,
         }];
 
-        let index_urls = IndexUrls::from_indexes(indexes.clone());
         let index_locations = IndexLocations::new(indexes, Vec::new(), false);
 
         let pytorch_url = IndexUrl::from_str("https://download.pytorch.org/whl/cu118").unwrap();
 
-        // IndexUrls should return the default for PyTorch
-        assert_eq!(index_urls.simple_api_cache_control_for(&pytorch_url), None);
-        assert_eq!(
-            index_urls.artifact_cache_control_for(&pytorch_url),
-            Some(HeaderValue::from_static(
-                "max-age=365000000, immutable, public",
-            ))
-        );
-
-        // IndexLocations should also return the default for PyTorch
         assert_eq!(
             index_locations.simple_api_cache_control_for(&pytorch_url),
             None
@@ -891,22 +784,10 @@ mod tests {
             exclude_newer: None,
         }];
 
-        let index_urls = IndexUrls::from_indexes(indexes.clone());
         let index_locations = IndexLocations::new(indexes, Vec::new(), false);
 
         let pytorch_url = IndexUrl::from_str("https://download.pytorch.org/whl/cu118").unwrap();
 
-        // User settings should override defaults
-        assert_eq!(
-            index_urls.simple_api_cache_control_for(&pytorch_url),
-            Some(HeaderValue::from_static("no-cache"))
-        );
-        assert_eq!(
-            index_urls.artifact_cache_control_for(&pytorch_url),
-            Some(HeaderValue::from_static("max-age=3600"))
-        );
-
-        // Same for IndexLocations
         assert_eq!(
             index_locations.simple_api_cache_control_for(&pytorch_url),
             Some(HeaderValue::from_static("no-cache"))
@@ -934,21 +815,10 @@ mod tests {
             exclude_newer: None,
         }];
 
-        let index_urls = IndexUrls::from_indexes(indexes.clone());
         let index_locations = IndexLocations::new(indexes, Vec::new(), false);
 
         let nvidia_url = IndexUrl::from_str("https://pypi.nvidia.com").unwrap();
 
-        // IndexUrls should return the default for NVIDIA
-        assert_eq!(index_urls.simple_api_cache_control_for(&nvidia_url), None);
-        assert_eq!(
-            index_urls.artifact_cache_control_for(&nvidia_url),
-            Some(HeaderValue::from_static(
-                "max-age=365000000, immutable, public",
-            ))
-        );
-
-        // IndexLocations should also return the default for NVIDIA
         assert_eq!(
             index_locations.simple_api_cache_control_for(&nvidia_url),
             None

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -23,8 +23,8 @@ use uv_configuration::{
 use uv_dispatch::BuildDispatch;
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies};
 use uv_distribution_types::{
-    Identifier, Index, IndexName, IndexUrl, IndexUrls, NameRequirementSpecification, Requirement,
-    RequirementSource, UnresolvedRequirement,
+    Identifier, Index, IndexLocations, IndexName, IndexUrl, NameRequirementSpecification,
+    Requirement, RequirementSource, UnresolvedRequirement,
 };
 use uv_fs::{LockedFile, LockedFileError, Simplified};
 use uv_git::store_credentials;
@@ -686,8 +686,8 @@ pub(crate) async fn add(
 
     // Add any indexes that were provided on the command-line, in priority order.
     if !raw {
-        let urls = IndexUrls::from_indexes(indexes);
-        let mut indexes = urls.defined_indexes().collect::<Vec<_>>();
+        let locations = IndexLocations::new(indexes, Vec::new(), false);
+        let mut indexes = locations.defined_indexes().collect::<Vec<_>>();
         indexes.reverse();
         for index in indexes {
             toml.add_index(index)?;


### PR DESCRIPTION
This is the first preparatory PR in the proxy-index stack. Later changes need `RegistryClient` to retain the complete index configuration, but it currently clones `IndexLocations` into a narrower `IndexUrls` representation and splits index state across two types.

This PR removes `IndexUrls` and makes `IndexLocations` the single source of truth. `uv add` now uses `IndexLocations::defined_indexes()` directly when persisting command-line indexes. `RegistryClientBuilder::build` and `wrap_existing` now share one construction path, so both cache credentials, apply index middleware, and retain the same locations.

This is a pure refactor, there should be no user-visible behavior changes.