### PR TITLE
fix: allow uv tool uninstall to remove tools with corrupt receipts

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,24 +133,29 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
-                // If the tool is not installed properly, attempt to remove the environment anyway.
-                match installed_tools.remove_environment(&name) {
-                    Ok(()) => {
-                        dangling = true;
-                        writeln!(
-                            printer.stderr(),
-                            "Removed dangling environment for `{name}`"
-                        )?;
-                        continue;
-                    }
-                    Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
-                        if err.kind() == std::io::ErrorKind::NotFound =>
-                    {
-                        bail!("`{name}` is not installed");
-                    }
-                    Err(err) => {
-                        return Err(err.into());
+            let receipt = match installed_tools.get_tool_receipt(&name) {
+                Ok(Some(receipt)) => receipt,
+                // If the tool receipt is missing or corrupt, attempt to remove the environment anyway.
+                Ok(None) | Err(_) => {
+                    match installed_tools.remove_environment(&name) {
+                        Ok(()) => {
+                            dangling = true;
+                            writeln!(
+                                printer.stderr(),
+                                "Removed dangling environment for `{name}`"
+                            )?;
+                            continue;
+                        }
+                        Err(err)
+                            if err
+                                .as_io_error()
+                                .is_some_and(|err| err.kind() == std::io::ErrorKind::NotFound) =>
+                        {
+                            bail!("`{name}` is not installed");
+                        }
+                        Err(err) => {
+                            return Err(err.into());
+                        }
                     }
                 }
             };


### PR DESCRIPTION
## Summary

When a tool's `uv-receipt.toml` gets corrupt (e.g. manually edited to invalid TOML), `uv tool list` suggests `uv tool uninstall <name>` to remove it — but `uv tool uninstall` fails because it tries to parse the corrupt receipt first.

Now `uv tool uninstall` handles corrupt receipts the same way as missing receipts: it removes the tool's environment directory with a warning, rather than propagating the TOML parse error.

## Changes

In `crates/uv/src/commands/tool/uninstall.rs`, changed the specific-name uninstall path to match on the full `Result` from `get_tool_receipt`, handling both `Ok(None)` (missing) and `Err(_)` (corrupt) by attempting to remove the environment via `remove_environment`. This is consistent with the existing "uninstall all" path which already handles corrupt receipts this way.

Also unified the `NotFound` check to use `err.as_io_error().is_some_and(...)` consistently (the existing code used two different patterns for the same check).

Closes #19630
