### PR TITLE
Avoid allocations in `ForkMap::contains`

### DIFF
--- a/crates/uv-resolver/src/resolver/fork_map.rs
+++ b/crates/uv-resolver/src/resolver/fork_map.rs
@@ -100,7 +100,9 @@ impl<T> ForkMap<T> {
     /// Returns `true` if the map contains any values for a package that are compatible with the
     /// given fork.
     pub(crate) fn contains(&self, package_name: &PackageName, env: &ResolverEnvironment) -> bool {
-        !self.get(package_name, env).is_empty()
+        self.0
+            .get(package_name)
+            .is_some_and(|values| values.iter().any(|entry| entry.scope.matches(env)))
     }
 
     /// Returns `true` if the map contains any values for a package.


### PR DESCRIPTION
## Summary

`ForkMap::contains` currently calls `get`, which collects every matching value into a temporary vector only to test whether that vector is empty.

This checks the underlying entries with `any` instead, avoiding the allocation and stopping at the first matching scope. The existing `ForkMap` test covers both matching and excluded scopes.

This was identified while reducing resolver overhead in #19993, but applies independently to existing `ForkMap` users.
