### PR TITLE
Prioritize active metadata requests

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -547,6 +547,7 @@ mod resolver {
                 &build_context,
                 concurrency.downloads_semaphore.clone(),
             ),
+            concurrency.downloads,
         )?;
 
         Ok(resolver.resolve().await?)

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -341,6 +341,7 @@ impl BuildContext for BuildDispatch<'_> {
                 self.concurrency.downloads_semaphore.clone(),
             )
             .with_build_stack(build_stack),
+            self.concurrency.downloads,
         )?;
         let resolution = Resolution::from(resolver.resolve().await.with_context(|| {
             format!(

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -13,7 +13,7 @@ use crate::resolver::Request;
 use crate::{
     InMemoryIndex, PythonRequirement, ResolveError, ResolverEnvironment, VersionsResponse,
 };
-use uv_distribution_types::{CompatibleDist, Identifier, IndexCapabilities, IndexMetadata};
+use uv_distribution_types::{CompatibleDist, IndexCapabilities, IndexMetadata};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
@@ -313,10 +313,11 @@ impl BatchPrefetcherRunner {
             );
             prefetch_count += 1;
 
-            if self.index.distributions().register(dist.distribution_id()) {
-                let request = Request::from(dist);
-                self.request_sink.blocking_send(request)?;
-            }
+            let request = match Request::from(dist) {
+                Request::Dist(dist) => Request::SpeculativeDist(dist),
+                _ => unreachable!("batch prefetch only emits registry distributions"),
+            };
+            self.request_sink.blocking_send(request)?;
         }
 
         match prefetch_count {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -16,7 +16,7 @@ use papaya::{HashMap, ResizeMode};
 use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::sync::oneshot;
+use tokio::sync::{Semaphore, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{Level, debug, info, instrument, trace, warn};
 
@@ -128,6 +128,7 @@ struct ResolverState<InstalledPackages: InstalledPackagesProvider> {
     workspace_members: BTreeSet<PackageName>,
     selector: CandidateSelector,
     index: InMemoryIndex,
+    speculative_metadata_requests: Semaphore,
     installed_packages: InstalledPackages,
     // Papaya's maps are large on Windows, so box them to keep resolver futures small.
     /// Incompatibilities for packages that are entirely unavailable.
@@ -175,6 +176,7 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
         build_context: &'a Context,
         installed_packages: InstalledPackages,
         database: DistributionDatabase<'a, Context>,
+        concurrent_downloads: usize,
     ) -> Result<Self, ResolveError> {
         let provider = DefaultResolverProvider::new(
             database,
@@ -204,6 +206,7 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
             build_context.locations(),
             provider,
             installed_packages,
+            concurrent_downloads,
         ))
     }
 }
@@ -227,12 +230,17 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
         locations: &IndexLocations,
         provider: Provider,
         installed_packages: InstalledPackages,
+        concurrent_downloads: usize,
     ) -> Self {
         let state = ResolverState {
             index: index.clone(),
             git: git.clone(),
             capabilities: capabilities.clone(),
             selector: CandidateSelector::for_resolution(&options, &manifest, &env),
+            // Do not let speculative batch prefetching claim more once-map entries than the
+            // downloader can actively service. A later active resolver request can then claim an
+            // entry before a queued speculative request starts.
+            speculative_metadata_requests: Semaphore::new(concurrent_downloads.max(1)),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, &env, git, options.dependency_mode),
             indexes: Indexes::from_manifest(&manifest, &env, options.dependency_mode),
@@ -2613,6 +2621,72 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         Ok::<(), ResolveError>(())
     }
 
+    async fn process_dist_request<Provider: ResolverProvider>(
+        &self,
+        dist: Dist,
+        provider: &Provider,
+    ) -> Result<Option<Response>, ResolveError> {
+        if let Some(version) = dist.version() {
+            if let Some(index) = dist.index() {
+                // Check the implicit indexes for pre-provided metadata.
+                let versions_response = self.index.implicit().get(dist.name());
+                if let Some(VersionsResponse::Found(version_maps)) = versions_response.as_deref() {
+                    for version_map in version_maps {
+                        if version_map.index() == Some(index) {
+                            let Some(metadata) = version_map.get_metadata(version) else {
+                                continue;
+                            };
+                            debug!("Found registry-provided metadata for: {dist}");
+                            return Ok(Some(Response::Dist {
+                                dist,
+                                metadata: MetadataResponse::Found(
+                                    ArchiveMetadata::from_metadata23(metadata),
+                                ),
+                            }));
+                        }
+                    }
+                }
+
+                // Check the explicit indexes for pre-provided metadata.
+                let versions_response = self
+                    .index
+                    .explicit()
+                    .get(&(dist.name().clone(), index.clone()));
+                if let Some(VersionsResponse::Found(version_maps)) = versions_response.as_deref() {
+                    for version_map in version_maps {
+                        let Some(metadata) = version_map.get_metadata(version) else {
+                            continue;
+                        };
+                        debug!("Found registry-provided metadata for: {dist}");
+                        return Ok(Some(Response::Dist {
+                            dist,
+                            metadata: MetadataResponse::Found(ArchiveMetadata::from_metadata23(
+                                metadata,
+                            )),
+                        }));
+                    }
+                }
+            }
+        }
+
+        let metadata = provider
+            .get_or_build_wheel_metadata(&dist)
+            .boxed_local()
+            .await?;
+
+        if let MetadataResponse::Found(metadata) = &metadata {
+            if &metadata.metadata.name != dist.name() {
+                return Err(ResolveError::MismatchedPackageName {
+                    request: "distribution metadata",
+                    expected: dist.name().clone(),
+                    actual: metadata.metadata.name.clone(),
+                });
+            }
+        }
+
+        Ok(Some(Response::Dist { dist, metadata }))
+    }
+
     #[instrument(skip_all, fields(%request))]
     async fn process_request<Provider: ResolverProvider>(
         &self,
@@ -2636,70 +2710,18 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             }
 
             // Fetch distribution metadata from the distribution database.
-            Request::Dist(dist) => {
-                if let Some(version) = dist.version() {
-                    if let Some(index) = dist.index() {
-                        // Check the implicit indexes for pre-provided metadata.
-                        let versions_response = self.index.implicit().get(dist.name());
-                        if let Some(VersionsResponse::Found(version_maps)) =
-                            versions_response.as_deref()
-                        {
-                            for version_map in version_maps {
-                                if version_map.index() == Some(index) {
-                                    let Some(metadata) = version_map.get_metadata(version) else {
-                                        continue;
-                                    };
-                                    debug!("Found registry-provided metadata for: {dist}");
-                                    return Ok(Some(Response::Dist {
-                                        dist,
-                                        metadata: MetadataResponse::Found(
-                                            ArchiveMetadata::from_metadata23(metadata),
-                                        ),
-                                    }));
-                                }
-                            }
-                        }
+            Request::Dist(dist) => self.process_dist_request(dist, provider).await,
 
-                        // Check the explicit indexes for pre-provided metadata.
-                        let versions_response = self
-                            .index
-                            .explicit()
-                            .get(&(dist.name().clone(), index.clone()));
-                        if let Some(VersionsResponse::Found(version_maps)) =
-                            versions_response.as_deref()
-                        {
-                            for version_map in version_maps {
-                                let Some(metadata) = version_map.get_metadata(version) else {
-                                    continue;
-                                };
-                                debug!("Found registry-provided metadata for: {dist}");
-                                return Ok(Some(Response::Dist {
-                                    dist,
-                                    metadata: MetadataResponse::Found(
-                                        ArchiveMetadata::from_metadata23(metadata),
-                                    ),
-                                }));
-                            }
-                        }
-                    }
+            Request::SpeculativeDist(dist) => {
+                let _permit = self
+                    .speculative_metadata_requests
+                    .acquire()
+                    .await
+                    .expect("resolver state outlives metadata requests");
+                if !self.index.distributions().register(dist.distribution_id()) {
+                    return Ok(None);
                 }
-
-                let metadata = provider
-                    .get_or_build_wheel_metadata(&dist)
-                    .boxed_local()
-                    .await?;
-
-                if let MetadataResponse::Found(metadata) = &metadata {
-                    if &metadata.metadata.name != dist.name() {
-                        return Err(ResolveError::MismatchedPackageName {
-                            request: "distribution metadata",
-                            expected: dist.name().clone(),
-                            actual: metadata.metadata.name.clone(),
-                        });
-                    }
-                }
-
-                Ok(Some(Response::Dist { dist, metadata }))
+                self.process_dist_request(dist, provider).await
             }
 
             Request::Installed(dist) => {
@@ -3804,6 +3826,8 @@ pub(crate) enum Request {
     Package(PackageName, Option<IndexMetadata>),
     /// A request to fetch the metadata for a built or source distribution.
     Dist(Dist),
+    /// A speculative request for distribution metadata emitted by batch prefetching.
+    SpeculativeDist(Dist),
     /// A request to fetch the metadata from an already-installed distribution.
     Installed(InstalledDist),
     /// A request to pre-fetch the metadata for a package and the best-guess distribution.
@@ -3855,6 +3879,9 @@ impl Display for Request {
             }
             Self::Dist(dist) => {
                 write!(f, "Metadata {dist}")
+            }
+            Self::SpeculativeDist(dist) => {
+                write!(f, "Speculative metadata {dist}")
             }
             Self::Installed(dist) => {
                 write!(f, "Installed metadata {dist}")

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -386,6 +386,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 build_dispatch,
                 concurrency.downloads_semaphore.clone(),
             ),
+            concurrency.downloads,
         )?
         .with_reporter(Arc::new(reporter));
 


### PR DESCRIPTION
## Summary

Batch prefetch currently claims each distribution in the shared once-map before its metadata request begins. When the download queue is saturated, a speculative request can therefore reserve a version that the resolver later needs immediately, leaving the active solve behind queued speculative work.

This changes batch-prefetched distribution metadata into a distinct speculative request. Speculative requests acquire a permit capped to the configured download concurrency before registering in the once-map; resolver-driven metadata requests keep the existing register-before-enqueue behavior. That lets active work claim a version first, while preserving ordinary deduplication and the current amount of concurrent prefetch I/O.

This does not change candidate selection or resolution results; it changes which pending metadata request gets serviced first. In local exploratory measurements, a cold-cache Transformers lock went from 48.8s to 27.0s (-44.6%). Across 80 alternating warm-cache packse runs, the median was effectively unchanged (118.5ms to 118.0ms). The resolver test suite, Transformers ecosystem test, formatting, and uv-bench compilation pass under the profiling profile.