### PR TITLE
[codex] Limit Tokio blocking worker threads

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2995,6 +2995,7 @@ where
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .thread_stack_size(min_stack_size)
+            .max_blocking_threads(2)
             .build()
             .expect("Failed building the Runtime");
         // Box the large main future to avoid stack overflows.


### PR DESCRIPTION
## Summary

uv runs its async entry point on Tokio's current-thread runtime and currently leaves the blocking pool at Tokio's default maximum of 512 threads. Warm resolves issue many short-lived cache reads through `spawn_blocking`; the profiled ecosystem workloads reached 19–21 concurrent workers while spending substantial time in system CPU and allocator work.

This bounds the runtime's blocking pool to two workers. A preliminary sweep across 1, 2, 4, 8, 16, 32, and 64 workers found a useful plateau at 2–8: two workers was the best-supported knee for resolve time, CPU, and memory; benefits weakened at 16 and disappeared at 32–64.

This is intentionally a draft because the setting applies to every `spawn_blocking` user, not only resolver cache reads. Builds, extraction, Git, keyring access, and other commands need broader validation. I also tested a narrower semaphore around `DataWithCachePolicy::from_path_async`; it was neutral at -0.77% wall time with a bootstrap 95% interval of -1.73% to +1.61%. The measured benefit therefore appears to come from bounding the blocking pool as a whole rather than cache-file admission alone.

## Performance

I measured real `uv lock` CLI behavior from `5cb184f67` with a fresh lockfile and warm shared cache across all seven active ecosystem projects. Control and treatment order was randomized within each pair, with three warmups and 20 measured pairs per project (140 pairs total). Python versions and `--exclude-newer` were fixed, and every generated lockfile was byte-identical. An identical-binary A/A calibration measured an aggregate wall-time delta of -0.59%, with a bootstrap 95% interval of -2.65% to +1.05%.

| Project | Wall-time change | Bootstrap 95% CI |
| --- | ---: | ---: |
| Black | 2.53% faster | 12.56% slower–9.07% faster |
| GitHub Wikidata Bot | 4.12% faster | 3.17% slower–9.66% faster |
| Home Assistant | 7.10% faster | 4.15–9.90% faster |
| Packse | 8.13% faster | 3.61–14.09% faster |
| Saleor | 13.91% faster | 8.03–17.50% faster |
| Transformers | 8.01% faster | 4.94–10.56% faster |
| Warehouse | 8.45% faster | 6.45–11.30% faster |
| **All pairs** | **7.72% faster** | **6.46–9.12% faster** |

Across all pairs, uv's reported resolve phase improved by 20.0%, system CPU by 31.24%, and peak RSS by 31.89%.

The profiling build, Rust formatting, and the 140-pair CLI lock-equivalence check pass.