### PR TITLE
Avoid shared temporary directories for Windows Python launchers

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 
 #[cfg(feature = "tokio")]
 use encoding_rs_io::DecodeReaderBytes;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempPath};
 use tracing::{debug, warn};
 
 pub use crate::locked_file::*;
@@ -622,8 +622,8 @@ async fn persist_with_retry(
 /// errors.
 ///
 /// This is a synchronous implementation of [`persist_with_retry`].
-pub fn persist_with_retry_sync(
-    from: NamedTempFile,
+pub fn persist_with_retry_sync<F>(
+    from: NamedTempFile<F>,
     to: impl AsRef<Path>,
 ) -> Result<(), std::io::Error> {
     #[cfg(windows)]
@@ -687,6 +687,14 @@ pub fn persist_with_retry_sync(
     {
         fs_err::rename(from, to)
     }
+}
+
+/// Persist a [`TempPath`] with [`persist_with_retry_sync`] without reopening it.
+pub fn persist_temp_path_with_retry_sync(
+    from: TempPath,
+    to: impl AsRef<Path>,
+) -> Result<(), std::io::Error> {
+    persist_with_retry_sync(NamedTempFile::from_parts((), from), to)
 }
 
 /// Iterate over the subdirectories of a directory.

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -899,19 +899,15 @@ pub fn create_link_to_executable(link: &Path, executable: &Path) -> Result<(), E
             Err(err) => Err(Error::LinkExecutable(err)),
         }
     } else if cfg!(windows) {
-        use uv_trampoline_builder::windows_python_launcher;
+        use uv_trampoline_builder::write_windows_python_launcher;
 
         // TODO(zanieb): Install GUI launchers as well
-        let launcher = windows_python_launcher(executable, false)?;
-
-        // OK to use `std::fs` here, `fs_err` does not support `File::create_new` and we attach
-        // error context anyway
-        #[expect(clippy::disallowed_types)]
-        {
-            std::fs::File::create_new(link)
-                .and_then(|mut file| file.write_all(launcher.as_ref()))
-                .map_err(Error::LinkExecutable)
-        }
+        let temp_file = uv_fs::tempfile_in(link_parent).map_err(Error::LinkExecutable)?;
+        let temp_path = temp_file.into_temp_path();
+        write_windows_python_launcher(&temp_path, executable, false)?;
+        temp_path
+            .persist_noclobber(link)
+            .map_err(|error| Error::LinkExecutable(error.into()))
     } else {
         unimplemented!("Only Windows and Unix are supported.")
     }
@@ -929,11 +925,13 @@ pub fn replace_link_to_executable(link: &Path, executable: &Path) -> Result<(), 
     if cfg!(unix) {
         replace_symlink(executable, link).map_err(Error::LinkExecutable)
     } else if cfg!(windows) {
-        use uv_trampoline_builder::windows_python_launcher;
+        use uv_trampoline_builder::write_windows_python_launcher;
 
-        let launcher = windows_python_launcher(executable, false)?;
-
-        uv_fs::write_atomic_sync(link, &*launcher).map_err(Error::LinkExecutable)
+        let temp_file = uv_fs::tempfile_in(link_parent).map_err(Error::LinkExecutable)?;
+        // Close the file for the Windows PE resource APIs.
+        let temp_path = temp_file.into_temp_path();
+        write_windows_python_launcher(&temp_path, executable, false)?;
+        uv_fs::persist_temp_path_with_retry_sync(temp_path, link).map_err(Error::LinkExecutable)
     } else {
         unimplemented!("Only Windows and Unix are supported.")
     }

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -432,57 +432,40 @@ pub fn windows_script_launcher(
     Ok(launcher)
 }
 
-/// Construct a Windows Python launcher.
+/// Write a Windows Python launcher to the given path.
 ///
-/// On Unix, this always returns [`Error::NotWindows`]. Trampolines are a Windows-specific feature
-/// and cannot be created on other platforms.
+/// On non-Windows platforms, this always returns [`Error::NotWindows`].
 #[cfg(not(windows))]
-pub fn windows_python_launcher(
+pub fn write_windows_python_launcher(
+    _path: &Path,
     _python_executable: impl AsRef<Path>,
     _is_gui: bool,
-) -> Result<Vec<u8>, Error> {
+) -> Result<(), Error> {
     Err(Error::NotWindows)
 }
 
-/// Construct a Windows Python launcher.
-///
-/// A minimal .exe launcher binary for Python.
-///
-/// Sort of equivalent to a `python` symlink on Unix.
+/// Write a Windows Python launcher to the given path.
 #[cfg(windows)]
-pub fn windows_python_launcher(
+pub fn write_windows_python_launcher(
+    path: &Path,
     python_executable: impl AsRef<Path>,
     is_gui: bool,
-) -> Result<Vec<u8>, Error> {
-    use uv_fs::Simplified;
+) -> Result<(), Error> {
+    let python_path = python_executable.as_ref().simplified_display().to_string();
 
-    let launcher_bin: &[u8] = get_launcher_bin(is_gui)?;
+    fs_err::write(path, get_launcher_bin(is_gui)?)?;
+    write_resources(
+        path,
+        &[
+            (
+                RESOURCE_TRAMPOLINE_KIND,
+                &[LauncherKind::Python.to_resource_value()][..],
+            ),
+            (RESOURCE_PYTHON_PATH, python_path.as_bytes()),
+        ],
+    )?;
 
-    let python = python_executable.as_ref();
-    let python_path = python.simplified_display().to_string();
-
-    // Create temporary file for the launcher
-    let temp_dir = tempfile::TempDir::new()?;
-    let temp_file = temp_dir
-        .path()
-        .join(format!("uv-trampoline-{}.exe", std::process::id()));
-    fs_err::write(&temp_file, launcher_bin)?;
-
-    // Write resources
-    let resources = &[
-        (
-            RESOURCE_TRAMPOLINE_KIND,
-            &[LauncherKind::Python.to_resource_value()][..],
-        ),
-        (RESOURCE_PYTHON_PATH, python_path.as_bytes()),
-    ];
-    write_resources(&temp_file, resources)?;
-
-    // Read back the complete file
-    let launcher = fs_err::read(&temp_file)?;
-    fs_err::remove_file(temp_file)?;
-
-    Ok(launcher)
+    Ok(())
 }
 
 #[cfg(all(test, windows))]
@@ -500,7 +483,7 @@ mod test {
 
     use which::which;
 
-    use super::{Launcher, LauncherKind, windows_python_launcher, windows_script_launcher};
+    use super::{Launcher, LauncherKind, windows_script_launcher, write_windows_python_launcher};
 
     #[test]
     #[cfg(all(windows, target_arch = "x86", feature = "production"))]
@@ -741,13 +724,8 @@ if __name__ == "__main__":
         // Locate an arbitrary python installation from PATH
         let python_executable_path = which("python")?;
 
-        // Generate Launcher Payload
-        let console_launcher = windows_python_launcher(&python_executable_path, false)?;
-
         // Create Launcher
-        {
-            File::create(console_bin_path.path())?.write_all(console_launcher.as_ref())?;
-        }
+        write_windows_python_launcher(console_bin_path.path(), &python_executable_path, false)?;
 
         println!(
             "Wrote Python Launcher in {}",


### PR DESCRIPTION
## Summary

Windows Python launcher construction currently creates a temporary directory under shared `%TEMP%`, writes and updates the launcher there, reads it back into memory, and then writes another temporary file beside the target before atomic replacement.

This removes the byte-returning Python launcher API and constructs launchers directly in temporary files beside their destination. The create-only path uses no-clobber persistence, while the replacement path retains the existing retrying atomic persistence. In both cases, the destination is only touched after the complete PE launcher has been constructed, avoiding both the shared temporary directory and the intermediate buffer.

