### PR TITLE
Avoid full site-packages scans for direct reinstalls

### DIFF
--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -125,8 +125,8 @@ impl SitePackages {
                     }
                 };
 
-                if package_names
-                    .is_some_and(|package_names| !package_names.contains(dist_info.name()))
+                if let Some(package_names) = package_names
+                    && !package_names.contains(dist_info.name())
                 {
                     continue;
                 }

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -62,11 +62,12 @@ impl SitePackages {
     }
 
     /// Build an index of the requested installed packages from the given Python environment.
-    pub fn from_environment_for_packages(
+    pub fn from_environment_for_packages<'a>(
         environment: &PythonEnvironment,
-        package_names: &FxHashSet<PackageName>,
+        package_names: impl IntoIterator<Item = &'a PackageName>,
     ) -> Result<Self> {
-        Self::from_interpreter_with_filter(environment.interpreter(), Some(package_names))
+        let package_names = package_names.into_iter().collect::<FxHashSet<_>>();
+        Self::from_interpreter_with_filter(environment.interpreter(), Some(&package_names))
     }
 
     /// Build an index of installed packages from the given Python executable.
@@ -77,7 +78,7 @@ impl SitePackages {
     /// Build an index of installed packages from the given Python executable.
     fn from_interpreter_with_filter(
         interpreter: &Interpreter,
-        package_names: Option<&FxHashSet<PackageName>>,
+        package_names: Option<&FxHashSet<&PackageName>>,
     ) -> Result<Self> {
         let mut distributions: Vec<Option<InstalledDist>> = Vec::new();
         let mut by_name = FxHashMap::default();
@@ -106,7 +107,8 @@ impl SitePackages {
             // Index all installed packages by name.
             for path in site_packages {
                 if let Some(package_names) = package_names
-                    && !path_matches_package_names(&path, package_names)
+                    && let Some(package_name) = installed_dist_name(&path)
+                    && !package_names.contains(&package_name)
                 {
                     continue;
                 }
@@ -636,46 +638,27 @@ pub enum SatisfiesResult {
     Unsatisfied(String),
 }
 
-/// Returns true if a distribution-like path could belong to one of the requested packages.
+/// Infer the package name from an installed distribution path without reading its metadata.
 ///
-/// Returns true for paths that cannot be identified from their filename alone, so they retain
-/// the existing parsing and error behavior.
-fn path_matches_package_names(path: &Path, package_names: &FxHashSet<PackageName>) -> bool {
-    let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
-        return true;
-    };
-    let Some(file_stem) = path.file_stem().and_then(|file_stem| file_stem.to_str()) else {
-        return true;
-    };
+/// Returns `None` when the name cannot safely be derived from the filename alone.
+fn installed_dist_name(path: &Path) -> Option<PackageName> {
+    let extension = path.extension()?.to_str()?;
+    let file_stem = path.file_stem()?.to_str()?;
 
-    let package_name = match extension {
+    match extension {
         "dist-info" => {
-            let Some((name, version)) = file_stem.split_once('-') else {
-                return true;
-            };
-            if Version::from_str(version).is_err() {
-                return true;
-            }
-            let Ok(package_name) = PackageName::from_str(name) else {
-                return true;
-            };
-            package_name
+            let (name, version) = file_stem.split_once('-')?;
+            Version::from_str(version).ok()?;
+            PackageName::from_str(name).ok()
         }
         "egg-info" => {
-            let Ok(filename) = EggInfoFilename::parse(file_stem) else {
-                return true;
-            };
-            if filename.version.is_none() {
-                return true;
-            }
-            filename.name
+            let filename = EggInfoFilename::parse(file_stem).ok()?;
+            filename.version?;
+            Some(filename.name)
         }
         // Legacy editables require reading metadata to determine their package name.
-        "egg-link" => return true,
-        _ => return true,
-    };
-
-    package_names.contains(&package_name)
+        _ => None,
+    }
 }
 
 impl IntoIterator for SitePackages {

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -1,12 +1,14 @@
 use std::borrow::Cow;
 use std::iter::Flatten;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use fs_err as fs;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use uv_configuration::{ExcludeDependency, Excludes, Override, Overrides};
+use uv_distribution_filename::EggInfoFilename;
 use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, Diagnostic, ExtraBuildRequires, ExtraBuildVariables,
     InstalledDist, InstalledDistKind, Name, NameRequirementSpecification, PackageConfigSettings,
@@ -44,13 +46,39 @@ pub struct SitePackages {
 }
 
 impl SitePackages {
+    /// Create an empty index for the given Python interpreter.
+    pub fn empty(interpreter: &Interpreter) -> Self {
+        Self {
+            interpreter: interpreter.clone(),
+            distributions: Vec::new(),
+            by_name: FxHashMap::default(),
+            by_url: FxHashMap::default(),
+        }
+    }
+
     /// Build an index of installed packages from the given Python environment.
     pub fn from_environment(environment: &PythonEnvironment) -> Result<Self> {
         Self::from_interpreter(environment.interpreter())
     }
 
+    /// Build an index of the requested installed packages from the given Python environment.
+    pub fn from_environment_for_packages(
+        environment: &PythonEnvironment,
+        package_names: &FxHashSet<PackageName>,
+    ) -> Result<Self> {
+        Self::from_interpreter_with_filter(environment.interpreter(), Some(package_names))
+    }
+
     /// Build an index of installed packages from the given Python executable.
     pub fn from_interpreter(interpreter: &Interpreter) -> Result<Self> {
+        Self::from_interpreter_with_filter(interpreter, None)
+    }
+
+    /// Build an index of installed packages from the given Python executable.
+    fn from_interpreter_with_filter(
+        interpreter: &Interpreter,
+        package_names: Option<&FxHashSet<PackageName>>,
+    ) -> Result<Self> {
         let mut distributions: Vec<Option<InstalledDist>> = Vec::new();
         let mut by_name = FxHashMap::default();
         let mut by_url = FxHashMap::default();
@@ -77,6 +105,12 @@ impl SitePackages {
 
             // Index all installed packages by name.
             for path in site_packages {
+                if let Some(package_names) = package_names
+                    && !path_matches_package_names(&path, package_names)
+                {
+                    continue;
+                }
+
                 let dist_info = match InstalledDist::try_from_path(&path) {
                     Ok(Some(dist_info)) => dist_info,
                     Ok(None) => continue,
@@ -98,6 +132,12 @@ impl SitePackages {
                         ));
                     }
                 };
+
+                if let Some(package_names) = package_names
+                    && !package_names.contains(dist_info.name())
+                {
+                    continue;
+                }
 
                 let idx = distributions.len();
 
@@ -594,6 +634,48 @@ pub enum SatisfiesResult {
     /// We found an unsatisfied requirement. Since we exit early, we only know about the first
     /// unsatisfied requirement.
     Unsatisfied(String),
+}
+
+/// Returns true if a distribution-like path could belong to one of the requested packages.
+///
+/// Returns true for paths that cannot be identified from their filename alone, so they retain
+/// the existing parsing and error behavior.
+fn path_matches_package_names(path: &Path, package_names: &FxHashSet<PackageName>) -> bool {
+    let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
+        return true;
+    };
+    let Some(file_stem) = path.file_stem().and_then(|file_stem| file_stem.to_str()) else {
+        return true;
+    };
+
+    let package_name = match extension {
+        "dist-info" => {
+            let Some((name, version)) = file_stem.split_once('-') else {
+                return true;
+            };
+            if Version::from_str(version).is_err() {
+                return true;
+            }
+            let Ok(package_name) = PackageName::from_str(name) else {
+                return true;
+            };
+            package_name
+        }
+        "egg-info" => {
+            let Ok(filename) = EggInfoFilename::parse(file_stem) else {
+                return true;
+            };
+            if filename.version.is_none() {
+                return true;
+            }
+            filename.name
+        }
+        // Legacy editables require reading metadata to determine their package name.
+        "egg-link" => return true,
+        _ => return true,
+    };
+
+    package_names.contains(&package_name)
 }
 
 impl IntoIterator for SitePackages {

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -46,16 +46,6 @@ pub struct SitePackages {
 }
 
 impl SitePackages {
-    /// Create an empty index for the given Python interpreter.
-    pub fn empty(interpreter: &Interpreter) -> Self {
-        Self {
-            interpreter: interpreter.clone(),
-            distributions: Vec::new(),
-            by_name: FxHashMap::default(),
-            by_url: FxHashMap::default(),
-        }
-    }
-
     /// Build an index of installed packages from the given Python environment.
     pub fn from_environment(environment: &PythonEnvironment) -> Result<Self> {
         Self::from_interpreter(environment.interpreter())

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -125,8 +125,8 @@ impl SitePackages {
                     }
                 };
 
-                if let Some(package_names) = package_names
-                    && !package_names.contains(dist_info.name())
+                if package_names
+                    .is_some_and(|package_names| !package_names.contains(dist_info.name()))
                 {
                     continue;
                 }

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -226,10 +226,21 @@ pub trait SourceBuildTrait {
     ) -> impl Future<Output = Result<String, AnyErrorBuild>> + 'a;
 }
 
-/// A wrapper for [`uv_installer::SitePackages`]
+/// Provides access to installed distributions during resolution.
 pub trait InstalledPackagesProvider: Clone + Send + Sync + 'static {
     fn iter(&self) -> impl Iterator<Item = &InstalledDist>;
     fn get_packages(&self, name: &PackageName) -> Vec<&InstalledDist>;
+}
+
+impl<Provider: InstalledPackagesProvider> InstalledPackagesProvider for Option<Provider> {
+    fn iter(&self) -> impl Iterator<Item = &InstalledDist> {
+        self.as_ref().into_iter().flat_map(Provider::iter)
+    }
+
+    fn get_packages(&self, name: &PackageName) -> Vec<&InstalledDist> {
+        self.as_ref()
+            .map_or_else(Vec::new, |provider| provider.get_packages(name))
+    }
 }
 
 /// An [`InstalledPackagesProvider`] with no packages in it.

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use rustc_hash::FxHashSet;
 use thiserror::Error;
 use tracing::{Level, debug, enabled, warn};
 
@@ -19,7 +20,7 @@ use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::LoweredExtraBuildDependencies;
 use uv_distribution_types::{
-    ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations,
+    ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations, Name,
     NameRequirementSpecification, Origin, PackageConfigSettings, Requirement, Resolution,
 };
 use uv_fs::Simplified;
@@ -308,8 +309,19 @@ pub(crate) async fn pip_install(
         interpreter,
     )?;
 
+    // A direct reinstall cannot reuse installed packages during resolution. Delay the environment
+    // scan until after resolution, when we can restrict it to the packages that will be reinstalled.
+    let direct_reinstall = matches!(&dependency_mode, DependencyMode::Direct)
+        && matches!(&reinstall, Reinstall::All)
+        && matches!(modifications, Modifications::Sufficient)
+        && pylock.is_none();
+
     // Determine the set of installed packages.
-    let site_packages = SitePackages::from_environment(&environment)?;
+    let site_packages = if direct_reinstall {
+        SitePackages::empty(interpreter)
+    } else {
+        SitePackages::from_environment(&environment)?
+    };
 
     // Check if the current environment satisfies the requirements.
     // Ideally, the resolver would be fast enough to let us remove this check. But right now, for large environments,
@@ -595,6 +607,17 @@ pub(crate) async fn pip_install(
 
     // If necessary, convert editable distributions to non-editable.
     let resolution = apply_editable_mode(resolution, editable);
+
+    // For direct reinstalls, only the resolved packages can be removed from the environment.
+    let site_packages = if direct_reinstall {
+        let package_names = resolution
+            .distributions()
+            .map(|distribution| distribution.name().clone())
+            .collect::<FxHashSet<_>>();
+        SitePackages::from_environment_for_packages(&environment, &package_names)?
+    } else {
+        site_packages
+    };
 
     // Constrain any build requirements marked as `match-runtime = true`.
     let extra_build_requires = extra_build_requires.match_runtime(&resolution)?;

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -308,14 +308,15 @@ pub(crate) async fn pip_install(
         interpreter,
     )?;
 
-    // A direct reinstall cannot reuse installed packages during resolution. Delay the environment
-    // scan until after resolution, when we can restrict it to the packages that will be reinstalled.
-    let direct_reinstall = matches!(&dependency_mode, DependencyMode::Direct)
-        && matches!(&reinstall, Reinstall::All)
-        && matches!(modifications, Modifications::Sufficient)
-        && pylock.is_none();
+    // With sufficient modifications, installation only needs installed distributions selected by
+    // the resolution. A `pylock.toml` resolution never consults the environment, while reinstalling
+    // every package excludes all installed distributions from candidate selection, including for
+    // transitive dependencies. Delay the environment scan in either case, then restrict it to the
+    // resolved package names.
+    let defer_site_packages = matches!(modifications, Modifications::Sufficient)
+        && (pylock.is_some() || matches!(&reinstall, Reinstall::All));
 
-    let site_packages = if direct_reinstall {
+    let site_packages = if defer_site_packages {
         None
     } else {
         Some(SitePackages::from_environment(&environment)?)
@@ -608,7 +609,7 @@ pub(crate) async fn pip_install(
     let resolution = apply_editable_mode(resolution, editable);
 
     let site_packages = match site_packages {
-        // For direct reinstalls, only the resolved packages can be removed from the environment.
+        // Only resolved packages can be modified when using sufficient installation semantics.
         None => SitePackages::from_environment_for_packages(
             &environment,
             resolution.distributions().map(Name::name),

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use rustc_hash::FxHashSet;
 use thiserror::Error;
 use tracing::{Level, debug, enabled, warn};
 
@@ -610,11 +609,10 @@ pub(crate) async fn pip_install(
 
     // For direct reinstalls, only the resolved packages can be removed from the environment.
     let site_packages = if direct_reinstall {
-        let package_names = resolution
-            .distributions()
-            .map(|distribution| distribution.name().clone())
-            .collect::<FxHashSet<_>>();
-        SitePackages::from_environment_for_packages(&environment, &package_names)?
+        SitePackages::from_environment_for_packages(
+            &environment,
+            resolution.distributions().map(Name::name),
+        )?
     } else {
         site_packages
     };

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -315,11 +315,10 @@ pub(crate) async fn pip_install(
         && matches!(modifications, Modifications::Sufficient)
         && pylock.is_none();
 
-    // Determine the set of installed packages.
     let site_packages = if direct_reinstall {
-        SitePackages::empty(interpreter)
+        None
     } else {
-        SitePackages::from_environment(&environment)?
+        Some(SitePackages::from_environment(&environment)?)
     };
 
     // Check if the current environment satisfies the requirements.
@@ -331,6 +330,7 @@ pub(crate) async fn pip_install(
         && groups.is_empty()
         && pylock.is_none()
         && matches!(modifications, Modifications::Sufficient)
+        && let Some(site_packages) = &site_packages
     {
         match site_packages.satisfies_spec(
             &requirements,
@@ -607,14 +607,13 @@ pub(crate) async fn pip_install(
     // If necessary, convert editable distributions to non-editable.
     let resolution = apply_editable_mode(resolution, editable);
 
-    // For direct reinstalls, only the resolved packages can be removed from the environment.
-    let site_packages = if direct_reinstall {
-        SitePackages::from_environment_for_packages(
+    let site_packages = match site_packages {
+        // For direct reinstalls, only the resolved packages can be removed from the environment.
+        None => SitePackages::from_environment_for_packages(
             &environment,
             resolution.distributions().map(Name::name),
-        )?
-    } else {
-        site_packages
+        )?,
+        Some(site_packages) => site_packages,
     };
 
     // Constrain any build requirements marked as `match-runtime = true`.

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -4917,6 +4917,7 @@ fn reinstall_duplicate() -> Result<()> {
     // Run `pip install`.
     uv_snapshot!(context1.pip_install()
         .arg("pip")
+        .arg("--no-deps")
         .arg("--reinstall"),
         @"
     success: true
@@ -5594,6 +5595,24 @@ fn path_name_version_change() {
 
     ----- stderr -----
     Checked 1 package in [TIME]
+    "
+    );
+
+    // Reinstalling a direct wheel without dependencies should reinstall the requested package.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(context.workspace_root.join("test/links/ok-1.0.0-py3-none-any.whl"))
+        .arg("--no-deps")
+        .arg("--reinstall"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ ok==1.0.0 (from file://[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl)
     "
     );
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -4044,6 +4044,12 @@ fn install_no_downgrade() -> Result<()> {
     "
     );
 
+    // An unrelated distribution should not be inspected when all resolved packages will be
+    // reinstalled.
+    let unrelated = context.site_packages().join("unrelated-1.0.0.dist-info");
+    fs::create_dir_all(&unrelated)?;
+    fs::write(unrelated.join("direct_url.json"), "invalid")?;
+
     // Install `anyio` with `--reinstall`, which should downgrade `idna`.
     uv_snapshot!(context.filters(), context.pip_install()
         .arg("--reinstall")
@@ -12643,6 +12649,11 @@ fn pep_751_install_registry_wheel() -> Result<()> {
      + iniconfig==2.0.0
     "
     );
+
+    // An unrelated distribution should not be inspected when installing from a `pylock.toml`.
+    let unrelated = context.site_packages().join("unrelated-1.0.0.dist-info");
+    fs::create_dir_all(&unrelated)?;
+    fs::write(unrelated.join("direct_url.json"), "invalid")?;
 
     uv_snapshot!(context.filters(), context.pip_install()
         .arg("--preview")


### PR DESCRIPTION
## Summary

`uv pip install` currently indexes every installed distribution before resolution, even when installed packages cannot affect the result. Large environments therefore pay for metadata reads unrelated to the packages that can actually be modified.

This defers the site-packages scan whenever installation uses sufficient semantics and resolution does not need the installed environment. With `--reinstall`, `Reinstall::All` excludes installed candidates for every selected package, including transitive dependencies. When installing from a `pylock.toml`, the resolution is derived directly from the lock and likewise does not consult installed packages. Exact installation semantics retain the full scan because they must identify extraneous packages for removal. After resolution, we index only installed distributions whose names occur in the resolution.

## Performance

Measurements of the direct-reinstall path on a separate machine show larger improvements as the installed environment grows:

| Fixture                                       | Baseline |  Patched | Change |
| --------------------------------------------- | -------: | -------: | -----: |
| 1,000 installed distributions, full reinstall | 200.4 ms | 183.7 ms |  -8.3% |
| 2,000 installed distributions, full reinstall | 223.9 ms | 182.9 ms | -18.3% |
| 2,000 distributions, dry-run/planning path    | 202.3 ms | 158.7 ms | -21.5% |
