### PR TITLE
Add json output to `uv tree`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -79,6 +79,15 @@ pub enum AuditOutputFormat {
     Sarif,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum TreeFormat {
+    /// Display the dependency graph as a human-readable tree.
+    #[default]
+    Text,
+    /// Display the dependency graph as JSON.
+    Json,
+}
+
 #[derive(Debug, Default, Clone, clap::ValueEnum)]
 pub enum ListFormat {
     /// Display the list of packages in a human-readable table.
@@ -4740,6 +4749,10 @@ pub struct TreeArgs {
     /// Multiple versions may be shown for a each package.
     #[arg(long)]
     pub universal: bool,
+
+    /// The format in which to display the dependency graph.
+    #[arg(long, value_enum, default_value_t = TreeFormat::default())]
+    pub format: TreeFormat,
 
     #[command(flatten)]
     pub tree: DisplayTreeArgs,

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -11,7 +11,7 @@ pub use fork_strategy::ForkStrategy;
 pub use lock::{
     DependencySelection, Installable, Lock, LockError, LockVersion, Metadata, Package, PackageMap,
     PylockToml, PylockTomlError, PylockTomlErrorKind, RequirementsTxtExport, ResolverManifest,
-    SatisfiesResult, SelectedDependency, TreeDisplay, VERSION, cyclonedx_json,
+    SatisfiesResult, SelectedDependency, TreeDisplay, TreeJsonTarget, VERSION, cyclonedx_json,
 };
 pub use manifest::Manifest;
 pub use options::{Flexibility, Options, OptionsBuilder};

--- a/crates/uv-resolver/src/lock/export/metadata.rs
+++ b/crates/uv-resolver/src/lock/export/metadata.rs
@@ -117,31 +117,68 @@ struct MetadataEnvironment {
 
 /// The script entry-point.
 #[derive(Debug, serde::Serialize)]
-struct MetadataScript {
+pub(crate) struct MetadataScript {
     /// Absolute path to the script.
     path: PortablePathBuf,
     /// Key for the script's node in the `resolution` graph.
     id: MetadataNodeIdFlat,
 }
 
+impl MetadataScript {
+    pub(in crate::lock) fn new(path: PortablePathBuf, id: MetadataNodeIdFlat) -> Self {
+        Self { path, id }
+    }
+}
+
 /// The workspace entry-point.
 #[derive(Debug, serde::Serialize)]
-struct MetadataWorkspace {
+pub(crate) struct MetadataWorkspace {
     /// Absolute path to the workspace root.
     path: PortablePathBuf,
     /// Key for the workspace's node in the `resolution` graph.
     id: MetadataNodeIdFlat,
 }
 
+impl MetadataWorkspace {
+    pub(in crate::lock) fn new(path: PortablePathBuf, id: MetadataNodeIdFlat) -> Self {
+        Self { path, id }
+    }
+}
+
 /// Info for looking up workspace members, most information is stored in the node behind `id`
 #[derive(Debug, serde::Serialize)]
-struct MetadataWorkspaceMember {
+pub(crate) struct MetadataWorkspaceMember {
     /// Package name
     name: PackageName,
     /// Absolute path to the member
     path: PortablePathBuf,
     /// Key for the package's node in the `resolve` graph
     id: MetadataNodeIdFlat,
+}
+
+impl MetadataWorkspaceMember {
+    /// Construct a workspace member from the local source recorded in the lockfile.
+    pub(crate) fn from_locked_package(
+        workspace_root: &PortablePathBuf,
+        package_id: &PackageId,
+    ) -> Option<Self> {
+        let path = match &package_id.source {
+            Source::Directory(path) | Source::Editable(path) | Source::Virtual(path) => path,
+            Source::Registry(_) | Source::Git(..) | Source::Direct(..) | Source::Path(_) => {
+                return None;
+            }
+        };
+        Some(Self {
+            name: package_id.name.clone(),
+            path: normalize_workspace_relative_path(workspace_root, path),
+            id: MetadataNodeId::from_package_id(
+                workspace_root,
+                package_id,
+                MetadataNodeKind::Package,
+            )
+            .to_flat(),
+        })
+    }
 }
 
 /// An installed distribution that provides an importable module.
@@ -153,15 +190,47 @@ struct MetadataModuleOwner {
 
 /// A node in the dependency graph.
 ///
-/// There are 5 kinds of nodes:
+/// There are 6 kinds of nodes:
 ///
-/// * scripts:  `script+/workspace/script.py`
-/// * packages: `mypackage==1.0.0@registry+https://pypi.org/simple`
-/// * extras:   `mypackage[myextra]==1.0.0@registry+https://pypi.org/simple`
-/// * groups:   `mypackage:mygroup==1.0.0@registry+https://pypi.org/simple`
-/// * build:    `mypackage(build)==1.0.0@registry+https://pypi.org/simple`
+/// * workspaces: `workspace+/workspace`
+/// * scripts:    `script+/workspace/script.py`
+/// * packages:   `mypackage==1.0.0@registry+https://pypi.org/simple`
+/// * extras:     `mypackage[myextra]==1.0.0@registry+https://pypi.org/simple`
+/// * groups:     `mypackage:mygroup==1.0.0@registry+https://pypi.org/simple`
+/// * build:      `mypackage(build)==1.0.0@registry+https://pypi.org/simple`
 ///
-/// -----------
+/// Workspace and script nodes are special cases that only ever exist in the root of the graph.
+///
+/// A workspace node is only ever used to hang `dependency-groups` off of, to represent the fact
+/// that workspaces can define groups that aren't otherwise associated with any package
+/// (in this way there's technically two kinds of group nodes, since this changes their id format).
+///
+/// A script node is basically just a package, but, it's a script so it's identified by path
+/// instead of name/version.
+///
+/// Build nodes are stubbed out, but never actually used yet, so they're under-defined.
+///
+///
+/// # What's an Edge?
+///
+/// Strictly speaking the only edges of the graph are the `dependencies` field of each node.
+/// These are the things that must be installed for the node's requirements to be satisfied
+/// (possibly qualified by a marker).
+///
+/// `optional-dependencies`, `dependency-groups` and `build-system` define things that *look*
+/// like edges but aren't really -- there is no dependency from `mypackage` to
+/// `mypackage[extra]` or `mypackage:group`. There *is* a dependency from `mypackage[extra]`
+/// to `mypackage`, and that is expressed by including `mypackage` in the `dependencies` of
+/// `mypackage[extra]`.
+///
+/// The `optional_dependencies` entry on a `mypackage` node is essentially just a listing
+/// that the `mypackage[extra]` node *exists*. In this way if `mypackage` is a workspace
+/// member then `mypackage`, `mypackage[extra]`, and `mypackage:group` are all equally "roots"
+/// of the dependency graph (and arguably `workspace` isn't a root at all even though
+/// `workspace:group` is).
+///
+///
+/// # Simple Example
 ///
 /// A package like this:
 ///
@@ -197,8 +266,12 @@ struct MetadataModuleOwner {
 /// Note that `mypackage[cli]` has a dependency edge on `mypackage` while `mypackage:dev` does not.
 /// This is because `mypackage[cli]` is fundamentally an augmentation of `mypackage` while `mypackage:dev`
 /// is just a list of packages that happens to be defined by `mypackage`'s pyproject.toml.
+///
+/// ---------
+///
+/// Workspace nodes and script nodes
 #[derive(Debug, Clone, serde::Serialize)]
-struct MetadataNode {
+pub(crate) struct MetadataNode {
     /// A unique id for this node that will be used to refer to it
     #[serde(flatten)]
     id: MetadataNodeId,
@@ -210,6 +283,9 @@ struct MetadataNode {
     /// Groups
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     dependency_groups: Vec<MetadataGroup>,
+    /// The latest known version of this package, when requested by the caller.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    latest_version: Option<Version>,
     /// Info about building the package
     #[serde(skip_serializing_if = "Option::is_none", default)]
     build_system: Option<MetadataBuildSystem>,
@@ -222,19 +298,20 @@ struct MetadataNode {
 }
 
 impl MetadataNode {
-    fn new(id: MetadataNodeId) -> Self {
+    pub(in crate::lock) fn new(id: MetadataNodeId) -> Self {
         Self {
             id,
             dependencies: Vec::new(),
             dependency_groups: Vec::new(),
             optional_dependencies: Vec::new(),
+            latest_version: None,
             wheels: Vec::new(),
             build_system: None,
             sdist: None,
         }
     }
 
-    fn from_package_id(
+    pub(in crate::lock) fn from_package_id(
         workspace_root: &PortablePathBuf,
         id: &PackageId,
         kind: MetadataNodeKind,
@@ -243,19 +320,13 @@ impl MetadataNode {
     }
 
     fn from_script(path: PortablePathBuf, dependencies: Vec<MetadataDependency>) -> Self {
-        let mut node = Self::new(MetadataNodeId::Script(MetadataScriptNodeId {
-            kind: MetadataScriptNodeKind::Script,
-            path,
-        }));
+        let mut node = Self::new(MetadataNodeId::from_script(path));
         node.dependencies = dependencies;
         node
     }
 
     fn from_workspace(path: PortablePathBuf, dependency_groups: Vec<MetadataGroup>) -> Self {
-        let mut node = Self::new(MetadataNodeId::Workspace(MetadataWorkspaceNodeId {
-            kind: MetadataWorkspaceNodeKind::Workspace,
-            path,
-        }));
+        let mut node = Self::new(MetadataNodeId::from_workspace(path));
         node.dependency_groups = dependency_groups;
         node
     }
@@ -265,12 +336,7 @@ impl MetadataNode {
         group: GroupName,
         dependencies: Vec<MetadataDependency>,
     ) -> Self {
-        let mut node = Self::new(MetadataNodeId::WorkspaceGroup(
-            MetadataWorkspaceGroupNodeId {
-                kind: MetadataWorkspaceGroupNodeKind::Group(group),
-                path,
-            },
-        ));
+        let mut node = Self::new(MetadataNodeId::from_workspace_group(path, group));
         node.dependencies = dependencies;
         node
     }
@@ -308,6 +374,54 @@ impl MetadataNode {
                 marker: marker.clone(),
             });
         }
+    }
+
+    pub(in crate::lock) fn add_resolution_dependency(
+        &mut self,
+        id: MetadataNodeIdFlat,
+        marker: Option<MetadataMarker>,
+    ) {
+        self.dependencies.push(MetadataDependency { id, marker });
+    }
+
+    pub(in crate::lock) fn add_optional_dependency(
+        &mut self,
+        name: ExtraName,
+        id: MetadataNodeIdFlat,
+    ) {
+        self.optional_dependencies.push(MetadataExtra { name, id });
+    }
+
+    pub(in crate::lock) fn add_dependency_group(
+        &mut self,
+        name: GroupName,
+        id: MetadataNodeIdFlat,
+    ) {
+        self.dependency_groups.push(MetadataGroup { name, id });
+    }
+
+    pub(in crate::lock) fn set_latest_version(&mut self, version: Option<Version>) {
+        self.latest_version = version;
+    }
+
+    pub(in crate::lock) fn set_wheels_from_lock(
+        &mut self,
+        workspace_root: &PortablePathBuf,
+        wheels: &[Wheel],
+    ) {
+        self.wheels = wheels
+            .iter()
+            .map(|wheel| MetadataWheel::from_wheel(workspace_root, wheel))
+            .collect();
+    }
+
+    pub(in crate::lock) fn normalize_resolution(&mut self) {
+        self.dependencies.sort();
+        self.dependencies.dedup();
+        self.optional_dependencies.sort();
+        self.optional_dependencies.dedup();
+        self.dependency_groups.sort();
+        self.dependency_groups.dedup();
     }
 }
 
@@ -563,7 +677,7 @@ fn add_metadata_reachability<'lock>(
 /// The unique key for every node in the graph.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(untagged)]
-enum MetadataNodeId {
+pub(crate) enum MetadataNodeId {
     Package(MetadataPackageNodeId),
     Script(MetadataScriptNodeId),
     Workspace(MetadataWorkspaceNodeId),
@@ -574,7 +688,7 @@ enum MetadataNodeId {
 ///
 /// (It's not entirely clear to me that two nodes can differ only by `source` but it doesn't hurt.)
 #[derive(Debug, Clone, serde::Serialize)]
-struct MetadataPackageNodeId {
+pub(crate) struct MetadataPackageNodeId {
     /// The name of the package
     name: PackageName,
     /// The version of the package, if any could be found (source trees may have no version)
@@ -588,7 +702,7 @@ struct MetadataPackageNodeId {
 
 /// The unique key for a script node.
 #[derive(Debug, Clone, serde::Serialize)]
-struct MetadataScriptNodeId {
+pub(crate) struct MetadataScriptNodeId {
     kind: MetadataScriptNodeKind,
     /// Absolute path to the script.
     path: PortablePathBuf,
@@ -596,7 +710,7 @@ struct MetadataScriptNodeId {
 
 /// The unique key for a workspace node.
 #[derive(Debug, Clone, serde::Serialize)]
-struct MetadataWorkspaceNodeId {
+pub(crate) struct MetadataWorkspaceNodeId {
     kind: MetadataWorkspaceNodeKind,
     /// Absolute path to the workspace root.
     path: PortablePathBuf,
@@ -604,7 +718,7 @@ struct MetadataWorkspaceNodeId {
 
 /// The unique key for a dependency group defined on the workspace root.
 #[derive(Debug, Clone, serde::Serialize)]
-struct MetadataWorkspaceGroupNodeId {
+pub(crate) struct MetadataWorkspaceGroupNodeId {
     kind: MetadataWorkspaceGroupNodeKind,
     /// Absolute path to the workspace root.
     path: PortablePathBuf,
@@ -616,7 +730,28 @@ struct MetadataWorkspaceGroupNodeId {
 type MetadataNodeIdFlat = String;
 
 impl MetadataNodeId {
-    fn from_package_id(
+    pub(crate) fn from_script(path: PortablePathBuf) -> Self {
+        Self::Script(MetadataScriptNodeId {
+            kind: MetadataScriptNodeKind::Script,
+            path,
+        })
+    }
+
+    pub(crate) fn from_workspace(path: PortablePathBuf) -> Self {
+        Self::Workspace(MetadataWorkspaceNodeId {
+            kind: MetadataWorkspaceNodeKind::Workspace,
+            path,
+        })
+    }
+
+    pub(crate) fn from_workspace_group(path: PortablePathBuf, group: GroupName) -> Self {
+        Self::WorkspaceGroup(MetadataWorkspaceGroupNodeId {
+            kind: MetadataWorkspaceGroupNodeKind::Group(group),
+            path,
+        })
+    }
+
+    pub(crate) fn from_package_id(
         workspace_root: &PortablePathBuf,
         id: &PackageId,
         kind: MetadataNodeKind,
@@ -640,7 +775,7 @@ impl MetadataNodeId {
         }
     }
 
-    fn to_flat(&self) -> MetadataNodeIdFlat {
+    pub(crate) fn to_flat(&self) -> MetadataNodeIdFlat {
         self.to_string()
     }
 }
@@ -666,7 +801,7 @@ impl Display for MetadataNodeId {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 struct MetadataDependency {
     id: MetadataNodeIdFlat,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -678,7 +813,7 @@ type MetadataMarker = String;
 /// The kind a node can have in the dependency graph
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-enum MetadataNodeKind {
+pub(crate) enum MetadataNodeKind {
     /// The node is the package itself
     /// its edges are `project.dependencies`
     Package,
@@ -990,13 +1125,13 @@ impl MetadataZstdWheel {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 struct MetadataExtra {
     name: ExtraName,
     id: MetadataNodeIdFlat,
 }
 
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 struct MetadataGroup {
     name: GroupName,
     id: MetadataNodeIdFlat,
@@ -1232,11 +1367,7 @@ impl Metadata {
                 meta_package.sdist = Some(MetadataSourceDist::from_sdist(&workspace_root, sdist));
             }
 
-            for wheel in &lock_package.wheels {
-                meta_package
-                    .wheels
-                    .push(MetadataWheel::from_wheel(&workspace_root, wheel));
-            }
+            meta_package.set_wheels_from_lock(&workspace_root, &lock_package.wheels);
 
             resolve.insert(meta_package.id.to_flat(), meta_package);
         }
@@ -1249,7 +1380,7 @@ impl Metadata {
             );
             let id = node.id.to_flat();
             resolve.insert(id.clone(), node);
-            MetadataScript { path, id }
+            MetadataScript::new(path, id)
         });
 
         let workspace_metadata = workspace.map(|_| {
@@ -1271,10 +1402,7 @@ impl Metadata {
             let node = MetadataNode::from_workspace(workspace_root.clone(), dependency_groups);
             let id = node.id.to_flat();
             resolve.insert(id.clone(), node);
-            MetadataWorkspace {
-                path: workspace_root.clone(),
-                id,
-            }
+            MetadataWorkspace::new(workspace_root.clone(), id)
         });
         let conflicts = MetadataConflicts::from_conflicts(&members, &resolve, &lock.conflicts);
 

--- a/crates/uv-resolver/src/lock/export/metadata.rs
+++ b/crates/uv-resolver/src/lock/export/metadata.rs
@@ -125,7 +125,7 @@ pub(crate) struct MetadataScript {
 }
 
 impl MetadataScript {
-    pub(in crate::lock) fn new(path: PortablePathBuf, id: MetadataNodeIdFlat) -> Self {
+    pub(crate) fn new(path: PortablePathBuf, id: MetadataNodeIdFlat) -> Self {
         Self { path, id }
     }
 }
@@ -140,7 +140,7 @@ pub(crate) struct MetadataWorkspace {
 }
 
 impl MetadataWorkspace {
-    pub(in crate::lock) fn new(path: PortablePathBuf, id: MetadataNodeIdFlat) -> Self {
+    pub(crate) fn new(path: PortablePathBuf, id: MetadataNodeIdFlat) -> Self {
         Self { path, id }
     }
 }
@@ -298,7 +298,7 @@ pub(crate) struct MetadataNode {
 }
 
 impl MetadataNode {
-    pub(in crate::lock) fn new(id: MetadataNodeId) -> Self {
+    pub(crate) fn new(id: MetadataNodeId) -> Self {
         Self {
             id,
             dependencies: Vec::new(),
@@ -311,7 +311,7 @@ impl MetadataNode {
         }
     }
 
-    pub(in crate::lock) fn from_package_id(
+    pub(crate) fn from_package_id(
         workspace_root: &PortablePathBuf,
         id: &PackageId,
         kind: MetadataNodeKind,
@@ -376,7 +376,7 @@ impl MetadataNode {
         }
     }
 
-    pub(in crate::lock) fn add_resolution_dependency(
+    pub(crate) fn add_resolution_dependency(
         &mut self,
         id: MetadataNodeIdFlat,
         marker: Option<MetadataMarker>,
@@ -384,38 +384,31 @@ impl MetadataNode {
         self.dependencies.push(MetadataDependency { id, marker });
     }
 
-    pub(in crate::lock) fn add_optional_dependency(
-        &mut self,
-        name: ExtraName,
-        id: MetadataNodeIdFlat,
-    ) {
+    pub(crate) fn add_optional_dependency(&mut self, name: ExtraName, id: MetadataNodeIdFlat) {
         self.optional_dependencies.push(MetadataExtra { name, id });
     }
 
-    pub(in crate::lock) fn add_dependency_group(
-        &mut self,
-        name: GroupName,
-        id: MetadataNodeIdFlat,
-    ) {
+    pub(crate) fn add_dependency_group(&mut self, name: GroupName, id: MetadataNodeIdFlat) {
         self.dependency_groups.push(MetadataGroup { name, id });
     }
 
-    pub(in crate::lock) fn set_latest_version(&mut self, version: Option<Version>) {
+    pub(crate) fn set_latest_version(&mut self, version: Option<Version>) {
         self.latest_version = version;
     }
 
-    pub(in crate::lock) fn set_wheels_from_lock(
+    pub(crate) fn set_wheels_from_package(
         &mut self,
         workspace_root: &PortablePathBuf,
-        wheels: &[Wheel],
+        package: &Package,
     ) {
-        self.wheels = wheels
+        self.wheels = package
+            .wheels
             .iter()
             .map(|wheel| MetadataWheel::from_wheel(workspace_root, wheel))
             .collect();
     }
 
-    pub(in crate::lock) fn normalize_resolution(&mut self) {
+    pub(crate) fn normalize_resolution(&mut self) {
         self.dependencies.sort();
         self.dependencies.dedup();
         self.optional_dependencies.sort();
@@ -1367,7 +1360,7 @@ impl Metadata {
                 meta_package.sdist = Some(MetadataSourceDist::from_sdist(&workspace_root, sdist));
             }
 
-            meta_package.set_wheels_from_lock(&workspace_root, &lock_package.wheels);
+            meta_package.set_wheels_from_package(&workspace_root, lock_package);
 
             resolve.insert(meta_package.id.to_flat(), meta_package);
         }

--- a/crates/uv-resolver/src/lock/export/mod.rs
+++ b/crates/uv-resolver/src/lock/export/mod.rs
@@ -18,6 +18,10 @@ use uv_pypi_types::ConflictItem;
 use crate::graph_ops::Reachable;
 use crate::lock::LockErrorKind;
 pub use crate::lock::export::metadata::Metadata;
+pub(crate) use crate::lock::export::metadata::{
+    MetadataNode, MetadataNodeId, MetadataNodeKind, MetadataScript, MetadataWorkspace,
+    MetadataWorkspaceMember,
+};
 pub(crate) use crate::lock::export::pylock_toml::PylockTomlPackage;
 pub use crate::lock::export::pylock_toml::{PylockToml, PylockTomlError, PylockTomlErrorKind};
 pub use crate::lock::export::requirements_txt::RequirementsTxtExport;

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -65,7 +65,7 @@ pub use crate::lock::export::{
 };
 pub use crate::lock::installable::Installable;
 pub use crate::lock::map::PackageMap;
-pub use crate::lock::tree::TreeDisplay;
+pub use crate::lock::tree::{TreeDisplay, TreeJsonTarget};
 use crate::resolution::{AnnotatedDist, ResolutionGraphNode};
 use crate::universal_marker::{ConflictMarker, UniversalMarker};
 use crate::{

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -1088,7 +1088,7 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
         }
     }
 
-    fn ensure_identity(&mut self, identity: MetadataNodeId) -> String {
+    fn ensure_node(&mut self, identity: MetadataNodeId) -> String {
         let id = identity.to_flat();
         self.resolution
             .entry(id.clone())
@@ -1132,12 +1132,12 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
     }
 
     fn ensure_workspace(&mut self) -> String {
-        self.ensure_identity(MetadataNodeId::from_workspace(self.workspace_root.clone()))
+        self.ensure_node(MetadataNodeId::from_workspace(self.workspace_root.clone()))
     }
 
     fn ensure_workspace_group(&mut self, group: &GroupName) -> String {
         let workspace = self.ensure_workspace();
-        let group_id = self.ensure_identity(MetadataNodeId::from_workspace_group(
+        let group_id = self.ensure_node(MetadataNodeId::from_workspace_group(
             self.workspace_root.clone(),
             group.clone(),
         ));
@@ -1146,7 +1146,7 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
     }
 
     fn ensure_script(&mut self, path: &Path) -> String {
-        self.ensure_identity(MetadataNodeId::from_script(PortablePathBuf::from(path)))
+        self.ensure_node(MetadataNodeId::from_script(PortablePathBuf::from(path)))
     }
 
     fn dependency_targets(

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Write;
+use std::path::Path;
 
 use either::Either;
 use itertools::Itertools;
@@ -9,16 +10,37 @@ use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::prelude::EdgeRef;
 use petgraph::{Direction, Graph};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use serde::Serialize;
 
 use uv_configuration::DependencyGroupsWithDefaults;
 use uv_console::human_readable_bytes;
+use uv_fs::PortablePathBuf;
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
 use uv_pypi_types::ResolverMarkerEnvironment;
 
+use crate::lock::export::{
+    MetadataNode, MetadataNodeId, MetadataNodeKind, MetadataScript, MetadataWorkspace,
+    MetadataWorkspaceMember,
+};
 use crate::lock::{Package, PackageId};
 use crate::{ConflictMarker, Lock, PackageMap, UniversalMarker};
+
+#[derive(Debug, Clone, Copy)]
+pub enum TreeJsonTarget<'a> {
+    Workspace(&'a Path),
+    Script(&'a Path),
+}
+
+impl<'a> TreeJsonTarget<'a> {
+    fn root(self) -> &'a Path {
+        match self {
+            Self::Workspace(root) => root,
+            Self::Script(script) => script.parent().unwrap_or_else(|| Path::new("")),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct TreeDisplay<'env> {
@@ -34,6 +56,10 @@ pub struct TreeDisplay<'env> {
     no_dedupe: bool,
     /// Whether the graph edges have been reversed (i.e., `--invert` mode).
     invert: bool,
+    /// Whether production dependencies are included in the tree.
+    prod: bool,
+    /// The dependency groups included in the tree.
+    groups: DependencyGroupsWithDefaults,
     /// Reference to the lock to look up additional metadata (e.g., wheel sizes).
     lock: &'env Lock,
     /// Whether to show sizes in the rendered output.
@@ -466,6 +492,8 @@ impl<'env> TreeDisplay<'env> {
             depth,
             no_dedupe,
             invert,
+            prod: groups.prod(),
+            groups: groups.clone(),
             lock,
             show_sizes,
             conflict_marker,
@@ -731,6 +759,647 @@ impl<'env> TreeDisplay<'env> {
             .filter(|extra| package.optional_dependencies.contains_key(*extra))
             .collect()
     }
+
+    /// Serialize the displayed dependency graph as JSON.
+    pub fn to_json(&self, target: TreeJsonTarget<'_>) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(&JsonGraph::new(self, target))
+    }
+
+    /// Return the packages and edges reachable from the displayed roots within the requested
+    /// depth.
+    ///
+    /// Depth follows the text tree's package-graph semantics. The targets of edges from
+    /// [`Node::Root`] start at depth zero; the synthetic root itself does not consume a level.
+    /// JSON subsequently represents a script or workspace-owned dependency group as an explicit
+    /// node, so its direct requirements remain at depth zero despite appearing one edge away from
+    /// a root in the serialized graph. Structural extra-to-package relationships likewise do not
+    /// participate in depth traversal.
+    fn json_traversal(&self) -> JsonTraversal {
+        let mut distances = FxHashMap::default();
+        let mut queue = VecDeque::new();
+        let mut nodes = FxHashSet::default();
+        let mut edges = FxHashSet::default();
+
+        for root in &self.roots {
+            match self.graph[*root] {
+                Node::Root => {
+                    for edge in self.graph.edges_directed(*root, Direction::Outgoing) {
+                        let Node::Package(package_id) = self.graph[edge.target()] else {
+                            continue;
+                        };
+                        let state = JsonTraversalNode {
+                            index: edge.target(),
+                            expanded_extras: self.expanded_extras(
+                                self.lock.find_by_id(package_id),
+                                Some(edge.weight()),
+                            ),
+                        };
+                        nodes.insert(state.index);
+                        if distances.insert(state.clone(), 0).is_none() {
+                            queue.push_back(state);
+                        }
+                    }
+                }
+                Node::Package(package_id) => {
+                    let state = JsonTraversalNode {
+                        index: *root,
+                        expanded_extras: self
+                            .expanded_extras(self.lock.find_by_id(package_id), None),
+                    };
+                    nodes.insert(state.index);
+                    if distances.insert(state.clone(), 0).is_none() {
+                        queue.push_back(state);
+                    }
+                }
+            }
+        }
+
+        while let Some(source) = queue.pop_front() {
+            let distance = distances[&source];
+            if distance >= self.depth {
+                continue;
+            }
+
+            for edge in self.graph.edges_directed(source.index, Direction::Outgoing) {
+                if !self.invert
+                    && let Edge::Optional(required_extra, ..) = edge.weight()
+                    && !source.expanded_extras.contains(required_extra)
+                {
+                    continue;
+                }
+
+                let target = edge.target();
+                if matches!(self.graph[target], Node::Root) {
+                    edges.insert(edge.id());
+                    continue;
+                }
+                let Node::Package(package_id) = self.graph[target] else {
+                    continue;
+                };
+                let state = JsonTraversalNode {
+                    index: target,
+                    expanded_extras: self
+                        .expanded_extras(self.lock.find_by_id(package_id), Some(edge.weight())),
+                };
+                nodes.insert(state.index);
+                edges.insert(edge.id());
+                if !distances.contains_key(&state) {
+                    distances.insert(state.clone(), distance + 1);
+                    queue.push_back(state);
+                }
+            }
+        }
+
+        JsonTraversal { nodes, edges }
+    }
+}
+
+#[derive(Debug)]
+struct JsonTraversal {
+    nodes: FxHashSet<NodeIndex>,
+    edges: FxHashSet<EdgeIndex>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct JsonTraversalNode<'env> {
+    index: NodeIndex,
+    expanded_extras: BTreeSet<&'env ExtraName>,
+}
+
+/// A JSON representation of the output of `uv tree`.
+///
+/// The core format is the one from `uv workspace metadata` ([`crate::lock::export::Metadata`]),
+/// because they're representing essentially the same data (the resolved dependency graph).
+///
+/// The two formats most notably diverge in what can or can't be roots, because `uv tree`
+/// supports filtering and inverting the graph. So while `metadata` has fixed "members",
+/// "workspace", and "script" entry points, `tree` needs to cope with filters
+/// and inversion making random nodes roots (that said, having workspace/member/script entries
+/// is still useful for quickly identifying those special kinds of node in the graph).
+/// (As with metadata it's discouraged for you to just iterate the `resolution`: you should
+/// start at a given entry point and traverse the graph from there.)
+///
+/// These more advanced operations raise interesting questions for the graph representation.
+/// The following discussion assumes you've read the documentation on
+/// [`crate::lock::export::MetadataNode`] and understand the notion of Node and Edge we use.
+///
+///
+/// # Roots
+///
+/// As noted in those docs, pedantically `roots` should include `mypackage`, `mypackage[extra]`,
+/// `mypackage:group` as separate roots. At first this seemed like a stance worth rejecting
+/// for ergonomics and clarity, but as I tried to rationalize the semantics of `uv tree` it
+/// felt increasingly necessary.
+///
+/// In particular, because `uv tree` has some limited support for changing what parts of the
+/// graph are "active" with flags like `--all-groups` or `--no-default-groups`, we "need" a
+/// way to refer to a package's groups without referring to the package itself. You can't
+/// actually toggle the extras on the workspace but I consider that a bug, and so our format
+/// should ideally support referring to *specifically* "a package with some extra(s) activated".
+///
+/// Thus with everything activated you *may* find all of `mypackage`, `mypackage[extra1]`,
+/// `mypackage[extra2]`, `mypackage:group1`, `mypackage:group2` in the `roots` list.
+///
+/// Conversely, we will *exclude* the workspace node from the `roots`, as it is a purely virtual
+/// concept that only exists to hang workspace-exclusive groups from (e.g. when you define
+/// `dependency-groups` in a `pyproject.toml` that does not contain a `[project]` table).
+///
+///
+/// # Depth
+///
+/// Node depth is an annoying concept. The baseline of the theory here is once again
+/// an appeal to `mypackage`, `mypackage[extra]`, and `mypackage:group` being all on an equal
+/// footing. However, `mypackage[extra]` and `mypackage:group` in the graph are "virtual"
+/// in the sense that they don't actually refer to a thing to install, but are instead a
+/// list of dependencies that should all be installed together.
+///
+/// Let's start with the nice examples with obvious answers to establish a baseline:
+/// a uv workspace with no extras or groups, just pure production dependencies.
+///
+/// * depth 0: lists off all workspace members
+/// * depth 1: lists off all workspace members and their direct dependencies
+/// * depth 2: lists off all workspace members and two levels of dependencies
+///
+/// So ok depth here refers to how many levels of edges we're willing to follow, great!
+/// Now let's add dependency groups and extras.
+///
+/// Do you list the *existence* of `mypackage:group` or `mypackage[extra]` at depth 0?
+/// Or do you only acknowledge their existence at depth 1 when they would be non-empty?
+///
+/// In the current textual display of `uv tree` we choose the second answer essentially
+/// garbage-collecting extras and groups that would be empty because all their edges
+/// have been deleted. For now the JSON output respects this behaviour, but we may
+/// change that decision if we decide we don't like it:
+/// <https://github.com/astral-sh/uv/issues/19973>
+///
+/// Now to be clear we do this "edge" analysis before lowering to the output graph,
+/// and this matters for several cases.
+///
+/// First, scripts and workspaces aren't considered nodes before the lowering, and
+/// so script dependencies and workspace-group dependencies appear at depth 0 (another case where
+/// the JSON output respects the behaviour of the textual output):
+/// <https://github.com/astral-sh/uv/issues/19976>
+///
+/// Second, the fact that `mypackage` is a dependency of `mypackage[extra]`.
+/// Specifically, in `metadata` if `foo` depends on `bar[extra1, extra2]`
+/// then we will only include edges to `bar[extra1]` and `bar[extra2]` and not to `bar` itself,
+/// because we know those two extra nodes will include the edge to `bar` anyway (nothing requires
+/// this, it just seemed tidier to simplify the graph in that way).
+///
+/// As long as we want to do that simplification, it is *not* correct for us to
+/// cut the edge from the extra to the package, and so we don't guarantee a simple
+/// statement like "the resulting graph will have at most depth N" when counting
+/// `dependencies` (and that's all muddy anyway since there can be cycles
+/// in the final graph).
+///
+///
+/// # Inversion
+///
+/// `--invert` should flip the edges of the graph, turning the leaves into roots
+/// (with operations like `--depth` being applied afterwards).
+///
+/// Unfortunately this is ill-defined at the moment in the face of leaf-cycles:
+/// <https://github.com/astral-sh/uv/issues/19972>
+///
+/// Ignoring the issue of cycles, the only thing to note here is that only the
+/// `dependencies` lists of nodes should be inverted. The `optional_dependencies`
+/// and `dependency_groups` listings remain unchanged, because those aren't edges
+/// of the graph, they're metadata on those packages (or the workspace).
+#[derive(Debug, Serialize)]
+struct JsonGraph {
+    schema: JsonSchema,
+    workspace_root: PortablePathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    script: Option<MetadataScript>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace: Option<MetadataWorkspace>,
+    roots: Vec<JsonRoot>,
+    inverted: bool,
+    /// Workspace members included in the projected resolution.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    members: Vec<MetadataWorkspaceMember>,
+    resolution: BTreeMap<String, MetadataNode>,
+}
+
+impl JsonGraph {
+    fn new(tree: &TreeDisplay<'_>, target: TreeJsonTarget<'_>) -> Self {
+        let traversal = tree.json_traversal();
+        let workspace_root = PortablePathBuf::from(target.root());
+        let mut builder = JsonGraphBuilder::new(tree, workspace_root.clone());
+
+        for index in traversal.nodes.iter().copied() {
+            let Node::Package(package_id) = tree.graph[index] else {
+                continue;
+            };
+            builder.ensure_package(package_id, MetadataNodeKind::Package);
+        }
+
+        for edge in tree
+            .graph
+            .edge_references()
+            .filter(|edge| traversal.edges.contains(&edge.id()))
+        {
+            builder.add_package_edge(edge.source(), edge.target(), edge.weight());
+        }
+
+        builder.add_target_edges(target, &traversal);
+        let (script, workspace) = match target {
+            TreeJsonTarget::Script(path) => {
+                let path = PortablePathBuf::from(path);
+                let id = builder.ensure_script(path.as_ref());
+                (Some(MetadataScript::new(path, id)), None)
+            }
+            TreeJsonTarget::Workspace(path) => {
+                let path = PortablePathBuf::from(path);
+                let id = builder.ensure_workspace();
+                (None, Some(MetadataWorkspace::new(path, id)))
+            }
+        };
+        let roots = builder.roots(target);
+        let members = builder.members(target);
+        let resolution = builder.finish();
+
+        Self {
+            schema: JsonSchema {
+                version: JsonSchemaVersion::Preview,
+            },
+            workspace_root,
+            script,
+            workspace,
+            roots,
+            inverted: tree.invert,
+            members,
+            resolution,
+        }
+    }
+}
+
+struct JsonGraphBuilder<'tree, 'env> {
+    tree: &'tree TreeDisplay<'env>,
+    workspace_root: PortablePathBuf,
+    resolution: BTreeMap<String, MetadataNode>,
+}
+
+impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
+    fn new(tree: &'tree TreeDisplay<'env>, workspace_root: PortablePathBuf) -> Self {
+        Self {
+            tree,
+            workspace_root,
+            resolution: BTreeMap::new(),
+        }
+    }
+
+    fn ensure_identity(&mut self, identity: MetadataNodeId) -> String {
+        let id = identity.to_flat();
+        self.resolution
+            .entry(id.clone())
+            .or_insert_with(|| MetadataNode::new(identity));
+        id
+    }
+
+    fn ensure_package(&mut self, package_id: &'env PackageId, kind: MetadataNodeKind) -> String {
+        let is_package = matches!(kind, MetadataNodeKind::Package);
+        let id = MetadataNodeId::from_package_id(&self.workspace_root, package_id, kind.clone())
+            .to_flat();
+        self.resolution.entry(id.clone()).or_insert_with(|| {
+            let package = self.tree.lock.find_by_id(package_id);
+            let mut node = MetadataNode::from_package_id(&self.workspace_root, package_id, kind);
+            if is_package {
+                node.set_latest_version(self.tree.latest.get(package_id).cloned());
+                node.set_wheels_from_lock(&self.workspace_root, &package.wheels);
+            }
+            node
+        });
+        id
+    }
+
+    fn ensure_extra(&mut self, package_id: &'env PackageId, extra: &ExtraName) -> String {
+        let package = self.ensure_package(package_id, MetadataNodeKind::Package);
+        let extra_id = self.ensure_package(package_id, MetadataNodeKind::Extra(extra.clone()));
+        self.add_link(
+            package.clone(),
+            extra_id.clone(),
+            JsonLink::Optional(extra.clone()),
+        );
+        self.add_link(extra_id.clone(), package, JsonLink::Dependency(None));
+        extra_id
+    }
+
+    fn ensure_group(&mut self, package_id: &'env PackageId, group: &GroupName) -> String {
+        let package = self.ensure_package(package_id, MetadataNodeKind::Package);
+        let group_id = self.ensure_package(package_id, MetadataNodeKind::Group(group.clone()));
+        self.add_link(package, group_id.clone(), JsonLink::Group(group.clone()));
+        group_id
+    }
+
+    fn ensure_workspace(&mut self) -> String {
+        self.ensure_identity(MetadataNodeId::from_workspace(self.workspace_root.clone()))
+    }
+
+    fn ensure_workspace_group(&mut self, group: &GroupName) -> String {
+        let workspace = self.ensure_workspace();
+        let group_id = self.ensure_identity(MetadataNodeId::from_workspace_group(
+            self.workspace_root.clone(),
+            group.clone(),
+        ));
+        self.add_link(workspace, group_id.clone(), JsonLink::Group(group.clone()));
+        group_id
+    }
+
+    fn ensure_script(&mut self, path: &Path) -> String {
+        self.ensure_identity(MetadataNodeId::from_script(PortablePathBuf::from(path)))
+    }
+
+    fn dependency_targets(
+        &mut self,
+        package_id: &'env PackageId,
+        extras: Option<RequestedExtras<'env>>,
+    ) -> Vec<String> {
+        let Some(extras) = extras.filter(|extras| !extras.is_empty()) else {
+            return vec![self.ensure_package(package_id, MetadataNodeKind::Package)];
+        };
+        extras
+            .iter()
+            .map(|extra| self.ensure_extra(package_id, extra))
+            .collect()
+    }
+
+    fn add_package_edge(&mut self, source: NodeIndex, target: NodeIndex, edge: &Edge<'env>) {
+        let (source, target) = if self.tree.invert {
+            (target, source)
+        } else {
+            (source, target)
+        };
+        let (Node::Package(source), Node::Package(target)) =
+            (&self.tree.graph[source], &self.tree.graph[target])
+        else {
+            return;
+        };
+        let (source, target) = (*source, *target);
+
+        let source = match edge {
+            Edge::Prod(..) => self.ensure_package(source, MetadataNodeKind::Package),
+            Edge::Optional(extra, ..) => self.ensure_extra(source, extra),
+            Edge::Dev(group, ..) => self.ensure_group(source, group),
+        };
+        let marker = self.marker(edge);
+        for target in self.dependency_targets(target, edge.extras()) {
+            self.add_link(source.clone(), target, JsonLink::Dependency(marker.clone()));
+        }
+    }
+
+    fn add_target_edges(&mut self, target: TreeJsonTarget<'_>, traversal: &JsonTraversal) {
+        // Forward edges from the synthetic root establish the target's depth-zero packages, so
+        // they are retained even though they are not part of `traversal.edges`. Inverted target
+        // edges must have been reached while traversing the reversed graph.
+        let edges = self
+            .tree
+            .graph
+            .edge_references()
+            .filter(|edge| !self.tree.invert || traversal.edges.contains(&edge.id()))
+            .filter_map(|edge| {
+                let package = match (
+                    &self.tree.graph[edge.source()],
+                    &self.tree.graph[edge.target()],
+                ) {
+                    (Node::Root, Node::Package(package)) | (Node::Package(package), Node::Root) => {
+                        *package
+                    }
+                    (Node::Root, Node::Root) | (Node::Package(_), Node::Package(_)) => return None,
+                };
+                Some((package, edge.weight()))
+            })
+            .collect::<Vec<_>>();
+
+        match target {
+            TreeJsonTarget::Script(path) => {
+                let script = self.ensure_script(path);
+                for (package, edge) in edges {
+                    let marker = self.marker(edge);
+                    for package in self.dependency_targets(package, edge.extras()) {
+                        self.add_link(
+                            script.clone(),
+                            package,
+                            JsonLink::Dependency(marker.clone()),
+                        );
+                    }
+                }
+            }
+            TreeJsonTarget::Workspace(_) => {
+                self.ensure_workspace();
+                for (package, edge) in edges {
+                    let Edge::Dev(group, ..) = edge else {
+                        continue;
+                    };
+                    let group = self.ensure_workspace_group(group);
+                    let marker = self.marker(edge);
+                    for package in self.dependency_targets(package, edge.extras()) {
+                        self.add_link(group.clone(), package, JsonLink::Dependency(marker.clone()));
+                    }
+                }
+            }
+        }
+    }
+
+    fn marker(&self, edge: &Edge<'_>) -> Option<String> {
+        self.tree
+            .lock
+            .simplify_environment(edge.marker().pep508())
+            .try_to_string()
+    }
+
+    fn add_link(&mut self, source: String, target: String, link: JsonLink) {
+        // `optional_dependencies` and `dependency_groups` advertise related nodes; they are not
+        // dependency edges. Keep those relationships attached to their owner when inverting the
+        // graph, and reverse only actual dependencies.
+        let (source, target) = if self.tree.invert && matches!(&link, JsonLink::Dependency(_)) {
+            (target, source)
+        } else {
+            (source, target)
+        };
+        let Some(node) = self.resolution.get_mut(&source) else {
+            return;
+        };
+        match link {
+            JsonLink::Dependency(marker) => {
+                node.add_resolution_dependency(target, marker);
+            }
+            JsonLink::Optional(name) => {
+                node.add_optional_dependency(name, target);
+            }
+            JsonLink::Group(name) => {
+                node.add_dependency_group(name, target);
+            }
+        }
+    }
+
+    fn add_package_roots(&mut self, roots: &mut Vec<JsonRoot>, package_id: &'env PackageId) {
+        let package = self.tree.lock.find_by_id(package_id);
+        let extras = package
+            .optional_dependencies
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let groups = package
+            .dependency_groups
+            .keys()
+            .filter(|group| self.tree.groups.contains(group))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if self.tree.prod {
+            roots.push(JsonRoot {
+                id: self.ensure_package(package_id, MetadataNodeKind::Package),
+            });
+            for extra in &extras {
+                let id = MetadataNodeId::from_package_id(
+                    &self.workspace_root,
+                    package_id,
+                    MetadataNodeKind::Extra(extra.clone()),
+                )
+                .to_flat();
+                if self.resolution.contains_key(&id) {
+                    roots.push(JsonRoot { id });
+                }
+            }
+        }
+
+        for group in &groups {
+            let id = MetadataNodeId::from_package_id(
+                &self.workspace_root,
+                package_id,
+                MetadataNodeKind::Group(group.clone()),
+            )
+            .to_flat();
+            if self.resolution.contains_key(&id) {
+                roots.push(JsonRoot { id });
+            }
+        }
+    }
+
+    fn roots(&mut self, target: TreeJsonTarget<'_>) -> Vec<JsonRoot> {
+        let mut roots = Vec::new();
+        for root in &self.tree.roots {
+            match self.tree.graph[*root] {
+                Node::Package(package_id) => {
+                    if self.tree.invert {
+                        roots.push(JsonRoot {
+                            id: self.ensure_package(package_id, MetadataNodeKind::Package),
+                        });
+                    } else {
+                        self.add_package_roots(&mut roots, package_id);
+                    }
+                }
+                Node::Root => match target {
+                    TreeJsonTarget::Script(path) => {
+                        let script = self.ensure_script(path);
+                        roots.push(JsonRoot { id: script });
+                    }
+                    TreeJsonTarget::Workspace(_) => {
+                        let packages = self
+                            .tree
+                            .graph
+                            .edges_directed(*root, Direction::Outgoing)
+                            .filter(|edge| matches!(edge.weight(), Edge::Prod(..)))
+                            .filter_map(|edge| {
+                                let Node::Package(package_id) = self.tree.graph[edge.target()]
+                                else {
+                                    return None;
+                                };
+                                Some(package_id)
+                            })
+                            .collect::<Vec<_>>();
+                        for package_id in packages {
+                            self.add_package_roots(&mut roots, package_id);
+                        }
+                        let groups = self
+                            .tree
+                            .lock
+                            .dependency_groups()
+                            .keys()
+                            .filter(|group| self.tree.groups.contains(group))
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        for group in groups {
+                            let id = MetadataNodeId::from_workspace_group(
+                                self.workspace_root.clone(),
+                                group,
+                            )
+                            .to_flat();
+                            if self.resolution.contains_key(&id) {
+                                roots.push(JsonRoot { id });
+                            }
+                        }
+                    }
+                },
+            }
+        }
+        roots.sort();
+        roots.dedup();
+        roots
+    }
+
+    fn members(&self, target: TreeJsonTarget<'_>) -> Vec<MetadataWorkspaceMember> {
+        if matches!(target, TreeJsonTarget::Script(_)) {
+            return Vec::new();
+        }
+
+        let packages = if self.tree.lock.members().is_empty() {
+            self.tree.lock.root().into_iter().collect::<Vec<_>>()
+        } else {
+            self.tree
+                .lock
+                .packages()
+                .iter()
+                .filter(|package| self.tree.lock.members().contains(&package.id.name))
+                .collect::<Vec<_>>()
+        };
+
+        packages
+            .into_iter()
+            .filter(|package| {
+                let id = MetadataNodeId::from_package_id(
+                    &self.workspace_root,
+                    &package.id,
+                    MetadataNodeKind::Package,
+                )
+                .to_flat();
+                self.resolution.contains_key(&id)
+            })
+            .filter_map(|package| {
+                MetadataWorkspaceMember::from_locked_package(&self.workspace_root, &package.id)
+            })
+            .collect()
+    }
+
+    fn finish(mut self) -> BTreeMap<String, MetadataNode> {
+        for node in self.resolution.values_mut() {
+            node.normalize_resolution();
+        }
+        self.resolution
+    }
+}
+
+enum JsonLink {
+    Dependency(Option<String>),
+    Optional(ExtraName),
+    Group(GroupName),
+}
+
+#[derive(Debug, Serialize)]
+struct JsonSchema {
+    version: JsonSchemaVersion,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum JsonSchemaVersion {
+    Preview,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+struct JsonRoot {
+    id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -793,6 +793,8 @@ impl<'env> TreeDisplay<'env> {
                                 self.lock.find_by_id(package_id),
                                 Some(edge.weight()),
                             ),
+                            marker: UniversalMarker::TRUE,
+                            reached_via_dependency_group: false,
                         };
                         nodes.insert(state.index);
                         if distances.insert(state.clone(), 0).is_none() {
@@ -805,6 +807,12 @@ impl<'env> TreeDisplay<'env> {
                         index: *root,
                         expanded_extras: self
                             .expanded_extras(self.lock.find_by_id(package_id), None),
+                        marker: if self.invert {
+                            self.conflict_marker
+                        } else {
+                            UniversalMarker::TRUE
+                        },
+                        reached_via_dependency_group: false,
                     };
                     nodes.insert(state.index);
                     if distances.insert(state.clone(), 0).is_none() {
@@ -816,17 +824,44 @@ impl<'env> TreeDisplay<'env> {
 
         while let Some(source) = queue.pop_front() {
             let distance = distances[&source];
-            if distance >= self.depth {
+            if distance >= self.depth || self.invert && source.reached_via_dependency_group {
                 continue;
             }
 
             for edge in self.graph.edges_directed(source.index, Direction::Outgoing) {
-                if !self.invert
-                    && let Edge::Optional(required_extra, ..) = edge.weight()
-                    && !source.expanded_extras.contains(required_extra)
-                {
-                    continue;
-                }
+                let edge_kind = edge.weight();
+                let marker = if self.invert {
+                    // If the path to the target requires an extra on this package, only follow
+                    // consumers that activate that extra.
+                    if !source.expanded_extras.is_empty()
+                        && edge_kind.extras().is_none_or(|extras| {
+                            !source
+                                .expanded_extras
+                                .iter()
+                                .all(|extra| extras.contains(extra))
+                        })
+                    {
+                        continue;
+                    }
+
+                    // Do not join incoming and outgoing edges that cannot coexist in the same
+                    // universal marker environment.
+                    let mut marker = source.marker;
+                    marker.and(edge_kind.marker());
+                    if marker.is_false() {
+                        continue;
+                    }
+                    marker
+                } else {
+                    // Only include extra-conditional dependencies if the activating extra is
+                    // enabled in the current context.
+                    if let Edge::Optional(required_extra, ..) = edge_kind
+                        && !source.expanded_extras.contains(required_extra)
+                    {
+                        continue;
+                    }
+                    UniversalMarker::TRUE
+                };
 
                 let target = edge.target();
                 if matches!(self.graph[target], Node::Root) {
@@ -840,6 +875,8 @@ impl<'env> TreeDisplay<'env> {
                     index: target,
                     expanded_extras: self
                         .expanded_extras(self.lock.find_by_id(package_id), Some(edge.weight())),
+                    marker,
+                    reached_via_dependency_group: self.invert && edge_kind.is_dev(),
                 };
                 nodes.insert(state.index);
                 edges.insert(edge.id());
@@ -864,6 +901,8 @@ struct JsonTraversal {
 struct JsonTraversalNode<'env> {
     index: NodeIndex,
     expanded_extras: BTreeSet<&'env ExtraName>,
+    marker: UniversalMarker,
+    reached_via_dependency_group: bool,
 }
 
 /// A JSON representation of the output of `uv tree`.

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -1105,7 +1105,7 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
             let mut node = MetadataNode::from_package_id(&self.workspace_root, package_id, kind);
             if is_package {
                 node.set_latest_version(self.tree.latest.get(package_id).cloned());
-                node.set_wheels_from_lock(&self.workspace_root, &package.wheels);
+                node.set_wheels_from_package(&self.workspace_root, package);
             }
             node
         });

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::path::Path;
 
 use anstream::print;
@@ -5,16 +6,18 @@ use anyhow::{Error, Result};
 use futures::StreamExt;
 use uv_cache::{Cache, Refresh};
 use uv_cache_info::Timestamp;
+use uv_cli::TreeFormat;
 use uv_client::{BaseClientBuilder, RegistryClientBuilder};
 use uv_configuration::{Concurrency, DependencyGroups, TargetTriple};
 use uv_distribution_types::IndexCapabilities;
 use uv_normalize::DefaultGroups;
 use uv_normalize::PackageName;
-use uv_preview::Preview;
+use uv_preview::{Preview, PreviewFeature};
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion};
-use uv_resolver::{PackageMap, TreeDisplay};
+use uv_resolver::{PackageMap, TreeDisplay, TreeJsonTarget};
 use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
+use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache};
 
 use crate::commands::pip::latest::LatestClient;
@@ -41,6 +44,7 @@ pub(crate) async fn tree(
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
     universal: bool,
+    format: TreeFormat,
     depth: u8,
     prune: Vec<PackageName>,
     package: Vec<PackageName>,
@@ -63,6 +67,13 @@ pub(crate) async fn tree(
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
+    if matches!(format, TreeFormat::Json) && !preview.is_enabled(PreviewFeature::JsonOutput) {
+        warn_user!(
+            "The `--format json` option is experimental and the schema may change without warning. Pass `--preview-features {}` to disable this warning.",
+            PreviewFeature::JsonOutput
+        );
+    }
+
     // Find the project requirements.
     let workspace_cache = WorkspaceCache::default();
     let virtual_project;
@@ -302,7 +313,19 @@ pub(crate) async fn tree(
         show_sizes,
     );
 
-    print!("{tree}");
+    match format {
+        TreeFormat::Text => print!("{tree}"),
+        TreeFormat::Json => writeln!(
+            printer.stdout_important(),
+            "{}",
+            tree.to_json(match target {
+                LockTarget::Workspace(workspace) => {
+                    TreeJsonTarget::Workspace(workspace.install_path())
+                }
+                LockTarget::Script(script) => TreeJsonTarget::Script(&script.path),
+            })?
+        )?,
+    }
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2731,6 +2731,7 @@ async fn run_project(
                 args.lock_check,
                 args.frozen,
                 args.universal,
+                args.format,
                 args.depth,
                 args.prune,
                 args.package,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -19,7 +19,7 @@ use uv_cli::{
     PipSyncArgs, PipTreeArgs, PipUninstallArgs, PythonFindArgs, PythonInstallArgs, PythonListArgs,
     PythonListFormat, PythonPinArgs, PythonUninstallArgs, PythonUpgradeArgs, RemoveArgs, RunArgs,
     SyncArgs, SyncFormat, ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs,
-    ToolUninstallArgs, TreeArgs, UpgradeArgs, VenvArgs, VersionArgs, VersionBumpSpec,
+    ToolUninstallArgs, TreeArgs, TreeFormat, UpgradeArgs, VenvArgs, VersionArgs, VersionBumpSpec,
     VersionFormat,
 };
 use uv_cli::{
@@ -2649,6 +2649,7 @@ pub(crate) struct TreeSettings {
     pub(super) lock_check: LockCheck,
     pub(super) frozen: Option<FrozenSource>,
     pub(super) universal: bool,
+    pub(super) format: TreeFormat,
     pub(super) depth: u8,
     pub(super) prune: Vec<PackageName>,
     pub(super) package: Vec<PackageName>,
@@ -2675,6 +2676,7 @@ impl TreeSettings {
         let TreeArgs {
             tree,
             universal,
+            format,
             dev,
             only_dev,
             no_dev,
@@ -2732,6 +2734,7 @@ impl TreeSettings {
             lock_check: resolve_lock_check(locked),
             frozen: resolve_frozen(frozen),
             universal,
+            format,
             depth: tree.depth,
             prune: tree.prune,
             package: tree.package,

--- a/crates/uv/tests/project/tree.rs
+++ b/crates/uv/tests/project/tree.rs
@@ -11,30 +11,6 @@ use url::Url;
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
 
-fn json_tree_package_names(command: &mut Command) -> Result<Vec<String>> {
-    let output = command
-        .arg("--preview-features")
-        .arg("json-output")
-        .arg("--format")
-        .arg("json")
-        .output()?;
-    output.clone().assert().success();
-
-    let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
-    report["resolution"]
-        .as_object()
-        .context("dependency graph resolution should be an object")?
-        .values()
-        .filter(|node| node["kind"] == "package")
-        .map(|node| {
-            node["name"]
-                .as_str()
-                .context("dependency graph node should have a name")
-                .map(ToOwned::to_owned)
-        })
-        .collect()
-}
-
 #[test]
 fn tree_centralized_environment_no_cache() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4698,4 +4674,29 @@ fn workspace_circular_dependencies() -> Result<()> {
     );
 
     Ok(())
+}
+
+fn json_tree_package_names(command: &mut Command) -> Result<Vec<String>> {
+    let assert = command
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .output()?
+        .assert()
+        .success();
+
+    let report: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
+    report["resolution"]
+        .as_object()
+        .context("dependency graph resolution should be an object")?
+        .values()
+        .filter(|node| node["kind"] == "package")
+        .map(|node| {
+            node["name"]
+                .as_str()
+                .context("dependency graph node should have a name")
+                .map(ToOwned::to_owned)
+        })
+        .collect()
 }

--- a/crates/uv/tests/project/tree.rs
+++ b/crates/uv/tests/project/tree.rs
@@ -9,6 +9,8 @@ use url::Url;
 
 #[cfg(feature = "test-universal")]
 use uv_static::EnvVars;
+#[cfg(feature = "test-universal")]
+use uv_test::TestContext;
 use uv_test::uv_snapshot;
 
 #[test]
@@ -91,53 +93,7 @@ fn nested_dependencies() -> Result<()> {
 #[test]
 fn json_output() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-
-    context.temp_dir.child("pyproject.toml").write_str(
-        r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = ["package-a[feature]"]
-
-        [dependency-groups]
-        dev = ["package-c"]
-
-        [tool.uv.sources]
-        package-a = { path = "packages/package-a" }
-        package-c = { path = "packages/package-c" }
-        "#,
-    )?;
-
-    let package_a = context.temp_dir.child("packages/package-a");
-    package_a.create_dir_all()?;
-    package_a.child("pyproject.toml").write_str(
-        r#"
-        [project]
-        name = "package-a"
-        version = "1.0.0"
-        requires-python = ">=3.12"
-
-        [project.optional-dependencies]
-        feature = ["package-b"]
-
-        [tool.uv.sources]
-        package-b = { path = "../package-b" }
-        "#,
-    )?;
-
-    for package in ["package-b", "package-c"] {
-        let directory = context.temp_dir.child(format!("packages/{package}"));
-        directory.create_dir_all()?;
-        directory
-            .child("pyproject.toml")
-            .write_str(&formatdoc! {r#"
-            [project]
-            name = "{package}"
-            version = "1.0.0"
-            requires-python = ">=3.12"
-        "#})?;
-    }
+    setup_json_output(&context)?;
 
     uv_snapshot!(context.filters(), context.tree()
         .arg("--preview-features")
@@ -271,7 +227,7 @@ fn json_output() -> Result<()> {
     Resolved 4 packages in [TIME]
     "#);
 
-    let output = context
+    let assert = context
         .tree()
         .arg("--preview-features")
         .arg("json-output")
@@ -279,10 +235,11 @@ fn json_output() -> Result<()> {
         .arg("json")
         .arg("--universal")
         .arg("--quiet")
-        .output()?;
-    output.clone().assert().success();
-    assert!(output.stderr.is_empty());
-    let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        .output()?
+        .assert()
+        .success();
+    assert!(assert.get_output().stderr.is_empty());
+    let report: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
     let package_names = report["resolution"]
         .as_object()
         .context("dependency graph resolution should be an object")?
@@ -302,6 +259,15 @@ fn json_output() -> Result<()> {
       "project"
     ]
     "#);
+
+    Ok(())
+}
+
+#[cfg(feature = "test-universal")]
+#[test]
+fn json_output_depth() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    setup_json_output(&context)?;
 
     uv_snapshot!(context.filters(), context.tree()
         .arg("--preview-features")
@@ -424,6 +390,15 @@ fn json_output() -> Result<()> {
     ----- stderr -----
     Resolved 4 packages in [TIME]
     "#);
+
+    Ok(())
+}
+
+#[cfg(feature = "test-universal")]
+#[test]
+fn json_output_inverted_depth() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    setup_json_output(&context)?;
 
     uv_snapshot!(context.filters(), context.tree()
         .arg("--preview-features")
@@ -557,6 +532,15 @@ fn json_output() -> Result<()> {
     Resolved 4 packages in [TIME]
     "#);
 
+    Ok(())
+}
+
+#[cfg(feature = "test-universal")]
+#[test]
+fn json_output_projected_members_respect_depth() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    setup_json_output(&context)?;
+
     let projected_members = |depth: Option<u8>| -> Result<Vec<String>> {
         let mut command = context.tree();
         command
@@ -571,9 +555,8 @@ fn json_output() -> Result<()> {
         if let Some(depth) = depth {
             command.arg("--depth").arg(depth.to_string());
         }
-        let output = command.output()?;
-        output.clone().assert().success();
-        let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        let assert = command.output()?.assert().success();
+        let report: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
         report["members"]
             .as_array()
             .into_iter()
@@ -4672,6 +4655,58 @@ fn workspace_circular_dependencies() -> Result<()> {
     Resolved 2 packages in [TIME]
     "
     );
+
+    Ok(())
+}
+
+#[cfg(feature = "test-universal")]
+fn setup_json_output(context: &TestContext) -> Result<()> {
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-a[feature]"]
+
+        [dependency-groups]
+        dev = ["package-c"]
+
+        [tool.uv.sources]
+        package-a = { path = "packages/package-a" }
+        package-c = { path = "packages/package-c" }
+        "#,
+    )?;
+
+    let package_a = context.temp_dir.child("packages/package-a");
+    package_a.create_dir_all()?;
+    package_a.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["package-b"]
+
+        [tool.uv.sources]
+        package-b = { path = "../package-b" }
+        "#,
+    )?;
+
+    for package in ["package-b", "package-c"] {
+        let directory = context.temp_dir.child(format!("packages/{package}"));
+        directory.create_dir_all()?;
+        directory
+            .child("pyproject.toml")
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{package}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+        "#})?;
+    }
 
     Ok(())
 }

--- a/crates/uv/tests/project/tree.rs
+++ b/crates/uv/tests/project/tree.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use anyhow::{Context, Result, bail};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
@@ -8,6 +10,30 @@ use url::Url;
 #[cfg(feature = "test-universal")]
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
+
+fn json_tree_package_names(command: &mut Command) -> Result<Vec<String>> {
+    let output = command
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .output()?;
+    output.clone().assert().success();
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    report["resolution"]
+        .as_object()
+        .context("dependency graph resolution should be an object")?
+        .values()
+        .filter(|node| node["kind"] == "package")
+        .map(|node| {
+            node["name"]
+                .as_str()
+                .context("dependency graph node should have a name")
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
 
 #[test]
 fn tree_centralized_environment_no_cache() -> Result<()> {
@@ -3259,6 +3285,24 @@ fn invert_preserves_extra_attribution() -> Result<()> {
     Resolved 4 packages in [TIME]
     ");
 
+    assert_json_snapshot!(
+        json_tree_package_names(
+            context
+                .tree()
+                .arg("--universal")
+                .arg("--invert")
+                .arg("--package")
+                .arg("package-x")
+        )?,
+        @r#"
+    [
+      "package-a",
+      "package-p",
+      "package-x"
+    ]
+    "#
+    );
+
     Ok(())
 }
 
@@ -3325,6 +3369,23 @@ fn invert_preserves_dependency_group_attribution() -> Result<()> {
     ----- stderr -----
     Resolved 3 packages in [TIME]
     ");
+
+    assert_json_snapshot!(
+        json_tree_package_names(
+            context
+                .tree()
+                .arg("--universal")
+                .arg("--invert")
+                .arg("--package")
+                .arg("package-x")
+        )?,
+        @r#"
+    [
+      "package-a",
+      "package-x"
+    ]
+    "#
+    );
 
     Ok(())
 }
@@ -3405,6 +3466,24 @@ fn invert_preserves_marker_attribution() -> Result<()> {
     ----- stderr -----
     Resolved 4 packages in [TIME]
     ");
+
+    assert_json_snapshot!(
+        json_tree_package_names(
+            context
+                .tree()
+                .arg("--universal")
+                .arg("--invert")
+                .arg("--package")
+                .arg("package-x")
+        )?,
+        @r#"
+    [
+      "package-b",
+      "package-p",
+      "package-x"
+    ]
+    "#
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/project/tree.rs
+++ b/crates/uv/tests/project/tree.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::{formatdoc, indoc};
-use insta::assert_snapshot;
+use insta::{assert_json_snapshot, assert_snapshot};
 use url::Url;
 
 #[cfg(feature = "test-universal")]
@@ -86,6 +86,1298 @@ fn nested_dependencies() -> Result<()> {
 }
 
 #[cfg(feature = "test-universal")]
+#[test]
+fn json_output() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-a[feature]"]
+
+        [dependency-groups]
+        dev = ["package-c"]
+
+        [tool.uv.sources]
+        package-a = { path = "packages/package-a" }
+        package-c = { path = "packages/package-c" }
+        "#,
+    )?;
+
+    let package_a = context.temp_dir.child("packages/package-a");
+    package_a.create_dir_all()?;
+    package_a.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["package-b"]
+
+        [tool.uv.sources]
+        package-b = { path = "../package-b" }
+        "#,
+    )?;
+
+    for package in ["package-b", "package-c"] {
+        let directory = context.temp_dir.child(format!("packages/{package}"));
+        directory.create_dir_all()?;
+        directory
+            .child("pyproject.toml")
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{package}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+        "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "project:dev==0.1.0@virtual+[TEMP_DIR]/"
+        },
+        {
+          "id": "project==0.1.0@virtual+[TEMP_DIR]/"
+        }
+      ],
+      "inverted": false,
+      "members": [
+        {
+          "name": "project",
+          "path": "[TEMP_DIR]/",
+          "id": "project==0.1.0@virtual+[TEMP_DIR]/"
+        }
+      ],
+      "resolution": {
+        "package-a==1.0.0@directory+[TEMP_DIR]/packages/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-a"
+          },
+          "kind": "package",
+          "dependencies": [],
+          "optional_dependencies": [
+            {
+              "name": "feature",
+              "id": "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            }
+          ]
+        },
+        "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-a"
+          },
+          "kind": {
+            "extra": "feature"
+          },
+          "dependencies": [
+            {
+              "id": "package-a==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            },
+            {
+              "id": "package-b==1.0.0@directory+[TEMP_DIR]/packages/package-b"
+            }
+          ]
+        },
+        "package-b==1.0.0@directory+[TEMP_DIR]/packages/package-b": {
+          "name": "package-b",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-b"
+          },
+          "kind": "package",
+          "dependencies": []
+        },
+        "package-c==1.0.0@directory+[TEMP_DIR]/packages/package-c": {
+          "name": "package-c",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-c"
+          },
+          "kind": "package",
+          "dependencies": []
+        },
+        "project:dev==0.1.0@virtual+[TEMP_DIR]/": {
+          "name": "project",
+          "version": "0.1.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/"
+          },
+          "kind": {
+            "group": "dev"
+          },
+          "dependencies": [
+            {
+              "id": "package-c==1.0.0@directory+[TEMP_DIR]/packages/package-c"
+            }
+          ]
+        },
+        "project==0.1.0@virtual+[TEMP_DIR]/": {
+          "name": "project",
+          "version": "0.1.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            }
+          ],
+          "dependency_groups": [
+            {
+              "name": "dev",
+              "id": "project:dev==0.1.0@virtual+[TEMP_DIR]/"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": []
+        }
+      }
+    }
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "#);
+
+    let output = context
+        .tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal")
+        .arg("--quiet")
+        .output()?;
+    output.clone().assert().success();
+    assert!(output.stderr.is_empty());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    let package_names = report["resolution"]
+        .as_object()
+        .context("dependency graph resolution should be an object")?
+        .values()
+        .filter(|node| node["kind"] == "package")
+        .map(|node| {
+            node["name"]
+                .as_str()
+                .context("dependency graph node should have a name")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    assert_json_snapshot!(package_names, @r#"
+    [
+      "package-a",
+      "package-b",
+      "package-c",
+      "project"
+    ]
+    "#);
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal")
+        .arg("--depth")
+        .arg("1"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "project:dev==0.1.0@virtual+[TEMP_DIR]/"
+        },
+        {
+          "id": "project==0.1.0@virtual+[TEMP_DIR]/"
+        }
+      ],
+      "inverted": false,
+      "members": [
+        {
+          "name": "project",
+          "path": "[TEMP_DIR]/",
+          "id": "project==0.1.0@virtual+[TEMP_DIR]/"
+        }
+      ],
+      "resolution": {
+        "package-a==1.0.0@directory+[TEMP_DIR]/packages/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-a"
+          },
+          "kind": "package",
+          "dependencies": [],
+          "optional_dependencies": [
+            {
+              "name": "feature",
+              "id": "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            }
+          ]
+        },
+        "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-a"
+          },
+          "kind": {
+            "extra": "feature"
+          },
+          "dependencies": [
+            {
+              "id": "package-a==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            }
+          ]
+        },
+        "package-c==1.0.0@directory+[TEMP_DIR]/packages/package-c": {
+          "name": "package-c",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-c"
+          },
+          "kind": "package",
+          "dependencies": []
+        },
+        "project:dev==0.1.0@virtual+[TEMP_DIR]/": {
+          "name": "project",
+          "version": "0.1.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/"
+          },
+          "kind": {
+            "group": "dev"
+          },
+          "dependencies": [
+            {
+              "id": "package-c==1.0.0@directory+[TEMP_DIR]/packages/package-c"
+            }
+          ]
+        },
+        "project==0.1.0@virtual+[TEMP_DIR]/": {
+          "name": "project",
+          "version": "0.1.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            }
+          ],
+          "dependency_groups": [
+            {
+              "name": "dev",
+              "id": "project:dev==0.1.0@virtual+[TEMP_DIR]/"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": []
+        }
+      }
+    }
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "#);
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal")
+        .arg("--invert")
+        .arg("--depth")
+        .arg("1"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "package-b==1.0.0@directory+[TEMP_DIR]/packages/package-b"
+        },
+        {
+          "id": "package-c==1.0.0@directory+[TEMP_DIR]/packages/package-c"
+        }
+      ],
+      "inverted": true,
+      "members": [
+        {
+          "name": "project",
+          "path": "[TEMP_DIR]/",
+          "id": "project==0.1.0@virtual+[TEMP_DIR]/"
+        }
+      ],
+      "resolution": {
+        "package-a==1.0.0@directory+[TEMP_DIR]/packages/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-a"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            }
+          ],
+          "optional_dependencies": [
+            {
+              "name": "feature",
+              "id": "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            }
+          ]
+        },
+        "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-a"
+          },
+          "kind": {
+            "extra": "feature"
+          },
+          "dependencies": []
+        },
+        "package-b==1.0.0@directory+[TEMP_DIR]/packages/package-b": {
+          "name": "package-b",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-b"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "package-a[feature]==1.0.0@directory+[TEMP_DIR]/packages/package-a"
+            }
+          ]
+        },
+        "package-c==1.0.0@directory+[TEMP_DIR]/packages/package-c": {
+          "name": "package-c",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/packages/package-c"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "project:dev==0.1.0@virtual+[TEMP_DIR]/"
+            }
+          ]
+        },
+        "project:dev==0.1.0@virtual+[TEMP_DIR]/": {
+          "name": "project",
+          "version": "0.1.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/"
+          },
+          "kind": {
+            "group": "dev"
+          },
+          "dependencies": []
+        },
+        "project==0.1.0@virtual+[TEMP_DIR]/": {
+          "name": "project",
+          "version": "0.1.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/"
+          },
+          "kind": "package",
+          "dependencies": [],
+          "dependency_groups": [
+            {
+              "name": "dev",
+              "id": "project:dev==0.1.0@virtual+[TEMP_DIR]/"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": []
+        }
+      }
+    }
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "#);
+
+    let projected_members = |depth: Option<u8>| -> Result<Vec<String>> {
+        let mut command = context.tree();
+        command
+            .arg("--preview-features")
+            .arg("json-output")
+            .arg("--format")
+            .arg("json")
+            .arg("--universal")
+            .arg("--invert")
+            .arg("--package")
+            .arg("package-b");
+        if let Some(depth) = depth {
+            command.arg("--depth").arg(depth.to_string());
+        }
+        let output = command.output()?;
+        output.clone().assert().success();
+        let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        report["members"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .map(|member| {
+                member["name"]
+                    .as_str()
+                    .context("workspace member should have a name")
+                    .map(ToOwned::to_owned)
+            })
+            .collect()
+    };
+
+    assert_json_snapshot!(projected_members(None)?, @r#"
+    [
+      "project"
+    ]
+    "#);
+    assert_json_snapshot!(projected_members(Some(1))?, @r#"[]"#);
+
+    Ok(())
+}
+
+#[test]
+fn json_output_root_contexts_respect_depth() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["extra-dependency"]
+
+        [dependency-groups]
+        dev = ["group-dependency"]
+
+        [tool.uv.sources]
+        extra-dependency = { path = "extra-dependency" }
+        group-dependency = { path = "group-dependency" }
+        "#,
+    )?;
+
+    for package in ["extra-dependency", "group-dependency"] {
+        let directory = context.temp_dir.child(package);
+        directory.create_dir_all()?;
+        directory
+            .child("pyproject.toml")
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{package}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+        "#})?;
+    }
+
+    let projected_contexts = |depth: usize| -> Result<(Vec<String>, Vec<String>)> {
+        let output = context
+            .tree()
+            .arg("--preview-features")
+            .arg("json-output")
+            .arg("--format")
+            .arg("json")
+            .arg("--universal")
+            .arg("--depth")
+            .arg(depth.to_string())
+            .output()?;
+        output.clone().assert().success();
+
+        let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        let roots = report["roots"]
+            .as_array()
+            .context("dependency graph roots should be an array")?;
+        let resolution = report["resolution"]
+            .as_object()
+            .context("dependency graph resolution should be an object")?;
+        let context_kind = |node: &serde_json::Value| {
+            let kind = &node["kind"];
+            if let Some(extra) = kind["extra"].as_str() {
+                Some(format!("extra: {extra}"))
+            } else {
+                kind["group"]
+                    .as_str()
+                    .map(|group| format!("group: {group}"))
+            }
+        };
+        let root_kinds = roots
+            .iter()
+            .map(|root| -> Result<String> {
+                let id = root["id"]
+                    .as_str()
+                    .context("dependency graph root should have an ID")?;
+                let node = resolution
+                    .get(id)
+                    .context("dependency graph root should be in the resolution")?;
+                let kind = &node["kind"];
+                if kind == "package" {
+                    Ok("package".to_owned())
+                } else if let Some(context) = context_kind(node) {
+                    Ok(context)
+                } else {
+                    bail!("dependency graph root should have a known kind")
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let contexts = resolution
+            .values()
+            .filter_map(context_kind)
+            .collect::<Vec<_>>();
+        Ok((root_kinds, contexts))
+    };
+
+    let (root_kinds, contexts) = projected_contexts(0)?;
+    assert_json_snapshot!(root_kinds, @r#"
+    [
+      "package"
+    ]
+    "#);
+    assert_json_snapshot!(contexts, @r#"[]"#);
+
+    let (root_kinds, contexts) = projected_contexts(1)?;
+    assert_json_snapshot!(root_kinds, @r#"
+    [
+      "group: dev",
+      "package",
+      "extra: feature"
+    ]
+    "#);
+    assert_json_snapshot!(contexts, @r#"
+    [
+      "group: dev",
+      "extra: feature"
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn json_output_virtual_root() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [dependency-groups]
+        dev = ["package-a"]
+
+        [tool.uv.sources]
+        package-a = { workspace = true }
+
+        [tool.uv.workspace]
+        members = ["package-a"]
+        "#,
+    )?;
+
+    let package_a = context.temp_dir.child("package-a");
+    package_a.create_dir_all()?;
+    package_a.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal")
+        // A workspace-owned group's direct requirements are at depth zero, even though the JSON
+        // graph represents the group itself as a root node.
+        .arg("--depth")
+        .arg("0")
+        .arg("--only-group")
+        .arg("dev"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "workspace+[TEMP_DIR]/:dev"
+        }
+      ],
+      "inverted": false,
+      "members": [
+        {
+          "name": "package-a",
+          "path": "[TEMP_DIR]/package-a",
+          "id": "package-a==1.0.0@editable+[TEMP_DIR]/package-a"
+        }
+      ],
+      "resolution": {
+        "package-a==1.0.0@editable+[TEMP_DIR]/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "editable": "[TEMP_DIR]/package-a"
+          },
+          "kind": "package",
+          "dependencies": []
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": [],
+          "dependency_groups": [
+            {
+              "name": "dev",
+              "id": "workspace+[TEMP_DIR]/:dev"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/:dev": {
+          "kind": {
+            "group": "dev"
+          },
+          "path": "[TEMP_DIR]/",
+          "dependencies": [
+            {
+              "id": "package-a==1.0.0@editable+[TEMP_DIR]/package-a"
+            }
+          ]
+        }
+      }
+    }
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    "#);
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal")
+        .arg("--only-group")
+        .arg("dev")
+        .arg("--invert"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "package-a==1.0.0@editable+[TEMP_DIR]/package-a"
+        }
+      ],
+      "inverted": true,
+      "members": [
+        {
+          "name": "package-a",
+          "path": "[TEMP_DIR]/package-a",
+          "id": "package-a==1.0.0@editable+[TEMP_DIR]/package-a"
+        }
+      ],
+      "resolution": {
+        "package-a==1.0.0@editable+[TEMP_DIR]/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "editable": "[TEMP_DIR]/package-a"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "workspace+[TEMP_DIR]/:dev"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": [],
+          "dependency_groups": [
+            {
+              "name": "dev",
+              "id": "workspace+[TEMP_DIR]/:dev"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/:dev": {
+          "kind": {
+            "group": "dev"
+          },
+          "path": "[TEMP_DIR]/",
+          "dependencies": []
+        }
+      }
+    }
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn virtual_workspace_members() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [tool.uv.workspace]
+        members = ["packages/*"]
+        "#,
+    )?;
+
+    let package_a = context.temp_dir.child("packages/package-a");
+    package_a.create_dir_all()?;
+    package_a.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-b"]
+
+        [tool.uv.sources]
+        package-b = { workspace = true }
+        "#,
+    )?;
+
+    let package_b = context.temp_dir.child("packages/package-b");
+    package_b.create_dir_all()?;
+    package_b.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-b"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.tree().arg("--universal"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    package-b v1.0.0
+    package-a v1.0.0
+    └── package-b v1.0.0
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "package-a==1.0.0@virtual+[TEMP_DIR]/packages/package-a"
+        },
+        {
+          "id": "package-b==1.0.0@editable+[TEMP_DIR]/packages/package-b"
+        }
+      ],
+      "inverted": false,
+      "members": [
+        {
+          "name": "package-a",
+          "path": "[TEMP_DIR]/packages/package-a",
+          "id": "package-a==1.0.0@virtual+[TEMP_DIR]/packages/package-a"
+        },
+        {
+          "name": "package-b",
+          "path": "[TEMP_DIR]/packages/package-b",
+          "id": "package-b==1.0.0@editable+[TEMP_DIR]/packages/package-b"
+        }
+      ],
+      "resolution": {
+        "package-a==1.0.0@virtual+[TEMP_DIR]/packages/package-a": {
+          "name": "package-a",
+          "version": "1.0.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/packages/package-a"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "package-b==1.0.0@editable+[TEMP_DIR]/packages/package-b"
+            }
+          ]
+        },
+        "package-b==1.0.0@editable+[TEMP_DIR]/packages/package-b": {
+          "name": "package-b",
+          "version": "1.0.0",
+          "source": {
+            "editable": "[TEMP_DIR]/packages/package-b"
+          },
+          "kind": "package",
+          "dependencies": []
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": []
+        }
+      }
+    }
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn virtual_workspace_dependency_groups_only() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [dependency-groups]
+        dev = ["group-dependency"]
+
+        [tool.uv.sources]
+        group-dependency = { path = "group-dependency" }
+
+        [tool.uv.workspace]
+        members = []
+        "#,
+    )?;
+
+    let dependency = context.temp_dir.child("group-dependency");
+    dependency.create_dir_all()?;
+    dependency.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "group-dependency"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--universal")
+        .arg("--only-group")
+        .arg("dev"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    group-dependency v1.0.0 (group: dev)
+
+    ----- stderr -----
+    warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
+    Resolved 1 package in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal")
+        .arg("--only-group")
+        .arg("dev"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "workspace+[TEMP_DIR]/:dev"
+        }
+      ],
+      "inverted": false,
+      "resolution": {
+        "group-dependency==1.0.0@directory+[TEMP_DIR]/group-dependency": {
+          "name": "group-dependency",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/group-dependency"
+          },
+          "kind": "package",
+          "dependencies": []
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": [],
+          "dependency_groups": [
+            {
+              "name": "dev",
+              "id": "workspace+[TEMP_DIR]/:dev"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/:dev": {
+          "kind": {
+            "group": "dev"
+          },
+          "path": "[TEMP_DIR]/",
+          "dependencies": [
+            {
+              "id": "group-dependency==1.0.0@directory+[TEMP_DIR]/group-dependency"
+            }
+          ]
+        }
+      }
+    }
+
+    ----- stderr -----
+    warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
+    Resolved 1 package in [TIME]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn json_output_frozen_missing_members() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [tool.uv.workspace]
+        members = ["generated/members/*"]
+        "#,
+    )?;
+
+    let generated = context.temp_dir.child("generated");
+    let app = generated.child("members/app");
+    app.create_dir_all()?;
+    app.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "app"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["bridge"]
+
+        [tool.uv.sources]
+        bridge = { path = "../../bridge" }
+        "#,
+    )?;
+
+    let bridge = generated.child("bridge");
+    bridge.create_dir_all()?;
+    bridge.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "bridge"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["target"]
+
+        [tool.uv.sources]
+        target = { path = "../target" }
+        "#,
+    )?;
+
+    let target = generated.child("target");
+    target.create_dir_all()?;
+    target.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "target"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    context.lock().assert().success();
+    fs_err::remove_dir_all(generated.path())?;
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--frozen")
+        .arg("--universal")
+        .arg("--invert")
+        .arg("--package")
+        .arg("target")
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "target==1.0.0@directory+[TEMP_DIR]/generated/target"
+        }
+      ],
+      "inverted": true,
+      "members": [
+        {
+          "name": "app",
+          "path": "[TEMP_DIR]/generated/members/app",
+          "id": "app==1.0.0@virtual+[TEMP_DIR]/generated/members/app"
+        }
+      ],
+      "resolution": {
+        "app==1.0.0@virtual+[TEMP_DIR]/generated/members/app": {
+          "name": "app",
+          "version": "1.0.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/generated/members/app"
+          },
+          "kind": "package",
+          "dependencies": []
+        },
+        "bridge==1.0.0@directory+[TEMP_DIR]/generated/bridge": {
+          "name": "bridge",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/generated/bridge"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "app==1.0.0@virtual+[TEMP_DIR]/generated/members/app"
+            }
+          ]
+        },
+        "target==1.0.0@directory+[TEMP_DIR]/generated/target": {
+          "name": "target",
+          "version": "1.0.0",
+          "source": {
+            "directory": "[TEMP_DIR]/generated/target"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "bridge==1.0.0@directory+[TEMP_DIR]/generated/bridge"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": []
+        }
+      }
+    }
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn json_output_depth_with_extra_context() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-a", "package-c"]
+
+        [tool.uv.sources]
+        package-a = { path = "packages/package-a" }
+        package-c = { path = "packages/package-c" }
+        "#,
+    )?;
+
+    let package_a = context.temp_dir.child("packages/package-a");
+    package_a.create_dir_all()?;
+    package_a.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["package-b"]
+
+        [tool.uv.sources]
+        package-b = { path = "../package-b" }
+        "#,
+    )?;
+
+    let package_c = context.temp_dir.child("packages/package-c");
+    package_c.create_dir_all()?;
+    package_c.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-c"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-a[feature]"]
+
+        [tool.uv.sources]
+        package-a = { path = "../package-a" }
+        "#,
+    )?;
+
+    let package_b = context.temp_dir.child("packages/package-b");
+    package_b.create_dir_all()?;
+    package_b.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-b"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    let package_names = |depth: u8| -> Result<Vec<String>> {
+        let output = context
+            .tree()
+            .arg("--preview-features")
+            .arg("json-output")
+            .arg("--format")
+            .arg("json")
+            .arg("--universal")
+            .arg("--depth")
+            .arg(depth.to_string())
+            .output()?;
+        output.clone().assert().success();
+        let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        report["resolution"]
+            .as_object()
+            .context("dependency graph resolution should be an object")?
+            .values()
+            .filter(|node| node["kind"] == "package")
+            .map(|node| {
+                node["name"]
+                    .as_str()
+                    .context("dependency graph node should have a name")
+                    .map(ToOwned::to_owned)
+            })
+            .collect()
+    };
+
+    assert_json_snapshot!(package_names(2)?, @r#"
+    [
+      "package-a",
+      "package-c",
+      "project"
+    ]
+    "#);
+    assert_json_snapshot!(package_names(3)?, @r#"
+    [
+      "package-a",
+      "package-b",
+      "package-c",
+      "project"
+    ]
+    "#);
+
+    Ok(())
+}
+
 #[test]
 fn nested_platform_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -307,6 +1599,23 @@ fn outdated() -> Result<()> {
     Resolved 4 packages in [TIME]
     "
     );
+
+    let output = context
+        .tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--outdated")
+        .arg("--universal")
+        .output()?;
+    output.clone().assert().success();
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    let anyio = report["resolution"]
+        .as_object()
+        .and_then(|resolution| resolution.values().find(|node| node["name"] == "anyio"))
+        .expect("anyio should be included in the dependency graph");
+    assert_eq!(anyio["latest_version"], "4.3.0");
 
     Ok(())
 }
@@ -620,6 +1929,98 @@ fn repeated_dependencies() -> Result<()> {
     Resolved 6 packages in [TIME]
     "
     );
+
+    let mut projected_edges = Vec::new();
+    for invert in [false, true] {
+        let mut command = context.tree();
+        command
+            .arg("--preview-features")
+            .arg("json-output")
+            .arg("--format")
+            .arg("json")
+            .arg("--universal");
+        if invert {
+            command.arg("--invert");
+        }
+        let output = command.output()?;
+        output.clone().assert().success();
+        let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        let resolution = report["resolution"]
+            .as_object()
+            .context("dependency graph resolution should be an object")?;
+        let project_edges = if invert {
+            resolution
+                .iter()
+                .filter(|(_, node)| node["name"] == "anyio" && node["kind"] == "package")
+                .flat_map(|(package, node)| {
+                    node["dependencies"]
+                        .as_array()
+                        .into_iter()
+                        .flatten()
+                        .filter(|dependency| {
+                            dependency["id"]
+                                .as_str()
+                                .is_some_and(|id| id.starts_with("project=="))
+                        })
+                        .map(move |dependency| {
+                            serde_json::json!({
+                                "package": package,
+                                "marker": dependency["marker"],
+                            })
+                        })
+                })
+                .collect::<Vec<_>>()
+        } else {
+            resolution
+                .values()
+                .find(|node| node["name"] == "project" && node["kind"] == "package")
+                .and_then(|node| node["dependencies"].as_array())
+                .context("project should have dependency graph edges")?
+                .iter()
+                .map(|dependency| {
+                    serde_json::json!({
+                        "package": dependency["id"],
+                        "marker": dependency["marker"],
+                    })
+                })
+                .collect::<Vec<_>>()
+        };
+
+        projected_edges.push(serde_json::json!({
+            "inverted": invert,
+            "edges": project_edges,
+        }));
+    }
+    assert_json_snapshot!(projected_edges, @r#"
+    [
+      {
+        "edges": [
+          {
+            "marker": "sys_platform == 'win32'",
+            "package": "anyio==1.4.0@registry+https://pypi.org/simple"
+          },
+          {
+            "marker": "sys_platform == 'linux'",
+            "package": "anyio==4.3.0@registry+https://pypi.org/simple"
+          }
+        ],
+        "inverted": false
+      },
+      {
+        "edges": [
+          {
+            "marker": "sys_platform == 'win32'",
+            "package": "anyio==1.4.0@registry+https://pypi.org/simple"
+          },
+          {
+            "marker": "sys_platform == 'linux'",
+            "package": "anyio==4.3.0@registry+https://pypi.org/simple"
+          }
+        ],
+        "inverted": true
+      }
+    ]
+    "#);
 
     // `uv tree` should update the lockfile
     let lock = context.read("uv.lock");
@@ -2378,6 +3779,82 @@ fn non_project_group_selection_with_extras() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--script")
+        .arg(script.path())
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        // A script's direct requirements are at depth zero, even though the JSON graph represents
+        // the script itself as a root node.
+        .arg("--depth")
+        .arg("0"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "script": {
+        "path": "[TEMP_DIR]/script.py",
+        "id": "script+[TEMP_DIR]/script.py"
+      },
+      "roots": [
+        {
+          "id": "script+[TEMP_DIR]/script.py"
+        }
+      ],
+      "inverted": false,
+      "resolution": {
+        "child==0.1.0@directory+[TEMP_DIR]/child": {
+          "name": "child",
+          "version": "0.1.0",
+          "source": {
+            "directory": "[TEMP_DIR]/child"
+          },
+          "kind": "package",
+          "dependencies": [],
+          "optional_dependencies": [
+            {
+              "name": "feature",
+              "id": "child[feature]==0.1.0@directory+[TEMP_DIR]/child"
+            }
+          ]
+        },
+        "child[feature]==0.1.0@directory+[TEMP_DIR]/child": {
+          "name": "child",
+          "version": "0.1.0",
+          "source": {
+            "directory": "[TEMP_DIR]/child"
+          },
+          "kind": {
+            "extra": "feature"
+          },
+          "dependencies": [
+            {
+              "id": "child==0.1.0@directory+[TEMP_DIR]/child"
+            }
+          ]
+        },
+        "script+[TEMP_DIR]/script.py": {
+          "kind": "script",
+          "path": "[TEMP_DIR]/script.py",
+          "dependencies": [
+            {
+              "id": "child[feature]==0.1.0@directory+[TEMP_DIR]/child"
+            }
+          ]
+        }
+      }
+    }
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "#);
+
     Ok(())
 }
 
@@ -2965,6 +4442,85 @@ fn show_sizes() -> Result<()> {
     Resolved 2 packages in [TIME]
     "
     );
+
+    uv_snapshot!(context.filters(), context.tree()
+        .arg("--preview-features")
+        .arg("json-output")
+        .arg("--format")
+        .arg("json")
+        .arg("--universal"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "workspace_root": "[TEMP_DIR]/",
+      "workspace": {
+        "path": "[TEMP_DIR]/",
+        "id": "workspace+[TEMP_DIR]/"
+      },
+      "roots": [
+        {
+          "id": "project==0.1.0@virtual+[TEMP_DIR]/"
+        }
+      ],
+      "inverted": false,
+      "members": [
+        {
+          "name": "project",
+          "path": "[TEMP_DIR]/",
+          "id": "project==0.1.0@virtual+[TEMP_DIR]/"
+        }
+      ],
+      "resolution": {
+        "iniconfig==2.0.0@registry+https://pypi.org/simple": {
+          "name": "iniconfig",
+          "version": "2.0.0",
+          "source": {
+            "registry": {
+              "url": "https://pypi.org/simple"
+            }
+          },
+          "kind": "package",
+          "dependencies": [],
+          "wheels": [
+            {
+              "url": "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl",
+              "hashes": {
+                "sha256": "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+              },
+              "size": 5892,
+              "upload_time": "2023-01-07T11:08:09.864Z",
+              "filename": "iniconfig-2.0.0-py3-none-any.whl"
+            }
+          ]
+        },
+        "project==0.1.0@virtual+[TEMP_DIR]/": {
+          "name": "project",
+          "version": "0.1.0",
+          "source": {
+            "virtual": "[TEMP_DIR]/"
+          },
+          "kind": "package",
+          "dependencies": [
+            {
+              "id": "iniconfig==2.0.0@registry+https://pypi.org/simple"
+            }
+          ]
+        },
+        "workspace+[TEMP_DIR]/": {
+          "kind": "workspace",
+          "path": "[TEMP_DIR]/",
+          "dependencies": []
+        }
+      }
+    }
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "#);
 
     Ok(())
 }


### PR DESCRIPTION
This is https://github.com/astral-sh/uv/pull/19904 reworked to use the `uv workspace metadata` format, which got really out of control as I tried to write down actual semantics and encountered many issues which for the moment I am proposing punting on so we can land this and unblock the usecase:

* #19972
* #19973
* #19975
* #19976

I am a bit fried from so many iterations so the only thing I strongly stand by is the doc-comments I've introduced as being the intended behaviour of this PR. I kinda expect someone will take issue with the stated semantics ("fix one of those issues you posted above first" or "no actually diverge from the behaviour of textual output" or "change the behaviour of textual output").