### PR TITLE
Reuse proven-safe resolver decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,8 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79d771681f6c21ebe25dda598774b6e6badca8b720ce2168df7788b2821c46d"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=66d45efb9e01551924cac41918c3e8fe6f785318#66d45efb9e01551924cac41918c3e8fe6f785318"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -293,8 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086f936efdefab117f5a72367fb3d68c4fded8ba5a7008e3c63365eecf723822"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=66d45efb9e01551924cac41918c3e8fe6f785318#66d45efb9e01551924cac41918c3e8fe6f785318"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.5.0"
-source = "git+https://github.com/astral-sh/pubgrub.git?rev=9c96d5c41536e535f94c8495f62afa08ad6420bd#9c96d5c41536e535f94c8495f62afa08ad6420bd"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=2fce3b4843a3ca3978b36341e9bfd10de3d7aaf9#2fce3b4843a3ca3978b36341e9bfd10de3d7aaf9"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/pubgrub.git?rev=9c96d5c41536e535f94c8495f62afa08ad6420bd#9c96d5c41536e535f94c8495f62afa08ad6420bd"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=2fce3b4843a3ca3978b36341e9bfd10de3d7aaf9#2fce3b4843a3ca3978b36341e9bfd10de3d7aaf9"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.5.0"
-source = "git+https://github.com/astral-sh/pubgrub.git?rev=66d45efb9e01551924cac41918c3e8fe6f785318#66d45efb9e01551924cac41918c3e8fe6f785318"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=9c96d5c41536e535f94c8495f62afa08ad6420bd#9c96d5c41536e535f94c8495f62afa08ad6420bd"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/pubgrub.git?rev=66d45efb9e01551924cac41918c3e8fe6f785318#66d45efb9e01551924cac41918c3e8fe6f785318"
+source = "git+https://github.com/astral-sh/pubgrub.git?rev=9c96d5c41536e535f94c8495f62afa08ad6420bd#9c96d5c41536e535f94c8495f62afa08ad6420bd"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -459,5 +459,5 @@ codegen-units = 1
 inherits = "release"
 
 [patch.crates-io]
-astral-pubgrub = { git = "https://github.com/astral-sh/pubgrub.git", rev = "66d45efb9e01551924cac41918c3e8fe6f785318" }
-astral-version-ranges = { git = "https://github.com/astral-sh/pubgrub.git", rev = "66d45efb9e01551924cac41918c3e8fe6f785318" }
+astral-pubgrub = { git = "https://github.com/astral-sh/pubgrub.git", rev = "9c96d5c41536e535f94c8495f62afa08ad6420bd" }
+astral-version-ranges = { git = "https://github.com/astral-sh/pubgrub.git", rev = "9c96d5c41536e535f94c8495f62afa08ad6420bd" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -457,3 +457,7 @@ codegen-units = 1
 # The profile that 'cargo dist' will build with.
 [profile.dist]
 inherits = "release"
+
+[patch.crates-io]
+astral-pubgrub = { git = "https://github.com/astral-sh/pubgrub.git", rev = "66d45efb9e01551924cac41918c3e8fe6f785318" }
+astral-version-ranges = { git = "https://github.com/astral-sh/pubgrub.git", rev = "66d45efb9e01551924cac41918c3e8fe6f785318" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -459,5 +459,5 @@ codegen-units = 1
 inherits = "release"
 
 [patch.crates-io]
-astral-pubgrub = { git = "https://github.com/astral-sh/pubgrub.git", rev = "9c96d5c41536e535f94c8495f62afa08ad6420bd" }
-astral-version-ranges = { git = "https://github.com/astral-sh/pubgrub.git", rev = "9c96d5c41536e535f94c8495f62afa08ad6420bd" }
+astral-pubgrub = { git = "https://github.com/astral-sh/pubgrub.git", rev = "2fce3b4843a3ca3978b36341e9bfd10de3d7aaf9" }
+astral-version-ranges = { git = "https://github.com/astral-sh/pubgrub.git", rev = "2fce3b4843a3ca3978b36341e9bfd10de3d7aaf9" }

--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashMap;
 
 use uv_distribution_types::{CompatibleDist, DistributionId, Identifier, ResolvedDist};
 use uv_normalize::PackageName;
+use uv_pep508::MarkerTree;
 
 use crate::candidate_selector::Candidate;
 
@@ -11,6 +12,8 @@ struct FilePin {
     dist: ResolvedDist,
     /// The concrete distribution whose metadata was used during resolution.
     metadata_id: DistributionId,
+    /// The environments supported by the selected distribution.
+    implied_markers: MarkerTree,
 }
 
 /// A set of package versions pinned to specific files.
@@ -34,6 +37,7 @@ impl FilePins {
             .or_insert_with(|| FilePin {
                 dist: dist.for_installation().to_owned(),
                 metadata_id: dist.for_resolution().distribution_id(),
+                implied_markers: dist.implied_markers(),
             });
     }
 
@@ -57,5 +61,16 @@ impl FilePins {
         self.0
             .get(&(name.clone(), version.clone()))
             .map(|pin| (&pin.dist, &pin.metadata_id))
+    }
+
+    /// Return the environments supported by the pinned distribution.
+    pub(crate) fn implied_markers(
+        &self,
+        name: &PackageName,
+        version: &uv_pep440::Version,
+    ) -> Option<MarkerTree> {
+        self.0
+            .get(&(name.clone(), version.clone()))
+            .map(|pin| pin.implied_markers)
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -513,14 +513,14 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         .expect("a package was chosen but we don't have a term");
                     let range = term_intersection.unwrap_positive();
 
-                    // In a specific environment, an implicit registry candidate is stable for a
-                    // given range. Avoid repeating candidate selection when PubGrub revisits an
-                    // identical decision after backtracking. If the range changed, reuse the
-                    // previous decision only when every better candidate is already known to
-                    // conflict with the current partial solution.
-                    let cache_selected_version = state.env.marker_environment().is_some()
-                        && url.is_none()
-                        && index.is_none();
+                    // An implicit registry candidate is stable for a given range. Avoid
+                    // repeating candidate selection when PubGrub revisits an identical decision
+                    // after backtracking. If the range changed, reuse the previous decision only
+                    // when every better candidate is already known to conflict with the current
+                    // partial solution. This is safe in universal resolution because we only
+                    // cache unforked decisions; any better candidate that can fork is neither
+                    // unavailable nor known to conflict, so it prevents reuse.
+                    let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -515,16 +515,41 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
                     // In a specific environment, an implicit registry candidate is stable for a
                     // given range. Avoid repeating candidate selection when PubGrub revisits an
-                    // identical decision after backtracking.
+                    // identical decision after backtracking. If the range changed, reuse the
+                    // previous decision only when every better candidate is already known to
+                    // conflict with the current partial solution.
                     let cache_selected_version = state.env.marker_environment().is_some()
                         && url.is_none()
                         && index.is_none();
-                    let decision = if cache_selected_version
+                    let phase_saved = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
-                        && selected_range == range
                     {
-                        Some(ResolverVersion::Unforked(version.clone()))
+                        let same_range = selected_range == range;
+                        let changed_range = if let Some(name) = next_package.name() {
+                            !same_range
+                                && range.contains(version)
+                                && preferences.get(name).is_empty()
+                                && (self.exclusions.reinstall(name)
+                                    || self.installed_packages.get_packages(name).is_empty())
+                                && self.all_better_versions_conflict(
+                                    name,
+                                    range,
+                                    version,
+                                    next_id,
+                                    &state.pubgrub,
+                                    &state.env,
+                                    &state.python_requirement,
+                                )?
+                        } else {
+                            false
+                        };
+                        (same_range || changed_range).then(|| version.clone())
+                    } else {
+                        None
+                    };
+                    let decision = if let Some(version) = phase_saved {
+                        Some(ResolverVersion::Unforked(version))
                     } else {
                         let decision = self.choose_version(
                             next_package,
@@ -1454,6 +1479,58 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         let version = candidate.version().clone();
         Ok(Some(ResolverVersion::Unforked(version)))
+    }
+
+    /// Return whether every registry candidate preferred over `selected` is already known to be
+    /// unavailable or incompatible with the current partial solution.
+    fn all_better_versions_conflict(
+        &self,
+        name: &PackageName,
+        range: &Range<Version>,
+        selected: &Version,
+        package: Id<PubGrubPackage>,
+        pubgrub: &State<UvDependencyProvider>,
+        env: &ResolverEnvironment,
+        python_requirement: &PythonRequirement,
+    ) -> Result<bool, ResolveError> {
+        let versions_response = self
+            .index
+            .implicit()
+            .wait_blocking(name)
+            .map_err(|_| ResolveError::UnregisteredTask(name.to_string()))?;
+        let VersionsResponse::Found(version_maps) = &*versions_response else {
+            return Ok(false);
+        };
+
+        let highest = self.selector.use_highest_version(name, env);
+        let mut remaining = if highest {
+            range.intersection(&Range::strictly_higher_than(selected.clone()))
+        } else {
+            range.intersection(&Range::strictly_lower_than(selected.clone()))
+        };
+        while let Some(candidate) =
+            self.selector
+                .select_no_preference(name, &remaining, version_maps, env)
+        {
+            let version = candidate.version().clone();
+            let unavailable = match candidate.dist() {
+                CandidateDist::Incompatible { .. } => true,
+                CandidateDist::Compatible(dist) => {
+                    Self::check_requires_python(dist, python_requirement).is_some()
+                }
+            };
+            if !unavailable
+                && !pubgrub.version_conflicts_with_partial_solution(package, version.clone())
+            {
+                return Ok(false);
+            }
+            remaining = if highest {
+                remaining.intersection(&Range::strictly_lower_than(version))
+            } else {
+                remaining.intersection(&Range::strictly_higher_than(version))
+            };
+        }
+        Ok(true)
     }
 
     /// Determine whether a candidate covers all supported platforms; and, if not, generate a fork.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{Level, debug, info, instrument, trace, warn};
 
-use uv_configuration::{Constraints, Excludes, Overrides};
+use uv_configuration::{Constraints, Excludes, IndexStrategy, Overrides};
 use uv_distribution::{ArchiveMetadata, DistributionDatabase};
 use uv_distribution_types::{
     BuiltDist, CompatibleDist, DerivationChain, Dist, DistErrorKind, Identifier, IncompatibleDist,
@@ -513,32 +513,36 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         .expect("a package was chosen but we don't have a term");
                     let range = term_intersection.unwrap_positive();
 
-                    // An implicit registry candidate is stable for a given range. Avoid
-                    // repeating candidate selection when PubGrub revisits an identical decision
-                    // after backtracking. If the range changed, reuse the previous decision only
-                    // when every better candidate is already known to conflict with the current
-                    // partial solution. This is safe in universal resolution because we only
-                    // cache unforked decisions; any better candidate that can fork is neither
-                    // unavailable nor known to conflict, so it prevents reuse.
+                    // Reuse a saved registry version after backtracking. If the allowed range
+                    // changed, only try it first after PubGrub has ruled out every preferred
+                    // version. Candidate compatibility is stable within a fork; required-
+                    // environment reachability is revalidated below.
                     let cache_selected_version = url.is_none() && index.is_none();
                     let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
                     {
                         let can_reuse = selected_range == range
-                            || if let Some(name) = next_package.name() {
+                            || if !version.is_local()
+                                && let Some(name) = next_package.name()
+                                && !uses_index_priority(
+                                    *self.selector.index_strategy(),
+                                    self.options.torch_backend.as_ref(),
+                                    name,
+                                )
+                            {
                                 range.contains(version)
                                     && preferences.get(name).is_empty()
                                     && (self.exclusions.reinstall(name)
                                         || self.installed_packages.get_packages(name).is_empty())
-                                    && self.all_better_versions_conflict(
+                                    && self.all_preferred_versions_conflict(
                                         name,
                                         range,
                                         version,
                                         next_id,
                                         &state.pubgrub,
                                         &state.env,
-                                        &state.python_requirement,
+                                        &mut state.checked_candidates,
                                     )?
                             } else {
                                 false
@@ -547,10 +551,27 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     } else {
                         None
                     };
-                    let decision = if let Some(version) = reusable_version {
-                        Some(ResolverVersion::Unforked(version))
+                    let saved_decision = reusable_version.and_then(|version| {
+                        let Some(name) = next_package.name() else {
+                            return Some(ResolverVersion::Unforked(version));
+                        };
+                        let implied_markers = state.pins.implied_markers(name, &version)?;
+                        Some(
+                            self.fork_version_for_required_environment(
+                                &version,
+                                implied_markers,
+                                next_id,
+                                name,
+                                &state.env,
+                                &state.pubgrub,
+                            )
+                            .unwrap_or(ResolverVersion::Unforked(version)),
+                        )
+                    });
+                    let decision = if let Some(decision) = saved_decision {
+                        Some(decision)
                     } else {
-                        let decision = self.choose_version(
+                        self.choose_version(
                             next_package,
                             next_id,
                             index.map(IndexMetadata::url),
@@ -563,18 +584,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             &state.pubgrub,
                             &mut visited,
                             request_sink,
-                        )?;
-
-                        if cache_selected_version
-                            && let Some(ResolverVersion::Unforked(version)) = &decision
-                        {
-                            state
-                                .selected_versions
-                                .insert(next_id, (range.clone(), version.clone()));
-                        }
-
-                        decision
+                        )?
                     };
+
+                    if cache_selected_version
+                        && let Some(ResolverVersion::Unforked(version)) = &decision
+                    {
+                        state
+                            .selected_versions
+                            .insert(next_id, (range.clone(), version.clone()));
+                    }
 
                     // Pick the next compatible version.
                     let Some(version) = decision else {
@@ -918,6 +937,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // into `forked_states`, and then only clone it if
         // there is at least one more fork to visit.
         let package = current_state.next;
+        let mut current_state = current_state;
+        current_state.selected_versions = FxHashMap::default();
+        current_state.checked_candidates = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
         forks
@@ -975,6 +997,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // as it needs to be. We basically move the state
         // into `forked_states`, and then only clone it if
         // there is at least one more fork to visit.
+        let mut current_state = current_state;
+        current_state.selected_versions = FxHashMap::default();
+        current_state.checked_candidates = FxHashMap::default();
         let mut cur_state = Some(current_state);
         let forks_len = forks.len();
         forks.into_iter().enumerate().map(move |(i, fork)| {
@@ -1363,7 +1388,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         debug!("Searching for a compatible version of {package} ({range})");
 
-        // Find a version.
         let Some(candidate) = self.selector.select(
             name,
             range,
@@ -1480,9 +1504,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         Ok(Some(ResolverVersion::Unforked(version)))
     }
 
-    /// Return whether every registry candidate preferred over `selected` is already known to be
-    /// unavailable or incompatible with the current partial solution.
-    fn all_better_versions_conflict(
+    /// Return whether every registry version preferred over `selected` is unavailable or
+    /// conflicts with the current PubGrub state.
+    fn all_preferred_versions_conflict(
         &self,
         name: &PackageName,
         range: &Range<Version>,
@@ -1490,7 +1514,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         package: Id<PubGrubPackage>,
         pubgrub: &State<UvDependencyProvider>,
         env: &ResolverEnvironment,
-        python_requirement: &PythonRequirement,
+        checked_candidates: &mut FxHashMap<Id<PubGrubPackage>, CheckedCandidates>,
     ) -> Result<bool, ResolveError> {
         let versions_response = self
             .index
@@ -1507,16 +1531,36 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         } else {
             range.intersection(&Range::strictly_lower_than(selected.clone()))
         };
+
+        // PubGrub works with ranges, but package indexes contain a fixed list of versions.
+        // Remember which versions the selector could choose so we can check them together on the
+        // next visit.
+        if let Some(checked) = checked_candidates.get(&package)
+            && remaining.subset_of(&checked.range)
+        {
+            let versions = remaining.intersection(&checked.versions);
+            if versions.is_empty()
+                || pubgrub.range_conflicts_with_partial_solution(package, versions)
+            {
+                return Ok(true);
+            }
+        }
+
+        if pubgrub.range_conflicts_with_partial_solution(package, remaining.clone()) {
+            return Ok(true);
+        }
+        let checked_range = remaining.clone();
+        let mut candidate_versions = Vec::new();
         while let Some(candidate) =
             self.selector
                 .select_no_preference(name, &remaining, version_maps, env)
         {
             let version = candidate.version().clone();
-            if let CandidateDist::Compatible(dist) = candidate.dist()
-                && Self::check_requires_python(dist, python_requirement).is_none()
-                && !pubgrub.version_conflicts_with_partial_solution(package, version.clone())
-            {
-                return Ok(false);
+            if matches!(candidate.dist(), CandidateDist::Compatible(_)) {
+                if !pubgrub.version_conflicts_with_partial_solution(package, version.clone()) {
+                    return Ok(false);
+                }
+                candidate_versions.push(version.clone());
             }
             remaining = if highest {
                 remaining.intersection(&Range::strictly_lower_than(version))
@@ -1524,6 +1568,25 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 remaining.intersection(&Range::strictly_higher_than(version))
             };
         }
+        // `Range` expects ascending bounds. Reverse versions selected from highest to lowest so it
+        // can append them without moving earlier entries.
+        if highest {
+            candidate_versions.reverse();
+        }
+        let versions = candidate_versions
+            .into_iter()
+            .map(|version| (Bound::Included(version.clone()), Bound::Included(version)))
+            .collect::<Range<_>>();
+        checked_candidates
+            .entry(package)
+            .and_modify(|checked| {
+                checked.range = checked.range.union(&checked_range);
+                checked.versions = checked.versions.union(&versions);
+            })
+            .or_insert(CheckedCandidates {
+                range: checked_range,
+                versions,
+            });
         Ok(true)
     }
 
@@ -1555,6 +1618,19 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         pins: &mut FilePins,
         request_sink: &Sender<Request>,
     ) -> Result<Option<ResolverVersion>, ResolveError> {
+        let implied_markers = dist.implied_markers();
+
+        if let Some(forked) = self.fork_version_for_required_environment(
+            candidate.version(),
+            implied_markers,
+            id,
+            name,
+            env,
+            pubgrub,
+        ) {
+            return Ok(Some(forked));
+        }
+
         // This only applies to universal resolutions.
         if env.marker_environment().is_some() {
             return Ok(None);
@@ -1562,55 +1638,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         // If the package is already compatible with all environments (as is the case for
         // packages that include a source distribution), we don't need to fork.
-        if dist.implied_markers().is_true() {
+        if implied_markers.is_true() {
             return Ok(None);
-        }
-
-        // If the caller marked an environment as requiring artifact coverage, ensure it has
-        // coverage.
-        for marker in self.options.artifact_environments.iter().copied() {
-            // If the platform is part of the current environment...
-            if env.included_by_marker(marker) {
-                // But isn't supported by the distribution...
-                if dist.implied_markers().is_disjoint(marker)
-                    && !find_environments(id, pubgrub).is_disjoint(marker)
-                {
-                    // Then we need to fork.
-                    let Some((left, right)) = fork_version_by_marker(env, marker) else {
-                        return Ok(Some(ResolverVersion::Unavailable(
-                            candidate.version().clone(),
-                            UnavailableVersion::IncompatibleDist(IncompatibleDist::Wheel(
-                                IncompatibleWheel::MissingPlatform(marker),
-                            )),
-                        )));
-                    };
-
-                    debug!(
-                        "Forking on required platform `{}` for {}=={} ({})",
-                        marker.try_to_string().unwrap_or_else(|| "true".to_string()),
-                        name,
-                        candidate.version(),
-                        [&left, &right]
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    );
-                    let forks = vec![
-                        VersionFork {
-                            env: left,
-                            id,
-                            version: None,
-                        },
-                        VersionFork {
-                            env: right,
-                            id,
-                            version: None,
-                        },
-                    ];
-                    return Ok(Some(ResolverVersion::Forked(forks)));
-                }
-            }
         }
 
         // For now, we only apply this to local versions.
@@ -1649,7 +1678,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // ...and the non-local version has greater platform support...
         let mut remainder = {
             let mut remainder = base_dist.implied_markers();
-            remainder.and(dist.implied_markers().negate());
+            remainder.and(implied_markers.negate());
             remainder
         };
         if remainder.is_false() {
@@ -1665,7 +1694,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         // Similarly, if the local distribution is incompatible with the current environment, then
         // use the base distribution instead (but don't fork).
-        if !env.included_by_marker(dist.implied_markers()) {
+        if !env.included_by_marker(implied_markers) {
             let filename = match dist.for_installation() {
                 ResolvedDistRef::InstallableRegistrySourceDist { sdist, .. } => sdist
                     .filename()
@@ -1715,9 +1744,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 operator: MarkerOperator::Equal,
                 value,
             });
-            if dist.implied_markers().is_disjoint(sys_platform)
-                && !remainder.is_disjoint(sys_platform)
-            {
+            if implied_markers.is_disjoint(sys_platform) && !remainder.is_disjoint(sys_platform) {
                 remainder.or(sys_platform);
             }
         }
@@ -1760,6 +1787,62 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             },
         ];
         Ok(Some(ResolverVersion::Forked(forks)))
+    }
+
+    /// Check required-environment coverage for a version.
+    fn fork_version_for_required_environment(
+        &self,
+        version: &Version,
+        implied_markers: MarkerTree,
+        id: Id<PubGrubPackage>,
+        name: &PackageName,
+        env: &ResolverEnvironment,
+        pubgrub: &State<UvDependencyProvider>,
+    ) -> Option<ResolverVersion> {
+        if env.marker_environment().is_some() || implied_markers.is_true() {
+            return None;
+        }
+
+        for marker in self.options.artifact_environments.iter().copied() {
+            if env.included_by_marker(marker)
+                && implied_markers.is_disjoint(marker)
+                && !find_environments(id, pubgrub).is_disjoint(marker)
+            {
+                let Some((left, right)) = fork_version_by_marker(env, marker) else {
+                    return Some(ResolverVersion::Unavailable(
+                        version.clone(),
+                        UnavailableVersion::IncompatibleDist(IncompatibleDist::Wheel(
+                            IncompatibleWheel::MissingPlatform(marker),
+                        )),
+                    ));
+                };
+
+                debug!(
+                    "Forking on required platform `{}` for {}=={} ({})",
+                    marker.try_to_string().unwrap_or_else(|| "true".to_string()),
+                    name,
+                    version,
+                    [&left, &right]
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                return Some(ResolverVersion::Forked(vec![
+                    VersionFork {
+                        env: left,
+                        id,
+                        version: None,
+                    },
+                    VersionFork {
+                        env: right,
+                        id,
+                        version: None,
+                    },
+                ]));
+            }
+        }
+        None
     }
 
     /// Visit a selected candidate.
@@ -3048,6 +3131,10 @@ pub(crate) struct ForkState {
     pre_visited: FxHashMap<Id<PubGrubPackage>, Range<Version>>,
     /// The last version selected for each package and range in a specific environment.
     selected_versions: FxHashMap<Id<PubGrubPackage>, (Range<Version>, Version)>,
+    /// Registry versions checked while deciding whether to reuse a saved version.
+    ///
+    /// This is cleared after a fork because available versions depend on the environment.
+    checked_candidates: FxHashMap<Id<PubGrubPackage>, CheckedCandidates>,
     /// The marker expression that created this state.
     ///
     /// The root state always corresponds to a marker expression that is always
@@ -3102,6 +3189,7 @@ impl ForkState {
             added_dependencies: FxHashMap::default(),
             pre_visited: FxHashMap::default(),
             selected_versions: FxHashMap::default(),
+            checked_candidates: FxHashMap::default(),
             env,
             python_requirement,
             conflict_tracker: ConflictTracker::default(),
@@ -3358,6 +3446,8 @@ impl ForkState {
     /// If the fork should be dropped (e.g., because its markers can never be true for its
     /// Python requirement), then this returns `None`.
     fn with_env(mut self, env: ResolverEnvironment) -> Self {
+        self.selected_versions.clear();
+        self.checked_candidates.clear();
         self.env = env;
         // If the fork contains a narrowed Python requirement, apply it.
         if let Some(req) = self.env.narrow_python_requirement(&self.python_requirement) {
@@ -3641,6 +3731,14 @@ impl ForkState {
             env: self.env,
         }
     }
+}
+
+#[derive(Clone)]
+struct CheckedCandidates {
+    /// Ranges where every index version was checked.
+    range: Range<Version>,
+    /// Versions that the candidate selector can choose.
+    versions: Range<Version>,
 }
 
 /// The resolution from a single fork including the virtual packages and the edges between them.
@@ -4391,6 +4489,44 @@ fn find_environments(id: Id<PubGrubPackage>, state: &State<UvDependencyProvider>
     }
 
     environments.remove(&id).unwrap_or(MarkerTree::FALSE)
+}
+
+/// Return whether candidate preference is index-first instead of version-first.
+fn uses_index_priority(
+    index_strategy: IndexStrategy,
+    torch_backend: Option<&TorchStrategy>,
+    package_name: &PackageName,
+) -> bool {
+    matches!(index_strategy, IndexStrategy::UnsafeFirstMatch)
+        || torch_backend.is_some_and(|torch_backend| torch_backend.applies_to(package_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use uv_torch::{TorchBackend, TorchSource};
+
+    use super::*;
+
+    #[test]
+    fn torch_backend_uses_index_priority_for_torch_packages() {
+        let torch_backend = TorchStrategy::Backend {
+            backend: TorchBackend::Cpu,
+            source: TorchSource::PyTorch,
+        };
+
+        assert!(uses_index_priority(
+            IndexStrategy::FirstIndex,
+            Some(&torch_backend),
+            &PackageName::from_str("torch").expect("torch should be a valid package name"),
+        ));
+        assert!(!uses_index_priority(
+            IndexStrategy::FirstIndex,
+            Some(&torch_backend),
+            &PackageName::from_str("numpy").expect("numpy should be a valid package name"),
+        ));
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -521,34 +521,33 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     let cache_selected_version = state.env.marker_environment().is_some()
                         && url.is_none()
                         && index.is_none();
-                    let phase_saved = if cache_selected_version
+                    let reusable_version = if cache_selected_version
                         && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
                     {
-                        let same_range = selected_range == range;
-                        let changed_range = if let Some(name) = next_package.name() {
-                            !same_range
-                                && range.contains(version)
-                                && preferences.get(name).is_empty()
-                                && (self.exclusions.reinstall(name)
-                                    || self.installed_packages.get_packages(name).is_empty())
-                                && self.all_better_versions_conflict(
-                                    name,
-                                    range,
-                                    version,
-                                    next_id,
-                                    &state.pubgrub,
-                                    &state.env,
-                                    &state.python_requirement,
-                                )?
-                        } else {
-                            false
-                        };
-                        (same_range || changed_range).then(|| version.clone())
+                        let can_reuse = selected_range == range
+                            || if let Some(name) = next_package.name() {
+                                range.contains(version)
+                                    && preferences.get(name).is_empty()
+                                    && (self.exclusions.reinstall(name)
+                                        || self.installed_packages.get_packages(name).is_empty())
+                                    && self.all_better_versions_conflict(
+                                        name,
+                                        range,
+                                        version,
+                                        next_id,
+                                        &state.pubgrub,
+                                        &state.env,
+                                        &state.python_requirement,
+                                    )?
+                            } else {
+                                false
+                            };
+                        can_reuse.then(|| version.clone())
                     } else {
                         None
                     };
-                    let decision = if let Some(version) = phase_saved {
+                    let decision = if let Some(version) = reusable_version {
                         Some(ResolverVersion::Unforked(version))
                     } else {
                         let decision = self.choose_version(
@@ -1513,13 +1512,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 .select_no_preference(name, &remaining, version_maps, env)
         {
             let version = candidate.version().clone();
-            let unavailable = match candidate.dist() {
-                CandidateDist::Incompatible { .. } => true,
-                CandidateDist::Compatible(dist) => {
-                    Self::check_requires_python(dist, python_requirement).is_some()
-                }
-            };
-            if !unavailable
+            if let CandidateDist::Compatible(dist) = candidate.dist()
+                && Self::check_requires_python(dist, python_requirement).is_none()
                 && !pubgrub.version_conflicts_with_partial_solution(package, version.clone())
             {
                 return Ok(false);

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1546,9 +1546,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             }
         }
 
-        if pubgrub.range_conflicts_with_partial_solution(package, remaining.clone()) {
-            return Ok(true);
-        }
         let checked_range = remaining.clone();
         let mut candidate_versions = Vec::new();
         while let Some(candidate) =

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -13228,6 +13228,46 @@ fn lock_phase_saving_preserves_universal_forks() -> Result<()> {
     Ok(())
 }
 
+/// Check that phase saving preserves index priority with `unsafe-first-match`.
+#[test]
+fn lock_phase_saving_preserves_unsafe_first_match_priority() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let first_index = PackseServer::new("fork/phase-saving-index-priority-first.toml");
+    let second_index = PackseServer::new("fork/phase-saving-index-priority-second.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["parent"]
+        "#,
+    )?;
+
+    let mut command = context.lock();
+    command
+        .arg("--index-url")
+        .arg(second_index.index_url())
+        .arg("--extra-index-url")
+        .arg(first_index.index_url())
+        .arg("--index-strategy")
+        .arg("unsafe-first-match")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .assert()
+        .success();
+
+    let lock = context.read("uv.lock");
+    assert!(lock.contains("name = \"a\"\nversion = \"1.0.0\""));
+    assert!(!lock.contains("name = \"a\"\nversion = \"2.0.0\""));
+
+    command.arg("--locked").assert().success();
+    assert_eq!(lock, context.read("uv.lock"));
+
+    Ok(())
+}
+
 /// Warn when there are missing bounds on transitive dependencies with `--resolution lowest`.
 #[test]
 fn lock_warn_missing_transitive_lower_bounds() -> Result<()> {

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -13184,6 +13184,50 @@ fn lock_upgrade_drop_fork_markers() -> Result<()> {
     Ok(())
 }
 
+/// Check that phase-saving preserves universal forks after backtracking.
+#[test]
+fn lock_phase_saving_preserves_universal_forks() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "forking"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["foo", "baz"]
+        "#,
+    )?;
+
+    context
+        .lock()
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .assert()
+        .success();
+
+    let lock = context.read("uv.lock");
+    assert!(lock.contains("name = \"foo\"\nversion = \"1.0.0\""));
+    assert!(!lock.contains("name = \"foo\"\nversion = \"2.0.0\""));
+    assert!(lock.contains("name = \"bar\"\nversion = \"1.0.0\""));
+    assert!(lock.contains("name = \"bar\"\nversion = \"2.0.0\""));
+
+    context
+        .lock()
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--locked")
+        .assert()
+        .success();
+    assert_eq!(lock, context.read("uv.lock"));
+
+    Ok(())
+}
+
 /// Warn when there are missing bounds on transitive dependencies with `--resolution lowest`.
 #[test]
 fn lock_warn_missing_transitive_lower_bounds() -> Result<()> {

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -3357,6 +3357,433 @@ fn fork_overlapping_markers_basic() -> Result<()> {
     Ok(())
 }
 
+/// After backtracking widens a package requirement, check again whether a saved local version must
+/// fork from its public version.
+///
+///
+/// ```text
+/// phase-saving-local-version
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   └── requires parent
+/// │       ├── satisfied by parent-1.0.0
+/// │       └── satisfied by parent-2.0.0
+/// ├── late
+/// │   └── late-1.0.0
+/// │       └── requires missing
+/// │           └── unsatisfied: no versions for package
+/// ├── parent
+/// │   ├── parent-1.0.0
+/// │   │   └── requires torch==1.0.0
+/// │   │       ├── satisfied by torch-1.0.0
+/// │   │       └── satisfied by torch-1.0.0+cpu
+/// │   └── parent-2.0.0
+/// │       ├── requires late==1.0.0
+/// │       │   └── satisfied by late-1.0.0
+/// │       └── requires torch==1.0.0+cpu
+/// │           └── satisfied by torch-1.0.0+cpu
+/// └── torch
+///     ├── torch-1.0.0
+///     └── torch-1.0.0+cpu
+/// ```
+#[test]
+fn phase_saving_local_version() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving-local-version.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''parent''',
+        ]
+        requires-python = ">=3.12"
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "sys_platform != 'darwin'",
+            "sys_platform == 'darwin'",
+        ]
+
+        [[package]]
+        name = "parent"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "torch", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'darwin'" },
+            { name = "torch", version = "1.0.0+cpu", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'darwin'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/parent-1.0.0.tar.gz", hash = "sha256:dfdc98da0cb358bca8a0179fdd008f91554df6372a315663429a7e031187abff", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/parent-1.0.0-py3-none-any.whl", hash = "sha256:ab4b17140d9229a0aa4cec233d049135af783e8860562b6820c24d5af5c164d8", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "parent" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "parent" }]
+
+        [[package]]
+        name = "torch"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform == 'darwin'",
+        ]
+        wheels = [
+            { url = "http://[LOCALHOST]/files/torch-1.0.0-py3-none-macosx_10_0_x86_64.whl", hash = "sha256:709a76c166bb5f6d5a49f6f1e18b27e4e6bd091cc5f4c16fc910cb5935acd62f", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "torch"
+        version = "1.0.0+cpu"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform != 'darwin'",
+        ]
+        wheels = [
+            { url = "http://[LOCALHOST]/files/torch-1.0.0+cpu-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a060635f53f33b89d2d72a6dca05d44d2d45c135d172dc1bc89f4b068bbfe7f7", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+/// After backtracking widens a package requirement, check again that the selected files support every
+/// required environment.
+///
+///
+/// ```text
+/// phase-saving-required-environment
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   └── requires parent
+/// │       ├── satisfied by parent-1.0.0
+/// │       └── satisfied by parent-2.0.0
+/// ├── a
+/// │   ├── a-0.9.0
+/// │   └── a-1.0.0
+/// ├── late
+/// │   └── late-1.0.0
+/// │       └── requires missing
+/// │           └── unsatisfied: no versions for package
+/// └── parent
+///     ├── parent-1.0.0
+///     │   └── requires a
+///     │       ├── satisfied by a-0.9.0
+///     │       └── satisfied by a-1.0.0
+///     └── parent-2.0.0
+///         ├── requires a==1.0.0 ; sys_platform != 'win32'
+///         │   └── satisfied by a-1.0.0
+///         └── requires late==1.0.0
+///             └── satisfied by late-1.0.0
+/// ```
+#[test]
+fn phase_saving_required_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving-required-environment.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''parent''',
+        ]
+        requires-python = ">=3.12"
+        [tool.uv]
+        required-environments = [
+          '''sys_platform == 'win32'''',
+        ]
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "sys_platform != 'win32'",
+            "sys_platform == 'win32'",
+        ]
+        required-markers = [
+            "sys_platform == 'win32'",
+        ]
+
+        [[package]]
+        name = "a"
+        version = "0.9.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform == 'win32'",
+        ]
+        wheels = [
+            { url = "http://[LOCALHOST]/files/a-0.9.0-py3-none-win_amd64.whl", hash = "sha256:d5cbc3502e518901a44fcf6560565530ac77e5d994bc3181a68e9e4c0f8a05f2", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "a"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform != 'win32'",
+        ]
+        wheels = [
+            { url = "http://[LOCALHOST]/files/a-1.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9c2c85239e2d6fe0ceeca5211b4b0ce1f02d6bd52967398bd55791d2d41e479a", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "parent"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "a", version = "0.9.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'win32'" },
+            { name = "a", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'win32'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/parent-1.0.0.tar.gz", hash = "sha256:e58f7845e014962152b8f15c4603fb804c8162b9281ddbe23cc101aa911b3275", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/parent-1.0.0-py3-none-any.whl", hash = "sha256:2a2d74615c39fc52c4d5076007a1f680a5bc26551f2980ad42b6242f568eea60", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "parent" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "parent" }]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+/// After backtracking widens a package requirement, keep the fork required by a package's Python
+/// version constraint.
+///
+///
+/// ```text
+/// phase-saving-requires-python
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   └── requires parent
+/// │       ├── satisfied by parent-1.0.0
+/// │       └── satisfied by parent-2.0.0
+/// ├── foo
+/// │   ├── foo-1.0.0
+/// │   └── foo-2.0.0
+/// │       └── requires python>=3.13 (incompatible with environment)
+/// ├── late
+/// │   └── late-1.0.0
+/// │       └── requires missing
+/// │           └── unsatisfied: no versions for package
+/// └── parent
+///     ├── parent-1.0.0
+///     │   └── requires foo
+///     │       ├── satisfied by foo-1.0.0
+///     │       └── satisfied by foo-2.0.0
+///     └── parent-2.0.0
+///         ├── requires foo==1.0.0
+///         │   └── satisfied by foo-1.0.0
+///         └── requires late==1.0.0
+///             └── satisfied by late-1.0.0
+/// ```
+#[test]
+fn phase_saving_requires_python() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving-requires-python.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''parent''',
+        ]
+        requires-python = ">=3.12"
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "python_full_version >= '3.13'",
+            "python_full_version < '3.13'",
+        ]
+
+        [[package]]
+        name = "foo"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "python_full_version < '3.13'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/foo-1.0.0.tar.gz", hash = "sha256:4d4cf959f969e0a39663aca6064428819f1e1c6be60d9a35164801ce17950ed4", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/foo-1.0.0-py3-none-any.whl", hash = "sha256:df9a39d54a6d71872deb1537d7e331de0ede3b725d630a050fee3efd3fe5145b", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "foo"
+        version = "2.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "python_full_version >= '3.13'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/foo-2.0.0.tar.gz", hash = "sha256:7f469469bd699483be052cfa623e942c393cf0a6ebf3ea3e3da79183230720ba", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/foo-2.0.0-py3-none-any.whl", hash = "sha256:6c776b7fcba8f4982f23be5c8d1c4cdfdc95aeb8178cb21fb1017dd261f0405b", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "parent"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "foo", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version < '3.13'" },
+            { name = "foo", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version >= '3.13'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/parent-1.0.0.tar.gz", hash = "sha256:7e2cabeee40c9e8babaf3e513e3a5475bd5e86a5cb1b36a74448b2c9bc4dc879", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/parent-1.0.0-py3-none-any.whl", hash = "sha256:1186d554a97e92e7ea5039b82e9cbc5055385f23394410f152a630bd564cf7a7", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "parent" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "parent" }]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 /// This test checks that phase-saving preserves universal forks after backtracking.
 ///
 ///

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -3357,6 +3357,167 @@ fn fork_overlapping_markers_basic() -> Result<()> {
     Ok(())
 }
 
+/// This test checks that phase-saving preserves universal forks after backtracking.
+///
+///
+/// ```text
+/// phase-saving
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   ├── requires baz
+/// │   │   └── satisfied by baz-1.0.0
+/// │   └── requires foo
+/// │       ├── satisfied by foo-1.0.0
+/// │       └── satisfied by foo-2.0.0
+/// ├── bar
+/// │   ├── bar-1.0.0
+/// │   └── bar-2.0.0
+/// ├── baz
+/// │   └── baz-1.0.0
+/// │       ├── requires bar==1 ; sys_platform == 'linux'
+/// │       │   └── satisfied by bar-1.0.0
+/// │       └── requires bar==2 ; sys_platform != 'linux'
+/// │           └── satisfied by bar-2.0.0
+/// └── foo
+///     ├── foo-1.0.0
+///     │   ├── requires bar==1 ; sys_platform == 'linux'
+///     │   │   └── satisfied by bar-1.0.0
+///     │   └── requires bar==2 ; sys_platform != 'linux'
+///     │       └── satisfied by bar-2.0.0
+///     └── foo-2.0.0
+///         └── requires bar==2
+///             └── satisfied by bar-2.0.0
+/// ```
+#[test]
+fn phase_saving() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''foo''',
+          '''baz''',
+        ]
+        requires-python = ">=3.12"
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "sys_platform == 'linux'",
+            "sys_platform != 'linux'",
+        ]
+
+        [[package]]
+        name = "bar"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform == 'linux'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/bar-1.0.0.tar.gz", hash = "sha256:d373f4858d602855ef53231a7f24ebff4e67e1fe30a2e810ee2b2a29b9d1a50a", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/bar-1.0.0-py3-none-any.whl", hash = "sha256:2fbf0e0a7dd4f48a8b1c2148f73ba0c314699d0bfa0a8ec9b9bcb8105882e9fc", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "bar"
+        version = "2.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform != 'linux'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/bar-2.0.0.tar.gz", hash = "sha256:fa9a4faf506228722784ed740a362bccd96913f4f98a4e10d45ab79d8abb270a", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/bar-2.0.0-py3-none-any.whl", hash = "sha256:563b1af3238a4ad819f2b95b74f940319a2ef30ed7991a2416fa98aa115da87d", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "baz"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "bar", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'linux'" },
+            { name = "bar", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'linux'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/baz-1.0.0.tar.gz", hash = "sha256:cd4bd6d8d98df82464c3de47bd1c0d1fd3b5b8d13ce934f20cf72d4d7a4458d7", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/baz-1.0.0-py3-none-any.whl", hash = "sha256:32eb7602c0ca51b0ffb5e40ad804254a73117157e64c9edb697d1540b3f10bdf", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "foo"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        dependencies = [
+            { name = "bar", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'linux'" },
+            { name = "bar", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'linux'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/foo-1.0.0.tar.gz", hash = "sha256:b7939168304bd17ae9606ea29edf36907eea6e1a10116335e927986680fd25a8", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/foo-1.0.0-py3-none-any.whl", hash = "sha256:b96e9e502ccd1918e47b93ecb446956c037f6855a7edadca5bc9365803cd106f", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "baz" },
+            { name = "foo" },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "baz" },
+            { name = "foo" },
+        ]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 /// This test contains a bistable resolution scenario when not using ahead-of-time
 /// splitting of resolution forks: We meet one of two fork points depending on the
 /// preferences, creating a resolution whose preferences lead us the other fork

--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -966,6 +966,84 @@ fn multiple_extras_required() {
     context.assert_installed("c", "1.0.0");
 }
 
+/// The higher-priority index contains the lower version.
+///
+/// ```text
+/// phase-saving-index-priority-first
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// └── a
+///     └── a-1.0.0
+/// ```
+#[test]
+fn phase_saving_index_priority_first() {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving-index-priority-first.toml");
+
+    uv_snapshot!(context.filters(), command(&context, &server)
+        , @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the following required arguments were not provided:
+      <PACKAGE|--requirements <REQUIREMENTS>|--editable <EDITABLE>|--group <GROUP>>
+
+    Usage: uv pip install --cache-dir [CACHE_DIR] --index-url <INDEX_URL> <PACKAGE|--requirements <REQUIREMENTS>|--editable <EDITABLE>|--group <GROUP>>
+
+    For more information, try '--help'.
+    ");
+}
+
+/// The lower-priority index forces backtracking after selecting the higher version.
+///
+/// ```text
+/// phase-saving-index-priority-second
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   └── requires parent
+/// │       ├── satisfied by parent-1.0.0
+/// │       └── satisfied by parent-2.0.0
+/// ├── a
+/// │   └── a-2.0.0
+/// ├── late
+/// │   └── late-1.0.0
+/// │       └── requires missing
+/// │           └── unsatisfied: no versions for package
+/// └── parent
+///     ├── parent-1.0.0
+///     │   └── requires a
+///     │       └── satisfied by a-2.0.0
+///     └── parent-2.0.0
+///         ├── requires a==2.0.0
+///         │   └── satisfied by a-2.0.0
+///         └── requires late==1.0.0
+///             └── satisfied by late-1.0.0
+/// ```
+#[test]
+fn phase_saving_index_priority_second() {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/phase-saving-index-priority-second.toml");
+
+    uv_snapshot!(context.filters(), command(&context, &server)
+        .arg("parent")
+        , @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + a==2.0.0
+     + parent==1.0.0
+    ");
+}
+
 /// The user requires two incompatible, existing versions of package `a`
 ///
 /// ```text

--- a/test/scenarios/fork/phase-saving-index-priority-first.toml
+++ b/test/scenarios/fork/phase-saving-index-priority-first.toml
@@ -1,0 +1,10 @@
+name = "phase-saving-index-priority-first"
+description = "The higher-priority index contains the lower version."
+
+[expected]
+satisfiable = true
+
+[root]
+requires = []
+
+[packages.a.versions."1.0.0"]

--- a/test/scenarios/fork/phase-saving-index-priority-second.toml
+++ b/test/scenarios/fork/phase-saving-index-priority-second.toml
@@ -1,0 +1,19 @@
+name = "phase-saving-index-priority-second"
+description = "The lower-priority index forces backtracking after selecting the higher version."
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["parent"]
+
+[packages.parent.versions."1.0.0"]
+requires = ["a"]
+
+[packages.parent.versions."2.0.0"]
+requires = ["a==2.0.0", "late==1.0.0"]
+
+[packages.a.versions."2.0.0"]
+
+[packages.late.versions."1.0.0"]
+requires = ["missing"]

--- a/test/scenarios/fork/phase-saving-local-version.toml
+++ b/test/scenarios/fork/phase-saving-local-version.toml
@@ -1,0 +1,34 @@
+name = "phase-saving-local-version"
+description = '''
+After backtracking widens a package requirement, check again whether a saved local version must
+fork from its public version.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["parent"]
+
+[packages.parent.versions."1.0.0"]
+requires = ["torch==1.0.0"]
+
+[packages.parent.versions."2.0.0"]
+requires = [
+  "torch==1.0.0+cpu",
+  "late==1.0.0",
+]
+
+[packages.late.versions."1.0.0"]
+requires = ["missing"]
+
+[packages.torch.versions."1.0.0"]
+sdist = false
+wheel_tags = ["py3-none-macosx_10_0_x86_64"]
+
+[packages.torch.versions."1.0.0+cpu"]
+sdist = false
+wheel_tags = ["py3-none-manylinux2014_x86_64"]

--- a/test/scenarios/fork/phase-saving-required-environment.toml
+++ b/test/scenarios/fork/phase-saving-required-environment.toml
@@ -1,0 +1,35 @@
+name = "phase-saving-required-environment"
+description = '''
+After backtracking widens a package requirement, check again that the selected files support every
+required environment.
+'''
+
+[resolver_options]
+universal = true
+required_environments = ['sys_platform == "win32"']
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["parent"]
+
+[packages.parent.versions."1.0.0"]
+requires = ["a"]
+
+[packages.parent.versions."2.0.0"]
+requires = [
+  "a==1.0.0; sys_platform != 'win32'",
+  "late==1.0.0",
+]
+
+[packages.late.versions."1.0.0"]
+requires = ["missing"]
+
+[packages.a.versions."0.9.0"]
+sdist = false
+wheel_tags = ["py3-none-win_amd64"]
+
+[packages.a.versions."1.0.0"]
+sdist = false
+wheel_tags = ["py3-none-manylinux2014_x86_64"]

--- a/test/scenarios/fork/phase-saving-requires-python.toml
+++ b/test/scenarios/fork/phase-saving-requires-python.toml
@@ -1,0 +1,32 @@
+name = "phase-saving-requires-python"
+description = '''
+After backtracking widens a package requirement, keep the fork required by a package's Python
+version constraint.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires_python = ">=3.12"
+requires = ["parent"]
+
+[packages.parent.versions."1.0.0"]
+requires = ["foo"]
+
+[packages.parent.versions."2.0.0"]
+requires = [
+  "foo==1.0.0",
+  "late==1.0.0",
+]
+
+[packages.foo.versions."1.0.0"]
+
+[packages.foo.versions."2.0.0"]
+requires_python = ">=3.13"
+
+[packages.late.versions."1.0.0"]
+requires = ["missing"]

--- a/test/scenarios/fork/phase-saving.toml
+++ b/test/scenarios/fork/phase-saving.toml
@@ -1,0 +1,31 @@
+name = "phase-saving"
+description = '''
+This test checks that phase-saving preserves universal forks after backtracking.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = ["foo", "baz"]
+
+[packages.foo.versions."1.0.0"]
+requires = [
+  "bar==1; sys_platform == 'linux'",
+  "bar==2; sys_platform != 'linux'",
+]
+
+[packages.foo.versions."2.0.0"]
+requires = ["bar==2"]
+
+[packages.baz.versions."1.0.0"]
+requires = [
+  "bar==1; sys_platform == 'linux'",
+  "bar==2; sys_platform != 'linux'",
+]
+
+[packages.bar.versions."1.0.0"]
+[packages.bar.versions."2.0.0"]


### PR DESCRIPTION
## Summary

Phase saving (also called [“progress saving”](https://doi.org/10.1007/978-3-540-72788-0_29)) is a backtracking-search technique for avoiding repeated work. When non-chronological backtracking erases assignments that were unrelated to the conflict, the solver remembers those assignments and prefers them when the corresponding variables are selected again. This helps the solver recover a previously discovered partial solution instead of reconstructing it from scratch.

PubGrub exhibits an analogous pattern during dependency resolution: after backtracking, it can revisit a package for which uv has already selected a version. [#20020](https://github.com/astral-sh/uv/pull/20020) introduced a limited form of phase saving by caching the selected version and reusing it when PubGrub revisits the package with exactly the same allowed range. This PR extends that optimization to changed ranges and to universal resolution, avoiding repeated candidate selection and compatibility work.

Unlike a SAT solver, however, uv cannot apply phase saving unconditionally. A SAT solver only needs to find any satisfying assignment, so changing the order in which assignments are explored does not change correctness. uv must also respect its version-selection strategy and produce a maximal solution. For example, if uv previously selected `1.0.0` from `<2` and backtracking later widens the range to `<3`, blindly reusing `1.0.0` could produce a valid but stale solution even though `2.0.0` is now available.

Now, when the allowed range is unchanged, we reuse the previous implicit-registry decision as before. But when the range has changed, we only reuse the saved version if it remains allowed, no lockfile preference or installed distribution changes the candidate ordering, and every candidate preferred over it is already unavailable or incompatible with the current partial solution. For this, we introduce a [`State::range_conflicts_with_partial_solution`](https://github.com/astral-sh/pubgrub/pull/73) query to evaluate hypothetical version ranges against the incompatibilities already known to the current solver state.

Here is the net effect on the number of versions visited for our ecosystem projects:

| Benchmark      | Before | After | Change |
| -------------- | -----: | ----: | -----: |
| Transformers   |  4,642 | 3,993 | -14.0% |
| Jupyter        |  2,215 | 1,761 | -20.5% |
| Home Assistant |    256 |   256 |   0.0% |
| Warehouse      |  2,491 | 1,038 | -58.3% |
| Total          |  9,604 | 7,048 | -26.6% |

And here's the wall time effect:

| Benchmark       | Before  | After   | Change |
| --------------- | ------: | ------: | -----: |
| Transformers    | 950.1ms | 774.5ms | -18.5% |
| Home Assistant  | 169.9ms | 159.9ms |  -5.9% |
| Warehouse       | 227.0ms | 221.4ms |  -2.5% |
| JupyterLab      | 193.8ms | 191.3ms |  -1.3% |
| Semantic Kernel | 453.9ms | 451.6ms |  -0.5% |
