### PR TITLE
Preserve context in resolution errors

### DIFF
--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -358,7 +358,7 @@ impl BuildContext for BuildDispatch<'_> {
                     // This requirement-specific context replaces the generic top-level
                     // no-solution heading for a nested build resolution.
                     uv_resolver::ResolveError::NoSolution { cause, .. } => {
-                        anyhow::Error::new(cause)
+                        anyhow::Error::new(*cause)
                     }
                     error => anyhow::Error::new(error),
                 })

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -82,6 +82,14 @@ impl uv_errors::Hint for BuildDispatchError {
                             return hints;
                         }
                     }
+                    if let Some(no_solution_error) =
+                        cause.downcast_ref::<uv_resolver::NoSolutionError>()
+                    {
+                        let hints = uv_errors::Hint::hints(no_solution_error);
+                        if !hints.is_empty() {
+                            return hints;
+                        }
+                    }
                 }
                 uv_errors::Hints::none()
             }
@@ -342,15 +350,28 @@ impl BuildContext for BuildDispatch<'_> {
             )
             .with_build_stack(build_stack),
         )?;
-        let resolution = Resolution::from(resolver.resolve().await.with_context(|| {
-            format!(
-                "No solution found when resolving: {}",
-                requirements
-                    .iter()
-                    .map(|requirement| format!("`{requirement}`"))
-                    .join(", ")
-            )
-        })?);
+        let resolution = Resolution::from(
+            resolver
+                .resolve()
+                .await
+                .map_err(|error| match error {
+                    // This requirement-specific context replaces the generic top-level
+                    // no-solution heading for a nested build resolution.
+                    uv_resolver::ResolveError::NoSolution { cause, .. } => {
+                        anyhow::Error::new(cause)
+                    }
+                    error => anyhow::Error::new(error),
+                })
+                .with_context(|| {
+                    format!(
+                        "No solution found when resolving: {}",
+                        requirements
+                            .iter()
+                            .map(|requirement| format!("`{requirement}`"))
+                            .join(", ")
+                    )
+                })?,
+        );
         Ok(ResolvedRequirements::new(resolution, hasher))
     }
 

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -111,8 +111,12 @@ pub enum ResolveError {
         #[source] Arc<uv_distribution::Error>,
     ),
 
-    #[error(transparent)]
-    NoSolution(#[from] Box<NoSolutionError>),
+    #[error("{header}")]
+    NoSolution {
+        header: NoSolutionHeader,
+        #[source]
+        cause: Box<NoSolutionError>,
+    },
 
     #[error("Attempted to construct an invalid version specifier")]
     InvalidVersion(#[from] uv_pep440::VersionSpecifierBuildError),
@@ -153,8 +157,22 @@ pub enum ResolveError {
 impl uv_errors::Hint for ResolveError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
-            Self::NoSolution(no_solution) => uv_errors::Hint::hints(no_solution.as_ref()),
+            Self::NoSolution { cause, .. } => uv_errors::Hint::hints(cause.as_ref()),
             _ => uv_errors::Hints::none(),
+        }
+    }
+}
+
+impl ResolveError {
+    /// Add command-specific context to a no-solution resolution failure.
+    #[must_use]
+    pub fn with_resolution_context(self, context: &'static str) -> Self {
+        match self {
+            Self::NoSolution { header, cause } => Self::NoSolution {
+                header: header.with_context(context),
+                cause,
+            },
+            error => error,
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2880,7 +2880,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             }
         }
 
-        ResolveError::NoSolution(Box::new(NoSolutionError::new(
+        let cause = Box::new(NoSolutionError::new(
             err,
             self.index.clone(),
             included_versions,
@@ -2899,7 +2899,11 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             self.tags.clone(),
             self.workspace_members.clone(),
             self.options.clone(),
-        )))
+        ));
+        ResolveError::NoSolution {
+            header: cause.header(),
+            cause,
+        }
     }
 
     fn on_progress(&self, package: &PubGrubPackage, version: &Version) {

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -79,9 +79,18 @@ impl OperationDiagnostic {
     ///
     /// Returns `Some` if the error was not handled.
     pub(crate) fn report(self, err: pip::operations::Error) -> Option<pip::operations::Error> {
+        let err = match (self.context, err) {
+            (Some(context), pip::operations::Error::Resolve(err)) => {
+                pip::operations::Error::Resolve(err.with_resolution_context(context))
+            }
+            (_, err) => err,
+        };
         let result = match err {
-            pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(err)) => {
-                no_solution(&err, self.context);
+            pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution {
+                header,
+                cause,
+            }) => {
+                no_solution(header, &cause);
                 None
             }
             pip::operations::Error::Resolve(uv_resolver::ResolveError::Dist(
@@ -228,12 +237,7 @@ fn dependencies_error(
 }
 
 /// Render a [`uv_resolver::NoSolutionError`].
-fn no_solution(err: &uv_resolver::NoSolutionError, context: Option<&'static str>) {
-    let header = if let Some(context) = context {
-        err.header().with_context(context)
-    } else {
-        err.header()
-    };
+fn no_solution(header: uv_resolver::NoSolutionHeader, err: &uv_resolver::NoSolutionError) {
     let report = miette::Report::msg(err.report().to_string()).context(header);
     anstream::eprint!("{report:?}");
     let hints = err.hints();

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -809,9 +809,10 @@ fn standard_library_hint(
     edits: &[DependencyEdit],
     python_minor: u8,
 ) -> Option<String> {
-    let crate::commands::pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(
-        no_solution_error,
-    )) = operation_error
+    let crate::commands::pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution {
+        cause: no_solution_error,
+        ..
+    }) = operation_error
     else {
         return None;
     };

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -644,8 +644,10 @@ pub(crate) async fn refine_interpreter(
     python_downloads: PythonDownloads,
     cache: &Cache,
 ) -> anyhow::Result<Option<Interpreter>, ProjectError> {
-    let pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(no_solution_err)) =
-        err
+    let pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution {
+        cause: no_solution_err,
+        ..
+    }) = err
     else {
         return Ok(None);
     };


### PR DESCRIPTION
## Summary

- store the user-facing no-solution header on `ResolveError`
- apply command-specific resolution context to the concrete resolver error before rendering
- preserve the requirement-specific chain for nested build dependency resolution

This prepares no-solution failures to flow through standard error rendering without losing context. It does not intentionally change the current output.

## Test plan

- `cargo fmt --all -- --check`
- `cargo check -p uv-resolver -p uv-dispatch -p uv --tests`
- `cargo test -p uv --test tool tool_run_resolution_error -- --nocapture`
- `cargo test -p uv --test build build_constraints -- --nocapture`
