### PR TITLE
Hint at package rename for frozen lockfile errors

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -371,12 +371,31 @@ impl<'env> LockOperation<'env> {
                 // Check if the discovered workspace members match the locked workspace members.
                 if let LockTarget::Workspace(workspace) = target {
                     for package_name in workspace.packages().keys() {
-                        existing
-                            .find_by_name(package_name)
-                            .map_err(|_| ProjectError::LockWorkspaceMismatch(package_name.clone()))?
-                            .ok_or_else(|| {
-                                ProjectError::LockWorkspaceMismatch(package_name.clone())
-                            })?;
+                        match existing.find_by_name(package_name) {
+                            Ok(Some(_)) => {}
+                            Ok(None) => {
+                                // The workspace member is missing from the lockfile. If a
+                                // workspace member recorded in the lockfile is no longer present
+                                // in the current workspace, it may have been renamed.
+                                let renamed_from = existing
+                                    .root()
+                                    .into_iter()
+                                    .map(Package::name)
+                                    .chain(existing.members().iter())
+                                    .find(|name| !workspace.packages().contains_key(*name))
+                                    .cloned();
+                                return Err(ProjectError::LockWorkspaceMismatch(
+                                    package_name.clone(),
+                                    renamed_from,
+                                ));
+                            }
+                            Err(_) => {
+                                return Err(ProjectError::LockWorkspaceMismatch(
+                                    package_name.clone(),
+                                    None,
+                                ));
+                            }
+                        }
                     }
                 }
                 Ok(LockResult::Unchanged(existing))

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -154,7 +154,7 @@ pub(crate) enum ProjectError {
     #[error(
         "The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `{0}`. To update the lockfile, run `uv lock`."
     )]
-    LockWorkspaceMismatch(PackageName),
+    LockWorkspaceMismatch(PackageName, Option<PackageName>),
 
     #[error(
         "The lockfile at `uv.lock` uses an unsupported schema version (v{1}, but only v{0} is supported). Downgrade to a compatible uv version, or remove the `uv.lock` prior to running `uv lock` or `uv sync`."
@@ -404,6 +404,11 @@ impl uv_errors::Hint for ProjectError {
         match self {
             Self::OverlappingMarkers(_, rhs, replacement) => {
                 uv_errors::Hints::from(format!("replace `{rhs}` with `{replacement}`"))
+            }
+            Self::LockWorkspaceMismatch(package_name, Some(renamed_from)) => {
+                uv_errors::Hints::from(format!(
+                    "If you renamed `{renamed_from}` to `{package_name}`, run `uv lock` to update the lockfile"
+                ))
             }
             Self::Lock(err) => err.hints(),
             Self::Python(err) => err.hints(),

--- a/crates/uv/tests/project/export.rs
+++ b/crates/uv/tests/project/export.rs
@@ -5214,6 +5214,9 @@ fn export_lock_workspace_mismatch_with_frozen() -> Result<()> {
         revision = 3
         requires-python = ">=3.12"
 
+        [manifest]
+        members = ["bar"]
+
         [[package]]
         name = "bar"
         version = "0.1.0"
@@ -5229,6 +5232,8 @@ fn export_lock_workspace_mismatch_with_frozen() -> Result<()> {
 
     ----- stderr -----
     error: The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `foo`. To update the lockfile, run `uv lock`.
+
+    hint: If you renamed `bar` to `foo`, run `uv lock` to update the lockfile
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

Closes #12661.

When `uv sync --frozen` (or any command that performs the frozen lockfile check, e.g. `uv export --frozen`) is run after a workspace member has been renamed, the lockfile still lists the old package name while the workspace declares the new one, so the frozen check fails with a bare `Missing workspace member \<new\>` error that doesn't explain what happened.

This adds a hint to `ProjectError::LockWorkspaceMismatch`: when the missing member can be matched to a package recorded in the lockfile that no longer exists in the current workspace, we suggest it may have been the source of a rename, e.g.:

```
error: The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `foo`. To update the lockfile, run `uv lock`.

hint: If you renamed `bar` to `foo`, run `uv lock` to update the lockfile
```

The detection is a best-effort heuristic: if any package recorded in the lockfile (root or manifest member) is no longer present in the current workspace, the first such package is offered as the possible previous name. This means a "delete + add" (rather than a true rename) will also surface the hint; the wording (`If you renamed...`) is conditional to keep that case from being misleading.

The fix lives in the shared `LockOperation::execute` path, so `uv sync`, `uv export`, `uv run`, `uv tree`, `uv lock --check`, `uv audit`, `uv version`, and `uv check` all benefit.

## Test Plan

- Extended the existing `export_lock_workspace_mismatch_with_frozen` snapshot to seed the lockfile with `[manifest] members = [\"bar\"]` (matching the real post-rename lockfile shape) and to assert the new `hint:` line.
- `cargo test -p uv --test project export::export_lock_workspace_mismatch_with_frozen` — passes.
- `cargo test -p uv --test project frozen` — all 9 frozen-related tests pass (no other snapshots affected; the hint only renders when a rename source is detected).
- `cargo fmt --check` — clean.
- `cargo clippy -p uv --tests --no-deps` — no warnings.
