### PR TITLE
Use SIMD for package name checks

### DIFF
--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -16,20 +16,53 @@ mod build_tag;
 mod egg;
 mod expanded_tags;
 mod extension;
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
+mod normalized_package_name_simd;
 mod source_dist;
 mod splitter;
 mod wheel;
 mod wheel_tag;
 
 fn normalized_package_name_matches(actual: &str, expected: &PackageName) -> bool {
-    actual
-        .bytes()
-        .map(|byte| match byte {
-            b'A'..=b'Z' => byte.to_ascii_lowercase(),
+    let expected: &str = expected.as_ref();
+    if actual.len() != expected.len() {
+        return false;
+    }
+
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
+    if actual.len() >= normalized_package_name_simd::MIN_LEN {
+        return normalized_package_name_simd::matches(actual.as_bytes(), expected.as_bytes());
+    }
+
+    #[cfg(target_arch = "x86")]
+    if actual.len() >= normalized_package_name_simd::MIN_LEN
+        && std::arch::is_x86_feature_detected!("sse2")
+    {
+        return normalized_package_name_simd::matches(actual.as_bytes(), expected.as_bytes());
+    }
+
+    normalized_package_name_matches_scalar(actual, expected)
+}
+
+fn normalized_package_name_matches_scalar(actual: &str, expected: &str) -> bool {
+    for (actual, expected) in actual.bytes().zip(expected.bytes()) {
+        let actual = match actual {
+            b'A'..=b'Z' => actual.to_ascii_lowercase(),
             b'_' | b'.' => b'-',
-            _ => byte,
-        })
-        .eq(expected.as_ref().bytes())
+            _ => actual,
+        };
+        if actual != expected {
+            return false;
+        }
+    }
+    true
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -146,7 +179,10 @@ mod tests {
 
     use uv_normalize::PackageName;
 
-    use crate::{DistFilename, DistFilenameError, WheelFilename};
+    use crate::{
+        DistFilename, DistFilenameError, WheelFilename, normalized_package_name_matches,
+        normalized_package_name_matches_scalar,
+    };
 
     #[test]
     fn wheel_filename_size() {
@@ -200,5 +236,44 @@ mod tests {
         let name = PackageName::from_str("my-package").unwrap();
         let parsed = DistFilename::try_from_filename("my_package-0.1.0-py3-none-any.whl", &name);
         assert!(parsed.is_some(), "expected wheel to parse successfully");
+    }
+
+    #[test]
+    fn normalized_package_name_matches_all_lengths() {
+        for length in 1..=64 {
+            let expected = "a".repeat(length);
+            let package_name = PackageName::from_str(&expected).unwrap();
+            let mut actual = vec![b'a'; length];
+
+            for index in 0..length {
+                for byte in 0..=127 {
+                    actual[index] = byte;
+                    let actual = std::str::from_utf8(&actual).expect("ASCII input should be UTF-8");
+                    assert_eq!(
+                        normalized_package_name_matches(actual, &package_name),
+                        normalized_package_name_matches_scalar(actual, &expected),
+                        "{actual:?}",
+                    );
+                }
+                actual[index] = b'a';
+            }
+        }
+
+        for length in 4..=64 {
+            let mut expected = vec![b'a'; length];
+            let mut actual = vec![b'A'; length];
+            for (offset, index) in (2..length.saturating_sub(1)).step_by(4).enumerate() {
+                expected[index] = b'-';
+                actual[index] = if offset.is_multiple_of(2) { b'_' } else { b'.' };
+            }
+            let expected = std::str::from_utf8(&expected).expect("ASCII input should be UTF-8");
+            let actual = std::str::from_utf8(&actual).expect("ASCII input should be UTF-8");
+            let package_name = PackageName::from_str(expected).unwrap();
+            assert!(normalized_package_name_matches(actual, &package_name));
+        }
+
+        let package_name = PackageName::from_str("a-b").unwrap();
+        assert!(!normalized_package_name_matches("a__b", &package_name));
+        assert!(!normalized_package_name_matches("a-α", &package_name));
     }
 }

--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -52,17 +52,14 @@ fn normalized_package_name_matches(actual: &str, expected: &PackageName) -> bool
 }
 
 fn normalized_package_name_matches_scalar(actual: &str, expected: &str) -> bool {
-    for (actual, expected) in actual.bytes().zip(expected.bytes()) {
-        let actual = match actual {
-            b'A'..=b'Z' => actual.to_ascii_lowercase(),
+    actual
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' => byte.to_ascii_lowercase(),
             b'_' | b'.' => b'-',
-            _ => actual,
-        };
-        if actual != expected {
-            return false;
-        }
-    }
-    true
+            _ => byte,
+        })
+        .eq(expected.bytes())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -54,17 +54,14 @@ fn normalized_package_name_matches(actual: &str, expected: &PackageName) -> bool
 }
 
 fn normalized_package_name_matches_scalar(actual: &str, expected: &str) -> bool {
-    for (actual, expected) in actual.bytes().zip(expected.bytes()) {
-        let actual = match actual {
-            b'A'..=b'Z' => actual.to_ascii_lowercase(),
+    actual
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' => byte.to_ascii_lowercase(),
             b'_' | b'.' => b'-',
-            _ => actual,
-        };
-        if actual != expected {
-            return false;
-        }
-    }
-    true
+            _ => byte,
+        })
+        .eq(expected.bytes())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -18,20 +18,53 @@ mod build_tag;
 mod egg;
 mod expanded_tags;
 mod extension;
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
+mod normalized_package_name_simd;
 mod source_dist;
 mod splitter;
 mod wheel;
 mod wheel_tag;
 
 fn normalized_package_name_matches(actual: &str, expected: &PackageName) -> bool {
-    actual
-        .bytes()
-        .map(|byte| match byte {
-            b'A'..=b'Z' => byte.to_ascii_lowercase(),
+    let expected: &str = expected.as_ref();
+    if actual.len() != expected.len() {
+        return false;
+    }
+
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
+    if actual.len() >= normalized_package_name_simd::MIN_LEN {
+        return normalized_package_name_simd::matches(actual.as_bytes(), expected.as_bytes());
+    }
+
+    #[cfg(target_arch = "x86")]
+    if actual.len() >= normalized_package_name_simd::MIN_LEN
+        && std::arch::is_x86_feature_detected!("sse2")
+    {
+        return normalized_package_name_simd::matches(actual.as_bytes(), expected.as_bytes());
+    }
+
+    normalized_package_name_matches_scalar(actual, expected)
+}
+
+fn normalized_package_name_matches_scalar(actual: &str, expected: &str) -> bool {
+    for (actual, expected) in actual.bytes().zip(expected.bytes()) {
+        let actual = match actual {
+            b'A'..=b'Z' => actual.to_ascii_lowercase(),
             b'_' | b'.' => b'-',
-            _ => byte,
-        })
-        .eq(expected.as_ref().bytes())
+            _ => actual,
+        };
+        if actual != expected {
+            return false;
+        }
+    }
+    true
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -149,7 +182,10 @@ mod tests {
 
     use uv_normalize::PackageName;
 
-    use crate::{DistFilename, DistFilenameError, WheelFilename};
+    use crate::{
+        DistFilename, DistFilenameError, WheelFilename, normalized_package_name_matches,
+        normalized_package_name_matches_scalar,
+    };
 
     #[test]
     fn wheel_filename_size() {
@@ -206,5 +242,44 @@ mod tests {
         let name = PackageName::from_str("my-package").unwrap();
         let parsed = DistFilename::try_from_filename("my_package-0.1.0-py3-none-any.whl", &name);
         assert!(parsed.is_some(), "expected wheel to parse successfully");
+    }
+
+    #[test]
+    fn normalized_package_name_matches_all_lengths() {
+        for length in 1..=64 {
+            let expected = "a".repeat(length);
+            let package_name = PackageName::from_str(&expected).unwrap();
+            let mut actual = vec![b'a'; length];
+
+            for index in 0..length {
+                for byte in 0..=127 {
+                    actual[index] = byte;
+                    let actual = std::str::from_utf8(&actual).expect("ASCII input should be UTF-8");
+                    assert_eq!(
+                        normalized_package_name_matches(actual, &package_name),
+                        normalized_package_name_matches_scalar(actual, &expected),
+                        "{actual:?}",
+                    );
+                }
+                actual[index] = b'a';
+            }
+        }
+
+        for length in 4..=64 {
+            let mut expected = vec![b'a'; length];
+            let mut actual = vec![b'A'; length];
+            for (offset, index) in (2..length.saturating_sub(1)).step_by(4).enumerate() {
+                expected[index] = b'-';
+                actual[index] = if offset.is_multiple_of(2) { b'_' } else { b'.' };
+            }
+            let expected = std::str::from_utf8(&expected).expect("ASCII input should be UTF-8");
+            let actual = std::str::from_utf8(&actual).expect("ASCII input should be UTF-8");
+            let package_name = PackageName::from_str(expected).unwrap();
+            assert!(normalized_package_name_matches(actual, &package_name));
+        }
+
+        let package_name = PackageName::from_str("a-b").unwrap();
+        assert!(!normalized_package_name_matches("a__b", &package_name));
+        assert!(!normalized_package_name_matches("a-α", &package_name));
     }
 }

--- a/crates/uv-distribution-filename/src/normalized_package_name_simd.rs
+++ b/crates/uv-distribution-filename/src/normalized_package_name_simd.rs
@@ -137,18 +137,15 @@ mod architecture {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod architecture {
+    use arch::{
+        __m128i, _mm_add_epi8, _mm_and_si128, _mm_andnot_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8,
+        _mm_cvtsi32_si128, _mm_loadl_epi64, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
+        _mm_set1_epi8,
+    };
     #[cfg(target_arch = "x86")]
-    use std::arch::x86::{
-        __m128i, _mm_add_epi8, _mm_and_si128, _mm_andnot_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8,
-        _mm_cvtsi32_si128, _mm_loadl_epi64, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
-        _mm_set1_epi8,
-    };
+    use std::arch::x86 as arch;
     #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::{
-        __m128i, _mm_add_epi8, _mm_and_si128, _mm_andnot_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8,
-        _mm_cvtsi32_si128, _mm_loadl_epi64, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
-        _mm_set1_epi8,
-    };
+    use std::arch::x86_64 as arch;
 
     pub(super) fn matches(actual: &[u8], expected: &[u8]) -> bool {
         // SAFETY: SSE2 is available on all x86-64 targets and checked by the caller on x86. The

--- a/crates/uv-distribution-filename/src/normalized_package_name_simd.rs
+++ b/crates/uv-distribution-filename/src/normalized_package_name_simd.rs
@@ -1,0 +1,258 @@
+//! SIMD comparison of package names after normalization.
+
+#![expect(
+    unsafe_code,
+    reason = "loading architecture-specific SIMD vectors requires unsafe intrinsics"
+)]
+
+pub(crate) const MIN_LEN: usize = 4;
+
+pub(crate) fn matches(actual: &[u8], expected: &[u8]) -> bool {
+    debug_assert_eq!(actual.len(), expected.len());
+    debug_assert!(actual.len() >= MIN_LEN);
+    architecture::matches(actual, expected)
+}
+
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+mod architecture {
+    use std::arch::aarch64::{
+        uint8x8_t, uint8x16_t, vadd_u8, vaddq_u8, vand_u8, vandq_u8, vceq_u8, vceqq_u8, vcge_u8,
+        vcgeq_u8, vcle_u8, vcleq_u8, vcreate_u8, vdup_n_u8, vdupq_n_u8, vld1_u8, vld1q_u8,
+        vminv_u8, vminvq_u8, vorr_u8, vorrq_u8,
+    };
+
+    pub(super) fn matches(actual: &[u8], expected: &[u8]) -> bool {
+        // SAFETY: Advanced SIMD is available on all AArch64 targets. The inner function only
+        // loads chunks that fit within both equal-length slices.
+        unsafe { matches_inner(actual, expected) }
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn matches_inner(actual: &[u8], expected: &[u8]) -> bool {
+        if actual.len() < 8 {
+            if !unsafe { matches4(actual.as_ptr(), expected.as_ptr()) } {
+                return false;
+            }
+            if actual.len() > 4 {
+                let index = actual.len() - 4;
+                return unsafe {
+                    matches4(actual.as_ptr().add(index), expected.as_ptr().add(index))
+                };
+            }
+            return true;
+        }
+
+        if actual.len() < 16 {
+            if !unsafe { matches8(actual.as_ptr(), expected.as_ptr()) } {
+                return false;
+            }
+            if actual.len() > 8 {
+                let index = actual.len() - 8;
+                return unsafe {
+                    matches8(actual.as_ptr().add(index), expected.as_ptr().add(index))
+                };
+            }
+            return true;
+        }
+
+        let full_chunks_end = actual.len() / 16 * 16;
+        for index in (0..full_chunks_end).step_by(16) {
+            if !unsafe { matches16(actual.as_ptr().add(index), expected.as_ptr().add(index)) } {
+                return false;
+            }
+        }
+        if !actual.len().is_multiple_of(16) {
+            let index = actual.len() - 16;
+            if !unsafe { matches16(actual.as_ptr().add(index), expected.as_ptr().add(index)) } {
+                return false;
+            }
+        }
+        true
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn matches4(actual: *const u8, expected: *const u8) -> bool {
+        // SAFETY: The caller guarantees that both pointers have four readable bytes.
+        let actual = u64::from(unsafe { actual.cast::<u32>().read_unaligned() });
+        let expected = u64::from(unsafe { expected.cast::<u32>().read_unaligned() });
+        vminv_u8(unsafe { match_mask8(vcreate_u8(actual), vcreate_u8(expected)) }) == u8::MAX
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn matches8(actual: *const u8, expected: *const u8) -> bool {
+        // SAFETY: The caller guarantees that both pointers have eight readable bytes.
+        let actual = unsafe { vld1_u8(actual) };
+        let expected = unsafe { vld1_u8(expected) };
+        vminv_u8(unsafe { match_mask8(actual, expected) }) == u8::MAX
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn matches16(actual: *const u8, expected: *const u8) -> bool {
+        // SAFETY: The caller guarantees that both pointers have 16 readable bytes.
+        let actual = unsafe { vld1q_u8(actual) };
+        let expected = unsafe { vld1q_u8(expected) };
+        vminvq_u8(unsafe { match_mask16(actual, expected) }) == u8::MAX
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn match_mask8(actual: uint8x8_t, expected: uint8x8_t) -> uint8x8_t {
+        let uppercase = vand_u8(
+            vcge_u8(actual, vdup_n_u8(b'A')),
+            vcle_u8(actual, vdup_n_u8(b'Z')),
+        );
+        let lowercase = vadd_u8(actual, vand_u8(uppercase, vdup_n_u8(0x20)));
+        let separator = vorr_u8(
+            vceq_u8(actual, vdup_n_u8(b'_')),
+            vceq_u8(actual, vdup_n_u8(b'.')),
+        );
+        vorr_u8(
+            vand_u8(separator, vceq_u8(expected, vdup_n_u8(b'-'))),
+            vand_u8(
+                vceq_u8(separator, vdup_n_u8(0)),
+                vceq_u8(lowercase, expected),
+            ),
+        )
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn match_mask16(actual: uint8x16_t, expected: uint8x16_t) -> uint8x16_t {
+        let uppercase = vandq_u8(
+            vcgeq_u8(actual, vdupq_n_u8(b'A')),
+            vcleq_u8(actual, vdupq_n_u8(b'Z')),
+        );
+        let lowercase = vaddq_u8(actual, vandq_u8(uppercase, vdupq_n_u8(0x20)));
+        let separator = vorrq_u8(
+            vceqq_u8(actual, vdupq_n_u8(b'_')),
+            vceqq_u8(actual, vdupq_n_u8(b'.')),
+        );
+        vorrq_u8(
+            vandq_u8(separator, vceqq_u8(expected, vdupq_n_u8(b'-'))),
+            vandq_u8(
+                vceqq_u8(separator, vdupq_n_u8(0)),
+                vceqq_u8(lowercase, expected),
+            ),
+        )
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod architecture {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::{
+        __m128i, _mm_add_epi8, _mm_and_si128, _mm_andnot_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8,
+        _mm_cvtsi32_si128, _mm_loadl_epi64, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
+        _mm_set1_epi8,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::{
+        __m128i, _mm_add_epi8, _mm_and_si128, _mm_andnot_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8,
+        _mm_cvtsi32_si128, _mm_loadl_epi64, _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128,
+        _mm_set1_epi8,
+    };
+
+    pub(super) fn matches(actual: &[u8], expected: &[u8]) -> bool {
+        // SAFETY: SSE2 is available on all x86-64 targets and checked by the caller on x86. The
+        // inner function only loads chunks that fit within both equal-length slices.
+        unsafe { matches_inner(actual, expected) }
+    }
+
+    #[target_feature(enable = "sse2")]
+    unsafe fn matches_inner(actual: &[u8], expected: &[u8]) -> bool {
+        if actual.len() < 8 {
+            if !unsafe { matches4(actual.as_ptr(), expected.as_ptr()) } {
+                return false;
+            }
+            if actual.len() > 4 {
+                let index = actual.len() - 4;
+                return unsafe {
+                    matches4(actual.as_ptr().add(index), expected.as_ptr().add(index))
+                };
+            }
+            return true;
+        }
+
+        if actual.len() < 16 {
+            if !unsafe { matches8(actual.as_ptr(), expected.as_ptr()) } {
+                return false;
+            }
+            if actual.len() > 8 {
+                let index = actual.len() - 8;
+                return unsafe {
+                    matches8(actual.as_ptr().add(index), expected.as_ptr().add(index))
+                };
+            }
+            return true;
+        }
+
+        let full_chunks_end = actual.len() / 16 * 16;
+        for index in (0..full_chunks_end).step_by(16) {
+            if !unsafe { matches16(actual.as_ptr().add(index), expected.as_ptr().add(index)) } {
+                return false;
+            }
+        }
+        if !actual.len().is_multiple_of(16) {
+            let index = actual.len() - 16;
+            if !unsafe { matches16(actual.as_ptr().add(index), expected.as_ptr().add(index)) } {
+                return false;
+            }
+        }
+        true
+    }
+
+    #[target_feature(enable = "sse2")]
+    unsafe fn matches4(actual: *const u8, expected: *const u8) -> bool {
+        // SAFETY: The caller guarantees that both pointers have four readable bytes.
+        let actual = unsafe { actual.cast::<u32>().read_unaligned() };
+        let expected = unsafe { expected.cast::<u32>().read_unaligned() };
+        unsafe {
+            matches_vector(
+                _mm_cvtsi32_si128(actual.cast_signed()),
+                _mm_cvtsi32_si128(expected.cast_signed()),
+            )
+        }
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[expect(
+        clippy::cast_ptr_alignment,
+        reason = "_mm_loadl_epi64 accepts unaligned pointers"
+    )]
+    unsafe fn matches8(actual: *const u8, expected: *const u8) -> bool {
+        // SAFETY: The caller guarantees that both pointers have eight readable bytes.
+        let actual = unsafe { _mm_loadl_epi64(actual.cast::<__m128i>()) };
+        let expected = unsafe { _mm_loadl_epi64(expected.cast::<__m128i>()) };
+        unsafe { matches_vector(actual, expected) }
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[expect(
+        clippy::cast_ptr_alignment,
+        reason = "_mm_loadu_si128 accepts unaligned pointers"
+    )]
+    unsafe fn matches16(actual: *const u8, expected: *const u8) -> bool {
+        // SAFETY: The caller guarantees that both pointers have 16 readable bytes.
+        let actual = unsafe { _mm_loadu_si128(actual.cast::<__m128i>()) };
+        let expected = unsafe { _mm_loadu_si128(expected.cast::<__m128i>()) };
+        unsafe { matches_vector(actual, expected) }
+    }
+
+    #[target_feature(enable = "sse2")]
+    unsafe fn matches_vector(actual: __m128i, expected: __m128i) -> bool {
+        let uppercase = _mm_and_si128(
+            _mm_cmpgt_epi8(actual, _mm_set1_epi8((b'A' - 1).cast_signed())),
+            _mm_cmpgt_epi8(_mm_set1_epi8((b'Z' + 1).cast_signed()), actual),
+        );
+        let lowercase = _mm_add_epi8(actual, _mm_and_si128(uppercase, _mm_set1_epi8(0x20)));
+        let separator = _mm_or_si128(
+            _mm_cmpeq_epi8(actual, _mm_set1_epi8(b'_'.cast_signed())),
+            _mm_cmpeq_epi8(actual, _mm_set1_epi8(b'.'.cast_signed())),
+        );
+        let separator_matches = _mm_and_si128(
+            separator,
+            _mm_cmpeq_epi8(expected, _mm_set1_epi8(b'-'.cast_signed())),
+        );
+        let regular_matches = _mm_andnot_si128(separator, _mm_cmpeq_epi8(lowercase, expected));
+        let matches = _mm_or_si128(separator_matches, regular_matches);
+        _mm_movemask_epi8(matches) == 0xffff
+    }
+}

--- a/crates/uv-normalize/src/lib.rs
+++ b/crates/uv-normalize/src/lib.rs
@@ -11,6 +11,8 @@ use uv_small_str::SmallString;
 mod dist_info_name;
 mod extra_name;
 mod group_name;
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
+mod normalized_simd;
 mod package_name;
 
 /// Validate and normalize an unowned package or extra name.
@@ -66,13 +68,36 @@ fn normalize(name: &str) -> Result<String, InvalidNameError> {
 
 /// Returns `true` if the name is already normalized.
 fn is_normalized(name: impl AsRef<str>) -> Result<bool, InvalidNameError> {
+    let name = name.as_ref();
+
     // An empty string is not a valid package, extra, or group name.
-    if name.as_ref().is_empty() {
-        return Err(InvalidNameError(name.as_ref().to_string()));
+    if name.is_empty() {
+        return Err(InvalidNameError(name.to_string()));
     }
 
-    let mut last = None;
-    for char in name.as_ref().bytes() {
+    is_normalized_bytes(name.as_bytes()).map_err(|()| InvalidNameError(name.to_string()))
+}
+
+/// Returns `true` if the bytes contain an already-normalized name.
+///
+/// The caller is responsible for rejecting an empty name.
+fn is_normalized_bytes(name: &[u8]) -> Result<bool, ()> {
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    if name.len() >= normalized_simd::MIN_LEN {
+        return normalized_simd::is_normalized(name);
+    }
+
+    #[cfg(target_arch = "x86")]
+    if name.len() >= normalized_simd::MIN_LEN && std::arch::is_x86_feature_detected!("sse2") {
+        return normalized_simd::is_normalized(name);
+    }
+
+    is_normalized_scalar(name, None)
+}
+
+/// Returns `true` if the remaining bytes contain an already-normalized name.
+fn is_normalized_scalar(name: &[u8], mut last: Option<u8>) -> Result<bool, ()> {
+    for &char in name {
         match char {
             b'A'..=b'Z' => {
                 // Uppercase characters need to be converted to lowercase.
@@ -86,7 +111,7 @@ fn is_normalized(name: impl AsRef<str>) -> Result<bool, InvalidNameError> {
             b'-' => {
                 match last {
                     // Names can't start with punctuation.
-                    None => return Err(InvalidNameError(name.as_ref().to_string())),
+                    None => return Err(()),
                     Some(b'-') => {
                         // Runs of `-` are normalized to a single `-`.
                         return Ok(false);
@@ -94,14 +119,14 @@ fn is_normalized(name: impl AsRef<str>) -> Result<bool, InvalidNameError> {
                     Some(_) => {}
                 }
             }
-            _ => return Err(InvalidNameError(name.as_ref().to_string())),
+            _ => return Err(()),
         }
         last = Some(char);
     }
 
     // Names can't end with punctuation.
     if matches!(last, Some(b'-' | b'_' | b'.')) {
-        return Err(InvalidNameError(name.as_ref().to_string()));
+        return Err(());
     }
 
     Ok(true)
@@ -235,6 +260,54 @@ mod tests {
         for input in failures {
             assert!(validate_and_normalize_ref(input).is_err());
             assert!(is_normalized(input).is_err());
+        }
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
+    #[test]
+    fn check_simd_matches_scalar() {
+        fn assert_matches(input: &[u8]) {
+            assert_eq!(
+                normalized_simd::is_normalized(input),
+                is_normalized_scalar(input, None),
+                "input: {input:?}",
+            );
+        }
+
+        #[cfg(target_arch = "x86")]
+        if !std::arch::is_x86_feature_detected!("sse2") {
+            return;
+        }
+
+        for length in normalized_simd::MIN_LEN..=80 {
+            let input = vec![b'a'; length];
+            assert_matches(&input);
+
+            for index in 0..length {
+                for byte in [b'z', b'0', b'9', b'-', b'_', b'.', b'A', b'Z', b'!', 0x80] {
+                    let mut input = vec![b'a'; length];
+                    input[index] = byte;
+                    assert_matches(&input);
+                }
+
+                if index + 1 < length {
+                    let mut input = vec![b'a'; length];
+                    input[index] = b'-';
+                    input[index + 1] = b'-';
+                    assert_matches(&input);
+                }
+            }
+        }
+
+        for input in [
+            &b"A!aaaaaaaaaaaaaa"[..],
+            &b"!Aaaaaaaaaaaaaaa"[..],
+            &b"a--!aaaaaaaaaaaa"[..],
+            &b"a!--aaaaaaaaaaaa"[..],
+            &b"aaaaaaaaaaaaaaa--"[..],
+            &b"aaaaaaaaaaaaaaa!-"[..],
+        ] {
+            assert_matches(input);
         }
     }
 }

--- a/crates/uv-normalize/src/normalized_simd.rs
+++ b/crates/uv-normalize/src/normalized_simd.rs
@@ -7,7 +7,10 @@
 
 use super::is_normalized_scalar;
 
+#[cfg(target_arch = "aarch64")]
 pub(crate) const MIN_LEN: usize = 8;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) const MIN_LEN: usize = 4;
 
 pub(crate) fn is_normalized(name: &[u8]) -> Result<bool, ()> {
     debug_assert!(name.len() >= MIN_LEN);

--- a/crates/uv-normalize/src/normalized_simd.rs
+++ b/crates/uv-normalize/src/normalized_simd.rs
@@ -110,16 +110,14 @@ mod architecture {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod architecture {
+    use arch::{
+        __m128i, _mm_and_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8, _mm_cvtsi32_si128, _mm_loadl_epi64,
+        _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128, _mm_set1_epi8,
+    };
     #[cfg(target_arch = "x86")]
-    use std::arch::x86::{
-        __m128i, _mm_and_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8, _mm_cvtsi32_si128, _mm_loadl_epi64,
-        _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128, _mm_set1_epi8,
-    };
+    use std::arch::x86 as arch;
     #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::{
-        __m128i, _mm_and_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8, _mm_cvtsi32_si128, _mm_loadl_epi64,
-        _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128, _mm_set1_epi8,
-    };
+    use std::arch::x86_64 as arch;
 
     use super::is_normalized_scalar;
 

--- a/crates/uv-normalize/src/normalized_simd.rs
+++ b/crates/uv-normalize/src/normalized_simd.rs
@@ -1,0 +1,193 @@
+//! SIMD fast path for recognizing already-normalized package names.
+
+#![expect(
+    unsafe_code,
+    reason = "loading architecture-specific SIMD vectors requires unsafe intrinsics"
+)]
+
+use super::is_normalized_scalar;
+
+pub(crate) const MIN_LEN: usize = 8;
+
+pub(crate) fn is_normalized(name: &[u8]) -> Result<bool, ()> {
+    debug_assert!(name.len() >= MIN_LEN);
+    if name.first() == Some(&b'-') || name.last() == Some(&b'-') {
+        return is_normalized_scalar(name, None);
+    }
+    architecture::is_normalized(name)
+}
+
+#[cfg(target_arch = "aarch64")]
+mod architecture {
+    use std::arch::aarch64::{
+        vand_u8, vandq_u8, vceq_u8, vceqq_u8, vcge_u8, vcgeq_u8, vcle_u8, vcleq_u8, vdup_n_u8,
+        vdupq_n_u8, vext_u8, vextq_u8, vld1_u8, vld1q_u8, vminv_u8, vminvq_u8, vmvn_u8, vmvnq_u8,
+        vorr_u8, vorrq_u8,
+    };
+
+    use super::is_normalized_scalar;
+
+    pub(super) fn is_normalized(name: &[u8]) -> Result<bool, ()> {
+        // SAFETY: Advanced SIMD is available on all AArch64 targets. The inner function only
+        // loads chunks that fit within `name`.
+        unsafe { is_normalized_inner(name) }
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn is_normalized_inner(name: &[u8]) -> Result<bool, ()> {
+        if name.len() < 16 {
+            if !unsafe { is_normalized_chunk8(name.as_ptr(), 0) } {
+                return is_normalized_scalar(name, None);
+            }
+            if name.len() > 8 {
+                let index = name.len() - 8;
+                let last = name[index - 1];
+                if !unsafe { is_normalized_chunk8(name.as_ptr().add(index), last) } {
+                    return is_normalized_scalar(&name[index..], Some(last));
+                }
+            }
+            return Ok(true);
+        }
+
+        let full_chunks_end = name.len() / 16 * 16;
+        for index in (0..full_chunks_end).step_by(16) {
+            let last = index.checked_sub(1).map(|index| name[index]);
+            if !unsafe { is_normalized_chunk16(name.as_ptr().add(index), last.unwrap_or(0)) } {
+                return is_normalized_scalar(&name[index..], last);
+            }
+        }
+        if !name.len().is_multiple_of(16) {
+            let index = name.len() - 16;
+            let last = name[index - 1];
+            if !unsafe { is_normalized_chunk16(name.as_ptr().add(index), last) } {
+                return is_normalized_scalar(&name[index..], Some(last));
+            }
+        }
+        Ok(true)
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn is_normalized_chunk8(name: *const u8, last: u8) -> bool {
+        // SAFETY: The caller guarantees that `name` has eight readable bytes.
+        let value = unsafe { vld1_u8(name) };
+        let lowercase = vand_u8(
+            vcge_u8(value, vdup_n_u8(b'a')),
+            vcle_u8(value, vdup_n_u8(b'z')),
+        );
+        let digit = vand_u8(
+            vcge_u8(value, vdup_n_u8(b'0')),
+            vcle_u8(value, vdup_n_u8(b'9')),
+        );
+        let dash = vceq_u8(value, vdup_n_u8(b'-'));
+        let valid = vorr_u8(vorr_u8(lowercase, digit), dash);
+        let shifted = vext_u8::<7>(vdup_n_u8(last), value);
+        let repeated_dash = vand_u8(dash, vceq_u8(shifted, vdup_n_u8(b'-')));
+        vminv_u8(vand_u8(valid, vmvn_u8(repeated_dash))) == u8::MAX
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn is_normalized_chunk16(name: *const u8, last: u8) -> bool {
+        // SAFETY: The caller guarantees that `name` has 16 readable bytes.
+        let value = unsafe { vld1q_u8(name) };
+        let lowercase = vandq_u8(
+            vcgeq_u8(value, vdupq_n_u8(b'a')),
+            vcleq_u8(value, vdupq_n_u8(b'z')),
+        );
+        let digit = vandq_u8(
+            vcgeq_u8(value, vdupq_n_u8(b'0')),
+            vcleq_u8(value, vdupq_n_u8(b'9')),
+        );
+        let dash = vceqq_u8(value, vdupq_n_u8(b'-'));
+        let valid = vorrq_u8(vorrq_u8(lowercase, digit), dash);
+        let shifted = vextq_u8::<15>(vdupq_n_u8(last), value);
+        let repeated_dash = vandq_u8(dash, vceqq_u8(shifted, vdupq_n_u8(b'-')));
+        vminvq_u8(vandq_u8(valid, vmvnq_u8(repeated_dash))) == u8::MAX
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod architecture {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::{
+        __m128i, _mm_and_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8, _mm_cvtsi32_si128, _mm_loadl_epi64,
+        _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128, _mm_set1_epi8,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::{
+        __m128i, _mm_and_si128, _mm_cmpeq_epi8, _mm_cmpgt_epi8, _mm_cvtsi32_si128, _mm_loadl_epi64,
+        _mm_loadu_si128, _mm_movemask_epi8, _mm_or_si128, _mm_set1_epi8,
+    };
+
+    use super::is_normalized_scalar;
+
+    pub(super) fn is_normalized(name: &[u8]) -> Result<bool, ()> {
+        // SAFETY: SSE2 is available on all x86-64 targets and checked by the caller on x86. The
+        // inner function only loads chunks that fit within `name`.
+        unsafe { is_normalized_inner(name) }
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[expect(
+        clippy::cast_ptr_alignment,
+        reason = "SSE2 unaligned loads accept byte-aligned pointers"
+    )]
+    unsafe fn is_normalized_inner(name: &[u8]) -> Result<bool, ()> {
+        let mut offset = 0;
+        let mut last = None;
+
+        let is_normalized_chunk = |bytes, expected_mask: u32, last| {
+            let lowercase = _mm_and_si128(
+                _mm_cmpgt_epi8(bytes, _mm_set1_epi8((b'a' - 1).cast_signed())),
+                _mm_cmpgt_epi8(_mm_set1_epi8((b'z' + 1).cast_signed()), bytes),
+            );
+            let digit = _mm_and_si128(
+                _mm_cmpgt_epi8(bytes, _mm_set1_epi8((b'0' - 1).cast_signed())),
+                _mm_cmpgt_epi8(_mm_set1_epi8((b'9' + 1).cast_signed()), bytes),
+            );
+            let dash = _mm_cmpeq_epi8(bytes, _mm_set1_epi8(b'-'.cast_signed()));
+
+            let dash_mask = _mm_movemask_epi8(dash).cast_unsigned();
+            let normalized = _mm_or_si128(lowercase, _mm_or_si128(digit, dash));
+            _mm_movemask_epi8(normalized).cast_unsigned() & expected_mask == expected_mask
+                && dash_mask & (dash_mask << 1) == 0
+                && (dash_mask & 1 == 0 || !matches!(last, None | Some(b'-')))
+        };
+
+        while offset + 16 <= name.len() {
+            // SAFETY: The loop condition guarantees that 16 bytes are available from `offset`,
+            // and `_mm_loadu_si128` permits an unaligned pointer.
+            let bytes = unsafe { _mm_loadu_si128(name.as_ptr().add(offset).cast::<__m128i>()) };
+            if !is_normalized_chunk(bytes, 0xffff, last) {
+                return is_normalized_scalar(&name[offset..], last);
+            }
+
+            offset += 16;
+            last = name.get(offset - 1).copied();
+        }
+
+        if offset + 8 <= name.len() {
+            // SAFETY: The condition guarantees that eight bytes are available from `offset`, and
+            // `_mm_loadl_epi64` permits an unaligned pointer.
+            let bytes = unsafe { _mm_loadl_epi64(name.as_ptr().add(offset).cast::<__m128i>()) };
+            if !is_normalized_chunk(bytes, 0xff, last) {
+                return is_normalized_scalar(&name[offset..], last);
+            }
+            offset += 8;
+            last = name.get(offset - 1).copied();
+        }
+
+        if offset + 4 <= name.len() {
+            // SAFETY: The condition guarantees that four bytes are available from `offset`, and
+            // `read_unaligned` permits a byte-aligned pointer.
+            let word = unsafe { name.as_ptr().add(offset).cast::<i32>().read_unaligned() };
+            let bytes = _mm_cvtsi32_si128(word);
+            if !is_normalized_chunk(bytes, 0xf, last) {
+                return is_normalized_scalar(&name[offset..], last);
+            }
+            offset += 4;
+            last = name.get(offset - 1).copied();
+        }
+
+        is_normalized_scalar(&name[offset..], last)
+    }
+}


### PR DESCRIPTION
## Summary

Package-name checks sit on two hot paths: `validate_and_normalize_ref` tests whether a name can be reused unchanged, while wheel parsing from #20110 tests whether the filename's embedded name normalizes to the requested package. Both previously scanned one byte at a time even though 82.9% of occurrence-weighted package names are 4–15 bytes long.

This adds NEON and SSE2 fast paths for both checks. Normalized-name validation uses SIMD from four bytes on x86 and eight bytes on AArch64, falling back to the scalar implementation at a failing chunk so invalid inputs and names requiring normalization retain their existing result and precedence. Package-name hint matching uses 4-, 8-, and 16-byte tiers with overlapping final loads.

Unsupported architectures retain the scalar implementations. SSE2 is used as part of the x86-64 baseline and detected at runtime on 32-bit x86. Equivalence tests cover lengths, character classes, normalization cases, invalid bytes, and separator boundaries. The native test suites, formatting, strict Clippy checks, and Windows x86-64 and i686 cross-compilation all pass.

## Performance

On x86-64, the normalized-name check improved as follows:

| Length |    Speedup |
| -----: | ---------: |
|    4–7 | 1.04–1.07x |
|      8 |      2.23x |
|      9 |      2.21x |
|     12 |      2.14x |
|     15 |      1.83x |
|     24 |      3.92x |

The improvement at 4–7 bytes is smaller, but that bucket accounts for 34.2% of lockfile occurrences, so the x86 path uses SSE2 there. The four-byte AArch64 normalized-name path was slower and remains scalar below eight bytes.

For package-name hint matching, the direct 4–7-byte AArch64 comparison was more than twice as fast. Across two local profiling runs of complete wheel parsing, the five-character NumPy case was effectively unchanged, the 12-character Cryptography case improved by roughly 8–14%, and the 18-character Charset Normalizer case improved by roughly 16–21%.
