### PR TITLE
Preserve indentation for multiline error causes

### DIFF
--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -226,7 +226,7 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
 
     let main_msg = err.to_string();
     let main_padding = " ".repeat(level.len() + 2);
-    let wrapped_main = wrap_text(&main_msg, width, &main_padding, &main_padding);
+    let wrapped_main = wrap_text(&main_msg, width, &main_padding, &main_padding, "");
     writeln!(
         &mut stream,
         "{}{} {}",
@@ -240,8 +240,9 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
         let padding = "  ";
         let cause = "Caused by";
         let child_padding = " ".repeat(padding.len() + cause.len() + 2);
+        let authored_line_padding = "    ";
 
-        let wrapped = wrap_text(&msg, width, "", &child_padding);
+        let wrapped = wrap_text(&msg, width, "", &child_padding, authored_line_padding);
 
         let mut lines = wrapped.lines();
         if let Some(first) = lines.next() {
@@ -582,9 +583,9 @@ mod tests {
         assert_snapshot!(rendered, @r"
         error: Failed to download Python 3.12
           Caused by: Failed to fetch https://example.com/upload/python3.13.tar.zst
-        Server says: This endpoint only support POST requests.
+            Server says: This endpoint only support POST requests.
 
-        For downloads, please refer to https://example.com/download/python3.13.tar.zst
+            For downloads, please refer to https://example.com/download/python3.13.tar.zst
           Caused by: Caused By: HTTP Error 400
         ");
     }

--- a/crates/uv-errors/src/line_wrap.rs
+++ b/crates/uv-errors/src/line_wrap.rs
@@ -42,17 +42,16 @@ pub(crate) fn wrap_text(
     width: Option<usize>,
     initial_indent: &str,
     subsequent_indent: &str,
+    authored_line_indent: &str,
 ) -> String {
-    let Some(width) = width else {
-        return format!("{initial_indent}{text}");
-    };
-
-    let options = textwrap::Options::new(width)
-        .initial_indent(initial_indent)
-        .subsequent_indent(subsequent_indent)
-        .break_words(false)
-        .word_separator(textwrap::WordSeparator::AsciiSpace)
-        .word_splitter(textwrap::WordSplitter::NoHyphenation);
+    let options = width.map(|width| {
+        textwrap::Options::new(width)
+            .initial_indent(initial_indent)
+            .subsequent_indent(subsequent_indent)
+            .break_words(false)
+            .word_separator(textwrap::WordSeparator::AsciiSpace)
+            .word_splitter(textwrap::WordSplitter::NoHyphenation)
+    });
 
     let mut wrapped = String::with_capacity(text.len());
 
@@ -65,16 +64,22 @@ pub(crate) fn wrap_text(
             continue;
         }
 
-        // Preserve authored line breaks and wrap each line independently. Hanging indentation is
-        // only for continuation lines created by wrapping, not for lines already in the message.
-        wrapped.push_str(&textwrap::fill(
-            line,
-            if index == 0 {
-                options.clone()
-            } else {
-                options.clone().initial_indent("")
-            },
-        ));
+        let line_indent = if index == 0 {
+            initial_indent
+        } else {
+            authored_line_indent
+        };
+        if let Some(options) = &options {
+            // Preserve authored line breaks and wrap each line independently. A caller may
+            // separately indent authored lines to keep nested diagnostic content aligned.
+            wrapped.push_str(&textwrap::fill(
+                line,
+                options.clone().initial_indent(line_indent),
+            ));
+        } else {
+            wrapped.push_str(line_indent);
+            wrapped.push_str(line);
+        }
     }
 
     wrapped

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -716,10 +716,10 @@ async fn proxy_invalid_url_in_uv_toml() {
     ----- stderr -----
     error: Failed to parse: `uv.toml`
       Caused by: TOML parse error at line 1, column 14
-      |
-    1 | http-proxy = "ftp://proxy.example.com:8080"
-      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    invalid proxy URL scheme `ftp` in `ftp://proxy.example.com:8080/`: expected http, https, socks5, or socks5h
+          |
+        1 | http-proxy = "ftp://proxy.example.com:8080"
+          |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        invalid proxy URL scheme `ftp` in `ftp://proxy.example.com:8080/`: expected http, https, socks5, or socks5h
     "#);
 }
 
@@ -747,10 +747,10 @@ async fn proxy_invalid_url_not_a_url_in_uv_toml() {
     ----- stderr -----
     error: Failed to parse: `uv.toml`
       Caused by: TOML parse error at line 1, column 14
-      |
-    1 | http-proxy = "not a valid url"
-      |              ^^^^^^^^^^^^^^^^^
-    invalid proxy URL: invalid international domain name
+          |
+        1 | http-proxy = "not a valid url"
+          |              ^^^^^^^^^^^^^^^^^
+        invalid proxy URL: invalid international domain name
     "#);
 }
 

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -20777,10 +20777,10 @@ fn lock_invalid_index() -> Result<()> {
 
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 31
-      |
-    9 |         iniconfig = { index = "internal proxy" }
-      |                               ^^^^^^^^^^^^^^^^
-    Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
+          |
+        9 |         iniconfig = { index = "internal proxy" }
+          |                               ^^^^^^^^^^^^^^^^
+        Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
     "#);
 
     Ok(())
@@ -21092,10 +21092,10 @@ fn lock_unnamed_explicit_index() -> Result<()> {
 
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 8, column 9
-      |
-    8 |         [[tool.uv.index]]
-      |         ^^^^^^^^^^^^^^^^^
-    An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
+          |
+        8 |         [[tool.uv.index]]
+          |         ^^^^^^^^^^^^^^^^^
+        An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
     ");
 
     Ok(())
@@ -21124,7 +21124,7 @@ fn lock_invalid_index_cache_control() -> Result<()> {
         "#,
     )?;
 
-    uv_snapshot!(context.filters(), context.lock(), @"
+    uv_snapshot!(context.filters(), context.lock(), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -21133,17 +21133,17 @@ fn lock_invalid_index_cache_control() -> Result<()> {
     warning: Failed to parse `pyproject.toml` during settings discovery:
       TOML parse error at line 11, column 9
          |
-      11 |         cache-control.api = \"\"\"
+      11 |         cache-control.api = """
          |         ^^^^^^^^^^^^^
       `cache-control.api` must be a valid HTTP header value
 
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 11, column 9
-       |
-    11 |         cache-control.api = \"\"\"
-       |         ^^^^^^^^^^^^^
-    `cache-control.api` must be a valid HTTP header value
-    ");
+           |
+        11 |         cache-control.api = """
+           |         ^^^^^^^^^^^^^
+        `cache-control.api` must be a valid HTTP header value
+    "#);
 
     Ok(())
 }
@@ -21584,10 +21584,10 @@ fn lock_repeat_named_index() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 8, column 9
-      |
-    8 |         [[tool.uv.index]]
-      |         ^^^^^^^^^^^^^^^^^
-    duplicate index name `pytorch`
+          |
+        8 |         [[tool.uv.index]]
+          |         ^^^^^^^^^^^^^^^^^
+        duplicate index name `pytorch`
     ");
 
     Ok(())
@@ -21627,10 +21627,10 @@ fn lock_multiple_default_indexes() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 8, column 9
-      |
-    8 |         [[tool.uv.index]]
-      |         ^^^^^^^^^^^^^^^^^
-    found multiple indexes with `default = true`; only one index may be marked as default
+          |
+        8 |         [[tool.uv.index]]
+          |         ^^^^^^^^^^^^^^^^^
+        found multiple indexes with `default = true`; only one index may be marked as default
     ");
 
     Ok(())
@@ -23830,10 +23830,10 @@ fn lock_duplicate_sources() -> Result<()> {
 
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 9
-      |
-    9 |         python-multipart = { url = "https://files.pythonhosted.org/packages/c0/3e/9fbfd74e7f5b54f653f7ca99d44ceb56e718846920162165061c4c22b71a/python_multipart-0.0.8-py3-none-any.whl" }
-      |         ^^^^^^^^^^^^^^^^
-    duplicate key
+          |
+        9 |         python-multipart = { url = "https://files.pythonhosted.org/packages/c0/3e/9fbfd74e7f5b54f653f7ca99d44ceb56e718846920162165061c4c22b71a/python_multipart-0.0.8-py3-none-any.whl" }
+          |         ^^^^^^^^^^^^^^^^
+        duplicate key
     "#);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -23934,10 +23934,10 @@ fn lock_missing_name() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 1
-      |
-    1 | [project]
-      | ^^^^^^^^^
-    `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+          |
+        1 | [project]
+          | ^^^^^^^^^
+        `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     ");
 
     Ok(())
@@ -23965,10 +23965,10 @@ fn lock_missing_version() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 1
-      |
-    1 | [project]
-      | ^^^^^^^^^
-    `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list
+          |
+        1 | [project]
+          | ^^^^^^^^^
+        `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list
     ");
 
     Ok(())
@@ -26721,8 +26721,8 @@ fn lock_group_invalid_entry_package() -> Result<()> {
     error: Project `project` has malformed dependency groups
       Caused by: Failed to parse entry in group `foo`: `invalid!`
       Caused by: no such comparison operator "!", must be one of ~= == != <= >= < > ===
-    invalid!
-           ^
+        invalid!
+               ^
     "#);
 
     uv_snapshot!(context.filters(), context.sync().arg("--group").arg("foo"), @r#"
@@ -26767,10 +26767,10 @@ fn lock_group_invalid_entry_group_name() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 16
-      |
-    9 |         foo = [{include-group = "invalid!"}]
-      |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    Not a valid package or extra name: "invalid!". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+          |
+        9 |         foo = [{include-group = "invalid!"}]
+          |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        Not a valid package or extra name: "invalid!". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     "#);
 
     Ok(())
@@ -26803,10 +26803,10 @@ fn lock_group_invalid_duplicate_group_name() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 8, column 9
-      |
-    8 |         [dependency-groups]
-      |         ^^^^^^^^^^^^^^^^^^^
-    duplicate dependency group: `foo-bar`
+          |
+        8 |         [dependency-groups]
+          |         ^^^^^^^^^^^^^^^^^^^
+        duplicate dependency group: `foo-bar`
     ");
 
     Ok(())
@@ -26901,10 +26901,10 @@ fn lock_group_invalid_entry_type() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 33
-      |
-    9 |         foo = [{include-group = true}]
-      |                                 ^^^^
-    invalid type: boolean `true`, expected a string
+          |
+        9 |         foo = [{include-group = true}]
+          |                                 ^^^^
+        invalid type: boolean `true`, expected a string
     ");
 
     Ok(())
@@ -26936,10 +26936,10 @@ fn lock_group_empty_entry_table() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 16
-      |
-    9 |         foo = [{}]
-      |                ^^
-    missing field `include-group`
+          |
+        9 |         foo = [{}]
+          |                ^^
+        missing field `include-group`
     ");
 
     Ok(())
@@ -36712,10 +36712,10 @@ async fn lock_check_multiple_default_indexes_explicit_assignment_dependency_grou
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 13, column 9
-       |
-    13 |         [[tool.uv.index]]
-       |         ^^^^^^^^^^^^^^^^^
-    found multiple indexes with `default = true`; only one index may be marked as default
+           |
+        13 |         [[tool.uv.index]]
+           |         ^^^^^^^^^^^^^^^^^
+        found multiple indexes with `default = true`; only one index may be marked as default
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -23858,10 +23858,10 @@ fn lock_duplicate_sources() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 7, column 9
-      |
-    7 |         [tool.uv.sources]
-      |         ^^^^^^^^^^^^^^^^^
-    duplicate sources for package `python-multipart`
+          |
+        7 |         [tool.uv.sources]
+          |         ^^^^^^^^^^^^^^^^^
+        duplicate sources for package `python-multipart`
     ");
 
     Ok(())
@@ -26734,8 +26734,8 @@ fn lock_group_invalid_entry_package() -> Result<()> {
     error: Project `project` has malformed dependency groups
       Caused by: Failed to parse entry in group `foo`: `invalid!`
       Caused by: no such comparison operator "!", must be one of ~= == != <= >= < > ===
-    invalid!
-           ^
+        invalid!
+               ^
     "#);
 
     Ok(())

--- a/crates/uv/tests/lock_scenarios/lock_conflict.rs
+++ b/crates/uv/tests/lock_scenarios/lock_conflict.rs
@@ -16098,10 +16098,10 @@ fn conflict_item_unknown_field() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 10, column 17
-       |
-    10 |               { name = "foo", extra = "extra1" },
-       |                 ^^^^
-    unknown field `name`, expected one of `package`, `extra`, `group`
+           |
+        10 |               { name = "foo", extra = "extra1" },
+           |                 ^^^^
+        unknown field `name`, expected one of `package`, `extra`, `group`
     "#);
 
     Ok(())

--- a/crates/uv/tests/lock_scenarios/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/lock_scenarios/lock_exclude_newer_relative.rs
@@ -1388,7 +1388,7 @@ fn lock_exclude_newer_package_relative_no_timestamp_in_lockfile() -> Result<()> 
     uv_snapshot!(context.filters(), context
         .lock()
         .env_remove(EnvVars::UV_EXCLUDE_NEWER)
-        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp), @r"
+        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp), @"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -1396,10 +1396,10 @@ fn lock_exclude_newer_package_relative_no_timestamp_in_lockfile() -> Result<()> 
     ----- stderr -----
     error: Failed to parse `uv.lock`
       Caused by: TOML parse error at line 5, column 1
-      |
-    5 | [options]
-      | ^^^^^^^^^
-    data did not match any variant of untagged enum Helper
+          |
+        5 | [options]
+          | ^^^^^^^^^
+        data did not match any variant of untagged enum Helper
     ");
 
     Ok(())

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -5929,8 +5929,8 @@ fn semicolon_no_space() -> Result<()> {
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.txt` at position 0
       Caused by: Expected direct URL (`https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl;python_version%20%3E%20'3.10'`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-    iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl;python_version > '3.10'
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl;python_version > '3.10'
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 

--- a/crates/uv/tests/pip/pip_uninstall.rs
+++ b/crates/uv/tests/pip/pip_uninstall.rs
@@ -41,8 +41,8 @@ fn invalid_requirement() {
     ----- stderr -----
     error: Failed to parse: `flask==1.0.x`
       Caused by: after parsing `1.0`, found `.x`, which is not part of a valid version
-    flask==1.0.x
-         ^^^^^^^
+        flask==1.0.x
+             ^^^^^^^
     ");
 }
 
@@ -80,8 +80,8 @@ fn invalid_requirements_txt_requirement() -> Result<()> {
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.txt` at position 0
       Caused by: after parsing `1.0`, found `.x`, which is not part of a valid version
-    flask==1.0.x
-         ^^^^^^^
+        flask==1.0.x
+             ^^^^^^^
     ");
 
     Ok(())

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -1068,10 +1068,10 @@ build-backend = "poetry.core.masonry.api"
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 13, column 1
-       |
-    13 | [project.dependencies]
-       | ^^^^^^^^^^^^^^^^^^^^^^
-    invalid type: map, expected a sequence
+           |
+        13 | [project.dependencies]
+           | ^^^^^^^^^^^^^^^^^^^^^^
+        invalid type: map, expected a sequence
     "
     );
 
@@ -1276,10 +1276,10 @@ dependencies = [
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 6, column 8
-      |
-    6 | name = "!project"
-      |        ^^^^^^^^^^
-    Not a valid package or extra name: "!project". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+          |
+        6 | name = "!project"
+          |        ^^^^^^^^^^
+        Not a valid package or extra name: "!project". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     "#
     );
 
@@ -4657,12 +4657,12 @@ fn override_dependency_from_workspace_invalid_syntax() -> Result<()> {
 
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 10, column 7
-       |
-    10 |       "werkzeug=2.3.0"
-       |       ^^^^^^^^^^^^^^^^
-    no such comparison operator "=", must be one of ~= == != <= >= < > ===
-    werkzeug=2.3.0
-            ^^^^^^
+           |
+        10 |       "werkzeug=2.3.0"
+           |       ^^^^^^^^^^^^^^^^
+        no such comparison operator "=", must be one of ~= == != <= >= < > ===
+        werkzeug=2.3.0
+                ^^^^^^
     "#
     );
 
@@ -5022,8 +5022,8 @@ fn error_missing_unnamed_env_var() -> Result<()> {
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.in` at position 0
       Caused by: Expected package name starting with an alphanumeric character, found `$`
-    ${URL}
-    ^
+        ${URL}
+        ^
     "
     );
 
@@ -7899,8 +7899,8 @@ fn unsupported_scheme() -> Result<()> {
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.in` at position 0
       Caused by: Unsupported URL prefix `bzr` in URL: `bzr+https://example.com/anyio` (Bazaar is not supported)
-    anyio @ bzr+https://example.com/anyio
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        anyio @ bzr+https://example.com/anyio
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 
@@ -14331,8 +14331,8 @@ fn invalid_tool_uv_sources() -> Result<()> {
     ----- stderr -----
     error: Failed to parse metadata from built wheel
       Caused by: Expected direct URL (`https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-    urllib3 @ https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        urllib3 @ https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 
@@ -14871,8 +14871,8 @@ fn invalid_extra() -> Result<()> {
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.in` at position 0
       Caused by: Expected an alphanumeric character starting the extra name, found `_`
-    .[_anyio]
-      ^
+        .[_anyio]
+          ^
     ");
 
     // Sync the `anyio` extra. We should reject it.

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -165,10 +165,10 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
     error: Failed to parse: `pyproject.toml`
       Caused by: Invalid `pyproject.toml`
       Caused by: TOML parse error at line 1, column 5
-      |
-    1 | 123 - 456
-      |     ^
-    key with no value, expected `=`
+          |
+        1 | 123 - 456
+          |     ^
+        key with no value, expected `=`
     "
     );
 
@@ -191,10 +191,10 @@ fn invalid_pyproject_toml_project_schema() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 1
-      |
-    1 | [project]
-      | ^^^^^^^^^
-    `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+          |
+        1 | [project]
+          | ^^^^^^^^^
+        `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     "
     );
 
@@ -2615,8 +2615,8 @@ fn install_git_unescaped_ref() {
     ----- stderr -----
     error: Failed to parse: `example @ git+https://example.com/repository@pkg@1.2.3`
       Caused by: Ambiguous Git URL `https://example.com/repository@pkg@1.2.3`: the path contains multiple `@` characters. If the Git revision contains `@`, percent-encode it as `%40`
-    example @ git+https://example.com/repository@pkg@1.2.3
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        example @ git+https://example.com/repository@pkg@1.2.3
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ");
 }
 
@@ -9683,8 +9683,8 @@ fn install_incompatible_python_version_interpreter_broken_in_path() -> Result<()
     error: Failed to inspect Python interpreter from first executable in the search path at `[BIN]/python3`
       Caused by: Querying Python at `[BIN]/python3` failed with exit status exit status: 1
 
-    [stderr]
-    error: intentionally broken python executable
+        [stderr]
+        error: intentionally broken python executable
     "
     );
 
@@ -10088,8 +10088,8 @@ fn invalid_extension() {
     ----- stderr -----
     error: Failed to parse: `ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz`
       Caused by: Expected direct URL (`https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-    ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ");
 }
 
@@ -10108,8 +10108,8 @@ fn no_extension() {
     ----- stderr -----
     error: Failed to parse: `ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6`
       Caused by: Expected direct URL (`https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-    ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ");
 }
 
@@ -10564,8 +10564,8 @@ fn missing_git_prefix() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `workspace-in-root-test @ https://github.com/astral-sh/workspace-in-root-test`
       Caused by: Direct URL (`https://github.com/astral-sh/workspace-in-root-test`) references a Git repository, but is missing the `git+` prefix (e.g., `git+https://github.com/astral-sh/workspace-in-root-test`)
-    workspace-in-root-test @ https://github.com/astral-sh/workspace-in-root-test
-                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        workspace-in-root-test @ https://github.com/astral-sh/workspace-in-root-test
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 
@@ -12181,8 +12181,8 @@ fn unsupported_git_scheme() {
     ----- stderr -----
     error: Failed to parse: `git+fantasy://foo`
       Caused by: Unsupported Git URL scheme `fantasy:` in `fantasy://foo` (expected one of `https:`, `ssh:`, or `file:`)
-    git+fantasy://foo
-    ^^^^^^^^^^^^^^^^^
+        git+fantasy://foo
+        ^^^^^^^^^^^^^^^^^
     "
     );
 }
@@ -13558,10 +13558,10 @@ fn pep_751_lock_version() -> Result<()> {
     ----- stderr -----
     error: Not a valid `pylock.toml` file: pylock.toml
       Caused by: TOML parse error at line 2, column 24
-      |
-    2 |         lock-version = "2.0"
-      |                        ^^^^^
-    unsupported lock version (`2.0`, but only major version 1 is supported)
+          |
+        2 |         lock-version = "2.0"
+          |                        ^^^^^
+        unsupported lock version (`2.0`, but only major version 1 is supported)
     "#
     );
 

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -1308,10 +1308,10 @@ fn check_no_sync_errors_on_invalid_lockfile() -> Result<()> {
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     error: Failed to parse `uv.lock`
       Caused by: TOML parse error at line 1, column 8
-      |
-    1 | invalid
-      |        ^
-    key with no value, expected `=`
+          |
+        1 | invalid
+          |        ^
+        key with no value, expected `=`
     "
     );
 
@@ -1355,10 +1355,10 @@ fn check_script_no_sync_errors_on_invalid_lockfile() -> Result<()> {
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     error: Failed to parse `uv.lock`
       Caused by: TOML parse error at line 1, column 8
-      |
-    1 | invalid
-      |        ^
-    key with no value, expected `=`
+          |
+        1 | invalid
+          |        ^
+        key with no value, expected `=`
     "
     );
 

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -13477,8 +13477,8 @@ fn add_unsupported_git_scheme() {
     ----- stderr -----
     error: Failed to parse: `git+fantasy://ferris/dreams/of/urls@7701ffcbae245819b828dc5f885a5201158897ef`
       Caused by: Unsupported Git URL scheme `fantasy:` in `fantasy://ferris/dreams/of/urls` (expected one of `https:`, `ssh:`, or `file:`)
-    git+fantasy://ferris/dreams/of/urls@7701ffcbae245819b828dc5f885a5201158897ef
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        git+fantasy://ferris/dreams/of/urls@7701ffcbae245819b828dc5f885a5201158897ef
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ");
 }
 
@@ -13921,10 +13921,10 @@ async fn add_invalid_ignore_error_code() -> Result<()> {
 
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 22
-      |
-    9 | ignore-error-codes = [401, 403, 1234]
-      |                      ^^^^^^^^^^^^^^^^
-    1234 is not a valid HTTP status code
+          |
+        9 | ignore-error-codes = [401, 403, 1234]
+          |                      ^^^^^^^^^^^^^^^^
+        1234 is not a valid HTTP status code
     "
     );
 
@@ -13955,12 +13955,12 @@ fn add_invalid_requires_python() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 4, column 19
-      |
-    4 | requires-python = "3.12"
-      |                   ^^^^^^
-    Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
-    3.12
-    ^^^^
+          |
+        4 | requires-python = "3.12"
+          |                   ^^^^^^
+        Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
+        3.12
+        ^^^^
     "#);
 
     Ok(())

--- a/crates/uv/tests/project/format.rs
+++ b/crates/uv/tests/project/format.rs
@@ -326,10 +326,10 @@ fn format_fails_malformed_pyproject() -> Result<()> {
     warning: `uv format` is experimental and may change without warning. Pass `--preview-features format-command` to disable this warning.
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 11
-      |
-    1 | malformed pyproject.toml
-      |           ^
-    key with no value, expected `=`
+          |
+        1 | malformed pyproject.toml
+          |           ^
+        key with no value, expected `=`
     ");
 
     // Check that the file is not formatted

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -4241,10 +4241,10 @@ fn run_invalid_project_table() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 2
-      |
-    1 | [project.urls]
-      |  ^^^^^^^
-    `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+          |
+        1 | [project.urls]
+          |  ^^^^^^^
+        `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     ");
 
     Ok(())

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -2263,10 +2263,10 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 7, column 13
-      |
-    7 | conflicts = [[]]
-      |             ^^^^
-    Each set of conflicts must have at least two entries, but found none
+          |
+        7 | conflicts = [[]]
+          |             ^^^^
+        Each set of conflicts must have at least two entries, but found none
     "
     );
 
@@ -2292,10 +2292,10 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 7, column 13
-      |
-    7 | conflicts = [
-      |             ^
-    Each set of conflicts must have at least two entries, but found only one
+          |
+        7 | conflicts = [
+          |             ^
+        Each set of conflicts must have at least two entries, but found only one
     "
     );
 
@@ -2525,10 +2525,10 @@ fn resolve_config_file() -> anyhow::Result<()> {
     warning: The `--config-file` argument expects to receive a `uv.toml` file, not a `pyproject.toml`. If you're trying to run a command from another project, use the `--project` argument instead.
     error: Failed to parse: `[CACHE_DIR]/pyproject.toml`
       Caused by: TOML parse error at line 9, column 3
-      |
-    9 | ""
-      |   ^
-    key with no value, expected `=`
+          |
+        9 | ""
+          |   ^
+        key with no value, expected `=`
     "#
     );
 
@@ -3586,10 +3586,10 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
     ----- stderr -----
     error: Failed to parse: `uv.toml`
       Caused by: TOML parse error at line 1, column 20
-      |
-    1 | preview-features = 123
-      |                    ^^^
-    invalid type: integer `123`, expected a boolean or a list of preview feature names
+          |
+        1 | preview-features = 123
+          |                    ^^^
+        invalid type: integer `123`, expected a boolean or a list of preview feature names
     ");
 
     Ok(())

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -2236,10 +2236,10 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 7, column 13
-      |
-    7 | conflicts = [
-      |             ^
-    Each set of conflicts must have at least two entries, but found only one
+          |
+        7 | conflicts = [
+          |             ^
+        Each set of conflicts must have at least two entries, but found only one
     "
     );
 
@@ -2490,10 +2490,10 @@ fn resolve_config_file() -> anyhow::Result<()> {
     ----- stderr -----
     error: Failed to parse: `[CACHE_DIR]/uv.toml`
       Caused by: TOML parse error at line 1, column 2
-      |
-    1 | [project]
-      |  ^^^^^^^
-    unknown field `project`, expected one of `required-version`, `system-certs`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `preview-features`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `http-proxy`, `https-proxy`, `no-proxy`, `allow-insecure-host`, `resolution`, `prerelease`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `no-sources-package`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `torch-backend`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `audit`, `pip`, `cache-keys`, `override-dependencies`, `exclude-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`
+          |
+        1 | [project]
+          |  ^^^^^^^
+        unknown field `project`, expected one of `required-version`, `system-certs`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `preview-features`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `http-proxy`, `https-proxy`, `no-proxy`, `allow-insecure-host`, `resolution`, `prerelease`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `no-sources-package`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `torch-backend`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `audit`, `pip`, `cache-keys`, `override-dependencies`, `exclude-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`
     "
     );
 
@@ -3561,7 +3561,7 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
     config.write_str(r#"preview-features = ["  "]"#)?;
 
     // Empty preview feature names should be rejected.
-    uv_snapshot!(context.filters(), add_shared_args(context.version()).arg("--show-settings"), @"
+    uv_snapshot!(context.filters(), add_shared_args(context.version()).arg("--show-settings"), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -3569,11 +3569,11 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
     ----- stderr -----
     error: Failed to parse: `uv.toml`
       Caused by: TOML parse error at line 1, column 20
-      |
-    1 | preview-features = [\"  \"]
-      |                    ^^^^^^
-    preview feature name cannot be empty
-    ");
+          |
+        1 | preview-features = ["  "]
+          |                    ^^^^^^
+        preview feature name cannot be empty
+    "#);
 
     config.write_str("preview-features = 123")?;
 

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -4760,10 +4760,10 @@ fn sync_default_groups_gibberish() -> Result<()> {
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 14, column 26
-       |
-    14 |         default-groups = "gibberish"
-       |                          ^^^^^^^^^^^
-    default-groups must be "all" or a ["list", "of", "groups"]
+           |
+        14 |         default-groups = "gibberish"
+           |                          ^^^^^^^^^^^
+        default-groups must be "all" or a ["list", "of", "groups"]
     "#);
 
     Ok(())
@@ -17012,10 +17012,10 @@ fn sync_fails_ambiguous_url() -> Result<()> {
 
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 10, column 15
-       |
-    10 |         url = "https://user/name:password@domain/a/b/c"
-       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
+           |
+        10 |         url = "https://user/name:password@domain/a/b/c"
+           |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
     "#);
 
     Ok(())

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -105,8 +105,8 @@ fn tool_run_at_version() {
     ----- stderr -----
     error: Failed to parse: `pytest@`
       Caused by: Expected URL
-    pytest@
-           ^
+        pytest@
+               ^
     ");
 
     // Invalid versions are just treated as package and command names

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -1841,7 +1841,7 @@ async fn tool_upgrade_lock_verifies_hashes() -> Result<()> {
         .env(EnvVars::UV_PREVIEW_FEATURES, "tool-install-locks")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
-        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1852,12 +1852,12 @@ async fn tool_upgrade_lock_verifies_hashes() -> Result<()> {
       Caused by: Failed to download `simple-launcher==0.1.0`
       Caused by: Hash mismatch for `simple-launcher==0.1.0`
 
-    Expected:
-      sha256:0000000000000000000000000000000000000000000000000000000000000000
+        Expected:
+          sha256:0000000000000000000000000000000000000000000000000000000000000000
 
-    Computed:
-      sha256:5327e0bb67cdb46800999de6dcf034bf0a5335702883494af0d8b7f6ca48cee4
-    "#);
+        Computed:
+          sha256:5327e0bb67cdb46800999de6dcf034bf0a5335702883494af0d8b7f6ca48cee4
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
Preserve authored line breaks inside nested error causes and indent those authored lines by four spaces.

Wrapped continuation lines retain their hanging indentation, while lines that were already present in the error message keep the diagnostic's previous four-space nesting. The behavior also applies when line wrapping is disabled or no terminal width is available.

This is stacked on #20155, which makes hints an explicit renderer argument.