### PR TITLE
Refactor guarded reads with ValidatedReader

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -11,7 +11,7 @@ use tracing::{debug, warn};
 
 pub use crate::locked_file::*;
 pub use crate::path::*;
-pub use crate::read::read_utf_8_file_if_starts_with;
+pub use crate::read::ValidatedReader;
 
 pub mod cachedir;
 pub mod link;

--- a/crates/uv-fs/src/read.rs
+++ b/crates/uv-fs/src/read.rs
@@ -1,64 +1,105 @@
 use std::io::{self, Read};
-use std::path::Path;
 
-/// Read a UTF-8 text file if it starts with `prefix`.
-///
-/// If the file does not start with `prefix`, no bytes after the prefix are read. If the prefix
-/// matches, the rest of the file is read incrementally and rejected as soon as it contains a NUL
-/// byte or invalid UTF-8.
-pub fn read_utf_8_file_if_starts_with(
-    path: impl AsRef<Path>,
-    prefix: &str,
-) -> io::Result<Option<Vec<u8>>> {
-    let mut file = fs_err::File::open(path.as_ref())?;
-    read_utf_8_if_starts_with(&mut file, prefix)
+const READ_BUFFER_SIZE: usize = 8 * 1024;
+
+/// A reader that validates its contents while reading.
+#[must_use]
+pub struct ValidatedReader<Reader> {
+    reader: Reader,
+    prefix: Option<String>,
+    require_utf8: bool,
 }
 
-fn read_utf_8_if_starts_with(mut reader: impl Read, prefix: &str) -> io::Result<Option<Vec<u8>>> {
-    const READ_BUFFER_SIZE: usize = 8 * 1024;
-
-    if prefix.as_bytes().contains(&0) {
-        return Ok(None);
+impl<Reader> ValidatedReader<Reader> {
+    /// Create a new validated reader.
+    pub fn new(reader: Reader) -> Self {
+        Self {
+            reader,
+            prefix: None,
+            require_utf8: false,
+        }
     }
 
-    let mut contents = vec![0; prefix.len()];
-    match reader.read_exact(&mut contents) {
-        Ok(()) if contents == prefix.as_bytes() => {}
-        Ok(()) => return Ok(None),
-        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
-        Err(err) => return Err(err),
+    /// Require the contents to start with `prefix`.
+    ///
+    /// If the prefix does not match, [`Self::read`] does not read any bytes after the prefix.
+    pub fn require_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(prefix.into());
+        self
     }
 
-    let mut valid_utf_8_len = contents.len();
-    let mut buffer = [0u8; READ_BUFFER_SIZE];
-    loop {
-        let count = match reader.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(count) => count,
-            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
-            Err(err) => return Err(err),
+    /// Require the contents to be valid UTF-8 text.
+    ///
+    /// The contents are read incrementally and rejected as soon as a NUL byte or invalid UTF-8 is
+    /// encountered.
+    pub fn require_utf8(mut self) -> Self {
+        self.require_utf8 = true;
+        self
+    }
+}
+
+impl<Reader: Read> ValidatedReader<Reader> {
+    /// Read the contents, returning `None` if a configured validation fails.
+    pub fn read(self) -> io::Result<Option<Vec<u8>>> {
+        let Self {
+            mut reader,
+            prefix,
+            require_utf8,
+        } = self;
+
+        let mut contents = if let Some(prefix) = prefix {
+            let mut contents = vec![0; prefix.len()];
+            match reader.read_exact(&mut contents) {
+                Ok(()) if contents == prefix.as_bytes() => {}
+                Ok(()) => return Ok(None),
+                Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(err) => return Err(err),
+            }
+            contents
+        } else {
+            Vec::new()
         };
 
-        let chunk = &buffer[..count];
-        if chunk.contains(&0) {
+        if !require_utf8 {
+            reader.read_to_end(&mut contents)?;
+            return Ok(Some(contents));
+        }
+
+        if contents.contains(&0) {
             return Ok(None);
         }
-        contents.extend_from_slice(chunk);
-        match std::str::from_utf8(&contents[valid_utf_8_len..]) {
-            Ok(_) => valid_utf_8_len = contents.len(),
-            Err(err) if err.error_len().is_some() => return Ok(None),
-            Err(err) => valid_utf_8_len += err.valid_up_to(),
-        }
-    }
 
-    Ok((valid_utf_8_len == contents.len()).then_some(contents))
+        let mut valid_utf_8_len = contents.len();
+        let mut buffer = [0u8; READ_BUFFER_SIZE];
+        loop {
+            let count = match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(count) => count,
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                Err(err) => return Err(err),
+            };
+
+            let chunk = &buffer[..count];
+            if chunk.contains(&0) {
+                return Ok(None);
+            }
+            contents.extend_from_slice(chunk);
+            match std::str::from_utf8(&contents[valid_utf_8_len..]) {
+                Ok(_) => valid_utf_8_len = contents.len(),
+                Err(err) if err.error_len().is_some() => return Ok(None),
+                Err(err) => valid_utf_8_len += err.valid_up_to(),
+            }
+        }
+
+        Ok((valid_utf_8_len == contents.len()).then_some(contents))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::io::{self, Cursor, Read};
 
-    use super::read_utf_8_if_starts_with;
+    use super::ValidatedReader;
 
     struct ErrorReader;
 
@@ -71,7 +112,23 @@ mod tests {
     #[test]
     fn stops_at_prefix_mismatch() -> io::Result<()> {
         let reader = Cursor::new(b"# ").chain(ErrorReader);
-        assert!(read_utf_8_if_starts_with(reader, "#!")?.is_none());
+        assert!(
+            ValidatedReader::new(reader)
+                .require_prefix("#!")
+                .read()?
+                .is_none()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn reads_without_utf_8_validation() -> io::Result<()> {
+        assert_eq!(
+            ValidatedReader::new(Cursor::new(b"#!\xff"))
+                .require_prefix("#!")
+                .read()?,
+            Some(b"#!\xff".to_vec())
+        );
         Ok(())
     }
 
@@ -79,7 +136,13 @@ mod tests {
     fn stops_at_binary_content() -> io::Result<()> {
         for marker in [0, 0xff] {
             let reader = Cursor::new([b'#', b'!', marker]).chain(ErrorReader);
-            assert!(read_utf_8_if_starts_with(reader, "#!")?.is_none());
+            assert!(
+                ValidatedReader::new(reader)
+                    .require_prefix("#!")
+                    .require_utf8()
+                    .read()?
+                    .is_none()
+            );
         }
         Ok(())
     }
@@ -88,7 +151,10 @@ mod tests {
     fn handles_split_utf_8() -> io::Result<()> {
         let reader = Cursor::new(b"#!\xc3").chain(Cursor::new(b"\xa9"));
         assert_eq!(
-            read_utf_8_if_starts_with(reader, "#!")?,
+            ValidatedReader::new(reader)
+                .require_prefix("#!")
+                .require_utf8()
+                .read()?,
             Some(b"#!\xc3\xa9".to_vec())
         );
         Ok(())

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 
 use owo_colors::OwoColorize;
 use uv_cache::Cache;
-use uv_fs::{CWD, Simplified, is_virtualenv_base, normalize_path, read_utf_8_file_if_starts_with};
+use uv_fs::{CWD, Simplified, ValidatedReader, is_virtualenv_base, normalize_path};
 use uv_preview::{Preview, PreviewFeature};
 use uv_scripts::Pep723Metadata;
 use uv_warnings::warn_user;
@@ -169,7 +169,10 @@ fn read_script_candidate(path: &Path) -> io::Result<Option<Vec<u8>>> {
         return fs_err::read(path).map(Some);
     }
 
-    read_utf_8_file_if_starts_with(path, "#!")
+    ValidatedReader::new(fs_err::File::open(path)?)
+        .require_prefix("#!")
+        .require_utf8()
+        .read()
 }
 
 /// Return whether a path could contain a Python script.


### PR DESCRIPTION
Amends the implementation in #20099 to use a reusable builder pattern instead of a special "utf-8 with prefix validation" function.