### PR TITLE
Measure niche-optimized PubGrub IDs in CodSpeed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,8 @@ dependencies = [
 
 [[package]]
 name = "astral-pubgrub"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6cb15b4f5096a3a1b41fdc2736a1c33d87c78f34d3c1ec2b669e766edadd559"
+version = "0.4.3"
+source = "git+https://github.com/astral-sh/pubgrub?rev=446f813fe7075abf1fb86bfdc0aee89c5e502c6e#446f813fe7075abf1fb86bfdc0aee89c5e502c6e"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -293,8 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31979bc305610246d78ac01d63467a12d8454c6e3b8b22b5811d343a1198dfbb"
+source = "git+https://github.com/astral-sh/pubgrub?rev=446f813fe7075abf1fb86bfdc0aee89c5e502c6e#446f813fe7075abf1fb86bfdc0aee89c5e502c6e"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
-pubgrub = { version = "0.3.3", package = "astral-pubgrub" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "446f813fe7075abf1fb86bfdc0aee89c5e502c6e", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
 rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
@@ -289,7 +289,7 @@ unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.16.0" }
-version-ranges = { version = "0.1.3", package = "astral-version-ranges" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "446f813fe7075abf1fb86bfdc0aee89c5e502c6e", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -3160,8 +3160,11 @@ impl ForkState {
 
             let proxy_package = self.pubgrub.package_store.alloc(package.clone());
             let base_package_id = self.pubgrub.package_store.alloc(base_package.clone());
-            self.pubgrub
-                .add_proxy_package(proxy_package, base_package_id, version.clone());
+            self.pubgrub.add_proxy_package_incompatibility(
+                proxy_package,
+                base_package_id,
+                version.clone(),
+            );
         }
 
         let conflict = self.pubgrub.add_package_version_dependencies(


### PR DESCRIPTION
## Summary

This draft pins `astral-pubgrub` and `astral-version-ranges` to [pubgrub#58](https://github.com/astral-sh/pubgrub/pull/58) at `446f813f` so uv's CodSpeed suites can measure the downstream effect of the niche-optimized `Id<T>` representation.

PubGrub #58 is stacked on [pubgrub#57](https://github.com/astral-sh/pubgrub/pull/57) and [pubgrub#56](https://github.com/astral-sh/pubgrub/pull/56), so this PR measures the cumulative PubGrub stack through #58 against uv's current crates.io dependency. Compare its CodSpeed report with [uv#20028](https://github.com/astral-sh/uv/pull/20028), which stops at pubgrub#57, to isolate the incremental effect of the niche representation. Moving from PubGrub 0.3.3 to the Git revision also requires adopting the renamed `add_proxy_package_incompatibility` API; that call-site update has no intended behavioral effect.

This PR is for CodSpeed measurement rather than merge. The locked `uv-bench` target compiles successfully, and the file-scoped repository hooks pass.
