### PR TITLE
Prioritize solver-blocking metadata requests over pre-fetch requests

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -547,6 +547,7 @@ mod resolver {
                 &build_context,
                 concurrency.downloads_semaphore.clone(),
             ),
+            concurrency.downloads,
         )?;
 
         Ok(resolver.resolve().await?)

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -341,6 +341,7 @@ impl BuildContext for BuildDispatch<'_> {
                 self.concurrency.downloads_semaphore.clone(),
             )
             .with_build_stack(build_stack),
+            self.concurrency.downloads,
         )?;
         let resolution = Resolution::from(resolver.resolve().await.with_context(|| {
             format!(

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -13,7 +13,7 @@ use crate::resolver::Request;
 use crate::{
     InMemoryIndex, PythonRequirement, ResolveError, ResolverEnvironment, VersionsResponse,
 };
-use uv_distribution_types::{CompatibleDist, Identifier, IndexCapabilities, IndexMetadata};
+use uv_distribution_types::{CompatibleDist, IndexCapabilities, IndexMetadata};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
@@ -313,10 +313,11 @@ impl BatchPrefetcherRunner {
             );
             prefetch_count += 1;
 
-            if self.index.distributions().register(dist.distribution_id()) {
-                let request = Request::from(dist);
-                self.request_sink.blocking_send(request)?;
-            }
+            let request = match Request::from(dist) {
+                Request::Dist(dist) => Request::SpeculativeDist(dist),
+                _ => unreachable!("batch prefetch only emits registry distributions"),
+            };
+            self.request_sink.blocking_send(request)?;
         }
 
         match prefetch_count {

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -313,11 +313,10 @@ impl BatchPrefetcherRunner {
             );
             prefetch_count += 1;
 
-            let request = match Request::from(dist) {
-                Request::Dist(dist) => Request::SpeculativeDist(dist),
-                _ => unreachable!("batch prefetch only emits registry distributions"),
-            };
-            self.request_sink.blocking_send(request)?;
+            if let Request::Dist(dist) = Request::from(dist) {
+                self.request_sink
+                    .blocking_send(Request::Speculative(dist))?;
+            }
         }
 
         match prefetch_count {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -128,7 +128,7 @@ struct ResolverState<InstalledPackages: InstalledPackagesProvider> {
     workspace_members: BTreeSet<PackageName>,
     selector: CandidateSelector,
     index: InMemoryIndex,
-    speculative_metadata_requests: Semaphore,
+    speculative_requests: Semaphore,
     installed_packages: InstalledPackages,
     // Papaya's maps are large on Windows, so box them to keep resolver futures small.
     /// Incompatibilities for packages that are entirely unavailable.
@@ -240,7 +240,7 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
             // Do not let speculative batch prefetching claim more once-map entries than the
             // downloader can actively service. A later active resolver request can then claim an
             // entry before a queued speculative request starts.
-            speculative_metadata_requests: Semaphore::new(concurrent_downloads.max(1)),
+            speculative_requests: Semaphore::new(concurrent_downloads.max(1)),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, &env, git, options.dependency_mode),
             indexes: Indexes::from_manifest(&manifest, &env, options.dependency_mode),
@@ -2558,9 +2558,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             // Fetch distribution metadata from the distribution database.
             Request::Dist(dist) => self.process_dist_request(dist, provider).await,
 
-            Request::SpeculativeDist(dist) => {
+            Request::Speculative(dist) => {
                 let _permit = self
-                    .speculative_metadata_requests
+                    .speculative_requests
                     .acquire()
                     .await
                     .expect("resolver state outlives metadata requests");
@@ -3658,7 +3658,7 @@ pub(crate) enum Request {
     /// A request to fetch the metadata for a built or source distribution.
     Dist(Dist),
     /// A speculative request for distribution metadata emitted by batch prefetching.
-    SpeculativeDist(Dist),
+    Speculative(Dist),
     /// A request to fetch the metadata from an already-installed distribution.
     Installed(InstalledDist),
     /// A request to pre-fetch the metadata for a package and the best-guess distribution.
@@ -3711,7 +3711,7 @@ impl Display for Request {
             Self::Dist(dist) => {
                 write!(f, "Metadata {dist}")
             }
-            Self::SpeculativeDist(dist) => {
+            Self::Speculative(dist) => {
                 write!(f, "Speculative metadata {dist}")
             }
             Self::Installed(dist) => {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -16,7 +16,7 @@ use papaya::{HashMap, ResizeMode};
 use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::sync::oneshot;
+use tokio::sync::{Semaphore, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{Level, debug, info, instrument, trace, warn};
 
@@ -128,6 +128,7 @@ struct ResolverState<InstalledPackages: InstalledPackagesProvider> {
     workspace_members: BTreeSet<PackageName>,
     selector: CandidateSelector,
     index: InMemoryIndex,
+    speculative_metadata_requests: Semaphore,
     installed_packages: InstalledPackages,
     // Papaya's maps are large on Windows, so box them to keep resolver futures small.
     /// Incompatibilities for packages that are entirely unavailable.
@@ -175,6 +176,7 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
         build_context: &'a Context,
         installed_packages: InstalledPackages,
         database: DistributionDatabase<'a, Context>,
+        concurrent_downloads: usize,
     ) -> Result<Self, ResolveError> {
         let provider = DefaultResolverProvider::new(
             database,
@@ -204,6 +206,7 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
             build_context.locations(),
             provider,
             installed_packages,
+            concurrent_downloads,
         ))
     }
 }
@@ -227,12 +230,17 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
         locations: &IndexLocations,
         provider: Provider,
         installed_packages: InstalledPackages,
+        concurrent_downloads: usize,
     ) -> Self {
         let state = ResolverState {
             index: index.clone(),
             git: git.clone(),
             capabilities: capabilities.clone(),
             selector: CandidateSelector::for_resolution(&options, &manifest, &env),
+            // Do not let speculative batch prefetching claim more once-map entries than the
+            // downloader can actively service. A later active resolver request can then claim an
+            // entry before a queued speculative request starts.
+            speculative_metadata_requests: Semaphore::new(concurrent_downloads.max(1)),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, &env, git, options.dependency_mode),
             indexes: Indexes::from_manifest(&manifest, &env, options.dependency_mode),
@@ -2459,6 +2467,72 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         Ok::<(), ResolveError>(())
     }
 
+    async fn process_dist_request<Provider: ResolverProvider>(
+        &self,
+        dist: Dist,
+        provider: &Provider,
+    ) -> Result<Option<Response>, ResolveError> {
+        if let Some(version) = dist.version() {
+            if let Some(index) = dist.index() {
+                // Check the implicit indexes for pre-provided metadata.
+                let versions_response = self.index.implicit().get(dist.name());
+                if let Some(VersionsResponse::Found(version_maps)) = versions_response.as_deref() {
+                    for version_map in version_maps {
+                        if version_map.index() == Some(index) {
+                            let Some(metadata) = version_map.get_metadata(version) else {
+                                continue;
+                            };
+                            debug!("Found registry-provided metadata for: {dist}");
+                            return Ok(Some(Response::Dist {
+                                dist,
+                                metadata: MetadataResponse::Found(
+                                    ArchiveMetadata::from_metadata23(metadata),
+                                ),
+                            }));
+                        }
+                    }
+                }
+
+                // Check the explicit indexes for pre-provided metadata.
+                let versions_response = self
+                    .index
+                    .explicit()
+                    .get(&(dist.name().clone(), index.clone()));
+                if let Some(VersionsResponse::Found(version_maps)) = versions_response.as_deref() {
+                    for version_map in version_maps {
+                        let Some(metadata) = version_map.get_metadata(version) else {
+                            continue;
+                        };
+                        debug!("Found registry-provided metadata for: {dist}");
+                        return Ok(Some(Response::Dist {
+                            dist,
+                            metadata: MetadataResponse::Found(ArchiveMetadata::from_metadata23(
+                                metadata,
+                            )),
+                        }));
+                    }
+                }
+            }
+        }
+
+        let metadata = provider
+            .get_or_build_wheel_metadata(&dist)
+            .boxed_local()
+            .await?;
+
+        if let MetadataResponse::Found(metadata) = &metadata {
+            if &metadata.metadata.name != dist.name() {
+                return Err(ResolveError::MismatchedPackageName {
+                    request: "distribution metadata",
+                    expected: dist.name().clone(),
+                    actual: metadata.metadata.name.clone(),
+                });
+            }
+        }
+
+        Ok(Some(Response::Dist { dist, metadata }))
+    }
+
     #[instrument(skip_all, fields(%request))]
     async fn process_request<Provider: ResolverProvider>(
         &self,
@@ -2482,70 +2556,18 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             }
 
             // Fetch distribution metadata from the distribution database.
-            Request::Dist(dist) => {
-                if let Some(version) = dist.version() {
-                    if let Some(index) = dist.index() {
-                        // Check the implicit indexes for pre-provided metadata.
-                        let versions_response = self.index.implicit().get(dist.name());
-                        if let Some(VersionsResponse::Found(version_maps)) =
-                            versions_response.as_deref()
-                        {
-                            for version_map in version_maps {
-                                if version_map.index() == Some(index) {
-                                    let Some(metadata) = version_map.get_metadata(version) else {
-                                        continue;
-                                    };
-                                    debug!("Found registry-provided metadata for: {dist}");
-                                    return Ok(Some(Response::Dist {
-                                        dist,
-                                        metadata: MetadataResponse::Found(
-                                            ArchiveMetadata::from_metadata23(metadata),
-                                        ),
-                                    }));
-                                }
-                            }
-                        }
+            Request::Dist(dist) => self.process_dist_request(dist, provider).await,
 
-                        // Check the explicit indexes for pre-provided metadata.
-                        let versions_response = self
-                            .index
-                            .explicit()
-                            .get(&(dist.name().clone(), index.clone()));
-                        if let Some(VersionsResponse::Found(version_maps)) =
-                            versions_response.as_deref()
-                        {
-                            for version_map in version_maps {
-                                let Some(metadata) = version_map.get_metadata(version) else {
-                                    continue;
-                                };
-                                debug!("Found registry-provided metadata for: {dist}");
-                                return Ok(Some(Response::Dist {
-                                    dist,
-                                    metadata: MetadataResponse::Found(
-                                        ArchiveMetadata::from_metadata23(metadata),
-                                    ),
-                                }));
-                            }
-                        }
-                    }
+            Request::SpeculativeDist(dist) => {
+                let _permit = self
+                    .speculative_metadata_requests
+                    .acquire()
+                    .await
+                    .expect("resolver state outlives metadata requests");
+                if !self.index.distributions().register(dist.distribution_id()) {
+                    return Ok(None);
                 }
-
-                let metadata = provider
-                    .get_or_build_wheel_metadata(&dist)
-                    .boxed_local()
-                    .await?;
-
-                if let MetadataResponse::Found(metadata) = &metadata {
-                    if &metadata.metadata.name != dist.name() {
-                        return Err(ResolveError::MismatchedPackageName {
-                            request: "distribution metadata",
-                            expected: dist.name().clone(),
-                            actual: metadata.metadata.name.clone(),
-                        });
-                    }
-                }
-
-                Ok(Some(Response::Dist { dist, metadata }))
+                self.process_dist_request(dist, provider).await
             }
 
             Request::Installed(dist) => {
@@ -3635,6 +3657,8 @@ pub(crate) enum Request {
     Package(PackageName, Option<IndexMetadata>),
     /// A request to fetch the metadata for a built or source distribution.
     Dist(Dist),
+    /// A speculative request for distribution metadata emitted by batch prefetching.
+    SpeculativeDist(Dist),
     /// A request to fetch the metadata from an already-installed distribution.
     Installed(InstalledDist),
     /// A request to pre-fetch the metadata for a package and the best-guess distribution.
@@ -3686,6 +3710,9 @@ impl Display for Request {
             }
             Self::Dist(dist) => {
                 write!(f, "Metadata {dist}")
+            }
+            Self::SpeculativeDist(dist) => {
+                write!(f, "Speculative metadata {dist}")
             }
             Self::Installed(dist) => {
                 write!(f, "Installed metadata {dist}")

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -128,7 +128,7 @@ struct ResolverState<InstalledPackages: InstalledPackagesProvider> {
     workspace_members: BTreeSet<PackageName>,
     selector: CandidateSelector,
     index: InMemoryIndex,
-    speculative_requests: Semaphore,
+    speculative_requests: Option<Semaphore>,
     installed_packages: InstalledPackages,
     // Papaya's maps are large on Windows, so box them to keep resolver futures small.
     /// Incompatibilities for packages that are entirely unavailable.
@@ -238,9 +238,10 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
             capabilities: capabilities.clone(),
             selector: CandidateSelector::for_resolution(&options, &manifest, &env),
             // Do not let speculative batch prefetching claim more once-map entries than the
-            // downloader can actively service. A later active resolver request can then claim an
-            // entry before a queued speculative request starts.
-            speculative_requests: Semaphore::new(concurrent_downloads.max(1)),
+            // downloader can actively service. Reserve one download slot for active resolver
+            // requests; if there is only one slot, disable speculative requests entirely.
+            speculative_requests: speculative_request_limit(concurrent_downloads)
+                .map(Semaphore::new),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, &env, git, options.dependency_mode),
             indexes: Indexes::from_manifest(&manifest, &env, options.dependency_mode),
@@ -2559,8 +2560,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             Request::Dist(dist) => self.process_dist_request(dist, provider).await,
 
             Request::Speculative(dist) => {
-                let _permit = self
-                    .speculative_requests
+                let Some(speculative_requests) = &self.speculative_requests else {
+                    return Ok(None);
+                };
+                let _permit = speculative_requests
                     .acquire()
                     .await
                     .expect("resolver state outlives metadata requests");
@@ -4347,6 +4350,25 @@ fn find_environments(id: Id<PubGrubPackage>, state: &State<UvDependencyProvider>
     }
 
     environments.remove(&id).unwrap_or(MarkerTree::FALSE)
+}
+
+/// Limit speculative requests while reserving download capacity for active resolver requests.
+fn speculative_request_limit(concurrent_downloads: usize) -> Option<usize> {
+    let limit = concurrent_downloads.saturating_sub(1);
+    (limit > 0).then_some(limit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::speculative_request_limit;
+
+    #[test]
+    fn reserve_download_for_active_requests() {
+        assert_eq!(speculative_request_limit(0), None);
+        assert_eq!(speculative_request_limit(1), None);
+        assert_eq!(speculative_request_limit(2), Some(1));
+        assert_eq!(speculative_request_limit(50), Some(49));
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -386,6 +386,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 build_dispatch,
                 concurrency.downloads_semaphore.clone(),
             ),
+            concurrency.downloads,
         )?
         .with_reporter(Arc::new(reporter));
 


### PR DESCRIPTION
## Summary

Batch prefetch currently claims each distribution in the shared once-map before its metadata request begins. When the download queue is saturated, a speculative request can therefore reserve a version that the resolver later needs immediately, leaving the active solve behind queued speculative work.

This changes batch-prefetched distribution metadata into a distinct speculative request. Speculative requests acquire a permit before registering in the once-map, and their concurrency is capped at one less than the configured download concurrency. That lets active work claim a version before a queued speculative request starts while reserving one download slot for solver-blocking work such as Simple API requests. When download concurrency is set to one, speculative metadata requests are disabled entirely.

This doesn't change resolution in any way, just the order in which requests are serviced: active requests that block the solve are prioritized over speculative pre-fetches, while ordinary deduplication is preserved.

In initial measurements, the cold-cache Transformers resolve went from 48.8s to 27.0s (-44.6%).
