### PR TITLE
Add `uv workspace list --scripts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "ignore",
  "indexmap",
  "indicatif",
  "indoc",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -8373,14 +8373,11 @@ pub struct WorkspaceDirArgs {
 #[derive(Args, Debug)]
 pub struct WorkspaceListArgs {
     /// Show paths instead of names.
-    ///
-    /// When used with `--scripts`, display absolute paths instead of paths relative to the
-    /// workspace root.
     #[arg(long)]
     pub paths: bool,
 
     /// List PEP 723 scripts instead of workspace members.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "paths")]
     pub scripts: bool,
 }
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -8373,8 +8373,15 @@ pub struct WorkspaceDirArgs {
 #[derive(Args, Debug)]
 pub struct WorkspaceListArgs {
     /// Show paths instead of names.
+    ///
+    /// When used with `--scripts`, display absolute paths instead of paths relative to the
+    /// workspace root.
     #[arg(long)]
     pub paths: bool,
+
+    /// List PEP 723 scripts instead of workspace members.
+    #[arg(long)]
+    pub scripts: bool,
 }
 
 /// See [PEP 517](https://peps.python.org/pep-0517/) and

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -8376,7 +8376,7 @@ pub struct WorkspaceListArgs {
     #[arg(long)]
     pub paths: bool,
 
-    /// List PEP 723 scripts instead of workspace members.
+    /// List all standalone scripts with inline metadata in the workspace.
     #[arg(long, conflicts_with = "paths")]
     pub scripts: bool,
 }

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -8377,7 +8377,7 @@ pub struct WorkspaceListArgs {
     pub paths: bool,
 
     /// List all standalone scripts with inline metadata in the workspace.
-    #[arg(long, conflicts_with = "paths")]
+    #[arg(long)]
     pub scripts: bool,
 }
 

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -260,6 +260,7 @@ pub enum PreviewFeature {
     PackagedInit = 1 << 34,
     CentralizedProjectEnvs = 1 << 35,
     ToolInstallLocks = 1 << 36,
+    WorkspaceListScripts = 1 << 37,
 }
 
 impl PreviewFeature {
@@ -303,6 +304,7 @@ impl PreviewFeature {
             Self::PackagedInit => "packaged-init",
             Self::CentralizedProjectEnvs => "centralized-project-envs",
             Self::ToolInstallLocks => "tool-install-locks",
+            Self::WorkspaceListScripts => "workspace-list-scripts",
         }
     }
 }
@@ -359,6 +361,7 @@ impl FromStr for PreviewFeature {
             "packaged-init" => Self::PackagedInit,
             "centralized-project-envs" => Self::CentralizedProjectEnvs,
             "tool-install-locks" => Self::ToolInstallLocks,
+            "workspace-list-scripts" => Self::WorkspaceListScripts,
             _ => return Err(PreviewFeatureParseError),
         })
     }
@@ -660,6 +663,10 @@ mod tests {
         assert_eq!(
             PreviewFeature::CentralizedProjectEnvs.as_str(),
             "centralized-project-envs"
+        );
+        assert_eq!(
+            PreviewFeature::WorkspaceListScripts.as_str(),
+            "workspace-list-scripts"
         );
     }
 

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -85,6 +85,7 @@ etcetera = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 http = { workspace = true }
+ignore = { workspace = true }
 jiff = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -149,11 +149,11 @@ fn find_scripts(workspace_root: &Path, cache: &Cache) -> Result<Vec<PathBuf>> {
 /// Return whether a path uses a conventional Python script filename.
 ///
 /// PEP 723 does not require a specific filename, and uv can run explicitly requested scripts with
-/// arbitrary extensions. For discovery, restrict the search to Python extensions and extensionless
-/// files to avoid treating metadata examples embedded in documentation as scripts. This could be
-/// expanded if arbitrary script filenames can be distinguished without introducing false positives.
+/// arbitrary extensions or no extension. For discovery, restrict the search to Python extensions
+/// to avoid treating metadata examples embedded in documentation as scripts. This could be expanded
+/// if arbitrary script filenames can be distinguished without introducing false positives.
 fn is_python_script_path(path: &Path) -> bool {
-    path.extension().is_none_or(|extension| {
+    path.extension().is_some_and(|extension| {
         extension.to_str().is_some_and(|extension| {
             extension.eq_ignore_ascii_case("py") || extension.eq_ignore_ascii_case("pyw")
         })

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
@@ -5,7 +6,7 @@ use anyhow::{Context, Result};
 
 use owo_colors::OwoColorize;
 use uv_cache::Cache;
-use uv_fs::{CWD, Simplified, normalize_path};
+use uv_fs::{CWD, Simplified, is_virtualenv_base, normalize_path};
 use uv_preview::{Preview, PreviewFeature};
 use uv_scripts::Pep723Metadata;
 use uv_warnings::warn_user;
@@ -72,21 +73,22 @@ fn find_scripts(workspace_root: &Path, cache: &Cache) -> Result<Vec<PathBuf>> {
     // Avoid descending into the cache when it is inside the workspace. If the workspace itself is
     // inside the cache, it is still the requested search root and must not be excluded.
     let cache_root = if cache.root().is_absolute() {
-        cache.root().to_path_buf()
+        Cow::Borrowed(cache.root())
     } else {
-        CWD.join(cache.root())
+        Cow::Owned(CWD.join(cache.root()))
     };
-    let cache_root = normalize_path(&cache_root).into_owned();
-    let cache_root = (!workspace_root.starts_with(&cache_root)).then_some(cache_root);
+    let cache_root = normalize_path(cache_root);
+    // The filter closure requires owned data, but only capture the cache root when it is strictly
+    // inside the workspace. This avoids allocation and per-entry comparisons for external caches.
+    let cache_is_nested =
+        cache_root.as_ref() != workspace_root && cache_root.starts_with(workspace_root);
+    let cache_root = cache_is_nested.then(|| cache_root.into_owned());
 
     let mut builder = ignore::WalkBuilder::new(workspace_root);
+    // Include scripts in hidden directories, such as `.github`.
     ignore::WalkBuilder::hidden(&mut builder, false);
     builder
-        .parents(true)
-        .ignore(true)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
+        // Respect `.gitignore` files in source archives and other workspaces without `.git`.
         .require_git(false)
         .filter_entry(move |entry| {
             let path = entry.path();
@@ -104,11 +106,20 @@ fn find_scripts(workspace_root: &Path, cache: &Cache) -> Result<Vec<PathBuf>> {
                 return true;
             }
 
-            // Repository internals and virtual environments can be very large and cannot contain
-            // scripts that belong to the workspace. Detect virtual environments by their marker
-            // file so custom environment directory names are handled too.
-            !matches!(entry.file_name().to_str(), Some(".git" | ".venv"))
-                && !path.join("pyvenv.cfg").is_file()
+            // Hidden directories are included above, but Git internals cannot contain workspace
+            // scripts and can be very large.
+            if entry.file_name() == ".git" {
+                return false;
+            }
+
+            // Ignore rules have already been applied, but `.venv` is not guaranteed to be ignored.
+            if entry.file_name() == ".venv" {
+                return false;
+            }
+
+            // Detect virtual environments by their marker file so custom directory names are
+            // handled too.
+            !is_virtualenv_base(path)
         });
     let walker = builder.build();
 

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -1,24 +1,36 @@
 use std::fmt::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use owo_colors::OwoColorize;
 use uv_cache::Cache;
-use uv_fs::Simplified;
+use uv_fs::{CWD, Simplified, normalize_path};
+use uv_preview::{Preview, PreviewFeature};
+use uv_scripts::Pep723Metadata;
+use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
-/// List workspace members
+/// List workspace members or PEP 723 scripts.
 pub(crate) async fn list(
     project_dir: &Path,
     paths: bool,
+    scripts: bool,
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     printer: Printer,
+    preview: Preview,
 ) -> Result<ExitStatus> {
+    if scripts && !preview.is_enabled(PreviewFeature::WorkspaceList) {
+        warn_user!(
+            "The `--scripts` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
+            PreviewFeature::WorkspaceList
+        );
+    }
+
     let workspace = Workspace::discover(
         project_dir,
         &DiscoveryOptions::default(),
@@ -26,6 +38,20 @@ pub(crate) async fn list(
         workspace_cache,
     )
     .await?;
+
+    if scripts {
+        for script in find_scripts(workspace.install_path(), cache)? {
+            let script = if paths {
+                script.as_path()
+            } else {
+                script
+                    .strip_prefix(workspace.install_path())
+                    .context("PEP 723 script was discovered outside the workspace root")?
+            };
+            writeln!(printer.stdout(), "{}", script.simplified_display().cyan())?;
+        }
+        return Ok(ExitStatus::Success);
+    }
 
     for (name, member) in workspace.packages() {
         if paths {
@@ -40,4 +66,92 @@ pub(crate) async fn list(
     }
 
     Ok(ExitStatus::Success)
+}
+
+/// Find PEP 723 scripts under a workspace root.
+fn find_scripts(workspace_root: &Path, cache: &Cache) -> Result<Vec<PathBuf>> {
+    // Avoid descending into the cache when it is inside the workspace. If the workspace itself is
+    // inside the cache, it is still the requested search root and must not be excluded.
+    let cache_root = if cache.root().is_absolute() {
+        cache.root().to_path_buf()
+    } else {
+        CWD.join(cache.root())
+    };
+    let cache_root = normalize_path(&cache_root).into_owned();
+    let cache_root = (!workspace_root.starts_with(&cache_root)).then_some(cache_root);
+
+    let mut builder = ignore::WalkBuilder::new(workspace_root);
+    ignore::WalkBuilder::hidden(&mut builder, false);
+    builder
+        .parents(true)
+        .ignore(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .require_git(false)
+        .filter_entry(move |entry| {
+            let path = entry.path();
+            if cache_root
+                .as_ref()
+                .is_some_and(|cache_root| path.starts_with(cache_root))
+            {
+                return false;
+            }
+
+            if !entry
+                .file_type()
+                .is_some_and(|file_type| file_type.is_dir())
+            {
+                return true;
+            }
+
+            // Repository internals and virtual environments can be very large and cannot contain
+            // scripts that belong to the workspace. Detect virtual environments by their marker
+            // file so custom environment directory names are handled too.
+            !matches!(entry.file_name().to_str(), Some(".git" | ".venv"))
+                && !path.join("pyvenv.cfg").is_file()
+        });
+    let walker = builder.build();
+
+    let mut scripts = Vec::new();
+    for entry in walker {
+        let entry = entry.context("Failed to walk workspace while discovering PEP 723 scripts")?;
+        if !entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_file())
+            || !is_python_script_path(entry.path())
+        {
+            continue;
+        }
+
+        let contents = fs_err::read(entry.path()).with_context(|| {
+            format!(
+                "Failed to read candidate PEP 723 script: {}",
+                entry.path().simplified_display()
+            )
+        })?;
+        if Pep723Metadata::parse(&contents)
+            .with_context(|| {
+                format!(
+                    "Failed to parse PEP 723 script: {}",
+                    entry.path().simplified_display()
+                )
+            })?
+            .is_some()
+        {
+            scripts.push(entry.into_path());
+        }
+    }
+
+    scripts.sort_unstable();
+    Ok(scripts)
+}
+
+/// Return whether a path can represent a Python script.
+fn is_python_script_path(path: &Path) -> bool {
+    path.extension().is_none_or(|extension| {
+        extension.to_str().is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("py") || extension.eq_ignore_ascii_case("pyw")
+        })
+    })
 }

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -65,6 +65,9 @@ pub(crate) async fn list(
 }
 
 /// Find PEP 723 scripts under a workspace root.
+///
+/// Respects ignore files and excludes repository internals, virtual environments, and the uv cache
+/// from traversal.
 fn find_scripts(workspace_root: &Path, cache: &Cache) -> Result<Vec<PathBuf>> {
     // Avoid descending into the cache when it is inside the workspace. If the workspace itself is
     // inside the cache, it is still the requested search root and must not be excluded.
@@ -143,7 +146,12 @@ fn find_scripts(workspace_root: &Path, cache: &Cache) -> Result<Vec<PathBuf>> {
     Ok(scripts)
 }
 
-/// Return whether a path can represent a Python script.
+/// Return whether a path uses a conventional Python script filename.
+///
+/// PEP 723 does not require a specific filename, and uv can run explicitly requested scripts with
+/// arbitrary extensions. For discovery, restrict the search to Python extensions and extensionless
+/// files to avoid treating metadata examples embedded in documentation as scripts. This could be
+/// expanded if arbitrary script filenames can be distinguished without introducing false positives.
 fn is_python_script_path(path: &Path) -> bool {
     path.extension().is_none_or(|extension| {
         extension.to_str().is_some_and(|extension| {

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -24,10 +24,10 @@ pub(crate) async fn list(
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
-    if scripts && !preview.is_enabled(PreviewFeature::WorkspaceList) {
+    if scripts && !preview.is_enabled(PreviewFeature::WorkspaceListScripts) {
         warn_user!(
             "The `--scripts` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
-            PreviewFeature::WorkspaceList
+            PreviewFeature::WorkspaceListScripts
         );
     }
 
@@ -41,13 +41,9 @@ pub(crate) async fn list(
 
     if scripts {
         for script in find_scripts(workspace.install_path(), cache)? {
-            let script = if paths {
-                script.as_path()
-            } else {
-                script
-                    .strip_prefix(workspace.install_path())
-                    .context("PEP 723 script was discovered outside the workspace root")?
-            };
+            let script = script
+                .strip_prefix(workspace.install_path())
+                .context("PEP 723 script was discovered outside the workspace root")?;
             writeln!(printer.stdout(), "{}", script.simplified_display().cyan())?;
         }
         return Ok(ExitStatus::Success);

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2062,7 +2062,16 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .await
             }
             WorkspaceCommand::List(args) => {
-                commands::list(&project_dir, args.paths, &cache, &workspace_cache, printer).await
+                commands::list(
+                    &project_dir,
+                    args.paths,
+                    args.scripts,
+                    &cache,
+                    &workspace_cache,
+                    printer,
+                    globals.preview,
+                )
+                .await
             }
         },
         Commands::BuildBackend { command } => spawn_blocking(move || match command {

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3055,6 +3055,7 @@ fn preview_features() {
     +            PackagedInit,
     +            CentralizedProjectEnvs,
     +            ToolInstallLocks,
+    +            WorkspaceListScripts,
     +        ],
          },
          python_preference: Managed,

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -237,7 +237,7 @@ fn workspace_list_no_project() {
 /// boundaries.
 #[test]
 fn workspace_list_scripts() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
+    let mut context = uv_test::test_context!("3.12");
 
     context.init().arg("project").assert().success();
     let project = context.temp_dir.child("project");
@@ -311,16 +311,33 @@ fn workspace_list_scripts() -> Result<()> {
         .arg("--scripts")
         .arg("--paths")
         .current_dir(&project), @"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
+    .github/hidden.py
+    script.py
+    scripts/nested.py
 
     ----- stderr -----
-    error: the argument '--scripts' cannot be used with '--paths'
+    warning: The `--scripts` option is experimental and may change without warning. Pass `--preview-features workspace-list-scripts` to disable this warning.
+    ");
 
-    Usage: uv workspace list --cache-dir [CACHE_DIR] --scripts
+    // The configured cache is excluded even when it has not been initialized with ignore files.
+    let cache = project.child("cache");
+    cache.child("script.py").write_str(script)?;
+    context.cache_dir = cache;
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--scripts")
+        .current_dir(&project), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    .github/hidden.py
+    script.py
+    scripts/nested.py
 
-    For more information, try '--help'.
+    ----- stderr -----
+    warning: The `--scripts` option is experimental and may change without warning. Pass `--preview-features workspace-list-scripts` to disable this warning.
     ");
 
     Ok(())

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
-use assert_fs::fixture::PathChild;
+use assert_fs::fixture::{FileWriteStr, PathChild};
 
 use uv_test::{copy_dir_ignore, uv_snapshot};
 
@@ -231,4 +231,82 @@ fn workspace_list_no_project() {
     error: No `pyproject.toml` found in current directory or any parent directory
     "
     );
+}
+
+/// Test recursively listing PEP 723 scripts while respecting ignore rules and environment
+/// boundaries.
+#[test]
+fn workspace_list_scripts() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.init().arg("project").assert().success();
+    let project = context.temp_dir.child("project");
+
+    let script = r#"# /// script
+# dependencies = []
+# ///
+"#;
+
+    project.child("script.py").write_str(script)?;
+    project.child("scripts/nested.py").write_str(script)?;
+    project.child(".github/hidden.py").write_str(script)?;
+    project.child("tool").write_str(script)?;
+
+    // PEP 723 examples in documentation are not Python scripts.
+    project
+        .child("docs/example.md")
+        .write_str(&format!("# Example\n\n{script}\n{script}"))?;
+
+    // Regular Python modules are not scripts.
+    project
+        .child("src/project/module.py")
+        .write_str("VALUE = 1\n")?;
+
+    project.child(".gitignore").write_str("ignored/\n")?;
+    project.child("ignored/script.py").write_str(script)?;
+    project
+        .child(".ignore")
+        .write_str("ignored-by-dot-ignore.py\n")?;
+    project
+        .child("ignored-by-dot-ignore.py")
+        .write_str(script)?;
+
+    project.child(".git/script.py").write_str(script)?;
+    project.child(".venv/script.py").write_str(script)?;
+    project.child("environment/pyvenv.cfg").write_str("")?;
+    project.child("environment/script.py").write_str(script)?;
+
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--scripts")
+        .current_dir(&project), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    .github/hidden.py
+    script.py
+    scripts/nested.py
+    tool
+
+    ----- stderr -----
+    warning: The `--scripts` option is experimental and may change without warning. Pass `--preview-features workspace-list` to disable this warning.
+    ");
+
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--scripts")
+        .arg("--paths")
+        .arg("--preview-features")
+        .arg("workspace-list")
+        .current_dir(&project), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/project/.github/hidden.py
+    [TEMP_DIR]/project/script.py
+    [TEMP_DIR]/project/scripts/nested.py
+    [TEMP_DIR]/project/tool
+
+    ----- stderr -----
+    ");
+
+    Ok(())
 }

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -250,6 +250,8 @@ fn workspace_list_scripts() -> Result<()> {
     project.child("script.py").write_str(script)?;
     project.child("scripts/nested.py").write_str(script)?;
     project.child(".github/hidden.py").write_str(script)?;
+
+    // Extensionless scripts are not discovered.
     project.child("tool").write_str(script)?;
 
     // PEP 723 examples in documentation are not Python scripts.
@@ -285,7 +287,6 @@ fn workspace_list_scripts() -> Result<()> {
     .github/hidden.py
     script.py
     scripts/nested.py
-    tool
 
     ----- stderr -----
     warning: The `--scripts` option is experimental and may change without warning. Pass `--preview-features workspace-list-scripts` to disable this warning.
@@ -302,7 +303,6 @@ fn workspace_list_scripts() -> Result<()> {
     .github/hidden.py
     script.py
     scripts/nested.py
-    tool
 
     ----- stderr -----
     ");

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -288,24 +288,39 @@ fn workspace_list_scripts() -> Result<()> {
     tool
 
     ----- stderr -----
-    warning: The `--scripts` option is experimental and may change without warning. Pass `--preview-features workspace-list` to disable this warning.
+    warning: The `--scripts` option is experimental and may change without warning. Pass `--preview-features workspace-list-scripts` to disable this warning.
+    ");
+
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--scripts")
+        .arg("--preview-features")
+        .arg("workspace-list-scripts")
+        .current_dir(&project), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    .github/hidden.py
+    script.py
+    scripts/nested.py
+    tool
+
+    ----- stderr -----
     ");
 
     uv_snapshot!(context.filters(), context.workspace_list()
         .arg("--scripts")
         .arg("--paths")
-        .arg("--preview-features")
-        .arg("workspace-list")
         .current_dir(&project), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 2
     ----- stdout -----
-    [TEMP_DIR]/project/.github/hidden.py
-    [TEMP_DIR]/project/script.py
-    [TEMP_DIR]/project/scripts/nested.py
-    [TEMP_DIR]/project/tool
 
     ----- stderr -----
+    error: the argument '--scripts' cannot be used with '--paths'
+
+    Usage: uv workspace list --cache-dir [CACHE_DIR] --scripts
+
+    For more information, try '--help'.
     ");
 
     Ok(())

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -242,10 +242,10 @@ fn workspace_list_scripts() -> Result<()> {
     context.init().arg("project").assert().success();
     let project = context.temp_dir.child("project");
 
-    let script = r#"# /// script
+    let script = r"# /// script
 # dependencies = []
 # ///
-"#;
+";
 
     project.child("script.py").write_str(script)?;
     project.child("scripts/nested.py").write_str(script)?;


### PR DESCRIPTION
Adds  `uv workspace list --scripts` for enumerating PEP 723 scripts in the workspace. It's in preview under the `workspace-list-scripts` feature.

We scan the workspace tree while respecting ignore rule and pruning repositories, virtual environments, and the uv cache from recursive searches.

We restrict discovery to `.py` and `.pyw` — we'll need to deal with extensionless scripts separately as I don't want to scan binaries in the tree.

There will certainly be bugs and performance issues here, but we should ship and iterate.
