### PR TITLE
Add automatic pruning of unreferenced cache archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6120,6 +6120,7 @@ name = "uv-cache"
 version = "0.0.59"
 dependencies = [
  "clap",
+ "filetime",
  "fs-err",
  "rmp-serde",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6136,6 +6136,7 @@ dependencies = [
  "uv-fastid",
  "uv-fs",
  "uv-normalize",
+ "uv-preview",
  "uv-pypi-types",
  "uv-redacted",
  "uv-static",

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -23,6 +23,7 @@ uv-distribution-types = { workspace = true }
 uv-fastid = { workspace = true, features = ["serde"] }
 uv-fs = { workspace = true, features = ["tokio"] }
 uv-normalize = { workspace = true }
+uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-redacted = { workspace = true }
 uv-static = { workspace = true }

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -37,3 +37,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }
+
+[dev-dependencies]
+filetime = { workspace = true }

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -13,8 +13,8 @@ use tracing::{debug, trace, warn};
 use uv_cache_info::Timestamp;
 use uv_fs::{LockedFile, LockedFileError, LockedFileMode, Simplified, cachedir, directories};
 use uv_normalize::PackageName;
+use uv_preview::PreviewFeature;
 use uv_pypi_types::ResolutionMetadata;
-use uv_static::{EnvVars, parse_boolish_environment_variable};
 
 pub use crate::by_timestamp::CachedByTimestamp;
 #[cfg(feature = "clap")]
@@ -526,24 +526,22 @@ impl Cache {
 
     /// Opportunistically prune unreferenced archives from the cache.
     ///
-    /// Pruning is enabled by setting [`EnvVars::UV_CACHE_AUTOPRUNE`], and runs at most once per
-    /// [`AUTOPRUNE_INTERVAL`]. To guarantee that no other uv process is reading from the cache,
-    /// pruning requires the exclusive lock; if the lock is unavailable, or if the caller already
-    /// holds a lock, the prune is skipped and retried on a subsequent invocation.
+    /// Pruning is enabled by the [`PreviewFeature::CacheAutoprune`] preview feature, and runs at
+    /// most once per [`AUTOPRUNE_INTERVAL`]. To guarantee that no other uv process is reading
+    /// from the cache, pruning requires the exclusive lock; if the lock is unavailable, or if
+    /// the caller already holds a lock, the prune is skipped and retried on a subsequent
+    /// invocation.
     ///
     /// Failures are logged and ignored, since pruning is best-effort.
     fn autoprune(&self) {
+        // The temporary-cache check must precede the preview check, since [`uv_preview`] panics
+        // if the global preview state is not initialized (e.g., in tests using [`Cache::temp`]).
         if self.lock_file.is_some() || self.is_temporary() {
             return;
         }
 
-        match parse_boolish_environment_variable(EnvVars::UV_CACHE_AUTOPRUNE) {
-            Ok(Some(true)) => {}
-            Ok(_) => return,
-            Err(err) => {
-                warn!("{err}");
-                return;
-            }
+        if !uv_preview::is_enabled(PreviewFeature::CacheAutoprune) {
+            return;
         }
 
         // Consult the marker file before taking the lock, to keep the common case cheap.

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -313,28 +313,46 @@ impl Cache {
     /// (which requires the exclusive main lock) cannot run between the decision to use an
     /// entry and the claim. Claims are best-effort: paths outside the cache are ignored, and
     /// failures are logged and ignored.
-    pub fn claim_in_use<'a>(&self, paths: impl IntoIterator<Item = &'a Path>) -> Vec<LockedFile> {
+    fn claim_in_use<'a>(&self, paths: impl IntoIterator<Item = &'a Path>) -> Vec<LockedFile> {
+        /// The number of times to retry a claim whose lock file was unlinked mid-acquisition.
+        const MAX_ATTEMPTS: usize = 4;
+
         let mut claims = Vec::new();
         for path in paths {
             let Some(lock_path) = self.in_use_lock_path(path) else {
                 continue;
             };
             if let Some(parent) = lock_path.parent() {
-                if let Err(err) = fs_err::create_dir_all(parent) {
+                if let Err(err) = create_in_use_lock_dir(parent, &self.root) {
                     warn!("Failed to create in-use lock directory: {err}");
                     continue;
                 }
             }
-            if let Some(lock) = LockedFile::acquire_no_wait(
-                &lock_path,
-                LockedFileMode::Shared,
-                lock_path.simplified_display(),
-            ) {
-                claims.push(lock);
-            } else {
-                // The lock is held exclusively by a removal operation (e.g., a concurrent
-                // `uv cache prune --force`); the entry may be removed out from under us, as it
-                // would have been before in-use locks existed.
+            let mut attempts = 0;
+            let claimed = loop {
+                let Some(lock) = LockedFile::acquire_no_wait(
+                    &lock_path,
+                    LockedFileMode::Shared,
+                    lock_path.simplified_display(),
+                ) else {
+                    // The lock is held exclusively by a removal operation (e.g., a concurrent
+                    // `uv cache prune --force`); the entry may be removed out from under us,
+                    // as it would have been before in-use locks existed.
+                    break false;
+                };
+                // A concurrent forced removal (which doesn't hold the main lock) may have
+                // unlinked the lock file between our create and our flock, in which case the
+                // lock guards an orphaned file rather than the path; retry on a fresh file.
+                if lock.verify_path() {
+                    claims.push(lock);
+                    break true;
+                }
+                attempts += 1;
+                if attempts >= MAX_ATTEMPTS {
+                    break false;
+                }
+            };
+            if !claimed {
                 warn!(
                     "Failed to mark cache entry as in use: `{}`",
                     lock_path.simplified_display()
@@ -344,15 +362,36 @@ impl Cache {
         claims
     }
 
-    /// Release the main cache lock, if held.
+    /// Claim the cache entries a child process runs from as in use, then release the main
+    /// cache lock so that cache maintenance (e.g., `uv cache prune`, automatic pruning) can
+    /// proceed while the child runs.
     ///
-    /// Long-lived commands release the lock before waiting on a child process, so that cache
-    /// maintenance (e.g., automatic pruning) can proceed while the child runs; the entries the
-    /// child depends on are protected by [`Cache::claim_in_use`] instead.
-    pub fn release_lock(&self) {
+    /// The ordering is essential: claims must be taken while the main lock is still held, so
+    /// that a removal operation (which requires the exclusive main lock) can never observe an
+    /// entry as both unclaimed and unlocked.
+    ///
+    /// Gated behind the [`PreviewFeature::CacheAutoprune`] preview feature: prior uv versions
+    /// hold the shared lock for the process lifetime, and their `uv cache prune`/`clean` do
+    /// not consult in-use locks (and delete the lock directory itself), so releasing the lock
+    /// by default would let an older uv sharing the cache remove entries a running child
+    /// depends on. When the feature is disabled, this is a no-op and the main lock is held
+    /// until exit, as before.
+    ///
+    /// The returned guards must be held for the lifetime of the child process.
+    pub fn claim_in_use_and_release_lock<'a>(
+        &self,
+        paths: impl IntoIterator<Item = &'a Path>,
+    ) -> Vec<LockedFile> {
+        // Treat an uninitialized preview state as disabled; this is an optimization, so
+        // panicking in library consumers that never initialize the state is not warranted.
+        if !uv_preview::try_is_enabled(PreviewFeature::CacheAutoprune).unwrap_or(false) {
+            return Vec::new();
+        }
+        let claims = self.claim_in_use(paths);
         if let Some(lock_file) = &self.lock_file {
             lock_file.release();
         }
+        claims
     }
 
     /// Return the path to the in-use lock file for the top-level cache entry containing `path`.
@@ -380,21 +419,25 @@ impl Cache {
     /// Lock files whose cache entry no longer exists are removed; a lock file is never removed
     /// while its entry exists, so that a concurrent claimer (which creates the lock file before
     /// locking it) can't be left holding a lock on a deleted file.
-    fn in_use_entries(&self, bucket: CacheBucket) -> FxHashSet<String> {
+    ///
+    /// Fails closed: an unreadable lock directory is an error (which aborts the removal
+    /// operation), not an empty set, since the set guards live processes' entries.
+    fn in_use_entries(&self, bucket: CacheBucket) -> Result<FxHashSet<String>, io::Error> {
+        self.in_use_entries_named(bucket.to_str())
+    }
+
+    /// As [`Cache::in_use_entries`], for a bucket directory name (e.g., `environments-v2`),
+    /// which may belong to an outdated bucket version in use by another uv version.
+    fn in_use_entries_named(&self, bucket: &str) -> Result<FxHashSet<String>, io::Error> {
         let mut in_use = FxHashSet::default();
-        let lock_dir = self.root.join(IN_USE_LOCKS_DIR).join(bucket.to_str());
+        let lock_dir = self.root.join(IN_USE_LOCKS_DIR).join(bucket);
         let entries = match fs_err::read_dir(&lock_dir) {
             Ok(entries) => entries,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return in_use,
-            Err(err) => {
-                warn!("Failed to read in-use lock directory: {err}");
-                return in_use;
-            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(in_use),
+            Err(err) => return Err(err),
         };
         for entry in entries {
-            let Ok(entry) = entry else {
-                continue;
-            };
+            let entry = entry?;
             let Some(file_name) = entry.file_name().to_str().map(ToString::to_string) else {
                 continue;
             };
@@ -406,7 +449,7 @@ impl Cache {
                 // No process holds a claim; if the cache entry itself is gone, the lock file
                 // is stale and can be removed.
                 Some(lock) => {
-                    if !self.bucket(bucket).join(&file_name).exists() {
+                    if !self.root.join(bucket).join(&file_name).exists() {
                         if let Err(err) = fs_err::remove_file(entry.path()) {
                             debug!("Failed to remove stale in-use lock file: {err}");
                         }
@@ -418,38 +461,63 @@ impl Cache {
                 }
             }
         }
-        in_use
+        Ok(in_use)
     }
 
-    /// Wait for all in-use cache entries to be released.
+    /// Release the main cache lock, if held.
     ///
-    /// Used by operations that remove the entire cache (e.g., `uv cache clean`), which
-    /// previously waited on the main cache lock for running processes to finish; since
-    /// long-lived commands now release the main lock while waiting on a child process, the
-    /// in-use locks must be awaited as well.
+    /// Used by `uv cache clean` to avoid holding the exclusive lock while waiting for in-use
+    /// entries to be released: a child process holding an in-use lock may itself invoke uv,
+    /// which would block on the main lock, deadlocking the wait.
+    pub fn release_lock(&self) {
+        if let Some(lock_file) = &self.lock_file {
+            lock_file.release();
+        }
+    }
+
+    /// Return the path of a held in-use lock file, if any.
     ///
-    /// The caller must hold the exclusive main cache lock, so that no new claims can appear
-    /// while waiting.
-    pub async fn wait_for_in_use(&self) -> Result<(), LockedFileError> {
+    /// Used by operations that remove the entire cache (e.g., `uv cache clean`), which must
+    /// wait for long-lived commands that released the main lock while a child process runs.
+    /// The caller should hold the exclusive main cache lock, so that no new claims can appear
+    /// concurrently.
+    pub fn find_held_in_use_lock(&self) -> Result<Option<PathBuf>, io::Error> {
         let locks_root = self.root.join(IN_USE_LOCKS_DIR);
         let buckets = match fs_err::read_dir(&locks_root) {
             Ok(buckets) => buckets,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
-            Err(err) => return Err(err.into()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err),
         };
         for bucket in buckets {
             let bucket = bucket?;
-            for entry in fs_err::read_dir(bucket.path())? {
+            let entries = match fs_err::read_dir(bucket.path()) {
+                Ok(entries) => entries,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(err),
+            };
+            for entry in entries {
                 let entry = entry?;
-                let lock = LockedFile::acquire(
+                if LockedFile::acquire_no_wait(
                     entry.path(),
                     LockedFileMode::Exclusive,
                     entry.path().simplified_display(),
                 )
-                .await?;
-                drop(lock);
+                .is_none()
+                {
+                    return Ok(Some(entry.path()));
+                }
             }
         }
+        Ok(None)
+    }
+
+    /// Wait for the in-use lock at the given path to be released.
+    ///
+    /// The caller must not hold the main cache lock (see [`Cache::release_lock`]).
+    pub async fn wait_for_in_use_lock(path: &Path) -> Result<(), LockedFileError> {
+        let lock =
+            LockedFile::acquire(path, LockedFileMode::Exclusive, path.simplified_display()).await?;
+        drop(lock);
         Ok(())
     }
 
@@ -699,19 +767,22 @@ impl Cache {
     ///
     /// Failures are logged and ignored, since pruning is best-effort.
     fn autoprune(&self) {
-        // The temporary-cache check must precede the preview check, since [`uv_preview`] panics
-        // if the global preview state is not initialized (e.g., in tests using [`Cache::temp`]).
         if self.lock_file.is_some() || self.is_temporary() {
             return;
         }
 
-        if !uv_preview::is_enabled(PreviewFeature::CacheAutoprune) {
+        // Treat an uninitialized preview state (e.g., library consumers that never call
+        // `uv_preview::set`) as disabled, since pruning is best-effort.
+        if !uv_preview::try_is_enabled(PreviewFeature::CacheAutoprune).unwrap_or(false) {
             return;
         }
 
-        // Consult the marker file before taking the lock, to keep the common case cheap: one
-        // `readdir` of the archive bucket and one read of the marker file.
+        // Check the time floor before counting the archive bucket, so that the common case
+        // (a recent run) costs a single `stat` of the marker file.
         let marker = self.root.join(AUTOPRUNE_MARKER);
+        if !autoprune_floor_elapsed(&marker) {
+            return;
+        }
         let archive_count = match count_dir_entries(&self.bucket(CacheBucket::Archive)) {
             Ok(count) => count,
             Err(err) => {
@@ -780,7 +851,7 @@ impl Cache {
     ///
     /// The caller must hold the exclusive cache lock.
     fn prune_unreferenced_archives(&self) -> Result<Removal, io::Error> {
-        let in_use = self.in_use_entries(CacheBucket::Archive);
+        let in_use = self.in_use_entries(CacheBucket::Archive)?;
         let references = self.find_archive_references_for_autoprune(&in_use)?;
         self.remove_unreferenced_archives(&references, &in_use)
     }
@@ -865,33 +936,11 @@ impl Cache {
             environment_archives.insert(archive_root.join(entry));
         }
 
-        for archive in environment_archives {
-            if !archive.is_dir() {
-                continue;
-            }
-            for entry in walkdir::WalkDir::new(&archive) {
-                let entry = match entry {
-                    Ok(entry) => entry,
-                    Err(err) => {
-                        debug!("Failed to walk cached environment: {err}");
-                        continue;
-                    }
-                };
-                if !entry.path_is_symlink() {
-                    continue;
-                }
-                let Ok(inner) = fs_err::canonicalize(entry.path()) else {
-                    continue;
-                };
-                let Some(inner) = archive_entry(&archive_root, &inner) else {
-                    continue;
-                };
-                references
-                    .entry(inner)
-                    .or_default()
-                    .push(entry.path().to_path_buf());
-            }
-        }
+        collect_environment_archive_references(
+            &archive_root,
+            environment_archives,
+            &mut references,
+        );
 
         Ok(references)
     }
@@ -1018,7 +1067,7 @@ impl Cache {
 
         // Remove any archives that are no longer referenced, unless they are in use by a
         // running process.
-        let in_use = self.in_use_entries(CacheBucket::Archive);
+        let in_use = self.in_use_entries(CacheBucket::Archive)?;
         for (target, references) in references {
             if target.starts_with(&archive_root) && references.iter().all(|path| !path.exists()) {
                 if target
@@ -1058,11 +1107,27 @@ impl Cache {
             }
 
             if metadata.is_dir() {
-                // If the directory is not a cache bucket, remove it.
+                // If the directory is not a cache bucket, remove it — unless a running
+                // process holds an in-use lock on one of its entries (e.g., another uv
+                // version, with a different bucket version, running a child from it).
                 if CacheBucket::iter().all(|bucket| entry.file_name() != bucket.to_str()) {
+                    if let Some(file_name) = entry.file_name().to_str()
+                        && !self.in_use_entries_named(file_name)?.is_empty()
+                    {
+                        debug!(
+                            "Retaining dangling cache bucket with in-use entries: {}",
+                            entry.path().display()
+                        );
+                        continue;
+                    }
                     let path = entry.path();
                     debug!("Removing dangling cache bucket: {}", path.display());
                     summary += rm_rf(path)?;
+                    // Remove the bucket's in-use lock directory, if any; its lock files are
+                    // no longer reachable once the bucket is gone.
+                    if let Some(file_name) = entry.file_name().to_str() {
+                        rm_rf(self.root.join(IN_USE_LOCKS_DIR).join(file_name))?;
+                    }
                 }
             } else {
                 // If the file is not a marker file, remove it.
@@ -1075,7 +1140,7 @@ impl Cache {
         // Second, remove all cached environments, except those that are in use by a running
         // process. Centralized project environments can be referenced by `.venv` links, but
         // are recreated when next needed.
-        let in_use_environments = self.in_use_entries(CacheBucket::Environments);
+        let in_use_environments = self.in_use_entries(CacheBucket::Environments)?;
         match fs_err::read_dir(self.bucket(CacheBucket::Environments)) {
             Ok(entries) => {
                 for entry in entries {
@@ -1159,9 +1224,20 @@ impl Cache {
 
         // Fourth, remove any unused archives (by searching for archives that are not symlinked),
         // except those that are in use by a running process (e.g., a cached environment that a
-        // `uv run`-launched process is running from).
-        let references = self.find_archive_references()?;
-        let in_use = self.in_use_entries(CacheBucket::Archive);
+        // `uv run`-launched process is running from). In-use environment archives are walked
+        // for internal symlinks (e.g., under `--link-mode=symlink`), so the wheel archives a
+        // running child's environment depends on are retained as well.
+        let mut references = self.find_archive_references()?;
+        let in_use = self.in_use_entries(CacheBucket::Archive)?;
+        if !in_use.is_empty()
+            && let Ok(archive_root) = fs_err::canonicalize(self.bucket(CacheBucket::Archive))
+        {
+            let in_use_archives = in_use
+                .iter()
+                .map(|entry| archive_root.join(entry))
+                .collect();
+            collect_environment_archive_references(&archive_root, in_use_archives, &mut references);
+        }
         summary += self.remove_unreferenced_archives(&references, &in_use)?;
 
         Ok(summary)
@@ -1363,20 +1439,8 @@ fn autoprune_due(marker: &Path, archive_count: u64) -> bool {
         return true;
     };
 
-    // Enforce the time floor, if the marker's modification time is readable.
-    if let Ok(metadata) = fs_err::metadata(marker)
-        && let Ok(modified) = metadata.modified()
-    {
-        let elapsed_floor = match SystemTime::now().duration_since(modified) {
-            Ok(elapsed) => elapsed >= AUTOPRUNE_MIN_INTERVAL,
-            // The marker is from the future (e.g., clock skew). Tolerate skew of up to one
-            // interval, but treat anything larger as elapsed, so that a wildly-future marker
-            // (e.g., written while the clock was fast) can't disable pruning indefinitely.
-            Err(err) => err.duration() >= AUTOPRUNE_MIN_INTERVAL,
-        };
-        if !elapsed_floor {
-            return false;
-        }
+    if !autoprune_floor_elapsed(marker) {
+        return false;
     }
 
     // If the archive bucket shrank (e.g., a manual `uv cache prune` or `clean`), the recorded
@@ -1386,6 +1450,24 @@ fn autoprune_due(marker: &Path, archive_count: u64) -> bool {
     }
 
     archive_count - recorded_count >= AUTOPRUNE_GROWTH_THRESHOLD
+}
+
+/// Returns `true` if at least [`AUTOPRUNE_MIN_INTERVAL`] has elapsed since the marker file was
+/// last written, or if the marker is missing or unreadable.
+fn autoprune_floor_elapsed(marker: &Path) -> bool {
+    let Ok(metadata) = fs_err::metadata(marker) else {
+        return true;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return true;
+    };
+    match SystemTime::now().duration_since(modified) {
+        Ok(elapsed) => elapsed >= AUTOPRUNE_MIN_INTERVAL,
+        // The marker is from the future (e.g., clock skew). Tolerate skew of up to one
+        // interval, but treat anything larger as elapsed, so that a wildly-future marker
+        // (e.g., written while the clock was fast) can't disable pruning indefinitely.
+        Err(err) => err.duration() >= AUTOPRUNE_MIN_INTERVAL,
+    }
 }
 
 /// Returns the number of entries in the given directory, or zero if it doesn't exist.
@@ -1411,6 +1493,80 @@ fn is_bucket_version(file_name: &str, family: &str) -> bool {
         .strip_prefix(family)
         .and_then(|suffix| suffix.strip_prefix("-v"))
         .is_some_and(|version| !version.is_empty() && version.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// Create the in-use lock directory for `lock_dir` (a path under `<root>/locks/`).
+///
+/// On Unix, the created directories are made world-writable (like the lock files themselves,
+/// see [`LockedFile`]), so that removal operations run by other users of a shared cache can
+/// read and clean them.
+fn create_in_use_lock_dir(lock_dir: &Path, root: &Path) -> io::Result<()> {
+    if lock_dir.is_dir() {
+        return Ok(());
+    }
+    fs_err::create_dir_all(lock_dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Both `<root>/locks` and `<root>/locks/<bucket>` may have just been created with the
+        // process umask applied; relax them. Failures are non-fatal (another user may own the
+        // directories already).
+        let mut dir = Some(lock_dir);
+        while let Some(current) = dir {
+            if let Err(err) =
+                fs_err::set_permissions(current, std::fs::Permissions::from_mode(0o777))
+            {
+                debug!("Failed to set permissions on in-use lock directory: {err}");
+            }
+            dir = current.parent().filter(|parent| *parent != root);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = root;
+    }
+    Ok(())
+}
+
+/// Collect references arising from symlinks within the given environment archives (e.g., an
+/// environment's site-packages symlinks into wheel archives under `--link-mode=symlink`),
+/// normalized to top-level archive entries.
+///
+/// Wheel archives contain no further archive references, so a single level of indirection
+/// suffices.
+fn collect_environment_archive_references(
+    archive_root: &Path,
+    environment_archives: FxHashSet<PathBuf>,
+    references: &mut FxHashMap<PathBuf, Vec<PathBuf>>,
+) {
+    for archive in environment_archives {
+        if !archive.is_dir() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&archive) {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    debug!("Failed to walk cached environment: {err}");
+                    continue;
+                }
+            };
+            if !entry.path_is_symlink() {
+                continue;
+            }
+            let Ok(inner) = fs_err::canonicalize(entry.path()) else {
+                continue;
+            };
+            let Some(inner) = archive_entry(archive_root, &inner) else {
+                continue;
+            };
+            references
+                .entry(inner)
+                .or_default()
+                .push(entry.path().to_path_buf());
+        }
+    }
 }
 
 /// Returns the top-level entry in the archive bucket that contains `target`, if any.
@@ -2326,6 +2482,70 @@ mod tests {
         assert!(!other_archive.exists());
     }
 
+    /// `uv cache prune` must retain the wheel archives referenced by an in-use environment
+    /// archive's internal symlinks (e.g., under `--link-mode=symlink`), even when nothing else
+    /// references them.
+    #[test]
+    #[cfg(unix)]
+    fn prune_retains_in_use_archive_internal_references() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let environment = archives.join("running-environment");
+        let wheel = archives.join("wheel");
+
+        // An environment archive with an internal symlink to a wheel archive; neither is
+        // referenced from any bucket (e.g., after a `--refresh` in another process).
+        fs_err::create_dir_all(&environment).unwrap();
+        fs_err::create_dir_all(&wheel).unwrap();
+        fs_err::write(wheel.join("payload.txt"), "payload").unwrap();
+        let site_packages = environment.join("lib").join("site-packages");
+        fs_err::create_dir_all(&site_packages).unwrap();
+        fs_err::os::unix::fs::symlink(wheel.join("payload.txt"), site_packages.join("module.py"))
+            .unwrap();
+
+        let cache = Cache::from_path(cache_root.path());
+        let claims = cache.claim_in_use(std::iter::once(environment.as_path()));
+        assert_eq!(claims.len(), 1);
+
+        cache.prune(false).unwrap();
+
+        assert!(environment.exists());
+        assert!(wheel.join("payload.txt").is_file());
+    }
+
+    /// `uv cache prune` must retain an outdated (non-current) bucket directory while a running
+    /// process holds an in-use lock on one of its entries (e.g., another uv version with a
+    /// different bucket version), and remove it once released.
+    #[test]
+    fn prune_retains_outdated_bucket_with_in_use_entries() {
+        use super::{Cache, IN_USE_LOCKS_DIR, LockedFile, LockedFileMode};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let outdated = cache_root.path().join("environments-v9999");
+        fs_err::create_dir_all(outdated.join("digest")).unwrap();
+
+        // Simulate another uv version's claim on an entry in the outdated bucket.
+        let lock_dir = cache_root
+            .path()
+            .join(IN_USE_LOCKS_DIR)
+            .join("environments-v9999");
+        fs_err::create_dir_all(&lock_dir).unwrap();
+        let claim =
+            LockedFile::acquire_no_wait(lock_dir.join("digest"), LockedFileMode::Shared, "test")
+                .unwrap();
+
+        let cache = Cache::from_path(cache_root.path());
+        cache.prune(false).unwrap();
+        assert!(outdated.exists());
+
+        drop(claim);
+        cache.prune(false).unwrap();
+        assert!(!outdated.exists());
+        assert!(!lock_dir.exists());
+    }
+
     /// Claims for paths outside the cache are ignored, and stale lock files (whose cache entry
     /// no longer exists) are cleaned up by removal operations.
     #[test]
@@ -2372,12 +2592,22 @@ mod tests {
         assert!(lock_file.exists());
 
         // While the entry exists, the lock file is retained.
-        assert!(cache.in_use_entries(CacheBucket::Archive).is_empty());
+        assert!(
+            cache
+                .in_use_entries(CacheBucket::Archive)
+                .unwrap()
+                .is_empty()
+        );
         assert!(lock_file.exists());
 
         // Once the entry is gone, the lock file is removed.
         fs_err::remove_dir_all(&archive).unwrap();
-        assert!(cache.in_use_entries(CacheBucket::Archive).is_empty());
+        assert!(
+            cache
+                .in_use_entries(CacheBucket::Archive)
+                .unwrap()
+                .is_empty()
+        );
         assert!(!lock_file.exists());
     }
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -311,9 +311,15 @@ impl Cache {
     ///
     /// The caller must hold the main cache lock while claiming, so that a removal operation
     /// (which requires the exclusive main lock) cannot run between the decision to use an
-    /// entry and the claim. Claims are best-effort: paths outside the cache are ignored, and
-    /// failures are logged and ignored.
-    fn claim_in_use<'a>(&self, paths: impl IntoIterator<Item = &'a Path>) -> Vec<LockedFile> {
+    /// entry and the claim. Paths outside the cache are ignored.
+    ///
+    /// Returns `None` if any cache-resident path could not be claimed (e.g., its lock is held
+    /// exclusively by a concurrent forced removal); the caller must then retain the main lock,
+    /// since the unclaimed entry would otherwise be unprotected.
+    fn claim_in_use<'a>(
+        &self,
+        paths: impl IntoIterator<Item = &'a Path>,
+    ) -> Option<Vec<LockedFile>> {
         /// The number of times to retry a claim whose lock file was unlinked mid-acquisition.
         const MAX_ATTEMPTS: usize = 4;
 
@@ -325,7 +331,7 @@ impl Cache {
             if let Some(parent) = lock_path.parent() {
                 if let Err(err) = create_in_use_lock_dir(parent, &self.root) {
                     warn!("Failed to create in-use lock directory: {err}");
-                    continue;
+                    return None;
                 }
             }
             let mut attempts = 0;
@@ -336,8 +342,7 @@ impl Cache {
                     lock_path.simplified_display(),
                 ) else {
                     // The lock is held exclusively by a removal operation (e.g., a concurrent
-                    // `uv cache prune --force`); the entry may be removed out from under us,
-                    // as it would have been before in-use locks existed.
+                    // `uv cache prune --force`).
                     break false;
                 };
                 // A concurrent forced removal (which doesn't hold the main lock) may have
@@ -357,9 +362,10 @@ impl Cache {
                     "Failed to mark cache entry as in use: `{}`",
                     lock_path.simplified_display()
                 );
+                return None;
             }
         }
-        claims
+        Some(claims)
     }
 
     /// Claim the cache entries a child process runs from as in use, then release the main
@@ -387,7 +393,13 @@ impl Cache {
         if !uv_preview::try_is_enabled(PreviewFeature::CacheAutoprune).unwrap_or(false) {
             return Vec::new();
         }
-        let claims = self.claim_in_use(paths);
+        // If any entry could not be claimed, retain the main lock: it protects the unclaimed
+        // entry (as it did before in-use locks existed), at the cost of blocking cache
+        // maintenance for this process's lifetime.
+        let Some(claims) = self.claim_in_use(paths) else {
+            debug!("Retaining the main cache lock: not all cache entries could be claimed");
+            return Vec::new();
+        };
         if let Some(lock_file) = &self.lock_file {
             lock_file.release();
         }
@@ -940,7 +952,7 @@ impl Cache {
             &archive_root,
             environment_archives,
             &mut references,
-        );
+        )?;
 
         Ok(references)
     }
@@ -1065,15 +1077,33 @@ impl Cache {
         // to paths outside the cache.
         let archive_root = fs_err::canonicalize(&self.root)?.join(CacheBucket::Archive.to_str());
 
-        // Remove any archives that are no longer referenced, unless they are in use by a
-        // running process.
+        // Collect references from within in-use environments (e.g., site-packages symlinks
+        // into wheel archives under `--link-mode=symlink`), so that archives a running child
+        // depends on are retained even after the package's bucket links are removed.
         let in_use = self.in_use_entries(CacheBucket::Archive)?;
+        let in_use_environments = self.in_use_entries(CacheBucket::Environments)?;
+        let mut internal_references = FxHashMap::default();
+        let environments_root = self.bucket(CacheBucket::Environments);
+        let in_use_dirs = in_use.iter().map(|entry| archive_root.join(entry)).chain(
+            in_use_environments
+                .iter()
+                .map(|entry| environments_root.join(entry)),
+        );
+        collect_environment_archive_references(
+            &archive_root,
+            in_use_dirs,
+            &mut internal_references,
+        )?;
+
+        // Remove any archives that are no longer referenced, unless they are in use by a
+        // running process (or referenced from within an in-use environment).
         for (target, references) in references {
             if target.starts_with(&archive_root) && references.iter().all(|path| !path.exists()) {
                 if target
                     .file_name()
                     .and_then(|file_name| file_name.to_str())
                     .is_some_and(|file_name| in_use.contains(file_name))
+                    || internal_references.contains_key(&target)
                 {
                     debug!("Retaining in-use cache entry: {}", target.display());
                     continue;
@@ -1224,19 +1254,22 @@ impl Cache {
 
         // Fourth, remove any unused archives (by searching for archives that are not symlinked),
         // except those that are in use by a running process (e.g., a cached environment that a
-        // `uv run`-launched process is running from). In-use environment archives are walked
-        // for internal symlinks (e.g., under `--link-mode=symlink`), so the wheel archives a
-        // running child's environment depends on are retained as well.
+        // `uv run`-launched process is running from). In-use environments — both environment
+        // archives and environments resident in the environments bucket (e.g., script
+        // environments) — are walked for internal symlinks (e.g., under `--link-mode=symlink`),
+        // so the wheel archives a running child's environment depends on are retained as well.
         let mut references = self.find_archive_references()?;
         let in_use = self.in_use_entries(CacheBucket::Archive)?;
-        if !in_use.is_empty()
+        if (!in_use.is_empty() || !in_use_environments.is_empty())
             && let Ok(archive_root) = fs_err::canonicalize(self.bucket(CacheBucket::Archive))
         {
-            let in_use_archives = in_use
-                .iter()
-                .map(|entry| archive_root.join(entry))
-                .collect();
-            collect_environment_archive_references(&archive_root, in_use_archives, &mut references);
+            let environments_root = self.bucket(CacheBucket::Environments);
+            let in_use_dirs = in_use.iter().map(|entry| archive_root.join(entry)).chain(
+                in_use_environments
+                    .iter()
+                    .map(|entry| environments_root.join(entry)),
+            );
+            collect_environment_archive_references(&archive_root, in_use_dirs, &mut references)?;
         }
         summary += self.remove_unreferenced_archives(&references, &in_use)?;
 
@@ -1529,34 +1562,34 @@ fn create_in_use_lock_dir(lock_dir: &Path, root: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Collect references arising from symlinks within the given environment archives (e.g., an
+/// Collect references arising from symlinks within the given environment directories (e.g., an
 /// environment's site-packages symlinks into wheel archives under `--link-mode=symlink`),
 /// normalized to top-level archive entries.
 ///
 /// Wheel archives contain no further archive references, so a single level of indirection
 /// suffices.
+///
+/// Fails closed: a traversal error is an error (which aborts the removal operation), not an
+/// incomplete reference set, since the set guards against removal. Dangling symlinks are
+/// tolerated, since they contribute no reference.
 fn collect_environment_archive_references(
     archive_root: &Path,
-    environment_archives: FxHashSet<PathBuf>,
+    environment_dirs: impl IntoIterator<Item = PathBuf>,
     references: &mut FxHashMap<PathBuf, Vec<PathBuf>>,
-) {
-    for archive in environment_archives {
-        if !archive.is_dir() {
+) -> Result<(), io::Error> {
+    for dir in environment_dirs {
+        if !dir.is_dir() {
             continue;
         }
-        for entry in walkdir::WalkDir::new(&archive) {
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(err) => {
-                    debug!("Failed to walk cached environment: {err}");
-                    continue;
-                }
-            };
+        for entry in walkdir::WalkDir::new(&dir) {
+            let entry = entry?;
             if !entry.path_is_symlink() {
                 continue;
             }
-            let Ok(inner) = fs_err::canonicalize(entry.path()) else {
-                continue;
+            let inner = match fs_err::canonicalize(entry.path()) {
+                Ok(inner) => inner,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(err),
             };
             let Some(inner) = archive_entry(archive_root, &inner) else {
                 continue;
@@ -1567,6 +1600,7 @@ fn collect_environment_archive_references(
                 .push(entry.path().to_path_buf());
         }
     }
+    Ok(())
 }
 
 /// Returns the top-level entry in the archive bucket that contains `target`, if any.
@@ -2420,7 +2454,9 @@ mod tests {
         fs_err::write(dangling.join("payload.txt"), "payload").unwrap();
 
         let cache = Cache::from_path(cache_root.path());
-        let claims = cache.claim_in_use(std::iter::once(environment.as_path()));
+        let claims = cache
+            .claim_in_use(std::iter::once(environment.as_path()))
+            .unwrap();
         assert_eq!(claims.len(), 1);
 
         let summary = cache.prune_unreferenced_archives().unwrap();
@@ -2452,24 +2488,27 @@ mod tests {
         let in_use_archive = archives.join("in-use-environment");
         let other_archive = archives.join("other-environment");
 
-        // Two environment links; only the first archive is claimed.
+        // Two environments, each linking to its own archive; only the first is claimed.
         fs_err::create_dir_all(&in_use_archive).unwrap();
         fs_err::write(in_use_archive.join("payload.txt"), "payload").unwrap();
         fs_err::create_dir_all(&other_archive).unwrap();
         fs_err::write(other_archive.join("payload.txt"), "payload").unwrap();
-        fs_err::create_dir_all(environments.join("digest")).unwrap();
-        fs_err::os::unix::fs::symlink(&in_use_archive, environments.join("digest").join("a"))
+        fs_err::create_dir_all(environments.join("digest-a")).unwrap();
+        fs_err::os::unix::fs::symlink(&in_use_archive, environments.join("digest-a").join("link"))
             .unwrap();
-        fs_err::os::unix::fs::symlink(&other_archive, environments.join("digest").join("b"))
+        fs_err::create_dir_all(environments.join("digest-b")).unwrap();
+        fs_err::os::unix::fs::symlink(&other_archive, environments.join("digest-b").join("link"))
             .unwrap();
 
         let cache = Cache::from_path(cache_root.path());
         // Claim through the environments-bucket path, as `uv run` does for script and
         // centralized environments, and through the archive path, as for cached environments.
-        let claims = cache.claim_in_use([
-            environments.join("digest").as_path(),
-            in_use_archive.as_path(),
-        ]);
+        let claims = cache
+            .claim_in_use([
+                environments.join("digest-a").as_path(),
+                in_use_archive.as_path(),
+            ])
+            .unwrap();
         assert_eq!(claims.len(), 2);
 
         let summary = cache.prune(false).unwrap();
@@ -2477,8 +2516,9 @@ mod tests {
         // The claimed environment directory and archive are retained; the unclaimed
         // environment is removed along with its archive.
         assert!(summary.num_files > 0);
-        assert!(environments.join("digest").exists());
+        assert!(environments.join("digest-a").exists());
         assert!(in_use_archive.join("payload.txt").is_file());
+        assert!(!environments.join("digest-b").exists());
         assert!(!other_archive.exists());
     }
 
@@ -2506,13 +2546,105 @@ mod tests {
             .unwrap();
 
         let cache = Cache::from_path(cache_root.path());
-        let claims = cache.claim_in_use(std::iter::once(environment.as_path()));
+        let claims = cache
+            .claim_in_use(std::iter::once(environment.as_path()))
+            .unwrap();
         assert_eq!(claims.len(), 1);
 
         cache.prune(false).unwrap();
 
         assert!(environment.exists());
         assert!(wheel.join("payload.txt").is_file());
+    }
+
+    /// `uv cache prune` must retain the wheel archives referenced by the internal symlinks of
+    /// an in-use environment resident in the environments bucket (e.g., a script environment
+    /// under `--link-mode=symlink`), even when nothing else references them.
+    #[test]
+    #[cfg(unix)]
+    fn prune_retains_in_use_environment_internal_references() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let environments = cache_root.path().join(CacheBucket::Environments.to_str());
+        let environment = environments.join("digest");
+        let wheel = archives.join("wheel");
+
+        // A script environment (a real directory in the environments bucket) whose
+        // site-packages symlink into a wheel archive that nothing else references.
+        fs_err::create_dir_all(&wheel).unwrap();
+        fs_err::write(wheel.join("payload.txt"), "payload").unwrap();
+        let site_packages = environment.join("lib").join("site-packages");
+        fs_err::create_dir_all(&site_packages).unwrap();
+        fs_err::os::unix::fs::symlink(wheel.join("payload.txt"), site_packages.join("module.py"))
+            .unwrap();
+
+        let cache = Cache::from_path(cache_root.path());
+        let claims = cache
+            .claim_in_use(std::iter::once(environment.as_path()))
+            .unwrap();
+        assert_eq!(claims.len(), 1);
+
+        cache.prune(true).unwrap();
+
+        assert!(environment.exists());
+        assert!(wheel.join("payload.txt").is_file());
+
+        // Once the claim is released, both are removed.
+        drop(claims);
+        cache.prune(true).unwrap();
+        assert!(!environment.exists());
+        assert!(!wheel.exists());
+    }
+
+    /// Package-scoped removal (`uv cache clean <package>`) must retain archives referenced by
+    /// an in-use environment's internal symlinks, even after the package's bucket links are
+    /// removed.
+    #[test]
+    #[cfg(unix)]
+    fn remove_retains_in_use_environment_internal_references() {
+        use std::str::FromStr;
+
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let environments = cache_root.path().join(CacheBucket::Environments.to_str());
+        let wheels = cache_root.path().join(CacheBucket::Wheels.to_str());
+        let environment = environments.join("digest");
+        let wheel = archives.join("wheel");
+
+        // A wheel archive linked from the wheels bucket for `anyio`, and also referenced from
+        // within an in-use script environment.
+        fs_err::create_dir_all(&wheel).unwrap();
+        fs_err::write(wheel.join("payload.txt"), "payload").unwrap();
+        fs_err::create_dir_all(wheels.join("pypi").join("anyio")).unwrap();
+        fs_err::os::unix::fs::symlink(&wheel, wheels.join("pypi").join("anyio").join("link"))
+            .unwrap();
+        let site_packages = environment.join("lib").join("site-packages");
+        fs_err::create_dir_all(&site_packages).unwrap();
+        fs_err::os::unix::fs::symlink(wheel.join("payload.txt"), site_packages.join("module.py"))
+            .unwrap();
+
+        let cache = Cache::from_path(cache_root.path());
+        let claims = cache
+            .claim_in_use(std::iter::once(environment.as_path()))
+            .unwrap();
+        assert_eq!(claims.len(), 1);
+
+        let name = uv_normalize::PackageName::from_str("anyio").unwrap();
+        cache.remove(&name).unwrap();
+
+        // The bucket link is gone, but the archive survives via the in-use environment's
+        // internal reference.
+        assert!(!wheels.join("pypi").join("anyio").exists());
+        assert!(wheel.join("payload.txt").is_file());
+
+        // Once the claim is released, a prune deletes the now-unreferenced archive.
+        drop(claims);
+        cache.prune(false).unwrap();
+        assert!(!wheel.exists());
     }
 
     /// `uv cache prune` must retain an outdated (non-current) bucket directory while a running
@@ -2566,11 +2698,13 @@ mod tests {
             .join("entry");
         fs_err::create_dir_all(locks_entry.parent().unwrap()).unwrap();
         fs_err::write(&locks_entry, []).unwrap();
-        let claims = cache.claim_in_use([
-            outside.path().join("dir").as_path(),
-            cache_root.path(),
-            locks_entry.as_path(),
-        ]);
+        let claims = cache
+            .claim_in_use([
+                outside.path().join("dir").as_path(),
+                cache_root.path(),
+                locks_entry.as_path(),
+            ])
+            .unwrap();
         assert_eq!(claims.len(), 0);
 
         // A released claim leaves a lock file behind; once the cache entry is gone, a removal
@@ -2580,7 +2714,9 @@ mod tests {
             .join(CacheBucket::Archive.to_str())
             .join("entry");
         fs_err::create_dir_all(&archive).unwrap();
-        let claims = cache.claim_in_use(std::iter::once(archive.as_path()));
+        let claims = cache
+            .claim_in_use(std::iter::once(archive.as_path()))
+            .unwrap();
         assert_eq!(claims.len(), 1);
         drop(claims);
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use rustc_hash::FxHashMap;
 use tracing::{debug, trace, warn};
@@ -13,6 +14,7 @@ use uv_cache_info::Timestamp;
 use uv_fs::{LockedFile, LockedFileError, LockedFileMode, Simplified, cachedir, directories};
 use uv_normalize::PackageName;
 use uv_pypi_types::ResolutionMetadata;
+use uv_static::{EnvVars, parse_boolish_environment_variable};
 
 pub use crate::by_timestamp::CachedByTimestamp;
 #[cfg(feature = "clap")]
@@ -34,6 +36,12 @@ mod wheel;
 ///
 /// Must be kept in-sync with the version in [`CacheBucket::to_str`].
 pub const ARCHIVE_VERSION: u8 = 0;
+
+/// The minimum interval between automatic cache pruning runs.
+const AUTOPRUNE_INTERVAL: Duration = Duration::from_hours(24);
+
+/// The name of the marker file recording the time of the last automatic cache pruning run.
+const AUTOPRUNE_MARKER: &str = ".autoprune";
 
 /// Error locking a cache entry or shard
 #[derive(Debug, thiserror::Error)]
@@ -467,6 +475,10 @@ impl Cache {
 
         Self::create_base_files(root).map_err(|err| Error::Init(root.clone(), err))?;
 
+        // Opportunistically prune unreferenced archives, if enabled. This must happen before
+        // acquiring the shared lock below, since the prune requires the exclusive lock.
+        self.autoprune();
+
         // Block cache removal operations from interfering.
         let lock_file = match LockedFile::acquire(
             root.join(".lock"),
@@ -495,6 +507,108 @@ impl Cache {
             lock_file,
             ..self
         })
+    }
+
+    /// Opportunistically prune unreferenced archives from the cache.
+    ///
+    /// Pruning is enabled by setting [`EnvVars::UV_CACHE_AUTOPRUNE`], and runs at most once per
+    /// [`AUTOPRUNE_INTERVAL`]. To guarantee that no other uv process is reading from the cache,
+    /// pruning requires the exclusive lock; if the lock is unavailable, or if the caller already
+    /// holds a lock, the prune is skipped and retried on a subsequent invocation.
+    ///
+    /// Failures are logged and ignored, since pruning is best-effort.
+    fn autoprune(&self) {
+        if self.lock_file.is_some() || self.is_temporary() {
+            return;
+        }
+
+        match parse_boolish_environment_variable(EnvVars::UV_CACHE_AUTOPRUNE) {
+            Ok(Some(true)) => {}
+            Ok(_) => return,
+            Err(err) => {
+                warn!("{err}");
+                return;
+            }
+        }
+
+        // Consult the marker file before taking the lock, to keep the common case cheap.
+        let marker = self.root.join(AUTOPRUNE_MARKER);
+        if !autoprune_due(&marker) {
+            return;
+        }
+
+        // Require the exclusive lock, so that the prune cannot race another uv process. If any
+        // other process holds the lock (shared or exclusive), skip pruning entirely. The lock is
+        // held until the prune completes.
+        let Some(_lock_file) = LockedFile::acquire_no_wait(
+            self.root.join(".lock"),
+            LockedFileMode::Exclusive,
+            self.root.simplified_display(),
+        ) else {
+            debug!("Skipping automatic cache pruning: the cache is in use");
+            return;
+        };
+
+        // Re-check the marker while holding the lock, in case another process pruned in between.
+        if !autoprune_due(&marker) {
+            return;
+        }
+
+        // Record the attempt before pruning, so that a failing prune isn't retried on every
+        // invocation.
+        if let Err(err) = fs_err::write(&marker, []) {
+            debug!("Failed to update autoprune marker: {err}");
+            return;
+        }
+
+        debug!("Automatically pruning unreferenced cache archives");
+        match self.prune_unreferenced_archives() {
+            Ok(removal) => {
+                debug!(
+                    "Removed {} unreferenced archive files ({} bytes)",
+                    removal.num_files, removal.total_bytes
+                );
+            }
+            Err(err) => {
+                debug!("Failed to prune cache archives: {err}");
+            }
+        }
+    }
+
+    /// Remove any archives that are no longer referenced, as in [`Cache::prune`].
+    ///
+    /// Unlike [`Cache::prune`], leaves cached environments (and the archives they reference)
+    /// intact, along with outdated cache buckets, which may be in use by other uv versions.
+    ///
+    /// The caller must hold the exclusive cache lock.
+    fn prune_unreferenced_archives(&self) -> Result<Removal, io::Error> {
+        let mut summary = Removal::default();
+
+        // Unlike `Cache::prune`, cached environments are retained, so their references must be
+        // included to avoid removing the archives that back them.
+        let references = self.find_archive_references_in([
+            CacheBucket::SourceDistributions,
+            CacheBucket::Wheels,
+            CacheBucket::Environments,
+        ])?;
+
+        match fs_err::read_dir(self.bucket(CacheBucket::Archive)) {
+            Ok(entries) => {
+                for entry in entries {
+                    let entry = entry?;
+                    let path = entry.path();
+                    let target = fs_err::canonicalize(&path)?;
+                    if !references.contains_key(&target) {
+                        debug!("Removing dangling cache archive: {}", path.display());
+                        summary += rm_rf(path)?;
+                    }
+                }
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => (),
+            Err(err) => return Err(err),
+        }
+
+        Ok(summary)
     }
 
     /// Initialize the [`Cache`], assuming that there are no other uv processes running.
@@ -595,6 +709,7 @@ impl Cache {
                 || entry.file_name() == ".gitignore"
                 || entry.file_name() == ".git"
                 || entry.file_name() == ".lock"
+                || entry.file_name() == AUTOPRUNE_MARKER
             {
                 continue;
             }
@@ -718,8 +833,16 @@ impl Cache {
     ///
     /// Returns a map from archive path to paths that reference it.
     fn find_archive_references(&self) -> Result<FxHashMap<PathBuf, Vec<PathBuf>>, io::Error> {
+        self.find_archive_references_in([CacheBucket::SourceDistributions, CacheBucket::Wheels])
+    }
+
+    /// Find all references to entries in the archive bucket from the given buckets.
+    fn find_archive_references_in(
+        &self,
+        buckets: impl IntoIterator<Item = CacheBucket>,
+    ) -> Result<FxHashMap<PathBuf, Vec<PathBuf>>, io::Error> {
         let mut references = FxHashMap::<PathBuf, Vec<PathBuf>>::default();
-        for bucket in [CacheBucket::SourceDistributions, CacheBucket::Wheels] {
+        for bucket in buckets {
             let bucket_path = self.bucket(bucket);
             if bucket_path.is_dir() {
                 let walker = walkdir::WalkDir::new(&bucket_path).into_iter();
@@ -862,6 +985,24 @@ impl Cache {
     #[cfg(unix)]
     pub fn resolve_link(&self, path: impl AsRef<Path>) -> io::Result<PathBuf> {
         path.as_ref().canonicalize()
+    }
+}
+
+/// Returns `true` if the automatic prune interval has elapsed since the last run.
+///
+/// The marker file's modification time records the last run. A missing marker (e.g., a fresh
+/// cache, or one predating this feature) is treated as due.
+fn autoprune_due(marker: &Path) -> bool {
+    let Ok(metadata) = fs_err::metadata(marker) else {
+        return true;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return true;
+    };
+    match SystemTime::now().duration_since(modified) {
+        Ok(elapsed) => elapsed >= AUTOPRUNE_INTERVAL,
+        // The marker is from the future (e.g., clock skew); treat the prune as not due.
+        Err(_) => false,
     }
 }
 
@@ -1536,5 +1677,98 @@ mod tests {
         assert!(victim_dir.is_dir());
         assert!(victim_dir.join("payload.txt").is_file());
         assert!(fs_err::symlink_metadata(symlink).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prune_unreferenced_archives_removes_dangling_archives() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let dangling = archives.join("dangling");
+
+        fs_err::create_dir_all(&dangling).unwrap();
+        fs_err::write(dangling.join("payload.txt"), "payload").unwrap();
+
+        let summary = Cache::from_path(cache_root.path())
+            .prune_unreferenced_archives()
+            .unwrap();
+
+        assert_eq!(summary.num_files, 1);
+        assert!(!dangling.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prune_unreferenced_archives_retains_wheel_references() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let wheels = cache_root.path().join(CacheBucket::Wheels.to_str());
+        let archive = archives.join("referenced");
+
+        fs_err::create_dir_all(&archive).unwrap();
+        fs_err::write(archive.join("payload.txt"), "payload").unwrap();
+        fs_err::create_dir_all(wheels.join("pypi").join("anyio")).unwrap();
+        fs_err::os::unix::fs::symlink(&archive, wheels.join("pypi").join("anyio").join("link"))
+            .unwrap();
+
+        let summary = Cache::from_path(cache_root.path())
+            .prune_unreferenced_archives()
+            .unwrap();
+
+        assert_eq!(summary.num_files, 0);
+        assert!(archive.join("payload.txt").is_file());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prune_unreferenced_archives_retains_environment_references() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let environments = cache_root.path().join(CacheBucket::Environments.to_str());
+        let archive = archives.join("environment");
+
+        fs_err::create_dir_all(&archive).unwrap();
+        fs_err::write(archive.join("payload.txt"), "payload").unwrap();
+        fs_err::create_dir_all(environments.join("interpreter-digest")).unwrap();
+        fs_err::os::unix::fs::symlink(
+            &archive,
+            environments.join("interpreter-digest").join("resolution"),
+        )
+        .unwrap();
+
+        let summary = Cache::from_path(cache_root.path())
+            .prune_unreferenced_archives()
+            .unwrap();
+
+        assert_eq!(summary.num_files, 0);
+        assert!(archive.join("payload.txt").is_file());
+    }
+
+    #[test]
+    fn autoprune_due_marker() {
+        use std::time::{Duration, SystemTime};
+
+        use super::{AUTOPRUNE_INTERVAL, autoprune_due};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let marker = cache_root.path().join(".autoprune");
+
+        // A missing marker is due.
+        assert!(autoprune_due(&marker));
+
+        // A fresh marker is not due.
+        fs_err::write(&marker, []).unwrap();
+        assert!(!autoprune_due(&marker));
+
+        // A marker older than the interval is due.
+        let stale = SystemTime::now() - AUTOPRUNE_INTERVAL - Duration::from_secs(60);
+        filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(stale)).unwrap();
+        assert!(autoprune_due(&marker));
     }
 }

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -2623,7 +2623,7 @@ mod tests {
         // A missing marker is due, regardless of growth.
         assert!(autoprune_due(&marker, 0));
 
-        // A marker with unparseable contents (e.g., from a previous format) is due.
+        // A marker with unparsable contents (e.g., from a previous format) is due.
         fs_err::write(&marker, "not a number").unwrap();
         assert!(autoprune_due(&marker, 0));
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace, warn};
 
 use uv_cache_info::Timestamp;
@@ -42,6 +42,21 @@ const AUTOPRUNE_INTERVAL: Duration = Duration::from_hours(24);
 
 /// The name of the marker file recording the time of the last automatic cache pruning run.
 const AUTOPRUNE_MARKER: &str = ".autoprune";
+
+/// The cache bucket families (at any version) that may contain links into the archive bucket,
+/// aside from the environments bucket.
+///
+/// Includes historical bucket names (e.g., `built-wheels` and `source-dists`, former names of
+/// the source distributions bucket), since outdated buckets may be in use by other uv versions.
+/// If a new bucket family gains links into the archive bucket, it must be added here.
+const DISTRIBUTION_BUCKET_FAMILIES: &[&str] = &["built-wheels", "sdists", "source-dists", "wheels"];
+
+/// The cache bucket family (at any version) containing cached environments.
+const ENVIRONMENTS_BUCKET_FAMILY: &str = "environments";
+
+/// The maximum size of an archive link file ([`Link`]) on Windows, used to avoid reading
+/// unrelated files when searching for archive references.
+const MAX_LINK_SIZE: u64 = 1024;
 
 /// Error locking a cache entry or shard
 #[derive(Debug, thiserror::Error)]
@@ -537,9 +552,10 @@ impl Cache {
             return;
         }
 
-        // Require the exclusive lock, so that the prune cannot race another uv process. If any
-        // other process holds the lock (shared or exclusive), skip pruning entirely. The lock is
-        // held until the prune completes.
+        // Require the exclusive lock, so that the prune cannot race any other uv process that
+        // takes the cache lock (as all versions since 0.10 do). If any other process holds the
+        // lock (shared or exclusive), skip pruning entirely. The lock is held until the prune
+        // completes.
         let Some(_lock_file) = LockedFile::acquire_no_wait(
             self.root.join(".lock"),
             LockedFileMode::Exclusive,
@@ -578,26 +594,134 @@ impl Cache {
     /// Remove any archives that are no longer referenced, as in [`Cache::prune`].
     ///
     /// Unlike [`Cache::prune`], leaves cached environments (and the archives they reference)
-    /// intact, along with outdated cache buckets, which may be in use by other uv versions.
+    /// intact, along with outdated cache buckets (and the archives they reference), which may
+    /// be in use by other uv versions.
     ///
     /// The caller must hold the exclusive cache lock.
     fn prune_unreferenced_archives(&self) -> Result<Removal, io::Error> {
-        let mut summary = Removal::default();
+        let references = self.find_archive_references_for_autoprune()?;
+        self.remove_unreferenced_archives(&references)
+    }
 
-        // Unlike `Cache::prune`, cached environments are retained, so their references must be
-        // included to avoid removing the archives that back them.
-        let references = self.find_archive_references_in([
-            CacheBucket::SourceDistributions,
-            CacheBucket::Wheels,
-            CacheBucket::Environments,
-        ])?;
+    /// Find all references to entries in the archive bucket, for automatic pruning.
+    ///
+    /// Unlike [`Cache::find_archive_references`], includes references from outdated cache
+    /// buckets (which may be in use by other uv versions) and from cached environments,
+    /// including references from within the environments themselves (e.g., under
+    /// `--link-mode=symlink`, an environment's files are symlinks into wheel archives).
+    fn find_archive_references_for_autoprune(
+        &self,
+    ) -> Result<FxHashMap<PathBuf, Vec<PathBuf>>, io::Error> {
+        // Collect references from every version of every bucket that can contain them, since
+        // outdated buckets are retained and may be in use by other uv versions.
+        let mut distribution_buckets = Vec::new();
+        let mut environment_buckets = Vec::new();
+        for entry in fs_err::read_dir(&self.root)? {
+            let entry = entry?;
+            let Some(file_name) = entry.file_name().to_str().map(ToString::to_string) else {
+                continue;
+            };
+            if DISTRIBUTION_BUCKET_FAMILIES
+                .iter()
+                .any(|family| is_bucket_version(&file_name, family))
+            {
+                distribution_buckets.push(entry.path());
+            } else if is_bucket_version(&file_name, ENVIRONMENTS_BUCKET_FAMILY) {
+                environment_buckets.push(entry.path());
+            }
+        }
+
+        let raw_references = self.find_archive_references_in(distribution_buckets)?;
+        let raw_environment_references = self.find_archive_references_in(environment_buckets)?;
+
+        // If the archive bucket doesn't exist, there's nothing to normalize (or prune).
+        let archive_root = match fs_err::canonicalize(self.bucket(CacheBucket::Archive)) {
+            Ok(archive_root) => archive_root,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok(raw_references);
+            }
+            Err(err) => return Err(err),
+        };
+
+        // References can point to paths within an archive (e.g., an in-place environment's
+        // file-level symlinks under `--link-mode=symlink`), while the removal check operates on
+        // top-level archive entries; normalize each reference to the archive it falls within.
+        let mut references = FxHashMap::<PathBuf, Vec<PathBuf>>::default();
+        for (target, links) in raw_references {
+            let target = archive_entry(&archive_root, &target).unwrap_or(target);
+            references.entry(target).or_default().extend(links);
+        }
+
+        // An environment that lives in the archive bucket can itself reference other archives
+        // via internal symlinks (e.g., under `--link-mode=symlink`). Wheel archives contain no
+        // further archive references, so a single level of indirection suffices.
+        let mut environment_archives = FxHashSet::default();
+        for (target, links) in raw_environment_references {
+            let target = match archive_entry(&archive_root, &target) {
+                Some(entry) => {
+                    environment_archives.insert(entry.clone());
+                    entry
+                }
+                None => target,
+            };
+            references.entry(target).or_default().extend(links);
+        }
+
+        for archive in environment_archives {
+            if !archive.is_dir() {
+                continue;
+            }
+            for entry in walkdir::WalkDir::new(&archive) {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(err) => {
+                        debug!("Failed to walk cached environment: {err}");
+                        continue;
+                    }
+                };
+                if !entry.path_is_symlink() {
+                    continue;
+                }
+                let Ok(inner) = fs_err::canonicalize(entry.path()) else {
+                    continue;
+                };
+                let Some(inner) = archive_entry(&archive_root, &inner) else {
+                    continue;
+                };
+                references
+                    .entry(inner)
+                    .or_default()
+                    .push(entry.path().to_path_buf());
+            }
+        }
+
+        Ok(references)
+    }
+
+    /// Remove any entries in the archive bucket that are not present in the given references.
+    fn remove_unreferenced_archives(
+        &self,
+        references: &FxHashMap<PathBuf, Vec<PathBuf>>,
+    ) -> Result<Removal, io::Error> {
+        let mut summary = Removal::default();
 
         match fs_err::read_dir(self.bucket(CacheBucket::Archive)) {
             Ok(entries) => {
                 for entry in entries {
                     let entry = entry?;
                     let path = entry.path();
-                    let target = fs_err::canonicalize(&path)?;
+                    // Skip entries that can't be resolved (e.g., broken symlinks), rather than
+                    // aborting the entire sweep.
+                    let target = match fs_err::canonicalize(&path) {
+                        Ok(target) => target,
+                        Err(err) => {
+                            warn!(
+                                "Failed to resolve cache archive `{}`: {err}",
+                                path.display()
+                            );
+                            continue;
+                        }
+                    };
                     if !references.contains_key(&target) {
                         debug!("Removing dangling cache archive: {}", path.display());
                         summary += rm_rf(path)?;
@@ -806,22 +930,7 @@ impl Cache {
 
         // Fourth, remove any unused archives (by searching for archives that are not symlinked).
         let references = self.find_archive_references()?;
-
-        match fs_err::read_dir(self.bucket(CacheBucket::Archive)) {
-            Ok(entries) => {
-                for entry in entries {
-                    let entry = entry?;
-                    let path = entry.path();
-                    let target = fs_err::canonicalize(&path)?;
-                    if !references.contains_key(&target) {
-                        debug!("Removing dangling cache archive: {}", path.display());
-                        summary += rm_rf(path)?;
-                    }
-                }
-            }
-            Err(err) if err.kind() == io::ErrorKind::NotFound => (),
-            Err(err) => return Err(err),
-        }
+        summary += self.remove_unreferenced_archives(&references)?;
 
         Ok(summary)
     }
@@ -833,17 +942,19 @@ impl Cache {
     ///
     /// Returns a map from archive path to paths that reference it.
     fn find_archive_references(&self) -> Result<FxHashMap<PathBuf, Vec<PathBuf>>, io::Error> {
-        self.find_archive_references_in([CacheBucket::SourceDistributions, CacheBucket::Wheels])
+        self.find_archive_references_in([
+            self.bucket(CacheBucket::SourceDistributions),
+            self.bucket(CacheBucket::Wheels),
+        ])
     }
 
-    /// Find all references to entries in the archive bucket from the given buckets.
+    /// Find all references to entries in the archive bucket from the given directories.
     fn find_archive_references_in(
         &self,
-        buckets: impl IntoIterator<Item = CacheBucket>,
+        buckets: impl IntoIterator<Item = PathBuf>,
     ) -> Result<FxHashMap<PathBuf, Vec<PathBuf>>, io::Error> {
         let mut references = FxHashMap::<PathBuf, Vec<PathBuf>>::default();
-        for bucket in buckets {
-            let bucket_path = self.bucket(bucket);
+        for bucket_path in buckets {
             if bucket_path.is_dir() {
                 let walker = walkdir::WalkDir::new(&bucket_path).into_iter();
                 for entry in walker.filter_entry(|entry| {
@@ -875,6 +986,15 @@ impl Cache {
                     // On Windows, archive references are files containing structured data.
                     if cfg!(windows) {
                         if !entry.file_type().is_file() {
+                            continue;
+                        }
+
+                        // Avoid reading files that are too large to be links (e.g., the contents
+                        // of an environment).
+                        if entry
+                            .metadata()
+                            .is_ok_and(|metadata| metadata.len() > MAX_LINK_SIZE)
+                        {
                             continue;
                         }
                     }
@@ -1001,9 +1121,31 @@ fn autoprune_due(marker: &Path) -> bool {
     };
     match SystemTime::now().duration_since(modified) {
         Ok(elapsed) => elapsed >= AUTOPRUNE_INTERVAL,
-        // The marker is from the future (e.g., clock skew); treat the prune as not due.
-        Err(_) => false,
+        // The marker is from the future (e.g., clock skew). Tolerate skew of up to one interval,
+        // but treat anything larger as due, so that a wildly-future marker (e.g., written while
+        // the clock was fast) can't disable pruning indefinitely.
+        Err(err) => err.duration() >= AUTOPRUNE_INTERVAL,
     }
+}
+
+/// Returns `true` if `file_name` is a versioned directory of the given cache bucket family
+/// (e.g., `wheels-v6` for the `wheels` family).
+fn is_bucket_version(file_name: &str, family: &str) -> bool {
+    file_name
+        .strip_prefix(family)
+        .and_then(|suffix| suffix.strip_prefix("-v"))
+        .is_some_and(|version| !version.is_empty() && version.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// Returns the top-level entry in the archive bucket that contains `target`, if any.
+///
+/// For example, given a target of `archive-v0/foo/lib/python3.12/site-packages`, returns
+/// `archive-v0/foo`. The archive root must be canonicalized; the target is assumed to be
+/// canonicalized (e.g., by [`Cache::resolve_link`]).
+fn archive_entry(archive_root: &Path, target: &Path) -> Option<PathBuf> {
+    let relative = target.strip_prefix(archive_root).ok()?;
+    let entry = relative.components().next()?;
+    Some(archive_root.join(entry))
 }
 
 /// An archive (unzipped wheel) that exists in the local cache.
@@ -1750,6 +1892,73 @@ mod tests {
         assert!(archive.join("payload.txt").is_file());
     }
 
+    /// Archives referenced only from an outdated cache bucket (e.g., `wheels-v5` when the
+    /// current bucket is `wheels-v6`) must be retained, since outdated buckets may be in use by
+    /// other uv versions.
+    #[test]
+    #[cfg(unix)]
+    fn prune_unreferenced_archives_retains_outdated_bucket_references() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let outdated_wheels = cache_root.path().join("wheels-v5");
+        let archive = archives.join("referenced");
+
+        fs_err::create_dir_all(&archive).unwrap();
+        fs_err::write(archive.join("payload.txt"), "payload").unwrap();
+        fs_err::create_dir_all(outdated_wheels.join("pypi").join("anyio")).unwrap();
+        fs_err::os::unix::fs::symlink(
+            &archive,
+            outdated_wheels.join("pypi").join("anyio").join("link"),
+        )
+        .unwrap();
+
+        let summary = Cache::from_path(cache_root.path())
+            .prune_unreferenced_archives()
+            .unwrap();
+
+        assert_eq!(summary.num_files, 0);
+        assert!(archive.join("payload.txt").is_file());
+    }
+
+    /// Archives referenced only from within a cached environment (e.g., site-packages symlinks
+    /// created under `--link-mode=symlink`) must be retained.
+    #[test]
+    #[cfg(unix)]
+    fn prune_unreferenced_archives_retains_environment_internal_references() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let environments = cache_root.path().join(CacheBucket::Environments.to_str());
+        let environment = archives.join("environment");
+        let wheel = archives.join("wheel");
+
+        // A wheel archive referenced only via a symlink within the environment archive.
+        fs_err::create_dir_all(&wheel).unwrap();
+        fs_err::write(wheel.join("payload.txt"), "payload").unwrap();
+        let site_packages = environment.join("lib").join("site-packages");
+        fs_err::create_dir_all(&site_packages).unwrap();
+        fs_err::os::unix::fs::symlink(wheel.join("payload.txt"), site_packages.join("module.py"))
+            .unwrap();
+
+        fs_err::create_dir_all(environments.join("interpreter-digest")).unwrap();
+        fs_err::os::unix::fs::symlink(
+            &environment,
+            environments.join("interpreter-digest").join("resolution"),
+        )
+        .unwrap();
+
+        let summary = Cache::from_path(cache_root.path())
+            .prune_unreferenced_archives()
+            .unwrap();
+
+        assert_eq!(summary.num_files, 0);
+        assert!(wheel.join("payload.txt").is_file());
+        assert!(environment.exists());
+    }
+
     #[test]
     fn autoprune_due_marker() {
         use std::time::{Duration, SystemTime};
@@ -1767,8 +1976,35 @@ mod tests {
         assert!(!autoprune_due(&marker));
 
         // A marker older than the interval is due.
-        let stale = SystemTime::now() - AUTOPRUNE_INTERVAL - Duration::from_secs(60);
+        let stale = SystemTime::now() - AUTOPRUNE_INTERVAL - Duration::from_mins(1);
         filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(stale)).unwrap();
         assert!(autoprune_due(&marker));
+
+        // A marker slightly in the future (e.g., clock skew) is not due.
+        let skewed = SystemTime::now() + Duration::from_mins(1);
+        filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(skewed)).unwrap();
+        assert!(!autoprune_due(&marker));
+
+        // A marker more than an interval in the future is due, so that a wildly-future marker
+        // can't disable pruning indefinitely.
+        let far_future = SystemTime::now() + AUTOPRUNE_INTERVAL + Duration::from_mins(1);
+        filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(far_future))
+            .unwrap();
+        assert!(autoprune_due(&marker));
+    }
+
+    #[test]
+    fn bucket_version_matching() {
+        use super::is_bucket_version;
+
+        assert!(is_bucket_version("wheels-v6", "wheels"));
+        assert!(is_bucket_version("wheels-v10", "wheels"));
+        assert!(is_bucket_version("built-wheels-v3", "built-wheels"));
+        assert!(!is_bucket_version("wheels-v6", "built-wheels"));
+        assert!(!is_bucket_version("built-wheels-v3", "wheels"));
+        assert!(!is_bucket_version("wheels-v", "wheels"));
+        assert!(!is_bucket_version("wheels-vX", "wheels"));
+        assert!(!is_bucket_version("wheels", "wheels"));
+        assert!(!is_bucket_version("wheels-v6-backup", "wheels"));
     }
 }

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -654,12 +654,16 @@ impl Cache {
 
         // An environment that lives in the archive bucket can itself reference other archives
         // via internal symlinks (e.g., under `--link-mode=symlink`). Wheel archives contain no
-        // further archive references, so a single level of indirection suffices.
+        // further archive references, so a single level of indirection suffices. Links to an
+        // environment archive point at the archive root, while an environment's internal
+        // symlinks resolve to paths within other archives; only the former need to be walked.
         let mut environment_archives = FxHashSet::default();
         for (target, links) in raw_environment_references {
             let target = match archive_entry(&archive_root, &target) {
                 Some(entry) => {
-                    environment_archives.insert(entry.clone());
+                    if entry == target {
+                        environment_archives.insert(entry.clone());
+                    }
                     entry
                 }
                 None => target,
@@ -976,27 +980,32 @@ impl Cache {
                 }) {
                     let entry = entry?;
 
-                    // On Unix, archive references use symlinks.
-                    if cfg!(unix) {
-                        if !entry.file_type().is_symlink() {
-                            continue;
+                    // On Unix, archive references are symlinks. On Windows, archive references
+                    // are files containing structured data ([`Link`]), though environments may
+                    // also contain real symlinks (e.g., under `--link-mode=symlink`).
+                    if entry.path_is_symlink() {
+                        if let Ok(target) = fs_err::canonicalize(entry.path()) {
+                            references
+                                .entry(target)
+                                .or_default()
+                                .push(entry.path().to_path_buf());
                         }
+                        continue;
                     }
 
-                    // On Windows, archive references are files containing structured data.
-                    if cfg!(windows) {
-                        if !entry.file_type().is_file() {
-                            continue;
-                        }
+                    if cfg!(unix) {
+                        continue;
+                    }
 
-                        // Avoid reading files that are too large to be links (e.g., the contents
-                        // of an environment).
-                        if entry
-                            .metadata()
-                            .is_ok_and(|metadata| metadata.len() > MAX_LINK_SIZE)
-                        {
-                            continue;
-                        }
+                    if !entry.file_type().is_file() {
+                        continue;
+                    }
+
+                    // Avoid reading files that are too large to be links (e.g., the contents of
+                    // an environment). Skip files whose size can't be determined.
+                    match entry.metadata() {
+                        Ok(metadata) if metadata.len() <= MAX_LINK_SIZE => {}
+                        _ => continue,
                     }
 
                     if let Ok(target) = self.resolve_link(entry.path()) {

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -37,11 +37,23 @@ mod wheel;
 /// Must be kept in-sync with the version in [`CacheBucket::to_str`].
 pub const ARCHIVE_VERSION: u8 = 0;
 
-/// The minimum interval between automatic cache pruning runs.
-const AUTOPRUNE_INTERVAL: Duration = Duration::from_hours(24);
-
-/// The name of the marker file recording the time of the last automatic cache pruning run.
+/// The name of the marker file recording the state of the last automatic cache pruning run.
 const AUTOPRUNE_MARKER: &str = ".autoprune";
+
+/// The minimum interval between automatic cache pruning runs.
+const AUTOPRUNE_MIN_INTERVAL: Duration = Duration::from_hours(1);
+
+/// The minimum number of new archive entries since the last automatic pruning run before
+/// another run is triggered.
+const AUTOPRUNE_GROWTH_THRESHOLD: u64 = 32;
+
+/// The name of the top-level cache directory containing in-use lock files for cache entries.
+///
+/// A process that runs a command from a cache entry (e.g., a cached environment) takes a shared
+/// lock on the entry's in-use lock file for the lifetime of the command, allowing it to release
+/// the main cache lock. Removal operations take a non-blocking exclusive lock on the in-use lock
+/// file before removing the entry, skipping entries that are in use.
+const IN_USE_LOCKS_DIR: &str = "locks";
 
 /// The cache bucket families (at any version) that may contain links into the archive bucket,
 /// aside from the environments bucket.
@@ -290,6 +302,157 @@ impl Cache {
         }
     }
 
+    /// Mark the top-level cache entries containing the given paths as in use.
+    ///
+    /// The returned guards hold shared locks on the entries' in-use lock files, which removal
+    /// operations respect: an entry whose in-use lock is held is retained. This allows a
+    /// long-lived command (e.g., a server started with `uv run`) to release the main cache
+    /// lock while protecting the cache entries it runs from.
+    ///
+    /// The caller must hold the main cache lock while claiming, so that a removal operation
+    /// (which requires the exclusive main lock) cannot run between the decision to use an
+    /// entry and the claim. Claims are best-effort: paths outside the cache are ignored, and
+    /// failures are logged and ignored.
+    pub fn claim_in_use<'a>(&self, paths: impl IntoIterator<Item = &'a Path>) -> Vec<LockedFile> {
+        let mut claims = Vec::new();
+        for path in paths {
+            let Some(lock_path) = self.in_use_lock_path(path) else {
+                continue;
+            };
+            if let Some(parent) = lock_path.parent() {
+                if let Err(err) = fs_err::create_dir_all(parent) {
+                    warn!("Failed to create in-use lock directory: {err}");
+                    continue;
+                }
+            }
+            if let Some(lock) = LockedFile::acquire_no_wait(
+                &lock_path,
+                LockedFileMode::Shared,
+                lock_path.simplified_display(),
+            ) {
+                claims.push(lock);
+            } else {
+                // The lock is held exclusively by a removal operation (e.g., a concurrent
+                // `uv cache prune --force`); the entry may be removed out from under us, as it
+                // would have been before in-use locks existed.
+                warn!(
+                    "Failed to mark cache entry as in use: `{}`",
+                    lock_path.simplified_display()
+                );
+            }
+        }
+        claims
+    }
+
+    /// Release the main cache lock, if held.
+    ///
+    /// Long-lived commands release the lock before waiting on a child process, so that cache
+    /// maintenance (e.g., automatic pruning) can proceed while the child runs; the entries the
+    /// child depends on are protected by [`Cache::claim_in_use`] instead.
+    pub fn release_lock(&self) {
+        if let Some(lock_file) = &self.lock_file {
+            lock_file.release();
+        }
+    }
+
+    /// Return the path to the in-use lock file for the top-level cache entry containing `path`.
+    ///
+    /// Returns `None` if `path` is not inside a cache bucket.
+    fn in_use_lock_path(&self, path: &Path) -> Option<PathBuf> {
+        // Canonicalize both sides: the path often is canonicalized (e.g., by
+        // [`Cache::resolve_link`]) while the root is merely absolute, which would otherwise
+        // fail the prefix check (e.g., `/private/var` vs. `/var` on macOS).
+        let root = fs_err::canonicalize(&self.root).unwrap_or_else(|_| self.root.clone());
+        let path = fs_err::canonicalize(path).ok()?;
+        let relative = path.strip_prefix(&root).ok()?;
+        let mut components = relative.components();
+        let bucket = components.next()?.as_os_str().to_owned();
+        let entry = components.next()?.as_os_str().to_owned();
+        if bucket == IN_USE_LOCKS_DIR {
+            return None;
+        }
+        Some(self.root.join(IN_USE_LOCKS_DIR).join(bucket).join(entry))
+    }
+
+    /// Return the top-level entries (by file name) of the given bucket that are currently
+    /// marked as in use.
+    ///
+    /// Lock files whose cache entry no longer exists are removed; a lock file is never removed
+    /// while its entry exists, so that a concurrent claimer (which creates the lock file before
+    /// locking it) can't be left holding a lock on a deleted file.
+    fn in_use_entries(&self, bucket: CacheBucket) -> FxHashSet<String> {
+        let mut in_use = FxHashSet::default();
+        let lock_dir = self.root.join(IN_USE_LOCKS_DIR).join(bucket.to_str());
+        let entries = match fs_err::read_dir(&lock_dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return in_use,
+            Err(err) => {
+                warn!("Failed to read in-use lock directory: {err}");
+                return in_use;
+            }
+        };
+        for entry in entries {
+            let Ok(entry) = entry else {
+                continue;
+            };
+            let Some(file_name) = entry.file_name().to_str().map(ToString::to_string) else {
+                continue;
+            };
+            match LockedFile::acquire_no_wait(
+                entry.path(),
+                LockedFileMode::Exclusive,
+                entry.path().simplified_display(),
+            ) {
+                // No process holds a claim; if the cache entry itself is gone, the lock file
+                // is stale and can be removed.
+                Some(lock) => {
+                    if !self.bucket(bucket).join(&file_name).exists() {
+                        if let Err(err) = fs_err::remove_file(entry.path()) {
+                            debug!("Failed to remove stale in-use lock file: {err}");
+                        }
+                    }
+                    drop(lock);
+                }
+                None => {
+                    in_use.insert(file_name);
+                }
+            }
+        }
+        in_use
+    }
+
+    /// Wait for all in-use cache entries to be released.
+    ///
+    /// Used by operations that remove the entire cache (e.g., `uv cache clean`), which
+    /// previously waited on the main cache lock for running processes to finish; since
+    /// long-lived commands now release the main lock while waiting on a child process, the
+    /// in-use locks must be awaited as well.
+    ///
+    /// The caller must hold the exclusive main cache lock, so that no new claims can appear
+    /// while waiting.
+    pub async fn wait_for_in_use(&self) -> Result<(), LockedFileError> {
+        let locks_root = self.root.join(IN_USE_LOCKS_DIR);
+        let buckets = match fs_err::read_dir(&locks_root) {
+            Ok(buckets) => buckets,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+        for bucket in buckets {
+            let bucket = bucket?;
+            for entry in fs_err::read_dir(bucket.path())? {
+                let entry = entry?;
+                let lock = LockedFile::acquire(
+                    entry.path(),
+                    LockedFileMode::Exclusive,
+                    entry.path().simplified_display(),
+                )
+                .await?;
+                drop(lock);
+            }
+        }
+        Ok(())
+    }
+
     /// Return the root of the cache.
     pub fn root(&self) -> &Path {
         &self.root
@@ -526,11 +689,13 @@ impl Cache {
 
     /// Opportunistically prune unreferenced archives from the cache.
     ///
-    /// Pruning is enabled by the [`PreviewFeature::CacheAutoprune`] preview feature, and runs at
-    /// most once per [`AUTOPRUNE_INTERVAL`]. To guarantee that no other uv process is reading
-    /// from the cache, pruning requires the exclusive lock; if the lock is unavailable, or if
-    /// the caller already holds a lock, the prune is skipped and retried on a subsequent
-    /// invocation.
+    /// Pruning is enabled by the [`PreviewFeature::CacheAutoprune`] preview feature, and is
+    /// triggered by growth of the archive bucket since the last run (see [`autoprune_due`]).
+    /// To guarantee that no other uv process is mid-operation on the cache, pruning requires
+    /// the exclusive lock; if the lock is unavailable, or if the caller already holds a lock,
+    /// the prune is skipped and retried on a subsequent invocation. Archives claimed by an
+    /// in-use lock (e.g., cached environments that a child process is running from) are
+    /// retained.
     ///
     /// Failures are logged and ignored, since pruning is best-effort.
     fn autoprune(&self) {
@@ -544,16 +709,23 @@ impl Cache {
             return;
         }
 
-        // Consult the marker file before taking the lock, to keep the common case cheap.
+        // Consult the marker file before taking the lock, to keep the common case cheap: one
+        // `readdir` of the archive bucket and one read of the marker file.
         let marker = self.root.join(AUTOPRUNE_MARKER);
-        if !autoprune_due(&marker) {
+        let archive_count = match count_dir_entries(&self.bucket(CacheBucket::Archive)) {
+            Ok(count) => count,
+            Err(err) => {
+                debug!("Failed to count cache archives: {err}");
+                return;
+            }
+        };
+        if !autoprune_due(&marker, archive_count) {
             return;
         }
 
         // Require the exclusive lock, so that the prune cannot race any other uv process that
-        // takes the cache lock (as all versions since 0.10 do). If any other process holds the
-        // lock (shared or exclusive), skip pruning entirely. The lock is held until the prune
-        // completes.
+        // is mid-operation on the cache. If any other process holds the lock (shared or
+        // exclusive), skip pruning entirely. The lock is held until the prune completes.
         let Some(_lock_file) = LockedFile::acquire_no_wait(
             self.root.join(".lock"),
             LockedFileMode::Exclusive,
@@ -564,13 +736,13 @@ impl Cache {
         };
 
         // Re-check the marker while holding the lock, in case another process pruned in between.
-        if !autoprune_due(&marker) {
+        if !autoprune_due(&marker, archive_count) {
             return;
         }
 
         // Record the attempt before pruning, so that a failing prune isn't retried on every
         // invocation.
-        if let Err(err) = fs_err::write(&marker, []) {
+        if let Err(err) = fs_err::write(&marker, archive_count.to_string()) {
             debug!("Failed to update autoprune marker: {err}");
             return;
         }
@@ -582,6 +754,17 @@ impl Cache {
                     "Removed {} unreferenced archive files ({} bytes)",
                     removal.num_files, removal.total_bytes
                 );
+                // Record the post-prune archive count as the baseline for the growth check.
+                match count_dir_entries(&self.bucket(CacheBucket::Archive)) {
+                    Ok(count) => {
+                        if let Err(err) = fs_err::write(&marker, count.to_string()) {
+                            debug!("Failed to update autoprune marker: {err}");
+                        }
+                    }
+                    Err(err) => {
+                        debug!("Failed to count cache archives: {err}");
+                    }
+                }
             }
             Err(err) => {
                 debug!("Failed to prune cache archives: {err}");
@@ -597,8 +780,9 @@ impl Cache {
     ///
     /// The caller must hold the exclusive cache lock.
     fn prune_unreferenced_archives(&self) -> Result<Removal, io::Error> {
-        let references = self.find_archive_references_for_autoprune()?;
-        self.remove_unreferenced_archives(&references)
+        let in_use = self.in_use_entries(CacheBucket::Archive);
+        let references = self.find_archive_references_for_autoprune(&in_use)?;
+        self.remove_unreferenced_archives(&references, &in_use)
     }
 
     /// Find all references to entries in the archive bucket, for automatic pruning.
@@ -607,8 +791,13 @@ impl Cache {
     /// buckets (which may be in use by other uv versions) and from cached environments,
     /// including references from within the environments themselves (e.g., under
     /// `--link-mode=symlink`, an environment's files are symlinks into wheel archives).
+    ///
+    /// In-use archives are also walked for internal references: an in-use environment archive
+    /// may no longer be linked from any bucket (e.g., after a `--refresh` in another process),
+    /// but the archives its internal symlinks point to must be retained while it runs.
     fn find_archive_references_for_autoprune(
         &self,
+        in_use: &FxHashSet<String>,
     ) -> Result<FxHashMap<PathBuf, Vec<PathBuf>>, io::Error> {
         // Collect references from every version of every bucket that can contain them, since
         // outdated buckets are retained and may be in use by other uv versions.
@@ -669,6 +858,13 @@ impl Cache {
             references.entry(target).or_default().extend(links);
         }
 
+        // In-use archives are retained even if unreferenced, and may themselves be environments
+        // with internal references (e.g., an ephemeral `uvx` environment under
+        // `--link-mode=symlink`); walk them as well.
+        for entry in in_use {
+            environment_archives.insert(archive_root.join(entry));
+        }
+
         for archive in environment_archives {
             if !archive.is_dir() {
                 continue;
@@ -700,10 +896,12 @@ impl Cache {
         Ok(references)
     }
 
-    /// Remove any entries in the archive bucket that are not present in the given references.
+    /// Remove any entries in the archive bucket that are not present in the given references,
+    /// retaining entries that are marked as in use.
     fn remove_unreferenced_archives(
         &self,
         references: &FxHashMap<PathBuf, Vec<PathBuf>>,
+        in_use: &FxHashSet<String>,
     ) -> Result<Removal, io::Error> {
         let mut summary = Removal::default();
 
@@ -712,6 +910,14 @@ impl Cache {
                 for entry in entries {
                     let entry = entry?;
                     let path = entry.path();
+                    if entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|file_name| in_use.contains(file_name))
+                    {
+                        debug!("Retaining in-use cache archive: {}", path.display());
+                        continue;
+                    }
                     // Skip entries that can't be resolved (e.g., broken symlinks), rather than
                     // aborting the entire sweep.
                     let target = match fs_err::canonicalize(&path) {
@@ -810,9 +1016,19 @@ impl Cache {
         // to paths outside the cache.
         let archive_root = fs_err::canonicalize(&self.root)?.join(CacheBucket::Archive.to_str());
 
-        // Remove any archives that are no longer referenced.
+        // Remove any archives that are no longer referenced, unless they are in use by a
+        // running process.
+        let in_use = self.in_use_entries(CacheBucket::Archive);
         for (target, references) in references {
             if target.starts_with(&archive_root) && references.iter().all(|path| !path.exists()) {
+                if target
+                    .file_name()
+                    .and_then(|file_name| file_name.to_str())
+                    .is_some_and(|file_name| in_use.contains(file_name))
+                {
+                    debug!("Retaining in-use cache entry: {}", target.display());
+                    continue;
+                }
                 debug!("Removing dangling cache entry: {}", target.display());
                 summary += rm_rf(target)?;
             }
@@ -836,6 +1052,7 @@ impl Cache {
                 || entry.file_name() == ".git"
                 || entry.file_name() == ".lock"
                 || entry.file_name() == AUTOPRUNE_MARKER
+                || entry.file_name() == IN_USE_LOCKS_DIR
             {
                 continue;
             }
@@ -855,13 +1072,23 @@ impl Cache {
             }
         }
 
-        // Second, remove all cached environments. Centralized project environments can be
-        // referenced by `.venv` links, but are recreated when next needed.
+        // Second, remove all cached environments, except those that are in use by a running
+        // process. Centralized project environments can be referenced by `.venv` links, but
+        // are recreated when next needed.
+        let in_use_environments = self.in_use_entries(CacheBucket::Environments);
         match fs_err::read_dir(self.bucket(CacheBucket::Environments)) {
             Ok(entries) => {
                 for entry in entries {
                     let entry = entry?;
                     let path = entry.path();
+                    if entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|file_name| in_use_environments.contains(file_name))
+                    {
+                        debug!("Retaining in-use cached environment: {}", path.display());
+                        continue;
+                    }
                     debug!("Removing cached environment: {}", path.display());
                     summary += rm_rf(path)?;
                 }
@@ -930,9 +1157,12 @@ impl Cache {
             }
         }
 
-        // Fourth, remove any unused archives (by searching for archives that are not symlinked).
+        // Fourth, remove any unused archives (by searching for archives that are not symlinked),
+        // except those that are in use by a running process (e.g., a cached environment that a
+        // `uv run`-launched process is running from).
         let references = self.find_archive_references()?;
-        summary += self.remove_unreferenced_archives(&references)?;
+        let in_use = self.in_use_entries(CacheBucket::Archive);
+        summary += self.remove_unreferenced_archives(&references, &in_use)?;
 
         Ok(summary)
     }
@@ -1115,23 +1345,62 @@ impl Cache {
     }
 }
 
-/// Returns `true` if the automatic prune interval has elapsed since the last run.
+/// Returns `true` if an automatic prune is due, based on cache growth since the last run.
 ///
-/// The marker file's modification time records the last run. A missing marker (e.g., a fresh
-/// cache, or one predating this feature) is treated as due.
-fn autoprune_due(marker: &Path) -> bool {
-    let Ok(metadata) = fs_err::metadata(marker) else {
+/// The marker file records the number of entries in the archive bucket at the end of the last
+/// run, and its modification time records when that run occurred. A prune is due when the
+/// archive bucket has grown by at least [`AUTOPRUNE_GROWTH_THRESHOLD`] entries since the last
+/// run, at most once per [`AUTOPRUNE_MIN_INTERVAL`] (so that rapid churn, e.g. from repeated
+/// `--refresh` invocations, doesn't rescan the cache on every run).
+///
+/// A missing or unreadable marker (e.g., a fresh cache, or one predating this feature) is
+/// treated as due, establishing a baseline for future growth checks.
+fn autoprune_due(marker: &Path, archive_count: u64) -> bool {
+    let Ok(contents) = fs_err::read_to_string(marker) else {
         return true;
     };
-    let Ok(modified) = metadata.modified() else {
+    let Ok(recorded_count) = contents.trim().parse::<u64>() else {
         return true;
     };
-    match SystemTime::now().duration_since(modified) {
-        Ok(elapsed) => elapsed >= AUTOPRUNE_INTERVAL,
-        // The marker is from the future (e.g., clock skew). Tolerate skew of up to one interval,
-        // but treat anything larger as due, so that a wildly-future marker (e.g., written while
-        // the clock was fast) can't disable pruning indefinitely.
-        Err(err) => err.duration() >= AUTOPRUNE_INTERVAL,
+
+    // Enforce the time floor, if the marker's modification time is readable.
+    if let Ok(metadata) = fs_err::metadata(marker)
+        && let Ok(modified) = metadata.modified()
+    {
+        let elapsed_floor = match SystemTime::now().duration_since(modified) {
+            Ok(elapsed) => elapsed >= AUTOPRUNE_MIN_INTERVAL,
+            // The marker is from the future (e.g., clock skew). Tolerate skew of up to one
+            // interval, but treat anything larger as elapsed, so that a wildly-future marker
+            // (e.g., written while the clock was fast) can't disable pruning indefinitely.
+            Err(err) => err.duration() >= AUTOPRUNE_MIN_INTERVAL,
+        };
+        if !elapsed_floor {
+            return false;
+        }
+    }
+
+    // If the archive bucket shrank (e.g., a manual `uv cache prune` or `clean`), the recorded
+    // baseline is stale; run once to re-establish it.
+    if archive_count < recorded_count {
+        return true;
+    }
+
+    archive_count - recorded_count >= AUTOPRUNE_GROWTH_THRESHOLD
+}
+
+/// Returns the number of entries in the given directory, or zero if it doesn't exist.
+fn count_dir_entries(path: &Path) -> io::Result<u64> {
+    match fs_err::read_dir(path) {
+        Ok(entries) => {
+            let mut count: u64 = 0;
+            for entry in entries {
+                entry?;
+                count += 1;
+            }
+            Ok(count)
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(0),
+        Err(err) => Err(err),
     }
 }
 
@@ -1966,38 +2235,205 @@ mod tests {
         assert!(environment.exists());
     }
 
+    /// Archives claimed as in use (e.g., by a `uv run`-launched child process) must be
+    /// retained even when unreferenced, e.g., after a `--refresh` in another process replaced
+    /// the link that pointed at them.
+    #[test]
+    #[cfg(unix)]
+    fn prune_unreferenced_archives_retains_in_use_archives() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let environment = archives.join("running-environment");
+        let wheel = archives.join("wheel");
+        let dangling = archives.join("dangling");
+
+        // An unreferenced environment archive, as after `--refresh`, containing an internal
+        // symlink to a wheel archive.
+        fs_err::create_dir_all(&environment).unwrap();
+        fs_err::create_dir_all(&wheel).unwrap();
+        fs_err::write(wheel.join("payload.txt"), "payload").unwrap();
+        let site_packages = environment.join("lib").join("site-packages");
+        fs_err::create_dir_all(&site_packages).unwrap();
+        fs_err::os::unix::fs::symlink(wheel.join("payload.txt"), site_packages.join("module.py"))
+            .unwrap();
+
+        // An unreferenced, unclaimed archive.
+        fs_err::create_dir_all(&dangling).unwrap();
+        fs_err::write(dangling.join("payload.txt"), "payload").unwrap();
+
+        let cache = Cache::from_path(cache_root.path());
+        let claims = cache.claim_in_use(std::iter::once(environment.as_path()));
+        assert_eq!(claims.len(), 1);
+
+        let summary = cache.prune_unreferenced_archives().unwrap();
+
+        // Only the dangling archive is removed; the in-use environment and the wheel archive
+        // referenced by its internal symlink are retained.
+        assert_eq!(summary.num_files, 1);
+        assert!(!dangling.exists());
+        assert!(environment.exists());
+        assert!(wheel.join("payload.txt").is_file());
+
+        // Once the claim is released, the archives are removed.
+        drop(claims);
+        let summary = cache.prune_unreferenced_archives().unwrap();
+        assert!(summary.num_files > 0);
+        assert!(!environment.exists());
+        assert!(!wheel.exists());
+    }
+
+    /// `uv cache prune` must retain in-use cached environments and the archives they link to.
+    #[test]
+    #[cfg(unix)]
+    fn prune_retains_in_use_environments() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let environments = cache_root.path().join(CacheBucket::Environments.to_str());
+        let in_use_archive = archives.join("in-use-environment");
+        let other_archive = archives.join("other-environment");
+
+        // Two environment links; only the first archive is claimed.
+        fs_err::create_dir_all(&in_use_archive).unwrap();
+        fs_err::write(in_use_archive.join("payload.txt"), "payload").unwrap();
+        fs_err::create_dir_all(&other_archive).unwrap();
+        fs_err::write(other_archive.join("payload.txt"), "payload").unwrap();
+        fs_err::create_dir_all(environments.join("digest")).unwrap();
+        fs_err::os::unix::fs::symlink(&in_use_archive, environments.join("digest").join("a"))
+            .unwrap();
+        fs_err::os::unix::fs::symlink(&other_archive, environments.join("digest").join("b"))
+            .unwrap();
+
+        let cache = Cache::from_path(cache_root.path());
+        // Claim through the environments-bucket path, as `uv run` does for script and
+        // centralized environments, and through the archive path, as for cached environments.
+        let claims = cache.claim_in_use([
+            environments.join("digest").as_path(),
+            in_use_archive.as_path(),
+        ]);
+        assert_eq!(claims.len(), 2);
+
+        let summary = cache.prune(false).unwrap();
+
+        // The claimed environment directory and archive are retained; the unclaimed
+        // environment is removed along with its archive.
+        assert!(summary.num_files > 0);
+        assert!(environments.join("digest").exists());
+        assert!(in_use_archive.join("payload.txt").is_file());
+        assert!(!other_archive.exists());
+    }
+
+    /// Claims for paths outside the cache are ignored, and stale lock files (whose cache entry
+    /// no longer exists) are cleaned up by removal operations.
+    #[test]
+    fn claim_in_use_scope_and_stale_lock_cleanup() {
+        use super::{Cache, CacheBucket, IN_USE_LOCKS_DIR};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let cache = Cache::from_path(cache_root.path());
+
+        // Paths outside the cache, at the cache root, or in the locks directory itself are
+        // not claimable.
+        fs_err::create_dir_all(outside.path().join("dir")).unwrap();
+        let locks_entry = cache_root
+            .path()
+            .join(IN_USE_LOCKS_DIR)
+            .join("bucket")
+            .join("entry");
+        fs_err::create_dir_all(locks_entry.parent().unwrap()).unwrap();
+        fs_err::write(&locks_entry, []).unwrap();
+        let claims = cache.claim_in_use([
+            outside.path().join("dir").as_path(),
+            cache_root.path(),
+            locks_entry.as_path(),
+        ]);
+        assert_eq!(claims.len(), 0);
+
+        // A released claim leaves a lock file behind; once the cache entry is gone, a removal
+        // operation cleans the lock file up.
+        let archive = cache_root
+            .path()
+            .join(CacheBucket::Archive.to_str())
+            .join("entry");
+        fs_err::create_dir_all(&archive).unwrap();
+        let claims = cache.claim_in_use(std::iter::once(archive.as_path()));
+        assert_eq!(claims.len(), 1);
+        drop(claims);
+
+        let lock_file = cache_root
+            .path()
+            .join(IN_USE_LOCKS_DIR)
+            .join(CacheBucket::Archive.to_str())
+            .join("entry");
+        assert!(lock_file.exists());
+
+        // While the entry exists, the lock file is retained.
+        assert!(cache.in_use_entries(CacheBucket::Archive).is_empty());
+        assert!(lock_file.exists());
+
+        // Once the entry is gone, the lock file is removed.
+        fs_err::remove_dir_all(&archive).unwrap();
+        assert!(cache.in_use_entries(CacheBucket::Archive).is_empty());
+        assert!(!lock_file.exists());
+    }
+
     #[test]
     fn autoprune_due_marker() {
         use std::time::{Duration, SystemTime};
 
-        use super::{AUTOPRUNE_INTERVAL, autoprune_due};
+        use super::{AUTOPRUNE_GROWTH_THRESHOLD, AUTOPRUNE_MIN_INTERVAL, autoprune_due};
 
         let cache_root = tempfile::tempdir().unwrap();
         let marker = cache_root.path().join(".autoprune");
 
-        // A missing marker is due.
-        assert!(autoprune_due(&marker));
+        // A missing marker is due, regardless of growth.
+        assert!(autoprune_due(&marker, 0));
 
-        // A fresh marker is not due.
-        fs_err::write(&marker, []).unwrap();
-        assert!(!autoprune_due(&marker));
+        // A marker with unparseable contents (e.g., from a previous format) is due.
+        fs_err::write(&marker, "not a number").unwrap();
+        assert!(autoprune_due(&marker, 0));
 
-        // A marker older than the interval is due.
-        let stale = SystemTime::now() - AUTOPRUNE_INTERVAL - Duration::from_mins(1);
-        filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(stale)).unwrap();
-        assert!(autoprune_due(&marker));
+        // Set the marker's mtime beyond the time floor, so that only growth gates below.
+        let elapsed = SystemTime::now() - AUTOPRUNE_MIN_INTERVAL - Duration::from_mins(1);
+        let set_elapsed = |marker: &std::path::Path| {
+            filetime::set_file_mtime(marker, filetime::FileTime::from_system_time(elapsed))
+                .unwrap();
+        };
 
-        // A marker slightly in the future (e.g., clock skew) is not due.
+        // Growth below the threshold is not due; growth at the threshold is due.
+        fs_err::write(&marker, "100").unwrap();
+        set_elapsed(&marker);
+        assert!(!autoprune_due(&marker, 100));
+        assert!(!autoprune_due(
+            &marker,
+            100 + AUTOPRUNE_GROWTH_THRESHOLD - 1
+        ));
+        assert!(autoprune_due(&marker, 100 + AUTOPRUNE_GROWTH_THRESHOLD));
+
+        // A shrunken archive bucket (e.g., after a manual prune) is due, to re-establish the
+        // baseline.
+        assert!(autoprune_due(&marker, 99));
+
+        // A fresh marker is not due within the time floor, even with sufficient growth.
+        fs_err::write(&marker, "100").unwrap();
+        assert!(!autoprune_due(&marker, 100 + AUTOPRUNE_GROWTH_THRESHOLD));
+
+        // A marker slightly in the future (e.g., clock skew) respects the time floor.
         let skewed = SystemTime::now() + Duration::from_mins(1);
         filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(skewed)).unwrap();
-        assert!(!autoprune_due(&marker));
+        assert!(!autoprune_due(&marker, 100 + AUTOPRUNE_GROWTH_THRESHOLD));
 
-        // A marker more than an interval in the future is due, so that a wildly-future marker
-        // can't disable pruning indefinitely.
-        let far_future = SystemTime::now() + AUTOPRUNE_INTERVAL + Duration::from_mins(1);
+        // A marker more than an interval in the future passes the time floor, so that a
+        // wildly-future marker can't disable pruning indefinitely.
+        let far_future = SystemTime::now() + AUTOPRUNE_MIN_INTERVAL + Duration::from_mins(1);
         filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(far_future))
             .unwrap();
-        assert!(autoprune_due(&marker));
+        assert!(autoprune_due(&marker, 100 + AUTOPRUNE_GROWTH_THRESHOLD));
+        assert!(!autoprune_due(&marker, 100));
     }
 
     #[test]

--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -217,6 +217,26 @@ impl LockedFile {
         self.unlock_or_log();
     }
 
+    /// Returns `true` if the locked file is still the file at its original path.
+    ///
+    /// A lock file can be unlinked (and recreated) by another process between this file being
+    /// opened and the lock being acquired; in that case, the lock is held on an orphaned file
+    /// and does not guard the path. Callers that create-then-lock should verify and retry.
+    pub fn verify_path(&self) -> bool {
+        let Ok(held) = self
+            .file
+            .file()
+            .try_clone()
+            .and_then(same_file::Handle::from_file)
+        else {
+            return false;
+        };
+        let Ok(current) = same_file::Handle::from_path(self.file.path()) else {
+            return false;
+        };
+        held == current
+    }
+
     /// Inner implementation for [`LockedFile::acquire`].
     async fn lock_file(
         file: fs_err::File,

--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -187,10 +187,36 @@ impl Display for LockedFileMode {
 #[cfg(feature = "tokio")]
 #[derive(Debug)]
 #[must_use]
-pub struct LockedFile(fs_err::File);
+pub struct LockedFile {
+    file: fs_err::File,
+    /// Whether the lock was explicitly released via [`LockedFile::release`].
+    released: std::sync::atomic::AtomicBool,
+}
 
 #[cfg(feature = "tokio")]
 impl LockedFile {
+    fn new(file: fs_err::File) -> Self {
+        Self {
+            file,
+            released: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Release the lock without dropping the [`LockedFile`].
+    ///
+    /// Unlike dropping, this can be used to release a lock behind shared ownership (e.g., an
+    /// [`std::sync::Arc`]) while other owners remain. Subsequent calls (and the eventual drop)
+    /// are no-ops.
+    pub fn release(&self) {
+        if self
+            .released
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            return;
+        }
+        self.unlock_or_log();
+    }
+
     /// Inner implementation for [`LockedFile::acquire`].
     async fn lock_file(
         file: fs_err::File,
@@ -206,7 +232,7 @@ impl LockedFile {
         let file = match try_lock_exclusive.await? {
             (Ok(()), file) => {
                 trace!("Acquired {mode} lock for `{resource}`");
-                return Ok(Self(file));
+                return Ok(Self::new(file));
             }
             (Err(err), file) => {
                 // Log error code and enum kind to help debugging more exotic failures.
@@ -239,7 +265,7 @@ impl LockedFile {
         })?;
 
         trace!("Acquired {mode} lock for `{resource}`");
-        Ok(Self(file))
+        Ok(Self::new(file))
     }
 
     /// Inner implementation for [`LockedFile::acquire_no_wait`].
@@ -251,7 +277,7 @@ impl LockedFile {
         match mode.try_lock(&file) {
             Ok(()) => {
                 trace!("Acquired {mode} lock for `{resource}`");
-                Some(Self(file))
+                Some(Self::new(file))
             }
             Err(err) => {
                 // Log error code and enum kind to help debugging more exotic failures.
@@ -402,7 +428,7 @@ impl LockedFile {
     /// [rust-lang/rust#148325]: https://github.com/rust-lang/rust/issues/148325
     #[cfg(not(target_os = "android"))]
     fn unlock(&self) -> Result<(), io::Error> {
-        self.0.unlock()
+        self.file.unlock()
     }
 
     /// Unlock the file.
@@ -416,17 +442,15 @@ impl LockedFile {
     fn unlock(&self) -> Result<(), io::Error> {
         use std::os::fd::AsFd;
 
-        rustix::fs::flock(self.0.as_fd(), rustix::fs::FlockOperation::Unlock)
+        rustix::fs::flock(self.file.as_fd(), rustix::fs::FlockOperation::Unlock)
             .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))
     }
-}
 
-#[cfg(feature = "tokio")]
-impl Drop for LockedFile {
-    fn drop(&mut self) {
+    /// Unlock the file, logging rather than propagating failures.
+    fn unlock_or_log(&self) {
         match self.unlock() {
             Ok(()) => {
-                trace!("Released lock at `{}`", self.0.path().display());
+                trace!("Released lock at `{}`", self.file.path().display());
             }
             // See <https://bugs.winehq.org/show_bug.cgi?id=59711>
             #[cfg(windows)]
@@ -434,14 +458,24 @@ impl Drop for LockedFile {
                 if uv_windows::is_wine()
                     && err.raw_os_error() == Some(ERROR_LOCK_VIOLATION.0.cast_signed()) =>
             {
-                trace!("Released lock at `{}`", self.0.path().display());
+                trace!("Released lock at `{}`", self.file.path().display());
             }
             Err(err) => {
                 error!(
                     "Failed to unlock resource at `{}`; program may be stuck: {err}",
-                    self.0.path().display()
+                    self.file.path().display()
                 );
             }
         }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl Drop for LockedFile {
+    fn drop(&mut self) {
+        if self.released.load(std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
+        self.unlock_or_log();
     }
 }

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -261,6 +261,7 @@ pub enum PreviewFeature {
     CentralizedProjectEnvs = 1 << 35,
     ToolInstallLocks = 1 << 36,
     WorkspaceListScripts = 1 << 37,
+    CacheAutoprune = 1 << 38,
 }
 
 impl PreviewFeature {
@@ -305,6 +306,7 @@ impl PreviewFeature {
             Self::CentralizedProjectEnvs => "centralized-project-envs",
             Self::ToolInstallLocks => "tool-install-locks",
             Self::WorkspaceListScripts => "workspace-list-scripts",
+            Self::CacheAutoprune => "cache-autoprune",
         }
     }
 }
@@ -362,6 +364,7 @@ impl FromStr for PreviewFeature {
             "centralized-project-envs" => Self::CentralizedProjectEnvs,
             "tool-install-locks" => Self::ToolInstallLocks,
             "workspace-list-scripts" => Self::WorkspaceListScripts,
+            "cache-autoprune" => Self::CacheAutoprune,
             _ => return Err(PreviewFeatureParseError),
         })
     }

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -132,6 +132,35 @@ pub fn is_enabled(flag: PreviewFeature) -> bool {
     get().is_enabled(flag)
 }
 
+/// Check if a specific preview feature is enabled globally, without panicking.
+///
+/// Unlike [`is_enabled`], returns `None` if the global preview state has not been initialized
+/// (or, with the `testing` feature, when the current thread does not hold a
+/// [`test::with_features`] guard). Intended for best-effort callers (e.g., opportunistic cache
+/// maintenance) that should treat an uninitialized state as "disabled" rather than crash.
+pub fn try_is_enabled(flag: PreviewFeature) -> Option<bool> {
+    match PREVIEW.get() {
+        Some(PreviewMode::Normal(mutex)) => {
+            let preview = match *mutex.lock().unwrap() {
+                PreviewState::Provisional(preview) => preview,
+                PreviewState::Final(preview) => preview,
+            };
+            Some(preview.is_enabled(flag))
+        }
+        #[cfg(feature = "testing")]
+        Some(PreviewMode::Test(rwlock)) => {
+            if !test::HELD.get() {
+                return None;
+            }
+            rwlock
+                .read()
+                .unwrap()
+                .map(|preview| preview.is_enabled(flag))
+        }
+        None => None,
+    }
+}
+
 /// Functions for unit tests, do not use from normal code!
 #[cfg(feature = "testing")]
 pub mod test {

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -77,6 +77,12 @@ impl EnvVars {
     #[attr_added_in("0.1.2")]
     pub const UV_NO_CACHE: &'static str = "UV_NO_CACHE";
 
+    /// If set to `1` or `true`, uv will periodically remove unreferenced archives from the
+    /// cache, as in `uv cache prune`. Pruning runs at most once per day, and only when no
+    /// other uv processes are running.
+    #[attr_added_in("next release")]
+    pub const UV_CACHE_AUTOPRUNE: &'static str = "UV_CACHE_AUTOPRUNE";
+
     /// Equivalent to the `--resolution` command-line argument. For example, if set to
     /// `lowest-direct`, uv will install the lowest compatible versions of all direct dependencies.
     #[attr_added_in("0.1.27")]

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -79,7 +79,8 @@ impl EnvVars {
 
     /// If set to `1` or `true`, uv will periodically remove unreferenced archives from the
     /// cache, as in `uv cache prune`. Pruning runs at most once per day, and only when no
-    /// other uv processes are running.
+    /// other uv processes are running. While the prune runs, other uv processes will wait for
+    /// it to complete before reading from the cache.
     #[attr_added_in("next release")]
     pub const UV_CACHE_AUTOPRUNE: &'static str = "UV_CACHE_AUTOPRUNE";
 

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -77,13 +77,6 @@ impl EnvVars {
     #[attr_added_in("0.1.2")]
     pub const UV_NO_CACHE: &'static str = "UV_NO_CACHE";
 
-    /// If set to `1` or `true`, uv will periodically remove unreferenced archives from the
-    /// cache, as in `uv cache prune`. Pruning runs at most once per day, and only when no
-    /// other uv processes are running. While the prune runs, other uv processes will wait for
-    /// it to complete before reading from the cache.
-    #[attr_added_in("next release")]
-    pub const UV_CACHE_AUTOPRUNE: &'static str = "UV_CACHE_AUTOPRUNE";
-
     /// Equivalent to the `--resolution` command-line argument. For example, if set to
     /// `lowest-direct`, uv will install the lowest compatible versions of all direct dependencies.
     #[attr_added_in("0.1.27")]

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -28,7 +28,7 @@ pub(crate) async fn cache_clean(
         return Ok(ExitStatus::Success);
     }
 
-    let cache = match cache.with_exclusive_lock_no_wait() {
+    let mut cache = match cache.with_exclusive_lock_no_wait() {
         Ok(cache) => cache,
         Err(cache) if force => {
             debug!("Cache is currently in use, proceeding due to `--force`");
@@ -45,9 +45,32 @@ pub(crate) async fn cache_clean(
 
     // Long-lived commands (e.g., servers started with `uv run`) release the main cache lock
     // while running, and instead hold in-use locks on the cache entries they run from. Since
-    // cleaning removes the entire cache, wait for those entries to be released as well.
-    if !force {
-        cache.wait_for_in_use().await?;
+    // removing the entire cache would delete those entries, wait for them to be released.
+    // (Package-scoped cleaning skips in-use entries instead of waiting.)
+    //
+    // The main lock must not be held while waiting: a child process holding an in-use lock
+    // may itself invoke uv, which would block on the main lock and prevent the child from
+    // ever exiting. Instead, probe under the main lock, release it while waiting on the
+    // in-use lock, then reacquire and re-check.
+    if !force && packages.is_empty() {
+        let mut warned = false;
+        while let Some(held) = cache
+            .find_held_in_use_lock()
+            .context("Failed to read the cache's in-use locks")?
+        {
+            if !warned {
+                writeln!(
+                    printer.stderr(),
+                    "Cache is currently in-use, waiting for other uv processes to finish (use `--force` to override)"
+                )?;
+                warned = true;
+            }
+            cache.release_lock();
+            Cache::wait_for_in_use_lock(&held).await.context(
+                "Failed waiting for a running uv-launched process to exit (use `--force` to override)",
+            )?;
+            cache = cache.with_exclusive_lock().await?;
+        }
     }
 
     let summary = if packages.is_empty() {

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -43,6 +43,13 @@ pub(crate) async fn cache_clean(
         }
     };
 
+    // Long-lived commands (e.g., servers started with `uv run`) release the main cache lock
+    // while running, and instead hold in-use locks on the cache entries they run from. Since
+    // cleaning removes the entire cache, wait for those entries to be released as well.
+    if !force {
+        cache.wait_for_in_use().await?;
+    }
+
     let summary = if packages.is_empty() {
         writeln!(
             printer.stderr(),

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -174,6 +174,11 @@ pub(super) async fn run(
         command.env_remove("TY_UV_METADATA");
     }
 
+    // Mark the ty binary's cache entry as in use, then release the main cache lock so that
+    // cache maintenance can proceed while ty runs.
+    let _claims = cache.claim_in_use(std::iter::once(ty_path.as_path()));
+    cache.release_lock();
+
     let mut handle = command.spawn().context("Failed to spawn `ty check`")?;
     let writer = if let Some(workspace_metadata) = workspace_metadata {
         debug!("Passing workspace metadata to `ty check` via stdin");

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -174,10 +174,11 @@ pub(super) async fn run(
         command.env_remove("TY_UV_METADATA");
     }
 
-    // Mark the ty binary's cache entry as in use, then release the main cache lock so that
-    // cache maintenance can proceed while ty runs.
-    let _claims = cache.claim_in_use(std::iter::once(ty_path.as_path()));
-    cache.release_lock();
+    // Mark the ty binary's cache entry and the environment ty analyzes (e.g., a cached script
+    // environment) as in use, then release the main cache lock so that cache maintenance can
+    // proceed while ty runs.
+    let _claims =
+        cache.claim_in_use_and_release_lock(std::iter::once(ty_path.as_path()).chain(venv_path));
 
     let mut handle = command.spawn().context("Failed to spawn `ty check`")?;
     let writer = if let Some(workspace_metadata) = workspace_metadata {

--- a/crates/uv/src/commands/project/format.rs
+++ b/crates/uv/src/commands/project/format.rs
@@ -199,6 +199,11 @@ pub(crate) async fn format(
     // Add any additional arguments passed after `--`
     command.args(extra_args.iter());
 
+    // Mark the ruff binary's cache entry as in use, then release the main cache lock so that
+    // cache maintenance can proceed while ruff runs.
+    let _claims = cache.claim_in_use(std::iter::once(ruff_path.as_path()));
+    cache.release_lock();
+
     let handle = command.spawn().context("Failed to spawn `ruff format`")?;
     run_to_completion(handle).await
 }

--- a/crates/uv/src/commands/project/format.rs
+++ b/crates/uv/src/commands/project/format.rs
@@ -201,8 +201,7 @@ pub(crate) async fn format(
 
     // Mark the ruff binary's cache entry as in use, then release the main cache lock so that
     // cache maintenance can proceed while ruff runs.
-    let _claims = cache.claim_in_use(std::iter::once(ruff_path.as_path()));
-    cache.release_lock();
+    let _claims = cache.claim_in_use_and_release_lock(std::iter::once(ruff_path.as_path()));
 
     let handle = command.spawn().context("Failed to spawn `ruff format`")?;
     run_to_completion(handle).await

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1304,6 +1304,20 @@ pub(crate) async fn run(
         process.env(EnvVars::VIRTUAL_ENV, interpreter.sys_prefix().as_os_str());
     }
 
+    // Mark the cache entries the child process runs from as in use, then release the main
+    // cache lock so that cache maintenance (e.g., `uv cache prune`, automatic pruning) can
+    // proceed while the child runs. The in-use claims must be taken before releasing the lock.
+    let _claims = cache.claim_in_use(
+        ephemeral_env
+            .as_ref()
+            .map(PythonEnvironment::root)
+            .into_iter()
+            .chain(requirements_env.as_ref().map(PythonEnvironment::root))
+            .chain(std::iter::once(interpreter.sys_prefix()))
+            .chain(std::iter::once(base_interpreter.sys_prefix())),
+    );
+    cache.release_lock();
+
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
     // TODO(zanieb): Throw a nicer error message if the command is not found

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1306,8 +1306,8 @@ pub(crate) async fn run(
 
     // Mark the cache entries the child process runs from as in use, then release the main
     // cache lock so that cache maintenance (e.g., `uv cache prune`, automatic pruning) can
-    // proceed while the child runs. The in-use claims must be taken before releasing the lock.
-    let _claims = cache.claim_in_use(
+    // proceed while the child runs.
+    let _claims = cache.claim_in_use_and_release_lock(
         ephemeral_env
             .as_ref()
             .map(PythonEnvironment::root)
@@ -1316,7 +1316,6 @@ pub(crate) async fn run(
             .chain(std::iter::once(interpreter.sys_prefix()))
             .chain(std::iter::once(base_interpreter.sys_prefix())),
     );
-    cache.release_lock();
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -369,6 +369,12 @@ pub(crate) async fn run(
     .context("Failed to build new PATH variable")?;
     process.env(EnvVars::PATH, new_path);
 
+    // Mark the cache entries the child process runs from as in use, then release the main
+    // cache lock so that cache maintenance (e.g., `uv cache prune`, automatic pruning) can
+    // proceed while the child runs. The in-use claims must be taken before releasing the lock.
+    let _claims = cache.claim_in_use(std::iter::once(environment.root()));
+    cache.release_lock();
+
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
     let space = if args.is_empty() { "" } else { " " };

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -371,9 +371,8 @@ pub(crate) async fn run(
 
     // Mark the cache entries the child process runs from as in use, then release the main
     // cache lock so that cache maintenance (e.g., `uv cache prune`, automatic pruning) can
-    // proceed while the child runs. The in-use claims must be taken before releasing the lock.
-    let _claims = cache.claim_in_use(std::iter::once(environment.root()));
-    cache.release_lock();
+    // proceed while the child runs.
+    let _claims = cache.claim_in_use_and_release_lock(std::iter::once(environment.root()));
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -505,7 +505,7 @@ fn autoprune() -> Result<()> {
     context
         .pip_sync()
         .arg("requirements.txt")
-        .env(EnvVars::UV_CACHE_AUTOPRUNE, "1")
+        .env(EnvVars::UV_PREVIEW_FEATURES, "cache-autoprune")
         .assert()
         .success();
 
@@ -522,7 +522,7 @@ fn autoprune() -> Result<()> {
     context
         .pip_sync()
         .arg("requirements.txt")
-        .env(EnvVars::UV_CACHE_AUTOPRUNE, "1")
+        .env(EnvVars::UV_PREVIEW_FEATURES, "cache-autoprune")
         .assert()
         .success();
     dangling.assert(predicates::path::exists());
@@ -534,7 +534,7 @@ fn autoprune() -> Result<()> {
     context
         .pip_sync()
         .arg("requirements.txt")
-        .env(EnvVars::UV_CACHE_AUTOPRUNE, "1")
+        .env(EnvVars::UV_PREVIEW_FEATURES, "cache-autoprune")
         .assert()
         .success();
 

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -495,7 +495,6 @@ fn prune_stale_revision() -> Result<()> {
 /// Automatic pruning should remove dangling archives during a normal command, but only when due,
 /// and without touching referenced archives.
 #[test]
-#[cfg(unix)]
 fn autoprune() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -529,7 +528,7 @@ fn autoprune() -> Result<()> {
     dangling.assert(predicates::path::exists());
 
     // Backdate the marker to make the prune due again.
-    let stale = std::time::SystemTime::now() - std::time::Duration::from_secs(60 * 60 * 24 * 2);
+    let stale = std::time::SystemTime::now() - std::time::Duration::from_hours(48);
     filetime::set_file_mtime(marker.path(), filetime::FileTime::from_system_time(stale))?;
 
     context
@@ -574,7 +573,6 @@ fn autoprune() -> Result<()> {
 
 /// Automatic pruning should not run when disabled (the default).
 #[test]
-#[cfg(unix)]
 fn autoprune_disabled() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -574,9 +574,10 @@ fn autoprune() -> Result<()> {
     Ok(())
 }
 
-/// A long-lived `uv run` process releases the main cache lock while its child runs, so cache
-/// maintenance can proceed; the cached environment the child runs from is protected by an
-/// in-use lock and survives both `uv cache prune` and automatic pruning.
+/// With the `cache-autoprune` preview feature enabled, a long-lived `uv run` process releases
+/// the main cache lock while its child runs, so cache maintenance can proceed; the cached
+/// environment the child runs from is protected by an in-use lock and survives both
+/// `uv cache prune` and automatic pruning.
 #[test]
 #[cfg(unix)]
 fn prune_skips_in_use_environment() -> Result<()> {
@@ -590,6 +591,7 @@ fn prune_skips_in_use_environment() -> Result<()> {
     // test can sequence around it without sleeps.
     let mut child = context
         .run()
+        .env(EnvVars::UV_PREVIEW_FEATURES, "cache-autoprune")
         .arg("--no-project")
         .arg("--with")
         .arg("iniconfig")
@@ -644,6 +646,7 @@ fn clean_waits_for_in_use_environment() -> Result<()> {
 
     let mut child = context
         .run()
+        .env(EnvVars::UV_PREVIEW_FEATURES, "cache-autoprune")
         .arg("--no-project")
         .arg("--with")
         .arg("iniconfig")

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -518,7 +518,8 @@ fn autoprune() -> Result<()> {
     dangling.create_dir_all()?;
     dangling.child("payload.txt").write_str("payload")?;
 
-    // The prune should not re-run within the interval.
+    // The prune should not re-run while the archive bucket's growth is below the threshold
+    // (and within the minimum interval).
     context
         .pip_sync()
         .arg("requirements.txt")
@@ -527,7 +528,9 @@ fn autoprune() -> Result<()> {
         .success();
     dangling.assert(predicates::path::exists());
 
-    // Backdate the marker to make the prune due again.
+    // Invalidate the marker's recorded archive count and backdate it past the minimum
+    // interval, to make the prune due again.
+    fs_err::write(marker.path(), "invalid")?;
     let stale = std::time::SystemTime::now() - std::time::Duration::from_hours(48);
     filetime::set_file_mtime(marker.path(), filetime::FileTime::from_system_time(stale))?;
 
@@ -567,6 +570,116 @@ fn autoprune() -> Result<()> {
     Installed 1 package in [TIME]
      ~ anyio==4.3.0
     ");
+
+    Ok(())
+}
+
+/// A long-lived `uv run` process releases the main cache lock while its child runs, so cache
+/// maintenance can proceed; the cached environment the child runs from is protected by an
+/// in-use lock and survives both `uv cache prune` and automatic pruning.
+#[test]
+#[cfg(unix)]
+fn prune_skips_in_use_environment() -> Result<()> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::process::Stdio;
+
+    let context = uv_test::test_context!("3.12");
+
+    // Start a long-lived child in a cached environment (`--with` uses an archive-backed
+    // cached environment). The child prints once it's running, then waits for stdin, so the
+    // test can sequence around it without sleeps.
+    let mut child = context
+        .run()
+        .arg("--no-project")
+        .arg("--with")
+        .arg("iniconfig")
+        .arg("python")
+        .arg("-c")
+        .arg("import importlib, iniconfig; print('ready', flush=True); input(); importlib.reload(iniconfig); print('ok', flush=True)")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    let mut line = String::new();
+    stdout.read_line(&mut line)?;
+    assert_eq!(line.trim(), "ready");
+
+    // The cached environment lives in the archive bucket.
+    let archives: Vec<_> = context
+        .cache_dir
+        .child("archive-v0")
+        .read_dir()?
+        .collect::<std::io::Result<Vec<_>>>()?;
+    assert!(!archives.is_empty());
+
+    // With the child still running, `uv cache prune` succeeds without waiting (the main lock
+    // was released) and retains the in-use environment.
+    context.prune().assert().success();
+
+    // The child can still (re)import from its environment after the prune, proving the
+    // environment's files were retained on disk.
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(b"\n")?;
+    drop(stdin);
+    line.clear();
+    stdout.read_line(&mut line)?;
+    assert_eq!(line.trim(), "ok");
+    let status = child.wait()?;
+    assert!(status.success());
+
+    Ok(())
+}
+
+/// `uv cache clean` (without `--force`) must wait for in-use cache entries to be released
+/// before removing the cache.
+#[test]
+#[cfg(unix)]
+fn clean_waits_for_in_use_environment() -> Result<()> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::process::Stdio;
+
+    let context = uv_test::test_context!("3.12");
+
+    let mut child = context
+        .run()
+        .arg("--no-project")
+        .arg("--with")
+        .arg("iniconfig")
+        .arg("python")
+        .arg("-c")
+        .arg("import iniconfig; print('ready', flush=True); input()")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    let mut line = String::new();
+    stdout.read_line(&mut line)?;
+    assert_eq!(line.trim(), "ready");
+
+    // Start `uv cache clean`; it should block on the in-use lock until the child exits.
+    let mut clean = context
+        .clean()
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    // Give the clean a moment to reach the wait, then verify it hasn't finished.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    assert!(
+        clean.try_wait()?.is_none(),
+        "clean should block on the in-use environment"
+    );
+
+    // Let the child exit; the clean should then complete.
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(b"\n")?;
+    drop(stdin);
+    assert!(child.wait()?.success());
+    assert!(clean.wait()?.success());
 
     Ok(())
 }

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -491,3 +491,104 @@ fn prune_stale_revision() -> Result<()> {
 
     Ok(())
 }
+
+/// Automatic pruning should remove dangling archives during a normal command, but only when due,
+/// and without touching referenced archives.
+#[test]
+#[cfg(unix)]
+fn autoprune() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("anyio==4.3.0")?;
+
+    // Install a requirement, to populate the cache.
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .env(EnvVars::UV_CACHE_AUTOPRUNE, "1")
+        .assert()
+        .success();
+
+    // The run above should have recorded an autoprune run.
+    let marker = context.cache_dir.child(".autoprune");
+    marker.assert(predicates::path::exists());
+
+    // Add a dangling archive to the cache.
+    let dangling = context.cache_dir.child("archive-v0").child("dangling");
+    dangling.create_dir_all()?;
+    dangling.child("payload.txt").write_str("payload")?;
+
+    // The prune should not re-run within the interval.
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .env(EnvVars::UV_CACHE_AUTOPRUNE, "1")
+        .assert()
+        .success();
+    dangling.assert(predicates::path::exists());
+
+    // Backdate the marker to make the prune due again.
+    let stale = std::time::SystemTime::now() - std::time::Duration::from_secs(60 * 60 * 24 * 2);
+    filetime::set_file_mtime(marker.path(), filetime::FileTime::from_system_time(stale))?;
+
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .env(EnvVars::UV_CACHE_AUTOPRUNE, "1")
+        .assert()
+        .success();
+
+    // The dangling archive should be removed; the installed package should be unaffected.
+    dangling.assert(predicates::path::missing());
+    uv_snapshot!(context.filters(), context.pip_list(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Package Version
+    ------- -------
+    anyio   4.3.0
+
+    ----- stderr -----
+    ");
+
+    // A reinstall from the cache should still succeed.
+    uv_snapshot!(context.filters(), context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--reinstall"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ anyio==4.3.0
+    ");
+
+    Ok(())
+}
+
+/// Automatic pruning should not run when disabled (the default).
+#[test]
+#[cfg(unix)]
+fn autoprune_disabled() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("anyio")?;
+
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .assert()
+        .success();
+
+    let marker = context.cache_dir.child(".autoprune");
+    marker.assert(predicates::path::missing());
+
+    Ok(())
+}

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3056,6 +3056,7 @@ fn preview_features() {
     +            CentralizedProjectEnvs,
     +            ToolInstallLocks,
     +            WorkspaceListScripts,
+    +            CacheAutoprune,
     +        ],
          },
          python_preference: Managed,

--- a/docs/concepts/preview.md
+++ b/docs/concepts/preview.md
@@ -71,8 +71,7 @@ The following preview features are available:
 - `add-bounds`: Allows configuring the
   [default bounds for `uv add`](../reference/settings.md#add-bounds) invocations.
 - `cache-autoprune`: Automatically removes unreferenced archives from the
-  [cache](../concepts/cache.md), as in `uv cache prune`, at most once per day and only when no other
-  uv processes are running.
+  [cache](../concepts/cache.md) as the cache grows, without interrupting running uv processes.
 - `centralized-project-envs`: Stores
   [project virtual environments](./projects/layout.md#centralized-project-environments) in the uv
   cache.

--- a/docs/concepts/preview.md
+++ b/docs/concepts/preview.md
@@ -70,6 +70,9 @@ The following preview features are available:
 
 - `add-bounds`: Allows configuring the
   [default bounds for `uv add`](../reference/settings.md#add-bounds) invocations.
+- `cache-autoprune`: Automatically removes unreferenced archives from the
+  [cache](../concepts/cache.md), as in `uv cache prune`, at most once per day and only when no other
+  uv processes are running.
 - `centralized-project-envs`: Stores
   [project virtual environments](./projects/layout.md#centralized-project-environments) in the uv
   cache.

--- a/docs/concepts/preview.md
+++ b/docs/concepts/preview.md
@@ -71,7 +71,12 @@ The following preview features are available:
 - `add-bounds`: Allows configuring the
   [default bounds for `uv add`](../reference/settings.md#add-bounds) invocations.
 - `cache-autoprune`: Automatically removes unreferenced archives from the
-  [cache](../concepts/cache.md) as the cache grows, without interrupting running uv processes.
+  [cache](../concepts/cache.md) as the cache grows. Long-lived commands (e.g., servers started with
+  `uv run`) release the cache lock while running, so pruning can proceed during long sessions; the
+  cache entries such commands run from are individually protected and retained. When sharing a cache
+  with older uv versions, note that their `uv cache prune` and `uv cache clean` do not respect these
+  protections. Virtual environments outside the cache that were populated with `--link-mode=symlink`
+  are not protected while a command runs from them.
 - `centralized-project-envs`: Stores
   [project virtual environments](./projects/layout.md#centralized-project-environments) in the uv
   cache.

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1762,7 +1762,8 @@
             "packaged-init",
             "centralized-project-envs",
             "tool-install-locks",
-            "workspace-list-scripts"
+            "workspace-list-scripts",
+            "cache-autoprune"
           ]
         },
         {


### PR DESCRIPTION
Alternative to #17211; addresses #5731.

## Summary

This PR adds automatic cache pruning as a preview feature. When the `cache-autoprune` preview feature is enabled (via `--preview-features cache-autoprune`, `UV_PREVIEW_FEATURES`, or `preview-features` in `uv.toml`/`pyproject.toml`), uv removes unreferenced archives from the cache at the start of an invocation, triggered by cache growth:

- when the archive bucket has grown by at least 32 entries since the last prune (checked at most once per hour; the common case costs a single `stat` of a marker file), and
- only if the **exclusive** cache lock can be acquired without waiting, so a prune can never race another uv process that is mid-operation on the cache.

The motivating problem in #5731 is long-lived sessions (e.g., editors and agent harnesses running uv-backed MCP servers) where the cache grows without bound and `uv cache prune` can't run because the cache is always "in use". Under the previous locking model, a `uv run`-launched server held the shared cache lock for its entire lifetime, so any lock-based prune could never fire mid-session. To fix that, this PR splits the lock's two roles:

1. **The main `.lock` is released once the child process starts.** `uv run`, `uvx`, `uv format`, and `uv ... check` release the shared lock before waiting on the child. uv itself is done with the cache at that point; the lock was only being held to protect the entries the child runs from.
2. **Per-entry in-use locks protect those entries.** Before releasing the main lock, the runner takes a shared flock on a per-entry lock file (under `<cache>/locks/<bucket>/<entry>`) for each cache entry the child runs from: the cached environment or ephemeral `uvx` environment in `archive-v0`, script/centralized environments in `environments-v2`, the environment `uv ... check` analyzes, and `uv format`/`check` binaries in `binaries-v0`. flocks are released automatically on process death, so a crashed process can't leave a stale claim. If any entry can't be claimed, the main lock is retained instead, so an entry is never left unprotected.

The early lock release is gated behind the same preview feature: uv versions that predate the in-use locks don't respect them (their `uv cache prune`/`clean` would also delete the `locks/` directory), so releasing the lock by default would let an older uv sharing the cache remove entries a running child depends on. With the feature disabled (the default), the lock is held for the process lifetime exactly as before. This mixed-version caveat is documented and is the main criterion for graduating the feature to default.

Removal operations compose the two locks: they still require the main exclusive lock (so they can't race an active install), and additionally skip any entry whose in-use lock is held. Since claims are only taken while holding the main lock, and removals hold it exclusively, an entry is always either protected by the main lock or by its in-use lock — there is no gap. In-use environments (both environment archives and environments resident in the environments bucket, e.g. script environments) are also walked for internal symlinks (`--link-mode=symlink`), so the wheel archives they depend on are retained too. The in-use checks fail closed: an unreadable lock directory or a failed environment walk aborts the removal operation rather than truncating the protection set.

For processes running with the feature enabled, this also improves `uv cache prune` and `uv cache clean` in the #5731 scenario:

- `uv cache prune` no longer blocks on long-lived `uv run` processes; it prunes immediately and retains the in-use environments (and the archives they reference), largely removing the need for `--force`. It also retains outdated bucket directories that contain entries with held in-use locks, so a future bucket-version bump can't delete an environment an older uv is running from.
- `uv cache clean` (which removes the entire cache) waits for in-use entries to be released, preserving its previous semantics; `--force` overrides as before. The wait releases the main lock while blocking (a claimed child that itself invokes uv would otherwise deadlock against the wait), then reacquires and re-checks. Package-scoped `uv cache clean <package>` doesn't wait; it skips in-use entries instead.

Compared to #17211, holding the exclusive lock during the prune makes deletion races structurally impossible rather than probabilistically unlikely. Review of the lock-free, grace-period approach turned up two problems: cached environments are "unreferenced but in use" by design, and the warm-cache read path resolves archives via `.http`/`.rev` pointer files without touching the symlink, so no grace period can rule out deleting an archive another process is about to read.

Because a prune runs while other uv versions' caches must keep working, the reference scan is broader than the one in `uv cache prune`:

- It scans **every version** of every link-bearing bucket family (`wheels-v*`, `sdists-v*`, and the historical `built-wheels-v*`/`source-dists-v*` names), since outdated buckets are retained and may be in use by other uv versions sharing the cache.
- It scans `environments-v*` and retains cached environments and the archives backing them, unlike `uv cache prune`, which deletes cached environments.

Notes on the design:

- Mixed-version safety: uv versions before this change hold the shared lock for their whole lifetime, so if any such process is alive, the autoprune's non-blocking exclusive acquisition fails and it skips — exactly the previous conservative behavior. The reverse direction (an old uv's `prune`/`clean` running while a new uv has released the lock) is why the lock release itself is preview-gated; see above.
- Virtual environments outside the cache that were populated with `--link-mode=symlink` cannot be claimed and are not protected while a command runs from them; this is documented with the preview feature.
- The growth trigger: the archive count baseline is recorded in a `.autoprune` marker file after each prune; the marker's mtime enforces a one-hour floor (checked before the archive `readdir`, so a not-due invocation costs one `stat`). A marker more than one interval in the future (severe clock skew) is treated as elapsed, so skew can't disable pruning indefinitely. The marker is updated _before_ pruning so that a failing prune isn't retried on every invocation.
- The sweep skips archive entries it can't resolve (e.g., broken symlinks) rather than aborting. On Windows, files too large to be link files are skipped without reading them.
- Stale in-use lock files (from exited processes) are removed during removal operations once their cache entry is gone; claims re-verify file identity after locking, so a racing forced removal can't leave a claim on an orphaned file. Lock directories are created world-writable for shared caches.
- Library consumers that never initialize the global preview state get the disabled behavior (via a new non-panicking `uv_preview::try_is_enabled`), rather than a panic.
- The intent is for this behavior to become the default once it has proven itself during the preview period and the old-version coexistence window is judged acceptable.

## Test Plan

- Unit tests covering: dangling archives are removed; archives referenced from the wheels bucket, from an outdated bucket (`wheels-v5`), from the environments bucket, and from within a cached environment's internal symlinks are all retained; in-use archives are retained even when unreferenced (the refresh-while-running case) and removed after release; `uv cache prune` retains in-use environments, the internal symlink references of in-use environment archives *and* of in-use environments resident in the environments bucket, and outdated buckets with held in-use locks; package-scoped removal retains archives referenced from in-use environments; claim scoping (paths outside the cache are ignored) and stale lock-file cleanup; growth-trigger logic including the time floor, shrunken-baseline reset, and clock skew; bucket-family name matching.
- Integration tests covering: the growth marker is written on first use and not re-triggered without growth; a due prune removes a dangling archive during a normal `pip sync` while leaving the installed environment and cache intact (verified by a subsequent `--reinstall` from cache); no marker is written when the feature is disabled (the default); with the feature enabled, `uv cache prune` completes without waiting while a `uv run`-launched child is alive and the child can still import from its environment afterward; `uv cache clean` blocks until the child exits.
