### PR TITLE
Freeze pre-commit hook refs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,12 @@ exclude: |
 
 repos:
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.25
+    rev: 4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7 # frozen: v0.25
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.48.0
+    rev: bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # frozen: v1.48.0
     hooks:
       - id: typos
 
@@ -44,7 +44,7 @@ repos:
         types_or: [yaml, json5]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.21
+    rev: 01a675ea018f2fb714478a5ffb83fcea8374bb06 # frozen: v0.15.21
     hooks:
       - id: ruff-format
       - id: ruff


### PR DESCRIPTION
## Summary

Pin pre-commit hook refs to the exact commits currently resolved by their existing tags. This is intended to be a no-op change; the version tags are preserved in `# frozen: ...` comments so Renovate can continue updating them normally.

uv does not appear to run `prek` or `pre-commit` in CI, so there is no CI invocation to lock in this PR.

See astral-sh/ruff#26386 for more information; mirrors astral-sh/ruff#26461 and astral-sh/ty#3897.

## Frozen hook refs

| Repo | Previous ref | Frozen commit | Release |
|---|---:|---|---|
| [`abravalheri/validate-pyproject`](https://github.com/abravalheri/validate-pyproject) | [`v0.25`](https://github.com/abravalheri/validate-pyproject/tree/v0.25) | [`4b2e70d`](https://github.com/abravalheri/validate-pyproject/commit/4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7) | [release](https://github.com/abravalheri/validate-pyproject/releases/tag/v0.25) |
| [`crate-ci/typos`](https://github.com/crate-ci/typos) | [`v1.48.0`](https://github.com/crate-ci/typos/tree/v1.48.0) | [`bee27e3`](https://github.com/crate-ci/typos/commit/bee27e3a4fd1ea2111cf90ab89cd076c870fce14) | [release](https://github.com/crate-ci/typos/releases/tag/v1.48.0) |
| [`astral-sh/ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) | [`v0.15.21`](https://github.com/astral-sh/ruff-pre-commit/tree/v0.15.21) | [`01a675e`](https://github.com/astral-sh/ruff-pre-commit/commit/01a675ea018f2fb714478a5ffb83fcea8374bb06) | [release](https://github.com/astral-sh/ruff-pre-commit/releases/tag/v0.15.21) |

## Test Plan

```bash
prek validate-config .pre-commit-config.yaml
prek run --all-files
```