### PR TITLE
Preserve direct dependency selection context for locked project tools

### DIFF
--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -11,7 +11,7 @@ pub use fork_strategy::ForkStrategy;
 pub use lock::{
     DependencySelection, Installable, Lock, LockError, LockVersion, Metadata, Package, PackageMap,
     PylockToml, PylockTomlError, PylockTomlErrorKind, RequirementsTxtExport, ResolverManifest,
-    SatisfiesResult, TreeDisplay, VERSION, cyclonedx_json,
+    SatisfiesResult, SelectedDependency, TreeDisplay, VERSION, cyclonedx_json,
 };
 pub use manifest::Manifest;
 pub use options::{Flexibility, Options, OptionsBuilder};

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -9,14 +9,19 @@ use itertools::Itertools;
 use petgraph::Graph;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
-use uv_configuration::ExtrasSpecificationWithDefaults;
-use uv_configuration::{BuildOptions, DependencyGroupsWithDefaults, InstallOptions};
+use uv_configuration::{
+    BuildOptions, DependencyGroupsWithDefaults, ExtrasSpecification,
+    ExtrasSpecificationWithDefaults, InstallOptions,
+};
 use uv_distribution_types::{Edge, Node, Resolution, ResolvedDist};
-use uv_normalize::{ExtraName, GroupName, PackageName};
+use uv_normalize::{DefaultExtras, ExtraName, GroupName, PackageName};
 use uv_platform_tags::Tags;
 use uv_pypi_types::{ConflictKind, ConflictSet, ResolverMarkerEnvironment};
 
-use crate::lock::{Dependency, HashedDist, LockErrorKind, Package, PackageId, TagPolicy};
+use crate::lock::{
+    Dependency, DependencySelectionContext, HashedDist, LockErrorKind, Package, PackageId,
+    SelectedDependency, TagPolicy,
+};
 use crate::{Lock, LockError, UniversalMarker};
 
 fn newly_activated_extras<'lock>(
@@ -101,6 +106,7 @@ pub trait Installable<'lock> {
             self,
             &roots,
             true,
+            DependencySelectionContext::None,
             marker_env,
             tags,
             extras,
@@ -190,6 +196,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
         &self,
         roots: &[&Package],
         include_manifest: bool,
+        selection_context: DependencySelectionContext<'lock>,
         marker_env: &ResolverMarkerEnvironment,
         tags: &Tags,
         extras: &ExtrasSpecificationWithDefaults,
@@ -212,6 +219,16 @@ trait InstallableExt<'lock>: Installable<'lock> {
         let mut dependencies_for_conflict_validation = vec![];
 
         let root = petgraph.add_node(Node::Root);
+
+        match selection_context {
+            DependencySelectionContext::None => {}
+            DependencySelectionContext::Production(project) => {
+                activated_projects.push(project);
+            }
+            DependencySelectionContext::Group(project, group) => {
+                activated_groups.push((project, group));
+            }
+        }
 
         // Determine the set of activated extras and groups, from the root.
         //
@@ -711,6 +728,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 .keys()
                 .map(|package_id| &package_id.name)
                 .collect::<FxHashSet<_>>();
+            let selection_context_package = selection_context.package();
 
             // The environment and conflict state are shared by every dependency, so repeated
             // markers have the same result.
@@ -721,7 +739,9 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 }
                 let mut marker = dependency.complexified_marker;
                 for item in self.lock().conflicts().iter().flat_map(ConflictSet::iter) {
-                    if !subgraph_packages.contains(item.package()) {
+                    if !subgraph_packages.contains(item.package())
+                        && selection_context_package != Some(item.package())
+                    {
                         continue;
                     }
 
@@ -786,6 +806,56 @@ impl<'lock> Installable<'lock> for LockedPackages<'lock> {
 }
 
 impl Lock {
+    /// Materialize a direct dependency selection from this lock.
+    ///
+    /// Like [`Self::to_resolution`], this materializes the selected dependency's subgraph. It also
+    /// preserves the extras activated by the direct edge and the project production or group
+    /// context used to select a conflict fork.
+    pub fn to_resolution_from_dependency<'lock>(
+        &'lock self,
+        install_path: &'lock Path,
+        dependency: &SelectedDependency<'lock>,
+        project_name: Option<&'lock PackageName>,
+        marker_env: &ResolverMarkerEnvironment,
+        tags: &Tags,
+        build_options: &BuildOptions,
+        install_options: &InstallOptions,
+    ) -> Result<Resolution, LockError> {
+        let selected_package = dependency.package();
+        let Some(index) = self.by_id.get(&selected_package.id) else {
+            return Err(LockErrorKind::RootPackageMissingFromLock {
+                id: selected_package.id.clone(),
+            }
+            .into());
+        };
+        let Some(package) = self.packages.get(*index) else {
+            return Err(LockErrorKind::RootPackageMissingFromLock {
+                id: selected_package.id.clone(),
+            }
+            .into());
+        };
+        let extras = ExtrasSpecification::from_extra(dependency.extras().cloned().collect())
+            .with_defaults(DefaultExtras::default());
+        let groups = DependencyGroupsWithDefaults::none();
+
+        LockedPackages {
+            lock: self,
+            install_path,
+            project_name,
+        }
+        .to_resolution_from_packages(
+            &[package],
+            false,
+            dependency.context(),
+            marker_env,
+            tags,
+            &extras,
+            &groups,
+            build_options,
+            install_options,
+        )
+    }
+
     /// Materialize the exact dependency subgraph reachable from concrete locked `roots`.
     ///
     /// Each root must be a [`Package`] from this lock. Unlike [`Installable::to_resolution`], this
@@ -840,6 +910,7 @@ impl Lock {
         .to_resolution_from_packages(
             &concrete_roots,
             false,
+            DependencySelectionContext::None,
             marker_env,
             tags,
             extras,
@@ -853,6 +924,7 @@ impl Lock {
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::str::FromStr;
     use std::sync::LazyLock;
 
     use petgraph::visit::EdgeRef;
@@ -1076,6 +1148,64 @@ provides-extras = ["cpu", "gpu"]
         .expect("valid lock")
     }
 
+    fn dependency_selection_lock() -> Lock {
+        toml::from_str(
+            r#"
+version = 1
+revision = 3
+requires-python = ">=3.11"
+conflicts = [[
+    { package = "project", group = "dev" },
+    { package = "project", group = "other" },
+]]
+
+[[package]]
+name = "contextual-dev-dependency"
+version = "1.0.0"
+source = { registry = "https://example.com/simple" }
+sdist = { url = "https://example.com/contextual_dev_dependency-1.0.0.tar.gz", hash = "sha256:1111111111111111111111111111111111111111111111111111111111111111" }
+
+[[package]]
+name = "contextual-other-dependency"
+version = "1.0.0"
+source = { registry = "https://example.com/simple" }
+sdist = { url = "https://example.com/contextual_other_dependency-1.0.0.tar.gz", hash = "sha256:2222222222222222222222222222222222222222222222222222222222222222" }
+
+[[package]]
+name = "optional-dependency"
+version = "1.0.0"
+source = { registry = "https://example.com/simple" }
+sdist = { url = "https://example.com/optional_dependency-1.0.0.tar.gz", hash = "sha256:3333333333333333333333333333333333333333333333333333333333333333" }
+
+[[package]]
+name = "project"
+version = "1.0.0"
+source = { virtual = "." }
+
+[package.dependency-groups]
+dev = [{ name = "tool", extra = ["cli"] }]
+other = [{ name = "tool" }]
+
+[[package]]
+name = "tool"
+version = "1.0.0"
+source = { registry = "https://example.com/simple" }
+dependencies = [
+    { name = "contextual-dev-dependency", marker = "extra == 'group-7-project-dev'" },
+    { name = "contextual-other-dependency", marker = "extra == 'group-7-project-other'" },
+]
+sdist = { url = "https://example.com/tool-1.0.0.tar.gz", hash = "sha256:4444444444444444444444444444444444444444444444444444444444444444" }
+
+[package.optional-dependencies]
+cli = [{ name = "optional-dependency" }]
+
+[package.metadata]
+provides-extras = ["cli"]
+"#,
+        )
+        .expect("valid lock")
+    }
+
     fn package<'lock>(lock: &'lock Lock, name: &str, version: &str) -> &'lock Package {
         lock.packages()
             .iter()
@@ -1128,6 +1258,31 @@ provides-extras = ["cpu", "gpu"]
             &BuildOptions::default(),
             &InstallOptions::default(),
         )
+    }
+
+    fn materialize_selected_dependency(lock: &Lock, group: &str) -> Resolution {
+        let project_name = PackageName::from_str("project").expect("valid package name");
+        let dependency_name = PackageName::from_str("tool").expect("valid package name");
+        let group = GroupName::from_str(group).expect("valid group name");
+        let selection = lock
+            .dependency_selection(
+                Some(&project_name),
+                &dependency_name,
+                DARWIN_MARKERS.markers(),
+            )
+            .expect("unique dependency selection");
+        let dependency = selection.group(&group).expect("group dependency");
+
+        lock.to_resolution_from_dependency(
+            Path::new("."),
+            dependency,
+            Some(&project_name),
+            &DARWIN_MARKERS,
+            &TAGS,
+            &BuildOptions::default(),
+            &InstallOptions::default(),
+        )
+        .expect("valid resolution")
     }
 
     struct OverridingInstallable<'lock> {
@@ -1336,6 +1491,54 @@ provides-extras = ["cpu", "gpu"]
                 "root --Prod--> tool==1.0.0 (install: true, hashes: sha256:[HASH])",
                 "runtime==1.0.0 (install: true, hashes: sha256:[HASH]) --Prod--> cpu-backend==1.0.0 (install: true, hashes: sha256:[HASH])",
                 "tool==1.0.0 (install: true, hashes: sha256:[HASH]) --Prod--> runtime==1.0.0 (install: true, hashes: sha256:[HASH])",
+            ],
+        )
+        "#);
+        });
+    }
+
+    #[test]
+    fn materializes_selected_dependency_extras() {
+        let resolution = materialize_selected_dependency(&dependency_selection_lock(), "dev");
+
+        insta::with_settings!({
+            filters => [(r"sha256:[0-9a-f]{64}", "sha256:[HASH]")],
+        }, {
+            insta::assert_debug_snapshot!(graph_snapshot(&resolution), @r#"
+        (
+            [
+                "contextual-dev-dependency==1.0.0 (install: true, hashes: sha256:[HASH])",
+                "optional-dependency==1.0.0 (install: true, hashes: sha256:[HASH])",
+                "root",
+                "tool==1.0.0 (install: true, hashes: sha256:[HASH])",
+            ],
+            [
+                "root --Prod--> tool==1.0.0 (install: true, hashes: sha256:[HASH])",
+                "tool==1.0.0 (install: true, hashes: sha256:[HASH]) --Optional(ExtraName(\"cli\"))--> optional-dependency==1.0.0 (install: true, hashes: sha256:[HASH])",
+                "tool==1.0.0 (install: true, hashes: sha256:[HASH]) --Prod--> contextual-dev-dependency==1.0.0 (install: true, hashes: sha256:[HASH])",
+            ],
+        )
+        "#);
+        });
+    }
+
+    #[test]
+    fn materializes_selected_dependency_project_conflict_context() {
+        let resolution = materialize_selected_dependency(&dependency_selection_lock(), "other");
+
+        insta::with_settings!({
+            filters => [(r"sha256:[0-9a-f]{64}", "sha256:[HASH]")],
+        }, {
+            insta::assert_debug_snapshot!(graph_snapshot(&resolution), @r#"
+        (
+            [
+                "contextual-other-dependency==1.0.0 (install: true, hashes: sha256:[HASH])",
+                "root",
+                "tool==1.0.0 (install: true, hashes: sha256:[HASH])",
+            ],
+            [
+                "root --Prod--> tool==1.0.0 (install: true, hashes: sha256:[HASH])",
+                "tool==1.0.0 (install: true, hashes: sha256:[HASH]) --Prod--> contextual-other-dependency==1.0.0 (install: true, hashes: sha256:[HASH])",
             ],
         )
         "#);

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -739,8 +739,8 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 }
                 let mut marker = dependency.complexified_marker;
                 for item in self.lock().conflicts().iter().flat_map(ConflictSet::iter) {
-                    if !subgraph_packages.contains(item.package())
-                        && selection_context_package != Some(item.package())
+                    if selection_context_package != Some(item.package())
+                        && !subgraph_packages.contains(item.package())
                     {
                         continue;
                     }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -341,16 +341,16 @@ impl<'lock> SelectedDependency<'lock> {
     }
 
     /// Returns the selected package.
-    pub fn package(&self) -> &'lock Package {
+    fn package(&self) -> &'lock Package {
         self.package
     }
 
     /// Returns the extras activated by the direct dependency edge.
-    pub fn extras(&self) -> impl Iterator<Item = &'lock ExtraName> + '_ {
+    fn extras(&self) -> impl Iterator<Item = &'lock ExtraName> + '_ {
         self.extras.iter().copied()
     }
 
-    pub(super) fn context(&self) -> DependencySelectionContext<'lock> {
+    fn context(&self) -> DependencySelectionContext<'lock> {
         self.context
     }
 }
@@ -363,7 +363,7 @@ pub(super) enum DependencySelectionContext<'lock> {
 }
 
 impl<'lock> DependencySelectionContext<'lock> {
-    pub(super) fn package(self) -> Option<&'lock PackageName> {
+    fn package(self) -> Option<&'lock PackageName> {
         match self {
             Self::None => None,
             Self::Production(package) | Self::Group(package, _) => Some(package),

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -303,31 +303,99 @@ pub struct Lock {
     manifest: ResolverManifest,
 }
 
-/// Package selections from a [`Lock`] for a named direct dependency.
+/// A direct dependency selected from a [`Lock`].
+#[derive(Clone, Debug)]
+pub struct SelectedDependency<'lock> {
+    package: &'lock Package,
+    extras: BTreeSet<&'lock ExtraName>,
+    context: DependencySelectionContext<'lock>,
+}
+
+impl<'lock> SelectedDependency<'lock> {
+    fn from_dependency(
+        package: &'lock Package,
+        dependency: &'lock Dependency,
+        context: DependencySelectionContext<'lock>,
+    ) -> Self {
+        Self {
+            package,
+            extras: dependency.extra.iter().collect(),
+            context,
+        }
+    }
+
+    fn from_requirement(package: &'lock Package, requirement: &'lock Requirement) -> Self {
+        Self {
+            package,
+            extras: requirement.extras.iter().collect(),
+            context: DependencySelectionContext::None,
+        }
+    }
+
+    fn extend_dependency(&mut self, dependency: &'lock Dependency) {
+        self.extras.extend(&dependency.extra);
+    }
+
+    fn extend_requirement(&mut self, requirement: &'lock Requirement) {
+        self.extras.extend(&requirement.extras);
+    }
+
+    /// Returns the selected package.
+    pub fn package(&self) -> &'lock Package {
+        self.package
+    }
+
+    /// Returns the extras activated by the direct dependency edge.
+    pub fn extras(&self) -> impl Iterator<Item = &'lock ExtraName> + '_ {
+        self.extras.iter().copied()
+    }
+
+    pub(super) fn context(&self) -> DependencySelectionContext<'lock> {
+        self.context
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum DependencySelectionContext<'lock> {
+    None,
+    Production(&'lock PackageName),
+    Group(&'lock PackageName, &'lock GroupName),
+}
+
+impl<'lock> DependencySelectionContext<'lock> {
+    pub(super) fn package(self) -> Option<&'lock PackageName> {
+        match self {
+            Self::None => None,
+            Self::Production(package) | Self::Group(package, _) => Some(package),
+        }
+    }
+}
+
+/// Direct dependency selections from a [`Lock`] for a named package.
 ///
 /// The dependency can come from the lock manifest, a dependency group, the production packages,
 /// or a combination thereof.
 #[derive(Debug)]
 pub struct DependencySelection<'lock> {
-    root: Option<&'lock Package>,
-    production: Option<&'lock Package>,
-    groups: BTreeMap<&'lock GroupName, &'lock Package>,
+    root: Option<SelectedDependency<'lock>>,
+    production: Option<SelectedDependency<'lock>>,
+    groups: BTreeMap<&'lock GroupName, SelectedDependency<'lock>>,
 }
 
 impl<'lock> DependencySelection<'lock> {
-    /// Returns the package selected by a direct requirement on the lock manifest.
-    pub fn root(&self) -> Option<&'lock Package> {
-        self.root
+    /// Returns the direct requirement selection from the lock manifest.
+    pub fn root(&self) -> Option<&SelectedDependency<'lock>> {
+        self.root.as_ref()
     }
 
-    /// Returns the package selected by the production dependency.
-    pub fn production(&self) -> Option<&'lock Package> {
-        self.production
+    /// Returns the production dependency selection.
+    pub fn production(&self) -> Option<&SelectedDependency<'lock>> {
+        self.production.as_ref()
     }
 
-    /// Returns the package selected by the given dependency group.
-    pub fn group(&self, group: &GroupName) -> Option<&'lock Package> {
-        self.groups.get(group).copied()
+    /// Returns the dependency selection for the given dependency group.
+    pub fn group(&self, group: &GroupName) -> Option<&SelectedDependency<'lock>> {
+        self.groups.get(group)
     }
 }
 
@@ -849,16 +917,16 @@ impl Lock {
                 });
             };
             let production =
-                self.find_project_dependency_package(project, dependency_name, marker_environment)?;
+                self.find_project_dependency(project, dependency_name, marker_environment)?;
             let mut groups = BTreeMap::new();
             for group in project.resolved_dependency_groups().keys() {
-                if let Some(package) = self.find_project_dependency_group_package(
+                if let Some(dependency) = self.find_project_dependency_group(
                     project,
                     group,
                     dependency_name,
                     marker_environment,
                 )? {
-                    groups.insert(group, package);
+                    groups.insert(group, dependency);
                 }
             }
             (None, production, groups)
@@ -867,33 +935,53 @@ impl Lock {
                 &requirement.name == dependency_name
                     && requirement.marker.evaluate(marker_environment, &[])
             });
+            let group_applies =
+                self.manifest
+                    .dependency_groups
+                    .values()
+                    .flatten()
+                    .any(|requirement| {
+                        &requirement.name == dependency_name
+                            && requirement.marker.evaluate(marker_environment, &[])
+                    });
 
             // Lock-manifest requirements and dependency groups only record requirements, not
-            // resolved package IDs. Select the environment-specific package once, then associate
-            // it with every applicable direct requirement.
-            let mut applicable_groups = self
-                .manifest
-                .dependency_groups
-                .iter()
-                .filter_map(|(group, requirements)| {
-                    requirements
-                        .iter()
-                        .any(|requirement| {
-                            &requirement.name == dependency_name
-                                && requirement.marker.evaluate(marker_environment, &[])
-                        })
-                        .then_some(group)
-                })
-                .peekable();
-            let package = if root_applies || applicable_groups.peek().is_some() {
+            // resolved package IDs. Select the environment-specific package once, then preserve
+            // every applicable direct edge that selected it.
+            let package = if root_applies || group_applies {
                 self.find_by_markers(dependency_name, marker_environment)?
             } else {
                 None
             };
-            let root = root_applies.then_some(package).flatten();
-            let groups = package.map_or_else(BTreeMap::new, |package| {
-                applicable_groups.map(|group| (group, package)).collect()
+            let root = package.and_then(|package| {
+                let mut applicable = self.manifest.requirements.iter().filter(|requirement| {
+                    &requirement.name == dependency_name
+                        && requirement.marker.evaluate(marker_environment, &[])
+                });
+                let requirement = applicable.next()?;
+                let mut selection = SelectedDependency::from_requirement(package, requirement);
+                for requirement in applicable {
+                    selection.extend_requirement(requirement);
+                }
+                Some(selection)
             });
+            let mut groups = BTreeMap::new();
+            if let Some(package) = package {
+                for (group, requirements) in &self.manifest.dependency_groups {
+                    let mut applicable = requirements.iter().filter(|requirement| {
+                        &requirement.name == dependency_name
+                            && requirement.marker.evaluate(marker_environment, &[])
+                    });
+                    let Some(requirement) = applicable.next() else {
+                        continue;
+                    };
+                    let mut selection = SelectedDependency::from_requirement(package, requirement);
+                    for requirement in applicable {
+                        selection.extend_requirement(requirement);
+                    }
+                    groups.insert(group, selection);
+                }
+            }
             (root, None, groups)
         };
         Ok(DependencySelection {
@@ -903,20 +991,20 @@ impl Lock {
         })
     }
 
-    /// Returns the package selected by a dependency group on a non-virtual project.
-    fn find_project_dependency_group_package(
-        &self,
-        project: &Package,
-        group: &GroupName,
+    /// Returns the direct dependency selected by a dependency group on a non-virtual project.
+    fn find_project_dependency_group<'lock>(
+        &'lock self,
+        project: &'lock Package,
+        group: &'lock GroupName,
         dependency_name: &PackageName,
         marker_environment: &MarkerEnvironment,
-    ) -> Result<Option<&Package>, String> {
+    ) -> Result<Option<SelectedDependency<'lock>>, String> {
         let Some(dependencies) = project.resolved_dependency_groups().get(group) else {
             return Ok(None);
         };
         let project_name = project.name();
 
-        let mut selected = None;
+        let mut selected: Option<SelectedDependency<'lock>> = None;
         for dependency in dependencies
             .iter()
             .filter(|dependency| &dependency.package_id.name == dependency_name)
@@ -939,26 +1027,37 @@ impl Lock {
             }
 
             let package = self.find_by_id(&dependency.package_id);
-            if selected.is_some_and(|selected: &Package| selected.id != package.id) {
+            if selected
+                .as_ref()
+                .is_some_and(|selected| selected.package.id != package.id)
+            {
                 return Err(format!(
                     "found multiple packages matching `{dependency_name}` in dependency group `{group}` for `{project_name}`"
                 ));
             }
-            selected = Some(package);
+            if let Some(selected) = selected.as_mut() {
+                selected.extend_dependency(dependency);
+            } else {
+                selected = Some(SelectedDependency::from_dependency(
+                    package,
+                    dependency,
+                    DependencySelectionContext::Group(project_name, group),
+                ));
+            }
         }
         Ok(selected)
     }
 
-    /// Returns the package selected by a production dependency on a non-virtual project.
-    fn find_project_dependency_package(
-        &self,
-        project: &Package,
+    /// Returns the direct production dependency selected on a non-virtual project.
+    fn find_project_dependency<'lock>(
+        &'lock self,
+        project: &'lock Package,
         dependency_name: &PackageName,
         marker_environment: &MarkerEnvironment,
-    ) -> Result<Option<&Package>, String> {
+    ) -> Result<Option<SelectedDependency<'lock>>, String> {
         let project_name = project.name();
 
-        let mut selected = None;
+        let mut selected: Option<SelectedDependency<'lock>> = None;
         for dependency in project
             .dependencies()
             .iter()
@@ -977,12 +1076,23 @@ impl Lock {
             }
 
             let package = self.find_by_id(&dependency.package_id);
-            if selected.is_some_and(|selected: &Package| selected.id != package.id) {
+            if selected
+                .as_ref()
+                .is_some_and(|selected| selected.package.id != package.id)
+            {
                 return Err(format!(
                     "found multiple packages matching production dependency `{dependency_name}` for `{project_name}`"
                 ));
             }
-            selected = Some(package);
+            if let Some(selected) = selected.as_mut() {
+                selected.extend_dependency(dependency);
+            } else {
+                selected = Some(SelectedDependency::from_dependency(
+                    package,
+                    dependency,
+                    DependencySelectionContext::Production(project_name),
+                ));
+            }
         }
         Ok(selected)
     }
@@ -7412,9 +7522,15 @@ source = { registry = "https://example.com/simple" }
         let selection = lock
             .dependency_selection(Some(&project_name), &dependency_name, &marker_environment)
             .expect("unique project package");
-        let preferred = selection.group(&dev).expect("dev dependency");
-        let included = selection.group(&typing).expect("typing dependency");
-        let production = selection.production().expect("production dependency");
+        let preferred = selection.group(&dev).expect("dev dependency").package();
+        let included = selection
+            .group(&typing)
+            .expect("typing dependency")
+            .package();
+        let production = selection
+            .production()
+            .expect("production dependency")
+            .package();
 
         assert!(std::ptr::eq(preferred, included));
         assert!(std::ptr::eq(preferred, production));
@@ -7446,7 +7562,7 @@ source = { registry = "https://example.com/simple" }
             .expect("unique root package");
         let root = selection.root().expect("root dependency");
 
-        assert_eq!(root.name(), &dependency_name);
+        assert_eq!(root.package().name(), &dependency_name);
         assert!(selection.production().is_none());
     }
 

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -536,7 +536,7 @@ pub(crate) async fn check(
                 let resolution = project::toolchain::resolution_from_lock(
                     project,
                     result.lock(),
-                    tool.package(),
+                    &tool,
                     &base_interpreter,
                     &settings.resolver.build_options,
                 )?;

--- a/crates/uv/src/commands/project/toolchain.rs
+++ b/crates/uv/src/commands/project/toolchain.rs
@@ -1,25 +1,23 @@
 use anyhow::Result;
 
-use uv_configuration::{
-    BuildOptions, DependencyGroupsWithDefaults, ExtrasSpecification, InstallOptions,
-};
+use uv_configuration::{BuildOptions, DependencyGroupsWithDefaults, InstallOptions};
 use uv_distribution_types::Resolution;
-use uv_normalize::{DefaultExtras, GroupName, PackageName};
+use uv_normalize::{GroupName, PackageName};
 use uv_python::Interpreter;
-use uv_resolver::{Lock, Package};
+use uv_resolver::{Lock, SelectedDependency};
 use uv_workspace::VirtualProject;
 
 use crate::commands::pip::{resolution_markers, resolution_tags};
 
 /// A locked package selected for use as a project tool.
 pub(crate) struct LockedTool<'lock> {
-    package: &'lock Package,
+    dependency: SelectedDependency<'lock>,
     requires_separate_environment: bool,
 }
 
 impl<'lock> LockedTool<'lock> {
-    pub(crate) fn package(&self) -> &'lock Package {
-        self.package
+    pub(crate) fn dependency(&self) -> &SelectedDependency<'lock> {
+        &self.dependency
     }
 
     /// Returns `true` if the tool must be installed outside the selected project environment.
@@ -46,40 +44,36 @@ pub(crate) fn find_locked_tool<'lock>(
             marker_environment.markers(),
         )
         .map_err(anyhow::Error::msg)?;
-    let (package, installed) = if let Some(package) = selection.group(dependency_group) {
-        (package, groups.contains(dependency_group))
-    } else if let Some(package) = selection.production() {
-        (package, groups.prod())
+    let (dependency, installed) = if let Some(dependency) = selection.group(dependency_group) {
+        (dependency.clone(), groups.contains(dependency_group))
+    } else if let Some(dependency) = selection.production() {
+        (dependency.clone(), groups.prod())
     } else {
         return Ok(None);
     };
 
     Ok(Some(LockedTool {
-        package,
+        dependency,
         requires_separate_environment: !installed,
     }))
 }
 
-/// Materialize the exact dependency subgraph rooted at a locked package.
+/// Materialize the exact dependency subgraph for a locked tool selection.
 pub(crate) fn resolution_from_lock(
     project: &VirtualProject,
     lock: &Lock,
-    package: &Package,
+    tool: &LockedTool<'_>,
     interpreter: &Interpreter,
     build_options: &BuildOptions,
 ) -> Result<Resolution> {
     let marker_environment = resolution_markers(None, None, interpreter);
     let tags = resolution_tags(None, None, interpreter)?;
-    let extras = ExtrasSpecification::default().with_defaults(DefaultExtras::default());
-    let groups = DependencyGroupsWithDefaults::none();
-    Ok(lock.to_resolution(
+    Ok(lock.to_resolution_from_dependency(
         project.workspace().install_path(),
-        [package],
+        tool.dependency(),
         project.project_name(),
         &marker_environment,
         &tags,
-        &extras,
-        &groups,
         build_options,
         &InstallOptions::default(),
     )?)

--- a/crates/uv/src/commands/project/toolchain.rs
+++ b/crates/uv/src/commands/project/toolchain.rs
@@ -16,7 +16,7 @@ pub(crate) struct LockedTool<'lock> {
 }
 
 impl<'lock> LockedTool<'lock> {
-    pub(crate) fn dependency(&self) -> &SelectedDependency<'lock> {
+    fn dependency(&self) -> &SelectedDependency<'lock> {
         &self.dependency
     }
 


### PR DESCRIPTION
`Lock::dependency_selection` selects the exact locked package for a direct project dependency, but the result currently discards information, like selected extras or dependency-group conflict context (used to select conflict forks). This isn't critical for our current use cases (ruff and ty), but it's worth fixing to avoid future confusion.

For a relatively contrived example, a workspace may use a local build of `ty` that depends on `a`, with two mutually exclusive groups pinning `a==1` and `a==2`. With `uv check --no-sync`, uv selects the correct locked `ty` for the enabled group, but previously discarded that group context when building the cached environment. The marker on `ty`’s dependency still referred to the project conflict outside the synthetic tool subgraph, so materialization failed instead of selecting the corresponding `a` fork.

This PR returns a `SelectedDependency` containing the exact package, the union of extras from applicable direct edges, and the production or dependency-group context. `Lock::to_resolution_from_dependency` passes that information into the existing locked-subgraph traversal, activating selected extras and resolving project conflict items even though the project itself is outside the cached subgraph.

This is a follow-up to #19982 and #19989.