### PR TITLE
Skip the ambiguous authority check for file transport VCS URLs

### DIFF
--- a/crates/uv-redacted/src/lib.rs
+++ b/crates/uv-redacted/src/lib.rs
@@ -112,8 +112,11 @@ impl DisplaySafeUrl {
     fn reject_ambiguous_credentials(input: &str, url: &Url) -> Result<(), DisplaySafeUrlError> {
         // `git://`, `http://`, and `https://` URLs may carry credentials, while `file://` URLs
         // on Windows may contain both sigils, but it's always safe, e.g.
-        // `file://C:/Users/ferris/project@home/workspace`.
-        if url.scheme() == "file" {
+        // `file://C:/Users/ferris/project@home/workspace`. The same holds for VCS URLs that use a
+        // file transport, such as `git+file://C:/Users/ferris/repo.git@v1.0`, which likewise carry
+        // no network credentials but can pair a drive-letter `:` with an `@` revision.
+        let scheme = url.scheme();
+        if scheme == "file" || scheme.ends_with("+file") {
             return Ok(());
         }
 
@@ -634,6 +637,12 @@ mod tests {
             "git+https://githubproxy.cc/https://github.com/user/repo.git@branch",
             "git+https://proxy.example.com/https://github.com/org/project@v1.0.0",
             "git+https://proxy.example.com/https://github.com/org/project@refs/heads/main",
+            // https://github.com/astral-sh/uv/issues/19887
+            // Windows `git+file://` URLs pair a drive-letter `:` with an `@` revision, but use a
+            // file transport and so carry no credentials.
+            "git+file:///C:/Users/ferris/repo.git@v1.0",
+            "git+file:///C:/Users/ferris/repo.git@10c049896212932ad5f7b19456d90bc604eeca53",
+            "hg+file:///C:/Users/ferris/repo@default",
         ] {
             DisplaySafeUrl::parse(url).unwrap();
         }


### PR DESCRIPTION
## Summary

On Windows, resolving a `git+file://` dependency panics. For example, running `uv add "mypkg @ git+file:///C:/path/to/repo.git" --tag v0.9.0`, or putting the same source in `[tool.uv.sources]` and running `uv lock`, aborts during resolution with:

```
thread 'uv-resolver' panicked at crates/uv-pypi-types/src/parsed_url.rs:638:14:
Git URL is invalid: AmbiguousAuthority("git+file:***@10c04989...")
```

The cause is the ambiguous authority check in `uv-redacted`. `DisplaySafeUrl::parse` rejects URLs where a `:` is followed by an `@` outside the scheme, so that unencoded credentials like `https://user/name:password@host` are not silently misparsed. It already skips this check for `file://` URLs, because on Windows a `file://` path can legitimately pair a drive letter `:` with an `@`. It did not skip VCS URLs that use a file transport. When uv serializes a resolved Git dependency it produces `git+file:///C:/path/repo.git@<rev>`, which trips the check, and the caller in `parsed_url.rs` unwraps the result with `expect`, so the resolver panics.

A file transport never carries network credentials, whether or not it has a VCS prefix, so this extends the existing `file` exemption to any scheme ending in `+file` (`git+file`, `hg+file`, `bzr+file`, `svn+file`). It is the same class of false positive already handled for plain `file://` paths in #16756 and for nested proxy schemes in #17214.

The issue also reports the URL being rewritten to `file:///d/...` on `uv sync`. On the current `main` both of the reporter's reproducers reach the panic above during resolution, and both succeed once the check is fixed, with the drive letter preserved in the locked URL.

Fixes #19887.

## Test Plan

Added cases to the existing `parse_url_not_ambiguous` unit test in `uv-redacted`, covering `git+file://` with a tag and with a full commit hash, and `hg+file://`. The test fails before the change (the parse returns `AmbiguousAuthority`) and passes after.

Also verified on Windows against a local bare repository: both `uv add "mypkg @ git+file:///C:/.../repo.git" --tag v0.9.0` and a `[tool.uv.sources]` entry followed by `uv lock` panicked before the change and complete successfully after, resolving, locking, and installing the package with the drive letter intact.
