### PR TITLE
Cache registry wheel metadata in offline mode

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -21,8 +21,8 @@ use uv_configuration::IndexStrategy;
 use uv_configuration::KeyringProviderType;
 use uv_distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
 use uv_distribution_types::{
-    BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-    IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
+    BuiltDist, DistributionId, File, Identifier, IndexCapabilities, IndexFormat, IndexLocations,
+    IndexMetadataRef, IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
 };
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
@@ -204,6 +204,7 @@ impl<'a> RegistryClientBuilder<'a> {
             client,
             read_timeout,
             flat_indexes: Arc::default(),
+            wheel_metadata_cache: Arc::default(),
             pyx_token_store: PyxTokenStore::from_settings().ok(),
         })
     }
@@ -228,6 +229,8 @@ pub struct RegistryClient {
     read_timeout: Duration,
     /// The flat index entries for each `--find-links`-style index URL, with one slot per index.
     flat_indexes: Arc<Mutex<FlatIndexCache>>,
+    /// Registry wheel metadata read in offline mode, shared across client clones.
+    wheel_metadata_cache: Arc<Mutex<FxHashMap<DistributionId, ResolutionMetadata>>>,
     /// The pyx token store to use for persistent credentials.
     // TODO(charlie): The token store is only needed for `is_known_url`; can we avoid storing it here?
     pyx_token_store: Option<PyxTokenStore>,
@@ -920,6 +923,24 @@ impl RegistryClient {
         capabilities: &IndexCapabilities,
         reporter: Option<Arc<dyn Reporter>>,
     ) -> Result<ResolutionMetadata, Error> {
+        let cache_id = if self.connectivity.is_offline()
+            && let BuiltDist::Registry(wheels) = built_dist
+        {
+            Some(wheels.distribution_id())
+        } else {
+            None
+        };
+        if let Some(cache_id) = &cache_id
+            && let Some(metadata) = self
+                .wheel_metadata_cache
+                .lock()
+                .await
+                .get(cache_id)
+                .cloned()
+        {
+            return Ok(metadata);
+        }
+
         let metadata = match &built_dist {
             BuiltDist::Registry(wheels) => {
                 #[derive(Debug, Clone)]
@@ -1047,6 +1068,13 @@ impl RegistryClient {
                 metadata: metadata.name,
                 given: built_dist.name().clone(),
             }));
+        }
+
+        if let Some(cache_id) = cache_id {
+            self.wheel_metadata_cache
+                .lock()
+                .await
+                .insert(cache_id, metadata.clone());
         }
 
         Ok(metadata)

--- a/crates/uv-client/tests/it/remote_metadata.rs
+++ b/crates/uv-client/tests/it/remote_metadata.rs
@@ -1,14 +1,21 @@
-use std::str::FromStr;
+use std::{path::Path, str::FromStr};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
+use fs_err as fs;
+use url::Url;
 
 use uv_cache::Cache;
-use uv_client::{BaseClientBuilder, RegistryClientBuilder};
+use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
 use uv_distribution_filename::WheelFilename;
-use uv_distribution_types::{BuiltDist, DirectUrlBuiltDist, IndexCapabilities};
+use uv_distribution_types::{
+    BuiltDist, DirectUrlBuiltDist, File, FileLocation, IndexCapabilities, IndexUrl,
+    RegistryBuiltDist, RegistryBuiltWheel,
+};
 use uv_git::GitResolver;
 use uv_pep508::VerbatimUrl;
+use uv_pypi_types::HashDigests;
 use uv_redacted::DisplaySafeUrl;
+use uv_small_str::SmallString;
 
 #[tokio::test]
 async fn remote_metadata_with_and_without_cache() -> Result<()> {
@@ -32,6 +39,66 @@ async fn remote_metadata_with_and_without_cache() -> Result<()> {
             .await?;
         assert_eq!(metadata.version.to_string(), "4.66.1");
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn offline_registry_metadata_is_cached_in_memory() -> Result<()> {
+    let directory = tempfile::tempdir()?;
+    let wheel_name = "basic_package-0.1.0-py3-none-any.whl";
+    let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../test/links")
+        .join(wheel_name);
+    let wheel_path = directory.path().join(wheel_name);
+    fs::copy(source, &wheel_path)?;
+
+    let wheel_url = Url::from_file_path(&wheel_path)
+        .map_err(|()| anyhow!("wheel path cannot be represented as a URL"))?;
+    let filename = WheelFilename::from_str(wheel_name)?;
+    let distribution = BuiltDist::Registry(RegistryBuiltDist {
+        wheels: vec![RegistryBuiltWheel {
+            filename,
+            file: Box::new(File {
+                dist_info_metadata: false,
+                filename: SmallString::from(wheel_name),
+                hashes: HashDigests::empty(),
+                requires_python: None,
+                size: None,
+                upload_time_utc_ms: None,
+                url: FileLocation::new(
+                    SmallString::from(wheel_url.as_str()),
+                    &SmallString::from(""),
+                ),
+                yanked: None,
+                zstd: None,
+            }),
+            index: IndexUrl::from_str("https://example.com/simple")?,
+        }],
+        best_wheel_index: 0,
+        sdist: None,
+    });
+    let client = RegistryClientBuilder::new(
+        BaseClientBuilder::default().connectivity(Connectivity::Offline),
+        Cache::temp()?,
+    )
+    .build()?;
+    let resolver = GitResolver::default();
+    let capabilities = IndexCapabilities::default();
+
+    let metadata = client
+        .wheel_metadata(&distribution, &resolver, &capabilities, None)
+        .await?;
+    assert_eq!(metadata.name.as_ref(), "basic-package");
+    assert_eq!(metadata.version.to_string(), "0.1.0");
+
+    fs::remove_file(&wheel_path)?;
+    let metadata = client
+        .clone()
+        .wheel_metadata(&distribution, &resolver, &capabilities, None)
+        .await?;
+    assert_eq!(metadata.name.as_ref(), "basic-package");
+    assert_eq!(metadata.version.to_string(), "0.1.0");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Offline resolution can reuse the same `RegistryClient` across multiple resolver runs, but each run currently reloads and deserializes identical registry wheel metadata from the on-disk cache. This is especially visible for PEP 658 metadata in warm resolver benchmarks.

This adds an in-memory cache keyed by distribution identity for registry wheel metadata read in offline mode. The cache is shared across `RegistryClient` clones and is populated only after metadata name validation, so online clients retain normal cache revalidation and non-registry distributions continue through their existing paths.

The integration coverage loads registry wheel metadata, removes the underlying wheel, and confirms that a cloned offline client reuses the validated metadata.
