### PR TITLE
Reduce VersionSpecifiers parsing allocations

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -20,6 +20,7 @@ use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::Requirement;
 use uv_install_wheel::{InstallState, Layout, LinkMode};
+use uv_pep440::VersionSpecifiers;
 use uv_preview::Preview;
 use uv_pypi_types::Scheme;
 use uv_python::PythonEnvironment;
@@ -308,6 +309,19 @@ fn resolve_warm_airflow(c: &mut Criterion<WallTime>) {
     c.bench_function("resolve_warm_airflow", |b| b.iter(&run));
 }
 
+fn parse_version_specifiers(c: &mut Criterion<WallTime>) {
+    let mut group = c.benchmark_group("parse_version_specifiers");
+    for specifiers in [">=3.8", ">=3.8,<4", ">=2.5, !=3.0.*, !=3.1.*, !=3.2.*, <4"] {
+        group.bench_with_input(specifiers, specifiers, |benchmark, specifiers| {
+            benchmark.iter(|| {
+                VersionSpecifiers::from_str(black_box(specifiers))
+                    .expect("benchmark input should be valid")
+            });
+        });
+    }
+    group.finish();
+}
+
 // This takes >5m to run in CodSpeed.
 // fn resolve_warm_airflow_universal(c: &mut Criterion<WallTime>) {
 //     let manifest = Manifest::simple(vec![
@@ -328,7 +342,8 @@ criterion_group!(
     install_wheel_many_files,
     resolve_warm_jupyter,
     resolve_warm_jupyter_universal,
-    resolve_warm_airflow
+    resolve_warm_airflow,
+    parse_version_specifiers
 );
 criterion_main!(uv);
 

--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -156,7 +156,23 @@ impl FromStr for VersionSpecifiers {
     type Err = VersionSpecifiersParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_version_specifiers(s).map(Self::from_unsorted)
+        let separator_count = s.bytes().filter(|byte| *byte == b',').count();
+        if separator_count == 0 {
+            if s.is_empty() {
+                return Ok(Self::empty());
+            }
+            return VersionSpecifier::from_str(s)
+                .map(Self::from)
+                .map_err(|err| VersionSpecifiersParseError {
+                    inner: Box::new(VersionSpecifiersParseErrorInner {
+                        err,
+                        line: s.to_string(),
+                        start: 0,
+                        end: s.len(),
+                    }),
+                });
+        }
+        parse_version_specifiers(s, separator_count + 1).map(Self::from_unsorted)
     }
 }
 
@@ -937,11 +953,9 @@ impl From<ParseErrorKind> for VersionSpecifierParseError {
 /// Parse a list of specifiers such as `>= 1.0, != 1.3.*, < 2.0`.
 fn parse_version_specifiers(
     spec: &str,
+    specifier_count: usize,
 ) -> Result<Vec<VersionSpecifier>, VersionSpecifiersParseError> {
-    let mut version_ranges = Vec::new();
-    if spec.is_empty() {
-        return Ok(version_ranges);
-    }
+    let mut version_ranges = Vec::with_capacity(specifier_count);
     let mut start: usize = 0;
     let separator = ",";
     for version_range_spec in spec.split(separator) {


### PR DESCRIPTION
## Summary

`VersionSpecifiers::from_str` currently collects every parsed constraint into a growable `Vec`, sorts it, and converts it to a boxed slice. Most `requires-python` values contain a single clause, so parsing a value like `>=3.8` pays for temporary spare capacity and sorting before shrinking the allocation.

This constructs empty and single-clause collections directly, and counts separators once so multi-clause inputs reserve their exact final size. Parsing and error behavior remain unchanged.

In profiling builds, the single-clause case improves from about 129 ns to 74 ns (-43%). Exact sizing improves a two-clause input by about 10% and a five-clause input by about 9%. A CodSpeed benchmark covers all three shapes.

The `uv-pep440` and `uv-pypi-types` suites pass, along with formatting and strict Clippy checks for `uv-pep440` and the new benchmark.