### PR TITLE
Route final errors through the printer

### DIFF
--- a/crates/uv/src/child.rs
+++ b/crates/uv/src/child.rs
@@ -284,7 +284,7 @@ pub(crate) async fn run_to_completion(mut handle: Child) -> anyhow::Result<ExitS
     if let Some(code) = status.code() {
         debug!("Command exited with code: {code}");
         if let Ok(code) = u8::try_from(code) {
-            Ok(ExitStatus::External(code))
+            Ok(ExitStatus::external(code))
         } else {
             #[expect(clippy::exit)]
             std::process::exit(code);
@@ -301,9 +301,9 @@ pub(crate) async fn run_to_completion(mut handle: Child) -> anyhow::Result<ExitS
                 .and_then(|signal| u8::try_from(signal).ok())
                 .and_then(|signal| 128u8.checked_add(signal))
             {
-                return Ok(ExitStatus::External(mapped_code));
+                return Ok(ExitStatus::external(mapped_code));
             }
         }
-        Ok(ExitStatus::Failure)
+        Ok(ExitStatus::FAILURE)
     }
 }

--- a/crates/uv/src/commands/auth/helper.rs
+++ b/crates/uv/src/commands/auth/helper.rs
@@ -144,5 +144,5 @@ pub(crate) async fn helper(
     )
     .context("Failed to serialize response as JSON")?;
     writeln!(printer.stdout_important(), "{response}")?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/auth/login.rs
+++ b/crates/uv/src/commands/auth/login.rs
@@ -57,7 +57,7 @@ pub(crate) async fn login(
             )?;
         }
 
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     let backend = AuthBackend::from_settings(preview).await?;
@@ -174,7 +174,7 @@ pub(crate) async fn login(
         "Stored credentials for {}",
         display_url.bold().cyan()
     )?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Log in via the [`PyxTokenStore`].

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -89,7 +89,7 @@ pub(crate) async fn logout(
         display_url.bold().cyan()
     )?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Log out via the [`PyxTokenStore`], invalidating the existing tokens.
@@ -108,7 +108,7 @@ async fn pyx_logout(
             "{}",
             format_args!("No credentials found for {}", store.api().bold().cyan())
         )?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     };
 
     // Add the token to the request.
@@ -149,5 +149,5 @@ async fn pyx_logout(
         format_args!("Logged out from {}", store.api().bold().cyan())
     )?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -30,7 +30,7 @@ pub(crate) async fn token(
             .build()?;
 
         pyx_refresh(&pyx_store, &client, printer).await?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     let backend = AuthBackend::from_settings(preview).await?;
@@ -83,7 +83,7 @@ pub(crate) async fn token(
     };
 
     writeln!(printer.stdout(), "{password}")?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Refresh the authentication tokens in the [`PyxTokenStore`], prompting for login if necessary.

--- a/crates/uv/src/commands/build_backend.rs
+++ b/crates/uv/src/commands/build_backend.rs
@@ -14,7 +14,7 @@ pub(crate) fn build_sdist(sdist_directory: &Path) -> Result<ExitStatus> {
     )?;
     // Tell the build frontend about the name of the artifact we built
     writeln!(&mut std::io::stdout(), "{filename}").context("stdout is closed")?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// PEP 517 hook to build a wheel.
@@ -31,7 +31,7 @@ pub(crate) fn build_wheel(
     )?;
     // Tell the build frontend about the name of the artifact we built
     writeln!(&mut std::io::stdout(), "{filename}").context("stdout is closed")?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// PEP 660 hook to build a wheel.
@@ -48,7 +48,7 @@ pub(crate) fn build_editable(
     )?;
     // Tell the build frontend about the name of the artifact we built
     writeln!(&mut std::io::stdout(), "{filename}").context("stdout is closed")?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Not used from Python code, exists for symmetry with PEP 517.
@@ -70,7 +70,7 @@ pub(crate) fn prepare_metadata_for_build_wheel(metadata_directory: &Path) -> Res
     )?;
     // Tell the build frontend about the name of the artifact we built
     writeln!(&mut std::io::stdout(), "{filename}").context("stdout is closed")?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Not used from Python code, exists for symmetry with PEP 660.
@@ -87,5 +87,5 @@ pub(crate) fn prepare_metadata_for_build_editable(metadata_directory: &Path) -> 
     )?;
     // Tell the build frontend about the name of the artifact we built
     writeln!(&mut std::io::stdout(), "{filename}").context("stdout is closed")?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -175,8 +175,8 @@ pub(crate) async fn build_frontend(
     .await?;
 
     match build_result {
-        BuildResult::Failure => Ok(ExitStatus::Error),
-        BuildResult::Success => Ok(ExitStatus::Success),
+        BuildResult::Failure => Ok(ExitStatus::ERROR),
+        BuildResult::Success => Ok(ExitStatus::SUCCESS),
     }
 }
 

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -25,7 +25,7 @@ pub(crate) async fn cache_clean(
             "No cache found at: {}",
             cache.root().user_display().cyan()
         )?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     let cache = match cache.with_exclusive_lock_no_wait() {
@@ -103,5 +103,5 @@ pub(crate) async fn cache_clean(
 
     writeln!(printer.stderr())?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/cache_dir.rs
+++ b/crates/uv/src/commands/cache_dir.rs
@@ -14,5 +14,5 @@ pub(crate) fn cache_dir(cache: &Cache, printer: Printer) -> anyhow::Result<ExitS
         "{}",
         cache.root().simplified_display().cyan()
     )?;
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/cache_prune.rs
+++ b/crates/uv/src/commands/cache_prune.rs
@@ -23,7 +23,7 @@ pub(crate) async fn cache_prune(
             "No cache found at: {}",
             cache.root().user_display().cyan()
         )?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     let cache = match cache.with_exclusive_lock_no_wait() {
@@ -90,5 +90,5 @@ pub(crate) async fn cache_prune(
 
     writeln!(printer.stderr())?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/cache_size.rs
+++ b/crates/uv/src/commands/cache_size.rs
@@ -29,7 +29,7 @@ pub(crate) fn cache_size(
         } else {
             writeln!(printer.stdout_important(), "0")?;
         }
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     let disk_usage = DiskUsage::new(vec![cache.root().to_path_buf()]);
@@ -43,5 +43,5 @@ pub(crate) fn cache_size(
         writeln!(printer.stdout_important(), "{total_bytes}")?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/help.rs
+++ b/crates/uv/src/commands/help.rs
@@ -111,7 +111,7 @@ pub(crate) fn help(query: &[String], printer: Printer, no_pager: bool) -> Result
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Get the first non-ANSI character starting at a given byte position.

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -101,41 +101,46 @@ mod venv;
 mod workspace;
 
 #[derive(Debug)]
-pub(crate) enum ExitStatus {
-    /// The command succeeded.
-    Success,
-
-    /// The command failed due to an error in the user input.
-    Failure,
-
-    /// The command failed with an unexpected error.
-    Error,
-
-    /// The command's exit status is propagated from an external command.
-    External(u8),
-
-    /// The command failed with an error that should be rendered before exiting.
-    WithError { code: u8, error: anyhow::Error },
+pub(crate) struct ExitStatus {
+    code: u8,
+    error: Option<anyhow::Error>,
 }
 
 impl ExitStatus {
-    /// Return an expected command failure with an error to render.
-    pub(crate) fn failure(error: impl Into<anyhow::Error>) -> Self {
-        Self::WithError {
+    /// The command succeeded.
+    pub(crate) const SUCCESS: Self = Self {
+        code: 0,
+        error: None,
+    };
+
+    /// The command failed due to an error in the user input.
+    pub(crate) const FAILURE: Self = Self {
+        code: 1,
+        error: None,
+    };
+
+    /// The command failed with an unexpected error.
+    pub(crate) const ERROR: Self = Self {
+        code: 2,
+        error: None,
+    };
+
+    /// Return the exit status propagated from an external command.
+    pub(crate) const fn external(code: u8) -> Self {
+        Self { code, error: None }
+    }
+
+    /// Return an expected command failure with an error to render before exiting.
+    pub(crate) fn failure_with_error(error: impl Into<anyhow::Error>) -> Self {
+        Self {
             code: 1,
-            error: error.into(),
+            error: Some(error.into()),
         }
     }
 
     /// Separate the process exit code from the optional error to render.
     pub(crate) fn into_parts(self) -> (ExitCode, Option<anyhow::Error>) {
-        match self {
-            Self::Success => (ExitCode::from(0), None),
-            Self::Failure => (ExitCode::from(1), None),
-            Self::Error => (ExitCode::from(2), None),
-            Self::External(code) => (ExitCode::from(code), None),
-            Self::WithError { code, error } => (ExitCode::from(code), Some(error)),
-        }
+        (ExitCode::from(self.code), self.error)
     }
 }
 

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -131,7 +131,7 @@ impl ExitStatus {
     }
 
     /// Return an expected command failure with an error to render before exiting.
-    pub(crate) fn failure_with_error(error: impl Into<anyhow::Error>) -> Self {
+    pub(crate) fn error(error: impl Into<anyhow::Error>) -> Self {
         Self {
             code: 1,
             error: Some(error.into()),

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -100,7 +100,7 @@ mod tool;
 mod venv;
 mod workspace;
 
-#[derive(Copy, Clone)]
+#[derive(Debug)]
 pub(crate) enum ExitStatus {
     /// The command succeeded.
     Success,
@@ -113,6 +113,30 @@ pub(crate) enum ExitStatus {
 
     /// The command's exit status is propagated from an external command.
     External(u8),
+
+    /// The command failed with an error that should be rendered before exiting.
+    WithError { code: u8, error: anyhow::Error },
+}
+
+impl ExitStatus {
+    /// Return an expected command failure with an error to render.
+    pub(crate) fn failure(error: impl Into<anyhow::Error>) -> Self {
+        Self::WithError {
+            code: 1,
+            error: error.into(),
+        }
+    }
+
+    /// Separate the process exit code from the optional error to render.
+    pub(crate) fn into_parts(self) -> (ExitCode, Option<anyhow::Error>) {
+        match self {
+            Self::Success => (ExitCode::from(0), None),
+            Self::Failure => (ExitCode::from(1), None),
+            Self::Error => (ExitCode::from(2), None),
+            Self::External(code) => (ExitCode::from(code), None),
+            Self::WithError { code, error } => (ExitCode::from(code), Some(error)),
+        }
+    }
 }
 
 /// Read dotenv files into an overlay for a spawned process.
@@ -201,17 +225,6 @@ fn read_env_files<'a>(
     environment.reverse();
 
     Ok(environment)
-}
-
-impl From<ExitStatus> for ExitCode {
-    fn from(status: ExitStatus) -> Self {
-        match status {
-            ExitStatus::Success => Self::from(0),
-            ExitStatus::Failure => Self::from(1),
-            ExitStatus::Error => Self::from(2),
-            ExitStatus::External(code) => Self::from(code),
-        }
-    }
 }
 
 /// Format a duration as a human-readable string, Cargo-style.

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -72,7 +72,7 @@ pub(crate) fn pip_check(
             "All installed packages are compatible".to_string().dimmed()
         )?;
 
-        Ok(ExitStatus::Success)
+        Ok(ExitStatus::SUCCESS)
     } else {
         let incompats = if diagnostics.len() == 1 {
             "incompatibility"
@@ -93,6 +93,6 @@ pub(crate) fn pip_check(
             writeln!(printer.stderr(), "{}", diagnostic.message().bold())?;
         }
 
-        Ok(ExitStatus::Failure)
+        Ok(ExitStatus::FAILURE)
     }
 }

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -605,7 +605,7 @@ pub(crate) async fn pip_compile(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
     };
 
@@ -795,7 +795,7 @@ pub(crate) async fn pip_compile(
     // Notify the user of any resolution diagnostics.
     operations::diagnose_resolution(resolution.diagnostics(), printer)?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Format the uv command used to generate the output file.

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -134,5 +134,5 @@ pub(crate) fn pip_freeze(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -350,7 +350,7 @@ pub(crate) async fn pip_install(
                 }
                 DefaultInstallLogger.on_check(requirements.len(), start, printer, dry_run)?;
 
-                return Ok(ExitStatus::Success);
+                return Ok(ExitStatus::SUCCESS);
             }
             SatisfiesResult::Unsatisfied(requirement) => {
                 debug!("At least one requirement is not satisfied: {requirement}");
@@ -586,7 +586,7 @@ pub(crate) async fn pip_install(
                     client_builder.system_certs(),
                 )
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
             }
         };
 
@@ -658,7 +658,7 @@ pub(crate) async fn pip_install(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
     }
 
@@ -677,5 +677,5 @@ pub(crate) async fn pip_install(
         )?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -308,7 +308,7 @@ pub(crate) async fn pip_list(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 #[derive(Debug)]

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -43,7 +43,7 @@ pub(crate) fn pip_show(
                 ":".bold(),
             )?;
         }
-        return Ok(ExitStatus::Failure);
+        return Ok(ExitStatus::FAILURE);
     }
 
     // Detect the current Python interpreter.
@@ -108,7 +108,7 @@ pub(crate) fn pip_show(
 
     // Like `pip`, if no packages were found, return a failure.
     if distributions.is_empty() {
-        return Ok(ExitStatus::Failure);
+        return Ok(ExitStatus::FAILURE);
     }
 
     // Since Requires and Required-by fields need data parsed from metadata, especially the
@@ -236,5 +236,5 @@ pub(crate) fn pip_show(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -159,7 +159,7 @@ pub(crate) async fn pip_sync(
                 printer.stderr(),
                 "No requirements found (hint: use `--allow-empty-requirements` to clear the environment)"
             )?;
-            return Ok(ExitStatus::Success);
+            return Ok(ExitStatus::SUCCESS);
         }
     }
 
@@ -490,7 +490,7 @@ pub(crate) async fn pip_sync(
                     client_builder.system_certs(),
                 )
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
             }
         };
 
@@ -559,7 +559,7 @@ pub(crate) async fn pip_sync(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
     }
 
@@ -578,5 +578,5 @@ pub(crate) async fn pip_sync(
         )?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -190,7 +190,7 @@ pub(crate) async fn pip_tree(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 #[derive(Debug)]

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -193,7 +193,7 @@ pub(crate) async fn pip_uninstall(
                 ":".bold(),
             )?;
         }
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     // Uninstall each package.
@@ -247,5 +247,5 @@ pub(crate) async fn pip_uninstall(
         )?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -708,7 +708,7 @@ pub(crate) async fn add(
     // If `--frozen`, exit early. There's no reason to lock and sync, since we don't need a `uv.lock`
     // to exist at all.
     if frozen.is_some() {
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     // If we're modifying a script, and lockfile doesn't exist, avoid creating it. We still need
@@ -777,7 +777,7 @@ pub(crate) async fn add(
     ))
     .await
     {
-        Ok(()) => Ok(ExitStatus::Success),
+        Ok(()) => Ok(ExitStatus::SUCCESS),
         Err(err) => {
             if modified {
                 let _ = snapshot.revert();
@@ -796,7 +796,7 @@ pub(crate) async fn add(
                     diagnostic
                         .with_hint(format!("If you want to add the package regardless of the failed resolution, provide the `{}` flag to skip locking and syncing", "--frozen".green()))
                         .report(err, printer)?
-                        .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+                        .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()))
                 }
                 err => Err(err.into()),
             }

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -201,7 +201,7 @@ pub(crate) async fn audit(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
@@ -380,9 +380,9 @@ impl AuditResults {
             .iter()
             .any(|finding| matches!(finding, Finding::Vulnerability(_)))
         {
-            ExitStatus::Failure
+            ExitStatus::FAILURE
         } else {
-            ExitStatus::Success
+            ExitStatus::SUCCESS
         }
     }
 

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -299,7 +299,7 @@ pub(crate) async fn check(
                     client_builder.system_certs(),
                 )
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
         };
@@ -358,7 +358,7 @@ pub(crate) async fn check(
                     client_builder.system_certs(),
                 )
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
         }
@@ -492,7 +492,7 @@ pub(crate) async fn check(
                     client_builder.system_certs(),
                 )
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
         };
@@ -566,7 +566,7 @@ pub(crate) async fn check(
                             client_builder.system_certs(),
                         )
                         .report(err, printer)?
-                        .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                        .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
                 };
@@ -610,7 +610,7 @@ pub(crate) async fn check(
                         client_builder.system_certs(),
                     )
                     .report(err, printer)?
-                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                    .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
             }

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -239,7 +239,7 @@ pub(crate) async fn export(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
@@ -476,7 +476,7 @@ pub(crate) async fn export(
 
     writer.commit().await?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Format the uv command used to generate the output file.

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -194,7 +194,7 @@ pub(crate) async fn init(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 #[expect(clippy::fn_params_excessive_bools)]

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -265,15 +265,15 @@ pub(crate) async fn lock(
                 }
             }
 
-            Ok(ExitStatus::Success)
+            Ok(ExitStatus::SUCCESS)
         }
         // Lock mismatches from `--check`/`--locked` are expected validation failures.
         // Handle them here so we return exit code 1 instead of bubbling up as an error (exit code 2).
-        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::failure(err)),
+        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::failure_with_error(err)),
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()))
         }
         Err(err) => Err(err.into()),
     }

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -269,10 +269,7 @@ pub(crate) async fn lock(
         }
         // Lock mismatches from `--check`/`--locked` are expected validation failures.
         // Handle them here so we return exit code 1 instead of bubbling up as an error (exit code 2).
-        Err(err @ ProjectError::LockMismatch(..)) => {
-            writeln!(printer.stderr(), "{}", err.to_string().bold())?;
-            Ok(ExitStatus::Failure)
-        }
+        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::failure(err)),
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
                 .report(err, printer)?

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -269,7 +269,7 @@ pub(crate) async fn lock(
         }
         // Lock mismatches from `--check`/`--locked` are expected validation failures.
         // Handle them here so we return exit code 1 instead of bubbling up as an error (exit code 2).
-        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::failure_with_error(err)),
+        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::error(err)),
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
                 .report(err, printer)?

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -194,7 +194,7 @@ pub(crate) async fn remove(
     // If `--frozen`, exit early. There's no reason to lock and sync, since we don't need a `uv.lock`
     // to exist at all.
     if frozen.is_some() {
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     // If we're modifying a script, and lockfile doesn't exist, don't create it.
@@ -205,7 +205,7 @@ pub(crate) async fn remove(
                 "Updated `{}`",
                 script.path.user_display().cyan()
             )?;
-            return Ok(ExitStatus::Success);
+            return Ok(ExitStatus::SUCCESS);
         }
     }
 
@@ -337,19 +337,19 @@ pub(crate) async fn remove(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
 
     let AddTarget::Project(project, environment) = target else {
         // If we're not adding to a project, exit early.
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     };
 
     let PythonTarget::Environment(venv) = &*environment else {
         // If we're not syncing, exit early.
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     };
 
     // Identify the installation target.
@@ -397,12 +397,12 @@ pub(crate) async fn remove(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Represents the destination where dependencies are added, either to a project or a script.

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -266,7 +266,7 @@ pub(crate) async fn run(
                     )
                     .with_context("script")
                     .report(err, printer)?
-                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                    .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
             };
@@ -314,7 +314,7 @@ pub(crate) async fn run(
                     )
                     .with_context("script")
                     .report(err, printer)?
-                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                    .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
             }
@@ -453,7 +453,7 @@ pub(crate) async fn run(
                         )
                         .with_context("script")
                         .report(err, printer)?
-                        .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                        .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
                 }
@@ -779,7 +779,7 @@ pub(crate) async fn run(
                             client_builder.system_certs(),
                         )
                         .report(err, printer)?
-                        .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                        .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
                 };
@@ -868,7 +868,7 @@ pub(crate) async fn run(
                             client_builder.system_certs(),
                         )
                         .report(err, printer)?
-                        .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                        .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
                 }
@@ -1023,7 +1023,7 @@ pub(crate) async fn run(
                     )
                     .with_context("`--with`")
                     .report(err, printer)?
-                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                    .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
             };
@@ -1260,7 +1260,7 @@ pub(crate) async fn run(
         }
         let help = format!("See `{}` for more information.", "uv run --help".bold());
         writeln!(printer.stdout(), "\n{help}")?;
-        return Ok(ExitStatus::Error);
+        return Ok(ExitStatus::ERROR);
     };
 
     debug!("Running `{command}`");

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -299,7 +299,7 @@ pub(crate) async fn sync(
                         output_format,
                         printer,
                     )?;
-                    return Ok(ExitStatus::Success);
+                    return Ok(ExitStatus::SUCCESS);
                 }
                 Err(ProjectError::Operation(operations::Error::OutdatedEnvironment(changelog))) => {
                     write_sync_report(
@@ -315,14 +315,14 @@ pub(crate) async fn sync(
                         client_builder.system_certs(),
                     )
                     .report(operations::Error::OutdatedEnvironment(changelog), printer)?
-                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                    .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                 }
                 Err(ProjectError::Operation(err)) => {
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
                     .report(err, printer)?
-                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                    .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
             }
@@ -371,7 +371,7 @@ pub(crate) async fn sync(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(ProjectError::LockMismatch(prev, cur, lock_source)) => {
             if dry_run.enabled() {
@@ -379,7 +379,7 @@ pub(crate) async fn sync(
                 // sync operation, but exit with a non-zero status.
                 Outcome::LockMismatch(prev, cur, lock_source)
             } else {
-                return Ok(ExitStatus::failure(ProjectError::LockMismatch(
+                return Ok(ExitStatus::failure_with_error(ProjectError::LockMismatch(
                     prev,
                     cur,
                     lock_source,
@@ -456,14 +456,14 @@ pub(crate) async fn sync(
                 client_builder.system_certs(),
             )
             .report(operations::Error::OutdatedEnvironment(changelog), printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(ProjectError::Operation(err)) => {
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
@@ -479,8 +479,8 @@ pub(crate) async fn sync(
     )?;
 
     match outcome {
-        Outcome::Success(..) => Ok(ExitStatus::Success),
-        Outcome::LockMismatch(prev, cur, lock_source) => Ok(ExitStatus::failure(
+        Outcome::Success(..) => Ok(ExitStatus::SUCCESS),
+        Outcome::LockMismatch(prev, cur, lock_source) => Ok(ExitStatus::failure_with_error(
             ProjectError::LockMismatch(prev, cur, lock_source),
         )),
     }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -379,14 +379,11 @@ pub(crate) async fn sync(
                 // sync operation, but exit with a non-zero status.
                 Outcome::LockMismatch(prev, cur, lock_source)
             } else {
-                writeln!(
-                    printer.stderr(),
-                    "{}",
-                    ProjectError::LockMismatch(prev, cur, lock_source)
-                        .to_string()
-                        .bold()
-                )?;
-                return Ok(ExitStatus::Failure);
+                return Ok(ExitStatus::failure(ProjectError::LockMismatch(
+                    prev,
+                    cur,
+                    lock_source,
+                )));
             }
         }
         Err(err) => return Err(err.into()),
@@ -483,16 +480,9 @@ pub(crate) async fn sync(
 
     match outcome {
         Outcome::Success(..) => Ok(ExitStatus::Success),
-        Outcome::LockMismatch(prev, cur, lock_source) => {
-            writeln!(
-                printer.stderr(),
-                "{}",
-                ProjectError::LockMismatch(prev, cur, lock_source)
-                    .to_string()
-                    .bold()
-            )?;
-            Ok(ExitStatus::Failure)
-        }
+        Outcome::LockMismatch(prev, cur, lock_source) => Ok(ExitStatus::failure(
+            ProjectError::LockMismatch(prev, cur, lock_source),
+        )),
     }
 }
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -379,7 +379,7 @@ pub(crate) async fn sync(
                 // sync operation, but exit with a non-zero status.
                 Outcome::LockMismatch(prev, cur, lock_source)
             } else {
-                return Ok(ExitStatus::failure_with_error(ProjectError::LockMismatch(
+                return Ok(ExitStatus::error(ProjectError::LockMismatch(
                     prev,
                     cur,
                     lock_source,
@@ -480,7 +480,7 @@ pub(crate) async fn sync(
 
     match outcome {
         Outcome::Success(..) => Ok(ExitStatus::SUCCESS),
-        Outcome::LockMismatch(prev, cur, lock_source) => Ok(ExitStatus::failure_with_error(
+        Outcome::LockMismatch(prev, cur, lock_source) => Ok(ExitStatus::error(
             ProjectError::LockMismatch(prev, cur, lock_source),
         )),
     }

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -173,7 +173,7 @@ pub(crate) async fn tree(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
@@ -306,5 +306,5 @@ pub(crate) async fn tree(
 
     print!("{tree}");
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -170,7 +170,7 @@ pub(crate) async fn upgrade(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
@@ -229,7 +229,7 @@ pub(crate) async fn upgrade(
         )?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Select the single production dependency declaration targeted by `uv upgrade`.

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -64,7 +64,7 @@ pub(crate) fn self_version(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Read or update project version (`uv version`)
@@ -336,7 +336,7 @@ pub(crate) async fn project_version(
 
     // Update the toml and lock
     let status = if dry_run {
-        ExitStatus::Success
+        ExitStatus::SUCCESS
     } else if let Some(new_version) = &new_version {
         let project = update_project(
             project,
@@ -369,7 +369,7 @@ pub(crate) async fn project_version(
         .await?
     } else {
         debug!("No changes to version; skipping update");
-        ExitStatus::Success
+        ExitStatus::SUCCESS
     };
 
     // Report the results
@@ -547,7 +547,7 @@ async fn print_frozen_version(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
@@ -572,7 +572,7 @@ async fn print_frozen_version(
     let old_version = ProjectVersionInfo::new(Some(name), version);
     print_version(old_version, None, short, output_format, printer)?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Re-lock and re-sync the project after a series of edits.
@@ -599,7 +599,7 @@ async fn lock_and_sync(
 ) -> Result<ExitStatus> {
     // If frozen, don't touch the lock or sync at all
     if frozen.is_some() {
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     // Determine the groups and extras that should be enabled.
@@ -696,19 +696,19 @@ async fn lock_and_sync(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
 
     let AddTarget::Project(project, environment) = target else {
         // If we're not adding to a project, exit early.
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     };
 
     let PythonTarget::Environment(venv) = &*environment else {
         // If we're not syncing, exit early.
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     };
 
     // Perform a full sync, because we don't know what exactly is affected by the version.
@@ -758,12 +758,12 @@ async fn lock_and_sync(
                 client_builder.system_certs(),
             )
             .report(err, printer)?
-            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 fn print_version(

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -417,10 +417,10 @@ pub(crate) async fn publish(
     if error_count > 0 {
         let failed = if error_count == 1 { "file" } else { "files" };
         writeln!(printer.stderr(), "Found issues with {error_count} {failed}")?;
-        return Ok(ExitStatus::Failure);
+        return Ok(ExitStatus::FAILURE);
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Whether to allow prompting for username and password.

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -133,7 +133,7 @@ pub(crate) async fn find(
         writeln!(printer.stdout(), "{}", path.simplified_display())?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 pub(crate) async fn find_script(
@@ -168,7 +168,7 @@ pub(crate) async fn find_script(
                 "{}",
                 ErrorWithHints::new(&error, uv_errors::Hint::hints(&error))
             )?;
-            return Ok(ExitStatus::Failure);
+            return Ok(ExitStatus::FAILURE);
         }
         Ok(ScriptInterpreter::Interpreter(interpreter)) => interpreter,
         Ok(ScriptInterpreter::Environment(environment)) => environment.into_interpreter(),
@@ -185,5 +185,5 @@ pub(crate) async fn find_script(
         writeln!(printer.stdout(), "{}", path.simplified_display())?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -426,7 +426,7 @@ async fn perform_install(
             }
             PythonUpgrade::Disabled => {}
         }
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     let requested_minor_versions = requests
@@ -461,7 +461,7 @@ async fn perform_install(
                     ),
                 )?;
             }
-            return Ok(ExitStatus::Failure);
+            return Ok(ExitStatus::FAILURE);
         }
     }
 
@@ -587,7 +587,7 @@ async fn perform_install(
             printer.stderr(),
             "Python downloads are not allowed (`python-downloads = \"never\"`). Change to `python-downloads = \"manual\"` to allow explicit installs.",
         )?;
-        return Ok(ExitStatus::Failure);
+        return Ok(ExitStatus::FAILURE);
     }
 
     // Find downloads for the requests
@@ -800,7 +800,7 @@ async fn perform_install(
                 writeln!(printer.stderr(), "All requested versions already installed")?;
             }
         }
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     if !changelog.installed.is_empty() {
@@ -963,11 +963,11 @@ async fn perform_install(
         }
 
         if fatal {
-            return Ok(ExitStatus::Failure);
+            return Ok(ExitStatus::FAILURE);
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Link the binaries of a managed Python installation to the bin directory.

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -320,5 +320,5 @@ pub(crate) async fn list(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -90,7 +90,7 @@ pub(crate) async fn pin(
             },
             file.path().user_display()
         )?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     let Some(request) = request else {
@@ -124,7 +124,7 @@ pub(crate) async fn pin(
                     );
                 }
             }
-            return Ok(ExitStatus::Success);
+            return Ok(ExitStatus::SUCCESS);
         }
         bail!("No Python version file found; specify a version to create one")
     };
@@ -251,7 +251,7 @@ pub(crate) async fn pin(
         )?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Check if pinned request is compatible with the workspace/project's `Requires-Python`.

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -55,7 +55,7 @@ pub(crate) async fn uninstall(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Perform the uninstallation of managed Python installations.
@@ -118,7 +118,7 @@ async fn do_uninstall(
 
             if matches!(requests.as_slice(), [PythonRequest::Default]) {
                 writeln!(printer.stderr(), "No Python installations found")?;
-                return Ok(ExitStatus::Failure);
+                return Ok(ExitStatus::FAILURE);
             }
 
             writeln!(
@@ -134,7 +134,7 @@ async fn do_uninstall(
             printer.stderr(),
             "No Python installations found matching the requests"
         )?;
-        return Ok(ExitStatus::Failure);
+        return Ok(ExitStatus::FAILURE);
     }
 
     // Remove registry entries first, so we don't have dangling entries between the file removal
@@ -331,8 +331,8 @@ async fn do_uninstall(
                 err.to_string().trim()
             )?;
         }
-        return Ok(ExitStatus::Failure);
+        return Ok(ExitStatus::FAILURE);
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/python/update_shell.rs
+++ b/crates/uv/src/commands/python/update_shell.rs
@@ -39,7 +39,7 @@ pub(crate) async fn update_shell(printer: Printer) -> Result<ExitStatus> {
             )?;
         }
 
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     if Shell::contains_path(&executable_directory) {
@@ -48,7 +48,7 @@ pub(crate) async fn update_shell(printer: Printer) -> Result<ExitStatus> {
             "Executable directory {} is already in PATH",
             executable_directory.simplified_display().cyan()
         )?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     // Determine the current shell.
@@ -143,7 +143,7 @@ pub(crate) async fn update_shell(printer: Printer) -> Result<ExitStatus> {
 
     if updated {
         writeln!(printer.stderr(), "Restart your shell to apply changes")?;
-        Ok(ExitStatus::Success)
+        Ok(ExitStatus::SUCCESS)
     } else {
         Err(anyhow::anyhow!(
             "The executable directory {} is not in PATH, but the {shell} configuration files are already up-to-date",

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -77,7 +77,7 @@ pub(crate) async fn self_update(
                 ":".bold()
             )
         )?;
-        return Ok(ExitStatus::Failure);
+        return Ok(ExitStatus::FAILURE);
     }
 
     let mut updater = AxoUpdater::new_for("uv");
@@ -108,7 +108,7 @@ pub(crate) async fn self_update(
                 ":".bold()
             )
         )?;
-        return Ok(ExitStatus::Error);
+        return Ok(ExitStatus::ERROR);
     };
 
     // If we know what our version is, ignore whatever the receipt thinks it is!
@@ -142,7 +142,7 @@ pub(crate) async fn self_update(
                 receipt_prefix.simplified_display().bold().cyan()
             )
         )?;
-        return Ok(ExitStatus::Error);
+        return Ok(ExitStatus::ERROR);
     }
 
     writeln!(
@@ -195,7 +195,7 @@ pub(crate) async fn self_update(
                     }
                 )
             )?;
-            return Ok(ExitStatus::Success);
+            return Ok(ExitStatus::SUCCESS);
         }
 
         if dry_run {
@@ -205,7 +205,7 @@ pub(crate) async fn self_update(
                 format!("v{}", env!("CARGO_PKG_VERSION")).bold().white(),
                 format!("v{}", resolved.version).bold().white(),
             )?;
-            return Ok(ExitStatus::Success);
+            return Ok(ExitStatus::SUCCESS);
         }
 
         return run_official_updater(
@@ -257,7 +257,7 @@ pub(crate) async fn self_update(
                 )
             )?;
         }
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     run_custom_updater(updater, printer, token.is_some()).await
@@ -391,7 +391,7 @@ async fn run_official_updater(
         )
     )?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Return the platform-specific standalone installer filename.
@@ -722,7 +722,7 @@ async fn run_custom_updater(
                             "`--token`".green().bold()
                         )
                     )?;
-                    Ok(ExitStatus::Error)
+                    Ok(ExitStatus::ERROR)
                 } else {
                     Err(err.into())
                 }
@@ -732,7 +732,7 @@ async fn run_custom_updater(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -643,7 +643,7 @@ pub(crate) async fn install(
                         requirement.cyan()
                     )?;
 
-                    return Ok(ExitStatus::Success);
+                    return Ok(ExitStatus::SUCCESS);
                 }
             }
         }
@@ -732,7 +732,7 @@ pub(crate) async fn install(
                             client_builder.system_certs(),
                         )
                         .report(err, printer)?
-                        .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                        .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                     }
                     Err(err) => return Err(err.into()),
                 };
@@ -811,7 +811,7 @@ pub(crate) async fn install(
                     "`{}` is already installed",
                     requirement.cyan()
                 )?;
-                return Ok(ExitStatus::Success);
+                return Ok(ExitStatus::SUCCESS);
             }
             let environment = if plan.is_empty() && !settings.compile_bytecode {
                 environment
@@ -865,7 +865,7 @@ pub(crate) async fn install(
                         client_builder.system_certs(),
                     )
                     .report(err, printer)?
-                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                    .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                 }
                 Err(err) => return Err(err.into()),
             };
@@ -958,7 +958,7 @@ pub(crate) async fn install(
                                 client_builder.system_certs(),
                             )
                             .report(err, printer)?
-                            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                            .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                         };
 
                         debug!(
@@ -994,7 +994,7 @@ pub(crate) async fn install(
                                     client_builder.system_certs(),
                                 )
                                 .report(err, printer)?
-                                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
                             }
                             Err(err) => return Err(err.into()),
                         }
@@ -1058,7 +1058,7 @@ pub(crate) async fn install(
                     client_builder.system_certs(),
                 )
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
             }
             Err(err) => return Err(err.into()),
         }
@@ -1086,7 +1086,7 @@ pub(crate) async fn install(
         printer,
     )?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 fn existing_environment_usable(

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -50,7 +50,7 @@ pub(crate) async fn list(
                 .is_some_and(|err| err.kind() == std::io::ErrorKind::NotFound) =>
         {
             writeln!(printer.stderr(), "No tools installed")?;
-            return Ok(ExitStatus::Success);
+            return Ok(ExitStatus::SUCCESS);
         }
         Err(err) => return Err(err.into()),
     };
@@ -60,7 +60,7 @@ pub(crate) async fn list(
 
     if tools.is_empty() {
         writeln!(printer.stderr(), "No tools installed")?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     // Collect valid tools (skip invalid ones) before checking for outdated versions.
@@ -295,5 +295,5 @@ pub(crate) async fn list(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -144,7 +144,7 @@ pub(crate) async fn run(
         // When a command isn't provided, we'll show a brief help including available tools
         show_help(invocation_source, &cache, printer).await?;
         // Exit as Clap would after displaying help
-        return Ok(ExitStatus::Error);
+        return Ok(ExitStatus::ERROR);
     };
 
     let (target, args) = command.split();
@@ -282,7 +282,7 @@ pub(crate) async fn run(
                 ))
                 .with_context("tool")
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
             }
 
             let diagnostic =
@@ -300,14 +300,14 @@ pub(crate) async fn run(
             };
             return diagnostic
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()));
         }
 
         Err(ProjectError::Requirements(err)) => {
             let err = miette::Report::msg(format!("{err}"))
                 .context("Failed to resolve `--with` requirement");
             eprint!("{err:?}");
-            return Ok(ExitStatus::Failure);
+            return Ok(ExitStatus::FAILURE);
         }
         Err(err) => return Err(err.into()),
     };
@@ -334,7 +334,7 @@ pub(crate) async fn run(
                 // If the user didn't use `--from` and the command isn't in the environment, we're now
                 // just invoking an arbitrary executable on the `PATH` and should exit instead.
                 writeln!(printer.stderr(), "{provider_hints}")?;
-                return Ok(ExitStatus::Failure);
+                return Ok(ExitStatus::FAILURE);
             }
             // In the case where `--from` is used, we'll warn on failure if the command is not found
             // TODO(zanieb): Consider if we should require `--with` instead of `--from` in this case?
@@ -387,7 +387,7 @@ pub(crate) async fn run(
                     // could have come from the `PATH`. Display a more helpful message instead of the
                     // OS error.
                     writeln!(printer.stderr(), "{provider_hints}")?;
-                    return Ok(ExitStatus::Failure);
+                    return Ok(ExitStatus::FAILURE);
                 }
             }
             Err(err)

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -26,10 +26,10 @@ pub(crate) async fn uninstall(name: Vec<PackageName>, printer: Printer) -> Resul
                 for name in name {
                     writeln!(printer.stderr(), "`{name}` is not installed")?;
                 }
-                return Ok(ExitStatus::Success);
+                return Ok(ExitStatus::SUCCESS);
             }
             writeln!(printer.stderr(), "Nothing to uninstall")?;
-            return Ok(ExitStatus::Success);
+            return Ok(ExitStatus::SUCCESS);
         }
         Err(err) => return Err(err.into()),
     };
@@ -51,7 +51,7 @@ pub(crate) async fn uninstall(name: Vec<PackageName>, printer: Printer) -> Resul
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 trait IoErrorExt: std::error::Error + 'static {

--- a/crates/uv/src/commands/tool/update_shell.rs
+++ b/crates/uv/src/commands/tool/update_shell.rs
@@ -39,7 +39,7 @@ pub(crate) async fn update_shell(printer: Printer) -> Result<ExitStatus> {
             )?;
         }
 
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     if Shell::contains_path(&executable_directory) {
@@ -48,7 +48,7 @@ pub(crate) async fn update_shell(printer: Printer) -> Result<ExitStatus> {
             "Executable directory {} is already in PATH",
             executable_directory.simplified_display().cyan()
         )?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     // Determine the current shell.
@@ -143,7 +143,7 @@ pub(crate) async fn update_shell(printer: Printer) -> Result<ExitStatus> {
 
     if updated {
         writeln!(printer.stderr(), "Restart your shell to apply changes")?;
-        Ok(ExitStatus::Success)
+        Ok(ExitStatus::SUCCESS)
     } else {
         Err(anyhow::anyhow!(
             "The executable directory {} is not in PATH, but the {shell} configuration files are already up-to-date",

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -85,7 +85,7 @@ pub(crate) async fn upgrade(
 
     if names.is_empty() {
         writeln!(printer.stderr(), "Nothing to upgrade")?;
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     let reporter = PythonDownloadReporter::single(printer);
@@ -179,7 +179,7 @@ pub(crate) async fn upgrade(
                 ErrorOptions::default().with_stream(printer.stderr()),
             )?;
         }
-        return Ok(ExitStatus::Failure);
+        return Ok(ExitStatus::FAILURE);
     }
 
     if did_upgrade_tool.is_empty() && did_upgrade_environment.is_empty() {
@@ -210,7 +210,7 @@ pub(crate) async fn upgrade(
         constraint.print(&name, printer)?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -410,5 +410,5 @@ pub(crate) async fn venv(
         writeln!(printer.stderr(), "Activate with: {}", act.green())?;
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/workspace/dir.rs
+++ b/crates/uv/src/commands/workspace/dir.rs
@@ -41,5 +41,5 @@ pub(crate) async fn dir(
 
     writeln!(printer.stdout(), "{}", dir.simplified_display().cyan())?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -47,7 +47,7 @@ pub(crate) async fn list(
                 .context("PEP 723 script was discovered outside the workspace root")?;
             writeln!(printer.stdout(), "{}", script.simplified_display().cyan())?;
         }
-        return Ok(ExitStatus::Success);
+        return Ok(ExitStatus::SUCCESS);
     }
 
     for (name, member) in workspace.packages() {
@@ -62,7 +62,7 @@ pub(crate) async fn list(
         }
     }
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }
 
 /// Find PEP 723 scripts under a workspace root.

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -236,11 +236,11 @@ pub(crate) async fn metadata(
 
             print_metadata(&export, printer)
         }
-        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::failure(err)),
+        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::failure_with_error(err)),
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
                 .report(err, printer)?
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+                .map_or(Ok(ExitStatus::FAILURE), |err| Err(err.into()))
         }
         Err(err) => Err(err.into()),
     }
@@ -285,5 +285,5 @@ fn metadata_for_target(target: InstallTarget<'_>) -> Result<Metadata> {
 fn print_metadata(export: &Metadata, printer: Printer) -> Result<ExitStatus> {
     writeln!(printer.stdout(), "{}", export.to_json()?)?;
 
-    Ok(ExitStatus::Success)
+    Ok(ExitStatus::SUCCESS)
 }

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -236,7 +236,7 @@ pub(crate) async fn metadata(
 
             print_metadata(&export, printer)
         }
-        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::failure_with_error(err)),
+        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::error(err)),
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
                 .report(err, printer)?

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -2,7 +2,6 @@ use std::fmt::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use owo_colors::OwoColorize;
 
 use uv_cache::{Cache, Refresh};
 use uv_client::BaseClientBuilder;
@@ -237,10 +236,7 @@ pub(crate) async fn metadata(
 
             print_metadata(&export, printer)
         }
-        Err(err @ ProjectError::LockMismatch(..)) => {
-            writeln!(printer.stderr(), "{}", err.to_string().bold())?;
-            Ok(ExitStatus::Failure)
-        }
+        Err(err @ ProjectError::LockMismatch(..)) => Ok(ExitStatus::failure(err)),
         Err(ProjectError::Operation(err)) => {
             diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs())
                 .report(err, printer)?

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -530,7 +530,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         ($arg:expr) => {
             if globals.show_settings {
                 writeln!(printer.stdout(), "{:#?}", $arg)?;
-                return Ok(ExitStatus::Success);
+                return Ok(ExitStatus::SUCCESS);
             }
         };
         ($arg:expr, false) => {
@@ -654,7 +654,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             command: AuthCommand::Dir(args),
         }) => {
             commands::auth_dir(args.service.as_ref(), printer)?;
-            Ok(ExitStatus::Success)
+            Ok(ExitStatus::SUCCESS)
         }
         Commands::Auth(AuthNamespace {
             command: AuthCommand::Helper(args),
@@ -1429,7 +1429,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 },
         }) => {
             commands::self_version(short, output_format, printer)?;
-            Ok(ExitStatus::Success)
+            Ok(ExitStatus::SUCCESS)
         }
         #[cfg(not(feature = "self-update"))]
         Commands::Self_(_) => {
@@ -1440,7 +1440,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         }
         Commands::GenerateShellCompletion(args) => {
             args.shell.generate(&mut Cli::command(), &mut stdout());
-            Ok(ExitStatus::Success)
+            Ok(ExitStatus::SUCCESS)
         }
         Commands::Tool(ToolNamespace {
             command: run_variant @ (ToolCommand::Uvx(_) | ToolCommand::Run(_)),
@@ -1473,7 +1473,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                     }
                 }
                 shell.generate(&mut uvx, &mut stdout());
-                return Ok(ExitStatus::Success);
+                return Ok(ExitStatus::SUCCESS);
             }
 
             // Resolve the settings from the command-line arguments and workspace configuration.
@@ -1741,7 +1741,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             command: ToolCommand::UpdateShell,
         }) => {
             commands::tool_update_shell(printer).await?;
-            Ok(ExitStatus::Success)
+            Ok(ExitStatus::SUCCESS)
         }
         Commands::Tool(ToolNamespace {
             command: ToolCommand::Dir(args),
@@ -1751,7 +1751,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             show_settings!(args);
 
             commands::tool_dir(args.bin, globals.preview, printer)?;
-            Ok(ExitStatus::Success)
+            Ok(ExitStatus::SUCCESS)
         }
         Commands::Python(PythonNamespace {
             command: PythonCommand::List(args),
@@ -1936,13 +1936,13 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             show_settings!(args);
 
             commands::python_dir(args.bin, printer)?;
-            Ok(ExitStatus::Success)
+            Ok(ExitStatus::SUCCESS)
         }
         Commands::Python(PythonNamespace {
             command: PythonCommand::UpdateShell,
         }) => {
             commands::python_update_shell(printer).await?;
-            Ok(ExitStatus::Success)
+            Ok(ExitStatus::SUCCESS)
         }
         Commands::Publish(args) => {
             show_settings!(args);
@@ -2171,7 +2171,7 @@ async fn run_project(
         ($arg:expr) => {
             if globals.show_settings {
                 writeln!(printer.stdout(), "{:#?}", $arg)?;
-                return Ok(ExitStatus::Success);
+                return Ok(ExitStatus::SUCCESS);
             }
         };
     }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -500,17 +500,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     }
 
     // Configure the `Printer`, which controls user-facing output in the CLI.
-    let printer = if globals.quiet == 1 {
-        Printer::Quiet
-    } else if globals.quiet > 1 {
-        Printer::Silent
-    } else if globals.verbose > 0 {
-        Printer::Verbose
-    } else if globals.no_progress {
-        Printer::NoProgress
-    } else {
-        Printer::Default
-    };
+    let printer = Printer::new(globals.quiet, globals.verbose, globals.no_progress);
 
     // Configure the `warn!` macros, which control user-facing warnings in the CLI.
     if globals.quiet > 0 {
@@ -2989,6 +2979,14 @@ where
         }
     };
 
+    // Configure a printer for errors that escape command execution. The resolved `no_progress`
+    // setting can differ due to environment variables, but it does not affect important stderr.
+    let printer = Printer::new(
+        cli.top_level.global_args.quiet,
+        cli.top_level.global_args.verbose,
+        cli.top_level.global_args.no_progress,
+    );
+
     // See `min_stack_size` doc comment about `main2`
     let min_stack_size = min_stack_size();
     let main2 = move || {
@@ -3016,18 +3014,28 @@ where
         .expect("Tokio executor failed, was there a panic?");
 
     match result {
-        Ok(code) => code.into(),
+        Ok(status) => {
+            let (code, error) = status.into_parts();
+            if let Some(error) = error {
+                trace!("Error trace: {error:?}");
+                writeln!(printer.stderr_important(), "{}", error.to_string().bold())
+                    .expect("writing to stderr should not fail");
+            }
+            code
+        }
         Err(err) => {
             trace!("Error trace: {err:?}");
 
             let hints = commands::diagnostics::hints_for_error(&err);
             uv_errors::write_error_chain_with_options(
                 err.as_ref(),
-                uv_errors::ErrorOptions::default().with_hints(hints),
+                uv_errors::ErrorOptions::default()
+                    .with_hints(hints)
+                    .with_stream(printer.stderr_important()),
             )
             .expect("writing to stderr should not fail");
 
-            ExitStatus::Error.into()
+            ExitCode::from(2)
         }
     }
 }

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -16,6 +16,21 @@ pub(crate) enum Printer {
 }
 
 impl Printer {
+    /// Create a printer from the global output settings.
+    pub(crate) fn new(quiet: u8, verbose: u8, no_progress: bool) -> Self {
+        if quiet == 1 {
+            Self::Quiet
+        } else if quiet > 1 {
+            Self::Silent
+        } else if verbose > 0 {
+            Self::Verbose
+        } else if no_progress {
+            Self::NoProgress
+        } else {
+            Self::Default
+        }
+    }
+
     /// Return the [`ProgressDrawTarget`] for this printer.
     pub(crate) fn target(self) -> ProgressDrawTarget {
         match self {

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -143,6 +143,52 @@ fn lock_wheel_registry() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn locked_quiet_modes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==3.7.0"]
+        "#,
+    )?;
+    context.lock().assert().success();
+
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--quiet").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 /// Lock a requirement from PyPI.
 #[test]
 fn lock_sdist_registry() -> Result<()> {

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -5281,6 +5281,23 @@ fn run_with_not_existing_env_file() -> Result<()> {
     error: No environment file found at: `.env.development`
     ");
 
+    uv_snapshot!(context.filters(), context.run().arg("--env-file").arg(".env.development").arg("--quiet").arg("test.py"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No environment file found at: `.env.development`
+    ");
+
+    uv_snapshot!(context.filters(), context.run().arg("--env-file").arg(".env.development").arg("--quiet").arg("--quiet").arg("test.py"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
     Ok(())
 }
 

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -255,6 +255,25 @@ fn locked() -> Result<()> {
     The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     ");
 
+    // Quiet mode suppresses the resolution summary, but preserves the final error.
+    uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    // Silent mode suppresses the final error too.
+    uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--quiet").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
     let updated = context.read("uv.lock");
 
     // And the lockfile should be unchanged.
@@ -12321,6 +12340,23 @@ fn sync_dry_run_and_locked() -> Result<()> {
     Would install 1 package
      + iniconfig==2.0.0
     The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--dry-run").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--dry-run").arg("--quiet").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
     ");
 
     let updated = context.read("uv.lock");

--- a/crates/uv/tests/workspace/workspace_metadata.rs
+++ b/crates/uv/tests/workspace/workspace_metadata.rs
@@ -128,6 +128,53 @@ fn workspace_metadata_simple() {
 }
 
 #[test]
+fn workspace_metadata_locked_quiet_modes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.init().arg("project").assert().success();
+    let project = context.temp_dir.child("project");
+    context.lock().current_dir(&project).assert().success();
+
+    project.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.2.0"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context
+        .workspace_metadata()
+        .current_dir(&project)
+        .arg("--locked")
+        .arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    uv_snapshot!(context.filters(), context
+        .workspace_metadata()
+        .current_dir(&project)
+        .arg("--locked")
+        .arg("--quiet")
+        .arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "test-pypi")]
 fn workspace_metadata_script() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

Final command errors currently take two paths: returned `anyhow::Error` values are rendered by the top-level entry point, while expected validation failures print directly and return a bare `ExitStatus`. The top-level renderer bypasses `Printer`, so `-qq` still emits errors, while lockfile mismatch messages use ordinary stderr and disappear under `-q`.

This separates the process exit code from an optional final error in `ExitStatus` and renders final errors through `stderr_important()`. Lockfile mismatch paths now return their error instead of printing it, so final diagnostics remain visible under `-q`, are suppressed under `-qq`, and retain their existing exit codes: 1 for expected lock mismatches and 2 for unexpected command errors.

Closes https://github.com/astral-sh/uv/issues/19326.