### PR TITLE
Enable SIMD-accelerated TOML parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,7 +279,7 @@ tokio-util = { version = "0.7.12", features = ["compat", "io"] }
 toml = { version = "1.1.0", features = ["fast_hash"] }
 toml_datetime = { version = "1.1.0" }
 toml_edit = { version = "0.25.8", features = ["serde"] }
-toml_parser = { version = "1.1.0" }
+toml_parser = { version = "1.1.0", features = ["simd"] }
 tracing = { version = "0.1.40" }
 tracing-durations-export = { version = "0.3.0", features = ["plot"] }
 tracing-subscriber = { version = "0.3.18" } # Default feature set for uv_build, uv activates extra features


### PR DESCRIPTION
## Summary

`toml_parser` includes an optional `simd` feature that enables SIMD-accelerated scanning through Winnow, but uv currently leaves it disabled.
