### PR TITLE
Route operation diagnostics through the printer

### DIFF
--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 
@@ -77,11 +78,16 @@ impl OperationDiagnostic {
 
     /// Attempt to report an error with rich diagnostic context.
     ///
-    /// Returns `Some` if the error was not handled.
-    pub(crate) fn report(self, err: pip::operations::Error) -> Option<pip::operations::Error> {
+    /// Returns `Some` if the error was not handled, or an error if the diagnostic could not be
+    /// written to the provided stream.
+    pub(crate) fn report(
+        self,
+        err: pip::operations::Error,
+        mut stream: impl Write,
+    ) -> Result<Option<pip::operations::Error>, std::fmt::Error> {
         let result = match err {
             pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(err)) => {
-                no_solution(&err, self.context);
+                no_solution(&err, self.context, &mut stream)?;
                 None
             }
             pip::operations::Error::Resolve(uv_resolver::ResolveError::Dist(
@@ -90,7 +96,7 @@ impl OperationDiagnostic {
                 chain,
                 err,
             )) => {
-                requested_dist_error(kind, dist, &chain, err);
+                requested_dist_error(kind, dist, &chain, err, &mut stream)?;
                 None
             }
             pip::operations::Error::Resolve(uv_resolver::ResolveError::Dependencies(
@@ -99,11 +105,17 @@ impl OperationDiagnostic {
                 version,
                 chain,
             )) => {
-                dependencies_error(error, &name, &version, &chain);
+                dependencies_error(error, &name, &version, &chain, &mut stream)?;
                 None
             }
             pip::operations::Error::Requirements(uv_requirements::Error::Dist(kind, dist, err)) => {
-                dist_error(kind, dist, &DerivationChain::default(), Arc::new(*err));
+                dist_error(
+                    kind,
+                    dist,
+                    &DerivationChain::default(),
+                    Arc::new(*err),
+                    &mut stream,
+                )?;
                 None
             }
             pip::operations::Error::Prepare(uv_installer::PrepareError::Dist(
@@ -112,14 +124,14 @@ impl OperationDiagnostic {
                 chain,
                 err,
             )) => {
-                dist_error(kind, dist, &chain, Arc::new(*err));
+                dist_error(kind, dist, &chain, Arc::new(*err), &mut stream)?;
                 None
             }
             pip::operations::Error::Requirements(err) => {
                 if let Some(context) = self.context {
                     let err = miette::Report::msg(format!("{err}"))
                         .context(format!("Failed to resolve {context} requirement"));
-                    anstream::eprint!("{err:?}");
+                    write!(stream, "{err:?}")?;
                     None
                 } else {
                     Some(pip::operations::Error::Requirements(err))
@@ -128,11 +140,11 @@ impl OperationDiagnostic {
             pip::operations::Error::Resolve(uv_resolver::ResolveError::Client(err))
                 if !self.system_certs && err.is_ssl() =>
             {
-                system_certs_hint(err);
+                system_certs_hint(err, &mut stream)?;
                 None
             }
             err @ pip::operations::Error::OutdatedEnvironment(..) => {
-                anstream::eprintln!("{}", err);
+                writeln!(stream, "{err}")?;
                 None
             }
             err => Some(err),
@@ -141,10 +153,10 @@ impl OperationDiagnostic {
         // Render the caller-provided hints after the error output.
         if result.is_none() {
             let hints: Hints<'_> = self.hints.into_iter().collect();
-            anstream::eprint!("{hints}");
+            write!(stream, "{hints}")?;
         }
 
-        result
+        Ok(result)
     }
 }
 
@@ -156,7 +168,8 @@ fn dist_error(
     dist: Box<Dist>,
     chain: &DerivationChain,
     cause: Arc<uv_distribution::Error>,
-) {
+    stream: &mut impl Write,
+) -> std::fmt::Result {
     #[derive(Debug, miette::Diagnostic, thiserror::Error)]
     #[error("{kind} `{dist}`")]
     #[diagnostic()]
@@ -169,8 +182,8 @@ fn dist_error(
 
     let hints = dist_hints(dist.name(), dist.version(), chain, cause.hints());
     let report = miette::Report::new(Diagnostic { kind, dist, cause });
-    anstream::eprint!("{report:?}");
-    anstream::eprint!("{hints}");
+    write!(stream, "{report:?}")?;
+    write!(stream, "{hints}")
 }
 
 /// Render a requested distribution failure (read, download or build) with a help message.
@@ -181,7 +194,8 @@ fn requested_dist_error(
     dist: Box<RequestedDist>,
     chain: &DerivationChain,
     cause: Arc<uv_distribution::Error>,
-) {
+    stream: &mut impl Write,
+) -> std::fmt::Result {
     #[derive(Debug, miette::Diagnostic, thiserror::Error)]
     #[error("{kind} `{dist}`")]
     #[diagnostic()]
@@ -194,8 +208,8 @@ fn requested_dist_error(
 
     let hints = dist_hints(dist.name(), dist.version(), chain, cause.hints());
     let report = miette::Report::new(Diagnostic { kind, dist, cause });
-    anstream::eprint!("{report:?}");
-    anstream::eprint!("{hints}");
+    write!(stream, "{report:?}")?;
+    write!(stream, "{hints}")
 }
 
 /// Render an error in fetching a package's dependencies.
@@ -206,7 +220,8 @@ fn dependencies_error(
     name: &PackageName,
     version: &Version,
     chain: &DerivationChain,
-) {
+    stream: &mut impl Write,
+) -> std::fmt::Result {
     #[derive(Debug, miette::Diagnostic, thiserror::Error)]
     #[error("Failed to resolve dependencies for `{}` ({})", name.cyan(), format!("v{version}").cyan())]
     #[diagnostic()]
@@ -223,27 +238,31 @@ fn dependencies_error(
         version: version.clone(),
         cause: error,
     });
-    anstream::eprint!("{report:?}");
-    anstream::eprint!("{hints}");
+    write!(stream, "{report:?}")?;
+    write!(stream, "{hints}")
 }
 
 /// Render a [`uv_resolver::NoSolutionError`].
-fn no_solution(err: &uv_resolver::NoSolutionError, context: Option<&'static str>) {
+fn no_solution(
+    err: &uv_resolver::NoSolutionError,
+    context: Option<&'static str>,
+    stream: &mut impl Write,
+) -> std::fmt::Result {
     let header = if let Some(context) = context {
         err.header().with_context(context)
     } else {
         err.header()
     };
     let report = miette::Report::msg(err.report().to_string()).context(header);
-    anstream::eprint!("{report:?}");
+    write!(stream, "{report:?}")?;
     let hints = err.hints();
-    anstream::eprint!("{hints}");
+    write!(stream, "{hints}")
 }
 
 /// Render a TLS error with a hint to enable native TLS.
 // https://github.com/rust-lang/rust/issues/147648
 #[allow(unused_assignments)]
-fn system_certs_hint(err: uv_client::Error) {
+fn system_certs_hint(err: uv_client::Error, stream: &mut impl Write) -> std::fmt::Result {
     #[derive(Debug, miette::Diagnostic)]
     #[diagnostic()]
     struct Error {
@@ -274,7 +293,7 @@ fn system_certs_hint(err: uv_client::Error) {
             "--system-certs".green()
         ),
     });
-    anstream::eprint!("{report:?}");
+    write!(stream, "{report:?}")
 }
 
 /// Walk an error chain and collect hint strings from all known error types.
@@ -472,7 +491,26 @@ mod tests {
 
     use uv_workspace::pyproject::{PyprojectTomlError, SourceError};
 
-    use super::hints_for_error;
+    use super::{OperationDiagnostic, hints_for_error};
+    use crate::commands::pip;
+
+    #[test]
+    fn propagates_writer_errors() {
+        struct FailingWriter;
+
+        impl std::fmt::Write for FailingWriter {
+            fn write_str(&mut self, _value: &str) -> std::fmt::Result {
+                Err(std::fmt::Error)
+            }
+        }
+
+        let result = OperationDiagnostic::default().report(
+            pip::operations::Error::OutdatedEnvironment(Box::default()),
+            FailingWriter,
+        );
+
+        assert!(result.is_err());
+    }
 
     #[test]
     fn collects_source_hints_through_pyproject_errors() {

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -23,6 +23,7 @@ use crate::commands::project::run::RecursionLimitError;
 use crate::commands::project::version::MissingProjectVersionError;
 use crate::commands::tool::common::NoExecutablesError;
 use crate::commands::tool::run::ToolRunScriptError;
+use crate::printer::Printer;
 
 static SUGGESTIONS: LazyLock<FxHashMap<PackageName, PackageName>> = LazyLock::new(|| {
     let suggestions: Vec<(String, String)> =
@@ -79,8 +80,17 @@ impl OperationDiagnostic {
     /// Attempt to report an error with rich diagnostic context.
     ///
     /// Returns `Some` if the error was not handled, or an error if the diagnostic could not be
-    /// written to the provided stream.
+    /// written.
     pub(crate) fn report(
+        self,
+        err: pip::operations::Error,
+        printer: Printer,
+    ) -> Result<Option<pip::operations::Error>, std::fmt::Error> {
+        self.report_to(err, printer.stderr_important())
+    }
+
+    /// Attempt to report an error to the provided stream.
+    fn report_to(
         self,
         err: pip::operations::Error,
         mut stream: impl Write,
@@ -491,26 +501,7 @@ mod tests {
 
     use uv_workspace::pyproject::{PyprojectTomlError, SourceError};
 
-    use super::{OperationDiagnostic, hints_for_error};
-    use crate::commands::pip;
-
-    #[test]
-    fn propagates_writer_errors() {
-        struct FailingWriter;
-
-        impl std::fmt::Write for FailingWriter {
-            fn write_str(&mut self, _value: &str) -> std::fmt::Result {
-                Err(std::fmt::Error)
-            }
-        }
-
-        let result = OperationDiagnostic::default().report(
-            pip::operations::Error::OutdatedEnvironment(Box::default()),
-            FailingWriter,
-        );
-
-        assert!(result.is_err());
-    }
+    use super::hints_for_error;
 
     #[test]
     fn collects_source_hints_through_pyproject_errors() {

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -604,7 +604,7 @@ pub(crate) async fn pip_compile(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
     };

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -604,7 +604,7 @@ pub(crate) async fn pip_compile(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
     };

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -585,7 +585,7 @@ pub(crate) async fn pip_install(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
         };
@@ -657,7 +657,7 @@ pub(crate) async fn pip_install(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
     }

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -585,7 +585,7 @@ pub(crate) async fn pip_install(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
         };
@@ -657,7 +657,7 @@ pub(crate) async fn pip_install(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
     }

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -489,7 +489,7 @@ pub(crate) async fn pip_sync(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
         };
@@ -558,7 +558,7 @@ pub(crate) async fn pip_sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
     }

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -489,7 +489,7 @@ pub(crate) async fn pip_sync(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
         };
@@ -558,7 +558,7 @@ pub(crate) async fn pip_sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
     }

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -795,7 +795,7 @@ pub(crate) async fn add(
                     };
                     diagnostic
                         .with_hint(format!("If you want to add the package regardless of the failed resolution, provide the `{}` flag to skip locking and syncing", "--frozen".green()))
-                        .report(err, printer.stderr_important())?
+                        .report(err, printer)?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
                 }
                 err => Err(err.into()),

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -795,7 +795,7 @@ pub(crate) async fn add(
                     };
                     diagnostic
                         .with_hint(format!("If you want to add the package regardless of the failed resolution, provide the `{}` flag to skip locking and syncing", "--frozen".green()))
-                        .report(err)
+                        .report(err, printer.stderr_important())?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
                 }
                 err => Err(err.into()),

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -200,7 +200,7 @@ pub(crate) async fn audit(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -200,7 +200,7 @@ pub(crate) async fn audit(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -298,7 +298,7 @@ pub(crate) async fn check(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
@@ -357,7 +357,7 @@ pub(crate) async fn check(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
@@ -491,7 +491,7 @@ pub(crate) async fn check(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
@@ -565,7 +565,7 @@ pub(crate) async fn check(
                         return diagnostics::OperationDiagnostic::with_system_certs(
                             client_builder.system_certs(),
                         )
-                        .report(err, printer.stderr_important())?
+                        .report(err, printer)?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -609,7 +609,7 @@ pub(crate) async fn check(
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
-                    .report(err, printer.stderr_important())?
+                    .report(err, printer)?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -298,7 +298,7 @@ pub(crate) async fn check(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
@@ -357,7 +357,7 @@ pub(crate) async fn check(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
@@ -491,7 +491,7 @@ pub(crate) async fn check(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
@@ -565,7 +565,7 @@ pub(crate) async fn check(
                         return diagnostics::OperationDiagnostic::with_system_certs(
                             client_builder.system_certs(),
                         )
-                        .report(err)
+                        .report(err, printer.stderr_important())?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -609,7 +609,7 @@ pub(crate) async fn check(
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
-                    .report(err)
+                    .report(err, printer.stderr_important())?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -238,7 +238,7 @@ pub(crate) async fn export(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -238,7 +238,7 @@ pub(crate) async fn export(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -275,7 +275,7 @@ pub(crate) async fn lock(
         }
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
         Err(err) => Err(err.into()),

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -275,7 +275,7 @@ pub(crate) async fn lock(
         }
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
         Err(err) => Err(err.into()),

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -336,7 +336,7 @@ pub(crate) async fn remove(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
@@ -396,7 +396,7 @@ pub(crate) async fn remove(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -336,7 +336,7 @@ pub(crate) async fn remove(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
@@ -396,7 +396,7 @@ pub(crate) async fn remove(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -265,7 +265,7 @@ pub(crate) async fn run(
                         client_builder.system_certs(),
                     )
                     .with_context("script")
-                    .report(err)
+                    .report(err, printer.stderr_important())?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
@@ -313,7 +313,7 @@ pub(crate) async fn run(
                         client_builder.system_certs(),
                     )
                     .with_context("script")
-                    .report(err)
+                    .report(err, printer.stderr_important())?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
@@ -452,7 +452,7 @@ pub(crate) async fn run(
                             client_builder.system_certs(),
                         )
                         .with_context("script")
-                        .report(err)
+                        .report(err, printer.stderr_important())?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -778,7 +778,7 @@ pub(crate) async fn run(
                         return diagnostics::OperationDiagnostic::with_system_certs(
                             client_builder.system_certs(),
                         )
-                        .report(err)
+                        .report(err, printer.stderr_important())?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -867,7 +867,7 @@ pub(crate) async fn run(
                         return diagnostics::OperationDiagnostic::with_system_certs(
                             client_builder.system_certs(),
                         )
-                        .report(err)
+                        .report(err, printer.stderr_important())?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -1022,7 +1022,7 @@ pub(crate) async fn run(
                         client_builder.system_certs(),
                     )
                     .with_context("`--with`")
-                    .report(err)
+                    .report(err, printer.stderr_important())?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -265,7 +265,7 @@ pub(crate) async fn run(
                         client_builder.system_certs(),
                     )
                     .with_context("script")
-                    .report(err, printer.stderr_important())?
+                    .report(err, printer)?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
@@ -313,7 +313,7 @@ pub(crate) async fn run(
                         client_builder.system_certs(),
                     )
                     .with_context("script")
-                    .report(err, printer.stderr_important())?
+                    .report(err, printer)?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
@@ -452,7 +452,7 @@ pub(crate) async fn run(
                             client_builder.system_certs(),
                         )
                         .with_context("script")
-                        .report(err, printer.stderr_important())?
+                        .report(err, printer)?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -778,7 +778,7 @@ pub(crate) async fn run(
                         return diagnostics::OperationDiagnostic::with_system_certs(
                             client_builder.system_certs(),
                         )
-                        .report(err, printer.stderr_important())?
+                        .report(err, printer)?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -867,7 +867,7 @@ pub(crate) async fn run(
                         return diagnostics::OperationDiagnostic::with_system_certs(
                             client_builder.system_certs(),
                         )
-                        .report(err, printer.stderr_important())?
+                        .report(err, printer)?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -1022,7 +1022,7 @@ pub(crate) async fn run(
                         client_builder.system_certs(),
                     )
                     .with_context("`--with`")
-                    .report(err, printer.stderr_important())?
+                    .report(err, printer)?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -314,14 +314,17 @@ pub(crate) async fn sync(
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
-                    .report(operations::Error::OutdatedEnvironment(changelog))
+                    .report(
+                        operations::Error::OutdatedEnvironment(changelog),
+                        printer.stderr_important(),
+                    )?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(ProjectError::Operation(err)) => {
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
-                    .report(err)
+                    .report(err, printer.stderr_important())?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
@@ -370,7 +373,7 @@ pub(crate) async fn sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(ProjectError::LockMismatch(prev, cur, lock_source)) => {
@@ -458,14 +461,17 @@ pub(crate) async fn sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(operations::Error::OutdatedEnvironment(changelog))
+            .report(
+                operations::Error::OutdatedEnvironment(changelog),
+                printer.stderr_important(),
+            )?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(ProjectError::Operation(err)) => {
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -314,17 +314,14 @@ pub(crate) async fn sync(
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
-                    .report(
-                        operations::Error::OutdatedEnvironment(changelog),
-                        printer.stderr_important(),
-                    )?
+                    .report(operations::Error::OutdatedEnvironment(changelog), printer)?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(ProjectError::Operation(err)) => {
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
-                    .report(err, printer.stderr_important())?
+                    .report(err, printer)?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
@@ -373,7 +370,7 @@ pub(crate) async fn sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(ProjectError::LockMismatch(prev, cur, lock_source)) => {
@@ -461,17 +458,14 @@ pub(crate) async fn sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(
-                operations::Error::OutdatedEnvironment(changelog),
-                printer.stderr_important(),
-            )?
+            .report(operations::Error::OutdatedEnvironment(changelog), printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(ProjectError::Operation(err)) => {
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -172,7 +172,7 @@ pub(crate) async fn tree(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -172,7 +172,7 @@ pub(crate) async fn tree(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -169,7 +169,7 @@ pub(crate) async fn upgrade(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -169,7 +169,7 @@ pub(crate) async fn upgrade(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -546,7 +546,7 @@ async fn print_frozen_version(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
@@ -695,7 +695,7 @@ async fn lock_and_sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
@@ -757,7 +757,7 @@ async fn lock_and_sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err)
+            .report(err, printer.stderr_important())?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -546,7 +546,7 @@ async fn print_frozen_version(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
@@ -695,7 +695,7 @@ async fn lock_and_sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
@@ -757,7 +757,7 @@ async fn lock_and_sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
-            .report(err, printer.stderr_important())?
+            .report(err, printer)?
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -731,7 +731,7 @@ pub(crate) async fn install(
                         return diagnostics::OperationDiagnostic::with_system_certs(
                             client_builder.system_certs(),
                         )
-                        .report(err, printer.stderr_important())?
+                        .report(err, printer)?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -864,7 +864,7 @@ pub(crate) async fn install(
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
-                    .report(err, printer.stderr_important())?
+                    .report(err, printer)?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
@@ -957,7 +957,7 @@ pub(crate) async fn install(
                             return diagnostics::OperationDiagnostic::with_system_certs(
                                 client_builder.system_certs(),
                             )
-                            .report(err, printer.stderr_important())?
+                            .report(err, printer)?
                             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                         };
 
@@ -993,7 +993,7 @@ pub(crate) async fn install(
                                 return diagnostics::OperationDiagnostic::with_system_certs(
                                     client_builder.system_certs(),
                                 )
-                                .report(err, printer.stderr_important())?
+                                .report(err, printer)?
                                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                             }
                             Err(err) => return Err(err.into()),
@@ -1057,7 +1057,7 @@ pub(crate) async fn install(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -731,7 +731,7 @@ pub(crate) async fn install(
                         return diagnostics::OperationDiagnostic::with_system_certs(
                             client_builder.system_certs(),
                         )
-                        .report(err)
+                        .report(err, printer.stderr_important())?
                         .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
@@ -864,7 +864,7 @@ pub(crate) async fn install(
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
-                    .report(err)
+                    .report(err, printer.stderr_important())?
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
@@ -957,7 +957,7 @@ pub(crate) async fn install(
                             return diagnostics::OperationDiagnostic::with_system_certs(
                                 client_builder.system_certs(),
                             )
-                            .report(err)
+                            .report(err, printer.stderr_important())?
                             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                         };
 
@@ -993,7 +993,7 @@ pub(crate) async fn install(
                                 return diagnostics::OperationDiagnostic::with_system_certs(
                                     client_builder.system_certs(),
                                 )
-                                .report(err)
+                                .report(err, printer.stderr_important())?
                                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                             }
                             Err(err) => return Err(err.into()),
@@ -1057,7 +1057,7 @@ pub(crate) async fn install(
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),
                 )
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -281,7 +281,7 @@ pub(crate) async fn run(
                     format!("uvx {rest}").green()
                 ))
                 .with_context("tool")
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
 
@@ -299,7 +299,7 @@ pub(crate) async fn run(
                 diagnostic.with_context("tool")
             };
             return diagnostic
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
 

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -281,7 +281,7 @@ pub(crate) async fn run(
                     format!("uvx {rest}").green()
                 ))
                 .with_context("tool")
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
             }
 
@@ -299,7 +299,7 @@ pub(crate) async fn run(
                 diagnostic.with_context("tool")
             };
             return diagnostic
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
 

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -243,7 +243,7 @@ pub(crate) async fn metadata(
         }
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
-                .report(err)
+                .report(err, printer.stderr_important())?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
         Err(err) => Err(err.into()),

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -243,7 +243,7 @@ pub(crate) async fn metadata(
         }
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
-                .report(err, printer.stderr_important())?
+                .report(err, printer)?
                 .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
         Err(err) => Err(err.into()),

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -52,8 +52,7 @@ impl Printer {
         }
     }
 
-    /// Return the [`Stderr`] for this printer.
-    #[allow(dead_code)] // Only used with the optional self-update feature.
+    /// Return the [`Stderr`] for this printer, preserving stderr in quiet mode.
     pub(crate) fn stderr_important(self) -> Stderr {
         match self {
             Self::Silent => Stderr::Disabled,

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -29920,6 +29920,28 @@ fn lock_self_incompatible() -> Result<()> {
     hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
     ");
 
+    // Resolution errors are important and should still be shown in quiet mode.
+    uv_snapshot!(context.filters(), context.lock().arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because your project depends on itself at an incompatible version (project==0.2.0), we can conclude that your project's requirements are unsatisfiable.
+
+    hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
+    ");
+
+    // Silent mode should suppress even important diagnostics.
+    uv_snapshot!(context.filters(), context.lock().arg("--quiet").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`OperationDiagnostic` currently renders rich resolution and installation errors with `anstream::eprint!`, bypassing `Printer`. As a result, these diagnostics are still emitted under `-qq` even though it selects silent mode.

This routes operation diagnostics through the caller's `Printer`. `OperationDiagnostic::report` selects `stderr_important()` internally, so diagnostics remain visible under `-q` while respecting `-qq`. The rendering helpers now write to the selected stream and propagate formatting errors, and callers pass the printer directly.
