### PR TITLE
Archive requirements structurally with rkyv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6647,6 +6647,7 @@ name = "uv-git-types"
 version = "0.0.59"
 dependencies = [
  "percent-encoding",
+ "rkyv",
  "serde",
  "thiserror",
  "tracing",
@@ -7088,8 +7089,10 @@ name = "uv-redacted"
 version = "0.0.59"
 dependencies = [
  "ref-cast",
+ "rkyv",
  "schemars",
  "serde",
+ "serde_json",
  "thiserror",
  "url",
 ]

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -1201,7 +1201,7 @@ impl CacheBucket {
             Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_clean.rs`.
-            Self::Simple => "simple-v21",
+            Self::Simple => "simple-v22",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_prune.rs`.
             Self::Wheels => "wheels-v6",

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1713,7 +1713,7 @@ mod tests {
     use tokio::sync::Semaphore;
     use url::Url;
     use uv_normalize::PackageName;
-    use uv_pypi_types::PypiSimpleDetail;
+    use uv_pypi_types::{PypiSimpleDetail, PyxSimpleDetail, ResolutionMetadata};
     use uv_redacted::DisplaySafeUrl;
     use uv_torch::{TorchBackend, TorchSource, TorchStrategy};
 
@@ -1747,6 +1747,58 @@ mod tests {
             .await;
 
         server
+    }
+
+    #[test]
+    fn simple_metadata_rkyv_round_trip() -> Result<(), Error> {
+        let response = r#"
+        {
+          "files": [
+            {
+              "core-metadata": true,
+              "filename": "demo-1.0-py3-none-any.whl",
+              "hashes": {"sha256": "1234"},
+              "url": "https://example.com/demo-1.0-py3-none-any.whl"
+            }
+          ],
+          "core-metadata": {
+            "1.0": {
+              "requires-python": ">=3.8",
+              "requires-dist": [
+                "anyio>=4; python_version >= '3.9' and sys_platform == 'linux'",
+                "direct @ https://example.com/direct-1.0-py3-none-any.whl?token=value#sha256=1234"
+              ],
+              "provides-extra": ["async"]
+            }
+          }
+        }
+        "#;
+        let data: PyxSimpleDetail = serde_json::from_str(response)?;
+        let base = DisplaySafeUrl::parse("https://example.com/simple/demo/")?;
+        let metadata = SimpleDetailMetadata::from_pyx_files(
+            data.files,
+            data.core_metadata,
+            &PackageName::from_str("demo")?,
+            data.project_status,
+            &base,
+        );
+
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&metadata)?;
+        let archived =
+            rkyv::access::<rkyv::Archived<SimpleDetailMetadata>, rkyv::rancor::Error>(&bytes)?;
+        let archived_metadata = archived
+            .datum(0)
+            .and_then(|datum| datum.metadata.as_ref())
+            .ok_or("expected core metadata for demo 1.0")?;
+        let metadata =
+            rkyv::deserialize::<ResolutionMetadata, rkyv::rancor::Error>(archived_metadata)?;
+
+        assert_eq!(metadata.name.as_ref(), "demo");
+        assert_eq!(metadata.version.to_string(), "1.0");
+        assert_eq!(metadata.requires_dist.len(), 2);
+        assert_eq!(metadata.requires_dist[0].name.as_ref(), "anyio");
+        assert_eq!(metadata.requires_dist[1].name.as_ref(), "direct");
+        Ok(())
     }
 
     fn no_index_client(flat_indexes: Vec<Index>) -> Result<RegistryClient, Error> {

--- a/crates/uv-distribution-filename/src/extension.rs
+++ b/crates/uv-distribution-filename/src/extension.rs
@@ -4,7 +4,20 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
 pub enum DistExtension {
     Wheel,
     Source(SourceDistExtension),

--- a/crates/uv-git-types/Cargo.toml
+++ b/crates/uv-git-types/Cargo.toml
@@ -21,7 +21,11 @@ uv-redacted = { workspace = true }
 uv-static = { workspace = true }
 
 percent-encoding = { workspace = true }
+rkyv = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+
+[features]
+rkyv = ["dep:rkyv", "uv-redacted/rkyv"]

--- a/crates/uv-git-types/src/lib.rs
+++ b/crates/uv-git-types/src/lib.rs
@@ -29,6 +29,11 @@ static UV_GIT_LFS: LazyLock<GitLfs> = LazyLock::new(|| {
 
 /// Configuration for Git LFS (Large File Storage) support.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum GitLfs {
     /// Git LFS is disabled (default).
     #[default]
@@ -100,6 +105,72 @@ pub struct GitUrl {
     precise: Option<GitOid>,
     /// Git LFS configuration for this repository.
     lfs: GitLfs,
+}
+
+#[cfg(feature = "rkyv")]
+#[derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[rkyv(derive(Debug))]
+#[doc(hidden)]
+/// The persisted fields of a [`GitUrl`], excluding its derived repository identity.
+pub struct GitUrlRkyv {
+    url: DisplaySafeUrl,
+    reference: GitReference,
+    precise: Option<GitOid>,
+    lfs: GitLfs,
+}
+
+#[cfg(feature = "rkyv")]
+impl GitUrlRkyv {
+    fn from_url(url: &GitUrl) -> Self {
+        Self {
+            url: url.url.clone(),
+            reference: url.reference.clone(),
+            precise: url.precise,
+            lfs: url.lfs,
+        }
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl rkyv::Archive for GitUrl {
+    type Archived = <GitUrlRkyv as rkyv::Archive>::Archived;
+    type Resolver = <GitUrlRkyv as rkyv::Archive>::Resolver;
+
+    fn resolve(&self, resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
+        GitUrlRkyv::from_url(self).resolve(resolver, out);
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl<S> rkyv::Serialize<S> for GitUrl
+where
+    S: rkyv::rancor::Fallible + ?Sized,
+    GitUrlRkyv: rkyv::Serialize<S>,
+{
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        GitUrlRkyv::from_url(self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl<D> rkyv::Deserialize<GitUrl, D> for ArchivedGitUrlRkyv
+where
+    D: rkyv::rancor::Fallible + ?Sized,
+    D::Error: rkyv::rancor::Source,
+    Self: rkyv::Deserialize<GitUrlRkyv, D>,
+{
+    fn deserialize(&self, deserializer: &mut D) -> Result<GitUrl, D::Error> {
+        use rkyv::rancor::ResultExt;
+
+        let archived: GitUrlRkyv = rkyv::Deserialize::deserialize(self, deserializer)?;
+        GitUrl::from_fields(
+            archived.url,
+            archived.reference,
+            archived.precise,
+            archived.lfs,
+        )
+        .into_error()
+    }
 }
 
 impl GitUrl {

--- a/crates/uv-git-types/src/oid.rs
+++ b/crates/uv-git-types/src/oid.rs
@@ -11,6 +11,11 @@ use thiserror::Error;
 /// If Git's SHA-256 support becomes more widespread in the future (in particular if GitHub ever
 /// adds support), we might need to make this an enum.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub struct GitOid {
     bytes: [u8; 40],
 }

--- a/crates/uv-git-types/src/reference.rs
+++ b/crates/uv-git-types/src/reference.rs
@@ -16,6 +16,11 @@ const GIT_REFERENCE_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
 
 /// A reference to commit or commit-ish.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum GitReference {
     /// A specific branch.
     Branch(String),

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -54,6 +54,6 @@ schemars = ["dep:schemars"]
 # be supported.
 non-pep508-extensions = []
 default = []
-rkyv = ["dep:rkyv"]
+rkyv = ["dep:rkyv", "uv-redacted/rkyv"]
 # Match the API of the published crate, for compatibility.
 serde = []

--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -52,6 +52,8 @@ use uv_pep440::{VersionSpecifier, VersionSpecifiers};
 mod cursor;
 pub mod marker;
 mod origin;
+#[cfg(feature = "rkyv")]
+mod rkyv_support;
 #[cfg(feature = "non-pep508-extensions")]
 mod unnamed;
 mod verbatim_url;
@@ -121,6 +123,10 @@ impl<E: Error + Debug, T: Pep508Url<Err = E>> std::error::Error for Pep508Error<
 
 /// A PEP 508 dependency specifier.
 #[derive(Hash, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Requirement<T: Pep508Url = VerbatimUrl> {
     /// The distribution name such as `requests` in
     /// `requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8"`.
@@ -137,7 +143,28 @@ pub struct Requirement<T: Pep508Url = VerbatimUrl> {
     /// Those are a nested and/or tree.
     pub marker: MarkerTree,
     /// The source file containing the requirement.
+    ///
+    /// Origins are not part of Core Metadata and are intentionally omitted from archives.
+    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Skip))]
     pub origin: Option<RequirementOrigin>,
+}
+
+#[cfg(feature = "rkyv")]
+impl<T> Debug for ArchivedRequirement<T>
+where
+    T: Pep508Url + rkyv::Archive,
+    T::Archived: Debug,
+{
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Requirement")
+            .field("name", &self.name)
+            .field("extras", &self.extras)
+            .field("version_or_url", &self.version_or_url)
+            .field("marker", &self.marker)
+            .field("origin", &self.origin)
+            .finish()
+    }
 }
 
 impl<T: Pep508Url> Requirement<T> {
@@ -405,11 +432,32 @@ pub struct Extras(Vec<ExtraName>);
 
 /// The actual version specifier or URL to install.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum VersionOrUrl<T: Pep508Url = VerbatimUrl> {
     /// A PEP 440 version specifier set
     VersionSpecifier(VersionSpecifiers),
     /// A installable URL
     Url(T),
+}
+
+#[cfg(feature = "rkyv")]
+impl<T> Debug for ArchivedVersionOrUrl<T>
+where
+    T: Pep508Url + rkyv::Archive,
+    T::Archived: Debug,
+{
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::VersionSpecifier(specifier) => formatter
+                .debug_tuple("VersionSpecifier")
+                .field(specifier)
+                .finish(),
+            Self::Url(url) => formatter.debug_tuple("Url").field(url).finish(),
+        }
+    }
 }
 
 impl<T: Pep508Url> Display for VersionOrUrl<T> {
@@ -1030,45 +1078,11 @@ fn parse_pep508_requirement<T: Pep508Url>(
     })
 }
 
-#[cfg(feature = "rkyv")]
-/// An [`rkyv`] implementation for [`Requirement`].
-impl<T: Pep508Url + Display> rkyv::Archive for Requirement<T> {
-    type Archived = rkyv::string::ArchivedString;
-    type Resolver = rkyv::string::StringResolver;
-
-    #[inline]
-    fn resolve(&self, resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
-        let as_str = self.to_string();
-        rkyv::string::ArchivedString::resolve_from_str(&as_str, resolver, out);
-    }
-}
-
-#[cfg(feature = "rkyv")]
-impl<T: Pep508Url + Display, S> rkyv::Serialize<S> for Requirement<T>
-where
-    S: rkyv::rancor::Fallible + rkyv::ser::Allocator + rkyv::ser::Writer + ?Sized,
-    S::Error: rkyv::rancor::Source,
-{
-    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
-        let as_str = self.to_string();
-        rkyv::string::ArchivedString::serialize_from_str(&as_str, serializer)
-    }
-}
-
-#[cfg(feature = "rkyv")]
-impl<T: Pep508Url + Display, D: rkyv::rancor::Fallible + ?Sized>
-    rkyv::Deserialize<Requirement<T>, D> for rkyv::string::ArchivedString
-{
-    fn deserialize(&self, _deserializer: &mut D) -> Result<Requirement<T>, D::Error> {
-        // SAFETY: We only serialize valid requirements.
-        Ok(Requirement::<T>::from_str(self.as_str()).unwrap())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     //! Half of these tests are copied from <https://github.com/pypa/packaging/pull/624>
 
+    use std::error::Error;
     use std::str::FromStr;
 
     use insta::assert_snapshot;
@@ -1087,6 +1101,34 @@ mod tests {
         Requirement::<VerbatimUrl>::from_str(input)
             .unwrap_err()
             .to_string()
+    }
+
+    #[cfg(feature = "rkyv")]
+    #[test]
+    fn rkyv_requirement_round_trip_is_structural() -> Result<(), Box<dyn Error>> {
+        for input in [
+            "demo",
+            "demo ; python_version < '0'",
+            "demo[async,security]>=1.2,<2 ; (python_version >= '3.8' and sys_platform == 'linux') or extra != 'security'",
+            "demo ; python_version in '3.9 3.10.0 3.11'",
+            "demo ; 'dev' in dependency_groups and 'nux' in os_name",
+            "demo @ https://example.com/demo-1.0.0-py3-none-any.whl?token=value#sha256=1234 ; os_name == 'posix'",
+        ] {
+            let expected = Requirement::<VerbatimUrl>::from_str(input)?;
+            let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&expected)?;
+            let archived = rkyv::access::<
+                rkyv::Archived<Requirement<VerbatimUrl>>,
+                rkyv::rancor::Error,
+            >(&bytes)?;
+
+            // Requirements are archived field-by-field rather than as PEP 508 strings.
+            assert_eq!(archived.extras.len(), expected.extras.len());
+
+            let actual =
+                rkyv::deserialize::<Requirement<VerbatimUrl>, rkyv::rancor::Error>(archived)?;
+            assert_eq!(actual, expected);
+        }
+        Ok(())
     }
 
     #[cfg(feature = "non-pep508-extensions")]

--- a/crates/uv-pep508/src/marker/lowering.rs
+++ b/crates/uv-pep508/src/marker/lowering.rs
@@ -164,6 +164,11 @@ impl Display for CanonicalMarkerValueExtra {
 ///
 /// Used for PEP 751 markers.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum CanonicalMarkerListPair {
     /// A valid [`ExtraName`].
     Extras(ExtraName),

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -51,6 +51,14 @@ pub enum MarkerWarningKind {
 
 /// Those environment markers with a PEP 440 version as value such as `python_version`
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(
+    feature = "rkyv",
+    rkyv(attr(expect(clippy::enum_variant_names)), derive(Debug))
+)]
 pub enum MarkerValueVersion {
     /// `implementation_version`
     ImplementationVersion,
@@ -72,6 +80,11 @@ impl Display for MarkerValueVersion {
 
 /// Those environment markers with an arbitrary string as value such as `sys_platform`
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum MarkerValueString {
     /// `implementation_name`
     ImplementationName,
@@ -129,6 +142,11 @@ impl Display for MarkerValueString {
 ///
 /// Contains PEP 751 lockfile markers.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum MarkerValueList {
     /// `extras`. This one is special because it's a list, and user-provided
     Extras,
@@ -220,6 +238,11 @@ impl Display for MarkerValue {
 
 /// How to compare key and value, such as by `==`, `>` or `not in`
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum MarkerOperator {
     /// `==`
     Equal,
@@ -463,6 +486,11 @@ impl Deref for StringVersion {
 
 /// The [`ExtraName`] value used in `extra` and `extras` markers.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum MarkerValueExtra {
     /// A valid [`ExtraName`].
     Extra(ExtraName),
@@ -499,6 +527,11 @@ impl Display for MarkerValueExtra {
 
 /// Represents one clause such as `python_version > "3.8"`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 #[allow(missing_docs)]
 pub enum MarkerExpression {
     /// A version expression, e.g. `<version key> <version op> <quoted PEP 440 version>`.
@@ -528,6 +561,10 @@ pub enum MarkerExpression {
     String {
         key: MarkerValueString,
         operator: MarkerOperator,
+        #[cfg_attr(
+            feature = "rkyv",
+            rkyv(with = crate::rkyv_support::ArcStrAsString)
+        )]
         value: ArcStr,
     },
     /// `'...' in <key>`, a PEP 751 expression.
@@ -559,6 +596,11 @@ pub(crate) enum MarkerExpressionKind {
 
 /// The operator for an extra expression, either '==' or '!='.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum ExtraOperator {
     /// `==`
     Equal,
@@ -598,6 +640,11 @@ impl Display for ExtraOperator {
 
 /// The operator for a container expression, either 'in' or 'not in'.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub enum ContainerOperator {
     /// `in`
     In,
@@ -799,6 +846,84 @@ impl FromStr for MarkerTree {
 
     fn from_str(markers: &str) -> Result<Self, Self::Err> {
         parse::parse_markers(markers, &mut TracingReporter)
+    }
+}
+
+#[cfg(feature = "rkyv")]
+#[derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[rkyv(derive(Debug))]
+#[doc(hidden)]
+/// A semantic archive representation that does not persist process-local [`NodeId`] values.
+pub enum MarkerTreeRkyv {
+    /// A marker that is always true.
+    True,
+    /// A marker that is always false.
+    False,
+    /// A non-trivial marker represented in disjunctive normal form.
+    Dnf(Vec<Vec<MarkerExpression>>),
+}
+
+#[cfg(feature = "rkyv")]
+impl MarkerTreeRkyv {
+    fn from_tree(tree: MarkerTree) -> Self {
+        if tree.is_true() {
+            Self::True
+        } else if tree.is_false() {
+            Self::False
+        } else {
+            Self::Dnf(tree.to_dnf())
+        }
+    }
+
+    fn into_tree(self) -> MarkerTree {
+        match self {
+            Self::True => MarkerTree::TRUE,
+            Self::False => MarkerTree::FALSE,
+            Self::Dnf(dnf) => {
+                let mut tree = MarkerTree::FALSE;
+                for conjunction in dnf {
+                    let mut clause = MarkerTree::TRUE;
+                    for expression in conjunction {
+                        clause.and(MarkerTree::expression(expression));
+                    }
+                    tree.or(clause);
+                }
+                tree
+            }
+        }
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl rkyv::Archive for MarkerTree {
+    type Archived = <MarkerTreeRkyv as rkyv::Archive>::Archived;
+    type Resolver = <MarkerTreeRkyv as rkyv::Archive>::Resolver;
+
+    fn resolve(&self, resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
+        MarkerTreeRkyv::from_tree(*self).resolve(resolver, out);
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl<S> rkyv::Serialize<S> for MarkerTree
+where
+    S: rkyv::rancor::Fallible + ?Sized,
+    MarkerTreeRkyv: rkyv::Serialize<S>,
+{
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        MarkerTreeRkyv::from_tree(*self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl<D> rkyv::Deserialize<MarkerTree, D> for ArchivedMarkerTreeRkyv
+where
+    D: rkyv::rancor::Fallible + ?Sized,
+    Self: rkyv::Deserialize<MarkerTreeRkyv, D>,
+{
+    fn deserialize(&self, deserializer: &mut D) -> Result<MarkerTree, D::Error> {
+        let tree: MarkerTreeRkyv = rkyv::Deserialize::deserialize(self, deserializer)?;
+        Ok(tree.into_tree())
     }
 }
 

--- a/crates/uv-pep508/src/rkyv_support.rs
+++ b/crates/uv-pep508/src/rkyv_support.rs
@@ -1,0 +1,35 @@
+use arcstr::ArcStr;
+use rkyv::rancor::{Fallible, Source};
+use rkyv::ser::Writer;
+use rkyv::string::{ArchivedString, StringResolver};
+use rkyv::with::{ArchiveWith, DeserializeWith, SerializeWith};
+
+pub(crate) struct ArcStrAsString;
+
+impl ArchiveWith<ArcStr> for ArcStrAsString {
+    type Archived = ArchivedString;
+    type Resolver = StringResolver;
+
+    fn resolve_with(field: &ArcStr, resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
+        ArchivedString::resolve_from_str(field, resolver, out);
+    }
+}
+
+impl<S> SerializeWith<ArcStr, S> for ArcStrAsString
+where
+    S: Fallible + Writer + ?Sized,
+    S::Error: Source,
+{
+    fn serialize_with(field: &ArcStr, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedString::serialize_from_str(field, serializer)
+    }
+}
+
+impl<D> DeserializeWith<ArchivedString, ArcStr, D> for ArcStrAsString
+where
+    D: Fallible + ?Sized,
+{
+    fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<ArcStr, D::Error> {
+        Ok(ArcStr::from(field.as_str()))
+    }
+}

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -22,6 +22,11 @@ use crate::Pep508Url;
 ///
 /// The original string is not preserved after serialization/deserialization.
 #[derive(Debug, Clone, Eq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", rkyv(derive(Debug)))]
 pub struct VerbatimUrl {
     /// The parsed URL.
     url: DisplaySafeUrl,
@@ -29,9 +34,11 @@ pub struct VerbatimUrl {
     ///
     /// Even if originally set, this will be [`None`] after
     /// serialization/deserialization.
+    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Skip))]
     given: Option<ArcStr>,
     /// Given value is a [`Pep508Url`] which contained variable references which were successfully
     /// expanded.
+    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Skip))]
     expanded: bool,
 }
 

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -18,11 +18,11 @@ workspace = true
 [dependencies]
 uv-cache-key = { workspace = true }
 uv-distribution-filename = { workspace = true }
-uv-git-types = { workspace = true }
+uv-git-types = { workspace = true, features = ["rkyv"] }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true, features = ["rkyv"] }
-uv-redacted = { workspace = true }
+uv-redacted = { workspace = true, features = ["rkyv"] }
 uv-small-str = { workspace = true }
 
 hashbrown = { workspace = true }

--- a/crates/uv-pypi-types/src/lib.rs
+++ b/crates/uv-pypi-types/src/lib.rs
@@ -24,6 +24,7 @@ mod metadata;
 mod module_name;
 mod parsed_url;
 mod project_status;
+mod rkyv_support;
 mod scheme;
 mod simple_json;
 mod supported_environments;

--- a/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
@@ -270,6 +270,7 @@ impl ResolutionMetadata {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
     use std::str::FromStr;
 
     use uv_normalize::PackageName;
@@ -277,6 +278,33 @@ mod tests {
 
     use super::*;
     use crate::MetadataError;
+
+    #[test]
+    fn rkyv_round_trip() -> Result<(), Box<dyn Error>> {
+        let content = br"Metadata-Version: 2.3
+Name: demo
+Version: 1.0
+Requires-Python: >=3.8
+Requires-Dist: anyio>=4; python_version >= '3.9' and sys_platform == 'linux'
+Requires-Dist: direct @ https://example.com/direct-1.0-py3-none-any.whl?token=value#sha256=1234
+Provides-Extra: async
+";
+        let expected = ResolutionMetadata::parse_metadata(content)?;
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&expected)?;
+        let archived =
+            rkyv::access::<rkyv::Archived<ResolutionMetadata>, rkyv::rancor::Error>(&bytes)?;
+
+        assert_eq!(archived.requires_dist.len(), 2);
+
+        let actual = rkyv::deserialize::<ResolutionMetadata, rkyv::rancor::Error>(archived)?;
+        assert_eq!(actual.name, expected.name);
+        assert_eq!(actual.version, expected.version);
+        assert_eq!(actual.requires_dist, expected.requires_dist);
+        assert_eq!(actual.requires_python, expected.requires_python);
+        assert_eq!(actual.provides_extra, expected.provides_extra);
+        assert_eq!(actual.dynamic, expected.dynamic);
+        Ok(())
+    }
 
     #[test]
     fn test_parse_metadata() {

--- a/crates/uv-pypi-types/src/parsed_url.rs
+++ b/crates/uv-pypi-types/src/parsed_url.rs
@@ -40,7 +40,19 @@ pub enum ParsedUrlError {
     MissingExtensionPath(PathBuf, ExtensionError),
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Ord,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
 pub struct VerbatimParsedUrl {
     pub parsed_url: ParsedUrl,
     pub verbatim: VerbatimUrl,
@@ -176,7 +188,19 @@ impl Display for VerbatimParsedUrl {
 /// * A remote archive (`https://`), optional with a subdirectory (source dist only).
 ///
 /// A URL in a requirement `foo @ <url>` must be one of the above.
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Hash,
+    Ord,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
 pub enum ParsedUrl {
     /// The direct URL is a path to a local file.
     Path(ParsedPathUrl),
@@ -209,10 +233,23 @@ impl ParsedUrl {
 /// Examples:
 /// * `file:///home/ferris/my_project/my_project-0.1.0.tar.gz`
 /// * `file:///home/ferris/my_project/my_project-0.1.0-py3-none-any.whl`
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Hash,
+    Ord,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
 pub struct ParsedPathUrl {
     pub url: DisplaySafeUrl,
     /// The absolute path to the distribution which we use for installing.
+    #[rkyv(with = crate::rkyv_support::BoxPathAsString)]
     pub install_path: Box<Path>,
     /// The file extension, e.g. `tar.gz`, `zip`, etc.
     pub ext: DistExtension,
@@ -233,10 +270,23 @@ impl ParsedPathUrl {
 ///
 /// Examples:
 /// * `file:///home/ferris/my_project`
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Hash,
+    Ord,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
 pub struct ParsedDirectoryUrl {
     pub url: DisplaySafeUrl,
     /// The absolute path to the distribution which we use for installing.
+    #[rkyv(with = crate::rkyv_support::BoxPathAsString)]
     pub install_path: Box<Path>,
     /// Whether the project at the given URL should be installed in editable mode.
     pub editable: Option<bool>,
@@ -269,9 +319,22 @@ impl ParsedDirectoryUrl {
 /// Examples:
 /// * `git+https://git.example.com/MyProject.git`
 /// * `git+https://git.example.com/MyProject.git@v1.0#egg=pkg&subdirectory=pkg_dir`
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Hash,
+    Ord,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
 pub struct ParsedGitDirectoryUrl {
     pub url: GitUrl,
+    #[rkyv(with = rkyv::with::Map<crate::rkyv_support::BoxPathAsString>)]
     pub subdirectory: Option<Box<Path>>,
 }
 
@@ -307,10 +370,23 @@ impl TryFrom<DisplaySafeUrl> for ParsedGitDirectoryUrl {
 ///
 /// Examples:
 /// * `git+https://git.example.com/MyProject.git@v1.0#egg=pkg&path=path/to/wheel.whl`
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Hash,
+    Ord,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
 pub struct ParsedGitPathUrl {
     pub url: GitUrl,
     /// The path to the distribution within the repository.
+    #[rkyv(with = rkyv::with::AsString)]
     pub install_path: PathBuf,
     /// The file extension, e.g. `tar.gz`, `zip`, etc.
     pub ext: DistExtension,
@@ -360,9 +436,22 @@ impl TryFrom<DisplaySafeUrl> for ParsedGitPathUrl {
 /// * A built distribution: `https://files.pythonhosted.org/packages/62/06/d5604a70d160f6a6ca5fd2ba25597c24abd5c5ca5f437263d177ac242308/tqdm-4.66.1-py2.py3-none-any.whl`
 /// * A source distribution with a valid name: `https://files.pythonhosted.org/packages/62/06/d5604a70d160f6a6ca5fd2ba25597c24abd5c5ca5f437263d177ac242308/tqdm-4.66.1.tar.gz`
 /// * A source dist with a recognizable extension but invalid name: `https://github.com/foo-labs/foo/archive/master.zip#egg=pkg&subdirectory=packages/bar`
-#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    PartialOrd,
+    Ord,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
 pub struct ParsedArchiveUrl {
     pub url: DisplaySafeUrl,
+    #[rkyv(with = rkyv::with::Map<crate::rkyv_support::BoxPathAsString>)]
     pub subdirectory: Option<Box<Path>>,
     pub ext: DistExtension,
 }

--- a/crates/uv-pypi-types/src/rkyv_support.rs
+++ b/crates/uv-pypi-types/src/rkyv_support.rs
@@ -1,0 +1,49 @@
+use std::error::Error;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use rkyv::rancor::{Fallible, OptionExt, Source};
+use rkyv::ser::Writer;
+use rkyv::string::{ArchivedString, StringResolver};
+use rkyv::with::{ArchiveWith, DeserializeWith, SerializeWith};
+
+#[derive(Debug)]
+struct InvalidUtf8Path;
+
+impl fmt::Display for InvalidUtf8Path {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("path is not valid UTF-8")
+    }
+}
+
+impl Error for InvalidUtf8Path {}
+
+pub(crate) struct BoxPathAsString;
+
+impl ArchiveWith<Box<Path>> for BoxPathAsString {
+    type Archived = ArchivedString;
+    type Resolver = StringResolver;
+
+    fn resolve_with(field: &Box<Path>, resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
+        ArchivedString::resolve_from_str(&field.to_string_lossy(), resolver, out);
+    }
+}
+
+impl<S> SerializeWith<Box<Path>, S> for BoxPathAsString
+where
+    S: Fallible + Writer + ?Sized,
+    S::Error: Source,
+{
+    fn serialize_with(field: &Box<Path>, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedString::serialize_from_str(field.to_str().into_trace(InvalidUtf8Path)?, serializer)
+    }
+}
+
+impl<D> DeserializeWith<ArchivedString, Box<Path>, D> for BoxPathAsString
+where
+    D: Fallible + ?Sized,
+{
+    fn deserialize_with(field: &ArchivedString, _: &mut D) -> Result<Box<Path>, D::Error> {
+        Ok(PathBuf::from(field.as_str()).into_boxed_path())
+    }
+}

--- a/crates/uv-redacted/Cargo.toml
+++ b/crates/uv-redacted/Cargo.toml
@@ -14,10 +14,13 @@ workspace = true
 
 [dependencies]
 ref-cast = { workspace = true }
+rkyv = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 
 [features]
+rkyv = ["dep:rkyv", "dep:serde_json"]
 schemars = ["dep:schemars"]

--- a/crates/uv-redacted/src/lib.rs
+++ b/crates/uv-redacted/src/lib.rs
@@ -2,10 +2,14 @@ use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};
+#[cfg(feature = "rkyv")]
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use thiserror::Error;
 use url::Url;
+#[cfg(feature = "rkyv")]
+use url::{Host, Position};
 
 const SENSITIVE_QUERY_PARAMETERS: &[&str] = &[
     "X-Amz-Credential",
@@ -63,6 +67,143 @@ pub enum DisplaySafeUrlError {
 #[cfg_attr(feature = "schemars", schemars(transparent))]
 #[repr(transparent)]
 pub struct DisplaySafeUrl(Url);
+
+#[cfg(feature = "rkyv")]
+#[derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[rkyv(derive(Debug))]
+enum UrlHostRkyv {
+    None,
+    Domain,
+    Ipv4(Ipv4Addr),
+    Ipv6(Ipv6Addr),
+}
+
+#[cfg(feature = "rkyv")]
+#[derive(serde::Serialize)]
+enum SerdeUrlHost {
+    None,
+    Domain,
+    Ipv4(Ipv4Addr),
+    Ipv6(Ipv6Addr),
+}
+
+#[cfg(feature = "rkyv")]
+impl From<UrlHostRkyv> for SerdeUrlHost {
+    fn from(host: UrlHostRkyv) -> Self {
+        match host {
+            UrlHostRkyv::None => Self::None,
+            UrlHostRkyv::Domain => Self::Domain,
+            UrlHostRkyv::Ipv4(address) => Self::Ipv4(address),
+            UrlHostRkyv::Ipv6(address) => Self::Ipv6(address),
+        }
+    }
+}
+
+#[cfg(feature = "rkyv")]
+#[derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[rkyv(derive(Debug))]
+#[doc(hidden)]
+/// The parsed components of a [`DisplaySafeUrl`], stored without reparsing its serialization.
+pub struct DisplaySafeUrlRkyv {
+    serialization: String,
+    scheme_end: u32,
+    username_end: u32,
+    host_start: u32,
+    host_end: u32,
+    host: UrlHostRkyv,
+    port: Option<u16>,
+    path_start: u32,
+    query_start: Option<u32>,
+    fragment_start: Option<u32>,
+}
+
+#[cfg(feature = "rkyv")]
+impl DisplaySafeUrlRkyv {
+    fn from_url(url: &DisplaySafeUrl) -> Self {
+        let index = |position| u32::try_from(url[..position].len()).unwrap_or(u32::MAX);
+        let host = match url.host() {
+            None => UrlHostRkyv::None,
+            Some(Host::Domain(_)) => UrlHostRkyv::Domain,
+            Some(Host::Ipv4(address)) => UrlHostRkyv::Ipv4(address),
+            Some(Host::Ipv6(address)) => UrlHostRkyv::Ipv6(address),
+        };
+
+        Self {
+            serialization: url.as_str().to_string(),
+            scheme_end: index(Position::AfterScheme),
+            username_end: index(Position::AfterUsername),
+            host_start: index(Position::BeforeHost),
+            host_end: index(Position::AfterHost),
+            host,
+            port: url.port(),
+            path_start: index(Position::BeforePath),
+            query_start: url
+                .query()
+                .map(|_| index(Position::BeforeQuery).saturating_sub(1)),
+            fragment_start: url
+                .fragment()
+                .map(|_| index(Position::BeforeFragment).saturating_sub(1)),
+        }
+    }
+
+    fn into_url<E>(self) -> Result<DisplaySafeUrl, E>
+    where
+        E: rkyv::rancor::Source,
+    {
+        use rkyv::rancor::ResultExt;
+
+        // `Url::deserialize_internal` accepts its parsed component tuple through Serde. Build the
+        // in-memory value directly; this does not format or parse JSON text.
+        let value = serde_json::to_value((
+            self.serialization,
+            self.scheme_end,
+            self.username_end,
+            self.host_start,
+            self.host_end,
+            SerdeUrlHost::from(self.host),
+            self.port,
+            self.path_start,
+            self.query_start,
+            self.fragment_start,
+        ))
+        .into_error()?;
+        DisplaySafeUrl::deserialize_internal(value).into_error()
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl rkyv::Archive for DisplaySafeUrl {
+    type Archived = <DisplaySafeUrlRkyv as rkyv::Archive>::Archived;
+    type Resolver = <DisplaySafeUrlRkyv as rkyv::Archive>::Resolver;
+
+    fn resolve(&self, resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
+        DisplaySafeUrlRkyv::from_url(self).resolve(resolver, out);
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl<S> rkyv::Serialize<S> for DisplaySafeUrl
+where
+    S: rkyv::rancor::Fallible + ?Sized,
+    DisplaySafeUrlRkyv: rkyv::Serialize<S>,
+{
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        DisplaySafeUrlRkyv::from_url(self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl<D> rkyv::Deserialize<DisplaySafeUrl, D> for ArchivedDisplaySafeUrlRkyv
+where
+    D: rkyv::rancor::Fallible + ?Sized,
+    D::Error: rkyv::rancor::Source,
+    Self: rkyv::Deserialize<DisplaySafeUrlRkyv, D>,
+{
+    fn deserialize(&self, deserializer: &mut D) -> Result<DisplaySafeUrl, D::Error> {
+        let url: DisplaySafeUrlRkyv = rkyv::Deserialize::deserialize(self, deserializer)?;
+        url.into_url()
+    }
+}
 
 /// Check if a path or fragment contains a credential-like pattern (`:` followed by `@`).
 ///
@@ -376,7 +517,30 @@ fn display_with_redacted_credentials(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "rkyv")]
+    use std::error::Error;
+
     use super::*;
+
+    #[cfg(feature = "rkyv")]
+    #[test]
+    fn rkyv_round_trip() -> Result<(), Box<dyn Error>> {
+        for input in [
+            "https://user:password@example.com:8443/path?query=value#fragment",
+            "https://127.0.0.1/simple/",
+            "https://[2001:db8::1]/simple/",
+            "file:///Users/ferris/project.whl",
+            "mailto:ferris@example.com?subject=hello#fragment",
+        ] {
+            let expected = DisplaySafeUrl::parse(input)?;
+            let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&expected)?;
+            let archived =
+                rkyv::access::<rkyv::Archived<DisplaySafeUrl>, rkyv::rancor::Error>(&bytes)?;
+            let actual = rkyv::deserialize::<DisplaySafeUrl, rkyv::rancor::Error>(archived)?;
+            assert_eq!(actual, expected);
+        }
+        Ok(())
+    }
 
     #[test]
     fn from_url_no_credentials() {

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -143,7 +143,7 @@ fn clean_package_pypi() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v21")
+        .child("simple-v22")
         .child("pypi")
         .child("iniconfig.rkyv");
     assert!(
@@ -219,7 +219,7 @@ fn clean_package_index() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v21")
+        .child("simple-v22")
         .child("index")
         .child("e8208120cae3ba69")
         .child("iniconfig.rkyv");


### PR DESCRIPTION
## Summary

`Requirement` currently implements `rkyv` by formatting the entire PEP 508 requirement as a string, then invoking the parser again when metadata is read from the cache. This discards the typed representation and adds parsing work to the warm-cache path.

This changes requirements to archive their fields structurally. Marker trees are stored as canonical DNF and rebuild the marker interner directly, while direct URLs, Git references, parsed URLs, and their supporting types preserve the parsed components needed for reconstruction. String-like values such as marker strings and paths remain strings, but archived requirements no longer use formatting or parser fallbacks during deserialization.

The Simple cache version is bumped for the new archive layout. Focused round-trip coverage now exercises requirements and markers, URL variants, resolution metadata, and the complete Simple metadata cache object; the affected package suites, cache integration tests, formatting, and strict Clippy checks pass.