### PR TITLE
fix: four bug fixes for uv tree, lock --upgrade, init --package stubs, and tool uninstall

### DIFF
--- a/crates/uv-configuration/src/package_options.rs
+++ b/crates/uv-configuration/src/package_options.rs
@@ -255,9 +255,10 @@ impl Upgrade {
     /// Combine a set of [`Upgrade`] values.
     #[must_use]
     pub fn combine(self, other: Self) -> Self {
-        // For `strategy`: `other` takes precedence for an explicit `All` or `None`; otherwise,
-        // merge.
+        // For `strategy`: `self` (CLI) takes precedence over `other` (config) for `All`;
+        // `other` takes precedence for `None`; otherwise merge.
         let strategy = match (self.strategy, other.strategy) {
+            (UpgradeStrategy::All, _) => UpgradeStrategy::All,
             (_, UpgradeStrategy::All) => UpgradeStrategy::All,
             (_, UpgradeStrategy::None) => UpgradeStrategy::None,
             (

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1268,9 +1268,22 @@ fn generate_package_scripts(
     is_lib: bool,
 ) -> Result<()> {
     let module_name = package.as_dist_info_name();
-
     let src_dir = path.join("src");
-    let pkg_dir = src_dir.join(&*module_name);
+
+    // Determine if this is a stubs-only package (name ends with `-stubs`).
+    let is_stubs = package.as_str().ends_with("-stubs");
+    let pkg_dir = if is_stubs {
+        // For stubs packages, the module directory must preserve the `-stubs` suffix
+        // so that `uv_build` can find it, e.g., `foo-stubs` not `foo_stubs`.
+        // See: `uv_build::find_module_path_from_package_name`
+        let stem = &package.as_str()[..package.as_str().len() - "-stubs".len()];
+        let normalized_stem = PackageName::from_str(stem)
+            .map(|name| name.as_dist_info_name().to_string())
+            .unwrap_or_else(|_| stem.to_string());
+        src_dir.join(format!("{normalized_stem}-stubs"))
+    } else {
+        src_dir.join(&*module_name)
+    };
     fs_err::create_dir_all(&pkg_dir)?;
 
     let pure_python_script = if is_lib {
@@ -1376,14 +1389,21 @@ fn generate_package_scripts(
         _ => pure_python_script,
     };
 
-    // Create `src/{name}/__init__.py`, if it doesn't exist already.
-    let init_py = pkg_dir.join("__init__.py");
-    if !init_py.try_exists()? {
-        fs_err::write(init_py, package_script)?;
+    // Create `src/{name}/__init__.py` (or `__init__.pyi` for stubs packages), if it doesn't exist already.
+    if is_stubs {
+        let init_pyi = pkg_dir.join("__init__.pyi");
+        if !init_pyi.try_exists()? {
+            fs_err::write(init_pyi, package_script)?;
+        }
+    } else {
+        let init_py = pkg_dir.join("__init__.py");
+        if !init_py.try_exists()? {
+            fs_err::write(init_py, package_script)?;
+        }
     }
 
     // Create `src/{name}/py.typed`, if it doesn't exist already.
-    if is_lib {
+    if is_lib && !is_stubs {
         let py_typed = pkg_dir.join("py.typed");
         if !py_typed.try_exists()? {
             fs_err::write(py_typed, "")?;

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -15,7 +15,7 @@ use uv_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion}
 use uv_resolver::{PackageMap, TreeDisplay};
 use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
-use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
+use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache};
 
 use crate::commands::pip::latest::LatestClient;
 use crate::commands::pip::loggers::DefaultResolveLogger;
@@ -65,18 +65,18 @@ pub(crate) async fn tree(
 ) -> Result<ExitStatus> {
     // Find the project requirements.
     let workspace_cache = WorkspaceCache::default();
-    let workspace;
+    let virtual_project;
     let target = if let Some(script) = script.as_ref() {
         LockTarget::Script(script)
     } else {
-        workspace = Workspace::discover(
+        virtual_project = VirtualProject::discover(
             project_dir,
             &DiscoveryOptions::default(),
             cache,
             &workspace_cache,
         )
         .await?;
-        LockTarget::Workspace(&workspace)
+        LockTarget::Workspace(virtual_project.workspace())
     };
 
     // Determine the groups to include.

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,24 +133,28 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
-                // If the tool is not installed properly, attempt to remove the environment anyway.
-                match installed_tools.remove_environment(&name) {
-                    Ok(()) => {
-                        dangling = true;
-                        writeln!(
-                            printer.stderr(),
-                            "Removed dangling environment for `{name}`"
-                        )?;
-                        continue;
-                    }
-                    Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
-                        if err.kind() == std::io::ErrorKind::NotFound =>
-                    {
-                        bail!("`{name}` is not installed");
-                    }
-                    Err(err) => {
-                        return Err(err.into());
+            let receipt = match installed_tools.get_tool_receipt(&name) {
+                Ok(Some(receipt)) => receipt,
+                Ok(None) | Err(_) => {
+                    // If the tool is not installed properly (e.g., corrupt receipt),
+                    // attempt to remove the environment anyway with a warning.
+                    match installed_tools.remove_environment(&name) {
+                        Ok(()) => {
+                            dangling = true;
+                            writeln!(
+                                printer.stderr(),
+                                "Removed dangling environment for `{name}`"
+                            )?;
+                            continue;
+                        }
+                        Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
+                            if err.kind() == std::io::ErrorKind::NotFound =>
+                        {
+                            bail!("`{name}` is not installed");
+                        }
+                        Err(err) => {
+                            return Err(err.into());
+                        }
                     }
                 }
             };


### PR DESCRIPTION
## Summary

Four separate bug fixes, each in its own commit:

### 1. #19975 — `uv tree` fails on dependency-group-only pyproject.tomls
- Use `VirtualProject::discover()` instead of `Workspace::discover()` to accept projects with only `[dependency-groups]`

### 2. #19954 — `uv lock --upgrade` ignored when `upgrade-package` set in config
- Add `(UpgradeStrategy::All, _)` as first arm in `Upgrade::combine()` so CLI `--upgrade` overrides config's `upgrade-package`

### 3. #19663 — `uv init --package` produces invalid layout for `-stubs` packages
- Generate `src/foo-stubs/__init__.pyi` instead of `src/foo_stubs/__init__.py`
- Skip `py.typed` for stubs packages (stubs are already type information)

### 4. #19630 — `uv tool uninstall` fails with corrupt receipts
- Treat corrupt receipts (`Err` from `get_tool_receipt()`) as dangling environments instead of hard errors

Closes #19975
Closes #19954
Closes #19663
Closes #19630