### PR TITLE
Verify lockfile hashes before reusing a cached ty in `uv check`

### DIFF
--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -520,7 +520,7 @@ pub(crate) async fn check(
                 )?;
                 project::sync::store_credentials_from_target(target, &client_builder)?;
                 let ty_state = state.fork();
-                let environment = match CachedEnvironment::from_resolution(
+                let environment = match CachedEnvironment::from_locked_resolution(
                     &resolution,
                     result
                         .lock()

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -14,14 +14,14 @@ use uv_cache::{Cache, CacheBucket};
 use uv_cache_info::CacheInfo;
 use uv_cache_key::{cache_digest, hash_digest};
 use uv_client::BaseClientBuilder;
-use uv_configuration::{Concurrency, Constraints, TargetTriple};
+use uv_configuration::{Concurrency, Constraints, HashCheckingMode, TargetTriple};
 use uv_distribution_types::{
     BuiltDist, Dist, Identifier, Node, Resolution, ResolvedDist, SourceDist,
 };
 use uv_fs::PythonExt;
 use uv_preview::Preview;
 use uv_python::{Interpreter, PythonEnvironment, canonicalize_executable};
-use uv_types::SourceTreeEditablePolicy;
+use uv_types::{HashStrategy, SourceTreeEditablePolicy};
 use uv_workspace::WorkspaceCache;
 
 /// An ephemeral [`PythonEnvironment`] for running an individual command.
@@ -115,6 +115,21 @@ struct CachedEnvironmentDist {
     cache_info: Option<CacheInfo>,
 }
 
+fn cached_environment_resolution_hash(
+    resolution_hash: String,
+    hash_strategy: &HashStrategy,
+) -> String {
+    match hash_strategy {
+        // Preserve existing cache identities for environments materialized without verification.
+        HashStrategy::None | HashStrategy::Generate(_) => resolution_hash,
+        // Never reuse an environment materialized without hash verification for a lock-backed
+        // resolution with the same distributions and expected hashes.
+        HashStrategy::Verify(_) | HashStrategy::Require(_) => {
+            hash_digest(&("verify", resolution_hash))
+        }
+    }
+}
+
 impl CachedEnvironment {
     /// Get or create an [`CachedEnvironment`] based on a given set of requirements.
     pub(crate) async fn from_spec(
@@ -159,6 +174,7 @@ impl CachedEnvironment {
 
         Self::from_resolution(
             &resolution,
+            HashStrategy::default(),
             build_constraints,
             &interpreter,
             settings,
@@ -174,18 +190,50 @@ impl CachedEnvironment {
         .await
     }
 
-    /// Get or create a [`CachedEnvironment`] from an existing [`Resolution`].
+    /// Get or create a [`CachedEnvironment`] from a lock-backed [`Resolution`].
     ///
     /// Prefer [`Self::from_spec`] when starting from unresolved requirements; it selects the base
     /// interpreter and resolves the requirements for that interpreter before delegating here.
     ///
-    /// This method is intended for callers that already have a concrete [`Resolution`], and
-    /// performs environment reuse or creation and installation without invoking the resolver.
-    /// `interpreter` must be the base interpreter for which `resolution` was produced. In
-    /// particular, callers materializing a universal lock must derive its markers and tags from
-    /// the same interpreter.
-    pub(crate) async fn from_resolution(
+    /// This method verifies the hashes recorded in `resolution`. `interpreter` must be the base
+    /// interpreter for which `resolution` was produced. In particular, callers materializing a
+    /// universal lock must derive its markers and tags from the same interpreter.
+    pub(crate) async fn from_locked_resolution(
         resolution: &Resolution,
+        build_constraints: Constraints,
+        interpreter: &Interpreter,
+        settings: &ResolverInstallerSettings,
+        client_builder: &BaseClientBuilder<'_>,
+        state: &PlatformState,
+        install: Box<dyn InstallLogger>,
+        installer_metadata: bool,
+        concurrency: &Concurrency,
+        cache: &Cache,
+        printer: Printer,
+        preview: Preview,
+    ) -> Result<Self, ProjectError> {
+        let hash_strategy = HashStrategy::from_resolution(resolution, HashCheckingMode::Verify)?;
+        Self::from_resolution(
+            resolution,
+            hash_strategy,
+            build_constraints,
+            interpreter,
+            settings,
+            client_builder,
+            state,
+            install,
+            installer_metadata,
+            concurrency,
+            cache,
+            printer,
+            preview,
+        )
+        .await
+    }
+
+    async fn from_resolution(
+        resolution: &Resolution,
+        hash_strategy: HashStrategy,
         build_constraints: Constraints,
         interpreter: &Interpreter,
         settings: &ResolverInstallerSettings,
@@ -224,7 +272,7 @@ impl CachedEnvironment {
                     .distribution_id()
                     .cmp(&right.dist.distribution_id())
             });
-            hash_digest(&distributions)
+            cached_environment_resolution_hash(hash_digest(&distributions), &hash_strategy)
         };
 
         // Construct a hash for the environment.
@@ -269,6 +317,7 @@ impl CachedEnvironment {
         sync_environment(
             venv,
             resolution,
+            hash_strategy,
             Modifications::Exact,
             build_constraints,
             settings.into(),
@@ -334,5 +383,28 @@ impl CachedEnvironment {
             );
             Ok(base_interpreter)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use uv_types::HashStrategy;
+
+    use super::{cached_environment_resolution_hash, hash_digest};
+
+    #[test]
+    fn verified_cached_environment_uses_separate_resolution_hash() {
+        let resolution_hash = hash_digest(&["ty==0.0.17"]);
+        let unverified =
+            cached_environment_resolution_hash(resolution_hash.clone(), &HashStrategy::None);
+        let verified = cached_environment_resolution_hash(
+            resolution_hash.clone(),
+            &HashStrategy::Verify(Arc::default()),
+        );
+
+        assert_eq!(unverified, resolution_hash);
+        assert_ne!(verified, unverified);
     }
 }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -2260,6 +2260,7 @@ pub(crate) async fn resolve_environment(
 pub(crate) async fn sync_environment(
     venv: PythonEnvironment,
     resolution: &Resolution,
+    hasher: HashStrategy,
     modifications: Modifications,
     build_constraints: Constraints,
     settings: InstallerSettingsRef<'_>,
@@ -2319,7 +2320,6 @@ pub(crate) async fn sync_environment(
     // optional on the downstream APIs.
     let build_hasher = HashStrategy::default();
     let dry_run = DryRun::default();
-    let hasher = HashStrategy::default();
     let workspace_cache = WorkspaceCache::default();
 
     // Resolve the flat indexes from `--find-links`.

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -28,7 +28,7 @@ use uv_python::{
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_tool::InstalledTools;
-use uv_types::SourceTreeEditablePolicy;
+use uv_types::{HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::WorkspaceCache;
 
@@ -762,6 +762,7 @@ pub(crate) async fn install(
         match sync_environment(
             environment,
             &resolution.into(),
+            HashStrategy::default(),
             Modifications::Exact,
             Constraints::from_requirements(build_constraints.iter().cloned()),
             (&settings).into(),

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -22,7 +22,7 @@ use uv_python::{
 use uv_requirements::RequirementsSpecification;
 use uv_settings::{Combine, PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_tool::{InstalledTools, Tool};
-use uv_types::SourceTreeEditablePolicy;
+use uv_types::{HashStrategy, SourceTreeEditablePolicy};
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{
@@ -367,6 +367,7 @@ async fn upgrade_tool(
         let environment = sync_environment(
             environment,
             &resolution.into(),
+            HashStrategy::default(),
             Modifications::Exact,
             build_constraints,
             (&settings).into(),

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -548,6 +548,75 @@ fn check_uses_exact_ty_version_from_selected_included_group() -> Result<()> {
     Ok(())
 }
 
+/// Ensure that the cached environment for a locked tool rejects invalid lockfile hashes.
+#[test]
+#[cfg(feature = "test-pypi")]
+fn check_locked_tool_rejects_invalid_hash() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"sha256:[0-9a-f]{64}", "sha256:[HASH]"));
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [dependency-groups]
+        dev = ["ty==0.0.17"]
+    "#})?;
+    context.temp_dir.child("main.py").write_str("x = 1")?;
+
+    context
+        .lock()
+        .arg("--exclude-newer")
+        .arg("2026-02-15T00:00:00Z")
+        .assert()
+        .success();
+
+    let mut lock = context.read("uv.lock");
+    let hash_indices = lock
+        .match_indices("sha256:")
+        .map(|(index, _)| index + "sha256:".len())
+        .collect::<Vec<_>>();
+    assert!(!hash_indices.is_empty());
+    for index in hash_indices.into_iter().rev() {
+        let replacement = if lock.as_bytes()[index] == b'0' {
+            "1"
+        } else {
+            "0"
+        };
+        lock.replace_range(index..=index, replacement);
+    }
+    context.temp_dir.child("uv.lock").write_str(&lock)?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.check().arg("--no-sync").arg("--frozen"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+      × Failed to download `ty==0.0.17`
+      ╰─▶ Hash mismatch for `ty==0.0.17`
+
+          Expected:
+            sha256:[HASH]
+
+          Computed:
+            sha256:[HASH]
+    "
+    );
+
+    Ok(())
+}
+
 #[test]
 #[cfg(feature = "test-pypi")]
 fn check_uses_ty_version_from_production_dependency() -> Result<()> {


### PR DESCRIPTION
The locked `uv check` tool path materializes the `ty` package selected from `uv.lock` into a cached environment. Hashes from the lockfile contribute to the cache key, but this path did not verify them when downloading and installing the package.

This PR fixes it.