### PR TITLE
Avoid blocking the async runtime when creating temporary files

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -906,9 +906,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
-                // Download the wheel to a temporary file.
-                let temp_file = tempfile::tempfile_in(self.build_context.cache().root())
-                    .map_err(Error::CacheWrite)?;
+                // Download the wheel to a temporary file. Creating the file can block, so run it
+                // on a blocking thread to avoid stalling the async runtime.
+                let cache_root = self.build_context.cache().root().to_path_buf();
+                let temp_file =
+                    tokio::task::spawn_blocking(move || tempfile::tempfile_in(cache_root))
+                        .await
+                        .map_err(|err| Error::CacheWrite(std::io::Error::other(err)))?
+                        .map_err(Error::CacheWrite)?;
                 let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
                     // It's an unnamed file on Linux so that's the best approximation.
                     fs_err::File::from_parts(temp_file, self.build_context.cache().root()),

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -378,14 +378,27 @@ pub fn tempfile_in(path: &Path) -> std::io::Result<NamedTempFile> {
     tempfile::Builder::new().tempfile_in(path)
 }
 
+/// Return a [`NamedTempFile`] in the specified directory without blocking the async runtime.
+///
+/// Creating a temporary file opens a file, which can block. This offloads that work to a blocking
+/// thread so it does not stall the async runtime.
+#[cfg(feature = "tokio")]
+pub async fn tempfile_in_async(path: &Path) -> std::io::Result<NamedTempFile> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || tempfile_in(&path))
+        .await
+        .map_err(std::io::Error::other)?
+}
+
 /// Write `data` to `path` atomically using a temporary file and atomic rename.
 #[cfg(feature = "tokio")]
 pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std::io::Result<()> {
-    let temp_file = tempfile_in(
+    let temp_file = tempfile_in_async(
         path.as_ref()
             .parent()
             .expect("Write path must have a parent"),
-    )?;
+    )
+    .await?;
     fs_err::tokio::write(&temp_file, &data).await?;
     persist_with_retry(temp_file, path.as_ref()).await
 }
@@ -979,6 +992,28 @@ mod tests {
 
         assert!(!clear_virtualenv(&environment)?);
         assert!(environment.is_dir());
+        Ok(())
+    }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn tempfile_in_async_creates_file_in_directory() -> io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+
+        let temp_file = tempfile_in_async(tempdir.path()).await?;
+        assert!(temp_file.path().is_file());
+        assert_eq!(temp_file.path().parent(), Some(tempdir.path()));
+
+        // The async wrapper must produce a file with the same permissions as the
+        // synchronous `tempfile_in`.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let sync_file = tempfile_in(tempdir.path())?;
+            let expected = fs_err::metadata(sync_file.path())?.permissions().mode() & 0o777;
+            let actual = fs_err::metadata(temp_file.path())?.permissions().mode() & 0o777;
+            assert_eq!(actual, expected);
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Creating a temporary file opens a file, which can block. As noted in #19429, several async code paths create temporary files with the blocking `tempfile` APIs, which can stall the tokio runtime. This does not usually block noticeably on local filesystems, but it is worth avoiding.

This adds a `tempfile_in_async` helper in `uv-fs` that runs the existing `tempfile_in` on a blocking thread via `spawn_blocking`, and converts the async call sites to use it.

## Changes

* `uv-fs`: new `tempfile_in_async`, used by `write_atomic`. `persist_with_retry` still takes the plain `NamedTempFile`, and the temporary file is written by path, so nothing else in `write_atomic` changes.
* `uv-distribution`: the wheel download creates its temporary file inside `spawn_blocking`. That path uses the anonymous-file `tempfile::tempfile_in` API directly, which is separate from `uv_fs::tempfile_in`.

## Scope

I only converted the call sites that actually run on the async runtime. The remaining `tempfile_in` uses run synchronously and do not block it, so I left them alone:

* `uv-build-backend` (`build_source_dist` and `write_wheel` are synchronous)
* `uv-install-wheel` (`install_script` is synchronous)
* `write_atomic_sync` and `copy_atomic_sync`

## Test

Added a `uv-fs` test that `tempfile_in_async` creates the file in the requested directory, and on unix that it carries the same `0o666` permissions as the synchronous `tempfile_in`. `cargo test -p uv-fs --features tokio` passes, and clippy is clean.

Refs #19429
