### PR TITLE
Remove build::build_with_hardlink test

### DIFF
--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2595,45 +2595,6 @@ fn build_with_symlink() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn build_with_hardlink() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    context
-        .temp_dir
-        .child("pyproject.toml.real")
-        .write_str(indoc! {r#"
-            [project]
-            name = "hardlinked"
-            version = "0.1.0"
-            requires-python = ">=3.12"
-
-            [build-system]
-            requires = ["hatchling"]
-            build-backend = "hatchling.build"
-    "#})?;
-    fs_err::hard_link(
-        context.temp_dir.child("pyproject.toml.real"),
-        context.temp_dir.child("pyproject.toml"),
-    )?;
-    context
-        .temp_dir
-        .child("src/hardlinked/__init__.py")
-        .touch()?;
-    fs_err::remove_dir_all(&context.venv)?;
-    uv_snapshot!(context.filters(), context.build(), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Building source distribution...
-    Building wheel from source distribution...
-    Successfully built dist/hardlinked-0.1.0.tar.gz
-    Successfully built dist/hardlinked-0.1.0-py3-none-any.whl
-    ");
-    Ok(())
-}
-
 /// This is bad project layout that is allowed: A project that defines PEP 621 metadata, but no
 /// PEP 517 build system not a setup.py, so we fallback to setuptools implicitly.
 #[test]


### PR DESCRIPTION
## Summary

This follows #19991 -- we're now rejecting the main situation in which hardlinks appear in source distributions.

For context: this test was originally added in https://github.com/astral-sh/uv/pull/11221 to backstop our behavior in astral-tokio-tar (which had accidentally regressed in terms of how hardlinks were extracted). But with #19979 our plan is to remove astral-tokio-tar entirely (eventually), so this test is effectively backstopping a behavior that we're intentionally removing (hardlinks are not well defined in sdist and are completely forbidden in wheels).

We _might_ also want to remove `build_with_symlink`, but it's more marginal since symlinks _do_ appear in real-world sdists/source trees. #19979 isn't currently changing how we handle them.

## Test Plan

Intentionally deleting a backstop test 🙈 