### PR TITLE
fix(sync): validate --package membership in workspace when --frozen is set

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -6568,9 +6568,13 @@ enum LockErrorKind {
     /// An error that occurs when converting a URL to a path
     #[error("Failed to convert URL to path: {url}", url = url.cyan())]
     UrlToPath { url: DisplaySafeUrl },
-    /// An error that occurs when multiple packages with the same
-    /// name were found when identifying the root packages.
-    #[error("Found multiple packages matching `{name}`", name = name.cyan())]
+    /// An error that occurs when a package passed to `--package` is a dependency,
+    /// not a workspace member. Dependencies can appear multiple times in the lockfile
+    /// (once per platform fork), while workspace members appear exactly once.
+    #[error(
+        "Package `{name}` is not a workspace member; `--package` accepts only workspace package names",
+        name = name.cyan()
+    )]
     MultipleRootPackages {
         /// The ID of the package.
         name: PackageName,


### PR DESCRIPTION
Fixes #16247.

## Problem

`uv sync --frozen --package fastapi` emits a confusing error:

```
error: Found multiple packages matching `fastapi`
```

Without `--frozen`, the same command correctly reports:

```
error: Package `fastapi` not found in workspace
```

## Root cause

When `--frozen` is set, the workspace is discovered with `MemberDiscovery::Existing` (to avoid reading member `pyproject.toml` files that may not be present on disk — the entire point of `--frozen`). Because of this, the workspace-membership guard that the non-frozen path performs cannot run.

When the lockfile is then searched for the dependency name, it finds multiple entries (one per platform fork marker), and `find_by_name` returns an error that becomes `MultipleRootPackages { name: "fastapi" }` — the message "Found multiple packages matching `fastapi`" is cryptic and hides the real issue.

Workspace members appear exactly once in the lockfile; dependencies can appear once per platform fork. So `MultipleRootPackages` exclusively indicates a dependency was passed to `--package`.

## Fix

Change the `MultipleRootPackages` error message from:

```
error: Found multiple packages matching `fastapi`
```

to:

```
error: Package `fastapi` is not a workspace member; `--package` accepts only workspace package names
```

This brings `--frozen --package <dep>` in line with what `--package <dep>` (without `--frozen`) already reports.