### PR TITLE
Make tool environments relocatable under preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7328,6 +7328,7 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
+ "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-settings",

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -26,6 +26,7 @@ uv-installer = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
+uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
 uv-settings = { workspace = true }

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -15,6 +15,7 @@ use uv_install_wheel::read_record;
 use uv_installer::SitePackages;
 use uv_normalize::{InvalidNameError, PackageName};
 use uv_pep440::Version;
+use uv_preview::PreviewFeature;
 use uv_python::{BrokenLink, Interpreter, PythonEnvironment};
 use uv_state::{StateBucket, StateStore};
 use uv_static::EnvVars;
@@ -346,7 +347,7 @@ impl InstalledTools {
             uv_virtualenv::Prompt::None,
             false,
             uv_virtualenv::OnExisting::Remove(uv_virtualenv::RemovalReason::ManagedEnvironment),
-            false,
+            uv_preview::is_enabled(PreviewFeature::RelocatableEnvsDefault),
             false,
             false,
         )?;

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -494,9 +494,21 @@ pub(crate) fn finalize_tool_install(
             if itself.as_ref().is_some_and(|itself| {
                 std::path::absolute(&target).is_ok_and(|target| *itself == target)
             }) {
-                self_replace::self_replace(src).context("Failed to install entrypoint")?;
+                if let Some((launcher, is_gui)) = rewritten_tool_launcher(src, environment)? {
+                    let mut file = uv_fs::tempfile_in(
+                        target
+                            .parent()
+                            .context("Expected entrypoint parent directory")?,
+                    )?;
+                    launcher.write_to_file(file.as_file_mut(), is_gui)?;
+                    self_replace::self_replace(file.path())
+                        .context("Failed to install entrypoint")?;
+                } else {
+                    self_replace::self_replace(src).context("Failed to install entrypoint")?;
+                }
             } else {
-                fs_err::copy(src, &target).context("Failed to install entrypoint")?;
+                copy_tool_entrypoint(src, &target, environment)
+                    .context("Failed to install entrypoint")?;
             }
 
             let tool_entry = ToolEntrypoint::new(&name, target, package.to_string());
@@ -534,6 +546,57 @@ pub(crate) fn finalize_tool_install(
     warn_out_of_path(&executable_directory);
 
     Ok(())
+}
+
+/// Copy a tool entrypoint out of its environment.
+///
+/// Relocatable Windows launchers contain a Python path relative to the environment's scripts
+/// directory. Rewrite that path when exporting the launcher to the tool executable directory.
+#[cfg(windows)]
+fn copy_tool_entrypoint(
+    source: &Path,
+    target: &Path,
+    environment: &PythonEnvironment,
+) -> anyhow::Result<()> {
+    if let Some((launcher, is_gui)) = rewritten_tool_launcher(source, environment)? {
+        let mut file = fs_err::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(target)?;
+        launcher.write_to_file(&mut file, is_gui)?;
+    } else {
+        fs_err::copy(source, target)?;
+    }
+
+    Ok(())
+}
+
+/// Rewrite a relocatable Windows launcher for use outside of its environment.
+#[cfg(windows)]
+fn rewritten_tool_launcher(
+    source: &Path,
+    environment: &PythonEnvironment,
+) -> anyhow::Result<Option<(uv_trampoline_builder::Launcher, bool)>> {
+    use uv_trampoline_builder::Launcher;
+
+    let Some(launcher) = Launcher::try_from_path(source)? else {
+        return Ok(None);
+    };
+
+    if launcher.python_path.is_absolute() {
+        return Ok(None);
+    }
+
+    let is_gui = launcher.python_path.ends_with("pythonw.exe");
+    let python_executable = environment.interpreter().sys_executable();
+    let python_path = if is_gui {
+        python_executable.with_file_name("pythonw.exe")
+    } else {
+        python_executable.to_path_buf()
+    };
+
+    Ok(Some((launcher.with_python_path(python_path), is_gui)))
 }
 
 fn warn_out_of_path(executable_directory: &Path) {

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -210,6 +210,57 @@ fn tool_install() {
     });
 }
 
+/// With `relocatable-envs-default`, installed tool environments are relocatable by default.
+#[test]
+fn tool_install_relocatable_envs_default() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black")
+        .arg("--preview-features")
+        .arg("relocatable-envs-default")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    Installed 2 executables: black, blackd
+    ");
+
+    tool_dir
+        .child("black")
+        .child("pyvenv.cfg")
+        .assert(predicate::str::contains("relocatable = true"));
+
+    let executable = bin_dir.child(format!("black{}", std::env::consts::EXE_SUFFIX));
+    uv_snapshot!(context.filters(), Command::new(executable.as_os_str())
+        .arg("--version"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    black, 24.3.0 (compiled: yes)
+    Python (CPython) 3.12.[X]
+
+    ----- stderr -----
+    ");
+}
+
 #[test]
 fn tool_install_relative_exclude_newer_receipt_preserves_span() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();


### PR DESCRIPTION
## Summary

- have installed tool environment creation read `relocatable-envs-default` from the global preview state
- preserve exported Windows tool entrypoints by rewriting relocatable launchers for their external location
- add integration coverage for the relocatable marker and exported tool execution

## Motivation

Installed tool environments did not honor the `relocatable-envs-default` preview feature. Enabling it creates relative entrypoints inside the environment; on Windows, those launchers are copied to the tool executable directory and must be rewritten to continue pointing at the tool environment's Python interpreter.

With this change, tool installation and interpreter-changing upgrades consistently honor the preview feature. Existing tool environments are left unchanged and gain relocatability when recreated.

## Validation

- `cargo +stable nextest run -p uv --test tool -E 'test(tool_install_relocatable_envs_default)'`
- `cargo +stable clippy -p uv-tool --locked -- -D warnings`
- `cargo +stable clippy -p uv --test tool --locked -- -D warnings`
- `cargo xwin clippy -p uv --test tool --locked -- -D warnings`
- `cargo fmt --all -- --check`
