### PR TITLE
Read cache entries into exact-sized buffers

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -1,5 +1,5 @@
 use std::time::{Duration, Instant};
-use std::{borrow::Cow, path::Path};
+use std::{borrow::Cow, io::Read, path::Path};
 
 use futures::FutureExt;
 use reqwest::{Request, Response};
@@ -825,12 +825,26 @@ impl DataWithCachePolicy {
     /// file given fails, then this returns an error.
     #[instrument]
     fn from_path_sync(path: &Path) -> Result<Self, Error> {
-        let file = fs_err::File::open(path).map_err(ErrorKind::Io)?;
-        // Note that we don't wrap our file in a buffer because it will just
-        // get passed to AlignedVec::extend_from_reader, which doesn't benefit
-        // from an intermediary buffer. In effect, the AlignedVec acts as the
-        // buffer.
-        Self::from_reader(file)
+        let mut file = fs_err::File::open(path).map_err(ErrorKind::Io)?;
+        let file_size = file.metadata().map_err(ErrorKind::Io)?.len();
+        let file_size = usize::try_from(file_size)
+            .ok()
+            .filter(|&file_size| file_size <= AlignedVec::<16>::MAX_CAPACITY)
+            .ok_or_else(|| {
+                ErrorKind::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "cache entry file size of {file_size} bytes exceeds the maximum supported \
+                         size of {} bytes",
+                        AlignedVec::<16>::MAX_CAPACITY,
+                    ),
+                ))
+            })?;
+
+        let mut aligned_bytes = AlignedVec::with_capacity(file_size);
+        aligned_bytes.resize(file_size, 0);
+        file.read_exact(&mut aligned_bytes).map_err(ErrorKind::Io)?;
+        Self::from_aligned_bytes(aligned_bytes)
     }
 
     /// Loads cached data and its associated HTTP cache policy from the given


### PR DESCRIPTION
## Summary

Warm cache hits currently read into an empty `AlignedVec` via `extend_from_reader`. This PR instead reads file-backed cache entries at their known size instead.

## Performance

| Project | Wall-time change | Bootstrap 95% CI |
| --- | ---: | ---: |
| Black | 11.32% faster | 7.57–14.77% faster |
| GitHub Wikidata Bot | 12.14% faster | 9.21–17.87% faster |
| Home Assistant | 11.40% faster | 3.41–14.91% faster |
| Packse | 8.51% faster | 0.43–13.41% faster |
| Saleor | 5.68% faster | 0.06% slower–9.00% faster |
| Transformers | 8.92% faster | 5.96–11.85% faster |
| Warehouse | 10.89% faster | 7.60–13.02% faster |
| **All pairs** | **9.69% faster** | **8.00–11.38% faster** |

Across all pairs, the reported resolve phase improved by 20.38%, system CPU by 29.24%, and peak RSS by 24.39%.

The existing `uv-client` suite, Rust formatting, and strict `uv-client` Clippy checks pass.