### PR TITLE
fix: hint supported Python request formats when executable name not found

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -3658,6 +3658,13 @@ impl fmt::Display for PythonNotFound {
             PythonRequest::Directory(_) => {
                 write!(f, "No interpreter found in {}", self.request)
             }
+            PythonRequest::ExecutableName(_) => {
+                write!(
+                    f,
+                    "No interpreter found for {} in {sources}. Supported request formats: `3.12`, `3.12.6`, `python3.12`, `cpython-3.12`, or `pypy3.8`",
+                    self.request
+                )
+            }
             _ => {
                 write!(f, "No interpreter found for {} in {sources}", self.request)
             }

--- a/crates/uv/tests/python/python_install.rs
+++ b/crates/uv/tests/python/python_install.rs
@@ -308,7 +308,7 @@ fn python_install_automatic() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for executable name `foobar` in [PYTHON SOURCES]
+    error: No interpreter found for executable name `foobar` in [PYTHON SOURCES]. Supported request formats: `3.12`, `3.12.6`, `python3.12`, `cpython-3.12`, or `pypy3.8`
     ");
 
     // Create a "broken" Python executable in the test context `bin`

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -2405,7 +2405,7 @@ fn tool_run_python_at_version() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for executable name `@311` in [PYTHON SOURCES]
+    error: No interpreter found for executable name `@311` in [PYTHON SOURCES]. Supported request formats: `3.12`, `3.12.6`, `python3.12`, `cpython-3.12`, or `pypy3.8`
     ");
 
     // Request a version in the tool and `-p`


### PR DESCRIPTION
## Summary

When a user provides an unrecognizable Python request (e.g., \oobar\, \@311\), uv parses it as an \ExecutableName\ request. If no interpreter is found, the error currently says just:

> No interpreter found for executable name \oobar\ in [PYTHON SOURCES]

This doesn't tell the user what formats _are_ supported. This PR adds format examples to the error message so users know what to try instead.

## Changes

Modified \PythonNotFound::Display\ in \crates/uv-python/src/discovery.rs\ to append format examples when the request is \ExecutableName\.

**Before:**
> No interpreter found for executable name \oobar\ in [PYTHON SOURCES]

**After:**
> No interpreter found for executable name \oobar\ in [PYTHON SOURCES]. Supported request formats: \3.12\, \3.12.6\, \python3.12\, \cpython-3.12\, or \pypy3.8\

Closes #4401