### PR TITLE
fix: hint at uv init when pyproject.toml is not found

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -184,7 +184,7 @@ impl Error for WorkspaceError {
 #[derive(thiserror::Error, Debug)]
 pub enum WorkspaceErrorKind {
     // Workspace structure errors.
-    #[error("No `pyproject.toml` found in current directory or any parent directory")]
+    #[error("No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/")]
     MissingPyprojectToml,
     #[error("Workspace member `{}` is missing a `pyproject.toml` (matches: `{}`)", _0.simplified_display(), _1)]
     MissingPyprojectTomlMember(PathBuf, String),

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -780,7 +780,7 @@ fn build_workspace() -> Result<()> {
 
     ----- stderr -----
     error: `--package` was provided, but no workspace was found
-      Caused by: No `pyproject.toml` found in current directory or any parent directory
+      Caused by: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     ");
 
     // Fail when `--all` is provided without a workspace.
@@ -791,7 +791,7 @@ fn build_workspace() -> Result<()> {
 
     ----- stderr -----
     error: `--all-packages` was provided, but no workspace was found
-      Caused by: No `pyproject.toml` found in current directory or any parent directory
+      Caused by: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     ");
 
     // Fail when `--package` is a non-existent member without a workspace.

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -2269,7 +2269,7 @@ fn version_get_fallback_missing_strict() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     ");
 
     Ok(())
@@ -2286,7 +2286,7 @@ fn version_get_missing_with_hint() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
 
     hint: If you meant to view uv's version, use `uv self version` instead
     ");

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -10855,7 +10855,7 @@ fn lock_peer_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     ");
 
     Ok(())
@@ -11259,7 +11259,7 @@ fn lock_dev_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     ");
 
     Ok(())

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -5967,7 +5967,7 @@ fn no_install_project() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     ");
 
     Ok(())
@@ -6130,7 +6130,7 @@ fn no_install_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     ");
 
     Ok(())

--- a/crates/uv/tests/workspace/workspace_dir.rs
+++ b/crates/uv/tests/workspace/workspace_dir.rs
@@ -154,7 +154,7 @@ fn workspace_metadata_no_project() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     "
     );
 }

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -228,7 +228,7 @@ fn workspace_list_no_project() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     "
     );
 }

--- a/crates/uv/tests/workspace/workspace_metadata.rs
+++ b/crates/uv/tests/workspace/workspace_metadata.rs
@@ -1876,7 +1876,7 @@ fn workspace_metadata_no_project() {
 
     ----- stderr -----
     warning: The `uv workspace metadata` command is experimental and may change without warning. Pass `--preview-features workspace-metadata` to disable this warning.
-    error: No `pyproject.toml` found in current directory or any parent directory
+    error: No `pyproject.toml` found in current directory or any parent directory. To create one, run `uv init` or see https://docs.astral.sh/uv/guides/projects/
     "
     );
 }


### PR DESCRIPTION
## Summary

When running \uv add\ or \uv sync\ outside a project directory, the error message said only:

> No \pyproject.toml\ found in current directory or any parent directory

This doesn't tell users migrating from pip how to get started. This PR adds a hint directing them to \uv init\ and the getting-started guide.

## Changes

Modified \WorkspaceErrorKind::MissingPyprojectToml\ error message in \crates/uv-workspace/src/workspace.rs\.

**Before:**
> No \pyproject.toml\ found in current directory or any parent directory

**After:**
> No \pyproject.toml\ found in current directory or any parent directory. To create one, run \uv init\ or see https://docs.astral.sh/uv/guides/projects/

Closes #12988