### PR TITLE
fix: show lock mismatch error even with --quiet

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -270,7 +270,7 @@ pub(crate) async fn lock(
         // Lock mismatches from `--check`/`--locked` are expected validation failures.
         // Handle them here so we return exit code 1 instead of bubbling up as an error (exit code 2).
         Err(err @ ProjectError::LockMismatch(..)) => {
-            writeln!(printer.stderr(), "{}", err.to_string().bold())?;
+            writeln!(printer.stderr_important(), "{}", err.to_string().bold())?;
             Ok(ExitStatus::Failure)
         }
         Err(ProjectError::Operation(err)) => {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -380,7 +380,7 @@ pub(crate) async fn sync(
                 Outcome::LockMismatch(prev, cur, lock_source)
             } else {
                 writeln!(
-                    printer.stderr(),
+                    printer.stderr_important(),
                     "{}",
                     ProjectError::LockMismatch(prev, cur, lock_source)
                         .to_string()

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -52,8 +52,7 @@ impl Printer {
         }
     }
 
-    /// Return the [`Stderr`] for this printer.
-    #[allow(dead_code)] // Only used with the optional self-update feature.
+    /// Return the [`Stderr`] for this printer, preserving stderr in quiet mode.
     pub(crate) fn stderr_important(self) -> Stderr {
         match self {
             Self::Silent => Stderr::Disabled,


### PR DESCRIPTION
## Summary

When running `uv sync --dev --locked --quiet` or `uv lock --locked --quiet`, the critical error message about the lockfile needing an update was silently suppressed because `printer.stderr()` is disabled in `--quiet` mode.

## Changes

Changed `printer.stderr()` to `printer.stderr_important()` for lock mismatch error messages in `sync.rs` and `lock.rs`. The `stderr_important()` variant preserves stderr output even in quiet mode, which is the correct behavior for error messages that terminate execution with a failure exit code.

Also removed the now-unnecessary `#[allow(dead_code)]` from `stderr_important()`.

Closes #19326
