### PR TITLE
Speed up candidate selection for disjoint ranges

### DIFF
--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -678,14 +678,14 @@ impl CandidateSelector {
 /// Unlike [`Range::contains`], which searches the segments for every version, the cursor visits
 /// each segment at most once.
 struct RangeCursor<'a, Segments> {
-    current: (&'a Bound<Version>, &'a Bound<Version>),
+    current: (Bound<&'a Version>, Bound<&'a Version>),
     segments: Segments,
     highest: bool,
 }
 
 impl<'a, Segments> RangeCursor<'a, Segments>
 where
-    Segments: Iterator<Item = (&'a Bound<Version>, &'a Bound<Version>)>,
+    Segments: Iterator<Item = (Bound<&'a Version>, Bound<&'a Version>)>,
 {
     /// Create a cursor over segments ordered in the same direction as the visited versions.
     fn new(mut segments: Segments, highest: bool) -> Option<Self> {
@@ -727,7 +727,7 @@ where
     }
 }
 
-fn is_before(version: &Version, bound: &Bound<Version>) -> bool {
+fn is_before(version: &Version, bound: Bound<&Version>) -> bool {
     match bound {
         Bound::Included(start) => version < start,
         Bound::Excluded(start) => version <= start,
@@ -735,7 +735,7 @@ fn is_before(version: &Version, bound: &Bound<Version>) -> bool {
     }
 }
 
-fn is_after(version: &Version, bound: &Bound<Version>) -> bool {
+fn is_after(version: &Version, bound: Bound<&Version>) -> bool {
     match bound {
         Bound::Included(end) => version > end,
         Bound::Excluded(end) => version >= end,

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -724,17 +724,14 @@ mod tests {
         value.parse().expect("valid test version")
     }
 
-    fn disjoint_range() -> Range<Version> {
-        [
+    fn assert_range_cursor(highest: bool, values: &[&str]) {
+        let range = [
             (Bound::Unbounded, Bound::Excluded(version("2"))),
             (Bound::Included(version("3")), Bound::Included(version("4"))),
             (Bound::Excluded(version("5")), Bound::Unbounded),
         ]
         .into_iter()
-        .collect()
-    }
-
-    fn assert_range_cursor(range: &Range<Version>, highest: bool, values: &[&str]) {
+        .collect::<Range<_>>();
         let segments = if highest {
             Either::Left(range.iter().rev())
         } else {
@@ -753,30 +750,13 @@ mod tests {
     }
 
     #[test]
-    fn range_cursor_single_segment() {
-        let range = [(Bound::Included(version("2")), Bound::Excluded(version("5")))]
-            .into_iter()
-            .collect();
-        assert_range_cursor(&range, false, &["1", "2", "3", "5", "6"]);
-        assert_range_cursor(&range, true, &["6", "5", "3", "2", "1"]);
-    }
-
-    #[test]
     fn range_cursor_ascending() {
-        assert_range_cursor(
-            &disjoint_range(),
-            false,
-            &["1", "2", "2.5", "3", "4", "5", "6"],
-        );
+        assert_range_cursor(false, &["1", "2", "2.5", "3", "4", "5", "6"]);
     }
 
     #[test]
     fn range_cursor_descending() {
-        assert_range_cursor(
-            &disjoint_range(),
-            true,
-            &["6", "5", "4", "3", "2.5", "2", "1"],
-        );
+        assert_range_cursor(true, &["6", "5", "4", "3", "2.5", "2", "1"]);
     }
 }
 

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -553,11 +553,13 @@ impl CandidateSelector {
                 |_| true,
             );
         };
-        let segments = [first_segment, second_segment]
-            .into_iter()
-            .chain(segments)
-            .collect::<SmallVec<[_; 8]>>();
-        let mut cursor = RangeCursor::new(segments, highest);
+        let segments = [first_segment, second_segment].into_iter().chain(segments);
+        let segments = if highest {
+            Either::Left(segments.rev())
+        } else {
+            Either::Right(segments)
+        };
+        let mut cursor = RangeCursor::new(segments, highest)?;
         Self::select_candidate_from(versions, package_name, range, allow_prerelease, |version| {
             cursor.contains(version)
         })
@@ -675,26 +677,23 @@ impl CandidateSelector {
 ///
 /// Unlike [`Range::contains`], which searches the segments for every version, the cursor visits
 /// each segment at most once.
-struct RangeCursor<'a> {
-    segments: SmallVec<[(&'a Bound<Version>, &'a Bound<Version>); 8]>,
-    index: usize,
+struct RangeCursor<'a, Segments> {
+    current: (&'a Bound<Version>, &'a Bound<Version>),
+    segments: Segments,
     highest: bool,
 }
 
-impl<'a> RangeCursor<'a> {
-    /// Create a cursor over at least two ascending, non-overlapping segments.
-    ///
-    /// `highest` must match the order in which versions are passed to [`Self::contains`].
-    fn new(
-        segments: SmallVec<[(&'a Bound<Version>, &'a Bound<Version>); 8]>,
-        highest: bool,
-    ) -> Self {
-        let index = if highest { segments.len() - 1 } else { 0 };
-        Self {
+impl<'a, Segments> RangeCursor<'a, Segments>
+where
+    Segments: Iterator<Item = (&'a Bound<Version>, &'a Bound<Version>)>,
+{
+    /// Create a cursor over segments ordered in the same direction as the visited versions.
+    fn new(mut segments: Segments, highest: bool) -> Option<Self> {
+        Some(Self {
+            current: segments.next()?,
             segments,
-            index,
             highest,
-        }
+        })
     }
 
     /// Return whether `version` is in the range, advancing past segments that cannot contain any
@@ -702,24 +701,24 @@ impl<'a> RangeCursor<'a> {
     fn contains(&mut self, version: &Version) -> bool {
         if self.highest {
             loop {
-                let (start, end) = self.segments[self.index];
+                let (start, end) = self.current;
                 if is_before(version, start) {
-                    if self.index == 0 {
+                    let Some(current) = self.segments.next() else {
                         return false;
-                    }
-                    self.index -= 1;
+                    };
+                    self.current = current;
                 } else {
                     return !is_after(version, end);
                 }
             }
         } else {
             loop {
-                let (start, end) = self.segments[self.index];
+                let (start, end) = self.current;
                 if is_after(version, end) {
-                    if self.index + 1 == self.segments.len() {
+                    let Some(current) = self.segments.next() else {
                         return false;
-                    }
-                    self.index += 1;
+                    };
+                    self.current = current;
                 } else {
                     return !is_before(version, start);
                 }
@@ -760,7 +759,12 @@ mod tests {
         ]
         .into_iter()
         .collect::<Range<_>>();
-        let mut cursor = RangeCursor::new(range.iter().collect(), highest);
+        let segments = if highest {
+            Either::Left(range.iter().rev())
+        } else {
+            Either::Right(range.iter())
+        };
+        let mut cursor = RangeCursor::new(segments, highest).expect("test range is not empty");
 
         for value in values {
             let version = version(value);

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -529,6 +529,9 @@ impl CandidateSelector {
     /// The returned [`Candidate`] _may not_ be compatible with the current platform; in such
     /// cases, the resolver is responsible for tracking the incompatibility and re-running the
     /// selection process with additional constraints.
+    ///
+    /// `versions` must be ordered from highest to lowest when `highest` is `true`, and from lowest
+    /// to highest otherwise.
     fn select_candidate<'a>(
         versions: impl Iterator<Item = (&'a Version, VersionMapDistHandle<'a>)>,
         package_name: &'a PackageName,
@@ -550,8 +553,8 @@ impl CandidateSelector {
                 |_| true,
             );
         };
-        let segments = std::iter::once(first_segment)
-            .chain(std::iter::once(second_segment))
+        let segments = [first_segment, second_segment]
+            .into_iter()
             .chain(segments)
             .collect::<SmallVec<[_; 8]>>();
         let mut cursor = RangeCursor::new(segments, highest);
@@ -560,6 +563,10 @@ impl CandidateSelector {
         })
     }
 
+    /// Run candidate selection with the given range-membership test.
+    ///
+    /// This keeps contiguous ranges on the no-filter fast path while disjoint ranges use a
+    /// [`RangeCursor`].
     fn select_candidate_from<'a>(
         versions: impl Iterator<Item = (&'a Version, VersionMapDistHandle<'a>)>,
         package_name: &'a PackageName,
@@ -675,6 +682,9 @@ struct RangeCursor<'a> {
 }
 
 impl<'a> RangeCursor<'a> {
+    /// Create a cursor over at least two ascending, non-overlapping segments.
+    ///
+    /// `highest` must match the order in which versions are passed to [`Self::contains`].
     fn new(
         segments: SmallVec<[(&'a Bound<Version>, &'a Bound<Version>); 8]>,
         highest: bool,
@@ -687,6 +697,8 @@ impl<'a> RangeCursor<'a> {
         }
     }
 
+    /// Return whether `version` is in the range, advancing past segments that cannot contain any
+    /// subsequently visited versions.
     fn contains(&mut self, version: &Version) -> bool {
         if self.highest {
             loop {
@@ -740,50 +752,34 @@ mod tests {
         value.parse().expect("valid test version")
     }
 
-    #[test]
-    fn range_cursor_ascending() {
-        let segments = [
+    fn assert_range_cursor(highest: bool, values: &[&str]) {
+        let range = [
             (Bound::Unbounded, Bound::Excluded(version("2"))),
             (Bound::Included(version("3")), Bound::Included(version("4"))),
             (Bound::Excluded(version("5")), Bound::Unbounded),
-        ];
-        let segments = segments.iter().map(|(start, end)| (start, end)).collect();
-        let mut cursor = RangeCursor::new(segments, false);
+        ]
+        .into_iter()
+        .collect::<Range<_>>();
+        let mut cursor = RangeCursor::new(range.iter().collect(), highest);
 
-        for (value, expected) in [
-            ("1", true),
-            ("2", false),
-            ("2.5", false),
-            ("3", true),
-            ("4", true),
-            ("5", false),
-            ("6", true),
-        ] {
-            assert_eq!(cursor.contains(&version(value)), expected, "{value}");
+        for value in values {
+            let version = version(value);
+            assert_eq!(
+                cursor.contains(&version),
+                range.contains(&version),
+                "{value}"
+            );
         }
     }
 
     #[test]
-    fn range_cursor_descending() {
-        let segments = [
-            (Bound::Unbounded, Bound::Excluded(version("2"))),
-            (Bound::Included(version("3")), Bound::Included(version("4"))),
-            (Bound::Excluded(version("5")), Bound::Unbounded),
-        ];
-        let segments = segments.iter().map(|(start, end)| (start, end)).collect();
-        let mut cursor = RangeCursor::new(segments, true);
+    fn range_cursor_ascending() {
+        assert_range_cursor(false, &["1", "2", "2.5", "3", "4", "5", "6"]);
+    }
 
-        for (value, expected) in [
-            ("6", true),
-            ("5", false),
-            ("4", true),
-            ("3", true),
-            ("2.5", false),
-            ("2", false),
-            ("1", true),
-        ] {
-            assert_eq!(cursor.contains(&version(value)), expected, "{value}");
-        }
+    #[test]
+    fn range_cursor_descending() {
+        assert_range_cursor(true, &["6", "5", "4", "3", "2.5", "2", "1"]);
     }
 }
 

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use std::ops::Bound;
 
 use either::Either;
 use itertools::Itertools;
@@ -455,6 +456,7 @@ impl CandidateSelector {
                     package_name,
                     range,
                     allow_prerelease,
+                    highest,
                 )
             } else {
                 Self::select_candidate(
@@ -477,6 +479,7 @@ impl CandidateSelector {
                     package_name,
                     range,
                     allow_prerelease,
+                    highest,
                 )
             }
         } else {
@@ -487,6 +490,7 @@ impl CandidateSelector {
                         package_name,
                         range,
                         allow_prerelease,
+                        highest,
                     )
                 })
             } else {
@@ -496,6 +500,7 @@ impl CandidateSelector {
                         package_name,
                         range,
                         allow_prerelease,
+                        highest,
                     )
                 })
             }
@@ -529,6 +534,38 @@ impl CandidateSelector {
         package_name: &'a PackageName,
         range: &Range<Version>,
         allow_prerelease: bool,
+        highest: bool,
+    ) -> Option<Candidate<'a>> {
+        let mut segments = range.iter();
+        let Some(first_segment) = segments.next() else {
+            trace!("Exhausted all candidates for package {package_name} with empty range");
+            return None;
+        };
+        let Some(second_segment) = segments.next() else {
+            return Self::select_candidate_from(
+                versions,
+                package_name,
+                range,
+                allow_prerelease,
+                |_| true,
+            );
+        };
+        let segments = std::iter::once(first_segment)
+            .chain(std::iter::once(second_segment))
+            .chain(segments)
+            .collect::<SmallVec<[_; 8]>>();
+        let mut cursor = RangeCursor::new(segments, highest);
+        Self::select_candidate_from(versions, package_name, range, allow_prerelease, |version| {
+            cursor.contains(version)
+        })
+    }
+
+    fn select_candidate_from<'a>(
+        versions: impl Iterator<Item = (&'a Version, VersionMapDistHandle<'a>)>,
+        package_name: &'a PackageName,
+        range: &Range<Version>,
+        allow_prerelease: bool,
+        mut range_contains: impl FnMut(&Version) -> bool,
     ) -> Option<Candidate<'a>> {
         let mut steps = 0usize;
         let mut incompatible: Option<Candidate> = None;
@@ -550,7 +587,7 @@ impl CandidateSelector {
                 if version.any_prerelease() && !allow_prerelease {
                     continue;
                 }
-                if !range.contains(version) {
+                if !range_contains(version) {
                     continue;
                 }
                 let Some(dist) = maybe_dist.prioritized_dist() else {
@@ -624,6 +661,129 @@ impl CandidateSelector {
             "Exhausted all candidates for package {package_name} with range {range} after {steps} steps"
         );
         None
+    }
+}
+
+/// Tracks membership in a disjoint range while visiting versions monotonically.
+///
+/// Unlike [`Range::contains`], which searches the segments for every version, the cursor visits
+/// each segment at most once.
+struct RangeCursor<'a> {
+    segments: SmallVec<[(&'a Bound<Version>, &'a Bound<Version>); 8]>,
+    index: usize,
+    highest: bool,
+}
+
+impl<'a> RangeCursor<'a> {
+    fn new(
+        segments: SmallVec<[(&'a Bound<Version>, &'a Bound<Version>); 8]>,
+        highest: bool,
+    ) -> Self {
+        let index = if highest { segments.len() - 1 } else { 0 };
+        Self {
+            segments,
+            index,
+            highest,
+        }
+    }
+
+    fn contains(&mut self, version: &Version) -> bool {
+        if self.highest {
+            loop {
+                let (start, end) = self.segments[self.index];
+                if is_before(version, start) {
+                    if self.index == 0 {
+                        return false;
+                    }
+                    self.index -= 1;
+                } else {
+                    return !is_after(version, end);
+                }
+            }
+        } else {
+            loop {
+                let (start, end) = self.segments[self.index];
+                if is_after(version, end) {
+                    if self.index + 1 == self.segments.len() {
+                        return false;
+                    }
+                    self.index += 1;
+                } else {
+                    return !is_before(version, start);
+                }
+            }
+        }
+    }
+}
+
+fn is_before(version: &Version, bound: &Bound<Version>) -> bool {
+    match bound {
+        Bound::Included(start) => version < start,
+        Bound::Excluded(start) => version <= start,
+        Bound::Unbounded => false,
+    }
+}
+
+fn is_after(version: &Version, bound: &Bound<Version>) -> bool {
+    match bound {
+        Bound::Included(end) => version > end,
+        Bound::Excluded(end) => version >= end,
+        Bound::Unbounded => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn version(value: &str) -> Version {
+        value.parse().expect("valid test version")
+    }
+
+    #[test]
+    fn range_cursor_ascending() {
+        let segments = [
+            (Bound::Unbounded, Bound::Excluded(version("2"))),
+            (Bound::Included(version("3")), Bound::Included(version("4"))),
+            (Bound::Excluded(version("5")), Bound::Unbounded),
+        ];
+        let segments = segments.iter().map(|(start, end)| (start, end)).collect();
+        let mut cursor = RangeCursor::new(segments, false);
+
+        for (value, expected) in [
+            ("1", true),
+            ("2", false),
+            ("2.5", false),
+            ("3", true),
+            ("4", true),
+            ("5", false),
+            ("6", true),
+        ] {
+            assert_eq!(cursor.contains(&version(value)), expected, "{value}");
+        }
+    }
+
+    #[test]
+    fn range_cursor_descending() {
+        let segments = [
+            (Bound::Unbounded, Bound::Excluded(version("2"))),
+            (Bound::Included(version("3")), Bound::Included(version("4"))),
+            (Bound::Excluded(version("5")), Bound::Unbounded),
+        ];
+        let segments = segments.iter().map(|(start, end)| (start, end)).collect();
+        let mut cursor = RangeCursor::new(segments, true);
+
+        for (value, expected) in [
+            ("6", true),
+            ("5", false),
+            ("4", true),
+            ("3", true),
+            ("2.5", false),
+            ("2", false),
+            ("1", true),
+        ] {
+            assert_eq!(cursor.contains(&version(value)), expected, "{value}");
+        }
     }
 }
 

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -539,43 +539,16 @@ impl CandidateSelector {
         allow_prerelease: bool,
         highest: bool,
     ) -> Option<Candidate<'a>> {
-        let mut segments = range.iter();
-        let Some(first_segment) = segments.next() else {
-            trace!("Exhausted all candidates for package {package_name} with empty range");
-            return None;
-        };
-        let Some(second_segment) = segments.next() else {
-            return Self::select_candidate_from(
-                versions,
-                package_name,
-                range,
-                allow_prerelease,
-                |_| true,
-            );
-        };
-        let segments = [first_segment, second_segment].into_iter().chain(segments);
+        let segments = range.iter();
         let segments = if highest {
             Either::Left(segments.rev())
         } else {
             Either::Right(segments)
         };
-        let mut cursor = RangeCursor::new(segments, highest)?;
-        Self::select_candidate_from(versions, package_name, range, allow_prerelease, |version| {
-            cursor.contains(version)
-        })
-    }
-
-    /// Run candidate selection with the given range-membership test.
-    ///
-    /// This keeps contiguous ranges on the no-filter fast path while disjoint ranges use a
-    /// [`RangeCursor`].
-    fn select_candidate_from<'a>(
-        versions: impl Iterator<Item = (&'a Version, VersionMapDistHandle<'a>)>,
-        package_name: &'a PackageName,
-        range: &Range<Version>,
-        allow_prerelease: bool,
-        mut range_contains: impl FnMut(&Version) -> bool,
-    ) -> Option<Candidate<'a>> {
+        let Some(mut cursor) = RangeCursor::new(segments, highest) else {
+            trace!("Exhausted all candidates for package {package_name} with empty range");
+            return None;
+        };
         let mut steps = 0usize;
         let mut incompatible: Option<Candidate> = None;
         for (version, maybe_dist) in versions {
@@ -596,7 +569,7 @@ impl CandidateSelector {
                 if version.any_prerelease() && !allow_prerelease {
                     continue;
                 }
-                if !range_contains(version) {
+                if !cursor.contains(version) {
                     continue;
                 }
                 let Some(dist) = maybe_dist.prioritized_dist() else {
@@ -673,7 +646,7 @@ impl CandidateSelector {
     }
 }
 
-/// Tracks membership in a disjoint range while visiting versions monotonically.
+/// Tracks membership in a range while visiting versions monotonically.
 ///
 /// Unlike [`Range::contains`], which searches the segments for every version, the cursor visits
 /// each segment at most once.
@@ -751,14 +724,17 @@ mod tests {
         value.parse().expect("valid test version")
     }
 
-    fn assert_range_cursor(highest: bool, values: &[&str]) {
-        let range = [
+    fn disjoint_range() -> Range<Version> {
+        [
             (Bound::Unbounded, Bound::Excluded(version("2"))),
             (Bound::Included(version("3")), Bound::Included(version("4"))),
             (Bound::Excluded(version("5")), Bound::Unbounded),
         ]
         .into_iter()
-        .collect::<Range<_>>();
+        .collect()
+    }
+
+    fn assert_range_cursor(range: &Range<Version>, highest: bool, values: &[&str]) {
         let segments = if highest {
             Either::Left(range.iter().rev())
         } else {
@@ -777,13 +753,30 @@ mod tests {
     }
 
     #[test]
+    fn range_cursor_single_segment() {
+        let range = [(Bound::Included(version("2")), Bound::Excluded(version("5")))]
+            .into_iter()
+            .collect();
+        assert_range_cursor(&range, false, &["1", "2", "3", "5", "6"]);
+        assert_range_cursor(&range, true, &["6", "5", "3", "2", "1"]);
+    }
+
+    #[test]
     fn range_cursor_ascending() {
-        assert_range_cursor(false, &["1", "2", "2.5", "3", "4", "5", "6"]);
+        assert_range_cursor(
+            &disjoint_range(),
+            false,
+            &["1", "2", "2.5", "3", "4", "5", "6"],
+        );
     }
 
     #[test]
     fn range_cursor_descending() {
-        assert_range_cursor(true, &["6", "5", "4", "3", "2.5", "2", "1"]);
+        assert_range_cursor(
+            &disjoint_range(),
+            true,
+            &["6", "5", "4", "3", "2.5", "2", "1"],
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

PubGrub can produce allowed version ranges with many disjoint segments as resolution progresses. Candidate selection previously called `Range::contains` for every candidate, repeating a binary search over those segments even though `VersionMap` visits candidates in sorted order.

This adds a monotonic cursor for candidate selection. The cursor holds the current segment and streams the remaining borrowed segments in the same direction as candidate selection, visiting each segment at most once without cloning or allocating. Empty ranges return immediately, while every non-empty range follows the same cursor-backed selection path.
