### PR TITLE
Use a priority-aware limiter for speculative metadata requests

### DIFF
--- a/crates/uv-audit/src/service/project_status.rs
+++ b/crates/uv-audit/src/service/project_status.rs
@@ -3,11 +3,10 @@
 //! [PEP 792]: https://peps.python.org/pep-0792/
 
 use futures::{StreamExt as _, stream};
-use tokio::sync::Semaphore;
 use tracing::trace;
 
 use uv_client::{MetadataFormat, RegistryClient};
-use uv_configuration::Concurrency;
+use uv_configuration::{Concurrency, PrioritySemaphore};
 use uv_distribution_types::{IndexCapabilities, IndexMetadataRef, IndexUrl};
 use uv_normalize::PackageName;
 use uv_pypi_types::{ProjectStatus as PypiProjectStatus, Status};
@@ -62,11 +61,11 @@ impl<'a> ProjectStatusAudit<'a> {
         &self,
         name: &PackageName,
         index: &IndexUrl,
-        semaphore: &Semaphore,
+        semaphore: &PrioritySemaphore,
     ) -> Option<Finding> {
         let results = match self
             .client
-            .simple_detail(
+            .simple_detail_with_priority(
                 name,
                 Some(IndexMetadataRef::from(index)),
                 self.capabilities,

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -547,6 +547,7 @@ mod resolver {
                 &build_context,
                 concurrency.downloads_semaphore.clone(),
             ),
+            concurrency.downloads,
         )?;
 
         Ok(resolver.resolve().await?)

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -11,14 +11,13 @@ use http::{HeaderMap, StatusCode};
 use itertools::Either;
 use reqwest::{Proxy, Response};
 use rustc_hash::FxHashMap;
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::{Mutex, Semaphore, SemaphorePermit};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 use url::Url;
 
 use uv_auth::{CredentialsCache, Indexes, PyxTokenStore};
 use uv_cache::{Cache, CacheBucket, CacheEntry, WheelCache};
-use uv_configuration::IndexStrategy;
-use uv_configuration::KeyringProviderType;
+use uv_configuration::{DownloadPriority, IndexStrategy, KeyringProviderType, PrioritySemaphore};
 use uv_distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
 use uv_distribution_types::{
     BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
@@ -47,6 +46,24 @@ use crate::rkyvutil::OwnedArchive;
 use crate::{
     BaseClient, CachedClient, Error, ErrorKind, FlatIndexClient, RedirectClientWithMiddleware,
 };
+
+#[derive(Clone, Copy)]
+enum DownloadConcurrency<'a> {
+    Semaphore(&'a Semaphore),
+    Priority(&'a PrioritySemaphore),
+}
+
+impl<'a> DownloadConcurrency<'a> {
+    async fn acquire(self) -> SemaphorePermit<'a> {
+        match self {
+            Self::Semaphore(semaphore) => semaphore
+                .acquire()
+                .await
+                .expect("download semaphore is never closed"),
+            Self::Priority(semaphore) => semaphore.acquire(DownloadPriority::Active).await,
+        }
+    }
+}
 
 /// A builder for an [`RegistryClient`].
 #[derive(Debug, Clone)]
@@ -310,13 +327,46 @@ impl RegistryClient {
     /// "Simple" here refers to [PEP 503 – Simple Repository API](https://peps.python.org/pep-0503/)
     /// and [PEP 691 – JSON-based Simple API for Python Package Indexes](https://peps.python.org/pep-0691/),
     /// which the PyPI JSON API implements.
-    #[instrument(skip_all, fields(package = % package_name))]
     pub async fn simple_detail<'index>(
         &'index self,
         package_name: &PackageName,
         index: Option<IndexMetadataRef<'index>>,
         capabilities: &IndexCapabilities,
         download_concurrency: &Semaphore,
+    ) -> Result<Vec<(&'index IndexUrl, MetadataFormat)>, Error> {
+        self.simple_detail_with_concurrency(
+            package_name,
+            index,
+            capabilities,
+            DownloadConcurrency::Semaphore(download_concurrency),
+        )
+        .await
+    }
+
+    /// Fetch package metadata using the priority-aware shared download limit.
+    pub async fn simple_detail_with_priority<'index>(
+        &'index self,
+        package_name: &PackageName,
+        index: Option<IndexMetadataRef<'index>>,
+        capabilities: &IndexCapabilities,
+        download_concurrency: &PrioritySemaphore,
+    ) -> Result<Vec<(&'index IndexUrl, MetadataFormat)>, Error> {
+        self.simple_detail_with_concurrency(
+            package_name,
+            index,
+            capabilities,
+            DownloadConcurrency::Priority(download_concurrency),
+        )
+        .await
+    }
+
+    #[instrument(skip_all, fields(package = % package_name))]
+    async fn simple_detail_with_concurrency<'index>(
+        &'index self,
+        package_name: &PackageName,
+        index: Option<IndexMetadataRef<'index>>,
+        capabilities: &IndexCapabilities,
+        download_concurrency: DownloadConcurrency<'_>,
     ) -> Result<Vec<(&'index IndexUrl, MetadataFormat)>, Error> {
         // If `--no-index` is specified, avoid fetching regardless of whether the index is implicit,
         // explicit, etc.
@@ -437,6 +487,32 @@ impl RegistryClient {
         &self,
         package_name: &PackageName,
         download_concurrency: &Semaphore,
+    ) -> Result<Vec<FlatIndexEntry>, Error> {
+        self.find_links_entries_with_concurrency(
+            package_name,
+            DownloadConcurrency::Semaphore(download_concurrency),
+        )
+        .await
+    }
+
+    /// Fetch `--find-links` entries using the priority-aware shared download limit.
+    pub async fn find_links_entries_with_priority(
+        &self,
+        package_name: &PackageName,
+        download_concurrency: &PrioritySemaphore,
+    ) -> Result<Vec<FlatIndexEntry>, Error> {
+        self.find_links_entries_with_concurrency(
+            package_name,
+            DownloadConcurrency::Priority(download_concurrency),
+        )
+        .await
+    }
+
+    #[instrument(skip_all, fields(package = % package_name))]
+    async fn find_links_entries_with_concurrency(
+        &self,
+        package_name: &PackageName,
+        download_concurrency: DownloadConcurrency<'_>,
     ) -> Result<Vec<FlatIndexEntry>, Error> {
         Ok(futures::stream::iter(self.indexes.flat_indexes())
             .map(async |index| {

--- a/crates/uv-configuration/src/concurrency.rs
+++ b/crates/uv-configuration/src/concurrency.rs
@@ -1,8 +1,107 @@
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-use tokio::sync::Semaphore;
+use tokio::sync::{Notify, Semaphore, SemaphorePermit};
+
+/// The priority of an operation using the shared download concurrency limit.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum DownloadPriority {
+    /// Work required to make progress on the current operation.
+    Active,
+    /// Work performed in anticipation of a future request.
+    Speculative,
+}
+
+/// A semaphore that prioritizes active downloads over speculative downloads.
+///
+/// This limiter does not preempt work that already holds a permit. When an active request is
+/// waiting, speculative requests wait outside the semaphore queue or yield a newly acquired permit
+/// until the active request can acquire it.
+pub struct PrioritySemaphore {
+    semaphore: Semaphore,
+    active_waiters: AtomicUsize,
+    active_waiters_done: Notify,
+}
+
+impl PrioritySemaphore {
+    /// Create a new priority-aware semaphore with the given number of permits.
+    pub fn new(permits: usize) -> Self {
+        Self {
+            semaphore: Semaphore::new(permits),
+            active_waiters: AtomicUsize::new(0),
+            active_waiters_done: Notify::new(),
+        }
+    }
+
+    /// Acquire a permit at the given [`DownloadPriority`].
+    pub async fn acquire(&self, priority: DownloadPriority) -> SemaphorePermit<'_> {
+        match priority {
+            DownloadPriority::Active => self.acquire_active().await,
+            DownloadPriority::Speculative => self.acquire_speculative().await,
+        }
+    }
+
+    async fn acquire_active(&self) -> SemaphorePermit<'_> {
+        let waiter = ActiveWaiter::new(self);
+        let permit = self
+            .semaphore
+            .acquire()
+            .await
+            .expect("download semaphore is never closed");
+        drop(waiter);
+        permit
+    }
+
+    async fn acquire_speculative(&self) -> SemaphorePermit<'_> {
+        loop {
+            self.wait_for_active_requests().await;
+
+            let permit = self
+                .semaphore
+                .acquire()
+                .await
+                .expect("download semaphore is never closed");
+            if self.active_waiters.load(Ordering::Acquire) == 0 {
+                return permit;
+            }
+            drop(permit);
+        }
+    }
+
+    async fn wait_for_active_requests(&self) {
+        loop {
+            let notified = self.active_waiters_done.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if self.active_waiters.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+struct ActiveWaiter<'a> {
+    semaphore: &'a PrioritySemaphore,
+}
+
+impl<'a> ActiveWaiter<'a> {
+    fn new(semaphore: &'a PrioritySemaphore) -> Self {
+        semaphore.active_waiters.fetch_add(1, Ordering::AcqRel);
+        Self { semaphore }
+    }
+}
+
+impl Drop for ActiveWaiter<'_> {
+    fn drop(&mut self) {
+        if self.semaphore.active_waiters.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.semaphore.active_waiters_done.notify_waiters();
+        }
+    }
+}
 
 /// Concurrency limit settings.
 // TODO(konsti): We should find a pattern that doesn't require having both semaphores and counts.
@@ -20,8 +119,8 @@ pub struct Concurrency {
     ///
     /// Note this value must be non-zero.
     pub installs: usize,
-    /// A global semaphore to limit the number of concurrent downloads.
-    pub downloads_semaphore: Arc<Semaphore>,
+    /// A priority-aware global semaphore to limit the number of concurrent downloads.
+    pub downloads_semaphore: Arc<PrioritySemaphore>,
     /// A global semaphore to limit the number of concurrent builds.
     pub builds_semaphore: Arc<Semaphore>,
 }
@@ -54,7 +153,7 @@ impl Concurrency {
             downloads,
             builds,
             installs,
-            downloads_semaphore: Arc::new(Semaphore::new(downloads)),
+            downloads_semaphore: Arc::new(PrioritySemaphore::new(downloads)),
             builds_semaphore: Arc::new(Semaphore::new(builds)),
         }
     }
@@ -64,5 +163,89 @@ impl Concurrency {
         std::thread::available_parallelism()
             .map(NonZeroUsize::get)
             .unwrap_or(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::{DownloadPriority, PrioritySemaphore};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn speculative_requests_use_all_available_permits() {
+        let semaphore = PrioritySemaphore::new(2);
+        let _first = semaphore.acquire(DownloadPriority::Speculative).await;
+        let _second = tokio::time::timeout(
+            Duration::from_secs(1),
+            semaphore.acquire(DownloadPriority::Speculative),
+        )
+        .await
+        .expect("speculative requests should use idle download capacity");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn active_request_overtakes_speculative_request() {
+        let semaphore = Arc::new(PrioritySemaphore::new(1));
+        let permit = semaphore.acquire(DownloadPriority::Active).await;
+        let (order_tx, mut order_rx) = mpsc::unbounded_channel();
+
+        let (speculative_started_tx, speculative_started_rx) = oneshot::channel();
+        let speculative = tokio::spawn({
+            let semaphore = Arc::clone(&semaphore);
+            let order_tx = order_tx.clone();
+            async move {
+                speculative_started_tx.send(()).ok();
+                let _permit = semaphore.acquire(DownloadPriority::Speculative).await;
+                order_tx.send(DownloadPriority::Speculative).ok();
+            }
+        });
+        speculative_started_rx
+            .await
+            .expect("speculative task should start");
+
+        let (active_started_tx, active_started_rx) = oneshot::channel();
+        let active = tokio::spawn({
+            let semaphore = Arc::clone(&semaphore);
+            async move {
+                active_started_tx.send(()).ok();
+                let _permit = semaphore.acquire(DownloadPriority::Active).await;
+                order_tx.send(DownloadPriority::Active).ok();
+            }
+        });
+        active_started_rx.await.expect("active task should start");
+
+        drop(permit);
+
+        assert_eq!(order_rx.recv().await, Some(DownloadPriority::Active));
+        assert_eq!(order_rx.recv().await, Some(DownloadPriority::Speculative));
+        active.await.expect("active task should complete");
+        speculative.await.expect("speculative task should complete");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_active_request_unblocks_speculative_request() {
+        let semaphore = Arc::new(PrioritySemaphore::new(1));
+        let permit = semaphore.acquire(DownloadPriority::Active).await;
+
+        let (active_started_tx, active_started_rx) = oneshot::channel();
+        let active = tokio::spawn({
+            let semaphore = Arc::clone(&semaphore);
+            async move {
+                active_started_tx.send(()).ok();
+                let _permit = semaphore.acquire(DownloadPriority::Active).await;
+            }
+        });
+        active_started_rx.await.expect("active task should start");
+        active.abort();
+        active
+            .await
+            .expect_err("active task should be cancelled while waiting");
+
+        drop(permit);
+        let _permit = semaphore.acquire(DownloadPriority::Speculative).await;
     }
 }

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -341,6 +341,7 @@ impl BuildContext for BuildDispatch<'_> {
                 self.concurrency.downloads_semaphore.clone(),
             )
             .with_build_stack(build_stack),
+            self.concurrency.downloads,
         )?;
         let resolution = Resolution::from(resolver.resolve().await.with_context(|| {
             format!(

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -7,7 +7,6 @@ use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
-use tokio::sync::Semaphore;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{Instrument, info_span, instrument, warn};
 use url::Url;
@@ -17,6 +16,7 @@ use uv_cache_info::{CacheInfo, Timestamp};
 use uv_client::{
     CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient,
 };
+use uv_configuration::{DownloadPriority, PrioritySemaphore};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::{
     BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, File, HashPolicy, Hashed, IndexUrl,
@@ -63,7 +63,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     pub fn new(
         client: &'a RegistryClient,
         build_context: &'a Context,
-        downloads_semaphore: Arc<Semaphore>,
+        downloads_semaphore: Arc<PrioritySemaphore>,
     ) -> Self {
         Self {
             build_context,
@@ -122,7 +122,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         hashes: HashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         match dist {
-            Dist::Built(built) => self.get_wheel(built, hashes).await,
+            Dist::Built(built) => {
+                self.get_wheel(built, hashes, DownloadPriority::Active)
+                    .await
+            }
             Dist::Source(source) => self.build_wheel(source, tags, hashes).await,
         }
     }
@@ -165,7 +168,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         hashes: HashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         match dist {
-            Dist::Built(built) => self.get_wheel_metadata(built, hashes).await,
+            Dist::Built(built) => {
+                self.get_wheel_metadata_with_priority(built, hashes, DownloadPriority::Active)
+                    .await
+            }
             Dist::Source(source) => {
                 self.build_wheel_metadata(&BuildableSource::Dist(source), hashes)
                     .await
@@ -181,6 +187,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         &self,
         dist: &BuiltDist,
         hashes: HashPolicy<'_>,
+        priority: DownloadPriority,
     ) -> Result<LocalWheel, Error> {
         match dist {
             BuiltDist::Registry(wheels) => {
@@ -226,6 +233,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         &wheel_entry,
                         dist,
                         hashes,
+                        priority,
                     )
                     .await
                 {
@@ -264,6 +272,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                                 &wheel_entry,
                                 dist,
                                 hashes,
+                                priority,
                             )
                             .await?;
 
@@ -303,6 +312,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         &wheel_entry,
                         dist,
                         hashes,
+                        priority,
                     )
                     .await
                 {
@@ -341,6 +351,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                                 &wheel_entry,
                                 dist,
                                 hashes,
+                                priority,
                             )
                             .await?;
                         Ok(LocalWheel {
@@ -555,14 +566,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         })
     }
 
-    /// Fetch the wheel metadata from the index, or from the cache if possible.
+    /// Fetch wheel metadata at the given [`DownloadPriority`], or from the cache if possible.
     ///
     /// While hashes will be generated in some cases, hash-checking is _not_ enforced and should
     /// instead be enforced by the caller.
-    async fn get_wheel_metadata(
+    pub async fn get_wheel_metadata_with_priority(
         &self,
         dist: &BuiltDist,
         hashes: HashPolicy<'_>,
+        priority: DownloadPriority,
     ) -> Result<ArchiveMetadata, Error> {
         // If hash generation is enabled, and the distribution isn't hosted on a registry, get the
         // entire wheel to ensure that the hashes are included in the response. If the distribution
@@ -579,7 +591,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         //
         // TODO(charlie): Request the hashes via a separate method, to reduce the coupling in this API.
         if hashes.is_generate(dist) {
-            let wheel = self.get_wheel(dist, hashes).await?;
+            let wheel = self.get_wheel(dist, hashes, priority).await?;
             // If the metadata was provided by the user directly, prefer it.
             let metadata = if let Some(metadata) = self
                 .build_context
@@ -608,7 +620,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let result = self
             .client
-            .managed(|client| {
+            .managed_with_priority(priority, |client| {
                 client
                     .wheel_metadata(
                         dist,
@@ -632,7 +644,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 // If the request failed due to an error that could be resolved by
                 // downloading the wheel directly, try that.
-                let wheel = self.get_wheel(dist, hashes).await?;
+                let wheel = self.get_wheel(dist, hashes, priority).await?;
                 let metadata = wheel.metadata()?;
                 let hashes = wheel.hashes;
                 Ok(ArchiveMetadata {
@@ -703,6 +715,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
         hashes: HashPolicy<'_>,
+        priority: DownloadPriority,
     ) -> Result<Archive, Error> {
         // Acquire an advisory lock, to guard against concurrent writes.
         #[cfg(windows)]
@@ -823,7 +836,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let archive = self
             .client
-            .managed(|client| {
+            .managed_with_priority(priority, |client| {
                 client.cached_client().get_serde_with_retry(
                     req,
                     &http_entry,
@@ -846,7 +859,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             archive
         } else {
             self.client
-                .managed(async |client| {
+                .managed_with_priority(priority, async |client| {
                     client
                         .cached_client()
                         .skip_cache_with_retry(
@@ -878,6 +891,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
         hashes: HashPolicy<'_>,
+        priority: DownloadPriority,
     ) -> Result<Archive, Error> {
         // Acquire an advisory lock, to guard against concurrent writes.
         #[cfg(windows)]
@@ -999,7 +1013,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let archive = self
             .client
-            .managed(|client| {
+            .managed_with_priority(priority, |client| {
                 client.cached_client().get_serde_with_retry(
                     req,
                     &http_entry,
@@ -1022,7 +1036,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             archive
         } else {
             self.client
-                .managed(async |client| {
+                .managed_with_priority(priority, async |client| {
                     client
                         .cached_client()
                         .skip_cache_with_retry(
@@ -1245,12 +1259,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 /// A wrapper around `RegistryClient` that manages a concurrency limit.
 pub struct ManagedClient<'a> {
     pub unmanaged: &'a RegistryClient,
-    control: Arc<Semaphore>,
+    control: Arc<PrioritySemaphore>,
 }
 
 impl<'a> ManagedClient<'a> {
     /// Create a new `ManagedClient` using the given client and concurrency semaphore.
-    fn new(client: &'a RegistryClient, control: Arc<Semaphore>) -> Self {
+    fn new(client: &'a RegistryClient, control: Arc<PrioritySemaphore>) -> Self {
         ManagedClient {
             unmanaged: client,
             control,
@@ -1265,7 +1279,20 @@ impl<'a> ManagedClient<'a> {
     where
         F: Future<Output = T>,
     {
-        let _permit = self.control.acquire().await.unwrap();
+        self.managed_with_priority(DownloadPriority::Active, f)
+            .await
+    }
+
+    /// Perform a request using the client at the given [`DownloadPriority`].
+    pub async fn managed_with_priority<F, T>(
+        &self,
+        priority: DownloadPriority,
+        f: impl FnOnce(&'a RegistryClient) -> F,
+    ) -> T
+    where
+        F: Future<Output = T>,
+    {
+        let _permit = self.control.acquire(priority).await;
         f(self.unmanaged).await
     }
 
@@ -1276,7 +1303,10 @@ impl<'a> ManagedClient<'a> {
     ///
     /// This method serves as an escape hatch for functions that may want to send multiple requests
     /// in parallel.
-    pub async fn manual<F, T>(&'a self, f: impl FnOnce(&'a RegistryClient, &'a Semaphore) -> F) -> T
+    pub async fn manual<F, T>(
+        &'a self,
+        f: impl FnOnce(&'a RegistryClient, &'a PrioritySemaphore) -> F,
+    ) -> T
     where
         F: Future<Output = T>,
     {

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -13,7 +13,7 @@ use crate::resolver::Request;
 use crate::{
     InMemoryIndex, PythonRequirement, ResolveError, ResolverEnvironment, VersionsResponse,
 };
-use uv_distribution_types::{CompatibleDist, IndexCapabilities, IndexMetadata};
+use uv_distribution_types::{CompatibleDist, Dist, IndexCapabilities, IndexMetadata};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
@@ -313,7 +313,7 @@ impl BatchPrefetcherRunner {
             );
             prefetch_count += 1;
 
-            if let Request::Dist(dist) = Request::from(dist) {
+            if let Request::Dist(Dist::Built(dist)) = Request::from(dist) {
                 self.request_sink
                     .blocking_send(Request::Speculative(dist))?;
             }

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -13,7 +13,7 @@ use crate::resolver::Request;
 use crate::{
     InMemoryIndex, PythonRequirement, ResolveError, ResolverEnvironment, VersionsResponse,
 };
-use uv_distribution_types::{CompatibleDist, Identifier, IndexCapabilities, IndexMetadata};
+use uv_distribution_types::{CompatibleDist, IndexCapabilities, IndexMetadata};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
@@ -313,10 +313,11 @@ impl BatchPrefetcherRunner {
             );
             prefetch_count += 1;
 
-            if self.index.distributions().register(dist.distribution_id()) {
-                let request = Request::from(dist);
-                self.request_sink.blocking_send(request)?;
-            }
+            let request = match Request::from(dist) {
+                Request::Dist(dist) => Request::SpeculativeDist(dist),
+                _ => unreachable!("batch prefetch only emits registry distributions"),
+            };
+            self.request_sink.blocking_send(request)?;
         }
 
         match prefetch_count {

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -313,11 +313,10 @@ impl BatchPrefetcherRunner {
             );
             prefetch_count += 1;
 
-            let request = match Request::from(dist) {
-                Request::Dist(dist) => Request::SpeculativeDist(dist),
-                _ => unreachable!("batch prefetch only emits registry distributions"),
-            };
-            self.request_sink.blocking_send(request)?;
+            if let Request::Dist(dist) = Request::from(dist) {
+                self.request_sink
+                    .blocking_send(Request::Speculative(dist))?;
+            }
         }
 
         match prefetch_count {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -128,7 +128,7 @@ struct ResolverState<InstalledPackages: InstalledPackagesProvider> {
     workspace_members: BTreeSet<PackageName>,
     selector: CandidateSelector,
     index: InMemoryIndex,
-    speculative_metadata_requests: Semaphore,
+    speculative_requests: Semaphore,
     installed_packages: InstalledPackages,
     // Papaya's maps are large on Windows, so box them to keep resolver futures small.
     /// Incompatibilities for packages that are entirely unavailable.
@@ -240,7 +240,7 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
             // Do not let speculative batch prefetching claim more once-map entries than the
             // downloader can actively service. A later active resolver request can then claim an
             // entry before a queued speculative request starts.
-            speculative_metadata_requests: Semaphore::new(concurrent_downloads.max(1)),
+            speculative_requests: Semaphore::new(concurrent_downloads.max(1)),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, &env, git, options.dependency_mode),
             indexes: Indexes::from_manifest(&manifest, &env, options.dependency_mode),
@@ -2558,9 +2558,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             // Fetch distribution metadata from the distribution database.
             Request::Dist(dist) => self.process_dist_request(dist, provider).await,
 
-            Request::SpeculativeDist(dist) => {
+            Request::Speculative(dist) => {
                 let _permit = self
-                    .speculative_metadata_requests
+                    .speculative_requests
                     .acquire()
                     .await
                     .expect("resolver state outlives metadata requests");
@@ -3658,7 +3658,7 @@ pub(crate) enum Request {
     /// A request to fetch the metadata for a built or source distribution.
     Dist(Dist),
     /// A speculative request for distribution metadata emitted by batch prefetching.
-    SpeculativeDist(Dist),
+    Speculative(Dist),
     /// A request to fetch the metadata from an already-installed distribution.
     Installed(InstalledDist),
     /// A request to pre-fetch the metadata for a package and the best-guess distribution.
@@ -3711,7 +3711,7 @@ impl Display for Request {
             Self::Dist(dist) => {
                 write!(f, "Metadata {dist}")
             }
-            Self::SpeculativeDist(dist) => {
+            Self::Speculative(dist) => {
                 write!(f, "Speculative metadata {dist}")
             }
             Self::Installed(dist) => {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -16,7 +16,7 @@ use papaya::{HashMap, ResizeMode};
 use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::sync::oneshot;
+use tokio::sync::{Semaphore, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{Level, debug, info, instrument, trace, warn};
 
@@ -128,6 +128,7 @@ struct ResolverState<InstalledPackages: InstalledPackagesProvider> {
     workspace_members: BTreeSet<PackageName>,
     selector: CandidateSelector,
     index: InMemoryIndex,
+    speculative_metadata_requests: Semaphore,
     installed_packages: InstalledPackages,
     // Papaya's maps are large on Windows, so box them to keep resolver futures small.
     /// Incompatibilities for packages that are entirely unavailable.
@@ -175,6 +176,7 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
         build_context: &'a Context,
         installed_packages: InstalledPackages,
         database: DistributionDatabase<'a, Context>,
+        concurrent_downloads: usize,
     ) -> Result<Self, ResolveError> {
         let provider = DefaultResolverProvider::new(
             database,
@@ -204,6 +206,7 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
             build_context.locations(),
             provider,
             installed_packages,
+            concurrent_downloads,
         ))
     }
 }
@@ -227,12 +230,17 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
         locations: &IndexLocations,
         provider: Provider,
         installed_packages: InstalledPackages,
+        concurrent_downloads: usize,
     ) -> Self {
         let state = ResolverState {
             index: index.clone(),
             git: git.clone(),
             capabilities: capabilities.clone(),
             selector: CandidateSelector::for_resolution(&options, &manifest, &env),
+            // Do not let speculative batch prefetching claim more once-map entries than the
+            // downloader can actively service. A later active resolver request can then claim an
+            // entry before a queued speculative request starts.
+            speculative_metadata_requests: Semaphore::new(concurrent_downloads.max(1)),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, &env, git, options.dependency_mode),
             indexes: Indexes::from_manifest(&manifest, &env, options.dependency_mode),
@@ -2459,6 +2467,72 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         Ok::<(), ResolveError>(())
     }
 
+    async fn process_dist_request<Provider: ResolverProvider>(
+        &self,
+        dist: Dist,
+        provider: &Provider,
+    ) -> Result<Option<Response>, ResolveError> {
+        if let Some(version) = dist.version() {
+            if let Some(index) = dist.index() {
+                // Check the implicit indexes for pre-provided metadata.
+                let versions_response = self.index.implicit().get(dist.name());
+                if let Some(VersionsResponse::Found(version_maps)) = versions_response.as_deref() {
+                    for version_map in version_maps {
+                        if version_map.index() == Some(index) {
+                            let Some(metadata) = version_map.get_metadata(version) else {
+                                continue;
+                            };
+                            debug!("Found registry-provided metadata for: {dist}");
+                            return Ok(Some(Response::Dist {
+                                dist,
+                                metadata: MetadataResponse::Found(
+                                    ArchiveMetadata::from_metadata23(metadata),
+                                ),
+                            }));
+                        }
+                    }
+                }
+
+                // Check the explicit indexes for pre-provided metadata.
+                let versions_response = self
+                    .index
+                    .explicit()
+                    .get(&(dist.name().clone(), index.clone()));
+                if let Some(VersionsResponse::Found(version_maps)) = versions_response.as_deref() {
+                    for version_map in version_maps {
+                        let Some(metadata) = version_map.get_metadata(version) else {
+                            continue;
+                        };
+                        debug!("Found registry-provided metadata for: {dist}");
+                        return Ok(Some(Response::Dist {
+                            dist,
+                            metadata: MetadataResponse::Found(ArchiveMetadata::from_metadata23(
+                                metadata,
+                            )),
+                        }));
+                    }
+                }
+            }
+        }
+
+        let metadata = provider
+            .get_or_build_wheel_metadata(&dist)
+            .boxed_local()
+            .await?;
+
+        if let MetadataResponse::Found(metadata) = &metadata {
+            if &metadata.metadata.name != dist.name() {
+                return Err(ResolveError::MismatchedPackageName {
+                    request: "distribution metadata",
+                    expected: dist.name().clone(),
+                    actual: metadata.metadata.name.clone(),
+                });
+            }
+        }
+
+        Ok(Some(Response::Dist { dist, metadata }))
+    }
+
     #[instrument(skip_all, fields(%request))]
     async fn process_request<Provider: ResolverProvider>(
         &self,
@@ -2482,70 +2556,18 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             }
 
             // Fetch distribution metadata from the distribution database.
-            Request::Dist(dist) => {
-                if let Some(version) = dist.version() {
-                    if let Some(index) = dist.index() {
-                        // Check the implicit indexes for pre-provided metadata.
-                        let versions_response = self.index.implicit().get(dist.name());
-                        if let Some(VersionsResponse::Found(version_maps)) =
-                            versions_response.as_deref()
-                        {
-                            for version_map in version_maps {
-                                if version_map.index() == Some(index) {
-                                    let Some(metadata) = version_map.get_metadata(version) else {
-                                        continue;
-                                    };
-                                    debug!("Found registry-provided metadata for: {dist}");
-                                    return Ok(Some(Response::Dist {
-                                        dist,
-                                        metadata: MetadataResponse::Found(
-                                            ArchiveMetadata::from_metadata23(metadata),
-                                        ),
-                                    }));
-                                }
-                            }
-                        }
+            Request::Dist(dist) => self.process_dist_request(dist, provider).await,
 
-                        // Check the explicit indexes for pre-provided metadata.
-                        let versions_response = self
-                            .index
-                            .explicit()
-                            .get(&(dist.name().clone(), index.clone()));
-                        if let Some(VersionsResponse::Found(version_maps)) =
-                            versions_response.as_deref()
-                        {
-                            for version_map in version_maps {
-                                let Some(metadata) = version_map.get_metadata(version) else {
-                                    continue;
-                                };
-                                debug!("Found registry-provided metadata for: {dist}");
-                                return Ok(Some(Response::Dist {
-                                    dist,
-                                    metadata: MetadataResponse::Found(
-                                        ArchiveMetadata::from_metadata23(metadata),
-                                    ),
-                                }));
-                            }
-                        }
-                    }
+            Request::SpeculativeDist(dist) => {
+                let _permit = self
+                    .speculative_metadata_requests
+                    .acquire()
+                    .await
+                    .expect("resolver state outlives metadata requests");
+                if !self.index.distributions().register(dist.distribution_id()) {
+                    return Ok(None);
                 }
-
-                let metadata = provider
-                    .get_or_build_wheel_metadata(&dist)
-                    .boxed_local()
-                    .await?;
-
-                if let MetadataResponse::Found(metadata) = &metadata {
-                    if &metadata.metadata.name != dist.name() {
-                        return Err(ResolveError::MismatchedPackageName {
-                            request: "distribution metadata",
-                            expected: dist.name().clone(),
-                            actual: metadata.metadata.name.clone(),
-                        });
-                    }
-                }
-
-                Ok(Some(Response::Dist { dist, metadata }))
+                self.process_dist_request(dist, provider).await
             }
 
             Request::Installed(dist) => {
@@ -3635,6 +3657,8 @@ pub(crate) enum Request {
     Package(PackageName, Option<IndexMetadata>),
     /// A request to fetch the metadata for a built or source distribution.
     Dist(Dist),
+    /// A speculative request for distribution metadata emitted by batch prefetching.
+    SpeculativeDist(Dist),
     /// A request to fetch the metadata from an already-installed distribution.
     Installed(InstalledDist),
     /// A request to pre-fetch the metadata for a package and the best-guess distribution.
@@ -3686,6 +3710,9 @@ impl Display for Request {
             }
             Self::Dist(dist) => {
                 write!(f, "Metadata {dist}")
+            }
+            Self::SpeculativeDist(dist) => {
+                write!(f, "Speculative metadata {dist}")
             }
             Self::Installed(dist) => {
                 write!(f, "Installed metadata {dist}")

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -20,7 +20,7 @@ use tokio::sync::{Semaphore, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{Level, debug, info, instrument, trace, warn};
 
-use uv_configuration::{Constraints, Excludes, Overrides};
+use uv_configuration::{Constraints, DownloadPriority, Excludes, Overrides};
 use uv_distribution::{ArchiveMetadata, DistributionDatabase};
 use uv_distribution_types::{
     BuiltDist, CompatibleDist, DerivationChain, Dist, DistErrorKind, Identifier, IncompatibleDist,
@@ -2471,6 +2471,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         &self,
         dist: Dist,
         provider: &Provider,
+        priority: DownloadPriority,
     ) -> Result<Option<Response>, ResolveError> {
         if let Some(version) = dist.version() {
             if let Some(index) = dist.index() {
@@ -2516,7 +2517,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         }
 
         let metadata = provider
-            .get_or_build_wheel_metadata(&dist)
+            .get_or_build_wheel_metadata(&dist, priority)
             .boxed_local()
             .await?;
 
@@ -2556,7 +2557,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             }
 
             // Fetch distribution metadata from the distribution database.
-            Request::Dist(dist) => self.process_dist_request(dist, provider).await,
+            Request::Dist(dist) => {
+                self.process_dist_request(dist, provider, DownloadPriority::Active)
+                    .await
+            }
 
             Request::Speculative(dist) => {
                 let _permit = self
@@ -2567,7 +2571,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 if !self.index.distributions().register(dist.distribution_id()) {
                     return Ok(None);
                 }
-                self.process_dist_request(dist, provider).await
+                self.process_dist_request(
+                    Dist::Built(dist),
+                    provider,
+                    DownloadPriority::Speculative,
+                )
+                .await
             }
 
             Request::Installed(dist) => {
@@ -2738,7 +2747,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     let response = match dist {
                         ResolvedDist::Installable { dist, .. } => {
                             let metadata = provider
-                                .get_or_build_wheel_metadata(&dist)
+                                .get_or_build_wheel_metadata(&dist, DownloadPriority::Active)
                                 .boxed_local()
                                 .await?;
 
@@ -3658,7 +3667,7 @@ pub(crate) enum Request {
     /// A request to fetch the metadata for a built or source distribution.
     Dist(Dist),
     /// A speculative request for distribution metadata emitted by batch prefetching.
-    Speculative(Dist),
+    Speculative(BuiltDist),
     /// A request to fetch the metadata from an already-installed distribution.
     Installed(InstalledDist),
     /// A request to pre-fetch the metadata for a package and the best-guess distribution.

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use reqwest::StatusCode;
 
 use uv_client::MetadataFormat;
-use uv_configuration::BuildOptions;
+use uv_configuration::{BuildOptions, DownloadPriority};
 use uv_distribution::{ArchiveMetadata, DistributionDatabase, Reporter};
 use uv_distribution_types::{
     Dist, IndexCapabilities, IndexLocations, IndexMetadata, IndexMetadataRef, InstalledDist,
@@ -98,6 +98,7 @@ pub trait ResolverProvider {
     fn get_or_build_wheel_metadata<'io>(
         &'io self,
         dist: &'io Dist,
+        priority: DownloadPriority,
     ) -> impl Future<Output = WheelMetadataResult> + 'io;
 
     /// Get the metadata for an installed distribution.
@@ -183,7 +184,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
             .fetcher
             .client()
             .manual(|client, semaphore| {
-                client.simple_detail(
+                client.simple_detail_with_priority(
                     package_name,
                     index.map(IndexMetadataRef::from),
                     self.capabilities,
@@ -272,12 +273,24 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
     }
 
     /// Fetch the metadata for a distribution, building it if necessary.
-    async fn get_or_build_wheel_metadata<'io>(&'io self, dist: &'io Dist) -> WheelMetadataResult {
-        match self
-            .fetcher
-            .get_or_build_wheel_metadata(dist, self.hasher.get(dist))
-            .await
-        {
+    async fn get_or_build_wheel_metadata<'io>(
+        &'io self,
+        dist: &'io Dist,
+        priority: DownloadPriority,
+    ) -> WheelMetadataResult {
+        let result = match dist {
+            Dist::Built(built) => {
+                self.fetcher
+                    .get_wheel_metadata_with_priority(built, self.hasher.get(dist), priority)
+                    .await
+            }
+            Dist::Source(_) => {
+                self.fetcher
+                    .get_or_build_wheel_metadata(dist, self.hasher.get(dist))
+                    .await
+            }
+        };
+        match result {
             Ok(metadata) => Ok(MetadataResponse::Found(metadata)),
             Err(err) => match err {
                 uv_distribution::Error::Client(client) => {

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -1,7 +1,7 @@
-use tokio::sync::Semaphore;
 use tracing::debug;
 
 use uv_client::{MetadataFormat, RegistryClient, VersionFiles};
+use uv_configuration::PrioritySemaphore;
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{
     File, IndexCapabilities, IndexLocations, IndexMetadataRef, IndexUrl, RequiresPython,
@@ -102,7 +102,7 @@ impl LatestClient<'_> {
         &self,
         package: &PackageName,
         index: Option<&IndexUrl>,
-        download_concurrency: &Semaphore,
+        download_concurrency: &PrioritySemaphore,
     ) -> Result<Option<DistFilename>, uv_client::Error> {
         debug!("Fetching latest version of: `{package}`");
 
@@ -122,7 +122,7 @@ impl LatestClient<'_> {
 
         let archives = match self
             .client
-            .simple_detail(
+            .simple_detail_with_priority(
                 package,
                 index.map(IndexMetadataRef::from),
                 self.capabilities,
@@ -175,7 +175,7 @@ impl LatestClient<'_> {
         if index.is_none() {
             for entry in self
                 .client
-                .find_links_entries(package, download_concurrency)
+                .find_links_entries_with_priority(package, download_concurrency)
                 .await?
             {
                 let (filename, file, index) = entry.into_parts();

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -386,6 +386,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 build_dispatch,
                 concurrency.downloads_semaphore.clone(),
             ),
+            concurrency.downloads,
         )?
         .with_reporter(Arc::new(reporter));
 


### PR DESCRIPTION
## Summary

Batch prefetch currently claims each distribution in the shared once-map before its metadata request begins. When the download queue is saturated, a speculative request can therefore reserve a version that the resolver later needs immediately, leaving active resolution work behind queued speculative requests.

This keeps batch-prefetched distribution metadata distinct from active requests, but moves the scheduling policy into the shared download limiter. Speculative requests can use every download permit while the resolver is idle. Once active work is waiting, speculative requests remain outside the semaphore queue or yield a newly acquired permit so that solver-blocking Simple API and wheel metadata requests can overtake them.

| Project | First pass | Second pass | Combined |
| --- | ---: | ---: | ---: |
| Transformers | +0.3% | -0.7% | 0.0% |
| Home Assistant | +0.9% | +0.2% | +0.6% |
| Warehouse | +0.5% | +3.1% | +1.4% |
| JupyterLab | -5.1% | -4.7% | -5.0% |
| Semantic Kernel | -2.9% | -3.3% | -3.0% |
| Packse | +1.3% | -2.2% | +0.1% |
