### PR TITLE
Update Rust toolchain to 1.96.1

### DIFF
--- a/crates/uv-build/rust-toolchain.toml
+++ b/crates/uv-build/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.1"


### PR DESCRIPTION
## Summary

Restore the pinned Rust toolchain to 1.96.1 for uv and `uv-build`.

We temporarily downgraded to Rust 1.95 in #19953 because Cargo 1.96.0 treated transient HTTP errors as fatal. [Rust 1.96.1](https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/) fixes the missing retries and timeouts in Cargo's HTTP client, so we can upgrade again. The locked workspace compiles successfully with all targets and features under the new toolchain.