### PR TITLE
Reuse package names when parsing wheel filenames

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -22,7 +21,7 @@ use uv_configuration::KeyringProviderType;
 use uv_distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
 use uv_distribution_types::{
     BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-    IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
+    IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name, RegistryBuiltWheel,
 };
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
@@ -962,7 +961,7 @@ impl RegistryClient {
                         })?
                     }
                     WheelLocation::Url(url) => {
-                        self.wheel_metadata_registry(&wheel.index, &wheel.file, &url, capabilities)
+                        self.wheel_metadata_registry(wheel, &url, capabilities)
                             .await?
                     }
                 }
@@ -1055,13 +1054,17 @@ impl RegistryClient {
     /// Fetch the metadata from a wheel file.
     async fn wheel_metadata_registry(
         &self,
-        index: &IndexUrl,
-        file: &File,
+        wheel: &RegistryBuiltWheel,
         url: &DisplaySafeUrl,
         capabilities: &IndexCapabilities,
     ) -> Result<ResolutionMetadata, Error> {
+        let RegistryBuiltWheel {
+            filename,
+            file,
+            index,
+        } = wheel;
+
         // If the metadata file is available at its own url (PEP 658), download it from there.
-        let filename = WheelFilename::from_str(&file.filename).map_err(ErrorKind::WheelFilename)?;
         if file.dist_info_metadata {
             let mut url = url.clone();
             let path = format!("{}.metadata", url.path());
@@ -1124,7 +1127,7 @@ impl RegistryClient {
             // `.dist-info/METADATA` file from the zip, and if that also fails, download the whole wheel
             // into the cache and read from there
             self.wheel_metadata_no_pep658(
-                &filename,
+                filename,
                 url,
                 Some(index),
                 WheelCache::Index(index),

--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -21,6 +21,17 @@ mod splitter;
 mod wheel;
 mod wheel_tag;
 
+pub(crate) fn normalized_package_name_matches(actual: &str, expected: &PackageName) -> bool {
+    actual
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' => byte.to_ascii_lowercase(),
+            b'_' | b'.' => b'-',
+            _ => byte,
+        })
+        .eq(expected.as_ref().bytes())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DistFilename {
     SourceDistFilename(SourceDistFilename),
@@ -44,10 +55,12 @@ impl DistFilename {
         package_name: &PackageName,
     ) -> Result<Self, DistFilenameError> {
         match DistExtension::from_path(filename) {
-            Ok(DistExtension::Wheel) => match WheelFilename::from_str(filename) {
-                Ok(filename) => Ok(Self::WheelFilename(filename)),
-                Err(err) => Err(DistFilenameError::InvalidWheel(err)),
-            },
+            Ok(DistExtension::Wheel) => {
+                match WheelFilename::from_str_with_expected_package_name(filename, package_name) {
+                    Ok(filename) => Ok(Self::WheelFilename(filename)),
+                    Err(err) => Err(DistFilenameError::InvalidWheel(err)),
+                }
+            }
             Ok(DistExtension::Source(extension)) => {
                 match SourceDistFilename::parse(filename, extension, package_name) {
                     Ok(filename) => Ok(Self::SourceDistFilename(filename)),

--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -21,7 +21,7 @@ mod splitter;
 mod wheel;
 mod wheel_tag;
 
-pub(crate) fn normalized_package_name_matches(actual: &str, expected: &PackageName) -> bool {
+fn normalized_package_name_matches(actual: &str, expected: &PackageName) -> bool {
     actual
         .bytes()
         .map(|byte| match byte {
@@ -55,12 +55,10 @@ impl DistFilename {
         package_name: &PackageName,
     ) -> Result<Self, DistFilenameError> {
         match DistExtension::from_path(filename) {
-            Ok(DistExtension::Wheel) => {
-                match WheelFilename::from_str_with_expected_package_name(filename, package_name) {
-                    Ok(filename) => Ok(Self::WheelFilename(filename)),
-                    Err(err) => Err(DistFilenameError::InvalidWheel(err)),
-                }
-            }
+            Ok(DistExtension::Wheel) => match WheelFilename::from_hint(filename, package_name) {
+                Ok(filename) => Ok(Self::WheelFilename(filename)),
+                Err(err) => Err(DistFilenameError::InvalidWheel(err)),
+            },
             Ok(DistExtension::Source(extension)) => {
                 match SourceDistFilename::parse(filename, extension, package_name) {
                     Ok(filename) => Ok(Self::SourceDistFilename(filename)),

--- a/crates/uv-distribution-filename/src/source_dist.rs
+++ b/crates/uv-distribution-filename/src/source_dist.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-use crate::SourceDistExtension;
+use crate::{SourceDistExtension, normalized_package_name_matches};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uv_normalize::{InvalidNameError, PackageName};
@@ -138,17 +138,6 @@ impl SourceDistFilename {
             extension,
         })
     }
-}
-
-fn normalized_package_name_matches(actual: &str, expected: &PackageName) -> bool {
-    actual
-        .bytes()
-        .map(|byte| match byte {
-            b'A'..=b'Z' => byte.to_ascii_lowercase(),
-            b'_' | b'.' => b'-',
-            _ => byte,
-        })
-        .eq(expected.as_ref().bytes())
 }
 
 impl Display for SourceDistFilename {

--- a/crates/uv-distribution-filename/src/wheel.rs
+++ b/crates/uv-distribution-filename/src/wheel.rs
@@ -16,7 +16,7 @@ use uv_platform_tags::{
 
 use crate::splitter::MemchrSplitter;
 use crate::wheel_tag::{TagSet, WheelTag, WheelTagLarge, WheelTagSmall};
-use crate::{BuildTag, BuildTagError};
+use crate::{BuildTag, BuildTagError, normalized_package_name_matches};
 
 #[derive(
     Debug,
@@ -41,13 +41,7 @@ impl FromStr for WheelFilename {
     type Err = WheelFilenameError;
 
     fn from_str(filename: &str) -> Result<Self, Self::Err> {
-        let stem = filename.strip_suffix(".whl").ok_or_else(|| {
-            WheelFilenameError::InvalidWheelFileName(
-                filename.to_string(),
-                "Must end with .whl".to_string(),
-            )
-        })?;
-        Self::parse(stem, filename)
+        Self::parse_filename(filename, None)
     }
 }
 
@@ -64,6 +58,26 @@ impl Display for WheelFilename {
 }
 
 impl WheelFilename {
+    fn parse_filename(
+        filename: &str,
+        expected_package_name: Option<&PackageName>,
+    ) -> Result<Self, WheelFilenameError> {
+        let stem = filename.strip_suffix(".whl").ok_or_else(|| {
+            WheelFilenameError::InvalidWheelFileName(
+                filename.to_string(),
+                "Must end with .whl".to_string(),
+            )
+        })?;
+        Self::parse(stem, filename, expected_package_name)
+    }
+
+    pub(crate) fn from_str_with_expected_package_name(
+        filename: &str,
+        expected_package_name: &PackageName,
+    ) -> Result<Self, WheelFilenameError> {
+        Self::parse_filename(filename, Some(expected_package_name))
+    }
+
     /// Create a [`WheelFilename`] from its components.
     pub fn new(
         name: PackageName,
@@ -161,13 +175,17 @@ impl WheelFilename {
         {
             return Err(WheelFilenameError::UnexpectedExtension(stem.to_string()));
         }
-        Self::parse(stem, stem)
+        Self::parse(stem, stem, None)
     }
 
     /// Parse a wheel filename from the stem (e.g., `foo-1.2.3-py3-none-any`).
     ///
     /// The originating `filename` is used for high-fidelity error messages.
-    fn parse(stem: &str, filename: &str) -> Result<Self, WheelFilenameError> {
+    fn parse(
+        stem: &str,
+        filename: &str,
+        expected_package_name: Option<&PackageName>,
+    ) -> Result<Self, WheelFilenameError> {
         // The wheel filename should contain either five or six entries. If six, then the third
         // entry is the build tag. If five, then the third entry is the Python tag.
         // https://www.python.org/dev/peps/pep-0427/#file-name-convention
@@ -234,8 +252,15 @@ impl WheelFilename {
                 )
             };
 
-        let name = PackageName::from_str(name)
-            .map_err(|err| WheelFilenameError::InvalidPackageName(filename.to_string(), err))?;
+        let name = match expected_package_name {
+            Some(expected_package_name)
+                if normalized_package_name_matches(name, expected_package_name) =>
+            {
+                expected_package_name.clone()
+            }
+            _ => PackageName::from_str(name)
+                .map_err(|err| WheelFilenameError::InvalidPackageName(filename.to_string(), err))?,
+        };
         let version = Version::from_str(version)
             .map_err(|err| WheelFilenameError::InvalidVersion(filename.to_string(), err))?;
         let build_tag = build_tag
@@ -371,7 +396,78 @@ pub enum WheelFilenameError {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
+    use std::io;
+    use std::mem::discriminant;
+
     use super::*;
+
+    #[test]
+    fn expected_package_name_matches_public_parser() -> Result<(), Box<dyn Error>> {
+        let cases = [
+            ("numpy-1.2.3-py3-none-any.whl", "numpy"),
+            ("foo_bar-1.2.3-py3-none-any.whl", "foo-bar"),
+            ("foo.bar-1.2.3-py3-none-any.whl", "foo-bar"),
+            ("Foo.Bar-1.2.3-py3-none-any.whl", "foo-bar"),
+            ("foo__bar-1.2.3-py3-none-any.whl", "foo-bar"),
+            ("foo_.bar-1.2.3-py3-none-any.whl", "foo-bar"),
+            ("other-1.2.3-py3-none-any.whl", "foo-bar"),
+            ("-1.2.3-py3-none-any.whl", "foo"),
+            ("f!oo-1.2.3-py3-none-any.whl", "foo"),
+            (".foo-1.2.3-py3-none-any.whl", "foo"),
+            ("foo.-1.2.3-py3-none-any.whl", "foo"),
+            ("föö-1.2.3-py3-none-any.whl", "foo"),
+            (".whl", "foo"),
+            ("foo.whl", "foo"),
+            ("foo-1.2.3.whl", "foo"),
+            ("foo-1.2.3-py3.whl", "foo"),
+            ("foo-1.2.3-py3-none.whl", "foo"),
+            ("foo-1.2.3-202206090410-py3-none-any-whoops.whl", "foo"),
+            ("foo-x.y.z-py3-none-any.whl", "foo"),
+            ("foo-1.2.3-tag-py3-none-any.whl", "foo"),
+            ("foo-1.2.3-py3-none-unknown..tag.whl", "foo"),
+        ];
+
+        for (filename, package_name) in cases {
+            let expected_package_name = PackageName::from_str(package_name)?;
+            let baseline = WheelFilename::from_str(filename);
+            let candidate = WheelFilename::from_str_with_expected_package_name(
+                filename,
+                &expected_package_name,
+            );
+            assert_eq!(
+                baseline.is_ok(),
+                candidate.is_ok(),
+                "success parity differed for {filename}"
+            );
+            match (baseline, candidate) {
+                (Ok(baseline), Ok(candidate)) => assert_eq!(baseline, candidate, "{filename}"),
+                (Err(baseline), Err(candidate)) => {
+                    assert_eq!(
+                        discriminant(&baseline),
+                        discriminant(&candidate),
+                        "{filename}"
+                    );
+                    assert_eq!(baseline.to_string(), candidate.to_string(), "{filename}");
+                }
+                _ => {
+                    return Err(io::Error::other(format!(
+                        "parser result kind differed for {filename}"
+                    ))
+                    .into());
+                }
+            }
+        }
+
+        let expected_package_name = PackageName::from_str("foo-bar")?;
+        let mismatched = WheelFilename::from_str_with_expected_package_name(
+            "other-1.2.3-py3-none-any.whl",
+            &expected_package_name,
+        )?;
+        assert_eq!(mismatched.name.as_ref(), "other");
+
+        Ok(())
+    }
 
     #[test]
     fn err_not_whl_extension() {

--- a/crates/uv-distribution-filename/src/wheel.rs
+++ b/crates/uv-distribution-filename/src/wheel.rs
@@ -60,7 +60,7 @@ impl Display for WheelFilename {
 impl WheelFilename {
     fn parse_filename(
         filename: &str,
-        expected_package_name: Option<&PackageName>,
+        hint: Option<&PackageName>,
     ) -> Result<Self, WheelFilenameError> {
         let stem = filename.strip_suffix(".whl").ok_or_else(|| {
             WheelFilenameError::InvalidWheelFileName(
@@ -68,14 +68,14 @@ impl WheelFilename {
                 "Must end with .whl".to_string(),
             )
         })?;
-        Self::parse(stem, filename, expected_package_name)
+        Self::parse(stem, filename, hint)
     }
 
-    pub(crate) fn from_str_with_expected_package_name(
+    pub(crate) fn from_hint(
         filename: &str,
-        expected_package_name: &PackageName,
+        hint: &PackageName,
     ) -> Result<Self, WheelFilenameError> {
-        Self::parse_filename(filename, Some(expected_package_name))
+        Self::parse_filename(filename, Some(hint))
     }
 
     /// Create a [`WheelFilename`] from its components.
@@ -184,7 +184,7 @@ impl WheelFilename {
     fn parse(
         stem: &str,
         filename: &str,
-        expected_package_name: Option<&PackageName>,
+        hint: Option<&PackageName>,
     ) -> Result<Self, WheelFilenameError> {
         // The wheel filename should contain either five or six entries. If six, then the third
         // entry is the build tag. If five, then the third entry is the Python tag.
@@ -252,14 +252,13 @@ impl WheelFilename {
                 )
             };
 
-        let name = match expected_package_name {
-            Some(expected_package_name)
-                if normalized_package_name_matches(name, expected_package_name) =>
-            {
-                expected_package_name.clone()
-            }
-            _ => PackageName::from_str(name)
-                .map_err(|err| WheelFilenameError::InvalidPackageName(filename.to_string(), err))?,
+        let name = if let Some(hint) = hint
+            && normalized_package_name_matches(name, hint)
+        {
+            hint.clone()
+        } else {
+            PackageName::from_str(name)
+                .map_err(|err| WheelFilenameError::InvalidPackageName(filename.to_string(), err))?
         };
         let version = Version::from_str(version)
             .map_err(|err| WheelFilenameError::InvalidVersion(filename.to_string(), err))?;
@@ -396,78 +395,7 @@ pub enum WheelFilenameError {
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
-    use std::io;
-    use std::mem::discriminant;
-
     use super::*;
-
-    #[test]
-    fn expected_package_name_matches_public_parser() -> Result<(), Box<dyn Error>> {
-        let cases = [
-            ("numpy-1.2.3-py3-none-any.whl", "numpy"),
-            ("foo_bar-1.2.3-py3-none-any.whl", "foo-bar"),
-            ("foo.bar-1.2.3-py3-none-any.whl", "foo-bar"),
-            ("Foo.Bar-1.2.3-py3-none-any.whl", "foo-bar"),
-            ("foo__bar-1.2.3-py3-none-any.whl", "foo-bar"),
-            ("foo_.bar-1.2.3-py3-none-any.whl", "foo-bar"),
-            ("other-1.2.3-py3-none-any.whl", "foo-bar"),
-            ("-1.2.3-py3-none-any.whl", "foo"),
-            ("f!oo-1.2.3-py3-none-any.whl", "foo"),
-            (".foo-1.2.3-py3-none-any.whl", "foo"),
-            ("foo.-1.2.3-py3-none-any.whl", "foo"),
-            ("föö-1.2.3-py3-none-any.whl", "foo"),
-            (".whl", "foo"),
-            ("foo.whl", "foo"),
-            ("foo-1.2.3.whl", "foo"),
-            ("foo-1.2.3-py3.whl", "foo"),
-            ("foo-1.2.3-py3-none.whl", "foo"),
-            ("foo-1.2.3-202206090410-py3-none-any-whoops.whl", "foo"),
-            ("foo-x.y.z-py3-none-any.whl", "foo"),
-            ("foo-1.2.3-tag-py3-none-any.whl", "foo"),
-            ("foo-1.2.3-py3-none-unknown..tag.whl", "foo"),
-        ];
-
-        for (filename, package_name) in cases {
-            let expected_package_name = PackageName::from_str(package_name)?;
-            let baseline = WheelFilename::from_str(filename);
-            let candidate = WheelFilename::from_str_with_expected_package_name(
-                filename,
-                &expected_package_name,
-            );
-            assert_eq!(
-                baseline.is_ok(),
-                candidate.is_ok(),
-                "success parity differed for {filename}"
-            );
-            match (baseline, candidate) {
-                (Ok(baseline), Ok(candidate)) => assert_eq!(baseline, candidate, "{filename}"),
-                (Err(baseline), Err(candidate)) => {
-                    assert_eq!(
-                        discriminant(&baseline),
-                        discriminant(&candidate),
-                        "{filename}"
-                    );
-                    assert_eq!(baseline.to_string(), candidate.to_string(), "{filename}");
-                }
-                _ => {
-                    return Err(io::Error::other(format!(
-                        "parser result kind differed for {filename}"
-                    ))
-                    .into());
-                }
-            }
-        }
-
-        let expected_package_name = PackageName::from_str("foo-bar")?;
-        let mismatched = WheelFilename::from_str_with_expected_package_name(
-            "other-1.2.3-py3-none-any.whl",
-            &expected_package_name,
-        )?;
-        assert_eq!(mismatched.name.as_ref(), "other");
-
-        Ok(())
-    }
 
     #[test]
     fn err_not_whl_extension() {


### PR DESCRIPTION
## Summary

Simple API conversion already knows the requested package name, but parsing every wheel filename independently normalizes that same embedded name and allocates a new `PackageName`. Large project responses repeat this work thousands of times.

This passes the requested name into a private wheel parser as a hint. When the embedded name normalizes to the hint, we clone the existing `PackageName`, sharing its `ArcStr` storage. Comparison misses fall back to the previous parser, so valid mismatched wheel names remain accepted and retained, malformed names keep their existing errors, and public `WheelFilename` parsing is unchanged. The archived representation and cache schema are also unchanged.

## Performance

Complete wheel-filename parsing improved on two captured large Simple API responses across 200 randomized profiling-build pairs:

| Fixture                    |   Before |    After |       Change |   Allocation reduction |
| -------------------------- | -------: | -------: | -----------: | ---------------------: |
| NumPy, 3,870 wheels        | 1.331 ms | 1.142 ms | 14.2% faster | 3,870 requests / 81 KB |
| Cryptography, 3,434 wheels | 1.080 ms | 0.930 ms | 13.9% faster | 3,434 requests / 96 KB |
