### PR TITLE
Deduplicate shared URL bases in rkyv archives

### DIFF
--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -8,7 +8,7 @@ use url::Url;
 use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::cache_digest;
 use uv_distribution_filename::DistFilename;
-use uv_distribution_types::{File, FileLocation, IndexUrl, UrlString};
+use uv_distribution_types::{File, FileLocation, FileLocationBuilder, IndexUrl};
 use uv_pypi_types::HashDigests;
 use uv_redacted::DisplaySafeUrl;
 use uv_small_str::SmallString;
@@ -222,13 +222,12 @@ impl<'a> FlatIndexClient<'a> {
                 } = SimpleDetailHTML::parse(&text, &url)
                     .map_err(|err| Error::from_html_err(err, url.clone()))?;
 
-                // Convert to a reference-counted string.
-                let base = SmallString::from(base.as_str());
+                let mut locations = FileLocationBuilder::new(SmallString::from(base.as_str()));
 
                 let unarchived: Vec<File> = files
                     .into_iter()
                     .filter_map(|file| {
-                        match File::try_from_pypi(file, &base) {
+                        match File::try_from_pypi(file, &mut locations) {
                             Ok(file) => Some(file),
                             Err(err) => {
                                 // Ignore files with unparsable version specifiers.
@@ -327,7 +326,7 @@ impl<'a> FlatIndexClient<'a> {
                 requires_python: None,
                 size: None,
                 upload_time_utc_ms: None,
-                url: FileLocation::AbsoluteUrl(UrlString::from(url)),
+                url: FileLocation::absolute(url.as_str()),
                 yanked: None,
                 zstd: None,
             };

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -20,8 +20,9 @@ use uv_configuration::IndexStrategy;
 use uv_configuration::KeyringProviderType;
 use uv_distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
 use uv_distribution_types::{
-    BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-    IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name, RegistryBuiltWheel,
+    BuiltDist, File, FileLocationBuilder, IndexCapabilities, IndexFormat, IndexLocations,
+    IndexMetadataRef, IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
+    RegistryBuiltWheel,
 };
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
@@ -1472,8 +1473,7 @@ impl SimpleDetailMetadata {
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
 
-        // Convert to a reference-counted string.
-        let base = SmallString::from(base.as_str());
+        let mut locations = FileLocationBuilder::new(SmallString::from(base.as_str()));
 
         // Group the distributions by version and kind
         for file in files {
@@ -1488,7 +1488,7 @@ impl SimpleDetailMetadata {
                         continue;
                     }
                 };
-            let file = match File::try_from_pypi(file, &base) {
+            let file = match File::try_from_pypi(file, &mut locations) {
                 Ok(file) => file,
                 Err(err) => {
                     // Ignore files with unparsable version specifiers.
@@ -1540,12 +1540,11 @@ impl SimpleDetailMetadata {
     ) -> Self {
         let mut version_map: BTreeMap<Version, VersionFiles> = BTreeMap::default();
 
-        // Convert to a reference-counted string.
-        let base = SmallString::from(base.as_str());
+        let mut locations = FileLocationBuilder::new(SmallString::from(base.as_str()));
 
         // Group the distributions by version and kind
         for file in files {
-            let file = match File::try_from_pyx(file, &base) {
+            let file = match File::try_from_pyx(file, &mut locations) {
                 Ok(file) => file,
                 Err(err) => {
                     // Ignore files with unparsable version specifiers.
@@ -1736,8 +1735,8 @@ mod tests {
     };
     use uv_cache::Cache;
     use uv_distribution_types::{
-        FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-        IndexUrl, ToUrlError,
+        FileLocationBuilder, Index, IndexCapabilities, IndexFormat, IndexLocations,
+        IndexMetadataRef, IndexUrl, ToUrlError,
     };
     use uv_small_str::SmallString;
     use wiremock::matchers::{basic_auth, method, path_regex};
@@ -2310,12 +2309,12 @@ mod tests {
             base,
             files,
         } = SimpleDetailHTML::parse(text, &base).unwrap();
-        let base = SmallString::from(base.as_str());
+        let mut locations = FileLocationBuilder::new(SmallString::from(base.as_str()));
 
         // Test parsing of the file urls
         let urls = files
             .into_iter()
-            .map(|file| FileLocation::new(file.url, &base).to_url())
+            .map(|file| locations.parse(file.url).to_url())
             .collect::<Result<Vec<_>, _>>()?;
         let urls = urls
             .iter()

--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -10,7 +10,7 @@ use uv_pep440::{VersionSpecifiers, VersionSpecifiersParseError};
 use uv_pep508::split_scheme;
 use uv_pypi_types::{CoreMetadata, HashDigests, Yanked};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
-use uv_small_str::SmallString;
+use uv_small_str::{RkyvShared, SmallString};
 
 /// Error converting [`uv_pypi_types::PypiFile`] to [`distribution_type::File`].
 #[derive(Debug, thiserror::Error)]
@@ -126,8 +126,9 @@ impl File {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 pub enum FileLocation {
-    /// URL relative to the base URL.
-    RelativeUrl(SmallString, SmallString),
+    /// URL relative to the base URL. The base URL allocation is shared by every relative file in
+    /// an index response, so archive it as a shared pointer.
+    RelativeUrl(#[rkyv(with = RkyvShared)] SmallString, SmallString),
     /// Absolute URL.
     AbsoluteUrl(UrlString),
 }

--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use jiff::Timestamp;
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 
 use uv_pep440::{VersionSpecifiers, VersionSpecifiersParseError};
@@ -48,7 +49,7 @@ impl File {
     /// `TryFrom` instead of `From` to filter out files with invalid requires python version specifiers
     pub fn try_from_pypi(
         file: uv_pypi_types::PypiFile,
-        base: &SmallString,
+        locations: &mut FileLocationBuilder,
     ) -> Result<Self, FileConversionError> {
         Ok(Self {
             dist_info_metadata: file
@@ -63,7 +64,7 @@ impl File {
                 .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?,
             size: file.size,
             upload_time_utc_ms: file.upload_time.map(Timestamp::as_millisecond),
-            url: FileLocation::new(file.url, base),
+            url: locations.parse(file.url),
             yanked: file.yanked,
             zstd: None,
         })
@@ -71,7 +72,7 @@ impl File {
 
     pub fn try_from_pyx(
         file: uv_pypi_types::PyxFile,
-        base: &SmallString,
+        locations: &mut FileLocationBuilder,
     ) -> Result<Self, FileConversionError> {
         let filename = if let Some(filename) = file.filename {
             filename
@@ -109,7 +110,7 @@ impl File {
                 .map_err(|err| FileConversionError::RequiresPython(err.line().clone(), err))?,
             size: file.size,
             upload_time_utc_ms: file.upload_time.map(Timestamp::as_millisecond),
-            url: FileLocation::new(file.url, base),
+            url: locations.parse(file.url),
             yanked: file.yanked,
             zstd: file
                 .zstd
@@ -122,27 +123,59 @@ impl File {
     }
 }
 
+/// Constructs [`FileLocation`] values while reusing URL base allocations.
+#[derive(Debug)]
+pub struct FileLocationBuilder {
+    relative_base: SmallString,
+    absolute_bases: FxHashSet<SmallString>,
+}
+
+impl FileLocationBuilder {
+    pub fn new(relative_base: SmallString) -> Self {
+        Self {
+            relative_base,
+            absolute_bases: FxHashSet::default(),
+        }
+    }
+
+    pub fn parse(&mut self, url: SmallString) -> FileLocation {
+        let Some((base, path)) = split_absolute_url(&url) else {
+            return FileLocation::RelativeUrl(self.relative_base.clone(), url);
+        };
+
+        let base = if let Some(base) = self.absolute_bases.get(base) {
+            base.clone()
+        } else {
+            let base = SmallString::from(base);
+            self.absolute_bases.insert(base.clone());
+            base
+        };
+
+        FileLocation::AbsoluteUrl(base, SmallString::from(path))
+    }
+}
+
 /// While a registry file is generally a remote URL, it can also be a file if it comes from a directory flat indexes.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 pub enum FileLocation {
     /// URL relative to the base URL. The base URL allocation is shared by every relative file in
     /// an index response, so archive it as a shared pointer.
     RelativeUrl(#[rkyv(with = RkyvShared)] SmallString, SmallString),
-    /// Absolute URL.
-    AbsoluteUrl(UrlString),
+    /// Absolute URL, split into its scheme and authority and the remaining path, query, and
+    /// fragment. The base allocation is shared by files served from the same origin.
+    AbsoluteUrl(#[rkyv(with = RkyvShared)] SmallString, SmallString),
 }
 
 impl FileLocation {
-    /// Parse a relative or absolute URL on a page with a base URL.
-    ///
-    /// This follows the HTML semantics where a link on a page is resolved relative to the URL of
-    /// that page.
-    pub fn new(url: SmallString, base: &SmallString) -> Self {
-        match split_scheme(&url) {
-            Some(..) => Self::AbsoluteUrl(UrlString::new(url)),
-            None => Self::RelativeUrl(base.clone(), url),
-        }
+    /// Construct a location from an absolute URL.
+    pub fn absolute(url: &str) -> Self {
+        let (base, path) = if let Some(parts) = split_absolute_url(url) {
+            parts
+        } else {
+            (url, "")
+        };
+        Self::AbsoluteUrl(SmallString::from(base), SmallString::from(path))
     }
 
     /// Convert this location to a URL.
@@ -171,7 +204,23 @@ impl FileLocation {
                 })?;
                 Ok(joined)
             }
-            Self::AbsoluteUrl(absolute) => absolute.to_url(),
+            Self::AbsoluteUrl(base, path) => UrlString::from_parts(base, path).to_url(),
+        }
+    }
+}
+
+impl fmt::Debug for FileLocation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RelativeUrl(base, path) => f
+                .debug_tuple("RelativeUrl")
+                .field(base)
+                .field(path)
+                .finish(),
+            Self::AbsoluteUrl(base, path) => f
+                .debug_tuple("AbsoluteUrl")
+                .field(&UrlString::from_parts(base, path))
+                .finish(),
         }
     }
 }
@@ -180,9 +229,29 @@ impl Display for FileLocation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::RelativeUrl(_base, url) => Display::fmt(&url, f),
-            Self::AbsoluteUrl(url) => Display::fmt(&url.0, f),
+            Self::AbsoluteUrl(base, path) => write!(f, "{base}{path}"),
         }
     }
+}
+
+fn split_absolute_url(url: &str) -> Option<(&str, &str)> {
+    let (scheme, remainder) = split_scheme(url)?;
+
+    // `split_scheme` trims leading and trailing control characters and spaces. Preserve such URLs
+    // verbatim instead of reconstructing them from the trimmed slices.
+    if url.len() != scheme.len() + ":".len() + remainder.len() {
+        return Some((url, ""));
+    }
+
+    let base_len = if let Some(authority) = remainder.strip_prefix("//") {
+        authority
+            .find(['/', '?', '#'])
+            .map_or(url.len(), |index| scheme.len() + "://".len() + index)
+    } else {
+        scheme.len() + ":".len()
+    };
+
+    Some(url.split_at(base_len))
 }
 
 /// A [`Url`] represented as a `String`.
@@ -210,6 +279,14 @@ impl UrlString {
     /// Create a new [`UrlString`] from a [`String`].
     fn new(url: SmallString) -> Self {
         Self(url)
+    }
+
+    /// Construct a URL from its shared base and unique path.
+    pub fn from_parts(base: &str, path: &str) -> Self {
+        let mut url = String::with_capacity(base.len() + path.len());
+        url.push_str(base);
+        url.push_str(path);
+        Self::new(SmallString::from(url))
     }
 
     /// Converts a [`UrlString`] to a [`DisplaySafeUrl`].

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -1459,7 +1459,7 @@ impl Identifier for FileLocation {
             Self::RelativeUrl(base, url) => {
                 DistributionId::RelativeUrl(base.to_string(), url.to_string())
             }
-            Self::AbsoluteUrl(url) => DistributionId::AbsoluteUrl(url.to_string()),
+            Self::AbsoluteUrl(base, path) => DistributionId::AbsoluteUrl(format!("{base}{path}")),
         }
     }
 
@@ -1468,7 +1468,7 @@ impl Identifier for FileLocation {
             Self::RelativeUrl(base, url) => {
                 ResourceId::RelativeUrl(base.to_string(), url.to_string())
             }
-            Self::AbsoluteUrl(url) => ResourceId::AbsoluteUrl(url.to_string()),
+            Self::AbsoluteUrl(base, path) => ResourceId::AbsoluteUrl(format!("{base}{path}")),
         }
     }
 }

--- a/crates/uv-distribution-types/tests/rkyv.rs
+++ b/crates/uv-distribution-types/tests/rkyv.rs
@@ -1,12 +1,13 @@
-use uv_distribution_types::{ArchivedFileLocation, FileLocation};
+use uv_distribution_types::{ArchivedFileLocation, FileLocation, FileLocationBuilder};
 use uv_small_str::SmallString;
 
 #[test]
 fn archives_shared_relative_url_bases_once() -> Result<(), Box<dyn std::error::Error>> {
-    let base = SmallString::from("https://example.com/simple/package/");
+    let mut locations =
+        FileLocationBuilder::new(SmallString::from("https://example.com/simple/package/"));
     let locations = vec![
-        FileLocation::new(SmallString::from("one.whl"), &base),
-        FileLocation::new(SmallString::from("two.whl"), &base),
+        locations.parse(SmallString::from("one.whl")),
+        locations.parse(SmallString::from("two.whl")),
     ];
 
     let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&locations)?;
@@ -18,6 +19,47 @@ fn archives_shared_relative_url_bases_once() -> Result<(), Box<dyn std::error::E
             ArchivedFileLocation::RelativeUrl(second_base, _),
         ) => assert!(std::ptr::eq(first_base.get(), second_base.get())),
         _ => return Err(std::io::Error::other("expected relative URLs").into()),
+    }
+
+    assert_eq!(
+        rkyv::from_bytes::<Vec<FileLocation>, rkyv::rancor::Error>(&bytes)?,
+        locations
+    );
+
+    Ok(())
+}
+
+#[test]
+fn archives_shared_absolute_url_bases_once() -> Result<(), Box<dyn std::error::Error>> {
+    let mut locations =
+        FileLocationBuilder::new(SmallString::from("https://example.com/simple/package/"));
+    let locations = vec![
+        locations.parse(SmallString::from(
+            "https://files.pythonhosted.org/packages/one.whl?query#fragment",
+        )),
+        locations.parse(SmallString::from(
+            "https://files.pythonhosted.org/packages/two.whl",
+        )),
+    ];
+
+    assert_eq!(
+        locations[0].to_string(),
+        "https://files.pythonhosted.org/packages/one.whl?query#fragment"
+    );
+    assert_eq!(
+        locations[0].to_url()?.as_str(),
+        "https://files.pythonhosted.org/packages/one.whl?query#fragment"
+    );
+
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&locations)?;
+    let archived = rkyv::access::<rkyv::Archived<Vec<FileLocation>>, rkyv::rancor::Error>(&bytes)?;
+
+    match (&archived[0], &archived[1]) {
+        (
+            ArchivedFileLocation::AbsoluteUrl(first_base, _),
+            ArchivedFileLocation::AbsoluteUrl(second_base, _),
+        ) => assert!(std::ptr::eq(first_base.get(), second_base.get())),
+        _ => return Err(std::io::Error::other("expected absolute URLs").into()),
     }
 
     assert_eq!(

--- a/crates/uv-distribution-types/tests/rkyv.rs
+++ b/crates/uv-distribution-types/tests/rkyv.rs
@@ -1,0 +1,29 @@
+use uv_distribution_types::{ArchivedFileLocation, FileLocation};
+use uv_small_str::SmallString;
+
+#[test]
+fn archives_shared_relative_url_bases_once() -> Result<(), Box<dyn std::error::Error>> {
+    let base = SmallString::from("https://example.com/simple/package/");
+    let locations = vec![
+        FileLocation::new(SmallString::from("one.whl"), &base),
+        FileLocation::new(SmallString::from("two.whl"), &base),
+    ];
+
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&locations)?;
+    let archived = rkyv::access::<rkyv::Archived<Vec<FileLocation>>, rkyv::rancor::Error>(&bytes)?;
+
+    match (&archived[0], &archived[1]) {
+        (
+            ArchivedFileLocation::RelativeUrl(first_base, _),
+            ArchivedFileLocation::RelativeUrl(second_base, _),
+        ) => assert!(std::ptr::eq(first_base.get(), second_base.get())),
+        _ => return Err(std::io::Error::other("expected relative URLs").into()),
+    }
+
+    assert_eq!(
+        rkyv::from_bytes::<Vec<FileLocation>, rkyv::rancor::Error>(&bytes)?,
+        locations
+    );
+
+    Ok(())
+}

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1452,7 +1452,7 @@ impl PylockTomlWheel {
             requires_python: None,
             size: self.size,
             upload_time_utc_ms: self.upload_time.map(Timestamp::as_millisecond),
-            url: FileLocation::AbsoluteUrl(file_url),
+            url: FileLocation::absolute(file_url.as_ref()),
             yanked: None,
             zstd: None,
         });
@@ -1610,7 +1610,7 @@ impl PylockTomlSdist {
             requires_python: None,
             size: self.size,
             upload_time_utc_ms: self.upload_time.map(Timestamp::as_millisecond),
-            url: FileLocation::AbsoluteUrl(file_url),
+            url: FileLocation::absolute(file_url.as_ref()),
             yanked: None,
             zstd: None,
         });

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3577,7 +3577,7 @@ impl Package {
                     requires_python: None,
                     size: sdist.size(),
                     upload_time_utc_ms: sdist.upload_time().map(Timestamp::as_millisecond),
-                    url: FileLocation::AbsoluteUrl(file_url.clone()),
+                    url: FileLocation::absolute(file_url.as_ref()),
                     yanked: None,
                     zstd: None,
                 });
@@ -3610,7 +3610,7 @@ impl Package {
 
                 let file_url = match sdist {
                     SourceDist::Url { url: file_url, .. } => {
-                        FileLocation::AbsoluteUrl(file_url.clone())
+                        FileLocation::absolute(file_url.as_ref())
                     }
                     SourceDist::Path {
                         path: file_path, ..
@@ -3622,7 +3622,7 @@ impl Package {
                                     path: file_path.into_boxed_path(),
                                 }
                             })?;
-                        FileLocation::AbsoluteUrl(UrlString::from(file_url))
+                        FileLocation::absolute(file_url.as_str())
                     }
                     SourceDist::Metadata { .. } => {
                         return Err(LockErrorKind::MissingPath {
@@ -5470,7 +5470,7 @@ impl Wheel {
             RegistrySource::Url(url) => {
                 let file_location = match &self.url {
                     WheelWireSource::Url { url: file_url } => {
-                        FileLocation::AbsoluteUrl(file_url.clone())
+                        FileLocation::absolute(file_url.as_ref())
                     }
                     WheelWireSource::Path { .. } | WheelWireSource::Filename { .. } => {
                         return Err(LockErrorKind::MissingUrl {
@@ -5510,7 +5510,7 @@ impl Wheel {
             RegistrySource::Path(index_path) => {
                 let file_location = match &self.url {
                     WheelWireSource::Url { url: file_url } => {
-                        FileLocation::AbsoluteUrl(file_url.clone())
+                        FileLocation::absolute(file_url.as_ref())
                     }
                     WheelWireSource::Path { path: file_path } => {
                         let file_path = root.join(index_path).join(file_path);
@@ -5520,7 +5520,7 @@ impl Wheel {
                                     path: file_path.into_boxed_path(),
                                 }
                             })?;
-                        FileLocation::AbsoluteUrl(UrlString::from(file_url))
+                        FileLocation::absolute(file_url.as_str())
                     }
                     WheelWireSource::Filename { .. } => {
                         return Err(LockErrorKind::MissingPath {
@@ -5957,7 +5957,9 @@ impl From<Hash> for Hashes {
 /// Convert a [`FileLocation`] into a normalized [`UrlString`].
 fn normalize_file_location(location: &FileLocation) -> Result<UrlString, ToUrlError> {
     match location {
-        FileLocation::AbsoluteUrl(absolute) => Ok(absolute.without_fragment().into_owned()),
+        FileLocation::AbsoluteUrl(base, path) => Ok(UrlString::from_parts(base, path)
+            .without_fragment()
+            .into_owned()),
         FileLocation::RelativeUrl(_, _) => Ok(normalize_url(location.to_url()?)),
     }
 }

--- a/crates/uv-small-str/src/lib.rs
+++ b/crates/uv-small-str/src/lib.rs
@@ -144,6 +144,49 @@ impl PartialOrd<SmallString> for rkyv::string::ArchivedString {
     }
 }
 
+/// An [`rkyv`] adapter that archives [`SmallString`] values sharing an [`arcstr::ArcStr`]
+/// allocation once.
+pub struct RkyvShared;
+
+impl rkyv::with::ArchiveWith<SmallString> for RkyvShared {
+    type Archived = rkyv::rc::ArchivedRc<str, rkyv::rc::ArcFlavor>;
+    type Resolver = rkyv::rc::RcResolver;
+
+    fn resolve_with(
+        field: &SmallString,
+        resolver: Self::Resolver,
+        out: rkyv::Place<Self::Archived>,
+    ) {
+        rkyv::rc::ArchivedRc::resolve_from_ref(field.as_ref(), resolver, out);
+    }
+}
+
+impl<S> rkyv::with::SerializeWith<SmallString, S> for RkyvShared
+where
+    S: rkyv::rancor::Fallible + rkyv::ser::Sharing + rkyv::ser::Writer + ?Sized,
+    S::Error: rkyv::rancor::Source,
+{
+    fn serialize_with(field: &SmallString, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        rkyv::rc::ArchivedRc::<str, rkyv::rc::ArcFlavor>::serialize_from_ref(
+            field.as_ref(),
+            serializer,
+        )
+    }
+}
+
+impl<D> rkyv::with::DeserializeWith<rkyv::rc::ArchivedRc<str, rkyv::rc::ArcFlavor>, SmallString, D>
+    for RkyvShared
+where
+    D: rkyv::rancor::Fallible + ?Sized,
+{
+    fn deserialize_with(
+        field: &rkyv::rc::ArchivedRc<str, rkyv::rc::ArcFlavor>,
+        _deserializer: &mut D,
+    ) -> Result<SmallString, D::Error> {
+        Ok(SmallString::from(field.get()))
+    }
+}
+
 /// An [`schemars::JsonSchema`] implementation for [`SmallString`].
 #[cfg(feature = "schemars")]
 impl schemars::JsonSchema for SmallString {


### PR DESCRIPTION
## Summary

`SmallString` is backed by `ArcStr`, but its default rkyv implementation archives each value independently as an `ArchivedString`. Simple API responses clone the same base URL into every relative file location, so large responses write that allocation repeatedly.

This adds an opt-in `RkyvShared` adapter backed by `ArchivedRc<str, ArcFlavor>` and applies it to the base URL in `FileLocation::RelativeUrl`. Values that share the same `ArcStr` allocation now share one archived string; separately allocated equal strings remain distinct. Keeping the adapter opt-in avoids sending unique filenames, hashes, and other strings through rkyv's sharing table.

Because this changes the archived layout of `FileLocation`, the Simple and FlatIndex cache schemas advance to `simple-v22` and `flat-index-v3`.

## Performance

Across generated, real-shaped Simple API responses, the targeted representation made large archives 5.8–6.5% smaller. The 8,192-file fixture decreased from 3.10 MB to 2.90 MB, while the 100,000-file no-marker stress fixture decreased from 41.50 MB to 39.10 MB.

In profiling builds, the ten-response parse, group, and archive aggregate measured 9.41 ms, compared with surrounding baseline runs of 9.97 ms and 10.53 ms. Applying shared-pointer archival to every `SmallString` was rejected because it made the same path roughly 14% slower.

A regression test verifies that relative URL bases point to one archived string and still round-trip correctly. The focused relative-URL, Simple-cache cleanup, and remote find-links tests pass, along with uv-cache unit tests, formatting, and strict Clippy checks for the affected crates.