### PR TITLE
Add exact-index metadata queries

### DIFF
--- a/crates/uv-audit/src/service/project_status.rs
+++ b/crates/uv-audit/src/service/project_status.rs
@@ -6,9 +6,9 @@ use futures::{StreamExt as _, stream};
 use tokio::sync::Semaphore;
 use tracing::trace;
 
-use uv_client::{MetadataFormat, RegistryClient};
+use uv_client::RegistryClient;
 use uv_configuration::Concurrency;
-use uv_distribution_types::{IndexCapabilities, IndexMetadataRef, IndexUrl};
+use uv_distribution_types::{IndexCapabilities, IndexUrl};
 use uv_normalize::PackageName;
 use uv_pypi_types::{ProjectStatus as PypiProjectStatus, Status};
 
@@ -64,32 +64,17 @@ impl<'a> ProjectStatusAudit<'a> {
         index: &IndexUrl,
         semaphore: &Semaphore,
     ) -> Option<Finding> {
-        let results = match self
+        let archive = match self
             .client
-            .simple_detail(
-                name,
-                Some(IndexMetadataRef::from(index)),
-                self.capabilities,
-                semaphore,
-            )
+            .simple_detail_for_index(name, index, self.capabilities, semaphore)
             .await
         {
-            Ok(results) => results,
+            Ok(archive) => archive,
             Err(err) => {
                 trace!("Skipping project-status check for `{name}`: {err}");
                 return None;
             }
         };
-
-        let archive = results
-            .into_iter()
-            .map(|(_, format)| match format {
-                MetadataFormat::Simple(archive) => archive,
-                MetadataFormat::Flat(_) => {
-                    unreachable!("Flat metadata should not be returned by `simple_detail`")
-                }
-            })
-            .next()?;
 
         let project_status: PypiProjectStatus =
             match rkyv::deserialize::<PypiProjectStatus, rkyv::rancor::Error>(

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -272,6 +272,35 @@ impl RegistryClient {
         self.client.uncached().credentials_cache()
     }
 
+    /// Fetch package metadata from an exact Simple API index.
+    pub async fn simple_detail_for_index(
+        &self,
+        package_name: &PackageName,
+        index: &IndexUrl,
+        capabilities: &IndexCapabilities,
+        download_concurrency: &Semaphore,
+    ) -> Result<OwnedArchive<SimpleDetailMetadata>, Error> {
+        if self.indexes.no_index() {
+            return Err(ErrorKind::NoIndex(package_name.to_string()).into());
+        }
+
+        let _permit = download_concurrency.acquire().await;
+        let status_code_strategy = self.indexes.status_code_strategy_for(index);
+        match self
+            .simple_detail_single_index(package_name, index, capabilities, &status_code_strategy)
+            .await?
+        {
+            SimpleMetadataSearchOutcome::Found(metadata) => Ok(metadata),
+            SimpleMetadataSearchOutcome::NotFound => match self.connectivity {
+                Connectivity::Online => {
+                    Err(ErrorKind::RemotePackageNotFound(package_name.clone()).into())
+                }
+                Connectivity::Offline => Err(ErrorKind::Offline(package_name.to_string()).into()),
+            },
+            SimpleMetadataSearchOutcome::StatusCodeFailure { error, .. } => Err(error),
+        }
+    }
+
     /// Return the appropriate index URLs for the given [`PackageName`].
     fn index_urls_for(
         &self,
@@ -358,7 +387,10 @@ impl RegistryClient {
                                 SimpleMetadataSearchOutcome::NotFound => {}
                                 // The search failed because of an HTTP status code that we don't ignore for
                                 // this index. We end our search here.
-                                SimpleMetadataSearchOutcome::StatusCodeFailure(status_code) => {
+                                SimpleMetadataSearchOutcome::StatusCodeFailure {
+                                    status_code,
+                                    ..
+                                } => {
                                     debug!(
                                         "Indexes search failed because of status code failure: {status_code}"
                                     );
@@ -573,7 +605,15 @@ impl RegistryClient {
                             return Err(err);
                         }
                     }
-                    Ok(SimpleMetadataSearchOutcome::from(decision))
+                    Ok(match decision {
+                        IndexStatusCodeDecision::Ignore => SimpleMetadataSearchOutcome::NotFound,
+                        IndexStatusCodeDecision::Fail(status_code) => {
+                            SimpleMetadataSearchOutcome::StatusCodeFailure {
+                                status_code,
+                                error: err,
+                            }
+                        }
+                    })
                 }
 
                 // The package is unavailable due to a lack of connectivity.
@@ -1323,16 +1363,10 @@ enum SimpleMetadataSearchOutcome {
     NotFound,
     /// A status code failure was encountered when searching for
     /// simple metadata and our strategy did not ignore it
-    StatusCodeFailure(StatusCode),
-}
-
-impl From<IndexStatusCodeDecision> for SimpleMetadataSearchOutcome {
-    fn from(item: IndexStatusCodeDecision) -> Self {
-        match item {
-            IndexStatusCodeDecision::Ignore => Self::NotFound,
-            IndexStatusCodeDecision::Fail(status_code) => Self::StatusCodeFailure(status_code),
-        }
-    }
+    StatusCodeFailure {
+        status_code: StatusCode,
+        error: Error,
+    },
 }
 
 /// A map from [`IndexUrl`] to [`FlatIndexEntry`] entries found at the given URL, indexed by
@@ -1710,6 +1744,7 @@ impl Connectivity {
 mod tests {
     use std::str::FromStr;
 
+    use serde_json::from_str as deserialize_json;
     use tokio::sync::Semaphore;
     use url::Url;
     use uv_normalize::PackageName;
@@ -1806,6 +1841,173 @@ mod tests {
         )
         .await?;
         assert_no_requests(&server).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exact_simple_index_returns_metadata() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/simple/validation/$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"{"files": []}"#, "application/vnd.pypi.simple.v1+json"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let index = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let registry_client =
+            RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?).build()?;
+
+        let metadata = registry_client
+            .simple_detail_for_index(
+                &PackageName::from_str("validation")?,
+                &index,
+                &IndexCapabilities::default(),
+                &Semaphore::new(1),
+            )
+            .await?;
+
+        assert_eq!(metadata.iter().count(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exact_simple_index_preserves_not_found_error() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/simple/validation/$"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let index = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let registry_client =
+            RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?).build()?;
+
+        let error = registry_client
+            .simple_detail_for_index(
+                &PackageName::from_str("validation")?,
+                &index,
+                &IndexCapabilities::default(),
+                &Semaphore::new(1),
+            )
+            .await
+            .expect_err("a missing package should return a not-found error");
+
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::RemotePackageNotFound(package) if package.as_ref() == "validation"
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn no_index_disables_exact_simple_index() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        let index = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let registry_client = no_index_client(vec![])?;
+
+        let error = registry_client
+            .simple_detail_for_index(
+                &PackageName::from_str("validation")?,
+                &index,
+                &IndexCapabilities::default(),
+                &Semaphore::new(1),
+            )
+            .await
+            .expect_err("index lookup should be disabled");
+
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::NoIndex(package) if package == "validation"
+        ));
+        assert_no_requests(&server).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exact_simple_index_preserves_offline_error() -> Result<(), Error> {
+        let index = IndexUrl::from_str("https://index.example.com/simple")?;
+        let registry_client = RegistryClientBuilder::new(
+            BaseClientBuilder::default().connectivity(Connectivity::Offline),
+            Cache::temp()?,
+        )
+        .build()?;
+
+        let error = registry_client
+            .simple_detail_for_index(
+                &PackageName::from_str("validation")?,
+                &index,
+                &IndexCapabilities::default(),
+                &Semaphore::new(1),
+            )
+            .await
+            .expect_err("an uncached offline lookup should fail");
+
+        assert!(matches!(error.kind(), crate::ErrorKind::Offline(_)));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exact_simple_index_preserves_authentication_error() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        let index = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let registry_client =
+            RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?).build()?;
+        let capabilities = IndexCapabilities::default();
+
+        let error = registry_client
+            .simple_detail_for_index(
+                &PackageName::from_str("validation")?,
+                &index,
+                &capabilities,
+                &Semaphore::new(1),
+            )
+            .await
+            .expect_err("an unauthorized lookup should fail");
+
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::WrappedReqwestError(_, _)
+        ));
+        assert!(capabilities.unauthorized(&index));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exact_simple_index_uses_per_index_status_code_policy() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let index = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let mut configured_index = Index::from(index.clone());
+        configured_index.ignore_error_codes = Some(vec![deserialize_json("500")?]);
+        let registry_client =
+            RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+                .index_locations(IndexLocations::new(vec![configured_index], vec![], false))
+                .build()?;
+
+        let error = registry_client
+            .simple_detail_for_index(
+                &PackageName::from_str("validation")?,
+                &index,
+                &IndexCapabilities::default(),
+                &Semaphore::new(1),
+            )
+            .await
+            .expect_err("an ignored status code should behave like a missing package");
+
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::RemotePackageNotFound(package) if package.as_ref() == "validation"
+        ));
         Ok(())
     }
 

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -26,8 +26,8 @@ use url::Url;
 use uv_auth::{Credentials, PyxTokenStore, Realm};
 use uv_cache::{Cache, Refresh};
 use uv_client::{
-    BaseClient, ClientBuildError, DEFAULT_MAX_REDIRECTS, MetadataFormat, OwnedArchive,
-    RegistryClientBuilder, RequestBuilder, RetryParsingError, RetryState,
+    BaseClient, ClientBuildError, DEFAULT_MAX_REDIRECTS, OwnedArchive, RegistryClientBuilder,
+    RequestBuilder, RetryParsingError, RetryState,
 };
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
 use uv_distribution_filename::{DistFilename, SourceDistExtension, SourceDistFilename};
@@ -967,16 +967,16 @@ pub async fn check_url(
         .wrap_existing(client)?;
 
     debug!("Checking for {filename} in the registry");
-    let response = match registry_client
-        .simple_detail(
+    let simple_metadata = match registry_client
+        .simple_detail_for_index(
             filename.name(),
-            Some(index_url.into()),
+            index_url,
             index_capabilities,
             download_concurrency,
         )
         .await
     {
-        Ok(response) => response,
+        Ok(simple_metadata) => simple_metadata,
         Err(err) => {
             return match err.kind() {
                 uv_client::ErrorKind::RemotePackageNotFound(_) => {
@@ -990,10 +990,7 @@ pub async fn check_url(
             };
         }
     };
-    let [(_, MetadataFormat::Simple(simple_metadata))] = response.as_slice() else {
-        unreachable!("We queried a single index, we must get a single response");
-    };
-    let simple_metadata = OwnedArchive::deserialize(simple_metadata);
+    let simple_metadata = OwnedArchive::deserialize(&simple_metadata);
     let Some(metadatum) = simple_metadata
         .iter()
         .find(|metadatum| &metadatum.version == filename.version())


### PR DESCRIPTION
`RegistryClient::simple_detail` performs a multi-index search even when a caller already knows the target Simple API index. The project-status query in `uv audit` and duplicate check in `uv publish --check-url` therefore unpack a one-element index/format response, and the search path turns authentication failures into package-not-found errors instead of returning the original error.

This PR adds `RegistryClient::simple_detail_for_index`, which queries one Simple API index and returns its archived metadata directly. Both commands from above now use this path without unreachable flat-index branches; there should be no user-visible behavior changes, this is a pure refactor PR.

This supplies the proxy-index stack with the primitive it needs to query canonical metadata directly, without re-entering multi-index routing. Depends on #19961 