### PR TITLE
Use locked dependency selection for `uv check --script`

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -305,14 +305,21 @@ pub struct Lock {
 
 /// Package selections from a [`Lock`] for a named direct dependency.
 ///
-/// The dependency can come from a dependency group, the production packages, or both.
+/// The dependency can come from the lock manifest, a dependency group, the production packages,
+/// or a combination thereof.
 #[derive(Debug)]
 pub struct DependencySelection<'lock> {
+    root: Option<&'lock Package>,
     production: Option<&'lock Package>,
     groups: BTreeMap<&'lock GroupName, &'lock Package>,
 }
 
 impl<'lock> DependencySelection<'lock> {
+    /// Returns the package selected by a direct requirement on the lock manifest.
+    pub fn root(&self) -> Option<&'lock Package> {
+        self.root
+    }
+
     /// Returns the package selected by the production dependency.
     pub fn production(&self) -> Option<&'lock Package> {
         self.production
@@ -820,16 +827,17 @@ impl Lock {
     /// Returns the environment-specific direct dependency selections for a lock target.
     ///
     /// If `project_name` is provided, dependencies attached to that package are used. Otherwise,
-    /// dependency groups attached directly to the lock manifest are used.
+    /// requirements and dependency groups attached directly to the lock manifest are used.
     pub fn dependency_selection<'lock>(
         &'lock self,
         project_name: Option<&PackageName>,
         dependency_name: &PackageName,
         marker_environment: &MarkerEnvironment,
     ) -> Result<DependencySelection<'lock>, String> {
-        let (production, groups) = if let Some(project_name) = project_name {
+        let (root, production, groups) = if let Some(project_name) = project_name {
             let Some(project) = self.find_by_name(project_name)? else {
                 return Ok(DependencySelection {
+                    root: None,
                     production: None,
                     groups: BTreeMap::new(),
                 });
@@ -847,11 +855,16 @@ impl Lock {
                     groups.insert(group, package);
                 }
             }
-            (production, groups)
+            (None, production, groups)
         } else {
-            // Lock-manifest dependency groups only record requirements, not resolved package IDs.
-            // Select the environment-specific package once, then associate it with each group that
-            // has an applicable direct requirement.
+            let root_applies = self.manifest.requirements.iter().any(|requirement| {
+                &requirement.name == dependency_name
+                    && requirement.marker.evaluate(marker_environment, &[])
+            });
+
+            // Lock-manifest requirements and dependency groups only record requirements, not
+            // resolved package IDs. Select the environment-specific package once, then associate
+            // it with every applicable direct requirement.
             let mut applicable_groups = self
                 .manifest
                 .dependency_groups
@@ -866,16 +879,22 @@ impl Lock {
                         .then_some(group)
                 })
                 .peekable();
-            let groups = if applicable_groups.peek().is_some()
-                && let Some(package) = self.find_by_markers(dependency_name, marker_environment)?
-            {
-                applicable_groups.map(|group| (group, package)).collect()
+            let package = if root_applies || applicable_groups.peek().is_some() {
+                self.find_by_markers(dependency_name, marker_environment)?
             } else {
-                BTreeMap::new()
+                None
             };
-            (None, groups)
+            let root = root_applies.then_some(package).flatten();
+            let groups = package.map_or_else(BTreeMap::new, |package| {
+                applicable_groups.map(|group| (group, package)).collect()
+            });
+            (root, None, groups)
         };
-        Ok(DependencySelection { production, groups })
+        Ok(DependencySelection {
+            root,
+            production,
+            groups,
+        })
     }
 
     /// Returns the package selected by a dependency group on a non-virtual project.
@@ -7304,6 +7323,36 @@ source = { registry = "https://example.com/simple" }
 
         assert!(std::ptr::eq(preferred, included));
         assert!(std::ptr::eq(preferred, production));
+    }
+
+    #[test]
+    fn dependency_selection_resolves_lock_manifest_requirement() {
+        let lock: Lock = toml::from_str(
+            r#"
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[manifest]
+requirements = [{ name = "ty" }]
+
+[[package]]
+name = "ty"
+version = "1.0.0"
+source = { registry = "https://example.com/simple" }
+"#,
+        )
+        .expect("valid lock");
+        let dependency_name = PackageName::from_str("ty").expect("valid package name");
+        let marker_environment = marker_environment();
+
+        let selection = lock
+            .dependency_selection(None, &dependency_name, &marker_environment)
+            .expect("unique root package");
+        let root = selection.root().expect("root dependency");
+
+        assert_eq!(root.name(), &dependency_name);
+        assert!(selection.production().is_none());
     }
 
     #[test]

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -304,6 +304,26 @@ pub(crate) async fn check(
             Err(err) => return Err(err.into()),
         };
 
+        let marker_environment = venv.interpreter().resolver_marker_environment();
+        if ty_path.is_none()
+            && ty_version.is_none()
+            && result
+                .lock()
+                .dependency_selection(
+                    None,
+                    &PackageName::from_str("ty")?,
+                    marker_environment.markers(),
+                )
+                .map_err(anyhow::Error::msg)?
+                .root()
+                .is_some()
+        {
+            locked_ty_path = Some(
+                venv.scripts()
+                    .join(format!("ty{}", std::env::consts::EXE_SUFFIX)),
+            );
+        }
+
         let target = InstallTarget::Script {
             script,
             lock: result.lock(),

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -900,6 +900,266 @@ fn check_script() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "test-pypi")]
+fn check_script_uses_ty_version_from_forked_lock() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"ty 0\.0\.17(?: \([^)]*\))?", "ty 0.0.17"));
+
+    let script = context.temp_dir.child("script.py");
+    script.write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "ty==0.0.16 ; python_version < '3.12'",
+        #   "ty==0.0.17 ; python_version >= '3.12'",
+        # ]
+        # ///
+
+        value: int = 1
+    "#})?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--script")
+            .arg(script.path())
+            .arg("--show-version"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    Installed 1 package in [TIME]
+    Using ty 0.0.17
+    "
+    );
+
+    assert!(!context.temp_dir.child("script.py.lock").exists());
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn check_script_uses_ty_from_path_with_transitive_dependency() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let ty = context.temp_dir.child("ty");
+    ty.create_dir_all()?;
+    ty.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "ty"
+        version = "1.2.3"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [project.scripts]
+        ty = "ty:main"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    let ty_package = ty.child("src").child("ty");
+    ty_package.create_dir_all()?;
+    ty_package.child("__init__.py").write_str(indoc! {r#"
+        import sys
+
+        import iniconfig
+
+        def main():
+            assert iniconfig is not None
+            if "--version" in sys.argv:
+                print("ty 1.2.3")
+            else:
+                print("All checks passed!")
+    "#})?;
+
+    let script = context.temp_dir.child("script.py");
+    script.write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["ty"]
+        #
+        # [tool.uv.sources]
+        # ty = { path = "ty" }
+        # ///
+
+        value: int = 1
+    "#})?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--script")
+            .arg(script.path())
+            .arg("--show-version"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    Installed 2 packages in [TIME]
+    Using ty 1.2.3
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn check_script_ty_override_precedence() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filter((r"ty 0\.0\.17(?: \([^)]*\))?", "ty 0.0.17"))
+        .with_filter((
+            r"(?m)^WARN Failed to fetch `ty` from .+; falling back to .+\n",
+            "",
+        ));
+    let tool_dir = context.root.child("tools");
+    let bin_dir = context.root.child("tool-bin");
+
+    context
+        .tool_install()
+        .arg("ty==0.0.17")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::UV_EXCLUDE_NEWER, "2026-02-15T00:00:00Z")
+        .assert()
+        .success();
+
+    let script = context.temp_dir.child("script.py");
+    script.write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["ty==0.0.16"]
+        # ///
+
+        value: int = 1
+    "#})?;
+    let ty_path = bin_dir.child(format!("ty{}", std::env::consts::EXE_SUFFIX));
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--script")
+            .arg(script.path())
+            .arg("--ty-version")
+            .arg(">=999.0.0")
+            .arg("--show-version")
+            .env(EnvVars::TY, ty_path.as_os_str()),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    Installed 1 package in [TIME]
+    Using ty 0.0.17
+    "
+    );
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--script")
+            .arg(script.path())
+            .arg("--ty-version")
+            .arg("0.0.17")
+            .arg("--show-version"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    Using ty 0.0.17
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn check_script_ignores_transitive_ty_for_tool_selection() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filter((r"ty 0\.0\.17(?: \([^)]*\))?", "ty 0.0.17"))
+        .with_filter((
+            r"(?m)^WARN Failed to fetch `ty` from .+; falling back to .+\n",
+            "",
+        ));
+
+    let wrapper = context.temp_dir.child("wrapper");
+    wrapper.create_dir_all()?;
+    wrapper.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "wrapper"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["ty==0.0.16"]
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    let wrapper_package = wrapper.child("src").child("wrapper");
+    wrapper_package.create_dir_all()?;
+    wrapper_package.child("__init__.py").write_str("")?;
+
+    let script = context.temp_dir.child("script.py");
+    script.write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["wrapper"]
+        #
+        # [tool.uv.sources]
+        # wrapper = { path = "wrapper" }
+        # ///
+
+        import wrapper
+    "#})?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--script")
+            .arg(script.path())
+            .arg("--exclude-newer")
+            .arg("2026-02-15T00:00:00Z")
+            .arg("--show-version"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    Installed 2 packages in [TIME]
+    Using ty 0.0.17
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn check_passes_workspace_metadata_to_ty() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
`uv check --script` currently ignores a direct `ty` dependency from PEP 723 metadata when choosing the checker. The script environment contains the locked package, but uv still selects a standalone `ty` from its built-in compatible range, so the checker can differ from the script’s dependency graph.

This extends `Lock::dependency_selection` to include applicable lock-manifest requirements. When a script directly declares `ty`, `uv check` now runs the marker-selected locked package from the script environment, preserving its source and transitive dependencies without another resolution.

This is a followup to #19884 and it depends on #19982.