### PR TITLE
Adapt uv to IDs-only PubGrub dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,8 @@ dependencies = [
 
 [[package]]
 name = "astral-pubgrub"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6cb15b4f5096a3a1b41fdc2736a1c33d87c78f34d3c1ec2b669e766edadd559"
+version = "0.4.3"
+source = "git+https://github.com/astral-sh/pubgrub?rev=446afc9f756253b94df0f9b0f167ec8fba0b3693#446afc9f756253b94df0f9b0f167ec8fba0b3693"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -293,8 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31979bc305610246d78ac01d63467a12d8454c6e3b8b22b5811d343a1198dfbb"
+source = "git+https://github.com/astral-sh/pubgrub?rev=446afc9f756253b94df0f9b0f167ec8fba0b3693#446afc9f756253b94df0f9b0f167ec8fba0b3693"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.4.3"
-source = "git+https://github.com/astral-sh/pubgrub?rev=446afc9f756253b94df0f9b0f167ec8fba0b3693#446afc9f756253b94df0f9b0f167ec8fba0b3693"
+source = "git+https://github.com/astral-sh/pubgrub?rev=8f31b20e3def5dbd1f68a6911f19190c87adf53d#8f31b20e3def5dbd1f68a6911f19190c87adf53d"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -291,8 +291,8 @@ dependencies = [
 
 [[package]]
 name = "astral-version-ranges"
-version = "0.1.4"
-source = "git+https://github.com/astral-sh/pubgrub?rev=446afc9f756253b94df0f9b0f167ec8fba0b3693#446afc9f756253b94df0f9b0f167ec8fba0b3693"
+version = "0.1.5"
+source = "git+https://github.com/astral-sh/pubgrub?rev=8f31b20e3def5dbd1f68a6911f19190c87adf53d#8f31b20e3def5dbd1f68a6911f19190c87adf53d"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,9 @@ dependencies = [
 
 [[package]]
 name = "astral-pubgrub"
-version = "0.4.3"
-source = "git+https://github.com/astral-sh/pubgrub?rev=8fd9709ea671b1b3ead53e6ec847da5fcad7c03d#8fd9709ea671b1b3ead53e6ec847da5fcad7c03d"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79d771681f6c21ebe25dda598774b6e6badca8b720ce2168df7788b2821c46d"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -291,8 +292,9 @@ dependencies = [
 
 [[package]]
 name = "astral-version-ranges"
-version = "0.1.5"
-source = "git+https://github.com/astral-sh/pubgrub?rev=8fd9709ea671b1b3ead53e6ec847da5fcad7c03d#8fd9709ea671b1b3ead53e6ec847da5fcad7c03d"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086f936efdefab117f5a72367fb3d68c4fded8ba5a7008e3c63365eecf723822"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.4.3"
-source = "git+https://github.com/astral-sh/pubgrub?rev=8f31b20e3def5dbd1f68a6911f19190c87adf53d#8f31b20e3def5dbd1f68a6911f19190c87adf53d"
+source = "git+https://github.com/astral-sh/pubgrub?rev=b8dd822dee1f94499787d2245dfe51e963bb411f#b8dd822dee1f94499787d2245dfe51e963bb411f"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.1.5"
-source = "git+https://github.com/astral-sh/pubgrub?rev=8f31b20e3def5dbd1f68a6911f19190c87adf53d#8f31b20e3def5dbd1f68a6911f19190c87adf53d"
+source = "git+https://github.com/astral-sh/pubgrub?rev=b8dd822dee1f94499787d2245dfe51e963bb411f#b8dd822dee1f94499787d2245dfe51e963bb411f"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.4.3"
-source = "git+https://github.com/astral-sh/pubgrub?rev=b8dd822dee1f94499787d2245dfe51e963bb411f#b8dd822dee1f94499787d2245dfe51e963bb411f"
+source = "git+https://github.com/astral-sh/pubgrub?rev=8fd9709ea671b1b3ead53e6ec847da5fcad7c03d#8fd9709ea671b1b3ead53e6ec847da5fcad7c03d"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.1.5"
-source = "git+https://github.com/astral-sh/pubgrub?rev=b8dd822dee1f94499787d2245dfe51e963bb411f#b8dd822dee1f94499787d2245dfe51e963bb411f"
+source = "git+https://github.com/astral-sh/pubgrub?rev=8fd9709ea671b1b3ead53e6ec847da5fcad7c03d#8fd9709ea671b1b3ead53e6ec847da5fcad7c03d"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "446afc9f756253b94df0f9b0f167ec8fba0b3693", package = "astral-pubgrub" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "8f31b20e3def5dbd1f68a6911f19190c87adf53d", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
 rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
@@ -289,7 +289,7 @@ unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.16.0" }
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "446afc9f756253b94df0f9b0f167ec8fba0b3693", package = "astral-version-ranges" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "8f31b20e3def5dbd1f68a6911f19190c87adf53d", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "8fd9709ea671b1b3ead53e6ec847da5fcad7c03d", package = "astral-pubgrub" }
+pubgrub = { version = "0.5.0", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
 rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
@@ -289,7 +289,7 @@ unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.16.0" }
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "8fd9709ea671b1b3ead53e6ec847da5fcad7c03d", package = "astral-version-ranges" }
+version-ranges = { version = "0.2.0", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "8f31b20e3def5dbd1f68a6911f19190c87adf53d", package = "astral-pubgrub" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "b8dd822dee1f94499787d2245dfe51e963bb411f", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
 rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
@@ -289,7 +289,7 @@ unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.16.0" }
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "8f31b20e3def5dbd1f68a6911f19190c87adf53d", package = "astral-version-ranges" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "b8dd822dee1f94499787d2245dfe51e963bb411f", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "b8dd822dee1f94499787d2245dfe51e963bb411f", package = "astral-pubgrub" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "8fd9709ea671b1b3ead53e6ec847da5fcad7c03d", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
 rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
@@ -289,7 +289,7 @@ unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.16.0" }
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "b8dd822dee1f94499787d2245dfe51e963bb411f", package = "astral-version-ranges" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "8fd9709ea671b1b3ead53e6ec847da5fcad7c03d", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
-pubgrub = { version = "0.3.3", package = "astral-pubgrub" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "446afc9f756253b94df0f9b0f167ec8fba0b3693", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
 rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
@@ -289,7 +289,7 @@ unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.16.0" }
-version-ranges = { version = "0.1.3", package = "astral-version-ranges" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "446afc9f756253b94df0f9b0f167ec8fba0b3693", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }

--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -83,7 +83,7 @@ impl VersionSpecifiers {
     ///
     /// This function is not applicable to ranges involving pre-release versions.
     pub fn from_release_only_bounds<'a>(
-        mut bounds: impl Iterator<Item = (&'a Bound<Version>, &'a Bound<Version>)>,
+        mut bounds: impl Iterator<Item = (Bound<&'a Version>, Bound<&'a Version>)>,
     ) -> Self {
         let mut specifiers = Vec::new();
 
@@ -552,7 +552,7 @@ impl VersionSpecifier {
     ///
     /// This function is not applicable to ranges involving pre-release versions.
     pub fn from_release_only_bounds(
-        bounds: (&Bound<Version>, &Bound<Version>),
+        bounds: (Bound<&Version>, Bound<&Version>),
     ) -> impl Iterator<Item = Self> {
         let (b1, b2) = match bounds {
             (Bound::Included(v1), Bound::Included(v2)) if v1 == v2 => {
@@ -572,8 +572,8 @@ impl VersionSpecifier {
                         (Some(Self::equals_star_version(version)), None)
                     }
                     _ => (
-                        Self::from_lower_bound(&Bound::Included(v1.clone())),
-                        Self::from_upper_bound(&Bound::Excluded(v2.clone())),
+                        Self::from_lower_bound(Bound::Included(v1)),
+                        Self::from_upper_bound(Bound::Excluded(v2)),
                     ),
                 }
             }
@@ -584,7 +584,7 @@ impl VersionSpecifier {
     }
 
     /// Returns a version specifier representing the given lower bound.
-    fn from_lower_bound(bound: &Bound<Version>) -> Option<Self> {
+    fn from_lower_bound(bound: Bound<&Version>) -> Option<Self> {
         match bound {
             Bound::Included(version) => {
                 Some(Self::from_version(Operator::GreaterThanEqual, version.clone()).unwrap())
@@ -597,7 +597,7 @@ impl VersionSpecifier {
     }
 
     /// Returns a version specifier representing the given upper bound.
-    fn from_upper_bound(bound: &Bound<Version>) -> Option<Self> {
+    fn from_upper_bound(bound: Bound<&Version>) -> Option<Self> {
         match bound {
             Bound::Included(version) => {
                 Some(Self::from_version(Operator::LessThanEqual, version.clone()).unwrap())

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -1438,13 +1438,13 @@ impl Edges {
 
         // Add the `true` edges.
         for (start, end) in range.iter() {
-            let range = Ranges::from_range_bounds((start.clone(), end.clone()));
+            let range = Ranges::from_range_bounds((start.cloned(), end.cloned()));
             edges.push((range, NodeId::TRUE));
         }
 
         // Add the `false` edges.
         for (start, end) in range.complement().iter() {
-            let range = Ranges::from_range_bounds((start.clone(), end.clone()));
+            let range = Ranges::from_range_bounds((start.cloned(), end.cloned()));
             edges.push((range, NodeId::FALSE));
         }
 

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -305,7 +305,7 @@ impl MarkerOperator {
 
     /// Returns the marker operator and value whose union represents the given range.
     pub(crate) fn from_bounds(
-        bounds: (&Bound<ArcStr>, &Bound<ArcStr>),
+        bounds: (Bound<&ArcStr>, Bound<&ArcStr>),
     ) -> impl Iterator<Item = (Self, ArcStr)> {
         let (b1, b2) = match bounds {
             (Bound::Included(v1), Bound::Included(v2)) if v1 == v2 => {
@@ -321,7 +321,7 @@ impl MarkerOperator {
     }
 
     /// Returns a value specifier representing the given lower bound.
-    fn from_lower_bound(bound: &Bound<ArcStr>) -> Option<(Self, ArcStr)> {
+    fn from_lower_bound(bound: Bound<&ArcStr>) -> Option<(Self, ArcStr)> {
         match bound {
             Bound::Included(value) => Some((Self::GreaterEqual, value.clone())),
             Bound::Excluded(value) => Some((Self::GreaterThan, value.clone())),
@@ -330,7 +330,7 @@ impl MarkerOperator {
     }
 
     /// Returns a value specifier representing the given upper bound.
-    fn from_upper_bound(bound: &Bound<ArcStr>) -> Option<(Self, ArcStr)> {
+    fn from_upper_bound(bound: Bound<&ArcStr>) -> Option<(Self, ArcStr)> {
         match bound {
             Bound::Included(value) => Some((Self::LessEqual, value.clone())),
             Bound::Excluded(value) => Some((Self::LessThan, value.clone())),

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1315,7 +1315,7 @@ impl SentinelRange<'_> {
     pub fn strip(&self) -> Ranges<Version> {
         self.0
             .iter()
-            .map(|(lower, upper)| Self::strip_sentinel(lower.clone(), upper.clone()))
+            .map(|(lower, upper)| Self::strip_sentinel(lower.cloned(), upper.cloned()))
             .collect()
     }
 
@@ -1406,7 +1406,7 @@ impl<'a> PrefixMatch<'a> {
     ///
     /// Prefix matches are desugared to (e.g.) `>=2.4.dev0,<2.5.dev0`, but we want to render them
     /// as `==2.4.*` in error messages.
-    pub(crate) fn from_range(lower: &'a Bound<Version>, upper: &'a Bound<Version>) -> Option<Self> {
+    pub(crate) fn from_range(lower: Bound<&'a Version>, upper: Bound<&'a Version>) -> Option<Self> {
         let Bound::Included(lower) = lower else {
             return None;
         };

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -2380,7 +2380,7 @@ fn update_availability_range(
     range
         .iter()
         .filter_map(|(lower, upper)| {
-            let segment_range = Range::from_range_bounds((lower.clone(), upper.clone()));
+            let segment_range = Range::from_range_bounds((lower.cloned(), upper.cloned()));
 
             // Drop the segment if it's disjoint with the available range, e.g., if the segment is
             // `foo>999`, and the available versions are all `<10` it's useless to show.
@@ -2412,13 +2412,13 @@ fn update_availability_range(
                 Bound::Included(version) if !version_contained_in(version, available_versions) => {
                     Bound::Excluded(version.clone())
                 }
-                _ => (*lower).clone(),
+                _ => lower.cloned(),
             };
             let upper = match upper {
                 Bound::Included(version) if !version_contained_in(version, available_versions) => {
                     Bound::Excluded(version.clone())
                 }
-                _ => (*upper).clone(),
+                _ => upper.cloned(),
             };
 
             Some((lower, upper))
@@ -2477,7 +2477,7 @@ impl std::fmt::Display for PackageRange<'_> {
                     }
                 }
                 (Bound::Included(v), Bound::Excluded(b)) => {
-                    if let Some(prefix) = PrefixMatch::from_range(lower, upper) {
+                    if let Some(prefix) = PrefixMatch::from_range(*lower, *upper) {
                         write!(f, "{package}{prefix}")?;
                     } else {
                         write!(f, "{package}>={v},<{b}")?;

--- a/crates/uv-resolver/src/resolver/derivation.rs
+++ b/crates/uv-resolver/src/resolver/derivation.rs
@@ -1,4 +1,4 @@
-use pubgrub::{Id, Kind, Ranges, State, Term};
+use pubgrub::{Id, Kind, Ranges, State};
 use rustc_hash::FxHashMap;
 
 use uv_distribution_types::{DerivationChain, DerivationStep};
@@ -38,27 +38,12 @@ impl DerivationChainBuilder {
 
                 // Find a dependency from a package to the current package.
                 if let Kind::FromDependencyOf(id1, id2) = &incompat.kind {
-                    let mut terms = incompat.iter();
-                    let Some((term_id1, Term::Positive(_))) = terms.next() else {
-                        unreachable!(
-                            "dependency incompatibility must start with its positive term"
-                        );
+                    let Some((_, dependency_versions)) = incompat.dependency_version_sets() else {
+                        continue;
                     };
-                    if term_id1 != *id1 {
-                        unreachable!("dependency incompatibility has a mismatched dependent term");
-                    }
-                    let v2 = match terms.next() {
-                        None => Ranges::empty(),
-                        Some((term_id2, Term::Negative(v2))) if term_id2 == *id2 => v2.clone(),
-                        _ => unreachable!(
-                            "dependency incompatibility must end with its negative term"
-                        ),
-                    };
-                    assert!(
-                        terms.next().is_none(),
-                        "dependency incompatibility must contain at most two terms"
-                    );
-                    if id == *id2 && v2.contains(version) {
+                    let dependency_versions =
+                        dependency_versions.cloned().unwrap_or_else(Ranges::empty);
+                    if id == *id2 && dependency_versions.contains(version) {
                         if let Some(version) = solution.get(id1) {
                             let p1 = &state.package_store[*id1];
                             let p2 = &state.package_store[*id2];
@@ -75,7 +60,7 @@ impl DerivationChainBuilder {
                                     p1.extra().cloned(),
                                     p1.group().cloned(),
                                     Some(version.clone()),
-                                    v2,
+                                    dependency_versions,
                                 ));
 
                                 // Recursively search the next package.

--- a/crates/uv-resolver/src/resolver/derivation.rs
+++ b/crates/uv-resolver/src/resolver/derivation.rs
@@ -1,4 +1,4 @@
-use pubgrub::{Id, Kind, State};
+use pubgrub::{Id, Kind, Ranges, State, Term};
 use rustc_hash::FxHashMap;
 
 use uv_distribution_types::{DerivationChain, DerivationStep};
@@ -37,7 +37,27 @@ impl DerivationChainBuilder {
                 let incompat = &state.incompatibility_store[*index];
 
                 // Find a dependency from a package to the current package.
-                if let Kind::FromDependencyOf(id1, _, id2, v2) = &incompat.kind {
+                if let Kind::FromDependencyOf(id1, id2) = &incompat.kind {
+                    let mut terms = incompat.iter();
+                    let Some((term_id1, Term::Positive(_))) = terms.next() else {
+                        unreachable!(
+                            "dependency incompatibility must start with its positive term"
+                        );
+                    };
+                    if term_id1 != *id1 {
+                        unreachable!("dependency incompatibility has a mismatched dependent term");
+                    }
+                    let v2 = match terms.next() {
+                        None => Ranges::empty(),
+                        Some((term_id2, Term::Negative(v2))) if term_id2 == *id2 => v2.clone(),
+                        _ => unreachable!(
+                            "dependency incompatibility must end with its negative term"
+                        ),
+                    };
+                    assert!(
+                        terms.next().is_none(),
+                        "dependency incompatibility must contain at most two terms"
+                    );
                     if id == *id2 && v2.contains(version) {
                         if let Some(version) = solution.get(id1) {
                             let p1 = &state.package_store[*id1];
@@ -55,7 +75,7 @@ impl DerivationChainBuilder {
                                     p1.extra().cloned(),
                                     p1.group().cloned(),
                                     Some(version.clone()),
-                                    v2.clone(),
+                                    v2,
                                 ));
 
                                 // Recursively search the next package.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -13,7 +13,7 @@ use either::Either;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use papaya::{HashMap, ResizeMode};
-use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
+use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State, Term};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
@@ -2666,7 +2666,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 if dist.wheel().is_none() {
                     if !self.selector.use_highest_version(&package_name, &env) {
                         if let Some((lower, _)) = range.iter().next() {
-                            if lower == &Bound::Unbounded {
+                            if lower == Bound::Unbounded {
                                 debug!(
                                     "Skipping prefetch for unbounded minimum-version range: {package_name} ({range})"
                                 );
@@ -3160,8 +3160,11 @@ impl ForkState {
 
             let proxy_package = self.pubgrub.package_store.alloc(package.clone());
             let base_package_id = self.pubgrub.package_store.alloc(base_package.clone());
-            self.pubgrub
-                .add_proxy_package(proxy_package, base_package_id, version.clone());
+            self.pubgrub.add_proxy_package_incompatibility(
+                proxy_package,
+                base_package_id,
+                version.clone(),
+            );
         }
 
         let conflict = self.pubgrub.add_package_version_dependencies(
@@ -3323,15 +3326,33 @@ impl ForkState {
         let mut edges: Vec<ResolutionDependencyEdge> = Vec::with_capacity(edge_count);
         for (package, self_version) in &solution {
             for id in &self.pubgrub.incompatibilities[package] {
-                let pubgrub::Kind::FromDependencyOf(
-                    self_package,
-                    ref self_range,
-                    dependency_package,
-                    ref dependency_range,
-                ) = self.pubgrub.incompatibility_store[*id].kind
+                let incompatibility = &self.pubgrub.incompatibility_store[*id];
+                let pubgrub::Kind::FromDependencyOf(self_package, dependency_package) =
+                    &incompatibility.kind
                 else {
                     continue;
                 };
+                let (self_package, dependency_package) = (*self_package, *dependency_package);
+                let mut terms = incompatibility.iter();
+                let Some((term_package, Term::Positive(self_range))) = terms.next() else {
+                    unreachable!("dependency incompatibility must start with its positive term");
+                };
+                if term_package != self_package {
+                    unreachable!("dependency incompatibility has a mismatched dependent term");
+                }
+                let dependency_range = match terms.next() {
+                    None => Cow::Owned(Ranges::empty()),
+                    Some((term_package, Term::Negative(range)))
+                        if term_package == dependency_package =>
+                    {
+                        Cow::Borrowed(range)
+                    }
+                    _ => unreachable!("dependency incompatibility must end with its negative term"),
+                };
+                assert!(
+                    terms.next().is_none(),
+                    "dependency incompatibility must contain at most two terms"
+                );
                 if *package != self_package {
                     continue;
                 }
@@ -4257,7 +4278,7 @@ fn find_environments(id: Id<PubGrubPackage>, state: &State<UvDependencyProvider>
 
         for index in incompatibilities {
             let incompat = &state.incompatibility_store[*index];
-            if let Kind::FromDependencyOf(parent, _, child, _) = &incompat.kind {
+            if let Kind::FromDependencyOf(parent, child) = &incompat.kind {
                 if current != *child {
                     continue;
                 }
@@ -4291,7 +4312,7 @@ fn find_environments(id: Id<PubGrubPackage>, state: &State<UvDependencyProvider>
 
         for index in incompatibilities {
             let incompat = &state.incompatibility_store[*index];
-            let Kind::FromDependencyOf(parent, _, child, _) = &incompat.kind else {
+            let Kind::FromDependencyOf(parent, child) = &incompat.kind else {
                 continue;
             };
             if current != *parent || !ancestors.contains(child) {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -13,7 +13,7 @@ use either::Either;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use papaya::{HashMap, ResizeMode};
-use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State, Term};
+use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
@@ -3333,26 +3333,13 @@ impl ForkState {
                     continue;
                 };
                 let (self_package, dependency_package) = (*self_package, *dependency_package);
-                let mut terms = incompatibility.iter();
-                let Some((term_package, Term::Positive(self_range))) = terms.next() else {
-                    unreachable!("dependency incompatibility must start with its positive term");
+                let Some((self_range, dependency_range)) =
+                    incompatibility.dependency_version_sets()
+                else {
+                    continue;
                 };
-                if term_package != self_package {
-                    unreachable!("dependency incompatibility has a mismatched dependent term");
-                }
-                let dependency_range = match terms.next() {
-                    None => Cow::Owned(Ranges::empty()),
-                    Some((term_package, Term::Negative(range)))
-                        if term_package == dependency_package =>
-                    {
-                        Cow::Borrowed(range)
-                    }
-                    _ => unreachable!("dependency incompatibility must end with its negative term"),
-                };
-                assert!(
-                    terms.next().is_none(),
-                    "dependency incompatibility must contain at most two terms"
-                );
+                let dependency_range =
+                    dependency_range.map_or_else(|| Cow::Owned(Ranges::empty()), Cow::Borrowed);
                 if *package != self_package {
                     continue;
                 }


### PR DESCRIPTION
## Summary

This adapts uv to [astral-sh/pubgrub#67](https://github.com/astral-sh/pubgrub/pull/67), where dependency incompatibility kinds store only the dependent and dependency package IDs. The resolver and derivation-chain consumers now recover the version ranges from the incompatibility's ordered terms, including the existing empty-range representation, while the two graph traversals that only need package IDs use the smaller variant directly.

The workspace now uses the published `astral-pubgrub` 0.5.0 and `astral-version-ranges` 0.2.0 releases from crates.io. Because those releases include the latest PubGrub changes, this also includes mechanical consumer updates for borrowed `Ranges::iter` bounds and the renamed proxy-package helper.