### PR TITLE
Move registry cache matching into the index

### DIFF
--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -5,13 +5,15 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use uv_cache::{Cache, CacheBucket, WheelCache};
 use uv_cache_info::CacheInfo;
+use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
     BuildInfo, BuildVariables, CachedRegistryDist, ConfigSettings, ExtraBuildRequirement,
     ExtraBuildRequires, ExtraBuildVariables, Hashed, Index, IndexLocations, IndexUrl,
-    PackageConfigSettings,
+    PackageConfigSettings, RegistryBuiltDist, RegistrySourceDist,
 };
 use uv_fs::{directories, files};
 use uv_normalize::PackageName;
+use uv_pep440::Version;
 use uv_platform_tags::Tags;
 use uv_types::HashStrategy;
 
@@ -20,7 +22,7 @@ use crate::source::{HTTP_REVISION, HttpRevisionPointer, LOCAL_REVISION, LocalRev
 
 /// An entry in the [`RegistryWheelIndex`].
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct IndexEntry<'index> {
+struct IndexEntry<'index> {
     /// The cached distribution.
     dist: CachedRegistryDist,
     /// Whether the wheel was built from source (true), or downloaded from the registry directly (false).
@@ -29,20 +31,41 @@ pub struct IndexEntry<'index> {
     index: &'index Index,
 }
 
-impl<'index> IndexEntry<'index> {
-    /// Return the cached distribution.
-    pub fn dist(&self) -> &CachedRegistryDist {
-        &self.dist
+impl IndexEntry<'_> {
+    fn matches_wheel(
+        &self,
+        index: &IndexUrl,
+        filename: &WheelFilename,
+        no_build: bool,
+        no_binary: bool,
+    ) -> bool {
+        self.matches_index_and_build_policy(index, no_build, no_binary)
+            && self.dist.filename == *filename
     }
 
-    /// Return whether the wheel was built from source.
-    pub fn is_built(&self) -> bool {
-        self.built
+    fn matches_source(
+        &self,
+        index: &IndexUrl,
+        name: &PackageName,
+        version: &Version,
+        no_build: bool,
+        no_binary: bool,
+    ) -> bool {
+        self.matches_index_and_build_policy(index, no_build, no_binary)
+            && self.dist.filename.name == *name
+            && self.dist.filename.version == *version
     }
 
-    /// Return the index from which the wheel was downloaded.
-    pub fn index(&self) -> &'index Index {
-        self.index
+    fn matches_index_and_build_policy(
+        &self,
+        index: &IndexUrl,
+        no_build: bool,
+        no_binary: bool,
+    ) -> bool {
+        if *self.index.url() != *index {
+            return false;
+        }
+        if self.built { !no_build } else { !no_binary }
     }
 }
 
@@ -85,10 +108,45 @@ impl<'a> RegistryWheelIndex<'a> {
         }
     }
 
+    /// Return a cached wheel that satisfies a registry wheel requirement.
+    pub fn wheel(
+        &mut self,
+        wheel: &'a RegistryBuiltDist,
+        no_build: bool,
+        no_binary: bool,
+    ) -> Option<&CachedRegistryDist> {
+        let wheel = wheel.best_wheel();
+        self.get(&wheel.filename.name).find_map(|entry| {
+            entry
+                .matches_wheel(&wheel.index, &wheel.filename, no_build, no_binary)
+                .then_some(&entry.dist)
+        })
+    }
+
+    /// Return a cached wheel that satisfies a registry source distribution requirement.
+    pub fn source(
+        &mut self,
+        source: &'a RegistrySourceDist,
+        no_build: bool,
+        no_binary: bool,
+    ) -> Option<&CachedRegistryDist> {
+        self.get(&source.name).find_map(|entry| {
+            entry
+                .matches_source(
+                    &source.index,
+                    &source.name,
+                    &source.version,
+                    no_build,
+                    no_binary,
+                )
+                .then_some(&entry.dist)
+        })
+    }
+
     /// Return an iterator over available wheels for a given package.
     ///
     /// If the package is not yet indexed, this will index the package by reading from the cache.
-    pub fn get(&mut self, name: &'a PackageName) -> impl Iterator<Item = &IndexEntry<'_>> {
+    fn get(&mut self, name: &'a PackageName) -> impl Iterator<Item = &IndexEntry<'_>> {
         self.get_impl(name).iter().rev()
     }
 

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -399,21 +399,7 @@ impl<'a> Planner<'a> {
             // Identify any cached distributions that satisfy the requirement.
             match dist.as_ref() {
                 Dist::Built(BuiltDist::Registry(wheel)) => {
-                    if let Some(distribution) = registry_index.get(wheel.name()).find_map(|entry| {
-                        if *entry.index().url() != wheel.best_wheel().index {
-                            return None;
-                        }
-                        if entry.dist().filename != wheel.best_wheel().filename {
-                            return None;
-                        }
-                        if entry.is_built() && no_build {
-                            return None;
-                        }
-                        if !entry.is_built() && no_binary {
-                            return None;
-                        }
-                        Some(entry.dist())
-                    }) {
+                    if let Some(distribution) = registry_index.wheel(wheel, no_build, no_binary) {
                         debug!("Registry requirement already cached: {distribution}");
                         cached.push(CachedDist::Registry(distribution.clone()));
                         continue;
@@ -607,24 +593,7 @@ impl<'a> Planner<'a> {
                     }
                 }
                 Dist::Source(SourceDist::Registry(sdist)) => {
-                    if let Some(distribution) = registry_index.get(sdist.name()).find_map(|entry| {
-                        if *entry.index().url() != sdist.index {
-                            return None;
-                        }
-                        if entry.dist().filename.name != sdist.name {
-                            return None;
-                        }
-                        if entry.dist().filename.version != sdist.version {
-                            return None;
-                        }
-                        if entry.is_built() && no_build {
-                            return None;
-                        }
-                        if !entry.is_built() && no_binary {
-                            return None;
-                        }
-                        Some(entry.dist())
-                    }) {
+                    if let Some(distribution) = registry_index.source(sdist, no_build, no_binary) {
                         debug!("Registry requirement already cached: {distribution}");
                         cached.push(CachedDist::Registry(distribution.clone()));
                         continue;

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -3436,9 +3436,9 @@ fn install_only_binary_all_and_no_binary_all() {
     context.assert_command("import anyio").failure();
 }
 
-/// Binary dependencies in the cache should be reused when the user provides `--no-build`.
+/// Cached registry wheels should respect `--no-build` and `--no-binary`.
 #[test]
-fn install_no_binary_cache() {
+fn install_build_policy_cache() {
     let context = uv_test::test_context!("3.12");
 
     // Install a binary distribution.
@@ -3490,6 +3490,53 @@ fn install_no_binary_cache() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + idna==3.6
+    "
+    );
+
+    // Re-create the virtual environment.
+    context.venv().arg("--clear").assert().success();
+
+    // Re-install with `--no-binary`. The locally built wheel should be reused from the source
+    // distribution cache, while the downloaded wheel should remain excluded.
+    uv_snapshot!(
+        context
+            .pip_install()
+            .arg("idna")
+            .arg("--no-binary")
+            .arg(":all:")
+            .arg("--offline"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + idna==3.6
+    "
+    );
+
+    // Re-create the virtual environment.
+    context.venv().arg("--clear").assert().success();
+
+    // Re-install with `--no-build`. The downloaded wheel should be reused from the wheel cache,
+    // while the locally built wheel should remain excluded.
+    uv_snapshot!(
+        context
+            .pip_install()
+            .arg("idna")
+            .arg("--no-build")
+            .arg("--offline"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
     Installed 1 package in [TIME]
      + idna==3.6
     "


### PR DESCRIPTION
The installer planner currently inspects raw `RegistryWheelIndex` entries to decide whether a cached registry distribution satisfies a resolved requirement. This moves those checks into `RegistryWheelIndex::wheel` and `RegistryWheelIndex::source`, then makes `IndexEntry` and the raw `get` iterator private.

Proxy indexes separate a package’s canonical index identity from the physical endpoint used to serve its artifacts. This refactor makes `RegistryWheelIndex` the boundary for selecting cached artifacts, allowing subsequent proxy-index changes to search and validate canonical and physical cache locations without adding proxy-specific logic to the installer planner.

This is a pure refactor, no functionality change. Depends on #19996 