### PR TITLE
Add `package/command` shorthand to `uvx` and `uv tool run`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5621,8 +5621,9 @@ pub enum ToolCommand {
     /// By default, the package to install is assumed to match the command name.
     ///
     /// The name of the command can include an exact version in the format `<package>@<version>`,
-    /// e.g., `uv tool run ruff@0.3.0`. If more complex version specification is desired or if the
-    /// command is provided by a different package, use `--from`.
+    /// e.g., `uv tool run ruff@0.3.0`. If more complex version specification is desired, use
+    /// `--from`. If the command is provided by a different package, use `--from` or the
+    /// `<package>/<command>` shorthand.
     ///
     /// `uvx` can be used to invoke Python, e.g., with `uvx python` or `uvx python@<version>`. A
     /// Python interpreter will be started in an isolated virtual environment.

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -92,6 +92,16 @@ fn find_verbose_flag(args: &[std::ffi::OsString]) -> Option<&str> {
     })
 }
 
+/// Parse the `package/command` shorthand into its package and command components.
+fn parse_package_command(target: &str) -> Option<(&str, &str)> {
+    let (package, command) = target.split_once('/')?;
+    if command.is_empty() || command.contains('/') || command.contains('\\') {
+        return None;
+    }
+    PackageName::from_str(package).ok()?;
+    Some((package, command))
+}
+
 /// Run a command.
 #[expect(clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -156,6 +166,15 @@ pub(crate) async fn run(
         return Err(anyhow::anyhow!(
             "Tool command could not be parsed as UTF-8 string. Use `--from` to specify the package name"
         ));
+    };
+
+    // Treat `package/command` as shorthand for `--from package command`.
+    let (target, from) = if from.is_none()
+        && let Some((package, command)) = parse_package_command(target)
+    {
+        (command, Some(package.to_string()))
+    } else {
+        (target, from)
     };
 
     if let Some(ref from) = from {
@@ -1254,5 +1273,40 @@ impl uv_errors::Hint for ToolRunScriptError {
                 format!("{invocation} --from {package_name} {target}").green(),
             ),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_package_command;
+
+    #[test]
+    fn parse_package_command_valid() {
+        assert_eq!(parse_package_command("foo/bar"), Some(("foo", "bar")));
+        assert_eq!(
+            parse_package_command("foo-bar/bar_baz"),
+            Some(("foo-bar", "bar_baz"))
+        );
+    }
+
+    #[test]
+    fn parse_package_command_rejects_requirements_and_paths() {
+        for target in [
+            "foo",
+            "/foo",
+            "foo/",
+            "foo/bar/baz",
+            r"foo/bar\baz",
+            "./foo",
+            "../foo",
+            "C:/foo",
+            "https://example.com/foo",
+            "git+https://example.com/foo",
+            "foo@latest/bar",
+            "foo[extra]/bar",
+            "foo==1/bar",
+        ] {
+            assert_eq!(parse_package_command(target), None, "target: {target}");
+        }
     }
 }

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -3027,6 +3027,54 @@ fn tool_run_from_at() {
 }
 
 #[test]
+fn tool_run_from_shorthand() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    let mut command = context.command();
+    command
+        .arg("tool")
+        .arg("uvx")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links"))
+        .arg("simple-launcher/simple_launcher")
+        .env(EnvVars::UV_SHOW_RESOLUTION, "1")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str());
+
+    uv_snapshot!(context.filters(), command, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Hi from the simple launcher!
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + simple-launcher==0.1.0
+    ");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links"))
+        .arg("simple-launcher/simple_launcher")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Hi from the simple launcher!
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+}
+
+#[test]
 fn tool_run_verbatim_name() {
     let context = uv_test::test_context!("3.12")
         .with_filtered_counts()

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -72,6 +72,13 @@ provided by `httpie`:
 $ uvx --from httpie http
 ```
 
+As a shorthand, separate the package name and command with a `/`:
+
+```console
+$ uvx httpie/http
+$ uv tool run httpie/http
+```
+
 ## Requesting specific versions
 
 To run a tool at a specific version, use `command@<version>`:


### PR DESCRIPTION
When a package exposes a differently named command, `uvx` and `uv tool run` require `--from`, e.g. `uvx --from httpie http`. This adds `<package>/<command>` shorthand to both entry points, so `uvx httpie/http` and `uv tool run httpie/http` select `httpie` and run `http`.

The shorthand requires exactly one slash, a valid package name on the left, and a nonempty command without path separators. Explicit `--from`, URLs, nested paths, and version or extra syntax keep their existing parsing. Bare `foo/bar` previously could name a relative package path; it now selects the shorthand, while `./foo/bar` remains explicit path syntax.