### PR TITLE
Require hints when rendering error chains

### DIFF
--- a/crates/uv-dev/src/main.rs
+++ b/crates/uv-dev/src/main.rs
@@ -68,7 +68,8 @@ async fn main() -> ExitCode {
     if let Err(err) = result {
         trace!("Error trace: {err:?}");
         let err = err.context("uv-dev failed");
-        uv_errors::write_error_chain(err.as_ref()).expect("writing to stderr should not fail");
+        uv_errors::write_error_chain(err.as_ref(), uv_errors::Hints::none())
+            .expect("writing to stderr should not fail");
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -140,7 +140,6 @@ impl fmt::Display for HintPrefix {
 pub struct ErrorOptions<'a, C = AnsiColors, W = Stderr> {
     level: Cow<'a, str>,
     color: C,
-    hints: Hints<'a>,
     width_override: Option<usize>,
     stream: W,
 }
@@ -161,7 +160,6 @@ impl Default for ErrorOptions<'_, AnsiColors, Stderr> {
         Self {
             level: Cow::Borrowed("error"),
             color: AnsiColors::Red,
-            hints: Hints::none(),
             width_override: None,
             stream: Stderr,
         }
@@ -180,16 +178,9 @@ impl<'a, C, W> ErrorOptions<'a, C, W> {
         ErrorOptions {
             level: self.level,
             color,
-            hints: self.hints,
             width_override: self.width_override,
             stream: self.stream,
         }
-    }
-
-    /// Render additional user-facing hints after the error chain.
-    pub fn with_hints(mut self, hints: Hints<'a>) -> Self {
-        self.hints = hints;
-        self
     }
 
     /// Override the terminal width used for wrapping.
@@ -205,16 +196,16 @@ impl<'a, C, W> ErrorOptions<'a, C, W> {
         ErrorOptions {
             level: self.level,
             color: self.color,
-            hints: self.hints,
             width_override: self.width_override,
             stream,
         }
     }
 }
 
-/// Format an error chain to standard error using the default level and color.
-pub fn write_error_chain(err: &dyn Error) -> fmt::Result {
-    write_error_chain_with_options(err, ErrorOptions::default())
+/// Format an error chain and explicitly supplied hints to standard error using the default level
+/// and color.
+pub fn write_error_chain(err: &dyn Error, hints: Hints<'_>) -> fmt::Result {
+    write_error_chain_with_options(err, hints, ErrorOptions::default())
 }
 
 /// Formats an error or warning chain with custom options.
@@ -222,12 +213,12 @@ pub fn write_error_chain(err: &dyn Error) -> fmt::Result {
 /// Each hint is rendered on its own line, prefixed with the styled `hint:` label.
 pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
     err: &dyn Error,
+    hints: Hints<'_>,
     options: ErrorOptions<'_, C, W>,
 ) -> fmt::Result {
     let ErrorOptions {
         level,
         color,
-        hints,
         width_override,
         mut stream,
     } = options;
@@ -331,6 +322,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
+            Hints::none(),
             ErrorOptions::default()
                 .with_width_override(80)
                 .with_stream(&mut output),
@@ -361,8 +353,12 @@ mod tests {
 
         let error = Outer { source: Inner };
         let mut output = String::new();
-        write_error_chain_with_options(&error, ErrorOptions::default().with_stream(&mut output))
-            .unwrap();
+        write_error_chain_with_options(
+            &error,
+            Hints::none(),
+            ErrorOptions::default().with_stream(&mut output),
+        )
+        .unwrap();
         assert_snapshot!(format!("{output:?}"), @r#""\u{1b}[1m\u{1b}[31merror\u{1b}[39m\u{1b}[0m\u{1b}[1m:\u{1b}[0m Failed to write file\n  \u{1b}[1m\u{1b}[31mCaused by\u{1b}[39m\u{1b}[0m: Permission denied\n""#);
         let output = anstream::adapter::strip_str(&output);
 
@@ -378,6 +374,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             error.as_ref(),
+            Hints::none(),
             ErrorOptions::default()
                 .with_level("warning")
                 .with_color(AnsiColors::Yellow)
@@ -402,6 +399,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
+            Hints::none(),
             ErrorOptions::default()
                 .with_width_override(50)
                 .with_stream(&mut output),
@@ -426,6 +424,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
+            Hints::none(),
             ErrorOptions::default()
                 .with_width_override(40)
                 .with_stream(&mut output),
@@ -465,6 +464,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
+            Hints::none(),
             ErrorOptions::default()
                 .with_width_override(60)
                 .with_stream(&mut output),
@@ -490,6 +490,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
+            Hints::none(),
             ErrorOptions::default()
                 .with_width_override(50)
                 .with_stream(&mut output),
@@ -516,6 +517,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
+            Hints::none(),
             ErrorOptions::default()
                 .with_width_override(50)
                 .with_stream(&mut output),
@@ -542,9 +544,8 @@ mod tests {
         let mut rendered = String::new();
         write_error_chain_with_options(
             err.as_ref(),
-            ErrorOptions::default()
-                .with_hints(hints)
-                .with_stream(&mut rendered),
+            hints,
+            ErrorOptions::default().with_stream(&mut rendered),
         )
         .unwrap();
         let rendered = anstream::adapter::strip_str(&rendered);
@@ -572,6 +573,7 @@ mod tests {
         let mut rendered = String::new();
         write_error_chain_with_options(
             err.as_ref(),
+            Hints::none(),
             ErrorOptions::default().with_stream(&mut rendered),
         )
         .unwrap();

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1542,7 +1542,7 @@ mod tests {
         group_files, upload,
     };
     use tokio::sync::Semaphore;
-    use uv_errors::{ErrorOptions, write_error_chain_with_options};
+    use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -2251,8 +2251,12 @@ mod tests {
         let err = mock_server_upload(&mock_server).await.unwrap_err();
 
         let mut capture = String::new();
-        write_error_chain_with_options(&err, ErrorOptions::default().with_stream(&mut capture))
-            .unwrap();
+        write_error_chain_with_options(
+            &err,
+            Hints::none(),
+            ErrorOptions::default().with_stream(&mut capture),
+        )
+        .unwrap();
 
         let capture = capture.replace(&mock_server.uri(), "[SERVER]");
         let capture = anstream::adapter::strip_str(&capture);
@@ -2280,8 +2284,12 @@ mod tests {
         let err = mock_server_upload(&mock_server).await.unwrap_err();
 
         let mut capture = String::new();
-        write_error_chain_with_options(&err, ErrorOptions::default().with_stream(&mut capture))
-            .unwrap();
+        write_error_chain_with_options(
+            &err,
+            Hints::none(),
+            ErrorOptions::default().with_stream(&mut capture),
+        )
+        .unwrap();
 
         let capture = capture.replace(&mock_server.uri(), "[SERVER]");
         let capture = anstream::adapter::strip_str(&capture);
@@ -2314,8 +2322,12 @@ mod tests {
         let err = mock_server_upload(&mock_server).await.unwrap_err();
 
         let mut capture = String::new();
-        write_error_chain_with_options(&err, ErrorOptions::default().with_stream(&mut capture))
-            .unwrap();
+        write_error_chain_with_options(
+            &err,
+            Hints::none(),
+            ErrorOptions::default().with_stream(&mut capture),
+        )
+        .unwrap();
 
         let capture = capture.replace(&mock_server.uri(), "[SERVER]");
         let capture = anstream::adapter::strip_str(&capture);
@@ -2351,8 +2363,12 @@ mod tests {
         let err = mock_server_upload(&mock_server).await.unwrap_err();
 
         let mut capture = String::new();
-        write_error_chain_with_options(&err, ErrorOptions::default().with_stream(&mut capture))
-            .unwrap();
+        write_error_chain_with_options(
+            &err,
+            Hints::none(),
+            ErrorOptions::default().with_stream(&mut capture),
+        )
+        .unwrap();
 
         let capture = capture.replace(&mock_server.uri(), "[SERVER]");
         let capture = anstream::adapter::strip_str(&capture);

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -13,6 +13,7 @@ use tracing::{debug, instrument, trace};
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_distribution_types::RequiresPython;
+use uv_errors::Hints;
 use uv_fs::Simplified;
 use uv_fs::which::is_executable;
 use uv_pep440::{
@@ -1552,7 +1553,8 @@ pub(crate) async fn find_best_python_installation(
                 let error = anyhow::Error::from(error).context(format!(
                     "A managed Python download is available for {request}, but an error occurred when attempting to download it."
                 ));
-                write_warning_chain(error.as_ref()).expect("writing to stderr should not fail");
+                write_warning_chain(error.as_ref(), Hints::none())
+                    .expect("writing to stderr should not fail");
                 previous_fetch_failed = true;
             }
         }

--- a/crates/uv-warnings/src/lib.rs
+++ b/crates/uv-warnings/src/lib.rs
@@ -9,7 +9,7 @@ pub use anstream;
 #[doc(hidden)]
 pub use owo_colors;
 use rustc_hash::FxHashSet;
-use uv_errors::{ErrorOptions, write_error_chain_with_options};
+use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 
 /// Whether user-facing warnings are enabled.
 pub static ENABLED: AtomicBool = AtomicBool::new(false);
@@ -25,16 +25,18 @@ pub fn disable() {
 }
 
 /// Format a warning chain to standard error.
-pub fn write_warning_chain(err: &dyn Error) -> fmt::Result {
-    write_warning_chain_with_options(err, ErrorOptions::default())
+pub fn write_warning_chain(err: &dyn Error, hints: Hints<'_>) -> fmt::Result {
+    write_warning_chain_with_options(err, hints, ErrorOptions::default())
 }
 
 fn write_warning_chain_with_options<C, W: fmt::Write>(
     err: &dyn Error,
+    hints: Hints<'_>,
     options: ErrorOptions<'_, C, W>,
 ) -> fmt::Result {
     write_error_chain_with_options(
         err,
+        hints,
         options
             .with_level("warning")
             .with_color(owo_colors::AnsiColors::Yellow),
@@ -81,7 +83,7 @@ macro_rules! warn_user_once {
 mod tests {
     use anyhow::anyhow;
     use insta::assert_snapshot;
-    use uv_errors::ErrorOptions;
+    use uv_errors::{ErrorOptions, Hints};
 
     use super::write_warning_chain_with_options;
 
@@ -91,6 +93,7 @@ mod tests {
         let mut output = String::new();
         write_warning_chain_with_options(
             error.as_ref(),
+            Hints::none(),
             ErrorOptions::default().with_stream(&mut output),
         )
         .unwrap();

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -14,7 +14,7 @@ use uv_client::{
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{IndexCapabilities, IndexLocations, IndexUrl};
-use uv_errors::{ErrorOptions, write_error_chain_with_options};
+use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 use uv_preview::{Preview, PreviewFeature};
 use uv_publish::{
     CheckUrlClient, FormMetadata, PublishError, TrustedPublishResult, check_trusted_publishing,
@@ -248,6 +248,7 @@ pub(crate) async fn publish(
                     if dry_run {
                         write_error_chain_with_options(
                             &err,
+                            Hints::none(),
                             ErrorOptions::default().with_stream(printer.stderr()),
                         )?;
                         error_count += 1;
@@ -289,6 +290,7 @@ pub(crate) async fn publish(
                     if dry_run {
                         write_error_chain_with_options(
                             &err,
+                            Hints::none(),
                             ErrorOptions::default().with_stream(printer.stderr()),
                         )?;
                         error_count += 1;
@@ -333,6 +335,7 @@ pub(crate) async fn publish(
                         let err: anyhow::Error = err.into();
                         write_error_chain_with_options(
                             err.as_ref(),
+                            Hints::none(),
                             ErrorOptions::default().with_stream(printer.stderr()),
                         )?;
                         error_count += 1;
@@ -394,6 +397,7 @@ pub(crate) async fn publish(
                         let err: anyhow::Error = err.into();
                         write_error_chain_with_options(
                             err.as_ref(),
+                            Hints::none(),
                             ErrorOptions::default().with_stream(printer.stderr()),
                         )?;
                         error_count += 1;
@@ -556,6 +560,7 @@ async fn gather_credentials(
                 anyhow::Error::from(err)
                     .context("Trusted publishing failed")
                     .as_ref(),
+                Hints::none(),
                 ErrorOptions::default().with_stream(printer.stderr()),
             )?;
         }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -17,7 +17,7 @@ use tracing::{debug, trace, warn};
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_configuration::Concurrency;
-use uv_errors::{ErrorOptions, write_error_chain_with_options};
+use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 use uv_fs::Simplified;
 use uv_platform::{Arch, Libc};
 use uv_preview::{Preview, PreviewFeature};
@@ -923,6 +923,7 @@ async fn perform_install(
                 InstallErrorKind::DownloadUnpack => {
                     write_error_chain_with_options(
                         err.context(format!("Failed to install {key}")).as_ref(),
+                        Hints::none(),
                         ErrorOptions::default().with_stream(printer.stderr()),
                     )?;
                 }
@@ -936,6 +937,7 @@ async fn perform_install(
                     write_error_chain_with_options(
                         err.context(format!("Failed to install executable for {key}"))
                             .as_ref(),
+                        Hints::none(),
                         ErrorOptions::default()
                             .with_level(level)
                             .with_color(color)
@@ -953,6 +955,7 @@ async fn perform_install(
                     write_error_chain_with_options(
                         err.context(format!("Failed to create registry entry for {key}"))
                             .as_ref(),
+                        Hints::none(),
                         ErrorOptions::default()
                             .with_level(level)
                             .with_color(color)

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -11,7 +11,7 @@ use uv_client::BaseClientBuilder;
 use uv_configuration::{Concurrency, Constraints, DryRun, HashCheckingMode, TargetTriple};
 use uv_distribution::LoweredExtraBuildDependencies;
 use uv_distribution_types::{ExtraBuildRequires, Name, Requirement, RequirementSource};
-use uv_errors::{ErrorOptions, write_error_chain_with_options};
+use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 use uv_fs::CWD;
 use uv_installer::{InstallationStrategy, Planner, SitePackages};
 use uv_normalize::PackageName;
@@ -176,6 +176,7 @@ pub(crate) async fn upgrade(
             write_error_chain_with_options(
                 err.context(format!("Failed to upgrade {}", name.green()))
                     .as_ref(),
+                Hints::none(),
                 ErrorOptions::default().with_stream(printer.stderr()),
             )?;
         }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -3021,11 +3021,8 @@ where
             trace!("Error trace: {err:?}");
 
             let hints = commands::diagnostics::hints_for_error(&err);
-            uv_errors::write_error_chain_with_options(
-                err.as_ref(),
-                uv_errors::ErrorOptions::default().with_hints(hints),
-            )
-            .expect("writing to stderr should not fail");
+            uv_errors::write_error_chain(err.as_ref(), hints)
+                .expect("writing to stderr should not fail");
 
             ExitStatus::Error.into()
         }


### PR DESCRIPTION
Require callers of the error and warning chain renderers to provide a `Hints` collection explicitly.

This keeps `ErrorOptions` focused on presentation settings and makes omission of hint extraction visible at each call site. Existing call sites that do not have applicable hints pass `Hints::none()`.