### PR TITLE
fix: detect when \pyproject.toml\ is a directory and show a clear error

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -186,6 +186,8 @@ pub enum WorkspaceErrorKind {
     // Workspace structure errors.
     #[error("No `pyproject.toml` found in current directory or any parent directory")]
     MissingPyprojectToml,
+    #[error("`pyproject.toml` at `{}` is a directory, expected a file", _0.simplified_display())]
+    PyprojectTomlIsDirectory(PathBuf),
     #[error("Workspace member `{}` is missing a `pyproject.toml` (matches: `{}`)", _0.simplified_display(), _1)]
     MissingPyprojectTomlMember(PathBuf, String),
     #[error("No `project` table found in: {}", _0.simplified_display())]
@@ -316,11 +318,25 @@ impl Workspace {
             .clone();
         let path = normalize_path(&path);
 
-        let project_path = path
+        let (pyproject_path, project_path) = path
             .ancestors()
-            .find(|path| path.join("pyproject.toml").is_file())
-            .ok_or(WorkspaceErrorKind::MissingPyprojectToml)?
-            .to_path_buf();
+            .find_map(|path| {
+                let candidate = path.join("pyproject.toml");
+                if candidate.is_file() {
+                    Some((candidate, path.to_path_buf()))
+                } else if candidate.is_dir() {
+                    // Return the dir path so we can give a specific error below
+                    Some((candidate, path.to_path_buf()))
+                } else {
+                    None
+                }
+            })
+            .ok_or(WorkspaceErrorKind::MissingPyprojectToml)?;
+
+        // Check for the case where `pyproject.toml` exists as a directory.
+        if pyproject_path.is_dir() {
+            return Err(WorkspaceErrorKind::PyprojectTomlIsDirectory(pyproject_path).into());
+        }
 
         // Fast path: The workspace was already fully discovered.
         // It's possible that there are two separate discoveries for the same workspace going on
@@ -333,7 +349,6 @@ impl Workspace {
             return workspace;
         }
 
-        let pyproject_path = project_path.join("pyproject.toml");
         let contents = fs_err::tokio::read_to_string(&pyproject_path).await?;
         let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
             .map_err(|err| WorkspaceErrorKind::Toml(pyproject_path.clone(), Box::new(err)))?;
@@ -1523,8 +1538,16 @@ impl ProjectWorkspace {
                     .and_then(Path::parent)
                     .is_none_or(|stop_discovery_at| stop_discovery_at != *path)
             })
-            .find(|path| path.join("pyproject.toml").is_file())
+            .find(|path| {
+                let candidate = path.join("pyproject.toml");
+                candidate.is_file() || candidate.is_dir()
+            })
             .ok_or_else(|| WorkspaceErrorKind::MissingPyprojectToml)?;
+
+        let pyproject_path = project_root.join("pyproject.toml");
+        if pyproject_path.is_dir() {
+            return Err(WorkspaceErrorKind::PyprojectTomlIsDirectory(pyproject_path).into());
+        }
 
         debug!(
             "Found project root: `{}`",
@@ -1547,6 +1570,10 @@ impl ProjectWorkspace {
 
         // Read the current `pyproject.toml`.
         let pyproject_path = project_root.join("pyproject.toml");
+
+        if pyproject_path.is_dir() {
+            return Err(WorkspaceErrorKind::PyprojectTomlIsDirectory(pyproject_path).into());
+        }
 
         let contents = fs_err::tokio::read_to_string(&pyproject_path).await?;
         let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
@@ -2016,8 +2043,16 @@ impl VirtualProject {
                     .and_then(Path::parent)
                     .is_none_or(|stop_discovery_at| stop_discovery_at != *path)
             })
-            .find(|path| path.join("pyproject.toml").is_file())
+            .find(|path| {
+                let candidate = path.join("pyproject.toml");
+                candidate.is_file() || candidate.is_dir()
+            })
             .ok_or(WorkspaceErrorKind::MissingPyprojectToml)?;
+
+        let pyproject_path = project_root.join("pyproject.toml");
+        if pyproject_path.is_dir() {
+            return Err(WorkspaceErrorKind::PyprojectTomlIsDirectory(pyproject_path).into());
+        }
 
         debug!(
             "Found project root: `{}`",
@@ -2047,6 +2082,11 @@ impl VirtualProject {
 
         // Read the current `pyproject.toml`.
         let pyproject_path = project_root.join("pyproject.toml");
+
+        if pyproject_path.is_dir() {
+            return Err(WorkspaceErrorKind::PyprojectTomlIsDirectory(pyproject_path).into());
+        }
+
         let contents = fs_err::tokio::read_to_string(&pyproject_path).await?;
         let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
             .map_err(|err| WorkspaceErrorKind::Toml(pyproject_path.clone(), Box::new(err)))?;

--- a/crates/uv/tests/workspace/workspace.rs
+++ b/crates/uv/tests/workspace/workspace.rs
@@ -2518,3 +2518,28 @@ fn workspace_unmanaged_member_no_project() -> Result<()> {
 
     Ok(())
 }
+
+/// Ensure a clear error when `pyproject.toml` exists as a directory rather than a file.
+#[test]
+fn pyproject_toml_is_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    // Create a directory named `pyproject.toml` in the temp directory root.
+    let pyproject_dir = context.temp_dir.child("pyproject.toml");
+    fs_err::create_dir(&pyproject_dir)?;
+
+    // Create a subdirectory with no real pyproject.toml.
+    let subdir = context.temp_dir.child("subdir");
+    fs_err::create_dir(&subdir)?;
+
+    uv_snapshot!(context.filters(), context.lock().current_dir(&subdir), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: `pyproject.toml` at `[TEMP_DIR]/pyproject.toml` is a directory, expected a file
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

When \pyproject.toml\ exists as a directory rather than a regular file, \uv\ would previously attempt to read it and fail with a confusing OS-level error like \Is a directory (os error 21)\.

Now \uv\ detects this case during workspace discovery and shows a clear error message.

### Before

\\\
error: failed to read from file \/pyproject.toml\: Is a directory (os error 21)
\\\

### After

\\\
error: \pyproject.toml\ at \/pyproject.toml\ is a directory, expected a file
\\\

## Changes

- Added \WorkspaceErrorKind::PyprojectTomlIsDirectory\ variant to \uv-workspace\
- Added \pyproject_path.is_dir()\ checks in both \Workspace\ and \VirtualProject\ discovery paths
- Updated ancestor searches to detect directories named \pyproject.toml\ in addition to regular files

## Test Plan

Added integration test \pyproject_toml_is_directory\ in \crates/uv/tests/workspace/workspace.rs\.

Closes #14584