### PR TITLE
Intern `requires-python` specifiers in Simple API parsing

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -1196,7 +1196,9 @@ impl CacheBucket {
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_prune.rs`.
             Self::SourceDistributions => "sdists-v9",
-            Self::FlatIndex => "flat-index-v2",
+            // Note that when bumping this, you'll also need to bump it
+            // in `crates/uv/tests/lock/lock.rs`.
+            Self::FlatIndex => "flat-index-v3",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -1201,7 +1201,7 @@ impl CacheBucket {
             Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_clean.rs`.
-            Self::Simple => "simple-v21",
+            Self::Simple => "simple-v22",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_prune.rs`.
             Self::Wheels => "wheels-v6",

--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -109,13 +109,13 @@ impl SimpleDetailHTML {
         );
 
         // Parse each `<a>` tag, to extract the filename, hash, and URL.
-        let mut requires_python_interner = RequiresPythonInterner::default();
+        let mut interner = RequiresPythonInterner::default();
         let mut files: Vec<PypiFile> = dom
             .nodes()
             .iter()
             .filter_map(|node| node.as_tag())
             .filter(|link| is_tag(link, b"a"))
-            .map(|link| Self::parse_anchor(link, &mut requires_python_interner))
+            .map(|link| Self::parse_anchor(link, &mut interner))
             .filter_map(|result| match result {
                 Ok(None) => None,
                 Ok(Some(file)) => Some(Ok(file)),
@@ -205,7 +205,7 @@ impl SimpleDetailHTML {
     /// Returns `None` if the `<a>` doesn't have an `href` attribute.
     fn parse_anchor(
         link: &HTMLTag,
-        requires_python_interner: &mut RequiresPythonInterner,
+        interner: &mut RequiresPythonInterner,
     ) -> Result<Option<PypiFile>, Error> {
         // Extract the href.
         let Some(href) = attribute(link, "href").filter(|href| !href.is_empty()) else {
@@ -269,7 +269,7 @@ impl SimpleDetailHTML {
         {
             let requires_python = std::str::from_utf8(requires_python.as_bytes())?;
             let requires_python = html_escape::decode_html_entities(requires_python);
-            Some(requires_python_interner.parse(requires_python.as_ref()))
+            Some(interner.parse(requires_python.as_ref()))
         } else {
             None
         };

--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -6,13 +6,13 @@ use tl::{HTMLTag, Node, Parser};
 use tracing::{debug, instrument, warn};
 
 use uv_normalize::PackageName;
-use uv_pep440::VersionSpecifiers;
+use uv_pep440::{VersionSpecifiers, VersionSpecifiersParseError};
 use uv_pypi_types::{BaseUrl, CoreMetadata, Hashes, ProjectStatus, PypiFile, Status, Yanked};
 use uv_pypi_types::{HashError, LenientVersionSpecifiers};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_small_str::SmallString;
 
-type RequiresPythonResult = Result<Arc<VersionSpecifiers>, uv_pep440::VersionSpecifiersParseError>;
+type RequiresPythonResult = Result<Arc<VersionSpecifiers>, VersionSpecifiersParseError>;
 
 #[derive(Default)]
 struct RequiresPythonInterner {

--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, str::FromStr, sync::Arc};
 
 use jiff::Timestamp;
 use tl::{HTMLTag, Node, Parser};
@@ -242,7 +242,11 @@ impl SimpleDetailHTML {
         {
             let requires_python = std::str::from_utf8(requires_python.as_bytes())?;
             let requires_python = html_escape::decode_html_entities(requires_python);
-            Some(LenientVersionSpecifiers::from_str(&requires_python).map(VersionSpecifiers::from))
+            Some(
+                LenientVersionSpecifiers::from_str(&requires_python)
+                    .map(VersionSpecifiers::from)
+                    .map(Arc::new),
+            )
         } else {
             None
         };

--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, str::FromStr, sync::Arc};
 
 use jiff::Timestamp;
+use rustc_hash::FxHashMap;
 use tl::{HTMLTag, Node, Parser};
 use tracing::{debug, instrument, warn};
 
@@ -10,6 +11,28 @@ use uv_pypi_types::{BaseUrl, CoreMetadata, Hashes, ProjectStatus, PypiFile, Stat
 use uv_pypi_types::{HashError, LenientVersionSpecifiers};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_small_str::SmallString;
+
+type RequiresPythonResult = Result<Arc<VersionSpecifiers>, uv_pep440::VersionSpecifiersParseError>;
+
+#[derive(Default)]
+struct RequiresPythonInterner {
+    values: FxHashMap<SmallString, RequiresPythonResult>,
+}
+
+impl RequiresPythonInterner {
+    fn parse(&mut self, value: &str) -> RequiresPythonResult {
+        if let Some(requires_python) = self.values.get(value) {
+            return requires_python.clone();
+        }
+
+        let requires_python = LenientVersionSpecifiers::from_str(value)
+            .map(VersionSpecifiers::from)
+            .map(Arc::new);
+        self.values
+            .insert(SmallString::from(value), requires_python.clone());
+        requires_python
+    }
+}
 
 /// Return `true` if this tag has the given HTML element name.
 fn is_tag(tag: &HTMLTag<'_>, name: &[u8]) -> bool {
@@ -86,12 +109,13 @@ impl SimpleDetailHTML {
         );
 
         // Parse each `<a>` tag, to extract the filename, hash, and URL.
+        let mut requires_python_interner = RequiresPythonInterner::default();
         let mut files: Vec<PypiFile> = dom
             .nodes()
             .iter()
             .filter_map(|node| node.as_tag())
             .filter(|link| is_tag(link, b"a"))
-            .map(|link| Self::parse_anchor(link))
+            .map(|link| Self::parse_anchor(link, &mut requires_python_interner))
             .filter_map(|result| match result {
                 Ok(None) => None,
                 Ok(Some(file)) => Some(Ok(file)),
@@ -179,7 +203,10 @@ impl SimpleDetailHTML {
     /// Parse a [`PypiFile`] from an `<a>` tag.
     ///
     /// Returns `None` if the `<a>` doesn't have an `href` attribute.
-    fn parse_anchor(link: &HTMLTag) -> Result<Option<PypiFile>, Error> {
+    fn parse_anchor(
+        link: &HTMLTag,
+        requires_python_interner: &mut RequiresPythonInterner,
+    ) -> Result<Option<PypiFile>, Error> {
         // Extract the href.
         let Some(href) = attribute(link, "href").filter(|href| !href.is_empty()) else {
             return Ok(None);
@@ -242,11 +269,7 @@ impl SimpleDetailHTML {
         {
             let requires_python = std::str::from_utf8(requires_python.as_bytes())?;
             let requires_python = html_escape::decode_html_entities(requires_python);
-            Some(
-                LenientVersionSpecifiers::from_str(&requires_python)
-                    .map(VersionSpecifiers::from)
-                    .map(Arc::new),
-            )
+            Some(requires_python_interner.parse(requires_python.as_ref()))
         } else {
             None
         };

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -10,7 +10,7 @@ use futures::{FutureExt, StreamExt, TryStreamExt};
 use http::{HeaderMap, StatusCode};
 use itertools::Either;
 use reqwest::{Proxy, Response};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::{Mutex, Semaphore};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 use url::Url;
@@ -27,7 +27,7 @@ use uv_distribution_types::{
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
 use uv_normalize::PackageName;
-use uv_pep440::Version;
+use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::MarkerEnvironment;
 use uv_platform_tags::Platform;
 use uv_pypi_types::ProjectStatus;
@@ -1468,6 +1468,7 @@ impl SimpleDetailMetadata {
         base: &Url,
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
+        let mut requires_python_cache: FxHashSet<Arc<VersionSpecifiers>> = FxHashSet::default();
 
         // Convert to a reference-counted string.
         let base = SmallString::from(base.as_str());
@@ -1485,7 +1486,9 @@ impl SimpleDetailMetadata {
                         continue;
                     }
                 };
-            let file = match File::try_from_pypi(file, &base) {
+            let file = match File::try_from_pypi_with(file, &base, |requires_python| {
+                intern_requires_python(&mut requires_python_cache, requires_python)
+            }) {
                 Ok(file) => file,
                 Err(err) => {
                     // Ignore files with unparsable version specifiers.
@@ -1536,13 +1539,16 @@ impl SimpleDetailMetadata {
         base: &Url,
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
+        let mut requires_python_cache: FxHashSet<Arc<VersionSpecifiers>> = FxHashSet::default();
 
         // Convert to a reference-counted string.
         let base = SmallString::from(base.as_str());
 
         // Group the distributions by version and kind
         for file in files {
-            let file = match File::try_from_pyx(file, &base) {
+            let file = match File::try_from_pyx_with(file, &base, |requires_python| {
+                intern_requires_python(&mut requires_python_cache, requires_python)
+            }) {
                 Ok(file) => file,
                 Err(err) => {
                     // Ignore files with unparsable version specifiers.
@@ -1618,6 +1624,19 @@ impl SimpleDetailMetadata {
             project_status,
             base.as_url(),
         ))
+    }
+}
+
+fn intern_requires_python(
+    cache: &mut FxHashSet<Arc<VersionSpecifiers>>,
+    requires_python: VersionSpecifiers,
+) -> Arc<VersionSpecifiers> {
+    if let Some(requires_python) = cache.get(&requires_python) {
+        Arc::clone(requires_python)
+    } else {
+        let requires_python = Arc::new(requires_python);
+        cache.insert(Arc::clone(&requires_python));
+        requires_python
     }
 }
 
@@ -1719,16 +1738,17 @@ impl Connectivity {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use tokio::sync::Semaphore;
     use url::Url;
     use uv_normalize::PackageName;
-    use uv_pypi_types::PypiSimpleDetail;
+    use uv_pypi_types::{PypiSimpleDetail, PyxSimpleDetail};
     use uv_redacted::DisplaySafeUrl;
     use uv_torch::{TorchBackend, TorchSource, TorchStrategy};
 
     use crate::{
-        BaseClientBuilder, Connectivity, RegistryClient, RegistryClientBuilder,
+        BaseClientBuilder, Connectivity, OwnedArchive, RegistryClient, RegistryClientBuilder,
         SimpleDetailMetadata, SimpleDetailMetadatum, html::SimpleDetailHTML,
     };
     use uv_cache::Cache;
@@ -1741,6 +1761,163 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     type Error = Box<dyn std::error::Error>;
+
+    fn assert_shared_requires_python(metadata: &SimpleDetailMetadata) {
+        let requires_python: Vec<_> = metadata
+            .iter()
+            .flat_map(|datum| {
+                datum.files.wheels.iter().map(|wheel| &wheel.file).chain(
+                    datum
+                        .files
+                        .source_dists
+                        .iter()
+                        .map(|source_dist| &source_dist.file),
+                )
+            })
+            .filter_map(|file| file.requires_python.as_ref())
+            .collect();
+        let first = requires_python
+            .first()
+            .expect("test metadata should contain requires-python specifiers");
+        assert!(
+            requires_python
+                .iter()
+                .all(|requires_python| Arc::ptr_eq(first, requires_python))
+        );
+    }
+
+    #[test]
+    fn pypi_file_order_and_requires_python_sharing() {
+        let response = r#"
+        {
+          "files": [
+            {"filename": "benchmark-2.0.0.tar.gz", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-2.0.0.tar.gz"},
+            {"filename": "benchmark-1.0.0-2-py3-none-any.whl", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-1.0.0-2-py3-none-any.whl"},
+            {"filename": "benchmark-2.0.0-2-py3-none-any.whl", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-2.0.0-2-py3-none-any.whl"},
+            {"filename": "benchmark-1.0.0.tar.gz", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-1.0.0.tar.gz"},
+            {"filename": "benchmark-2.0.0-1-py3-none-any.whl", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-2.0.0-1-py3-none-any.whl"},
+            {"filename": "benchmark-1.0.0-1-py3-none-any.whl", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-1.0.0-1-py3-none-any.whl"}
+          ]
+        }
+        "#;
+        let data: PypiSimpleDetail =
+            serde_json::from_str(response).expect("test response should be valid");
+        let base = DisplaySafeUrl::parse("https://pypi.org/simple/benchmark/")
+            .expect("test URL should be valid");
+        let simple_metadata = SimpleDetailMetadata::from_pypi_files(
+            data.files,
+            &PackageName::from_str("benchmark").expect("test package name should be valid"),
+            data.project_status,
+            &base,
+        );
+
+        let filenames: Vec<_> = simple_metadata
+            .iter()
+            .flat_map(|datum| {
+                let version = datum.version.to_string();
+                datum
+                    .files
+                    .wheels
+                    .iter()
+                    .map(|wheel| wheel.file.filename.as_ref())
+                    .chain(
+                        datum
+                            .files
+                            .source_dists
+                            .iter()
+                            .map(|source_dist| source_dist.file.filename.as_ref()),
+                    )
+                    .map(move |filename| format!("{version}: {filename}"))
+            })
+            .collect();
+        insta::assert_debug_snapshot!(filenames, @r#"
+        [
+            "1.0.0: benchmark-1.0.0-1-py3-none-any.whl",
+            "1.0.0: benchmark-1.0.0-2-py3-none-any.whl",
+            "1.0.0: benchmark-1.0.0.tar.gz",
+            "2.0.0: benchmark-2.0.0-1-py3-none-any.whl",
+            "2.0.0: benchmark-2.0.0-2-py3-none-any.whl",
+            "2.0.0: benchmark-2.0.0.tar.gz",
+        ]
+        "#);
+
+        assert_shared_requires_python(&simple_metadata);
+        let archived =
+            OwnedArchive::from_unarchived(&simple_metadata).expect("test metadata should archive");
+        assert_shared_requires_python(&OwnedArchive::deserialize(&archived));
+    }
+
+    #[test]
+    fn pyx_file_msgpack_deserialization() {
+        let response = serde_json::json!({
+            "files": [
+                {
+                    "data-dist-info-metadata": true,
+                    "filename": "benchmark-1.0.0-py3-none-any.whl",
+                    "hashes": {},
+                    "requires-python": ">=3.8",
+                    "size": 42,
+                    "url": "benchmark-1.0.0-py3-none-any.whl",
+                    "yanked": false,
+                },
+                {
+                    "filename": "benchmark-1.0.0.tar.gz",
+                    "hashes": {},
+                    "requires-python": ">=3.8",
+                    "url": "benchmark-1.0.0.tar.gz",
+                }
+            ]
+        });
+        let encoded = rmp_serde::to_vec_named(&response)
+            .expect("test response should serialize to MessagePack");
+        let detail: PyxSimpleDetail =
+            rmp_serde::from_slice(&encoded).expect("test MessagePack response should be valid");
+        let file = detail
+            .files
+            .first()
+            .expect("test response should have a file");
+        let requires_python = file
+            .requires_python
+            .as_ref()
+            .and_then(|requires_python| requires_python.as_ref().ok())
+            .expect("test file should have a valid requires-python specifier");
+
+        insta::assert_debug_snapshot!(
+            (
+                file.filename.as_deref(),
+                requires_python.to_string(),
+                file.size,
+                file.core_metadata.as_ref(),
+            ),
+            @r#"
+        (
+            Some(
+                "benchmark-1.0.0-py3-none-any.whl",
+            ),
+            ">=3.8",
+            Some(
+                42,
+            ),
+            Some(
+                Bool(
+                    true,
+                ),
+            ),
+        )
+        "#
+        );
+
+        let base = DisplaySafeUrl::parse("https://pypi.org/simple/benchmark/")
+            .expect("test URL should be valid");
+        let simple_metadata = SimpleDetailMetadata::from_pyx_files(
+            detail.files,
+            detail.core_metadata,
+            &PackageName::from_str("benchmark").expect("test package name should be valid"),
+            detail.project_status,
+            &base,
+        );
+        assert_shared_requires_python(&simple_metadata);
+    }
 
     async fn start_test_server(username: &'static str, password: &'static str) -> MockServer {
         let server = MockServer::start().await;

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::hash_map::Entry;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -10,7 +11,7 @@ use futures::{FutureExt, StreamExt, TryStreamExt};
 use http::{HeaderMap, StatusCode};
 use itertools::Either;
 use reqwest::{Proxy, Response};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use tokio::sync::{Mutex, Semaphore};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 use url::Url;
@@ -1468,7 +1469,7 @@ impl SimpleDetailMetadata {
         base: &Url,
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
-        let mut requires_python_cache: FxHashSet<Arc<VersionSpecifiers>> = FxHashSet::default();
+        let mut requires_python_cache: FxHashMap<Arc<VersionSpecifiers>, ()> = FxHashMap::default();
 
         // Convert to a reference-counted string.
         let base = SmallString::from(base.as_str());
@@ -1539,7 +1540,7 @@ impl SimpleDetailMetadata {
         base: &Url,
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
-        let mut requires_python_cache: FxHashSet<Arc<VersionSpecifiers>> = FxHashSet::default();
+        let mut requires_python_cache: FxHashMap<Arc<VersionSpecifiers>, ()> = FxHashMap::default();
 
         // Convert to a reference-counted string.
         let base = SmallString::from(base.as_str());
@@ -1628,15 +1629,16 @@ impl SimpleDetailMetadata {
 }
 
 fn intern_requires_python(
-    cache: &mut FxHashSet<Arc<VersionSpecifiers>>,
+    cache: &mut FxHashMap<Arc<VersionSpecifiers>, ()>,
     requires_python: VersionSpecifiers,
 ) -> Arc<VersionSpecifiers> {
-    if let Some(requires_python) = cache.get(&requires_python) {
-        Arc::clone(requires_python)
-    } else {
-        let requires_python = Arc::new(requires_python);
-        cache.insert(Arc::clone(&requires_python));
-        requires_python
+    match cache.entry(Arc::new(requires_python)) {
+        Entry::Occupied(entry) => Arc::clone(entry.key()),
+        Entry::Vacant(entry) => {
+            let requires_python = Arc::clone(entry.key());
+            entry.insert(());
+            requires_python
+        }
     }
 }
 
@@ -1738,17 +1740,16 @@ impl Connectivity {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
-    use std::sync::Arc;
 
     use tokio::sync::Semaphore;
     use url::Url;
     use uv_normalize::PackageName;
-    use uv_pypi_types::{PypiSimpleDetail, PyxSimpleDetail};
+    use uv_pypi_types::PypiSimpleDetail;
     use uv_redacted::DisplaySafeUrl;
     use uv_torch::{TorchBackend, TorchSource, TorchStrategy};
 
     use crate::{
-        BaseClientBuilder, Connectivity, OwnedArchive, RegistryClient, RegistryClientBuilder,
+        BaseClientBuilder, Connectivity, RegistryClient, RegistryClientBuilder,
         SimpleDetailMetadata, SimpleDetailMetadatum, html::SimpleDetailHTML,
     };
     use uv_cache::Cache;
@@ -1761,163 +1762,6 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     type Error = Box<dyn std::error::Error>;
-
-    fn assert_shared_requires_python(metadata: &SimpleDetailMetadata) {
-        let requires_python: Vec<_> = metadata
-            .iter()
-            .flat_map(|datum| {
-                datum.files.wheels.iter().map(|wheel| &wheel.file).chain(
-                    datum
-                        .files
-                        .source_dists
-                        .iter()
-                        .map(|source_dist| &source_dist.file),
-                )
-            })
-            .filter_map(|file| file.requires_python.as_ref())
-            .collect();
-        let first = requires_python
-            .first()
-            .expect("test metadata should contain requires-python specifiers");
-        assert!(
-            requires_python
-                .iter()
-                .all(|requires_python| Arc::ptr_eq(first, requires_python))
-        );
-    }
-
-    #[test]
-    fn pypi_file_order_and_requires_python_sharing() {
-        let response = r#"
-        {
-          "files": [
-            {"filename": "benchmark-2.0.0.tar.gz", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-2.0.0.tar.gz"},
-            {"filename": "benchmark-1.0.0-2-py3-none-any.whl", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-1.0.0-2-py3-none-any.whl"},
-            {"filename": "benchmark-2.0.0-2-py3-none-any.whl", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-2.0.0-2-py3-none-any.whl"},
-            {"filename": "benchmark-1.0.0.tar.gz", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-1.0.0.tar.gz"},
-            {"filename": "benchmark-2.0.0-1-py3-none-any.whl", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-2.0.0-1-py3-none-any.whl"},
-            {"filename": "benchmark-1.0.0-1-py3-none-any.whl", "hashes": {}, "requires-python": ">=3.8", "url": "benchmark-1.0.0-1-py3-none-any.whl"}
-          ]
-        }
-        "#;
-        let data: PypiSimpleDetail =
-            serde_json::from_str(response).expect("test response should be valid");
-        let base = DisplaySafeUrl::parse("https://pypi.org/simple/benchmark/")
-            .expect("test URL should be valid");
-        let simple_metadata = SimpleDetailMetadata::from_pypi_files(
-            data.files,
-            &PackageName::from_str("benchmark").expect("test package name should be valid"),
-            data.project_status,
-            &base,
-        );
-
-        let filenames: Vec<_> = simple_metadata
-            .iter()
-            .flat_map(|datum| {
-                let version = datum.version.to_string();
-                datum
-                    .files
-                    .wheels
-                    .iter()
-                    .map(|wheel| wheel.file.filename.as_ref())
-                    .chain(
-                        datum
-                            .files
-                            .source_dists
-                            .iter()
-                            .map(|source_dist| source_dist.file.filename.as_ref()),
-                    )
-                    .map(move |filename| format!("{version}: {filename}"))
-            })
-            .collect();
-        insta::assert_debug_snapshot!(filenames, @r#"
-        [
-            "1.0.0: benchmark-1.0.0-1-py3-none-any.whl",
-            "1.0.0: benchmark-1.0.0-2-py3-none-any.whl",
-            "1.0.0: benchmark-1.0.0.tar.gz",
-            "2.0.0: benchmark-2.0.0-1-py3-none-any.whl",
-            "2.0.0: benchmark-2.0.0-2-py3-none-any.whl",
-            "2.0.0: benchmark-2.0.0.tar.gz",
-        ]
-        "#);
-
-        assert_shared_requires_python(&simple_metadata);
-        let archived =
-            OwnedArchive::from_unarchived(&simple_metadata).expect("test metadata should archive");
-        assert_shared_requires_python(&OwnedArchive::deserialize(&archived));
-    }
-
-    #[test]
-    fn pyx_file_msgpack_deserialization() {
-        let response = serde_json::json!({
-            "files": [
-                {
-                    "data-dist-info-metadata": true,
-                    "filename": "benchmark-1.0.0-py3-none-any.whl",
-                    "hashes": {},
-                    "requires-python": ">=3.8",
-                    "size": 42,
-                    "url": "benchmark-1.0.0-py3-none-any.whl",
-                    "yanked": false,
-                },
-                {
-                    "filename": "benchmark-1.0.0.tar.gz",
-                    "hashes": {},
-                    "requires-python": ">=3.8",
-                    "url": "benchmark-1.0.0.tar.gz",
-                }
-            ]
-        });
-        let encoded = rmp_serde::to_vec_named(&response)
-            .expect("test response should serialize to MessagePack");
-        let detail: PyxSimpleDetail =
-            rmp_serde::from_slice(&encoded).expect("test MessagePack response should be valid");
-        let file = detail
-            .files
-            .first()
-            .expect("test response should have a file");
-        let requires_python = file
-            .requires_python
-            .as_ref()
-            .and_then(|requires_python| requires_python.as_ref().ok())
-            .expect("test file should have a valid requires-python specifier");
-
-        insta::assert_debug_snapshot!(
-            (
-                file.filename.as_deref(),
-                requires_python.to_string(),
-                file.size,
-                file.core_metadata.as_ref(),
-            ),
-            @r#"
-        (
-            Some(
-                "benchmark-1.0.0-py3-none-any.whl",
-            ),
-            ">=3.8",
-            Some(
-                42,
-            ),
-            Some(
-                Bool(
-                    true,
-                ),
-            ),
-        )
-        "#
-        );
-
-        let base = DisplaySafeUrl::parse("https://pypi.org/simple/benchmark/")
-            .expect("test URL should be valid");
-        let simple_metadata = SimpleDetailMetadata::from_pyx_files(
-            detail.files,
-            detail.core_metadata,
-            &PackageName::from_str("benchmark").expect("test package name should be valid"),
-            detail.project_status,
-            &base,
-        );
-        assert_shared_requires_python(&simple_metadata);
-    }
 
     async fn start_test_server(username: &'static str, password: &'static str) -> MockServer {
         let server = MockServer::start().await;

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1468,6 +1468,7 @@ impl SimpleDetailMetadata {
         base: &Url,
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
+
         // Convert to a reference-counted string.
         let base = SmallString::from(base.as_str());
 
@@ -1535,6 +1536,7 @@ impl SimpleDetailMetadata {
         base: &Url,
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
+
         // Convert to a reference-counted string.
         let base = SmallString::from(base.as_str());
 

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::collections::hash_map::Entry;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -28,7 +27,7 @@ use uv_distribution_types::{
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
 use uv_normalize::PackageName;
-use uv_pep440::{Version, VersionSpecifiers};
+use uv_pep440::Version;
 use uv_pep508::MarkerEnvironment;
 use uv_platform_tags::Platform;
 use uv_pypi_types::ProjectStatus;
@@ -1469,8 +1468,6 @@ impl SimpleDetailMetadata {
         base: &Url,
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
-        let mut requires_python_cache: FxHashMap<Arc<VersionSpecifiers>, ()> = FxHashMap::default();
-
         // Convert to a reference-counted string.
         let base = SmallString::from(base.as_str());
 
@@ -1487,9 +1484,7 @@ impl SimpleDetailMetadata {
                         continue;
                     }
                 };
-            let file = match File::try_from_pypi_with(file, &base, |requires_python| {
-                intern_requires_python(&mut requires_python_cache, requires_python)
-            }) {
+            let file = match File::try_from_pypi(file, &base) {
                 Ok(file) => file,
                 Err(err) => {
                     // Ignore files with unparsable version specifiers.
@@ -1540,16 +1535,12 @@ impl SimpleDetailMetadata {
         base: &Url,
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
-        let mut requires_python_cache: FxHashMap<Arc<VersionSpecifiers>, ()> = FxHashMap::default();
-
         // Convert to a reference-counted string.
         let base = SmallString::from(base.as_str());
 
         // Group the distributions by version and kind
         for file in files {
-            let file = match File::try_from_pyx_with(file, &base, |requires_python| {
-                intern_requires_python(&mut requires_python_cache, requires_python)
-            }) {
+            let file = match File::try_from_pyx(file, &base) {
                 Ok(file) => file,
                 Err(err) => {
                     // Ignore files with unparsable version specifiers.
@@ -1625,20 +1616,6 @@ impl SimpleDetailMetadata {
             project_status,
             base.as_url(),
         ))
-    }
-}
-
-fn intern_requires_python(
-    cache: &mut FxHashMap<Arc<VersionSpecifiers>, ()>,
-    requires_python: VersionSpecifiers,
-) -> Arc<VersionSpecifiers> {
-    match cache.entry(Arc::new(requires_python)) {
-        Entry::Occupied(entry) => Arc::clone(entry.key()),
-        Entry::Vacant(entry) => {
-            let requires_python = Arc::clone(entry.key());
-            entry.insert(());
-            requires_python
-        }
     }
 }
 

--- a/crates/uv-distribution-types/src/buildable.rs
+++ b/crates/uv-distribution-types/src/buildable.rs
@@ -82,7 +82,7 @@ impl BuildableSource<'_> {
         let Self::Dist(SourceDist::Registry(dist)) = self else {
             return None;
         };
-        dist.file.requires_python.as_ref()
+        dist.file.requires_python.as_deref()
     }
 }
 

--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -50,15 +50,6 @@ impl File {
         file: uv_pypi_types::PypiFile,
         base: &SmallString,
     ) -> Result<Self, FileConversionError> {
-        Self::try_from_pypi_with(file, base, Arc::new)
-    }
-
-    /// Like [`File::try_from_pypi`], with a caller-provided `requires-python` interner.
-    pub fn try_from_pypi_with(
-        file: uv_pypi_types::PypiFile,
-        base: &SmallString,
-        intern_requires_python: impl FnOnce(VersionSpecifiers) -> Arc<VersionSpecifiers>,
-    ) -> Result<Self, FileConversionError> {
         Ok(Self {
             dist_info_metadata: file
                 .core_metadata
@@ -69,8 +60,7 @@ impl File {
             requires_python: file
                 .requires_python
                 .transpose()
-                .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?
-                .map(intern_requires_python),
+                .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?,
             size: file.size,
             upload_time_utc_ms: file.upload_time.map(Timestamp::as_millisecond),
             url: FileLocation::new(file.url, base),
@@ -82,15 +72,6 @@ impl File {
     pub fn try_from_pyx(
         file: uv_pypi_types::PyxFile,
         base: &SmallString,
-    ) -> Result<Self, FileConversionError> {
-        Self::try_from_pyx_with(file, base, Arc::new)
-    }
-
-    /// Like [`File::try_from_pyx`], with a caller-provided `requires-python` interner.
-    pub fn try_from_pyx_with(
-        file: uv_pypi_types::PyxFile,
-        base: &SmallString,
-        intern_requires_python: impl FnOnce(VersionSpecifiers) -> Arc<VersionSpecifiers>,
     ) -> Result<Self, FileConversionError> {
         let filename = if let Some(filename) = file.filename {
             filename
@@ -125,8 +106,7 @@ impl File {
             requires_python: file
                 .requires_python
                 .transpose()
-                .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?
-                .map(intern_requires_python),
+                .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?,
             size: file.size,
             upload_time_utc_ms: file.upload_time.map(Timestamp::as_millisecond),
             url: FileLocation::new(file.url, base),

--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
+use std::sync::Arc;
 
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -31,7 +32,7 @@ pub struct File {
     pub dist_info_metadata: bool,
     pub filename: SmallString,
     pub hashes: HashDigests,
-    pub requires_python: Option<VersionSpecifiers>,
+    pub requires_python: Option<Arc<VersionSpecifiers>>,
     pub size: Option<u64>,
     // N.B. We don't use a Jiff timestamp here because it's a little
     // annoying to do so with rkyv. Since we only use this field for doing
@@ -49,6 +50,15 @@ impl File {
         file: uv_pypi_types::PypiFile,
         base: &SmallString,
     ) -> Result<Self, FileConversionError> {
+        Self::try_from_pypi_with(file, base, Arc::new)
+    }
+
+    /// Like [`File::try_from_pypi`], with a caller-provided `requires-python` interner.
+    pub fn try_from_pypi_with(
+        file: uv_pypi_types::PypiFile,
+        base: &SmallString,
+        intern_requires_python: impl FnOnce(VersionSpecifiers) -> Arc<VersionSpecifiers>,
+    ) -> Result<Self, FileConversionError> {
         Ok(Self {
             dist_info_metadata: file
                 .core_metadata
@@ -59,7 +69,8 @@ impl File {
             requires_python: file
                 .requires_python
                 .transpose()
-                .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?,
+                .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?
+                .map(intern_requires_python),
             size: file.size,
             upload_time_utc_ms: file.upload_time.map(Timestamp::as_millisecond),
             url: FileLocation::new(file.url, base),
@@ -71,6 +82,15 @@ impl File {
     pub fn try_from_pyx(
         file: uv_pypi_types::PyxFile,
         base: &SmallString,
+    ) -> Result<Self, FileConversionError> {
+        Self::try_from_pyx_with(file, base, Arc::new)
+    }
+
+    /// Like [`File::try_from_pyx`], with a caller-provided `requires-python` interner.
+    pub fn try_from_pyx_with(
+        file: uv_pypi_types::PyxFile,
+        base: &SmallString,
+        intern_requires_python: impl FnOnce(VersionSpecifiers) -> Arc<VersionSpecifiers>,
     ) -> Result<Self, FileConversionError> {
         let filename = if let Some(filename) = file.filename {
             filename
@@ -105,7 +125,8 @@ impl File {
             requires_python: file
                 .requires_python
                 .transpose()
-                .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?,
+                .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?
+                .map(intern_requires_python),
             size: file.size,
             upload_time_utc_ms: file.upload_time.map(Timestamp::as_millisecond),
             url: FileLocation::new(file.url, base),

--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -85,9 +85,9 @@ impl CompatibleDist<'_> {
     pub fn requires_python(&self) -> Option<&VersionSpecifiers> {
         match self {
             Self::InstalledDist(_) => None,
-            Self::SourceDist { sdist, .. } => sdist.file.requires_python.as_ref(),
-            Self::CompatibleWheel { wheel, .. } => wheel.file.requires_python.as_ref(),
-            Self::IncompatibleWheel { sdist, .. } => sdist.file.requires_python.as_ref(),
+            Self::SourceDist { sdist, .. } => sdist.file.requires_python.as_deref(),
+            Self::CompatibleWheel { wheel, .. } => wheel.file.requires_python.as_deref(),
+            Self::IncompatibleWheel { sdist, .. } => sdist.file.requires_python.as_deref(),
         }
     }
 

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -22,6 +22,7 @@ pub struct PypiSimpleDetail {
     #[serde(default)]
     pub project_status: ProjectStatus,
     /// The list of [`PypiFile`]s available for download.
+    #[serde(deserialize_with = "deserialize_pypi_files")]
     pub files: Vec<PypiFile>,
 }
 
@@ -41,74 +42,231 @@ pub struct PypiFile {
     pub yanked: Option<Box<Yanked>>,
 }
 
+#[derive(Deserialize)]
+#[serde(field_identifier, rename_all = "kebab-case")]
+enum FileField {
+    #[serde(alias = "dist-info-metadata", alias = "data-dist-info-metadata")]
+    CoreMetadata,
+    Filename,
+    Hashes,
+    RequiresPython,
+    Size,
+    UploadTime,
+    Url,
+    Yanked,
+    Zstd,
+    #[serde(other)]
+    Ignore,
+}
+
+type RequiresPythonResult = Result<VersionSpecifiers, VersionSpecifiersParseError>;
+type RequiresPythonCache = FxHashMap<SmallString, RequiresPythonResult>;
+
+/// Deserialize files while parsing each distinct `requires-python` value only once.
+fn deserialize_pypi_files<'de, D>(deserializer: D) -> Result<Vec<PypiFile>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut requires_python_cache = RequiresPythonCache::default();
+    serde::de::DeserializeSeed::deserialize(
+        PypiFilesSeed {
+            requires_python_cache: &mut requires_python_cache,
+        },
+        deserializer,
+    )
+}
+
+struct RequiresPythonSeed<'a> {
+    cache: &'a mut RequiresPythonCache,
+}
+
+impl<'de> serde::de::DeserializeSeed<'de> for RequiresPythonSeed<'_> {
+    type Value = Option<RequiresPythonResult>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_option(RequiresPythonOptionVisitor { cache: self.cache })
+    }
+}
+
+struct RequiresPythonOptionVisitor<'a> {
+    cache: &'a mut RequiresPythonCache,
+}
+
+impl<'de> serde::de::Visitor<'de> for RequiresPythonOptionVisitor<'_> {
+    type Value = Option<RequiresPythonResult>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a Python version specifier or null")
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_str(RequiresPythonStringVisitor { cache: self.cache })
+            .map(Some)
+    }
+}
+
+struct RequiresPythonStringVisitor<'a> {
+    cache: &'a mut RequiresPythonCache,
+}
+
+impl serde::de::Visitor<'_> for RequiresPythonStringVisitor<'_> {
+    type Value = RequiresPythonResult;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a Python version specifier")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        if let Some(requires_python) = self.cache.get(value) {
+            return Ok(requires_python.clone());
+        }
+
+        let requires_python =
+            LenientVersionSpecifiers::from_str(value).map(VersionSpecifiers::from);
+        self.cache
+            .insert(SmallString::from(value), requires_python.clone());
+        Ok(requires_python)
+    }
+}
+
+struct PypiFileSeed<'a> {
+    requires_python_cache: &'a mut RequiresPythonCache,
+}
+
+impl<'de> serde::de::DeserializeSeed<'de> for PypiFileSeed<'_> {
+    type Value = PypiFile;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(PypiFileVisitor {
+            requires_python_cache: self.requires_python_cache,
+        })
+    }
+}
+
+struct PypiFilesSeed<'a> {
+    requires_python_cache: &'a mut RequiresPythonCache,
+}
+
+impl<'de> serde::de::DeserializeSeed<'de> for PypiFilesSeed<'_> {
+    type Value = Vec<PypiFile>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FilesVisitor<'a> {
+            requires_python_cache: &'a mut RequiresPythonCache,
+        }
+
+        impl<'de> serde::de::Visitor<'de> for FilesVisitor<'_> {
+            type Value = Vec<PypiFile>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a list of PyPI file metadata")
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut files = Vec::with_capacity(sequence.size_hint().unwrap_or(0));
+                while let Some(file) = sequence.next_element_seed(PypiFileSeed {
+                    requires_python_cache: &mut *self.requires_python_cache,
+                })? {
+                    files.push(file);
+                }
+                Ok(files)
+            }
+        }
+
+        deserializer.deserialize_seq(FilesVisitor {
+            requires_python_cache: self.requires_python_cache,
+        })
+    }
+}
+
 impl<'de> Deserialize<'de> for PypiFile {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        struct FileVisitor;
+        let mut requires_python_cache = RequiresPythonCache::default();
+        deserializer.deserialize_map(PypiFileVisitor {
+            requires_python_cache: &mut requires_python_cache,
+        })
+    }
+}
 
-        impl<'de> serde::de::Visitor<'de> for FileVisitor {
-            type Value = PypiFile;
+struct PypiFileVisitor<'a> {
+    requires_python_cache: &'a mut RequiresPythonCache,
+}
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a map containing file metadata")
-            }
+impl<'de> serde::de::Visitor<'de> for PypiFileVisitor<'_> {
+    type Value = PypiFile;
 
-            fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
-            where
-                M: serde::de::MapAccess<'de>,
-            {
-                let mut core_metadata = None;
-                let mut filename = None;
-                let mut hashes = None;
-                let mut requires_python = None;
-                let mut size = None;
-                let mut upload_time = None;
-                let mut url = None;
-                let mut yanked = None;
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a map containing file metadata")
+    }
 
-                while let Some(key) = access.next_key::<Cow<'_, str>>()? {
-                    match &*key {
-                        "core-metadata" | "dist-info-metadata" | "data-dist-info-metadata"
-                            if core_metadata.is_none() =>
-                        {
-                            core_metadata = access.next_value()?;
-                        }
-                        "filename" => filename = Some(access.next_value()?),
-                        "hashes" => hashes = Some(access.next_value()?),
-                        "requires-python" => {
-                            requires_python =
-                                access.next_value::<Option<Cow<'_, str>>>()?.map(|s| {
-                                    LenientVersionSpecifiers::from_str(s.as_ref())
-                                        .map(VersionSpecifiers::from)
-                                });
-                        }
-                        "size" => size = Some(access.next_value()?),
-                        "upload-time" => upload_time = Some(access.next_value()?),
-                        "url" => url = Some(access.next_value()?),
-                        "yanked" => yanked = Some(access.next_value()?),
-                        _ => {
-                            let _: serde::de::IgnoredAny = access.next_value()?;
-                        }
-                    }
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+    where
+        M: serde::de::MapAccess<'de>,
+    {
+        let mut core_metadata = None;
+        let mut filename = None;
+        let mut hashes = None;
+        let mut requires_python = None;
+        let mut size = None;
+        let mut upload_time = None;
+        let mut url = None;
+        let mut yanked = None;
+
+        while let Some(key) = access.next_key::<FileField>()? {
+            match key {
+                FileField::CoreMetadata if core_metadata.is_none() => {
+                    core_metadata = access.next_value()?;
                 }
-
-                Ok(PypiFile {
-                    core_metadata,
-                    filename: filename
-                        .ok_or_else(|| serde::de::Error::missing_field("filename"))?,
-                    hashes: hashes.ok_or_else(|| serde::de::Error::missing_field("hashes"))?,
-                    requires_python,
-                    size,
-                    upload_time,
-                    url: url.ok_or_else(|| serde::de::Error::missing_field("url"))?,
-                    yanked,
-                })
+                FileField::Filename => filename = Some(access.next_value()?),
+                FileField::Hashes => hashes = Some(access.next_value()?),
+                FileField::RequiresPython => {
+                    requires_python = access.next_value_seed(RequiresPythonSeed {
+                        cache: &mut *self.requires_python_cache,
+                    })?;
+                }
+                FileField::Size => size = Some(access.next_value()?),
+                FileField::UploadTime => upload_time = Some(access.next_value()?),
+                FileField::Url => url = Some(access.next_value()?),
+                FileField::Yanked => yanked = Some(access.next_value()?),
+                _ => {
+                    let _: serde::de::IgnoredAny = access.next_value()?;
+                }
             }
         }
 
-        deserializer.deserialize_map(FileVisitor)
+        Ok(PypiFile {
+            core_metadata,
+            filename: filename.ok_or_else(|| serde::de::Error::missing_field("filename"))?,
+            hashes: hashes.ok_or_else(|| serde::de::Error::missing_field("hashes"))?,
+            requires_python,
+            size,
+            upload_time,
+            url: url.ok_or_else(|| serde::de::Error::missing_field("url"))?,
+            yanked,
+        })
     }
 }
 
@@ -169,27 +327,25 @@ impl<'de> Deserialize<'de> for PyxFile {
                 let mut yanked = None;
                 let mut zstd = None;
 
-                while let Some(key) = access.next_key::<Cow<'_, str>>()? {
-                    match &*key {
-                        "core-metadata" | "dist-info-metadata" | "data-dist-info-metadata"
-                            if core_metadata.is_none() =>
-                        {
+                while let Some(key) = access.next_key::<FileField>()? {
+                    match key {
+                        FileField::CoreMetadata if core_metadata.is_none() => {
                             core_metadata = access.next_value()?;
                         }
-                        "filename" => filename = Some(access.next_value()?),
-                        "hashes" => hashes = Some(access.next_value()?),
-                        "requires-python" => {
+                        FileField::Filename => filename = Some(access.next_value()?),
+                        FileField::Hashes => hashes = Some(access.next_value()?),
+                        FileField::RequiresPython => {
                             requires_python =
-                                access.next_value::<Option<Cow<'_, str>>>()?.map(|s| {
-                                    LenientVersionSpecifiers::from_str(s.as_ref())
+                                access.next_value::<Option<Cow<'_, str>>>()?.map(|value| {
+                                    LenientVersionSpecifiers::from_str(value.as_ref())
                                         .map(VersionSpecifiers::from)
                                 });
                         }
-                        "size" => size = access.next_value()?,
-                        "upload-time" => upload_time = Some(access.next_value()?),
-                        "url" => url = Some(access.next_value()?),
-                        "yanked" => yanked = Some(access.next_value()?),
-                        "zstd" => {
+                        FileField::Size => size = access.next_value()?,
+                        FileField::UploadTime => upload_time = Some(access.next_value()?),
+                        FileField::Url => url = Some(access.next_value()?),
+                        FileField::Yanked => yanked = Some(access.next_value()?),
+                        FileField::Zstd => {
                             zstd = Some(access.next_value()?);
                         }
                         _ => {

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use jiff::Timestamp;
 use rustc_hash::FxHashMap;
@@ -35,7 +36,7 @@ pub struct PypiFile {
     pub core_metadata: Option<CoreMetadata>,
     pub filename: SmallString,
     pub hashes: Hashes,
-    pub requires_python: Option<Result<VersionSpecifiers, VersionSpecifiersParseError>>,
+    pub requires_python: Option<Result<Arc<VersionSpecifiers>, VersionSpecifiersParseError>>,
     pub size: Option<u64>,
     pub upload_time: Option<Timestamp>,
     pub url: SmallString,
@@ -59,144 +60,68 @@ enum FileField {
     Ignore,
 }
 
-type RequiresPythonResult = Result<VersionSpecifiers, VersionSpecifiersParseError>;
-type RequiresPythonCache = FxHashMap<SmallString, RequiresPythonResult>;
+type RequiresPythonResult = Result<Arc<VersionSpecifiers>, VersionSpecifiersParseError>;
+
+#[derive(Default)]
+struct RequiresPythonInterner {
+    values: FxHashMap<SmallString, RequiresPythonResult>,
+}
+
+impl RequiresPythonInterner {
+    fn parse(&mut self, value: &str) -> RequiresPythonResult {
+        if let Some(requires_python) = self.values.get(value) {
+            return requires_python.clone();
+        }
+
+        let requires_python = LenientVersionSpecifiers::from_str(value)
+            .map(VersionSpecifiers::from)
+            .map(Arc::new);
+        self.values
+            .insert(SmallString::from(value), requires_python.clone());
+        requires_python
+    }
+}
+
+struct PypiFileWire<'a> {
+    core_metadata: Option<CoreMetadata>,
+    filename: SmallString,
+    hashes: Hashes,
+    requires_python: Option<Cow<'a, str>>,
+    size: Option<u64>,
+    upload_time: Option<Timestamp>,
+    url: SmallString,
+    yanked: Option<Box<Yanked>>,
+}
+
+impl PypiFileWire<'_> {
+    fn into_file(self, interner: &mut RequiresPythonInterner) -> PypiFile {
+        PypiFile {
+            core_metadata: self.core_metadata,
+            filename: self.filename,
+            hashes: self.hashes,
+            requires_python: self
+                .requires_python
+                .as_deref()
+                .map(|value| interner.parse(value)),
+            size: self.size,
+            upload_time: self.upload_time,
+            url: self.url,
+            yanked: self.yanked,
+        }
+    }
+}
 
 /// Deserialize files while parsing each distinct `requires-python` value only once.
 fn deserialize_pypi_files<'de, D>(deserializer: D) -> Result<Vec<PypiFile>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let mut requires_python_cache = RequiresPythonCache::default();
-    serde::de::DeserializeSeed::deserialize(
-        PypiFilesSeed {
-            requires_python_cache: &mut requires_python_cache,
-        },
-        deserializer,
-    )
-}
-
-struct RequiresPythonSeed<'a> {
-    cache: &'a mut RequiresPythonCache,
-}
-
-impl<'de> serde::de::DeserializeSeed<'de> for RequiresPythonSeed<'_> {
-    type Value = Option<RequiresPythonResult>;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_option(RequiresPythonOptionVisitor { cache: self.cache })
-    }
-}
-
-struct RequiresPythonOptionVisitor<'a> {
-    cache: &'a mut RequiresPythonCache,
-}
-
-impl<'de> serde::de::Visitor<'de> for RequiresPythonOptionVisitor<'_> {
-    type Value = Option<RequiresPythonResult>;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a Python version specifier or null")
-    }
-
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(None)
-    }
-
-    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer
-            .deserialize_str(RequiresPythonStringVisitor { cache: self.cache })
-            .map(Some)
-    }
-}
-
-struct RequiresPythonStringVisitor<'a> {
-    cache: &'a mut RequiresPythonCache,
-}
-
-impl serde::de::Visitor<'_> for RequiresPythonStringVisitor<'_> {
-    type Value = RequiresPythonResult;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a Python version specifier")
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
-        if let Some(requires_python) = self.cache.get(value) {
-            return Ok(requires_python.clone());
-        }
-
-        let requires_python =
-            LenientVersionSpecifiers::from_str(value).map(VersionSpecifiers::from);
-        self.cache
-            .insert(SmallString::from(value), requires_python.clone());
-        Ok(requires_python)
-    }
-}
-
-struct PypiFileSeed<'a> {
-    requires_python_cache: &'a mut RequiresPythonCache,
-}
-
-impl<'de> serde::de::DeserializeSeed<'de> for PypiFileSeed<'_> {
-    type Value = PypiFile;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_map(PypiFileVisitor {
-            requires_python_cache: self.requires_python_cache,
-        })
-    }
-}
-
-struct PypiFilesSeed<'a> {
-    requires_python_cache: &'a mut RequiresPythonCache,
-}
-
-impl<'de> serde::de::DeserializeSeed<'de> for PypiFilesSeed<'_> {
-    type Value = Vec<PypiFile>;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct FilesVisitor<'a> {
-            requires_python_cache: &'a mut RequiresPythonCache,
-        }
-
-        impl<'de> serde::de::Visitor<'de> for FilesVisitor<'_> {
-            type Value = Vec<PypiFile>;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a list of PyPI file metadata")
-            }
-
-            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                let mut files = Vec::with_capacity(sequence.size_hint().unwrap_or(0));
-                while let Some(file) = sequence.next_element_seed(PypiFileSeed {
-                    requires_python_cache: &mut *self.requires_python_cache,
-                })? {
-                    files.push(file);
-                }
-                Ok(files)
-            }
-        }
-
-        deserializer.deserialize_seq(FilesVisitor {
-            requires_python_cache: self.requires_python_cache,
-        })
-    }
+    let files = Vec::<PypiFileWire<'de>>::deserialize(deserializer)?;
+    let mut requires_python_interner = RequiresPythonInterner::default();
+    Ok(files
+        .into_iter()
+        .map(|file| file.into_file(&mut requires_python_interner))
+        .collect())
 }
 
 impl<'de> Deserialize<'de> for PypiFile {
@@ -204,19 +129,25 @@ impl<'de> Deserialize<'de> for PypiFile {
     where
         D: Deserializer<'de>,
     {
-        let mut requires_python_cache = RequiresPythonCache::default();
-        deserializer.deserialize_map(PypiFileVisitor {
-            requires_python_cache: &mut requires_python_cache,
-        })
+        let file = PypiFileWire::deserialize(deserializer)?;
+        let mut requires_python_interner = RequiresPythonInterner::default();
+        Ok(file.into_file(&mut requires_python_interner))
     }
 }
 
-struct PypiFileVisitor<'a> {
-    requires_python_cache: &'a mut RequiresPythonCache,
+impl<'de> Deserialize<'de> for PypiFileWire<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(PypiFileWireVisitor)
+    }
 }
 
-impl<'de> serde::de::Visitor<'de> for PypiFileVisitor<'_> {
-    type Value = PypiFile;
+struct PypiFileWireVisitor;
+
+impl<'de> serde::de::Visitor<'de> for PypiFileWireVisitor {
+    type Value = PypiFileWire<'de>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         formatter.write_str("a map containing file metadata")
@@ -243,9 +174,7 @@ impl<'de> serde::de::Visitor<'de> for PypiFileVisitor<'_> {
                 FileField::Filename => filename = Some(access.next_value()?),
                 FileField::Hashes => hashes = Some(access.next_value()?),
                 FileField::RequiresPython => {
-                    requires_python = access.next_value_seed(RequiresPythonSeed {
-                        cache: &mut *self.requires_python_cache,
-                    })?;
+                    requires_python = access.next_value::<Option<Cow<'de, str>>>()?;
                 }
                 FileField::Size => size = Some(access.next_value()?),
                 FileField::UploadTime => upload_time = Some(access.next_value()?),
@@ -257,7 +186,7 @@ impl<'de> serde::de::Visitor<'de> for PypiFileVisitor<'_> {
             }
         }
 
-        Ok(PypiFile {
+        Ok(PypiFileWire {
             core_metadata,
             filename: filename.ok_or_else(|| serde::de::Error::missing_field("filename"))?,
             hashes: hashes.ok_or_else(|| serde::de::Error::missing_field("hashes"))?,
@@ -278,6 +207,7 @@ pub struct PyxSimpleDetail {
     #[serde(default)]
     pub project_status: ProjectStatus,
     /// The list of [`PyxFile`]s available for download sorted by filename.
+    #[serde(deserialize_with = "deserialize_pyx_files")]
     pub files: Vec<PyxFile>,
     /// The core metadata for the project, keyed by version.
     #[serde(default)]
@@ -291,7 +221,7 @@ pub struct PyxFile {
     pub core_metadata: Option<CoreMetadata>,
     pub filename: Option<SmallString>,
     pub hashes: Hashes,
-    pub requires_python: Option<Result<VersionSpecifiers, VersionSpecifiersParseError>>,
+    pub requires_python: Option<Result<Arc<VersionSpecifiers>, VersionSpecifiersParseError>>,
     pub size: Option<u64>,
     pub upload_time: Option<Timestamp>,
     pub url: SmallString,
@@ -299,76 +229,127 @@ pub struct PyxFile {
     pub zstd: Option<Zstd>,
 }
 
+struct PyxFileWire<'a> {
+    core_metadata: Option<CoreMetadata>,
+    filename: Option<SmallString>,
+    hashes: Hashes,
+    requires_python: Option<Cow<'a, str>>,
+    size: Option<u64>,
+    upload_time: Option<Timestamp>,
+    url: SmallString,
+    yanked: Option<Box<Yanked>>,
+    zstd: Option<Zstd>,
+}
+
+impl PyxFileWire<'_> {
+    fn into_file(self, interner: &mut RequiresPythonInterner) -> PyxFile {
+        PyxFile {
+            core_metadata: self.core_metadata,
+            filename: self.filename,
+            hashes: self.hashes,
+            requires_python: self
+                .requires_python
+                .as_deref()
+                .map(|value| interner.parse(value)),
+            size: self.size,
+            upload_time: self.upload_time,
+            url: self.url,
+            yanked: self.yanked,
+            zstd: self.zstd,
+        }
+    }
+}
+
+/// Deserialize files while parsing each distinct `requires-python` value only once.
+fn deserialize_pyx_files<'de, D>(deserializer: D) -> Result<Vec<PyxFile>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let files = Vec::<PyxFileWire<'de>>::deserialize(deserializer)?;
+    let mut requires_python_interner = RequiresPythonInterner::default();
+    Ok(files
+        .into_iter()
+        .map(|file| file.into_file(&mut requires_python_interner))
+        .collect())
+}
+
 impl<'de> Deserialize<'de> for PyxFile {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        struct FileVisitor;
+        let file = PyxFileWire::deserialize(deserializer)?;
+        let mut requires_python_interner = RequiresPythonInterner::default();
+        Ok(file.into_file(&mut requires_python_interner))
+    }
+}
 
-        impl<'de> serde::de::Visitor<'de> for FileVisitor {
-            type Value = PyxFile;
+impl<'de> Deserialize<'de> for PyxFileWire<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(PyxFileWireVisitor)
+    }
+}
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a map containing file metadata")
-            }
+struct PyxFileWireVisitor;
 
-            fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
-            where
-                M: serde::de::MapAccess<'de>,
-            {
-                let mut core_metadata = None;
-                let mut filename = None;
-                let mut hashes = None;
-                let mut requires_python = None;
-                let mut size = None;
-                let mut upload_time = None;
-                let mut url = None;
-                let mut yanked = None;
-                let mut zstd = None;
+impl<'de> serde::de::Visitor<'de> for PyxFileWireVisitor {
+    type Value = PyxFileWire<'de>;
 
-                while let Some(key) = access.next_key::<FileField>()? {
-                    match key {
-                        FileField::CoreMetadata if core_metadata.is_none() => {
-                            core_metadata = access.next_value()?;
-                        }
-                        FileField::Filename => filename = Some(access.next_value()?),
-                        FileField::Hashes => hashes = Some(access.next_value()?),
-                        FileField::RequiresPython => {
-                            requires_python =
-                                access.next_value::<Option<Cow<'_, str>>>()?.map(|value| {
-                                    LenientVersionSpecifiers::from_str(value.as_ref())
-                                        .map(VersionSpecifiers::from)
-                                });
-                        }
-                        FileField::Size => size = access.next_value()?,
-                        FileField::UploadTime => upload_time = Some(access.next_value()?),
-                        FileField::Url => url = Some(access.next_value()?),
-                        FileField::Yanked => yanked = Some(access.next_value()?),
-                        FileField::Zstd => {
-                            zstd = Some(access.next_value()?);
-                        }
-                        _ => {
-                            let _: serde::de::IgnoredAny = access.next_value()?;
-                        }
-                    }
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a map containing file metadata")
+    }
+
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+    where
+        M: serde::de::MapAccess<'de>,
+    {
+        let mut core_metadata = None;
+        let mut filename = None;
+        let mut hashes = None;
+        let mut requires_python = None;
+        let mut size = None;
+        let mut upload_time = None;
+        let mut url = None;
+        let mut yanked = None;
+        let mut zstd = None;
+
+        while let Some(key) = access.next_key::<FileField>()? {
+            match key {
+                FileField::CoreMetadata if core_metadata.is_none() => {
+                    core_metadata = access.next_value()?;
                 }
-
-                Ok(PyxFile {
-                    core_metadata,
-                    filename,
-                    hashes: hashes.ok_or_else(|| serde::de::Error::missing_field("hashes"))?,
-                    requires_python,
-                    size,
-                    upload_time,
-                    url: url.ok_or_else(|| serde::de::Error::missing_field("url"))?,
-                    yanked,
-                    zstd,
-                })
+                FileField::Filename => filename = Some(access.next_value()?),
+                FileField::Hashes => hashes = Some(access.next_value()?),
+                FileField::RequiresPython => {
+                    requires_python = access.next_value::<Option<Cow<'de, str>>>()?;
+                }
+                FileField::Size => size = access.next_value()?,
+                FileField::UploadTime => upload_time = Some(access.next_value()?),
+                FileField::Url => url = Some(access.next_value()?),
+                FileField::Yanked => yanked = Some(access.next_value()?),
+                FileField::Zstd => {
+                    zstd = Some(access.next_value()?);
+                }
+                _ => {
+                    let _: serde::de::IgnoredAny = access.next_value()?;
+                }
             }
         }
 
-        deserializer.deserialize_map(FileVisitor)
+        Ok(PyxFileWire {
+            core_metadata,
+            filename,
+            hashes: hashes.ok_or_else(|| serde::de::Error::missing_field("hashes"))?,
+            requires_python,
+            size,
+            upload_time,
+            url: url.ok_or_else(|| serde::de::Error::missing_field("url"))?,
+            yanked,
+            zstd,
+        })
     }
 }
 

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -117,10 +117,10 @@ where
     D: Deserializer<'de>,
 {
     let files = Vec::<PypiFileWire<'de>>::deserialize(deserializer)?;
-    let mut requires_python_interner = RequiresPythonInterner::default();
+    let mut interner = RequiresPythonInterner::default();
     Ok(files
         .into_iter()
-        .map(|file| file.into_file(&mut requires_python_interner))
+        .map(|file| file.into_file(&mut interner))
         .collect())
 }
 
@@ -130,8 +130,8 @@ impl<'de> Deserialize<'de> for PypiFile {
         D: Deserializer<'de>,
     {
         let file = PypiFileWire::deserialize(deserializer)?;
-        let mut requires_python_interner = RequiresPythonInterner::default();
-        Ok(file.into_file(&mut requires_python_interner))
+        let mut interner = RequiresPythonInterner::default();
+        Ok(file.into_file(&mut interner))
     }
 }
 
@@ -266,10 +266,10 @@ where
     D: Deserializer<'de>,
 {
     let files = Vec::<PyxFileWire<'de>>::deserialize(deserializer)?;
-    let mut requires_python_interner = RequiresPythonInterner::default();
+    let mut interner = RequiresPythonInterner::default();
     Ok(files
         .into_iter()
-        .map(|file| file.into_file(&mut requires_python_interner))
+        .map(|file| file.into_file(&mut interner))
         .collect())
 }
 
@@ -279,8 +279,8 @@ impl<'de> Deserialize<'de> for PyxFile {
         D: Deserializer<'de>,
     {
         let file = PyxFileWire::deserialize(deserializer)?;
-        let mut requires_python_interner = RequiresPythonInterner::default();
-        Ok(file.into_file(&mut requires_python_interner))
+        let mut interner = RequiresPythonInterner::default();
+        Ok(file.into_file(&mut interner))
     }
 }
 

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -143,7 +143,7 @@ fn clean_package_pypi() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v21")
+        .child("simple-v22")
         .child("pypi")
         .child("iniconfig.rkyv");
     assert!(
@@ -219,7 +219,7 @@ fn clean_package_index() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v21")
+        .child("simple-v22")
         .child("index")
         .child("e8208120cae3ba69")
         .child("iniconfig.rkyv");

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -13708,6 +13708,8 @@ fn lock_find_links_http_wheel() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
+    assert!(context.cache_dir.child("flat-index-v3").is_dir());
+
     let lock = context.read("uv.lock");
 
     insta::with_settings!({


### PR DESCRIPTION
## Summary

Large Simple API responses often repeat the same `requires-python` value across many files. Prior to this change, we parsed and allocated every occurrence independently.

This parses each distinct `requires-python` string once per response and shares the resulting `VersionSpecifiers` across files. The interning applies to PyPI JSON, Pyx JSON and MessagePack, and HTML responses. Deterministic file ordering is handled after grouping by version and distribution kind as of #20112, so it is unchanged by this PR.

The archived representation changes to retain that sharing, so the Simple API and flat-index cache namespaces are bumped.

## Performance

On a captured NumPy Simple API response with 4,056 files and a 2.65 MB JSON payload, `uv pip compile numpy --no-deps` was measured against an in-memory localhost index with the fixture server and `uv` pinned to separate CPUs. Each sample used a fresh cache, and each run used 10 warmups followed by 301 randomized base/head pairs.

| Run | Before | After | Change | Bootstrap 95% CI |
| --- | ---: | ---: | ---: | ---: |
| 1 | 139.3 ms | 136.2 ms | 3.1 ms / 2.3% faster | 1.0-3.9% faster |
| 2 | 136.9 ms | 131.4 ms | 5.5 ms / 4.0% faster | 2.5-5.2% faster |

The same response's archived cache entry shrank from 2.51 MB to 2.26 MB, or 10%.
