### PR TITLE
Add jitter to Docker release builds

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -241,6 +241,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.docker-plan.outputs.extra-images) }}
     steps:
+      # Add a random jitter during release builds to reduce chance of race conditions in release environment gate
+      - name: Jitter release builds
+        if: ${{ needs.docker-plan.outputs.push-version == 'true' }}
+        run: sleep "$((RANDOM % 11))"
+
       # Login to DockerHub (when not pushing, it's to avoid rate-limiting)
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         if: ${{ needs.docker-plan.outputs.login == 'true' }}


### PR DESCRIPTION
Attempting to avoid stuck releases due to race conditions in event delivery which only really occur in uv because of this big Docker matrix by adding some jitter.