### PR TITLE
Split slow group `run_groups_requires_python` test

### DIFF
--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -5697,6 +5697,22 @@ fn run_groups_requires_python_environment() -> Result<()> {
         .assert()
         .success();
 
+    // TMP: Attempt to catch this flake with verbose output
+    // See https://github.com/astral-sh/uv/issues/14160
+    let output = context
+        .run()
+        .arg("-vv")
+        .arg("--no-default-groups")
+        .arg("python")
+        .arg("--version")
+        .output()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Removed virtual environment"),
+        "{}",
+        stderr
+    );
+
     // Disabling the default group shouldn't churn a compatible environment.
     uv_snapshot!(context.filters(), context.run()
         .arg("--no-default-groups")

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -5608,154 +5608,171 @@ fn run_default_groups() -> Result<()> {
     Ok(())
 }
 
+/// Ensures default dependency groups participate in automatic Python selection.
 #[test]
 fn run_groups_requires_python() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&["3.11", "3.12", "3.13"])
-        .with_filtered_python_sources();
-
-    let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(
+    let context = uv_test::test_context_with_versions!(&["3.12", "3.13"]);
+    context.temp_dir.child("pyproject.toml").write_str(
         r#"
         [project]
         name = "project"
         version = "0.1.0"
-        requires-python = ">=3.11"
-        dependencies = ["typing-extensions"]
+        requires-python = ">=3.12"
+        dependencies = []
 
         [dependency-groups]
-        foo = ["anyio"]
-        bar = ["iniconfig"]
-        dev = ["sniffio"]
+        foo = []
+        dev = []
 
         [tool.uv.dependency-groups]
-        foo = {requires-python=">=3.100"}
-        bar = {requires-python=">=3.13"}
-        dev = {requires-python=">=3.12"}
+        foo = { requires-python = ">=3.100" }
+        dev = { requires-python = ">=3.13" }
         "#,
     )?;
-
-    context.lock().assert().success();
 
     // With --no-default-groups only the main requires-python should be consulted
     uv_snapshot!(context.filters(), context.run()
         .arg("--no-default-groups")
-        .arg("python").arg("-c").arg("import typing_extensions"), @"
+        .arg("python").arg("--version"), @"
     success: true
     exit_code: 0
     ----- stdout -----
+    Python 3.12.[X]
 
     ----- stderr -----
-    Using CPython 3.11.[X] interpreter at: [PYTHON-3.11]
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Resolved 6 packages in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + typing-extensions==4.10.0
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
     ");
 
     // The main requires-python and the default group's requires-python should be consulted
     // (This should trigger a version bump)
     uv_snapshot!(context.filters(), context.run()
-        .arg("python").arg("-c").arg("import typing_extensions"), @"
+        .arg("python").arg("--version"), @"
     success: true
     exit_code: 0
     ----- stdout -----
-
-    ----- stderr -----
-    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    Removed virtual environment at: .venv
-    Creating virtual environment at: .venv
-    Resolved 6 packages in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 2 packages in [TIME]
-     + sniffio==1.3.1
-     + typing-extensions==4.10.0
-    ");
-
-    // The main requires-python and "dev" and "bar" requires-python should be consulted
-    // (This should trigger a version bump)
-    uv_snapshot!(context.filters(), context.run()
-        .arg("--group").arg("bar")
-        .arg("python").arg("-c").arg("import typing_extensions"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
+    Python 3.13.[X]
 
     ----- stderr -----
     Using CPython 3.13.[X] interpreter at: [PYTHON-3.13]
     Removed virtual environment at: .venv
     Creating virtual environment at: .venv
-    Resolved 6 packages in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 3 packages in [TIME]
-     + iniconfig==2.0.0
-     + sniffio==1.3.1
-     + typing-extensions==4.10.0
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
     ");
 
-    // TMP: Attempt to catch this flake with verbose output
-    // See https://github.com/astral-sh/uv/issues/14160
-    let output = context
-        .run()
-        .arg("-vv")
-        .arg("python")
-        .arg("-c")
-        .arg("import typing_extensions")
-        .output()?;
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        !stderr.contains("Removed virtual environment"),
-        "{}",
-        stderr
-    );
+    Ok(())
+}
 
-    // Going back to just "dev" we shouldn't churn the venv needlessly
+/// Ensures relaxing group requirements reuses a compatible environment, while an explicit Python
+/// request can downgrade it.
+#[test]
+fn run_groups_requires_python_environment() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.12", "3.13"]);
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [dependency-groups]
+        foo = []
+        dev = []
+
+        [tool.uv.dependency-groups]
+        foo = { requires-python = ">=3.100" }
+        dev = { requires-python = ">=3.13" }
+        "#,
+    )?;
+
+    // Start with an environment that includes "dev" and requires Python 3.13.
+    context
+        .run()
+        .arg("python")
+        .arg("--version")
+        .assert()
+        .success();
+
+    // Disabling the default group shouldn't churn a compatible environment.
     uv_snapshot!(context.filters(), context.run()
-        .arg("python").arg("-c").arg("import typing_extensions"), @"
+        .arg("--no-default-groups")
+        .arg("python").arg("--version"), @"
     success: true
     exit_code: 0
     ----- stdout -----
+    Python 3.13.[X]
 
     ----- stderr -----
-    Resolved 6 packages in [TIME]
-    Checked 2 packages in [TIME]
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
     ");
 
     // Explicitly requesting an in-range python can downgrade
     uv_snapshot!(context.filters(), context.run()
+        .arg("--no-default-groups")
         .arg("-p").arg("3.12")
-        .arg("python").arg("-c").arg("import typing_extensions"), @"
+        .arg("python").arg("--version"), @"
     success: true
     exit_code: 0
     ----- stdout -----
+    Python 3.12.[X]
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Removed virtual environment at: .venv
     Creating virtual environment at: .venv
-    Resolved 6 packages in [TIME]
-    Installed 2 packages in [TIME]
-     + sniffio==1.3.1
-     + typing-extensions==4.10.0
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
     ");
+
+    Ok(())
+}
+
+/// Ensures `uv run` distinguishes an incompatible explicit Python request from a group requirement
+/// that no available interpreter satisfies.
+#[test]
+fn run_groups_requires_python_errors() -> Result<()> {
+    let context =
+        uv_test::test_context_with_versions!(&["3.12", "3.13"]).with_filtered_python_sources();
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [dependency-groups]
+        foo = []
+        dev = []
+
+        [tool.uv.dependency-groups]
+        foo = { requires-python = ">=3.100" }
+        dev = { requires-python = ">=3.13" }
+        "#,
+    )?;
 
     // Explicitly requesting an out-of-range python fails
     uv_snapshot!(context.filters(), context.run()
-        .arg("-p").arg("3.11")
-        .arg("python").arg("-c").arg("import typing_extensions"), @"
+        .arg("-p").arg("3.12")
+        .arg("python").arg("--version"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Using CPython 3.11.[X] interpreter at: [PYTHON-3.11]
-    error: The requested interpreter resolved to Python 3.11.[X], which is incompatible with the project's Python requirement: `>=3.12` (from `tool.uv.dependency-groups.dev.requires-python`).
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    error: The requested interpreter resolved to Python 3.12.[X], which is incompatible with the project's Python requirement: `>=3.13` (from `tool.uv.dependency-groups.dev.requires-python`).
     ");
 
     // Enabling foo we can't find an interpreter
     uv_snapshot!(context.filters(), context.run()
         .arg("--group").arg("foo")
-        .arg("python").arg("-c").arg("import typing_extensions"), @"
+        .arg("python").arg("--version"), @"
     success: false
     exit_code: 2
     ----- stdout -----


### PR DESCRIPTION
`run_groups_requires_python` performs a long sequence of interpreter selection, virtual environment replacement, reuse, downgrade, and error checks in one test. The repeated `uv run` invocations make it substantially slower than nearby tests and cause frequent slow timeouts.

This splits the scenario into focused tests for automatic interpreter selection, environment reuse and explicit downgrade, and error reporting. Each test uses only Python 3.12 and 3.13, empty dependency groups, and `python --version`, preserving the group `requires-python` behavior without unrelated registry resolution or package installation.
