### PR TITLE
fix(uvx): show correct flag name in error when --from path is invalid

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -304,8 +304,12 @@ pub(crate) async fn run(
         }
 
         Err(ProjectError::Requirements(err)) => {
+            // Determine which flag the error is associated with. If `--from` was provided, the
+            // error likely refers to the package specified via `--from`; otherwise, refer to
+            // `--with`.
+            let flag = if from.is_some() { "--from" } else { "--with" };
             let err = miette::Report::msg(format!("{err}"))
-                .context("Failed to resolve `--with` requirement");
+                .context(format!("Failed to resolve `{flag}` requirement"));
             eprint!("{err:?}");
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -1928,6 +1928,24 @@ fn tool_run_with_editable() -> anyhow::Result<()> {
       ╰─▶ Distribution not found at: file://[TEMP_DIR]/foo
     ");
 
+    // If invalid, we should reference `--from`.
+    uv_snapshot!(context.filters(), context
+        .tool_run()
+        .arg("--from")
+        .arg("./foo")
+        .arg("flask")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir
+        .as_os_str()).env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × Failed to resolve `--from` requirement
+      ╰─▶ Distribution not found at: file://[TEMP_DIR]/foo
+    ");
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

When a user passes an invalid local path to \uvx --from\ (e.g., \uvx --from ./nonexistent-path some-command\), the error message incorrectly showed \--with\ instead of \--from\:

**Before:**
\\\
× Failed to resolve \--with\ requirement
╰─▶ Distribution not found at: file:///.../nonexistent-path
\\\

**After:**
\\\
× Failed to resolve \--from\ requirement
╰─▶ Distribution not found at: file:///.../nonexistent-path
\\\

## Changes

- \crates/uv/src/commands/tool/run.rs\: Check if \--from\ was provided and use the correct flag name in the error context message
- \crates/uv/tests/tool/tool_run.rs\: Added test \	ool_run_with_invalid_from\ to verify the fix

Closes #8757