### PR TITLE
Sort Simple API files after grouping

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1505,6 +1505,16 @@ impl SimpleDetailMetadata {
             }
         }
 
+        // Keep file ordering deterministic without sorting the complete Simple API response.
+        for files in version_map.values_mut() {
+            files
+                .wheels
+                .sort_unstable_by(|left, right| left.file.filename.cmp(&right.file.filename));
+            files
+                .source_dists
+                .sort_unstable_by(|left, right| left.file.filename.cmp(&right.file.filename));
+        }
+
         Self {
             versions: version_map
                 .into_iter()
@@ -1713,7 +1723,7 @@ mod tests {
     use tokio::sync::Semaphore;
     use url::Url;
     use uv_normalize::PackageName;
-    use uv_pypi_types::PypiSimpleDetail;
+    use uv_pypi_types::{Hashes, ProjectStatus, PypiFile, PypiSimpleDetail};
     use uv_redacted::DisplaySafeUrl;
     use uv_torch::{TorchBackend, TorchSource, TorchStrategy};
 
@@ -2015,6 +2025,66 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn sort_pypi_files_after_grouping() {
+        let file = |filename: &str| PypiFile {
+            core_metadata: None,
+            filename: SmallString::from(filename),
+            hashes: Hashes::default(),
+            requires_python: None,
+            size: None,
+            upload_time: None,
+            url: SmallString::from(filename),
+            yanked: None,
+        };
+        let base = DisplaySafeUrl::parse("https://example.com/simple/demo/").unwrap();
+        let simple_metadata = SimpleDetailMetadata::from_pypi_files(
+            vec![
+                file("demo-1.0.zip"),
+                file("demo-1.0-py3-none-any.whl"),
+                file("demo-1.0.tar.gz"),
+                file("demo-1.0-py2.py3-none-any.whl"),
+            ],
+            &PackageName::from_str("demo").unwrap(),
+            ProjectStatus::default(),
+            &base,
+        );
+        let files = simple_metadata
+            .iter()
+            .map(|metadatum| {
+                (
+                    metadatum
+                        .files
+                        .wheels
+                        .iter()
+                        .map(|wheel| wheel.file.filename.as_ref())
+                        .collect::<Vec<_>>(),
+                    metadatum
+                        .files
+                        .source_dists
+                        .iter()
+                        .map(|source_dist| source_dist.file.filename.as_ref())
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        insta::assert_debug_snapshot!(files, @r#"
+        [
+            (
+                [
+                    "demo-1.0-py2.py3-none-any.whl",
+                    "demo-1.0-py3-none-any.whl",
+                ],
+                [
+                    "demo-1.0.tar.gz",
+                    "demo-1.0.zip",
+                ],
+            ),
+        ]
+        "#);
     }
 
     #[test]

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1723,7 +1723,7 @@ mod tests {
     use tokio::sync::Semaphore;
     use url::Url;
     use uv_normalize::PackageName;
-    use uv_pypi_types::{Hashes, ProjectStatus, PypiFile, PypiSimpleDetail};
+    use uv_pypi_types::PypiSimpleDetail;
     use uv_redacted::DisplaySafeUrl;
     use uv_torch::{TorchBackend, TorchSource, TorchStrategy};
 
@@ -2025,66 +2025,6 @@ mod tests {
         );
 
         Ok(())
-    }
-
-    #[test]
-    fn sort_pypi_files_after_grouping() {
-        let file = |filename: &str| PypiFile {
-            core_metadata: None,
-            filename: SmallString::from(filename),
-            hashes: Hashes::default(),
-            requires_python: None,
-            size: None,
-            upload_time: None,
-            url: SmallString::from(filename),
-            yanked: None,
-        };
-        let base = DisplaySafeUrl::parse("https://example.com/simple/demo/").unwrap();
-        let simple_metadata = SimpleDetailMetadata::from_pypi_files(
-            vec![
-                file("demo-1.0.zip"),
-                file("demo-1.0-py3-none-any.whl"),
-                file("demo-1.0.tar.gz"),
-                file("demo-1.0-py2.py3-none-any.whl"),
-            ],
-            &PackageName::from_str("demo").unwrap(),
-            ProjectStatus::default(),
-            &base,
-        );
-        let files = simple_metadata
-            .iter()
-            .map(|metadatum| {
-                (
-                    metadatum
-                        .files
-                        .wheels
-                        .iter()
-                        .map(|wheel| wheel.file.filename.as_ref())
-                        .collect::<Vec<_>>(),
-                    metadatum
-                        .files
-                        .source_dists
-                        .iter()
-                        .map(|source_dist| source_dist.file.filename.as_ref())
-                        .collect::<Vec<_>>(),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        insta::assert_debug_snapshot!(files, @r#"
-        [
-            (
-                [
-                    "demo-1.0-py2.py3-none-any.whl",
-                    "demo-1.0-py3-none-any.whl",
-                ],
-                [
-                    "demo-1.0.tar.gz",
-                    "demo-1.0.zip",
-                ],
-            ),
-        ]
-        "#);
     }
 
     #[test]

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -21,25 +21,8 @@ pub struct PypiSimpleDetail {
     /// PEP 792 project status information.
     #[serde(default)]
     pub project_status: ProjectStatus,
-    /// The list of [`PypiFile`]s available for download sorted by filename.
-    #[serde(deserialize_with = "sorted_simple_json_files")]
+    /// The list of [`PypiFile`]s available for download.
     pub files: Vec<PypiFile>,
-}
-
-/// Deserializes a sequence of "simple" files from `PyPI` and ensures that they
-/// are sorted in a stable order.
-fn sorted_simple_json_files<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<PypiFile>, D::Error> {
-    let mut files = <Vec<PypiFile>>::deserialize(d)?;
-    // While it has not been positively observed, we sort the files
-    // to ensure we have a defined ordering. Otherwise, if we rely on
-    // the API to provide a stable ordering and doesn't, it can lead
-    // non-deterministic behavior elsewhere. (This is somewhat hand-wavy
-    // and a bit of a band-aide, since arguably, the order of this API
-    // response probably shouldn't have an impact on things downstream from
-    // this. That is, if something depends on ordering, then it should
-    // probably be the thing that does the sorting.)
-    files.sort_unstable_by(|f1, f2| f1.filename.cmp(&f2.filename));
-    Ok(files)
 }
 
 /// A single (remote) file belonging to a package, either a wheel or a source distribution, as


### PR DESCRIPTION
## Summary

Simple JSON responses are currently sorted in full by filename during deserialization to guarantee deterministic downstream ordering. We immediately group those files by parsed version and distribution kind, and consumers only observe the resulting per-version wheel and source-distribution lists.

This moves the filename sort to those final lists. Versions remain ordered by the existing `BTreeMap`, while wheels and source distributions remain deterministically ordered by filename. Sorting after grouping avoids comparisons across unrelated versions and excludes invalid files before sorting.
