### PR TITLE
Derive pre-release authorization from the partial solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,8 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79d771681f6c21ebe25dda598774b6e6badca8b720ce2168df7788b2821c46d"
+source = "git+https://github.com/astral-sh/pubgrub?rev=bb628cc4264ab2bd50e0e8ccffcb9ab490128288#bb628cc4264ab2bd50e0e8ccffcb9ab490128288"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -293,8 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086f936efdefab117f5a72367fb3d68c4fded8ba5a7008e3c63365eecf723822"
+source = "git+https://github.com/astral-sh/pubgrub?rev=bb628cc4264ab2bd50e0e8ccffcb9ab490128288#bb628cc4264ab2bd50e0e8ccffcb9ab490128288"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
-pubgrub = { version = "0.5.0", package = "astral-pubgrub" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "bb628cc4264ab2bd50e0e8ccffcb9ab490128288", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
 rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
@@ -289,7 +289,7 @@ unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.16.0" }
-version-ranges = { version = "0.2.0", package = "astral-version-ranges" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "bb628cc4264ab2bd50e0e8ccffcb9ab490128288", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -3036,11 +3036,6 @@ pub(crate) struct ForkState {
     ///
     /// Tracked on the fork state to avoid counting each identical version between forks as new try.
     prefetcher: BatchPrefetcher,
-    /// Reverse index of pre-release proxy package IDs discovered for each package name.
-    ///
-    /// Entries are not removed on backtracking. This map only avoids scanning PubGrub's package
-    /// graph; whether a proxy is active is always derived from the current partial solution.
-    prerelease_by_name: FxHashMap<PackageName, Vec<Id<PubGrubPackage>>>,
 }
 
 impl ForkState {
@@ -3066,29 +3061,24 @@ impl ForkState {
             python_requirement,
             conflict_tracker: ConflictTracker::default(),
             prefetcher,
-            prerelease_by_name: FxHashMap::default(),
         }
     }
 
     /// Returns `true` if an active pre-release proxy authorizes this package in the current fork.
     fn has_active_prerelease_proxy(&self, package: &PubGrubPackage) -> bool {
-        if self.prerelease_by_name.is_empty() {
-            return false;
-        }
         let Some(name) = package.name_no_root() else {
             return false;
         };
-        self.prerelease_by_name
-            .get(name)
-            .into_iter()
-            .flatten()
-            .any(|proxy| {
-                matches!(
-                    self.pubgrub
-                        .partial_solution
-                        .term_intersection_for_package(*proxy),
-                    Some(Term::Positive(_))
-                )
+        self.pubgrub
+            .partial_solution
+            .package_terms()
+            .any(|(package_id, term)| {
+                matches!(term, Term::Positive(_))
+                    && matches!(
+                        &*self.pubgrub.package_store[package_id],
+                        PubGrubPackageInner::Prerelease { package: wrapped }
+                            if wrapped.name_no_root() == Some(name)
+                    )
             })
     }
 
@@ -3207,17 +3197,6 @@ impl ForkState {
                 parent: _,
                 source: _,
             } = dependency;
-
-            if let PubGrubPackageInner::Prerelease { package: wrapped } = &**package {
-                let Some(name) = wrapped.name_no_root() else {
-                    continue;
-                };
-                let proxy = self.pubgrub.package_store.alloc(package.clone());
-                let proxy_ids = self.prerelease_by_name.entry(name.clone()).or_default();
-                if !proxy_ids.contains(&proxy) {
-                    proxy_ids.push(proxy);
-                }
-            }
 
             let Some(base_package) = package.base_package() else {
                 continue;


### PR DESCRIPTION
## Summary

This is a stacked experiment on #19993.

#19993 keeps a reverse index from package names to every pre-release proxy ID discovered in a fork. The index intentionally survives backtracking, while each lookup consults PubGrub's current partial solution to determine whether a proxy is still active.

This PR instead derives the same answer directly from PubGrub's current package terms. [The pinned PubGrub commit](https://github.com/astral-sh/pubgrub/commit/bb628cc4264ab2bd50e0e8ccffcb9ab490128288) exposes those terms and verifies that the iterator drops assignments removed by backtracking. uv can therefore remove the reverse index and its update path, leaving PubGrub as the sole source of truth for active pre-release authorization.

The tradeoff is that candidate selection now scans the active partial solution instead of performing an indexed lookup. This draft exists to assess that cost in CodSpeed before deciding whether the simpler state model is worthwhile. Both PubGrub workspace crates are temporarily pinned to the same commit and can return to crates.io after the API is released.

The focused pre-release authorization and backtracking scenarios pass with both the local checkout and the final remote pin, along with strict `uv-resolver` Clippy checks.
