### PR TITLE
Reuse proven-safe resolver decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,8 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79d771681f6c21ebe25dda598774b6e6badca8b720ce2168df7788b2821c46d"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=66d45efb9e01551924cac41918c3e8fe6f785318#66d45efb9e01551924cac41918c3e8fe6f785318"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -293,8 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086f936efdefab117f5a72367fb3d68c4fded8ba5a7008e3c63365eecf723822"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=66d45efb9e01551924cac41918c3e8fe6f785318#66d45efb9e01551924cac41918c3e8fe6f785318"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -457,3 +457,7 @@ codegen-units = 1
 # The profile that 'cargo dist' will build with.
 [profile.dist]
 inherits = "release"
+
+[patch.crates-io]
+astral-pubgrub = { git = "https://github.com/astral-sh/pubgrub.git", rev = "66d45efb9e01551924cac41918c3e8fe6f785318" }
+astral-version-ranges = { git = "https://github.com/astral-sh/pubgrub.git", rev = "66d45efb9e01551924cac41918c3e8fe6f785318" }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -513,14 +513,14 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         .expect("a package was chosen but we don't have a term");
                     let range = term_intersection.unwrap_positive();
 
-                    // In a specific environment, an implicit registry candidate is stable for a
-                    // given range. Avoid repeating candidate selection when PubGrub revisits an
-                    // identical decision after backtracking. If the range changed, reuse the
-                    // previous decision only when every better candidate is already known to
-                    // conflict with the current partial solution.
-                    let cache_selected_version = state.env.marker_environment().is_some()
-                        && url.is_none()
-                        && index.is_none();
+                    // An implicit registry candidate is stable for a given range. Avoid
+                    // repeating candidate selection when PubGrub revisits an identical decision
+                    // after backtracking. If the range changed, reuse the previous decision only
+                    // when every better candidate is already known to conflict with the current
+                    // partial solution. This is safe in universal resolution because we only
+                    // cache unforked decisions; any better candidate that can fork is neither
+                    // unavailable nor known to conflict, so it prevents reuse.
+                    let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -515,16 +515,41 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
                     // In a specific environment, an implicit registry candidate is stable for a
                     // given range. Avoid repeating candidate selection when PubGrub revisits an
-                    // identical decision after backtracking.
+                    // identical decision after backtracking. If the range changed, reuse the
+                    // previous decision only when every better candidate is already known to
+                    // conflict with the current partial solution.
                     let cache_selected_version = state.env.marker_environment().is_some()
                         && url.is_none()
                         && index.is_none();
-                    let decision = if cache_selected_version
+                    let phase_saved = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
-                        && selected_range == range
                     {
-                        Some(ResolverVersion::Unforked(version.clone()))
+                        let same_range = selected_range == range;
+                        let changed_range = if let Some(name) = next_package.name() {
+                            !same_range
+                                && range.contains(version)
+                                && preferences.get(name).is_empty()
+                                && (self.exclusions.reinstall(name)
+                                    || self.installed_packages.get_packages(name).is_empty())
+                                && self.all_better_versions_conflict(
+                                    name,
+                                    range,
+                                    version,
+                                    next_id,
+                                    &state.pubgrub,
+                                    &state.env,
+                                    &state.python_requirement,
+                                )?
+                        } else {
+                            false
+                        };
+                        (same_range || changed_range).then(|| version.clone())
+                    } else {
+                        None
+                    };
+                    let decision = if let Some(version) = phase_saved {
+                        Some(ResolverVersion::Unforked(version))
                     } else {
                         let decision = self.choose_version(
                             next_package,
@@ -1454,6 +1479,58 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         let version = candidate.version().clone();
         Ok(Some(ResolverVersion::Unforked(version)))
+    }
+
+    /// Return whether every registry candidate preferred over `selected` is already known to be
+    /// unavailable or incompatible with the current partial solution.
+    fn all_better_versions_conflict(
+        &self,
+        name: &PackageName,
+        range: &Range<Version>,
+        selected: &Version,
+        package: Id<PubGrubPackage>,
+        pubgrub: &State<UvDependencyProvider>,
+        env: &ResolverEnvironment,
+        python_requirement: &PythonRequirement,
+    ) -> Result<bool, ResolveError> {
+        let versions_response = self
+            .index
+            .implicit()
+            .wait_blocking(name)
+            .map_err(|_| ResolveError::UnregisteredTask(name.to_string()))?;
+        let VersionsResponse::Found(version_maps) = &*versions_response else {
+            return Ok(false);
+        };
+
+        let highest = self.selector.use_highest_version(name, env);
+        let mut remaining = if highest {
+            range.intersection(&Range::strictly_higher_than(selected.clone()))
+        } else {
+            range.intersection(&Range::strictly_lower_than(selected.clone()))
+        };
+        while let Some(candidate) =
+            self.selector
+                .select_no_preference(name, &remaining, version_maps, env)
+        {
+            let version = candidate.version().clone();
+            let unavailable = match candidate.dist() {
+                CandidateDist::Incompatible { .. } => true,
+                CandidateDist::Compatible(dist) => {
+                    Self::check_requires_python(dist, python_requirement).is_some()
+                }
+            };
+            if !unavailable
+                && !pubgrub.version_conflicts_with_partial_solution(package, version.clone())
+            {
+                return Ok(false);
+            }
+            remaining = if highest {
+                remaining.intersection(&Range::strictly_lower_than(version))
+            } else {
+                remaining.intersection(&Range::strictly_higher_than(version))
+            };
+        }
+        Ok(true)
     }
 
     /// Determine whether a candidate covers all supported platforms; and, if not, generate a fork.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -521,34 +521,33 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     let cache_selected_version = state.env.marker_environment().is_some()
                         && url.is_none()
                         && index.is_none();
-                    let phase_saved = if cache_selected_version
+                    let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
                     {
-                        let same_range = selected_range == range;
-                        let changed_range = if let Some(name) = next_package.name() {
-                            !same_range
-                                && range.contains(version)
-                                && preferences.get(name).is_empty()
-                                && (self.exclusions.reinstall(name)
-                                    || self.installed_packages.get_packages(name).is_empty())
-                                && self.all_better_versions_conflict(
-                                    name,
-                                    range,
-                                    version,
-                                    next_id,
-                                    &state.pubgrub,
-                                    &state.env,
-                                    &state.python_requirement,
-                                )?
-                        } else {
-                            false
-                        };
-                        (same_range || changed_range).then(|| version.clone())
+                        let can_reuse = selected_range == range
+                            || if let Some(name) = next_package.name() {
+                                range.contains(version)
+                                    && preferences.get(name).is_empty()
+                                    && (self.exclusions.reinstall(name)
+                                        || self.installed_packages.get_packages(name).is_empty())
+                                    && self.all_better_versions_conflict(
+                                        name,
+                                        range,
+                                        version,
+                                        next_id,
+                                        &state.pubgrub,
+                                        &state.env,
+                                        &state.python_requirement,
+                                    )?
+                            } else {
+                                false
+                            };
+                        can_reuse.then(|| version.clone())
                     } else {
                         None
                     };
-                    let decision = if let Some(version) = phase_saved {
+                    let decision = if let Some(version) = reusable_version {
                         Some(ResolverVersion::Unforked(version))
                     } else {
                         let decision = self.choose_version(
@@ -1513,13 +1512,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 .select_no_preference(name, &remaining, version_maps, env)
         {
             let version = candidate.version().clone();
-            let unavailable = match candidate.dist() {
-                CandidateDist::Incompatible { .. } => true,
-                CandidateDist::Compatible(dist) => {
-                    Self::check_requires_python(dist, python_requirement).is_some()
-                }
-            };
-            if !unavailable
+            if let CandidateDist::Compatible(dist) = candidate.dist()
+                && Self::check_requires_python(dist, python_requirement).is_none()
                 && !pubgrub.version_conflicts_with_partial_solution(package, version.clone())
             {
                 return Ok(false);

--- a/crates/uv/tests/it/snapshots/it__ecosystem__transformers-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__transformers-lock-file.snap
@@ -5302,9 +5302,14 @@ wheels = [
 name = "tf2onnx"
 version = "1.8.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.10' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
 dependencies = [
-    { name = "flatbuffers", version = "1.12", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
-    { name = "flatbuffers", version = "24.3.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
+    { name = "flatbuffers", version = "24.3.25", source = { registry = "https://pypi.org/simple" } },
     { name = "numpy" },
     { name = "onnx" },
     { name = "requests" },
@@ -5312,6 +5317,35 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/32/33ce509a79c207a39cf04bfa3ec3353da15d1e6553a6ad912f117cc29130/tf2onnx-1.8.4-py3-none-any.whl", hash = "sha256:1ebabb96c914da76e23222b6107a8b248a024bf259d77f027e6690099512d457", size = 345298, upload-time = "2021-03-17T19:37:21.224Z" },
+]
+
+[[package]]
+name = "tf2onnx"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.10.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+dependencies = [
+    { name = "flatbuffers", version = "1.12", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "protobuf", version = "3.20.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "requests" },
+    { name = "six" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/48/826db3d02645d84e7ee5d5ce8407f771057d40fe224d9c3e89536674ccef/tf2onnx-1.16.1-py3-none-any.whl", hash = "sha256:90fb5f62575896d47884d27dc313cfebff36b8783e1094335ad00824ce923a8a", size = 455820, upload-time = "2024-01-16T10:30:19.345Z" },
 ]
 
 [[package]]
@@ -5627,7 +5661,8 @@ all = [
     { name = "tensorflow", version = "2.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
     { name = "tensorflow-text", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "tensorflow-text", version = "2.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
-    { name = "tf2onnx" },
+    { name = "tf2onnx", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
+    { name = "tf2onnx", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "timm" },
     { name = "tokenizers" },
     { name = "torch" },
@@ -5707,7 +5742,8 @@ docs = [
     { name = "tensorflow", version = "2.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
     { name = "tensorflow-text", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "tensorflow-text", version = "2.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
-    { name = "tf2onnx" },
+    { name = "tf2onnx", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
+    { name = "tf2onnx", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "timm" },
     { name = "tokenizers" },
     { name = "torch" },
@@ -5755,7 +5791,8 @@ onnx = [
     { name = "onnxconverter-common", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "onnxruntime" },
     { name = "onnxruntime-tools" },
-    { name = "tf2onnx" },
+    { name = "tf2onnx", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
+    { name = "tf2onnx", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
 ]
 onnxruntime = [
     { name = "onnxruntime" },
@@ -5814,7 +5851,8 @@ tf = [
     { name = "tensorflow", version = "2.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
     { name = "tensorflow-text", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "tensorflow-text", version = "2.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
-    { name = "tf2onnx" },
+    { name = "tf2onnx", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
+    { name = "tf2onnx", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
 ]
 tf-cpu = [
     { name = "keras-nlp" },
@@ -5824,7 +5862,8 @@ tf-cpu = [
     { name = "tensorflow-cpu", version = "2.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
     { name = "tensorflow-text", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "tensorflow-text", version = "2.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
-    { name = "tf2onnx" },
+    { name = "tf2onnx", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
+    { name = "tf2onnx", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
 ]
 tf-speech = [
     { name = "kenlm" },
@@ -5936,7 +5975,8 @@ dev = [
     { name = "tensorflow", version = "2.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
     { name = "tensorflow-text", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "tensorflow-text", version = "2.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
-    { name = "tf2onnx" },
+    { name = "tf2onnx", version = "1.8.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.13' and sys_platform == 'darwin')" },
+    { name = "tf2onnx", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version >= '3.10' and sys_platform != 'darwin')" },
     { name = "timeout-decorator" },
     { name = "timm" },
     { name = "tokenizers" },

--- a/crates/uv/tests/it/snapshots/it__ecosystem__transformers-uv-lock-output.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__transformers-uv-lock-output.snap
@@ -7,4 +7,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-Resolved 303 packages in [TIME]
+Resolved 304 packages in [TIME]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -13102,6 +13102,50 @@ fn lock_upgrade_drop_fork_markers() -> Result<()> {
     Ok(())
 }
 
+/// Check that phase-saving preserves universal forks after backtracking.
+#[test]
+fn lock_phase_saving_preserves_universal_forks() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "forking"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["foo", "baz"]
+        "#,
+    )?;
+
+    context
+        .lock()
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .assert()
+        .success();
+
+    let lock = context.read("uv.lock");
+    assert!(lock.contains("name = \"foo\"\nversion = \"1.0.0\""));
+    assert!(!lock.contains("name = \"foo\"\nversion = \"2.0.0\""));
+    assert!(lock.contains("name = \"bar\"\nversion = \"1.0.0\""));
+    assert!(lock.contains("name = \"bar\"\nversion = \"2.0.0\""));
+
+    context
+        .lock()
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--locked")
+        .assert()
+        .success();
+    assert_eq!(lock, context.read("uv.lock"));
+
+    Ok(())
+}
+
 /// Warn when there are missing bounds on transitive dependencies with `--resolution lowest`.
 #[test]
 fn lock_warn_missing_transitive_lower_bounds() -> Result<()> {

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -3357,6 +3357,167 @@ fn fork_overlapping_markers_basic() -> Result<()> {
     Ok(())
 }
 
+/// This test checks that phase-saving preserves universal forks after backtracking.
+///
+///
+/// ```text
+/// phase-saving
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   ├── requires baz
+/// │   │   └── satisfied by baz-1.0.0
+/// │   └── requires foo
+/// │       ├── satisfied by foo-1.0.0
+/// │       └── satisfied by foo-2.0.0
+/// ├── bar
+/// │   ├── bar-1.0.0
+/// │   └── bar-2.0.0
+/// ├── baz
+/// │   └── baz-1.0.0
+/// │       ├── requires bar==1 ; sys_platform == 'linux'
+/// │       │   └── satisfied by bar-1.0.0
+/// │       └── requires bar==2 ; sys_platform != 'linux'
+/// │           └── satisfied by bar-2.0.0
+/// └── foo
+///     ├── foo-1.0.0
+///     │   ├── requires bar==1 ; sys_platform == 'linux'
+///     │   │   └── satisfied by bar-1.0.0
+///     │   └── requires bar==2 ; sys_platform != 'linux'
+///     │       └── satisfied by bar-2.0.0
+///     └── foo-2.0.0
+///         └── requires bar==2
+///             └── satisfied by bar-2.0.0
+/// ```
+#[test]
+fn phase_saving() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''foo''',
+          '''baz''',
+        ]
+        requires-python = ">=3.12"
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "sys_platform == 'linux'",
+            "sys_platform != 'linux'",
+        ]
+
+        [[package]]
+        name = "bar"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform == 'linux'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/bar-1.0.0.tar.gz", hash = "sha256:d373f4858d602855ef53231a7f24ebff4e67e1fe30a2e810ee2b2a29b9d1a50a", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/bar-1.0.0-py3-none-any.whl", hash = "sha256:2fbf0e0a7dd4f48a8b1c2148f73ba0c314699d0bfa0a8ec9b9bcb8105882e9fc", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "bar"
+        version = "2.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform != 'linux'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/bar-2.0.0.tar.gz", hash = "sha256:fa9a4faf506228722784ed740a362bccd96913f4f98a4e10d45ab79d8abb270a", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/bar-2.0.0-py3-none-any.whl", hash = "sha256:563b1af3238a4ad819f2b95b74f940319a2ef30ed7991a2416fa98aa115da87d", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "baz"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "bar", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'linux'" },
+            { name = "bar", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'linux'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/baz-1.0.0.tar.gz", hash = "sha256:cd4bd6d8d98df82464c3de47bd1c0d1fd3b5b8d13ce934f20cf72d4d7a4458d7", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/baz-1.0.0-py3-none-any.whl", hash = "sha256:32eb7602c0ca51b0ffb5e40ad804254a73117157e64c9edb697d1540b3f10bdf", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "foo"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "bar", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'linux'" },
+            { name = "bar", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'linux'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/foo-1.0.0.tar.gz", hash = "sha256:b7939168304bd17ae9606ea29edf36907eea6e1a10116335e927986680fd25a8", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/foo-1.0.0-py3-none-any.whl", hash = "sha256:b96e9e502ccd1918e47b93ecb446956c037f6855a7edadca5bc9365803cd106f", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "baz" },
+            { name = "foo" },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "baz" },
+            { name = "foo" },
+        ]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 /// This test contains a bistable resolution scenario when not using ahead-of-time
 /// splitting of resolution forks: We meet one of two fork points depending on the
 /// preferences, creating a resolution whose preferences lead us the other fork

--- a/test/scenarios/fork/phase-saving.toml
+++ b/test/scenarios/fork/phase-saving.toml
@@ -1,0 +1,31 @@
+name = "phase-saving"
+description = '''
+This test checks that phase-saving preserves universal forks after backtracking.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["foo", "baz"]
+
+[packages.foo.versions."1.0.0"]
+requires = [
+  "bar==1; sys_platform == 'linux'",
+  "bar==2; sys_platform != 'linux'",
+]
+
+[packages.foo.versions."2.0.0"]
+requires = ["bar==2"]
+
+[packages.baz.versions."1.0.0"]
+requires = [
+  "bar==1; sys_platform == 'linux'",
+  "bar==2; sys_platform != 'linux'",
+]
+
+[packages.bar.versions."1.0.0"]
+[packages.bar.versions."2.0.0"]


### PR DESCRIPTION
## Summary

Phase saving (also called called [“progress saving”](https://doi.org/10.1007/978-3-540-72788-0_29)) is a backtracking-search technique for avoiding repeated work. When non-chronological backtracking erases assignments that were unrelated to the conflict, the solver remembers those assignments and prefers them when the corresponding variables are selected again. This helps the solver recover a previously discovered partial solution instead of reconstructing it from scratch.

PubGrub exhibits an analogous pattern during dependency resolution: after backtracking, it can revisit a package for which uv has already selected a version. [#20020](https://github.com/astral-sh/uv/pull/20020) introduced a limited form of phase saving by caching the selected version and reusing it when PubGrub revisits the package with exactly the same allowed range. This PR extends that optimization to changed ranges and to universal resolution, avoiding repeated candidate selection and compatibility work.

Unlike a SAT solver, however, uv cannot apply phase saving unconditionally. A SAT solver only needs to find any satisfying assignment, so changing the order in which assignments are explored does not change correctness. uv must also respect its version-selection strategy and produce a maximal solution. For example, if uv previously selected `1.0.0` from `<2` and backtracking later widens the range to `<3`, blindly reusing `1.0.0` could produce a valid but stale solution even though `2.0.0` is now available.

Now, when the allowed range is unchanged, we reuse the previous implicit-registry decision as before. But when the range has changed, we only reuse the saved version if it remains allowed, no lockfile preference or installed distribution changes the candidate ordering, and every candidate preferred over it is already unavailable or incompatible with the current partial solution. For this, we introduce a [`State::version_conflicts_with_partial_solution`](https://github.com/astral-sh/pubgrub/pull/73) query to evaluate a hypothetical version decision against the incompatibilities already known to the current solver state.

The proof is recomputed whenever the package is revisited rather than cached alongside the version. If backtracking removes an assignment that previously ruled out a better candidate, the PubGrub query no longer reports a conflict and uv considers that candidate normally. This preserves maximal version selection while retaining the work-reuse benefit of phase saving.

Here is the net effect on the number of versions visited for our ecosystem projects:

| Benchmark      | Before | After | Change |
| -------------- | -----: | ----: | -----: |
| Transformers   |  4,642 | 3,993 | -14.0% |
| Jupyter        |  2,215 | 1,761 | -20.5% |
| Home Assistant |    256 |   256 |   0.0% |
| Warehouse      |  2,491 | 1,038 | -58.3% |
| Total          |  9,604 | 7,048 | -26.6% |

This is stacked on [astral-sh/pubgrub#73](https://github.com/astral-sh/pubgrub/pull/73) and temporarily pins `astral-pubgrub` and `astral-version-ranges` to that commit until the companion API is released.
