### PR TITLE
Centralize base dist traversal

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -40,7 +40,6 @@ use uv_small_str::SmallString;
 
 use crate::lock::export::ExportableRequirements;
 use crate::lock::{Source, WheelTagHint, each_element_on_its_line_array, is_wheel_unreachable};
-use crate::resolution::ResolutionGraphNode;
 use crate::{Installable, LockError, ResolverOutput};
 
 #[derive(Debug, thiserror::Error)]
@@ -390,13 +389,7 @@ impl<'lock> PylockToml {
 
         // Convert each node to a `pylock.toml`-style package.
         let mut packages = Vec::with_capacity(resolution.graph.node_count());
-        for node_index in resolution.graph.node_indices() {
-            let ResolutionGraphNode::Dist(node) = &resolution.graph[node_index] else {
-                continue;
-            };
-            if !node.is_base() {
-                continue;
-            }
+        for (node_index, node) in resolution.base_dists() {
             let ResolvedDist::Installable { dist, version } = &node.dist else {
                 continue;
             };

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -329,27 +329,14 @@ impl Lock {
         // Determine the set of packages included at multiple versions.
         let mut seen = FxHashSet::default();
         let mut duplicates = FxHashSet::default();
-        for node_index in resolution.graph.node_indices() {
-            let ResolutionGraphNode::Dist(dist) = &resolution.graph[node_index] else {
-                continue;
-            };
-            if !dist.is_base() {
-                continue;
-            }
+        for (_, dist) in resolution.base_dists() {
             if !seen.insert(dist.name()) {
                 duplicates.insert(dist.name());
             }
         }
 
         // Lock all base packages.
-        for node_index in resolution.graph.node_indices() {
-            let ResolutionGraphNode::Dist(dist) = &resolution.graph[node_index] else {
-                continue;
-            };
-            if !dist.is_base() {
-                continue;
-            }
-
+        for (node_index, dist) in resolution.base_dists() {
             // If there are multiple distributions for the same package, include the markers of all
             // forks that included the current distribution.
             //

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -598,14 +598,24 @@ impl ResolverOutput {
             })
     }
 
+    /// Returns an iterator over the base distributions in the graph.
+    pub(crate) fn base_dists(&self) -> impl Iterator<Item = (NodeIndex, &AnnotatedDist)> {
+        self.graph
+            .node_indices()
+            .filter_map(move |node_index| match &self.graph[node_index] {
+                ResolutionGraphNode::Root => None,
+                ResolutionGraphNode::Dist(dist) => dist.is_base().then_some((node_index, dist)),
+            })
+    }
+
     /// Return the number of distinct packages in the graph.
     pub fn len(&self) -> usize {
-        self.dists().filter(|dist| dist.is_base()).count()
+        self.base_dists().count()
     }
 
     /// Return `true` if there are no packages in the graph.
     pub fn is_empty(&self) -> bool {
-        !self.dists().any(AnnotatedDist::is_base)
+        self.base_dists().next().is_none()
     }
 
     /// Returns `true` if the graph contains the given package.


### PR DESCRIPTION
`ResolverOutput` consumers independently traverse the graph to find base distributions. This PR adds a crate-private `base_dists()` iterator and uses it for lock construction, pylock export, `len()`, and `is_empty()` without changing graph semantics.

Later proxy-index work uses the same `(NodeIndex, &AnnotatedDist)` view to canonicalize lock artifacts. This is a pure refactor with no user-visible changes. Depends on #20001.