### PR TITLE
Bump `quinn-proto` to 0.11.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

Bumps `quinn-proto` from 0.11.14 to 0.11.15 to address [GHSA-4w2j-m93h-cj5j](https://github.com/quinn-rs/quinn/security/advisories/GHSA-4w2j-m93h-cj5j), a remote memory exhaustion issue in the `Assembler`.

We're not actually affected by this. It's used in `reqwest` if you enable `http3`, which we don't. But it's in our `Cargo.lock` anyway so we might as well bump.
