### PR TITLE
fix(python): quote version ranges in the 'downloads manual' install hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6969,6 +6969,7 @@ dependencies = [
  "uv-preview",
  "uv-pypi-types",
  "uv-redacted",
+ "uv-shell",
  "uv-state",
  "uv-static",
  "uv-trampoline-builder",

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -34,6 +34,7 @@ uv-platform-tags = { workspace = true }
 uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-redacted = { workspace = true }
+uv-shell = { workspace = true }
 uv-state = { workspace = true }
 uv-static = { workspace = true }
 uv-trampoline-builder = { workspace = true }

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -140,11 +140,18 @@ impl std::fmt::Display for MissingPythonHint {
                 )
             }
             Self::DownloadsManual(request) => {
+                let canonical = request.to_canonical_string();
+                // Version ranges like `>=3.13, <3.14` contain spaces and must be quoted
+                // so the hint is valid shell syntax.
+                let arg = if canonical.contains(' ') {
+                    format!("\"{canonical}\"")
+                } else {
+                    canonical
+                };
                 write!(
                     f,
-                    "A managed Python download is available{}, but Python downloads are set to 'manual', use `uv python install {}` to install the required version",
+                    "A managed Python download is available{}, but Python downloads are set to 'manual', use `uv python install {arg}` to install the required version",
                     Self::for_request(request),
-                    request.to_canonical_string(),
                 )
             }
             Self::DownloadsNever(request) => {

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -141,10 +141,8 @@ impl std::fmt::Display for MissingPythonHint {
             }
             Self::DownloadsManual(request) => {
                 let canonical = request.to_canonical_string();
-                // Version ranges like `>=3.13, <3.14` contain spaces and must be quoted
-                // so the hint is valid shell syntax.
                 let arg = if canonical.contains(' ') {
-                    format!("\"{canonical}\"")
+                    format!("'{}'", uv_shell::escape_posix_for_single_quotes(&canonical))
                 } else {
                     canonical
                 };


### PR DESCRIPTION
Fixes #17051.

## Problem

When `requires-python` is a range (e.g. `>=3.13, <3.14`) and Python downloads are set to `manual`, the error hint reads:

```
hint: A managed Python download is available for Python >=3.13, <3.14,
      but Python downloads are set to 'manual', use `uv python install >=3.13, <3.14`
      to install the required version
```

Running that literally in a shell fails because the shell splits on spaces and treats `, <3.14` as a separate argument:

```console
$ uv python install >=3.13, <3.14
-bash: 3.14: No such file or directory
```

## Fix

In `MissingPythonHint::DownloadsManual`, wrap the canonical request string in double-quotes when it contains a space:

```
hint: ... use `uv python install ">=3.13, <3.14"` to install the required version
```

Single-version requests (`3.12`, `cpython@3.11`, `pypy`, etc.) contain no spaces and are left unquoted.