### PR TITLE
Avoid blank line for empty `uv pip tree`

### DIFF
--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -164,7 +164,9 @@ pub(crate) async fn pip_tree(
     .render()
     .join("\n");
 
-    writeln!(printer.stdout(), "{rendered_tree}")?;
+    if !rendered_tree.is_empty() {
+        writeln!(printer.stdout(), "{rendered_tree}")?;
+    }
 
     if rendered_tree.contains("(*)") {
         let message = if no_dedupe {

--- a/crates/uv/tests/pip/pip_tree.rs
+++ b/crates/uv/tests/pip/pip_tree.rs
@@ -18,7 +18,6 @@ fn no_package() {
     exit_code: 0
     ----- stdout -----
 
-
     ----- stderr -----
     "
     );


### PR DESCRIPTION
## Summary

When `uv pip tree` ran in an environment without installed packages, we rendered an empty tree and still wrote it with `writeln!`, producing an unnecessary blank line.

Skip writing the rendered tree when it is empty. The existing empty-environment snapshot now expects no stdout.

Closes https://github.com/astral-sh/uv/issues/20000.
