### PR TITLE
Recommend our own build backend in the build frontend

### DIFF
--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -299,10 +299,10 @@ async fn build_impl(
             let name = &package.project().name;
             let pyproject_toml = package.root().join("pyproject.toml");
             return Err(anyhow::anyhow!(
-                "Package `{}` is missing a `{}`. For example, to build with `{}`, add the following to `{}`:\n```toml\n[build-system]\nrequires = [\"setuptools\"]\nbuild-backend = \"setuptools.build_meta\"\n```",
+                "Package `{}` is missing a `{}`. For example, to build with `{}`, add the following to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build\"]\nbuild-backend = \"uv_build\"\n```",
                 name.cyan(),
                 "build-system".green(),
-                "setuptools".cyan(),
+                "uv_build".cyan(),
                 pyproject_toml.user_display().cyan()
             ));
         }
@@ -344,9 +344,9 @@ async fn build_impl(
             let name = &member.project().name;
             let pyproject_toml = member.root().join("pyproject.toml");
             return Err(anyhow::anyhow!(
-                "Workspace does not contain any buildable packages. For example, to build `{}` with `{}`, add a `{}` to `{}`:\n```toml\n[build-system]\nrequires = [\"setuptools\"]\nbuild-backend = \"setuptools.build_meta\"\n```",
+                "Workspace does not contain any buildable packages. For example, to build `{}` with `{}`, add a `{}` to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build\"]\nbuild-backend = \"uv_build\"\n```",
                 name.cyan(),
-                "setuptools".cyan(),
+                "uv_build".cyan(),
                 "build-system".green(),
                 pyproject_toml.user_display().cyan()
             ));

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -3,7 +3,7 @@ use std::fmt::Write as _;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::{fmt, io};
+use std::{fmt, io, iter};
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
@@ -275,6 +275,20 @@ async fn build_impl(
     )
     .await;
 
+    // Limit to the stable version range.
+    let min_version = Version::from_str(uv_version::version()).unwrap();
+    debug_assert!(
+        min_version.release()[0] == 0,
+        "migrate to major version bumps"
+    );
+    let max_version = Version::new(
+        [0, min_version.release()[1] + 1]
+            .into_iter()
+            // Add trailing zeroes to match the version length, to use the same style
+            // as `--bounds`.
+            .chain(iter::repeat_n(0, min_version.release().len() - 2)),
+    );
+
     // If a `--package` or `--all-packages` was provided, adjust the source directory.
     let packages = if let Some(package) = package {
         if matches!(src, Source::File(_)) {
@@ -299,7 +313,7 @@ async fn build_impl(
             let name = &package.project().name;
             let pyproject_toml = package.root().join("pyproject.toml");
             return Err(anyhow::anyhow!(
-                "Package `{}` is missing a `{}`. For example, to build with `{}`, add the following to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build>=0.11.9,<0.12.0\"]\nbuild-backend = \"uv_build\"\n```",
+                "Package `{}` is missing a `{}`. For example, to build with `{}`, add the following to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build>={min_version},<{max_version}\"]\nbuild-backend = \"uv_build\"\n```",
                 name.cyan(),
                 "build-system".green(),
                 "uv_build".cyan(),
@@ -344,7 +358,7 @@ async fn build_impl(
             let name = &member.project().name;
             let pyproject_toml = member.root().join("pyproject.toml");
             return Err(anyhow::anyhow!(
-                "Workspace does not contain any buildable packages. For example, to build `{}` with `{}`, add a `{}` to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build>=0.11.9,<0.12.0\"]\nbuild-backend = \"uv_build\"\n```",
+                "Workspace does not contain any buildable packages. For example, to build `{}` with `{}`, add a `{}` to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build>={min_version},<{max_version}\"]\nbuild-backend = \"uv_build\"\n```",
                 name.cyan(),
                 "uv_build".cyan(),
                 "build-system".green(),

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -299,7 +299,7 @@ async fn build_impl(
             let name = &package.project().name;
             let pyproject_toml = package.root().join("pyproject.toml");
             return Err(anyhow::anyhow!(
-                "Package `{}` is missing a `{}`. For example, to build with `{}`, add the following to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build\"]\nbuild-backend = \"uv_build\"\n```",
+                "Package `{}` is missing a `{}`. For example, to build with `{}`, add the following to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build>=0.11.9,<0.12.0\"]\nbuild-backend = \"uv_build\"\n```",
                 name.cyan(),
                 "build-system".green(),
                 "uv_build".cyan(),
@@ -344,7 +344,7 @@ async fn build_impl(
             let name = &member.project().name;
             let pyproject_toml = member.root().join("pyproject.toml");
             return Err(anyhow::anyhow!(
-                "Workspace does not contain any buildable packages. For example, to build `{}` with `{}`, add a `{}` to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build\"]\nbuild-backend = \"uv_build\"\n```",
+                "Workspace does not contain any buildable packages. For example, to build `{}` with `{}`, add a `{}` to `{}`:\n```toml\n[build-system]\nrequires = [\"uv_build>=0.11.9,<0.12.0\"]\nbuild-backend = \"uv_build\"\n```",
                 name.cyan(),
                 "uv_build".cyan(),
                 "build-system".green(),

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2069,7 +2069,7 @@ fn build_non_package() -> Result<()> {
     error: Package `member` is missing a `build-system`. For example, to build with `uv_build`, add the following to `packages/member/pyproject.toml`:
     ```toml
     [build-system]
-    requires = ["uv_build>=0.11.9,<0.12.0"]
+    requires = ["uv_build>=[CURRENT_VERSION],<[NEXT_BREAKING]"]
     build-backend = "uv_build"
     ```
     "#);
@@ -2093,7 +2093,7 @@ fn build_non_package() -> Result<()> {
     error: Workspace does not contain any buildable packages. For example, to build `member` with `uv_build`, add a `build-system` to `packages/member/pyproject.toml`:
     ```toml
     [build-system]
-    requires = ["uv_build>=0.11.9,<0.12.0"]
+    requires = ["uv_build>=[CURRENT_VERSION],<[NEXT_BREAKING]"]
     build-backend = "uv_build"
     ```
     "#);

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2066,11 +2066,11 @@ fn build_non_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Package `member` is missing a `build-system`. For example, to build with `setuptools`, add the following to `packages/member/pyproject.toml`:
+    error: Package `member` is missing a `build-system`. For example, to build with `uv_build`, add the following to `packages/member/pyproject.toml`:
     ```toml
     [build-system]
-    requires = ["setuptools"]
-    build-backend = "setuptools.build_meta"
+    requires = ["uv_build"]
+    build-backend = "uv_build"
     ```
     "#);
 
@@ -2090,11 +2090,11 @@ fn build_non_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Workspace does not contain any buildable packages. For example, to build `member` with `setuptools`, add a `build-system` to `packages/member/pyproject.toml`:
+    error: Workspace does not contain any buildable packages. For example, to build `member` with `uv_build`, add a `build-system` to `packages/member/pyproject.toml`:
     ```toml
     [build-system]
-    requires = ["setuptools"]
-    build-backend = "setuptools.build_meta"
+    requires = ["uv_build"]
+    build-backend = "uv_build"
     ```
     "#);
 

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2069,7 +2069,7 @@ fn build_non_package() -> Result<()> {
     error: Package `member` is missing a `build-system`. For example, to build with `uv_build`, add the following to `packages/member/pyproject.toml`:
     ```toml
     [build-system]
-    requires = ["uv_build"]
+    requires = ["uv_build>=0.11.9,<0.12.0"]
     build-backend = "uv_build"
     ```
     "#);
@@ -2093,7 +2093,7 @@ fn build_non_package() -> Result<()> {
     error: Workspace does not contain any buildable packages. For example, to build `member` with `uv_build`, add a `build-system` to `packages/member/pyproject.toml`:
     ```toml
     [build-system]
-    requires = ["uv_build"]
+    requires = ["uv_build>=0.11.9,<0.12.0"]
     build-backend = "uv_build"
     ```
     "#);


### PR DESCRIPTION
## Summary

<img width="186" height="176" alt="image" src="https://github.com/user-attachments/assets/37ba708f-8a1d-44db-b7fa-c03984c31eda" />

I noticed this while working on #19991.

I _believe_ we don't need a version range on `uv_build`, since (IIUC) it'll select uv's own built-in version.

## Test Plan

Updated the snapshots.
