### PR TITLE
Added Testing for No interpreter and No space left

### DIFF
--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15510,6 +15510,85 @@ fn install_missing_python_with_target() {
     );
 }
 
+/// If there are no Python interpreters available and downloads are disabled, `uv pip install`
+/// into a `--target` directory should fail with a clear hint pointing at the cause, rather
+/// than a generic "no interpreter found" error.
+#[test]
+fn install_missing_python_with_target_downloads_disabled() {
+    // Zero installed interpreters, and downloads are disabled by default in tests
+    // (`UV_PYTHON_DOWNLOADS=never` unless `.with_managed_python_dirs()` is used).
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    let target_dir = context.temp_dir.child("target-dir");
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("anyio")
+        .arg("--target").arg(target_dir.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found in virtual environments, managed installations, or search path
+
+    hint: A managed Python download is available, but Python downloads are set to 'never'
+    ");
+}
+
+/// If the target directory is on a filesystem with no space remaining,
+/// `uv pip install --target` should fail with a clear error indicating
+/// the cause (No space left on device / os error 28).
+#[test]
+#[cfg(target_os = "linux")]
+fn install_target_no_space_left_on_device() {
+    // Check if unprivileged user namespaces are available.
+    // Some kernels disable this (kernel.unprivileged_userns_clone=0).
+    let ns_check = std::process::Command::new("unshare")
+        .args(["--user", "--map-root-user", "--mount", "true"])
+        .output();
+    let Ok(ns_output) = ns_check else {
+        return; // unshare not available, skip
+    };
+    if !ns_output.status.success() {
+        return; // user namespaces disabled, skip
+    }
+
+    let context = TestContext::new("3.12");
+    let target_dir = context.temp_dir.child("tiny-target");
+    fs_err::create_dir_all(target_dir.path()).unwrap();
+
+    // Build the uv command string to run inside the new mount namespace.
+    // We mount a 16KB tmpfs over the target dir, then run uv pip install into it.
+    // Any package will exceed 16KB and trigger ENOSPC during extraction.
+    let uv_bin = context.uv_bin(); // path to the uv binary under test
+    let cmd = format!(
+        "mount -t tmpfs -o size=16k tmpfs {target} && \
+         {uv} pip install certifi --target {target} --no-cache",
+        target = target_dir.path().display(),
+        uv = uv_bin.display(),
+    );
+
+    let output = std::process::Command::new("unshare")
+        .args(["--user", "--map-root-user", "--mount", "sh", "-c", &cmd])
+        // Mirror the env vars that TestContext sets so uv behaves the same way
+        .env("UV_PYTHON_DOWNLOADS", "never")
+        .env("UV_NO_PROGRESS", "1")
+        .env("UV_PYTHON", context.python_path())
+        .output()
+        .expect("failed to spawn unshare");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected uv to fail with ENOSPC, but it succeeded"
+    );
+    assert!(
+        stderr.contains("No space left on device") || stderr.contains("os error 28"),
+        "expected 'No space left on device' in stderr, got:\n{stderr}"
+    );
+}
+
 #[cfg(feature = "test-python-managed")]
 #[test]
 fn install_missing_python_version_with_target() {

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15517,10 +15517,11 @@ fn install_missing_python_with_target() {
 fn install_missing_python_with_target_downloads_disabled() {
     let context = uv_test::test_context_with_versions!(&[]);
 
-    // TestContext creates a .venv automatically. Remove it so uv doesn't
-    // find and try to inspect it — we want it to fall through to the
-    // "no interpreter found" + downloads hint path.
-    fs_err::remove_dir_all(context.venv.path()).unwrap();
+    // Remove the venv if TestContext created one, so uv doesn't try to
+    // inspect a venv with no Python binary inside it.
+    if context.venv.path().exists() {
+        fs_err::remove_dir_all(context.venv.path()).unwrap();
+    }
 
     let target_dir = context.temp_dir.child("target-dir");
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15514,11 +15514,13 @@ fn install_missing_python_with_target() {
 /// into a `--target` directory should fail with a clear hint pointing at the cause, rather
 /// than a generic "no interpreter found" error.
 #[test]
-#[cfg(not(windows))]
 fn install_missing_python_with_target_downloads_disabled() {
-    // Zero installed interpreters, and downloads are disabled by default in tests
-    // (`UV_PYTHON_DOWNLOADS=never` unless `.with_managed_python_dirs()` is used).
     let context = uv_test::test_context_with_versions!(&[]);
+
+    // TestContext creates a .venv automatically. Remove it so uv doesn't
+    // find and try to inspect it — we want it to fall through to the
+    // "no interpreter found" + downloads hint path.
+    fs_err::remove_dir_all(context.venv.path()).unwrap();
 
     let target_dir = context.temp_dir.child("target-dir");
 
@@ -15533,27 +15535,6 @@ fn install_missing_python_with_target_downloads_disabled() {
     error: No interpreter found in virtual environments, managed installations, or search path
 
     hint: A managed Python download is available, but Python downloads are set to 'never'
-    ");
-}
-
-/// Same scenario on Windows: uv finds the `TestContext` venv but the interpreter
-/// binary doesn't exist, producing a different but equally clear error.
-#[test]
-#[cfg(windows)]
-fn install_missing_python_with_target_downloads_disabled_windows() {
-    let context = uv_test::test_context_with_versions!(&[]);
-    let target_dir = context.temp_dir.child("target-dir");
-
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg("anyio")
-        .arg("--target").arg(target_dir.path()), @"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Failed to inspect Python interpreter from active virtual environment at `.venv\\Scripts\\python.exe`
-      Caused by: Python interpreter not found at `[VENV]\\Scripts\\python.exe`
     ");
 }
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15557,7 +15557,7 @@ fn install_target_no_space_left_on_device() {
         return; // user namespaces disabled on this kernel, skip
     }
 
-    let context = TestContext::new("3.12");
+    let context = TestContext::new_with_versions_and_bin("3.12");
     let target_dir = context.temp_dir.child("tiny-target");
     fs_err::create_dir_all(target_dir.path()).unwrap();
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15557,7 +15557,7 @@ fn install_target_no_space_left_on_device() {
         return; // user namespaces disabled on this kernel, skip
     }
 
-    let context = TestContext::new_bin("3.12");
+    let context = TestContext::new_with_bin("3.12");
     let target_dir = context.temp_dir.child("tiny-target");
     fs_err::create_dir_all(target_dir.path()).unwrap();
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15514,6 +15514,7 @@ fn install_missing_python_with_target() {
 /// into a `--target` directory should fail with a clear hint pointing at the cause, rather
 /// than a generic "no interpreter found" error.
 #[test]
+#[cfg(not(windows))]
 fn install_missing_python_with_target_downloads_disabled() {
     // Zero installed interpreters, and downloads are disabled by default in tests
     // (`UV_PYTHON_DOWNLOADS=never` unless `.with_managed_python_dirs()` is used).
@@ -15532,6 +15533,27 @@ fn install_missing_python_with_target_downloads_disabled() {
     error: No interpreter found in virtual environments, managed installations, or search path
 
     hint: A managed Python download is available, but Python downloads are set to 'never'
+    ");
+}
+
+/// Same scenario on Windows: uv finds the TestContext venv but the interpreter
+/// binary doesn't exist, producing a different but equally clear error.
+#[test]
+#[cfg(windows)]
+fn install_missing_python_with_target_downloads_disabled_windows() {
+    let context = uv_test::test_context_with_versions!(&[]);
+    let target_dir = context.temp_dir.child("target-dir");
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("anyio")
+        .arg("--target").arg(target_dir.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to inspect Python interpreter from active virtual environment at `.venv\\Scripts\\python.exe`
+      Caused by: Python interpreter not found at `[VENV]\\Scripts\\python.exe`
     ");
 }
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15557,7 +15557,7 @@ fn install_target_no_space_left_on_device() {
         return; // user namespaces disabled on this kernel, skip
     }
 
-    let context = TestContext::new_with_versions_and_bin("3.12");
+    let context = TestContext::new_bin("3.12"); 
     let target_dir = context.temp_dir.child("tiny-target");
     fs_err::create_dir_all(target_dir.path()).unwrap();
 
@@ -15573,7 +15573,7 @@ fn install_target_no_space_left_on_device() {
              --no-cache \
              --link-mode copy",
         target = target_dir.path().display(),
-        uv = context.uv_bin().display(),
+        uv = context.uv_bin.display(), // ← was context.uv_bin() — it's a field, not a method
     );
 
     let output = std::process::Command::new("unshare")

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15545,27 +15545,22 @@ fn install_missing_python_with_target_downloads_disabled() {
 #[test]
 #[cfg(target_os = "linux")]
 fn install_target_no_space_left_on_device() {
-    // Verify that unprivileged user namespaces are available on this kernel.
-    // Some distros disable them via kernel.unprivileged_userns_clone=0.
     let ns_check = std::process::Command::new("unshare")
         .args(["--user", "--map-root-user", "--mount", "true"])
         .output();
     let Ok(ns_output) = ns_check else {
-        return; // `unshare` binary not found, skip
+        return;
     };
     if !ns_output.status.success() {
-        return; // user namespaces disabled on this kernel, skip
+        return;
     }
 
-    let context = TestContext::new_with_bin("3.12");
+    let uv_bin = get_bin!(); // ← the macro gives us the path
+    let context = TestContext::new_with_bin("3.12", uv_bin.clone()); // ← pass it here
+
     let target_dir = context.temp_dir.child("tiny-target");
     fs_err::create_dir_all(target_dir.path()).unwrap();
 
-    // Mount a 16KB tmpfs over target_dir, then install into it.
-    // --link-mode=copy avoids the cross-device hardlink warning
-    // (hardlinks fail because tmpfs and cache are on different mounts).
-    // --no-cache ensures bytes are actually written to the target,
-    // triggering ENOSPC rather than a zero-cost hardlink.
     let cmd = format!(
         "mount -t tmpfs -o size=16k tmpfs {target} && \
          {uv} pip install certifi \
@@ -15573,7 +15568,7 @@ fn install_target_no_space_left_on_device() {
              --no-cache \
              --link-mode copy",
         target = target_dir.path().display(),
-        uv = context.uv_bin.display(), // ← was context.uv_bin() — it's a field, not a method
+        uv = uv_bin.display(), // ← use the local variable, not context.uv_bin
     );
 
     let output = std::process::Command::new("unshare")

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15514,6 +15514,7 @@ fn install_missing_python_with_target() {
 /// into a `--target` directory should fail with a clear hint pointing at the cause, rather
 /// than a generic "no interpreter found" error.
 #[test]
+#[cfg(not(windows))]
 fn install_missing_python_with_target_downloads_disabled() {
     let context = uv_test::test_context_with_versions!(&[]);
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15536,7 +15536,7 @@ fn install_missing_python_with_target_downloads_disabled() {
     ");
 }
 
-/// Same scenario on Windows: uv finds the TestContext venv but the interpreter
+/// Same scenario on Windows: uv finds the `TestContext` venv but the interpreter
 /// binary doesn't exist, producing a different but equally clear error.
 #[test]
 #[cfg(windows)]

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15517,8 +15517,6 @@ fn install_missing_python_with_target() {
 fn install_missing_python_with_target_downloads_disabled() {
     let context = uv_test::test_context_with_versions!(&[]);
 
-    // Remove the venv if TestContext created one, so uv doesn't try to
-    // inspect a venv with no Python binary inside it.
     if context.venv.path().exists() {
         fs_err::remove_dir_all(context.venv.path()).unwrap();
     }
@@ -15527,7 +15525,9 @@ fn install_missing_python_with_target_downloads_disabled() {
 
     uv_snapshot!(context.filters(), context.pip_install()
         .arg("anyio")
-        .arg("--target").arg(target_dir.path()), @"
+        .arg("--target").arg(target_dir.path())
+        .env_remove("VIRTUAL_ENV"),  // ← stop uv following the env var to the deleted venv
+    @"
     success: false
     exit_code: 2
     ----- stdout -----

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15557,7 +15557,7 @@ fn install_target_no_space_left_on_device() {
         return; // user namespaces disabled on this kernel, skip
     }
 
-    let context = TestContext::new_bin("3.12"); 
+    let context = TestContext::new_bin("3.12");
     let target_dir = context.temp_dir.child("tiny-target");
     fs_err::create_dir_all(target_dir.path()).unwrap();
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -15535,42 +15535,49 @@ fn install_missing_python_with_target_downloads_disabled() {
     ");
 }
 
-/// If the target directory is on a filesystem with no space remaining,
-/// `uv pip install --target` should fail with a clear error indicating
-/// the cause (No space left on device / os error 28).
+/// If the target directory has insufficient disk space, `uv pip install --target`
+/// should fail with a clear error indicating the cause (No space left on device),
+/// rather than a confusing or generic failure message.
+///
+/// This test mounts a 16KB tmpfs over the target directory using an unprivileged
+/// mount namespace (Linux only). Any package will exceed 16KB and trigger ENOSPC
+/// during wheel extraction.
 #[test]
 #[cfg(target_os = "linux")]
 fn install_target_no_space_left_on_device() {
-    // Check if unprivileged user namespaces are available.
-    // Some kernels disable this (kernel.unprivileged_userns_clone=0).
+    // Verify that unprivileged user namespaces are available on this kernel.
+    // Some distros disable them via kernel.unprivileged_userns_clone=0.
     let ns_check = std::process::Command::new("unshare")
         .args(["--user", "--map-root-user", "--mount", "true"])
         .output();
     let Ok(ns_output) = ns_check else {
-        return; // unshare not available, skip
+        return; // `unshare` binary not found, skip
     };
     if !ns_output.status.success() {
-        return; // user namespaces disabled, skip
+        return; // user namespaces disabled on this kernel, skip
     }
 
     let context = TestContext::new("3.12");
     let target_dir = context.temp_dir.child("tiny-target");
     fs_err::create_dir_all(target_dir.path()).unwrap();
 
-    // Build the uv command string to run inside the new mount namespace.
-    // We mount a 16KB tmpfs over the target dir, then run uv pip install into it.
-    // Any package will exceed 16KB and trigger ENOSPC during extraction.
-    let uv_bin = context.uv_bin(); // path to the uv binary under test
+    // Mount a 16KB tmpfs over target_dir, then install into it.
+    // --link-mode=copy avoids the cross-device hardlink warning
+    // (hardlinks fail because tmpfs and cache are on different mounts).
+    // --no-cache ensures bytes are actually written to the target,
+    // triggering ENOSPC rather than a zero-cost hardlink.
     let cmd = format!(
         "mount -t tmpfs -o size=16k tmpfs {target} && \
-         {uv} pip install certifi --target {target} --no-cache",
+         {uv} pip install certifi \
+             --target {target} \
+             --no-cache \
+             --link-mode copy",
         target = target_dir.path().display(),
-        uv = uv_bin.display(),
+        uv = context.uv_bin().display(),
     );
 
     let output = std::process::Command::new("unshare")
         .args(["--user", "--map-root-user", "--mount", "sh", "-c", &cmd])
-        // Mirror the env vars that TestContext sets so uv behaves the same way
         .env("UV_PYTHON_DOWNLOADS", "never")
         .env("UV_NO_PROGRESS", "1")
         .env("UV_PYTHON", context.python_path())
@@ -15581,7 +15588,7 @@ fn install_target_no_space_left_on_device() {
 
     assert!(
         !output.status.success(),
-        "expected uv to fail with ENOSPC, but it succeeded"
+        "expected uv to fail with ENOSPC, but it succeeded\nstderr: {stderr}"
     );
     assert!(
         stderr.contains("No space left on device") || stderr.contains("os error 28"),


### PR DESCRIPTION
## Summary

Add two tests covering error-path behavior for `uv pip install --target`:

1. **No Python interpreter + downloads disabled** — verifies that when no
   interpreter is found and Python downloads are set to `never`, uv fails
   with a clear hint pointing at the cause rather than a generic
   "no interpreter found" message.

2. **No space left on device** — verifies that when the target directory
   runs out of disk space, uv fails with a clear, actionable error rather
   than a confusing or generic failure.

The second test was prompted by a real-world error encountered during installation:

```
error: Failed to install: certifi-2026.6.17-py3-none-any.whl (certifi==2026.6.17)
  Caused by: Failed to copy to `/home/user/tinydisk/certifi/.tmpO4oEOv/cacert.pem`
  Caused by: failed to copy file from /root/.cache/uv/archive-v0/.../cacert.pem
             to .../cacert.pem: No space left on device (os error 28)
```

The ENOSPC test is Linux-only and uses an unprivileged mount namespace
(`unshare --user --map-root-user --mount`) to mount a 16KB tmpfs over
the target directory — no root required. Any package will exceed 16KB,
triggering `ENOSPC` during wheel extraction. The test skips gracefully
if `unshare` is unavailable or if the kernel has unprivileged user
namespaces disabled (`kernel.unprivileged_userns_clone=0`).

**Key findings during development of the ENOSPC test:**

- Without `--link-mode=copy`, uv first attempts to hardlink files from
  cache into the target. Since the tmpfs and the cache are on different
  mounts, hardlinking fails and uv falls back to a full copy — which
  then hits `ENOSPC`. The test explicitly passes `--link-mode=copy` to
  skip the hardlink attempt and produce a clean, warning-free error path.
- `--no-cache` is required to ensure bytes are actually written to the
  target filesystem. Without it, uv may resolve the install via
  zero-cost hardlinks from the global cache, bypassing the space limit
  entirely and causing the test to incorrectly pass.

## Test Plan

**Test 1 — missing Python with downloads disabled:**

Run directly with `cargo nextest run install_missing_python_with_target_downloads_disabled`.
Confirmed the hint message appears pointing at `UV_PYTHON_DOWNLOADS=never`.

**Test 2 — no space left on device:**

Manually verified the failure path before writing the test:

```bash
mkdir /tmp/tiny
unshare --user --map-root-user --mount sh -c \
  "mount -t tmpfs -o size=16k tmpfs /tmp/tiny && \
   uv pip install certifi --target /tmp/tiny --no-cache --link-mode copy"
```

Output confirmed:

```
error: Failed to install: certifi-2026.6.17-py3-none-any.whl (certifi==2026.6.17)
  Caused by: Failed to copy to `/tmp/tiny/certifi-2026.6.17.dist-info/licenses/.tmpxIujRP/LICENSE`
  Caused by: failed to copy file from /tmp/.tmpuj4BJj/archive-v0/.../LICENSE
             to /tmp/tiny/.../LICENSE: No space left on device (os error 28)
```

The Rust test mirrors this setup using `unshare` as a subprocess,
mounts a 16KB tmpfs over the target dir, runs `uv pip install certifi`
into it, and asserts that the process exits non-zero with
`No space left on device` or `os error 28` in stderr.