### PR TITLE
Check PEP 723 scrolls in CI

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -42,12 +42,23 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.11.25"
-      - run: |
-          uvx ty check python/uv
-          uvx \
-            --directory crates/uv-python \
-            --with-requirements fetch-download-metadata.py \
-            ty check --python-version 3.13 fetch-download-metadata.py
+      # `uv check` checks the entire repository; keep this scoped to the Python package.
+      - run: uvx ty check python/uv
+      - name: "Check scrolls"
+        env:
+          # Let ty infer the Python version from each script environment instead of the root project.
+          TY_CONFIG_FILE: /dev/null
+        run: |
+          # TODO: Replace this with `uv workspace list-scripts` once available.
+          mapfile -t scripts < <(git grep -l '^# /// script$' -- '*.py')
+          for script in "${scripts[@]}"; do
+            echo "Checking ${script}"
+            check_args=(--script "${script}")
+            if [[ -f "${script}.lock" ]]; then
+              check_args+=(--locked)
+            fi
+            uv --preview-features check-command check "${check_args[@]}"
+          done
 
   shellcheck:
     timeout-minutes: 10

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -46,18 +46,18 @@ jobs:
       - run: uvx ty check python/uv
       - name: "Check scrolls"
         env:
-          # Let ty infer the Python version from each script environment instead of the root project.
+          # TODO: Remove once ty infers Python versions from script environments instead of the root project.
           TY_CONFIG_FILE: /dev/null
+          UV_PREVIEW_FEATURES: check-command,workspace-list-scripts
         run: |
-          # TODO: Replace this with `uv workspace list-scripts` once available.
-          mapfile -t scripts < <(git grep -l '^# /// script$' -- '*.py')
+          mapfile -t scripts < <(uv workspace list --scripts)
           for script in "${scripts[@]}"; do
             echo "Checking ${script}"
             check_args=(--script "${script}")
             if [[ -f "${script}.lock" ]]; then
               check_args+=(--locked)
             fi
-            uv --preview-features check-command check "${check_args[@]}"
+            uv check "${check_args[@]}"
           done
 
   shellcheck:


### PR DESCRIPTION
The existing `ty` job checks `python/uv` and one PEP 723 script with a bespoke invocation, leaving the repository’s other inline-metadata scripts unchecked.

This replaces the one-off script check with an auto-discovered `uv check --script` pass over every `# /// script` file. Scripts with adjacent lockfiles run with `--locked`, while an empty explicit `ty` configuration lets each script environment supply its Python version instead of inheriting the root project’s Python 3.8 minimum.

The package-scoped `uvx ty check python/uv` remains unchanged because project-level `uv check` would traverse the entire repository, we should fix this separately once we can have `uv check` only check a member of the workspace.