### PR TITLE
Re-add `pub` APIs used in Pixi

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -217,7 +217,7 @@ impl<'a> BaseClientBuilder<'a> {
     /// Note that some configuration options from this builder will still be applied
     /// to the client via middleware.
     #[must_use]
-    pub(crate) fn custom_client(mut self, client: Client) -> Self {
+    pub fn custom_client(mut self, client: Client) -> Self {
         self.custom_client = Some(client);
         self
     }

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -1,8 +1,8 @@
 pub use base_client::{
     AuthIntegration, BaseClient, BaseClientBuilder, ClientBuildError, DEFAULT_CONNECT_TIMEOUT,
     DEFAULT_MAX_REDIRECTS, DEFAULT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT_UPLOAD, DEFAULT_RETRIES,
-    RedirectClientWithMiddleware, RedirectPolicy, RequestBuilder, RetryParsingError,
-    fetch_with_url_fallback,
+    ExtraMiddleware, RedirectClientWithMiddleware, RedirectPolicy, RequestBuilder,
+    RetryParsingError, fetch_with_url_fallback,
 };
 pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithCachePolicy};
 pub use error::{Error, ErrorKind, ProblemDetails, WrappedReqwestError};

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -22,7 +22,7 @@ use crate::source::{HTTP_REVISION, HttpRevisionPointer, LOCAL_REVISION, LocalRev
 
 /// An entry in the [`RegistryWheelIndex`].
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct IndexEntry<'index> {
+pub struct IndexEntry<'index> {
     /// The cached distribution.
     dist: CachedRegistryDist,
     /// Whether the wheel was built from source (true), or downloaded from the registry directly (false).
@@ -32,6 +32,21 @@ struct IndexEntry<'index> {
 }
 
 impl IndexEntry<'_> {
+    /// The index from which the wheel was downloaded.
+    pub fn index(&self) -> &Index {
+        self.index
+    }
+
+    /// Whether the wheel was built from source.
+    pub fn is_built(&self) -> bool {
+        self.built
+    }
+
+    /// The cached distribution.
+    pub fn dist(&self) -> &CachedRegistryDist {
+        &self.dist
+    }
+
     fn matches_wheel(
         &self,
         index: &IndexUrl,
@@ -146,7 +161,7 @@ impl<'a> RegistryWheelIndex<'a> {
     /// Return an iterator over available wheels for a given package.
     ///
     /// If the package is not yet indexed, this will index the package by reading from the cache.
-    fn get(&mut self, name: &'a PackageName) -> impl Iterator<Item = &IndexEntry<'_>> {
+    pub fn get(&mut self, name: &'a PackageName) -> impl Iterator<Item = &IndexEntry<'_>> {
         self.get_impl(name).iter().rev()
     }
 

--- a/crates/uv-resolver/src/python_requirement.rs
+++ b/crates/uv-resolver/src/python_requirement.rs
@@ -75,7 +75,7 @@ impl PythonRequirement {
     /// This has the same "source" as
     /// [`PythonRequirement::from_requires_python`], but is useful for
     /// constructing a `PythonRequirement` without an [`Interpreter`].
-    pub(crate) fn from_marker_environment(
+    pub fn from_marker_environment(
         marker_env: &MarkerEnvironment,
         requires_python: RequiresPython,
     ) -> Self {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -212,7 +212,7 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
     Resolver<Provider, InstalledPackages>
 {
     /// Initialize a new resolver using a user provided backend.
-    fn new_custom_io(
+    pub fn new_custom_io(
         manifest: Manifest,
         options: Options,
         hasher: &HashStrategy,

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -131,7 +131,7 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext> {
 
 impl<'a, Context: BuildContext> DefaultResolverProvider<'a, Context> {
     /// Reads the flat index entries and builds the provider.
-    pub(crate) fn new(
+    pub fn new(
         fetcher: DistributionDatabase<'a, Context>,
         flat_index: &'a FlatIndex,
         tags: Option<&'a Tags>,

--- a/crates/uv-resolver/src/yanks.rs
+++ b/crates/uv-resolver/src/yanks.rs
@@ -14,7 +14,7 @@ use crate::{DependencyMode, Manifest, ResolverEnvironment};
 pub struct AllowedYanks(Arc<FxHashMap<PackageName, FxHashSet<Version>>>);
 
 impl AllowedYanks {
-    pub(crate) fn from_manifest(
+    pub fn from_manifest(
         manifest: &Manifest,
         env: &ResolverEnvironment,
         dependencies: DependencyMode,


### PR DESCRIPTION
## Summary

Some APIs were made `pub(crate)` in recent releases which blocks us from upgrading in Pixi.
If possible, it would be very nice if we can use them without patching.

## Test Plan

Tested by updating `uv` in Pixi. Shouldn't change anything for `uv` itself.
