### PR TITLE
Cache proven phase-saving candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.5.0"
-source = "git+https://github.com/astral-sh/pubgrub.git?rev=66d45efb9e01551924cac41918c3e8fe6f785318#66d45efb9e01551924cac41918c3e8fe6f785318"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=9c96d5c41536e535f94c8495f62afa08ad6420bd#9c96d5c41536e535f94c8495f62afa08ad6420bd"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/pubgrub.git?rev=66d45efb9e01551924cac41918c3e8fe6f785318#66d45efb9e01551924cac41918c3e8fe6f785318"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=9c96d5c41536e535f94c8495f62afa08ad6420bd#9c96d5c41536e535f94c8495f62afa08ad6420bd"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -459,5 +459,5 @@ codegen-units = 1
 inherits = "release"
 
 [patch.crates-io]
-astral-pubgrub = { git = "https://github.com/astral-sh/pubgrub.git", rev = "66d45efb9e01551924cac41918c3e8fe6f785318" }
-astral-version-ranges = { git = "https://github.com/astral-sh/pubgrub.git", rev = "66d45efb9e01551924cac41918c3e8fe6f785318" }
+astral-pubgrub = { git = "https://github.com/astral-sh/pubgrub.git", rev = "9c96d5c41536e535f94c8495f62afa08ad6420bd" }
+astral-version-ranges = { git = "https://github.com/astral-sh/pubgrub.git", rev = "9c96d5c41536e535f94c8495f62afa08ad6420bd" }

--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashMap;
 
 use uv_distribution_types::{CompatibleDist, DistributionId, Identifier, ResolvedDist};
 use uv_normalize::PackageName;
+use uv_pep508::MarkerTree;
 
 use crate::candidate_selector::Candidate;
 
@@ -11,6 +12,8 @@ struct FilePin {
     dist: ResolvedDist,
     /// The concrete distribution whose metadata was used during resolution.
     metadata_id: DistributionId,
+    /// The environments supported by the selected distribution.
+    implied_markers: MarkerTree,
 }
 
 /// A set of package versions pinned to specific files.
@@ -34,6 +37,7 @@ impl FilePins {
             .or_insert_with(|| FilePin {
                 dist: dist.for_installation().to_owned(),
                 metadata_id: dist.for_resolution().distribution_id(),
+                implied_markers: dist.implied_markers(),
             });
     }
 
@@ -57,5 +61,16 @@ impl FilePins {
         self.0
             .get(&(name.clone(), version.clone()))
             .map(|pin| (&pin.dist, &pin.metadata_id))
+    }
+
+    /// Return the environments supported by the pinned distribution.
+    pub(crate) fn implied_markers(
+        &self,
+        name: &PackageName,
+        version: &uv_pep440::Version,
+    ) -> Option<MarkerTree> {
+        self.0
+            .get(&(name.clone(), version.clone()))
+            .map(|pin| pin.implied_markers)
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -513,10 +513,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         .expect("a package was chosen but we don't have a term");
                     let range = term_intersection.unwrap_positive();
 
-                    // Reuse an implicit registry version after backtracking. If the range changed,
-                    // only use it as a hint when every preferred candidate conflicts with the
-                    // current partial solution. Candidate evaluation below still reruns
-                    // fork-sensitive checks.
+                    // Reuse a saved registry version after backtracking. If the allowed range
+                    // changed, only try it first after PubGrub has ruled out every preferred
+                    // version. The saved version still goes through the normal checks below.
                     let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
@@ -535,7 +534,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                         next_id,
                                         &state.pubgrub,
                                         &state.env,
-                                        &mut state.candidate_coverage,
+                                        &mut state.checked_candidates,
                                     )?
                             } else {
                                 false
@@ -911,7 +910,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // there is at least one more fork to visit.
         let package = current_state.next;
         let mut current_state = current_state;
-        current_state.candidate_coverage = FxHashMap::default();
+        current_state.checked_candidates = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
         forks
@@ -970,7 +969,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // into `forked_states`, and then only clone it if
         // there is at least one more fork to visit.
         let mut current_state = current_state;
-        current_state.candidate_coverage = FxHashMap::default();
+        current_state.checked_candidates = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
         forks.into_iter().enumerate().map(move |(i, fork)| {
@@ -1362,8 +1361,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         debug!("Searching for a compatible version of {package} ({range})");
 
-        // Find a version. A phase-saved version narrows only candidate lookup; candidate
-        // evaluation still receives the full allowed range below.
+        // If a version was saved, look it up alone. Checks below still receive the full allowed
+        // range.
         let select = |range| {
             self.selector.select(
                 name,
@@ -1489,8 +1488,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         Ok(Some(ResolverVersion::Unforked(version)))
     }
 
-    /// Return whether every registry candidate preferred over `selected` is already known to be
-    /// statically unavailable or incompatible with the current partial solution.
+    /// Return whether every registry version preferred over `selected` is unavailable or
+    /// conflicts with the current PubGrub state.
     fn all_preferred_versions_conflict(
         &self,
         name: &PackageName,
@@ -1499,7 +1498,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         package: Id<PubGrubPackage>,
         pubgrub: &State<UvDependencyProvider>,
         env: &ResolverEnvironment,
-        candidate_coverage: &mut FxHashMap<Id<PubGrubPackage>, CandidateCoverage>,
+        checked_candidates: &mut FxHashMap<Id<PubGrubPackage>, CheckedCandidates>,
     ) -> Result<bool, ResolveError> {
         let versions_response = self
             .index
@@ -1517,16 +1516,15 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             range.intersection(&Range::strictly_lower_than(selected.clone()))
         };
 
-        // PubGrub reasons over mathematical version ranges, while package indexes expose a finite
-        // set of actual versions. Remember the selector-compatible registry candidates we already
-        // inspected so a later revisit in the same fork can prove that finite set conflicts
-        // without selecting every candidate again.
-        if let Some(cache) = candidate_coverage.get(&package)
-            && remaining.subset_of(&cache.checked)
+        // PubGrub works with ranges, but package indexes contain a fixed list of versions.
+        // Remember which versions the selector could choose so we can check them together on the
+        // next visit.
+        if let Some(checked) = checked_candidates.get(&package)
+            && remaining.subset_of(&checked.range)
         {
-            let selectable = remaining.intersection(&cache.selectable);
-            if selectable.is_empty()
-                || pubgrub.range_conflicts_with_partial_solution(package, selectable)
+            let versions = remaining.intersection(&checked.versions);
+            if versions.is_empty()
+                || pubgrub.range_conflicts_with_partial_solution(package, versions)
             {
                 return Ok(true);
             }
@@ -1535,8 +1533,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         if pubgrub.range_conflicts_with_partial_solution(package, remaining.clone()) {
             return Ok(true);
         }
-        let checked = remaining.clone();
-        let mut selectable_versions = Vec::new();
+        let checked_range = remaining.clone();
+        let mut candidate_versions = Vec::new();
         while let Some(candidate) =
             self.selector
                 .select_no_preference(name, &remaining, version_maps, env)
@@ -1546,7 +1544,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 if !pubgrub.version_conflicts_with_partial_solution(package, version.clone()) {
                     return Ok(false);
                 }
-                selectable_versions.push(version.clone());
+                candidate_versions.push(version.clone());
             }
             remaining = if highest {
                 remaining.intersection(&Range::strictly_lower_than(version))
@@ -1554,25 +1552,24 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 remaining.intersection(&Range::strictly_higher_than(version))
             };
         }
-        // Candidate selection visits versions in preference order. Reverse highest-resolution
-        // candidates so the range constructor receives both modes in ascending order and can
-        // append each disjoint singleton without repeatedly shifting existing segments.
+        // `Range` expects ascending bounds. Reverse versions selected from highest to lowest so it
+        // can append them without moving earlier entries.
         if highest {
-            selectable_versions.reverse();
+            candidate_versions.reverse();
         }
-        let selectable = selectable_versions
+        let versions = candidate_versions
             .into_iter()
             .map(|version| (Bound::Included(version.clone()), Bound::Included(version)))
             .collect::<Range<_>>();
-        candidate_coverage
+        checked_candidates
             .entry(package)
-            .and_modify(|cache| {
-                cache.checked = cache.checked.union(&checked);
-                cache.selectable = cache.selectable.union(&selectable);
+            .and_modify(|checked| {
+                checked.range = checked.range.union(&checked_range);
+                checked.versions = checked.versions.union(&versions);
             })
-            .or_insert(CandidateCoverage {
-                checked,
-                selectable,
+            .or_insert(CheckedCandidates {
+                range: checked_range,
+                versions,
             });
         Ok(true)
     }
@@ -3098,10 +3095,10 @@ pub(crate) struct ForkState {
     pre_visited: FxHashMap<Id<PubGrubPackage>, Range<Version>>,
     /// The last version selected for each package and range in a specific environment.
     selected_versions: FxHashMap<Id<PubGrubPackage>, (Range<Version>, Version)>,
-    /// Cached registry candidate coverage used to prove a saved version remains maximal.
+    /// Registry versions checked while deciding whether to reuse a saved version.
     ///
-    /// This is scoped to one fork because candidate selection depends on its markers.
-    candidate_coverage: FxHashMap<Id<PubGrubPackage>, CandidateCoverage>,
+    /// This is cleared after a fork because available versions depend on the environment.
+    checked_candidates: FxHashMap<Id<PubGrubPackage>, CheckedCandidates>,
     /// The marker expression that created this state.
     ///
     /// The root state always corresponds to a marker expression that is always
@@ -3156,7 +3153,7 @@ impl ForkState {
             added_dependencies: FxHashMap::default(),
             pre_visited: FxHashMap::default(),
             selected_versions: FxHashMap::default(),
-            candidate_coverage: FxHashMap::default(),
+            checked_candidates: FxHashMap::default(),
             env,
             python_requirement,
             conflict_tracker: ConflictTracker::default(),
@@ -3414,7 +3411,7 @@ impl ForkState {
     /// Python requirement), then this returns `None`.
     fn with_env(mut self, env: ResolverEnvironment) -> Self {
         self.selected_versions.clear();
-        self.candidate_coverage.clear();
+        self.checked_candidates.clear();
         self.env = env;
         // If the fork contains a narrowed Python requirement, apply it.
         if let Some(req) = self.env.narrow_python_requirement(&self.python_requirement) {
@@ -3701,11 +3698,11 @@ impl ForkState {
 }
 
 #[derive(Clone)]
-struct CandidateCoverage {
-    /// Mathematical ranges for which every actual registry candidate was inspected.
-    checked: Range<Version>,
-    /// Selector-compatible candidates within checked; state-dependent checks are excluded.
-    selectable: Range<Version>,
+struct CheckedCandidates {
+    /// Ranges where every index version was checked.
+    range: Range<Version>,
+    /// Versions that the candidate selector can choose.
+    versions: Range<Version>,
 }
 
 /// The resolution from a single fork including the virtual packages and the edges between them.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -916,6 +916,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // there is at least one more fork to visit.
         let package = current_state.next;
         let mut current_state = current_state;
+        current_state.selected_versions = FxHashMap::default();
         current_state.checked_candidates = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
@@ -975,6 +976,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // into `forked_states`, and then only clone it if
         // there is at least one more fork to visit.
         let mut current_state = current_state;
+        current_state.selected_versions = FxHashMap::default();
         current_state.checked_candidates = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -515,14 +515,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
                     // Reuse a saved registry version after backtracking. If the allowed range
                     // changed, only try it first after PubGrub has ruled out every preferred
-                    // version. The saved version still goes through the normal checks below.
+                    // version. Candidate compatibility is stable within a fork; required-
+                    // environment reachability is revalidated below.
                     let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
                     {
                         let can_reuse = selected_range == range
-                            || if let Some(name) = next_package.name()
+                            || if !version.is_local()
+                                && let Some(name) = next_package.name()
                                 && !uses_index_priority(
                                     *self.selector.index_strategy(),
                                     self.options.torch_backend.as_ref(),
@@ -549,21 +551,41 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     } else {
                         None
                     };
-                    let decision = self.choose_version(
-                        next_package,
-                        next_id,
-                        index.map(IndexMetadata::url),
-                        range,
-                        reusable_version.as_ref(),
-                        &mut state.pins,
-                        &preferences,
-                        &state.fork_urls,
-                        &state.env,
-                        &state.python_requirement,
-                        &state.pubgrub,
-                        &mut visited,
-                        request_sink,
-                    )?;
+                    let saved_decision = reusable_version.and_then(|version| {
+                        let Some(name) = next_package.name() else {
+                            return Some(ResolverVersion::Unforked(version));
+                        };
+                        let implied_markers = state.pins.implied_markers(name, &version)?;
+                        Some(
+                            self.fork_version_for_required_environment(
+                                &version,
+                                implied_markers,
+                                next_id,
+                                name,
+                                &state.env,
+                                &state.pubgrub,
+                            )
+                            .unwrap_or(ResolverVersion::Unforked(version)),
+                        )
+                    });
+                    let decision = if let Some(decision) = saved_decision {
+                        Some(decision)
+                    } else {
+                        self.choose_version(
+                            next_package,
+                            next_id,
+                            index.map(IndexMetadata::url),
+                            range,
+                            &mut state.pins,
+                            &preferences,
+                            &state.fork_urls,
+                            &state.env,
+                            &state.python_requirement,
+                            &state.pubgrub,
+                            &mut visited,
+                            request_sink,
+                        )?
+                    };
 
                     if cache_selected_version
                         && let Some(ResolverVersion::Unforked(version)) = &decision
@@ -1137,7 +1159,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         id: Id<PubGrubPackage>,
         index: Option<&IndexUrl>,
         range: &Range<Version>,
-        saved_version: Option<&Version>,
         pins: &mut FilePins,
         preferences: &Preferences,
         fork_urls: &ForkUrls,
@@ -1180,7 +1201,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         name,
                         index,
                         range,
-                        saved_version,
                         preferences,
                         env,
                         python_requirement,
@@ -1322,7 +1342,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         name: &PackageName,
         index: Option<&IndexUrl>,
         range: &Range<Version>,
-        saved_version: Option<&Version>,
         preferences: &Preferences,
         env: &ResolverEnvironment,
         python_requirement: &PythonRequirement,
@@ -1369,28 +1388,17 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         debug!("Searching for a compatible version of {package} ({range})");
 
-        // If a version was saved, look it up alone. Checks below still receive the full allowed
-        // range.
-        let select = |range| {
-            self.selector.select(
-                name,
-                range,
-                version_maps,
-                preferences,
-                &self.installed_packages,
-                &self.exclusions,
-                index,
-                env,
-                self.tags.as_ref(),
-            )
-        };
-        let candidate = if let Some(saved_version) = saved_version {
-            let saved_range = Range::singleton(saved_version.clone());
-            select(&saved_range).or_else(|| select(range))
-        } else {
-            select(range)
-        };
-        let Some(candidate) = candidate else {
+        let Some(candidate) = self.selector.select(
+            name,
+            range,
+            version_maps,
+            preferences,
+            &self.installed_packages,
+            &self.exclusions,
+            index,
+            env,
+            self.tags.as_ref(),
+        ) else {
             // Short circuit: we couldn't find _any_ versions for a package.
             return Ok(None);
         };
@@ -1610,6 +1618,19 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         pins: &mut FilePins,
         request_sink: &Sender<Request>,
     ) -> Result<Option<ResolverVersion>, ResolveError> {
+        let implied_markers = dist.implied_markers();
+
+        if let Some(forked) = self.fork_version_for_required_environment(
+            candidate.version(),
+            implied_markers,
+            id,
+            name,
+            env,
+            pubgrub,
+        ) {
+            return Ok(Some(forked));
+        }
+
         // This only applies to universal resolutions.
         if env.marker_environment().is_some() {
             return Ok(None);
@@ -1617,55 +1638,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         // If the package is already compatible with all environments (as is the case for
         // packages that include a source distribution), we don't need to fork.
-        if dist.implied_markers().is_true() {
+        if implied_markers.is_true() {
             return Ok(None);
-        }
-
-        // If the caller marked an environment as requiring artifact coverage, ensure it has
-        // coverage.
-        for marker in self.options.artifact_environments.iter().copied() {
-            // If the platform is part of the current environment...
-            if env.included_by_marker(marker) {
-                // But isn't supported by the distribution...
-                if dist.implied_markers().is_disjoint(marker)
-                    && !find_environments(id, pubgrub).is_disjoint(marker)
-                {
-                    // Then we need to fork.
-                    let Some((left, right)) = fork_version_by_marker(env, marker) else {
-                        return Ok(Some(ResolverVersion::Unavailable(
-                            candidate.version().clone(),
-                            UnavailableVersion::IncompatibleDist(IncompatibleDist::Wheel(
-                                IncompatibleWheel::MissingPlatform(marker),
-                            )),
-                        )));
-                    };
-
-                    debug!(
-                        "Forking on required platform `{}` for {}=={} ({})",
-                        marker.try_to_string().unwrap_or_else(|| "true".to_string()),
-                        name,
-                        candidate.version(),
-                        [&left, &right]
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    );
-                    let forks = vec![
-                        VersionFork {
-                            env: left,
-                            id,
-                            version: None,
-                        },
-                        VersionFork {
-                            env: right,
-                            id,
-                            version: None,
-                        },
-                    ];
-                    return Ok(Some(ResolverVersion::Forked(forks)));
-                }
-            }
         }
 
         // For now, we only apply this to local versions.
@@ -1704,7 +1678,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // ...and the non-local version has greater platform support...
         let mut remainder = {
             let mut remainder = base_dist.implied_markers();
-            remainder.and(dist.implied_markers().negate());
+            remainder.and(implied_markers.negate());
             remainder
         };
         if remainder.is_false() {
@@ -1720,7 +1694,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         // Similarly, if the local distribution is incompatible with the current environment, then
         // use the base distribution instead (but don't fork).
-        if !env.included_by_marker(dist.implied_markers()) {
+        if !env.included_by_marker(implied_markers) {
             let filename = match dist.for_installation() {
                 ResolvedDistRef::InstallableRegistrySourceDist { sdist, .. } => sdist
                     .filename()
@@ -1770,9 +1744,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 operator: MarkerOperator::Equal,
                 value,
             });
-            if dist.implied_markers().is_disjoint(sys_platform)
-                && !remainder.is_disjoint(sys_platform)
-            {
+            if implied_markers.is_disjoint(sys_platform) && !remainder.is_disjoint(sys_platform) {
                 remainder.or(sys_platform);
             }
         }
@@ -1815,6 +1787,62 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             },
         ];
         Ok(Some(ResolverVersion::Forked(forks)))
+    }
+
+    /// Check required-environment coverage for a version.
+    fn fork_version_for_required_environment(
+        &self,
+        version: &Version,
+        implied_markers: MarkerTree,
+        id: Id<PubGrubPackage>,
+        name: &PackageName,
+        env: &ResolverEnvironment,
+        pubgrub: &State<UvDependencyProvider>,
+    ) -> Option<ResolverVersion> {
+        if env.marker_environment().is_some() || implied_markers.is_true() {
+            return None;
+        }
+
+        for marker in self.options.artifact_environments.iter().copied() {
+            if env.included_by_marker(marker)
+                && implied_markers.is_disjoint(marker)
+                && !find_environments(id, pubgrub).is_disjoint(marker)
+            {
+                let Some((left, right)) = fork_version_by_marker(env, marker) else {
+                    return Some(ResolverVersion::Unavailable(
+                        version.clone(),
+                        UnavailableVersion::IncompatibleDist(IncompatibleDist::Wheel(
+                            IncompatibleWheel::MissingPlatform(marker),
+                        )),
+                    ));
+                };
+
+                debug!(
+                    "Forking on required platform `{}` for {}=={} ({})",
+                    marker.try_to_string().unwrap_or_else(|| "true".to_string()),
+                    name,
+                    version,
+                    [&left, &right]
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                return Some(ResolverVersion::Forked(vec![
+                    VersionFork {
+                        env: left,
+                        id,
+                        version: None,
+                    },
+                    VersionFork {
+                        env: right,
+                        id,
+                        version: None,
+                    },
+                ]));
+            }
+        }
+        None
     }
 
     /// Visit a selected candidate.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -515,20 +515,17 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
                     // An implicit registry candidate is stable for a given range. Avoid
                     // repeating candidate selection when PubGrub revisits an identical decision
-                    // after backtracking. If the range changed, reuse the previous decision only
+                    // after backtracking. If the range changed, reuse the previous version only
                     // when every preferred candidate is already known to conflict with the current
-                    // partial solution. This is safe in universal resolution because we only
-                    // cache unforked decisions; any preferred candidate that can fork is neither
-                    // unavailable nor known to conflict, so it prevents reuse.
+                    // partial solution. Selector-compatible candidates with state-dependent
+                    // incompatibilities prevent reuse until PubGrub has ruled them out.
                     let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
                     {
                         let can_reuse = selected_range == range
-                            || if !version.is_local()
-                                && let Some(name) = next_package.name()
-                            {
+                            || if let Some(name) = next_package.name() {
                                 range.contains(version)
                                     && preferences.get(name).is_empty()
                                     && (self.exclusions.reinstall(name)
@@ -540,8 +537,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                         next_id,
                                         &state.pubgrub,
                                         &state.env,
-                                        &state.python_requirement,
-                                        &mut state.candidate_viability,
+                                        &mut state.candidate_coverage,
                                     )?
                             } else {
                                 false
@@ -550,58 +546,32 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     } else {
                         None
                     };
-                    // Artifact coverage depends on the current dependency graph, which can change
-                    // after backtracking. Re-run selection for only the saved version so its fork
-                    // checks are revalidated without scanning the full allowed range again.
-                    let revalidation_range = if state.env.marker_environment().is_none()
-                        && !self.options.artifact_environments.is_empty()
-                    {
-                        reusable_version
-                            .as_ref()
-                            .map(|version| Range::singleton(version.clone()))
-                    } else {
-                        None
-                    };
-                    let decision = if revalidation_range.is_none()
-                        && let Some(version) = reusable_version
-                    {
-                        Some(ResolverVersion::Unforked(version))
-                    } else {
-                        let decision = {
-                            let mut choose_version = |selection_range| {
-                                self.choose_version(
-                                    next_package,
-                                    next_id,
-                                    index.map(IndexMetadata::url),
-                                    selection_range,
-                                    &mut state.pins,
-                                    &preferences,
-                                    &state.fork_urls,
-                                    &state.env,
-                                    &state.python_requirement,
-                                    &state.pubgrub,
-                                    &mut visited,
-                                    request_sink,
-                                )
-                            };
-                            let mut decision =
-                                choose_version(revalidation_range.as_ref().unwrap_or(range))?;
-                            if revalidation_range.is_some() && decision.is_none() {
-                                decision = choose_version(range)?;
-                            }
-                            decision
-                        };
+                    // Treat a reusable version as a candidate lookup hint, then run it through the
+                    // normal evaluation path. Fork checks depend on the current solver state and
+                    // must not be cached with the version-selection proof.
+                    let decision = self.choose_version(
+                        next_package,
+                        next_id,
+                        index.map(IndexMetadata::url),
+                        range,
+                        reusable_version.as_ref(),
+                        &mut state.pins,
+                        &preferences,
+                        &state.fork_urls,
+                        &state.env,
+                        &state.python_requirement,
+                        &state.pubgrub,
+                        &mut visited,
+                        request_sink,
+                    )?;
 
-                        if cache_selected_version
-                            && let Some(ResolverVersion::Unforked(version)) = &decision
-                        {
-                            state
-                                .selected_versions
-                                .insert(next_id, (range.clone(), version.clone()));
-                        }
-
-                        decision
-                    };
+                    if cache_selected_version
+                        && let Some(ResolverVersion::Unforked(version)) = &decision
+                    {
+                        state
+                            .selected_versions
+                            .insert(next_id, (range.clone(), version.clone()));
+                    }
 
                     // Pick the next compatible version.
                     let Some(version) = decision else {
@@ -946,7 +916,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // there is at least one more fork to visit.
         let package = current_state.next;
         let mut current_state = current_state;
-        current_state.candidate_viability = FxHashMap::default();
+        current_state.candidate_coverage = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
         forks
@@ -1005,7 +975,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // into `forked_states`, and then only clone it if
         // there is at least one more fork to visit.
         let mut current_state = current_state;
-        current_state.candidate_viability = FxHashMap::default();
+        current_state.candidate_coverage = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
         forks.into_iter().enumerate().map(move |(i, fork)| {
@@ -1165,6 +1135,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         id: Id<PubGrubPackage>,
         index: Option<&IndexUrl>,
         range: &Range<Version>,
+        saved_version: Option<&Version>,
         pins: &mut FilePins,
         preferences: &Preferences,
         fork_urls: &ForkUrls,
@@ -1207,6 +1178,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         name,
                         index,
                         range,
+                        saved_version,
                         preferences,
                         env,
                         python_requirement,
@@ -1348,6 +1320,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         name: &PackageName,
         index: Option<&IndexUrl>,
         range: &Range<Version>,
+        saved_version: Option<&Version>,
         preferences: &Preferences,
         env: &ResolverEnvironment,
         python_requirement: &PythonRequirement,
@@ -1394,18 +1367,28 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         debug!("Searching for a compatible version of {package} ({range})");
 
-        // Find a version.
-        let Some(candidate) = self.selector.select(
-            name,
-            range,
-            version_maps,
-            preferences,
-            &self.installed_packages,
-            &self.exclusions,
-            index,
-            env,
-            self.tags.as_ref(),
-        ) else {
+        // Find a version. A phase-saved version narrows only candidate lookup; candidate
+        // evaluation still receives the full allowed range below.
+        let select = |range| {
+            self.selector.select(
+                name,
+                range,
+                version_maps,
+                preferences,
+                &self.installed_packages,
+                &self.exclusions,
+                index,
+                env,
+                self.tags.as_ref(),
+            )
+        };
+        let candidate = if let Some(saved_version) = saved_version {
+            let saved_range = Range::singleton(saved_version.clone());
+            select(&saved_range).or_else(|| select(range))
+        } else {
+            select(range)
+        };
+        let Some(candidate) = candidate else {
             // Short circuit: we couldn't find _any_ versions for a package.
             return Ok(None);
         };
@@ -1512,7 +1495,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
     }
 
     /// Return whether every registry candidate preferred over `selected` is already known to be
-    /// unavailable or incompatible with the current partial solution.
+    /// statically unavailable or incompatible with the current partial solution.
     fn all_preferred_versions_conflict(
         &self,
         name: &PackageName,
@@ -1521,8 +1504,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         package: Id<PubGrubPackage>,
         pubgrub: &State<UvDependencyProvider>,
         env: &ResolverEnvironment,
-        python_requirement: &PythonRequirement,
-        candidate_viability: &mut FxHashMap<Id<PubGrubPackage>, CandidateViability>,
+        candidate_coverage: &mut FxHashMap<Id<PubGrubPackage>, CandidateCoverage>,
     ) -> Result<bool, ResolveError> {
         let versions_response = self
             .index
@@ -1541,14 +1523,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         };
 
         // PubGrub reasons over mathematical version ranges, while package indexes expose a finite
-        // set of actual versions. Remember the viable registry candidates we already inspected so
-        // a later revisit in the same fork can prove that finite set conflicts without selecting
-        // every candidate again.
-        if let Some(cache) = candidate_viability.get(&package)
+        // set of actual versions. Remember the selector-compatible registry candidates we already
+        // inspected so a later revisit in the same fork can prove that finite set conflicts
+        // without selecting every candidate again.
+        if let Some(cache) = candidate_coverage.get(&package)
             && remaining.subset_of(&cache.checked)
         {
-            let viable = remaining.intersection(&cache.viable);
-            if viable.is_empty() || pubgrub.range_conflicts_with_partial_solution(package, viable) {
+            let selectable = remaining.intersection(&cache.selectable);
+            if selectable.is_empty()
+                || pubgrub.range_conflicts_with_partial_solution(package, selectable)
+            {
                 return Ok(true);
             }
         }
@@ -1557,28 +1541,17 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             return Ok(true);
         }
         let checked = remaining.clone();
-        let mut viable_versions = Vec::new();
+        let mut selectable_versions = Vec::new();
         while let Some(candidate) =
             self.selector
                 .select_no_preference(name, &remaining, version_maps, env)
         {
             let version = candidate.version().clone();
-            if let CandidateDist::Compatible(dist) = candidate.dist() {
-                let incompatible_python = Self::check_requires_python(dist, python_requirement);
-                if let Some((requires_python, _)) = &incompatible_python
-                    && matches!(self.options.fork_strategy, ForkStrategy::RequiresPython)
-                    && env.marker_environment().is_none()
-                    && !fork_version_by_python_requirement(requires_python, python_requirement, env)
-                        .is_empty()
-                {
+            if matches!(candidate.dist(), CandidateDist::Compatible(_)) {
+                if !pubgrub.version_conflicts_with_partial_solution(package, version.clone()) {
                     return Ok(false);
                 }
-                if incompatible_python.is_none() {
-                    if !pubgrub.version_conflicts_with_partial_solution(package, version.clone()) {
-                        return Ok(false);
-                    }
-                    viable_versions.push(version.clone());
-                }
+                selectable_versions.push(version.clone());
             }
             remaining = if highest {
                 remaining.intersection(&Range::strictly_lower_than(version))
@@ -1590,19 +1563,22 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // candidates so the range constructor receives both modes in ascending order and can
         // append each disjoint singleton without repeatedly shifting existing segments.
         if highest {
-            viable_versions.reverse();
+            selectable_versions.reverse();
         }
-        let viable = viable_versions
+        let selectable = selectable_versions
             .into_iter()
             .map(|version| (Bound::Included(version.clone()), Bound::Included(version)))
             .collect::<Range<_>>();
-        candidate_viability
+        candidate_coverage
             .entry(package)
             .and_modify(|cache| {
                 cache.checked = cache.checked.union(&checked);
-                cache.viable = cache.viable.union(&viable);
+                cache.selectable = cache.selectable.union(&selectable);
             })
-            .or_insert(CandidateViability { checked, viable });
+            .or_insert(CandidateCoverage {
+                checked,
+                selectable,
+            });
         Ok(true)
     }
 
@@ -3127,11 +3103,10 @@ pub(crate) struct ForkState {
     pre_visited: FxHashMap<Id<PubGrubPackage>, Range<Version>>,
     /// The last version selected for each package and range in a specific environment.
     selected_versions: FxHashMap<Id<PubGrubPackage>, (Range<Version>, Version)>,
-    /// Cached registry candidate viability used to prove a saved version remains maximal.
+    /// Cached registry candidate coverage used to prove a saved version remains maximal.
     ///
-    /// This is scoped to one fork because candidate viability depends on its markers and Python
-    /// requirement.
-    candidate_viability: FxHashMap<Id<PubGrubPackage>, CandidateViability>,
+    /// This is scoped to one fork because candidate selection depends on its markers.
+    candidate_coverage: FxHashMap<Id<PubGrubPackage>, CandidateCoverage>,
     /// The marker expression that created this state.
     ///
     /// The root state always corresponds to a marker expression that is always
@@ -3186,7 +3161,7 @@ impl ForkState {
             added_dependencies: FxHashMap::default(),
             pre_visited: FxHashMap::default(),
             selected_versions: FxHashMap::default(),
-            candidate_viability: FxHashMap::default(),
+            candidate_coverage: FxHashMap::default(),
             env,
             python_requirement,
             conflict_tracker: ConflictTracker::default(),
@@ -3444,7 +3419,7 @@ impl ForkState {
     /// Python requirement), then this returns `None`.
     fn with_env(mut self, env: ResolverEnvironment) -> Self {
         self.selected_versions.clear();
-        self.candidate_viability.clear();
+        self.candidate_coverage.clear();
         self.env = env;
         // If the fork contains a narrowed Python requirement, apply it.
         if let Some(req) = self.env.narrow_python_requirement(&self.python_requirement) {
@@ -3731,11 +3706,14 @@ impl ForkState {
 }
 
 #[derive(Clone)]
-struct CandidateViability {
+struct CandidateCoverage {
     /// Mathematical ranges for which every actual registry candidate was inspected.
     checked: Range<Version>,
-    /// Compatible candidates within checked; unavailable candidates are intentionally omitted.
-    viable: Range<Version>,
+    /// Selector-compatible candidates within checked.
+    ///
+    /// State-dependent checks, such as Requires-Python and platform forks, are intentionally not
+    /// cached here.
+    selectable: Range<Version>,
 }
 
 /// The resolution from a single fork including the virtual packages and the edges between them.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1527,7 +1527,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             return Ok(true);
         }
         let checked = remaining.clone();
-        let mut viable = Range::empty();
+        let mut viable_versions = Vec::new();
         while let Some(candidate) =
             self.selector
                 .select_no_preference(name, &remaining, version_maps, env)
@@ -1539,7 +1539,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 if !pubgrub.version_conflicts_with_partial_solution(package, version.clone()) {
                     return Ok(false);
                 }
-                viable = viable.union(&Range::singleton(version.clone()));
+                viable_versions.push(version.clone());
             }
             remaining = if highest {
                 remaining.intersection(&Range::strictly_lower_than(version))
@@ -1547,6 +1547,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 remaining.intersection(&Range::strictly_higher_than(version))
             };
         }
+        // Candidate selection visits versions in preference order. Reverse highest-resolution
+        // candidates so the range constructor receives both modes in ascending order and can
+        // append each disjoint singleton without repeatedly shifting existing segments.
+        if highest {
+            viable_versions.reverse();
+        }
+        let viable = viable_versions
+            .into_iter()
+            .map(|version| (Bound::Included(version.clone()), Bound::Included(version)))
+            .collect::<Range<_>>();
         candidate_viability
             .entry(package)
             .and_modify(|cache| {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -526,7 +526,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             state.selected_versions.get(&next_id)
                     {
                         let can_reuse = selected_range == range
-                            || if let Some(name) = next_package.name() {
+                            || if !version.is_local()
+                                && let Some(name) = next_package.name()
+                            {
                                 range.contains(version)
                                     && preferences.get(name).is_empty()
                                     && (self.exclusions.reinstall(name)

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{Level, debug, info, instrument, trace, warn};
 
-use uv_configuration::{Constraints, Excludes, Overrides};
+use uv_configuration::{Constraints, Excludes, IndexStrategy, Overrides};
 use uv_distribution::{ArchiveMetadata, DistributionDatabase};
 use uv_distribution_types::{
     BuiltDist, CompatibleDist, DerivationChain, Dist, DistErrorKind, Identifier, IncompatibleDist,
@@ -522,7 +522,11 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             state.selected_versions.get(&next_id)
                     {
                         let can_reuse = selected_range == range
-                            || if let Some(name) = next_package.name() {
+                            || if !matches!(
+                                self.selector.index_strategy(),
+                                IndexStrategy::UnsafeFirstMatch
+                            ) && let Some(name) = next_package.name()
+                            {
                                 range.contains(version)
                                     && preferences.get(name).is_empty()
                                     && (self.exclusions.reinstall(name)

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -520,7 +520,13 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     // partial solution. This is safe in universal resolution because we only
                     // cache unforked decisions; any preferred candidate that can fork is neither
                     // unavailable nor known to conflict, so it prevents reuse.
-                    let cache_selected_version = url.is_none() && index.is_none();
+                    // Required-environment coverage depends on the current dependency graph, which
+                    // can change after backtracking. Re-run selection in that case so artifact
+                    // coverage is revalidated.
+                    let cache_selected_version = url.is_none()
+                        && index.is_none()
+                        && (state.env.marker_environment().is_some()
+                            || self.options.artifact_environments.is_empty());
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -919,6 +919,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // into `forked_states`, and then only clone it if
         // there is at least one more fork to visit.
         let package = current_state.next;
+        let mut current_state = current_state;
+        current_state.candidate_viability = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
         forks
@@ -976,6 +978,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // as it needs to be. We basically move the state
         // into `forked_states`, and then only clone it if
         // there is at least one more fork to visit.
+        let mut current_state = current_state;
+        current_state.candidate_viability = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
         forks.into_iter().enumerate().map(move |(i, fork)| {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -3443,6 +3443,7 @@ impl ForkState {
     /// If the fork should be dropped (e.g., because its markers can never be true for its
     /// Python requirement), then this returns `None`.
     fn with_env(mut self, env: ResolverEnvironment) -> Self {
+        self.selected_versions.clear();
         self.candidate_viability.clear();
         self.env = env;
         // If the fork contains a narrowed Python requirement, apply it.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -516,9 +516,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     // An implicit registry candidate is stable for a given range. Avoid
                     // repeating candidate selection when PubGrub revisits an identical decision
                     // after backtracking. If the range changed, reuse the previous decision only
-                    // when every better candidate is already known to conflict with the current
+                    // when every preferred candidate is already known to conflict with the current
                     // partial solution. This is safe in universal resolution because we only
-                    // cache unforked decisions; any better candidate that can fork is neither
+                    // cache unforked decisions; any preferred candidate that can fork is neither
                     // unavailable nor known to conflict, so it prevents reuse.
                     let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
@@ -531,7 +531,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                     && preferences.get(name).is_empty()
                                     && (self.exclusions.reinstall(name)
                                         || self.installed_packages.get_packages(name).is_empty())
-                                    && self.all_better_versions_conflict(
+                                    && self.all_preferred_versions_conflict(
                                         name,
                                         range,
                                         version,
@@ -539,6 +539,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                         &state.pubgrub,
                                         &state.env,
                                         &state.python_requirement,
+                                        &mut state.candidate_viability,
                                     )?
                             } else {
                                 false
@@ -1482,7 +1483,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
     /// Return whether every registry candidate preferred over `selected` is already known to be
     /// unavailable or incompatible with the current partial solution.
-    fn all_better_versions_conflict(
+    fn all_preferred_versions_conflict(
         &self,
         name: &PackageName,
         range: &Range<Version>,
@@ -1491,6 +1492,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         pubgrub: &State<UvDependencyProvider>,
         env: &ResolverEnvironment,
         python_requirement: &PythonRequirement,
+        candidate_viability: &mut FxHashMap<Id<PubGrubPackage>, CandidateViability>,
     ) -> Result<bool, ResolveError> {
         let versions_response = self
             .index
@@ -1507,6 +1509,25 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         } else {
             range.intersection(&Range::strictly_lower_than(selected.clone()))
         };
+
+        // PubGrub reasons over mathematical version ranges, while package indexes expose a finite
+        // set of actual versions. Remember the viable registry candidates we already inspected so
+        // a later revisit in the same fork can prove that finite set conflicts without selecting
+        // every candidate again.
+        if let Some(cache) = candidate_viability.get(&package)
+            && remaining.subset_of(&cache.checked)
+        {
+            let viable = remaining.intersection(&cache.viable);
+            if viable.is_empty() || pubgrub.range_conflicts_with_partial_solution(package, viable) {
+                return Ok(true);
+            }
+        }
+
+        if pubgrub.range_conflicts_with_partial_solution(package, remaining.clone()) {
+            return Ok(true);
+        }
+        let checked = remaining.clone();
+        let mut viable = Range::empty();
         while let Some(candidate) =
             self.selector
                 .select_no_preference(name, &remaining, version_maps, env)
@@ -1514,9 +1535,11 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             let version = candidate.version().clone();
             if let CandidateDist::Compatible(dist) = candidate.dist()
                 && Self::check_requires_python(dist, python_requirement).is_none()
-                && !pubgrub.version_conflicts_with_partial_solution(package, version.clone())
             {
-                return Ok(false);
+                if !pubgrub.version_conflicts_with_partial_solution(package, version.clone()) {
+                    return Ok(false);
+                }
+                viable = viable.union(&Range::singleton(version.clone()));
             }
             remaining = if highest {
                 remaining.intersection(&Range::strictly_lower_than(version))
@@ -1524,6 +1547,13 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 remaining.intersection(&Range::strictly_higher_than(version))
             };
         }
+        candidate_viability
+            .entry(package)
+            .and_modify(|cache| {
+                cache.checked = cache.checked.union(&checked);
+                cache.viable = cache.viable.union(&viable);
+            })
+            .or_insert(CandidateViability { checked, viable });
         Ok(true)
     }
 
@@ -3048,6 +3078,11 @@ pub(crate) struct ForkState {
     pre_visited: FxHashMap<Id<PubGrubPackage>, Range<Version>>,
     /// The last version selected for each package and range in a specific environment.
     selected_versions: FxHashMap<Id<PubGrubPackage>, (Range<Version>, Version)>,
+    /// Cached registry candidate viability used to prove a saved version remains maximal.
+    ///
+    /// This is scoped to one fork because candidate viability depends on its markers and Python
+    /// requirement.
+    candidate_viability: FxHashMap<Id<PubGrubPackage>, CandidateViability>,
     /// The marker expression that created this state.
     ///
     /// The root state always corresponds to a marker expression that is always
@@ -3102,6 +3137,7 @@ impl ForkState {
             added_dependencies: FxHashMap::default(),
             pre_visited: FxHashMap::default(),
             selected_versions: FxHashMap::default(),
+            candidate_viability: FxHashMap::default(),
             env,
             python_requirement,
             conflict_tracker: ConflictTracker::default(),
@@ -3358,6 +3394,7 @@ impl ForkState {
     /// If the fork should be dropped (e.g., because its markers can never be true for its
     /// Python requirement), then this returns `None`.
     fn with_env(mut self, env: ResolverEnvironment) -> Self {
+        self.candidate_viability.clear();
         self.env = env;
         // If the fork contains a narrowed Python requirement, apply it.
         if let Some(req) = self.env.narrow_python_requirement(&self.python_requirement) {
@@ -3641,6 +3678,14 @@ impl ForkState {
             env: self.env,
         }
     }
+}
+
+#[derive(Clone)]
+struct CandidateViability {
+    /// Mathematical ranges for which every actual registry candidate was inspected.
+    checked: Range<Version>,
+    /// Compatible candidates within checked; unavailable candidates are intentionally omitted.
+    viable: Range<Version>,
 }
 
 /// The resolution from a single fork including the virtual packages and the edges between them.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1543,13 +1543,22 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 .select_no_preference(name, &remaining, version_maps, env)
         {
             let version = candidate.version().clone();
-            if let CandidateDist::Compatible(dist) = candidate.dist()
-                && Self::check_requires_python(dist, python_requirement).is_none()
-            {
-                if !pubgrub.version_conflicts_with_partial_solution(package, version.clone()) {
+            if let CandidateDist::Compatible(dist) = candidate.dist() {
+                let incompatible_python = Self::check_requires_python(dist, python_requirement);
+                if let Some((requires_python, _)) = &incompatible_python
+                    && matches!(self.options.fork_strategy, ForkStrategy::RequiresPython)
+                    && env.marker_environment().is_none()
+                    && !fork_version_by_python_requirement(requires_python, python_requirement, env)
+                        .is_empty()
+                {
                     return Ok(false);
                 }
-                viable_versions.push(version.clone());
+                if incompatible_python.is_none() {
+                    if !pubgrub.version_conflicts_with_partial_solution(package, version.clone()) {
+                        return Ok(false);
+                    }
+                    viable_versions.push(version.clone());
+                }
             }
             remaining = if highest {
                 remaining.intersection(&Range::strictly_lower_than(version))

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -520,13 +520,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     // partial solution. This is safe in universal resolution because we only
                     // cache unforked decisions; any preferred candidate that can fork is neither
                     // unavailable nor known to conflict, so it prevents reuse.
-                    // Required-environment coverage depends on the current dependency graph, which
-                    // can change after backtracking. Re-run selection in that case so artifact
-                    // coverage is revalidated.
-                    let cache_selected_version = url.is_none()
-                        && index.is_none()
-                        && (state.env.marker_environment().is_some()
-                            || self.options.artifact_environments.is_empty());
+                    let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
@@ -554,23 +548,47 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     } else {
                         None
                     };
-                    let decision = if let Some(version) = reusable_version {
+                    // Artifact coverage depends on the current dependency graph, which can change
+                    // after backtracking. Re-run selection for only the saved version so its fork
+                    // checks are revalidated without scanning the full allowed range again.
+                    let revalidation_range = if state.env.marker_environment().is_none()
+                        && !self.options.artifact_environments.is_empty()
+                    {
+                        reusable_version
+                            .as_ref()
+                            .map(|version| Range::singleton(version.clone()))
+                    } else {
+                        None
+                    };
+                    let decision = if revalidation_range.is_none()
+                        && let Some(version) = reusable_version
+                    {
                         Some(ResolverVersion::Unforked(version))
                     } else {
-                        let decision = self.choose_version(
-                            next_package,
-                            next_id,
-                            index.map(IndexMetadata::url),
-                            range,
-                            &mut state.pins,
-                            &preferences,
-                            &state.fork_urls,
-                            &state.env,
-                            &state.python_requirement,
-                            &state.pubgrub,
-                            &mut visited,
-                            request_sink,
-                        )?;
+                        let decision = {
+                            let mut choose_version = |selection_range| {
+                                self.choose_version(
+                                    next_package,
+                                    next_id,
+                                    index.map(IndexMetadata::url),
+                                    selection_range,
+                                    &mut state.pins,
+                                    &preferences,
+                                    &state.fork_urls,
+                                    &state.env,
+                                    &state.python_requirement,
+                                    &state.pubgrub,
+                                    &mut visited,
+                                    request_sink,
+                                )
+                            };
+                            let mut decision =
+                                choose_version(revalidation_range.as_ref().unwrap_or(range))?;
+                            if revalidation_range.is_some() && decision.is_none() {
+                                decision = choose_version(range)?;
+                            }
+                            decision
+                        };
 
                         if cache_selected_version
                             && let Some(ResolverVersion::Unforked(version)) = &decision

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -513,12 +513,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         .expect("a package was chosen but we don't have a term");
                     let range = term_intersection.unwrap_positive();
 
-                    // An implicit registry candidate is stable for a given range. Avoid
-                    // repeating candidate selection when PubGrub revisits an identical decision
-                    // after backtracking. If the range changed, reuse the previous version only
-                    // when every preferred candidate is already known to conflict with the current
-                    // partial solution. Selector-compatible candidates with state-dependent
-                    // incompatibilities prevent reuse until PubGrub has ruled them out.
+                    // Reuse an implicit registry version after backtracking. If the range changed,
+                    // only use it as a hint when every preferred candidate conflicts with the
+                    // current partial solution. Candidate evaluation below still reruns
+                    // fork-sensitive checks.
                     let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
@@ -546,9 +544,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     } else {
                         None
                     };
-                    // Treat a reusable version as a candidate lookup hint, then run it through the
-                    // normal evaluation path. Fork checks depend on the current solver state and
-                    // must not be cached with the version-selection proof.
                     let decision = self.choose_version(
                         next_package,
                         next_id,
@@ -3709,10 +3704,7 @@ impl ForkState {
 struct CandidateCoverage {
     /// Mathematical ranges for which every actual registry candidate was inspected.
     checked: Range<Version>,
-    /// Selector-compatible candidates within checked.
-    ///
-    /// State-dependent checks, such as Requires-Python and platform forks, are intentionally not
-    /// cached here.
+    /// Selector-compatible candidates within checked; state-dependent checks are excluded.
     selectable: Range<Version>,
 }
 

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -522,10 +522,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             state.selected_versions.get(&next_id)
                     {
                         let can_reuse = selected_range == range
-                            || if !matches!(
-                                self.selector.index_strategy(),
-                                IndexStrategy::UnsafeFirstMatch
-                            ) && let Some(name) = next_package.name()
+                            || if let Some(name) = next_package.name()
+                                && !uses_index_priority(
+                                    *self.selector.index_strategy(),
+                                    self.options.torch_backend.as_ref(),
+                                    name,
+                                )
                             {
                                 range.contains(version)
                                     && preferences.get(name).is_empty()
@@ -4457,6 +4459,44 @@ fn find_environments(id: Id<PubGrubPackage>, state: &State<UvDependencyProvider>
     }
 
     environments.remove(&id).unwrap_or(MarkerTree::FALSE)
+}
+
+/// Return whether candidate preference is index-first instead of version-first.
+fn uses_index_priority(
+    index_strategy: IndexStrategy,
+    torch_backend: Option<&TorchStrategy>,
+    package_name: &PackageName,
+) -> bool {
+    matches!(index_strategy, IndexStrategy::UnsafeFirstMatch)
+        || torch_backend.is_some_and(|torch_backend| torch_backend.applies_to(package_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use uv_torch::{TorchBackend, TorchSource};
+
+    use super::*;
+
+    #[test]
+    fn torch_backend_uses_index_priority_for_torch_packages() {
+        let torch_backend = TorchStrategy::Backend {
+            backend: TorchBackend::Cpu,
+            source: TorchSource::PyTorch,
+        };
+
+        assert!(uses_index_priority(
+            IndexStrategy::FirstIndex,
+            Some(&torch_backend),
+            &PackageName::from_str("torch").expect("torch should be a valid package name"),
+        ));
+        assert!(!uses_index_priority(
+            IndexStrategy::FirstIndex,
+            Some(&torch_backend),
+            &PackageName::from_str("numpy").expect("numpy should be a valid package name"),
+        ));
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -13146,6 +13146,46 @@ fn lock_phase_saving_preserves_universal_forks() -> Result<()> {
     Ok(())
 }
 
+/// Check that phase saving preserves index priority with `unsafe-first-match`.
+#[test]
+fn lock_phase_saving_preserves_unsafe_first_match_priority() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let first_index = PackseServer::new("fork/phase-saving-index-priority-first.toml");
+    let second_index = PackseServer::new("fork/phase-saving-index-priority-second.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["parent"]
+        "#,
+    )?;
+
+    let mut command = context.lock();
+    command
+        .arg("--index-url")
+        .arg(second_index.index_url())
+        .arg("--extra-index-url")
+        .arg(first_index.index_url())
+        .arg("--index-strategy")
+        .arg("unsafe-first-match")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .assert()
+        .success();
+
+    let lock = context.read("uv.lock");
+    assert!(lock.contains("name = \"a\"\nversion = \"1.0.0\""));
+    assert!(!lock.contains("name = \"a\"\nversion = \"2.0.0\""));
+
+    command.arg("--locked").assert().success();
+    assert_eq!(lock, context.read("uv.lock"));
+
+    Ok(())
+}
+
 /// Warn when there are missing bounds on transitive dependencies with `--resolution lowest`.
 #[test]
 fn lock_warn_missing_transitive_lower_bounds() -> Result<()> {

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -3357,6 +3357,145 @@ fn fork_overlapping_markers_basic() -> Result<()> {
     Ok(())
 }
 
+/// This test checks that phase-saving revalidates local-version forks after backtracking widens a
+/// package requirement to include its public version.
+///
+///
+/// ```text
+/// phase-saving-local-version
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   └── requires parent
+/// │       ├── satisfied by parent-1.0.0
+/// │       └── satisfied by parent-2.0.0
+/// ├── late
+/// │   └── late-1.0.0
+/// │       └── requires missing
+/// │           └── unsatisfied: no versions for package
+/// ├── parent
+/// │   ├── parent-1.0.0
+/// │   │   └── requires torch==1.0.0
+/// │   │       ├── satisfied by torch-1.0.0
+/// │   │       └── satisfied by torch-1.0.0+cpu
+/// │   └── parent-2.0.0
+/// │       ├── requires late==1.0.0
+/// │       │   └── satisfied by late-1.0.0
+/// │       └── requires torch==1.0.0+cpu
+/// │           └── satisfied by torch-1.0.0+cpu
+/// └── torch
+///     ├── torch-1.0.0
+///     └── torch-1.0.0+cpu
+/// ```
+#[test]
+fn phase_saving_local_version() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving-local-version.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''parent''',
+        ]
+        requires-python = ">=3.12"
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "sys_platform != 'darwin'",
+            "sys_platform == 'darwin'",
+        ]
+
+        [[package]]
+        name = "parent"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "torch", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'darwin'" },
+            { name = "torch", version = "1.0.0+cpu", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'darwin'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/parent-1.0.0.tar.gz", hash = "sha256:dfdc98da0cb358bca8a0179fdd008f91554df6372a315663429a7e031187abff", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/parent-1.0.0-py3-none-any.whl", hash = "sha256:ab4b17140d9229a0aa4cec233d049135af783e8860562b6820c24d5af5c164d8", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "parent" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "parent" }]
+
+        [[package]]
+        name = "torch"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform == 'darwin'",
+        ]
+        wheels = [
+            { url = "http://[LOCALHOST]/files/torch-1.0.0-py3-none-macosx_10_0_x86_64.whl", hash = "sha256:709a76c166bb5f6d5a49f6f1e18b27e4e6bd091cc5f4c16fc910cb5935acd62f", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "torch"
+        version = "1.0.0+cpu"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform != 'darwin'",
+        ]
+        wheels = [
+            { url = "http://[LOCALHOST]/files/torch-1.0.0+cpu-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a060635f53f33b89d2d72a6dca05d44d2d45c135d172dc1bc89f4b068bbfe7f7", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 /// This test checks that phase-saving revalidates required-environment artifact coverage after
 /// backtracking widens a package requirement.
 ///

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -3357,6 +3357,152 @@ fn fork_overlapping_markers_basic() -> Result<()> {
     Ok(())
 }
 
+/// This test checks that phase-saving revalidates required-environment artifact coverage after
+/// backtracking widens a package requirement.
+///
+///
+/// ```text
+/// phase-saving-required-environment
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   └── requires parent
+/// │       ├── satisfied by parent-1.0.0
+/// │       └── satisfied by parent-2.0.0
+/// ├── a
+/// │   ├── a-0.9.0
+/// │   └── a-1.0.0
+/// ├── late
+/// │   └── late-1.0.0
+/// │       └── requires missing
+/// │           └── unsatisfied: no versions for package
+/// └── parent
+///     ├── parent-1.0.0
+///     │   └── requires a
+///     │       ├── satisfied by a-0.9.0
+///     │       └── satisfied by a-1.0.0
+///     └── parent-2.0.0
+///         ├── requires a==1.0.0 ; sys_platform != 'win32'
+///         │   └── satisfied by a-1.0.0
+///         └── requires late==1.0.0
+///             └── satisfied by late-1.0.0
+/// ```
+#[test]
+fn phase_saving_required_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving-required-environment.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''parent''',
+        ]
+        requires-python = ">=3.12"
+        [tool.uv]
+        required-environments = [
+          '''sys_platform == 'win32'''',
+        ]
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "sys_platform != 'win32'",
+            "sys_platform == 'win32'",
+        ]
+        required-markers = [
+            "sys_platform == 'win32'",
+        ]
+
+        [[package]]
+        name = "a"
+        version = "0.9.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform == 'win32'",
+        ]
+        wheels = [
+            { url = "http://[LOCALHOST]/files/a-0.9.0-py3-none-win_amd64.whl", hash = "sha256:d5cbc3502e518901a44fcf6560565530ac77e5d994bc3181a68e9e4c0f8a05f2", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "a"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform != 'win32'",
+        ]
+        wheels = [
+            { url = "http://[LOCALHOST]/files/a-1.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9c2c85239e2d6fe0ceeca5211b4b0ce1f02d6bd52967398bd55791d2d41e479a", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "parent"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "a", version = "0.9.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'win32'" },
+            { name = "a", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'win32'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/parent-1.0.0.tar.gz", hash = "sha256:e58f7845e014962152b8f15c4603fb804c8162b9281ddbe23cc101aa911b3275", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/parent-1.0.0-py3-none-any.whl", hash = "sha256:2a2d74615c39fc52c4d5076007a1f680a5bc26551f2980ad42b6242f568eea60", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "parent" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "parent" }]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 /// This test checks that phase-saving preserves universal forks after backtracking.
 ///
 ///

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -3357,8 +3357,8 @@ fn fork_overlapping_markers_basic() -> Result<()> {
     Ok(())
 }
 
-/// This test checks that phase-saving revalidates local-version forks after backtracking widens a
-/// package requirement to include its public version.
+/// After backtracking widens a package requirement, check again whether a saved local version must
+/// fork from its public version.
 ///
 ///
 /// ```text
@@ -3496,8 +3496,8 @@ fn phase_saving_local_version() -> Result<()> {
     Ok(())
 }
 
-/// This test checks that phase-saving revalidates required-environment artifact coverage after
-/// backtracking widens a package requirement.
+/// After backtracking widens a package requirement, check again that the selected files support every
+/// required environment.
 ///
 ///
 /// ```text
@@ -3642,8 +3642,8 @@ fn phase_saving_required_environment() -> Result<()> {
     Ok(())
 }
 
-/// This test checks that phase-saving preserves a Requires-Python fork after backtracking widens a
-/// package requirement.
+/// After backtracking widens a package requirement, keep the fork required by a package's Python
+/// version constraint.
 ///
 ///
 /// ```text

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -3503,6 +3503,148 @@ fn phase_saving_required_environment() -> Result<()> {
     Ok(())
 }
 
+/// This test checks that phase-saving preserves a Requires-Python fork after backtracking widens a
+/// package requirement.
+///
+///
+/// ```text
+/// phase-saving-requires-python
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   └── requires parent
+/// │       ├── satisfied by parent-1.0.0
+/// │       └── satisfied by parent-2.0.0
+/// ├── foo
+/// │   ├── foo-1.0.0
+/// │   └── foo-2.0.0
+/// │       └── requires python>=3.13 (incompatible with environment)
+/// ├── late
+/// │   └── late-1.0.0
+/// │       └── requires missing
+/// │           └── unsatisfied: no versions for package
+/// └── parent
+///     ├── parent-1.0.0
+///     │   └── requires foo
+///     │       ├── satisfied by foo-1.0.0
+///     │       └── satisfied by foo-2.0.0
+///     └── parent-2.0.0
+///         ├── requires foo==1.0.0
+///         │   └── satisfied by foo-1.0.0
+///         └── requires late==1.0.0
+///             └── satisfied by late-1.0.0
+/// ```
+#[test]
+fn phase_saving_requires_python() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving-requires-python.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''parent''',
+        ]
+        requires-python = ">=3.12"
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "python_full_version >= '3.13'",
+            "python_full_version < '3.13'",
+        ]
+
+        [[package]]
+        name = "foo"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "python_full_version < '3.13'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/foo-1.0.0.tar.gz", hash = "sha256:4d4cf959f969e0a39663aca6064428819f1e1c6be60d9a35164801ce17950ed4", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/foo-1.0.0-py3-none-any.whl", hash = "sha256:df9a39d54a6d71872deb1537d7e331de0ede3b725d630a050fee3efd3fe5145b", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "foo"
+        version = "2.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "python_full_version >= '3.13'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/foo-2.0.0.tar.gz", hash = "sha256:7f469469bd699483be052cfa623e942c393cf0a6ebf3ea3e3da79183230720ba", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/foo-2.0.0-py3-none-any.whl", hash = "sha256:6c776b7fcba8f4982f23be5c8d1c4cdfdc95aeb8178cb21fb1017dd261f0405b", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "parent"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "foo", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version < '3.13'" },
+            { name = "foo", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version >= '3.13'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/parent-1.0.0.tar.gz", hash = "sha256:7e2cabeee40c9e8babaf3e513e3a5475bd5e86a5cb1b36a74448b2c9bc4dc879", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/parent-1.0.0-py3-none-any.whl", hash = "sha256:1186d554a97e92e7ea5039b82e9cbc5055385f23394410f152a630bd564cf7a7", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "parent" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "parent" }]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 /// This test checks that phase-saving preserves universal forks after backtracking.
 ///
 ///

--- a/test/scenarios/fork/phase-saving-index-priority-first.toml
+++ b/test/scenarios/fork/phase-saving-index-priority-first.toml
@@ -1,0 +1,10 @@
+name = "phase-saving-index-priority-first"
+description = "The higher-priority index contains the lower version."
+
+[expected]
+satisfiable = true
+
+[root]
+requires = []
+
+[packages.a.versions."1.0.0"]

--- a/test/scenarios/fork/phase-saving-index-priority-second.toml
+++ b/test/scenarios/fork/phase-saving-index-priority-second.toml
@@ -1,0 +1,19 @@
+name = "phase-saving-index-priority-second"
+description = "The lower-priority index forces backtracking after selecting the higher version."
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["parent"]
+
+[packages.parent.versions."1.0.0"]
+requires = ["a"]
+
+[packages.parent.versions."2.0.0"]
+requires = ["a==2.0.0", "late==1.0.0"]
+
+[packages.a.versions."2.0.0"]
+
+[packages.late.versions."1.0.0"]
+requires = ["missing"]

--- a/test/scenarios/fork/phase-saving-local-version.toml
+++ b/test/scenarios/fork/phase-saving-local-version.toml
@@ -1,7 +1,7 @@
 name = "phase-saving-local-version"
 description = '''
-This test checks that phase-saving revalidates local-version forks after backtracking widens a
-package requirement to include its public version.
+After backtracking widens a package requirement, check again whether a saved local version must
+fork from its public version.
 '''
 
 [resolver_options]

--- a/test/scenarios/fork/phase-saving-local-version.toml
+++ b/test/scenarios/fork/phase-saving-local-version.toml
@@ -1,0 +1,34 @@
+name = "phase-saving-local-version"
+description = '''
+This test checks that phase-saving revalidates local-version forks after backtracking widens a
+package requirement to include its public version.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["parent"]
+
+[packages.parent.versions."1.0.0"]
+requires = ["torch==1.0.0"]
+
+[packages.parent.versions."2.0.0"]
+requires = [
+  "torch==1.0.0+cpu",
+  "late==1.0.0",
+]
+
+[packages.late.versions."1.0.0"]
+requires = ["missing"]
+
+[packages.torch.versions."1.0.0"]
+sdist = false
+wheel_tags = ["py3-none-macosx_10_0_x86_64"]
+
+[packages.torch.versions."1.0.0+cpu"]
+sdist = false
+wheel_tags = ["py3-none-manylinux2014_x86_64"]

--- a/test/scenarios/fork/phase-saving-required-environment.toml
+++ b/test/scenarios/fork/phase-saving-required-environment.toml
@@ -1,0 +1,35 @@
+name = "phase-saving-required-environment"
+description = '''
+This test checks that phase-saving revalidates required-environment artifact coverage after
+backtracking widens a package requirement.
+'''
+
+[resolver_options]
+universal = true
+required_environments = ['sys_platform == "win32"']
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["parent"]
+
+[packages.parent.versions."1.0.0"]
+requires = ["a"]
+
+[packages.parent.versions."2.0.0"]
+requires = [
+  "a==1.0.0; sys_platform != 'win32'",
+  "late==1.0.0",
+]
+
+[packages.late.versions."1.0.0"]
+requires = ["missing"]
+
+[packages.a.versions."0.9.0"]
+sdist = false
+wheel_tags = ["py3-none-win_amd64"]
+
+[packages.a.versions."1.0.0"]
+sdist = false
+wheel_tags = ["py3-none-manylinux2014_x86_64"]

--- a/test/scenarios/fork/phase-saving-required-environment.toml
+++ b/test/scenarios/fork/phase-saving-required-environment.toml
@@ -1,7 +1,7 @@
 name = "phase-saving-required-environment"
 description = '''
-This test checks that phase-saving revalidates required-environment artifact coverage after
-backtracking widens a package requirement.
+After backtracking widens a package requirement, check again that the selected files support every
+required environment.
 '''
 
 [resolver_options]

--- a/test/scenarios/fork/phase-saving-requires-python.toml
+++ b/test/scenarios/fork/phase-saving-requires-python.toml
@@ -1,0 +1,32 @@
+name = "phase-saving-requires-python"
+description = '''
+This test checks that phase-saving preserves a Requires-Python fork after backtracking widens a
+package requirement.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires_python = ">=3.12"
+requires = ["parent"]
+
+[packages.parent.versions."1.0.0"]
+requires = ["foo"]
+
+[packages.parent.versions."2.0.0"]
+requires = [
+  "foo==1.0.0",
+  "late==1.0.0",
+]
+
+[packages.foo.versions."1.0.0"]
+
+[packages.foo.versions."2.0.0"]
+requires_python = ">=3.13"
+
+[packages.late.versions."1.0.0"]
+requires = ["missing"]

--- a/test/scenarios/fork/phase-saving-requires-python.toml
+++ b/test/scenarios/fork/phase-saving-requires-python.toml
@@ -1,7 +1,7 @@
 name = "phase-saving-requires-python"
 description = '''
-This test checks that phase-saving preserves a Requires-Python fork after backtracking widens a
-package requirement.
+After backtracking widens a package requirement, keep the fork required by a package's Python
+version constraint.
 '''
 
 [resolver_options]


### PR DESCRIPTION
## Summary

When phase saving revisits a package with a changed range, #20063 checks each preferred registry candidate individually to prove that the saved version remains maximal. Backtracking can cause us to repeat that proof even when we already inspected the same finite set of candidates earlier in the fork.

This caches the ranges of registry candidates covered by a successful proof, along with the subset that are compatible with the candidate selector. On a later revisit within a cached range, we can ask PubGrub whether that finite candidate set conflicts with the current partial solution in one range query. State-dependent compatibility checks are deliberately excluded from the cache, so candidates that could require a Python or platform fork continue through normal selection until PubGrub has ruled them out.

A saved version is used only as a candidate lookup hint. We narrow lookup to its singleton, but evaluate the candidate with the full current range through the normal Requires-Python, required-environment, and local-version fork checks. If the saved candidate is no longer selectable, we fall back to the full range. Both phase-saving decisions and candidate coverage are cleared when the resolver environment changes.

Cross-range reuse is limited to packages whose effective index strategy follows version order. `unsafe-first-match` retains same-range reuse, but reruns normal selection when the range changes because a numerically lower version from an earlier index can be preferred over the saved version. The same restriction applies to packages routed through a configured Torch backend, which uses index-first ordering independently of the configured global strategy.

Before creating environment forks, we discard both phase-saving caches so cloning a fork state does not copy entries that each child immediately invalidates.

The regression scenarios cover required-environment reachability discovered after backtracking, a newly available public version that should fork from its saved local version, a preferred candidate that should produce a Requires-Python split, and index priority after backtracking under `unsafe-first-match`.

This is stacked on #20063 and advances the temporary PubGrub pin to [astral-sh/pubgrub#73](https://github.com/astral-sh/pubgrub/pull/73), which adds the hypothetical range-conflict query.
