### PR TITLE
Pin Prettier 3.9.0

### DIFF
--- a/.github/workflows/check-fmt.yml
+++ b/.github/workflows/check-fmt.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - run: npx prettier --check .
+      - run: npx prettier@3.9.0 --check .
 
   python:
     timeout-minutes: 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,9 +153,9 @@ cargo fmt --all
 uvx ruff format .
 
 # Markdown, YAML, and other files (requires Node.js)
-npx prettier --write .
+npx prettier@3.9.0 --write .
 # or in Docker
-docker run --rm -v .:/src/ -w /src/ node:alpine npx prettier --write .
+docker run --rm -v .:/src/ -w /src/ node:alpine npx prettier@3.9.0 --write .
 ```
 
 ## Linting

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -37,7 +37,8 @@ The following distroless images are available:
 
 And the following derived images are available:
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
+
 - Based on `alpine:3.23`:
     - `ghcr.io/astral-sh/uv:alpine`
     - `ghcr.io/astral-sh/uv:alpine3.23`
@@ -88,6 +89,7 @@ And the following derived images are available:
     - `ghcr.io/astral-sh/uv:python3.11-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.10-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.9-trixie-slim`
+
 <!-- prettier-ignore-end -->
 
 As with the distroless image, each derived image is published with uv version tags as


### PR DESCRIPTION
## Summary

Our formatting workflow and contributor instructions invoked an unversioned `npx prettier`, so every run resolved the latest release. When Prettier 3.9 upgraded its Markdown parser (in the most recent release, two hours ago), the current `main` branch began failing its formatting check despite no corresponding repository change.

This pins Prettier 3.9.0 in CI and in both documented contributor commands so formatting remains reproducible across releases.

The Docker guide also began an ignored block with `<!-- prettier-ignore -->` but ended it with `<!-- prettier-ignore-end -->`. This replaces the opening marker with `prettier-ignore-start` and adds the required blank lines around the range markers, preserving the intentionally hand-maintained image list while making the range valid for the new parser.
