### PR TITLE
Use standard rendering for `uv build` errors

### DIFF
--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -26,6 +26,7 @@ use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations,
     PackageConfigSettings, Requirement, SourceDist,
 };
+use uv_errors::{ErrorOptions, Hint, Hints, write_error_chain_with_options};
 use uv_fs::{Simplified, normalize_path, relative_to};
 use uv_install_wheel::LinkMode;
 use uv_normalize::PackageName;
@@ -51,7 +52,7 @@ use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 
 #[derive(Debug, Error)]
-enum Error {
+pub(crate) enum Error {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
@@ -99,16 +100,37 @@ enum Error {
     VersionMismatch(Version, Version),
 }
 
-/// Collect hints from a build [`Error`] by inspecting its inner types.
-fn collect_build_hints(err: &Error) -> uv_errors::Hints<'_> {
-    use uv_errors::Hint;
-    match err {
-        Error::BuildBackend(err) => err.hints(),
-        Error::BuildFrontend(err) => err.hints(),
-        Error::BuildDispatch(err) => err.hints(),
-        Error::Project(err) => err.hints(),
-        Error::Operations(err) => err.hints(),
-        _ => uv_errors::Hints::none(),
+impl Hint for Error {
+    fn hints(&self) -> Hints<'_> {
+        match self {
+            Self::BuildBackend(err) => err.hints(),
+            Self::BuildFrontend(err) => err.hints(),
+            Self::BuildDispatch(err) => err.hints(),
+            Self::Project(err) => err.hints(),
+            Self::Operations(err) => err.hints(),
+            Self::Extract(uv_extract::Error::Tar(err)) => {
+                // TODO(konsti): astral-tokio-tar should use a proper error instead of
+                // encoding everything in strings
+                // NOTE(ww): We check for both messages below because they indicate
+                // different external extraction scenarios; the first is for any
+                // absolute path outside of the target directory, and the second
+                // is specifically for symlinks that point outside.
+                if err.to_string().contains("/bin/python")
+                    && std::error::Error::source(err).is_some_and(|err| {
+                        let err = err.to_string();
+                        err.ends_with("outside of the target directory")
+                            || err.ends_with("external symlinks are not allowed")
+                    })
+                {
+                    Hints::from(
+                        "The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.",
+                    )
+                } else {
+                    Hints::none()
+                }
+            }
+            _ => Hints::none(),
+        }
     }
 }
 
@@ -443,53 +465,13 @@ async fn build_impl(
                 }
             }
             Err(err) => {
-                #[derive(Debug, miette::Diagnostic, thiserror::Error)]
-                #[error("Failed to build `{source}`", source = source.cyan())]
-                #[diagnostic()]
-                struct Diagnostic {
-                    source: String,
-                    #[source]
-                    cause: anyhow::Error,
-                    #[help]
-                    help: Option<String>,
-                }
-
-                let help = if let Error::Extract(uv_extract::Error::Tar(err)) = &err {
-                    // TODO(konsti): astral-tokio-tar should use a proper error instead of
-                    // encoding everything in strings
-                    // NOTE(ww): We check for both messages below because the both indicate
-                    // different external extraction scenarios; the first is for any
-                    // absolute path outside of the target directory, and the second
-                    // is specifically for symlinks that point outside.
-                    if err.to_string().contains("/bin/python")
-                        && std::error::Error::source(err).is_some_and(|err| {
-                            let err = err.to_string();
-                            err.ends_with("outside of the target directory")
-                                || err.ends_with("external symlinks are not allowed")
-                        })
-                    {
-                        Some(
-                            "This file seems to be part of a virtual environment. Virtual environments must be excluded from source distributions."
-                                .to_string(),
-                        )
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
-                let hints = collect_build_hints(&err).into_owned();
-                let report = miette::Report::new(Diagnostic {
-                    source: source.to_string(),
-                    cause: err.into(),
-                    help,
-                });
-                anstream::eprint!("{report:?}");
-                anstream::eprint!("{hints}");
-                if !hints.is_empty() {
-                    anstream::eprintln!();
-                }
+                let err = anyhow::Error::from(err).context(format!("Failed to build `{source}`"));
+                let hints = crate::commands::diagnostics::hints_for_error(&err);
+                write_error_chain_with_options(
+                    err.as_ref(),
+                    hints,
+                    ErrorOptions::default().with_stream(printer.stderr_important()),
+                )?;
 
                 success = false;
             }

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -298,6 +298,7 @@ pub(crate) fn hints_for_error(err: &anyhow::Error) -> Hints<'static> {
         collect_hint::<NoExecutablesError>(cause, &mut hints);
         collect_hint::<ExternallyManagedError>(cause, &mut hints);
         collect_hint::<MissingProjectVersionError>(cause, &mut hints);
+        collect_hint::<crate::commands::build_frontend::Error>(cause, &mut hints);
         collect_hint::<uv_build_backend::Error>(cause, &mut hints);
         collect_hint::<uv_build_frontend::Error>(cause, &mut hints);
         collect_hint::<uv_python::Error>(cause, &mut hints);

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -119,8 +119,8 @@ fn build_basic() -> Result<()> {
 
     ----- stderr -----
     Building source distribution...
-      × Failed to build `[TEMP_DIR]/`
-      ╰─▶ [TEMP_DIR]/ does not appear to be a Python project, as neither `pyproject.toml` nor `setup.py` are present in the directory
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: [TEMP_DIR]/ does not appear to be a Python project, as neither `pyproject.toml` nor `setup.py` are present in the directory
     ");
 
     // Build to a specified path.
@@ -240,8 +240,8 @@ fn build_sdist_missing_backend_path() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     Building wheel from source distribution...
-      × Failed to build `[TEMP_DIR]/project`
-      ╰─▶ `backend-path` entry `backend_dir` does not exist or is not a directory
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: `backend-path` entry `backend_dir` does not exist or is not a directory
     ");
 
     Ok(())
@@ -477,8 +477,8 @@ fn build_wheel_from_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-      × Failed to build `[TEMP_DIR]/project/dist/project-0.1.0.tar.gz`
-      ╰─▶ Pass `--wheel` explicitly to build a wheel from a source distribution
+    error: Failed to build `[TEMP_DIR]/project/dist/project-0.1.0.tar.gz`
+      Caused by: Pass `--wheel` explicitly to build a wheel from a source distribution
     ");
 
     // Error if `--sdist` is specified.
@@ -488,8 +488,8 @@ fn build_wheel_from_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-      × Failed to build `[TEMP_DIR]/project/dist/project-0.1.0.tar.gz`
-      ╰─▶ Building an `--sdist` from a source distribution is not supported
+    error: Failed to build `[TEMP_DIR]/project/dist/project-0.1.0.tar.gz`
+      Caused by: Building an `--sdist` from a source distribution is not supported
     ");
 
     // Build the wheel from the sdist.
@@ -519,8 +519,8 @@ fn build_wheel_from_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-      × Failed to build `[TEMP_DIR]/project/dist/project-0.1.0-py3-none-any.whl`
-      ╰─▶ `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`.
+    error: Failed to build `[TEMP_DIR]/project/dist/project-0.1.0-py3-none-any.whl`
+      Caused by: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`.
     ");
 
     Ok(())
@@ -592,9 +592,9 @@ fn build_fail() -> Result<()> {
       File "<string>", line 2
         from setuptools import setup
     IndentationError: unexpected indent
-      × Failed to build `[TEMP_DIR]/project`
-      ├─▶ The build backend returned an error
-      ╰─▶ Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: The build backend returned an error
+      Caused by: Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
 
     hint: Build failures usually indicate a problem with the package or the build environment
     "#);
@@ -923,9 +923,9 @@ fn build_all_with_failure() -> Result<()> {
     [PKG] Building wheel from source distribution...
     Successfully built dist/member_a-0.1.0.tar.gz
     Successfully built dist/member_a-0.1.0-py3-none-any.whl
-      × Failed to build `member-b @ [TEMP_DIR]/project/packages/member_b`
-      ├─▶ The build backend returned an error
-      ╰─▶ Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
+    error: Failed to build `member-b @ [TEMP_DIR]/project/packages/member_b`
+      Caused by: The build backend returned an error
+      Caused by: Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
 
     hint: Build failures usually indicate a problem with the package or the build environment
     Successfully built dist/project-0.1.0.tar.gz
@@ -997,10 +997,10 @@ fn build_constraints() -> Result<()> {
 
     ----- stderr -----
     Building source distribution...
-      × Failed to build `[TEMP_DIR]/project`
-      ├─▶ Failed to resolve requirements from `build-system.requires`
-      ├─▶ No solution found when resolving: `hatchling>=1.0`
-      ╰─▶ Because you require hatchling>=1.0 and hatchling==0.1.0, we can conclude that your requirements are unsatisfiable.
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to resolve requirements from `build-system.requires`
+      Caused by: No solution found when resolving: `hatchling>=1.0`
+      Caused by: Because you require hatchling>=1.0 and hatchling==0.1.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     project
@@ -1400,17 +1400,17 @@ fn build_sha() -> Result<()> {
 
     ----- stderr -----
     Building source distribution...
-      × Failed to build `[TEMP_DIR]/project`
-      ├─▶ Failed to install requirements from `build-system.requires`
-      ├─▶ Failed to download `hatchling==1.22.4`
-      ╰─▶ Hash mismatch for `hatchling==1.22.4`
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to install requirements from `build-system.requires`
+      Caused by: Failed to download `hatchling==1.22.4`
+      Caused by: Hash mismatch for `hatchling==1.22.4`
 
-          Expected:
-            sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
-            sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+    Expected:
+      sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
+      sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
 
-          Computed:
-            sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+    Computed:
+      sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
     ");
 
     project
@@ -1432,17 +1432,17 @@ fn build_sha() -> Result<()> {
 
     ----- stderr -----
     Building source distribution...
-      × Failed to build `[TEMP_DIR]/project`
-      ├─▶ Failed to install requirements from `build-system.requires`
-      ├─▶ Failed to download `hatchling==1.22.4`
-      ╰─▶ Hash mismatch for `hatchling==1.22.4`
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to install requirements from `build-system.requires`
+      Caused by: Failed to download `hatchling==1.22.4`
+      Caused by: Hash mismatch for `hatchling==1.22.4`
 
-          Expected:
-            sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
-            sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+    Expected:
+      sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
+      sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
 
-          Computed:
-            sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+    Computed:
+      sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
     ");
 
     project
@@ -1467,10 +1467,10 @@ fn build_sha() -> Result<()> {
 
     ----- stderr -----
     Building source distribution...
-      × Failed to build `[TEMP_DIR]/project`
-      ├─▶ Failed to resolve requirements from `build-system.requires`
-      ├─▶ No solution found when resolving: `hatchling`
-      ╰─▶ In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `hatchling`
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to resolve requirements from `build-system.requires`
+      Caused by: No solution found when resolving: `hatchling`
+      Caused by: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `hatchling`
     ");
 
     project
@@ -1810,9 +1810,9 @@ fn build_hide_build_output_on_failure() -> Result<()> {
 
     ----- stderr -----
     Building source distribution...
-      × Failed to build `[TEMP_DIR]/project`
-      ├─▶ The build backend returned an error
-      ╰─▶ Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: The build backend returned an error
+      Caused by: Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -1952,9 +1952,9 @@ fn build_named_index_config_file_hint() -> Result<()> {
 
     ----- stderr -----
     Building source distribution...
-      × Failed to build `[TEMP_DIR]/project`
-      ├─▶ Failed to parse entry: `hatchling`
-      ╰─▶ Package `hatchling` references an undeclared index: `privindex`
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to parse entry: `hatchling`
+      Caused by: Package `hatchling` references an undeclared index: `privindex`
 
     hint: Index `privindex` was found in a project-level `uv.toml`, but indexes referenced via `tool.uv.sources` must be defined in the project's `pyproject.toml`
     ");
@@ -2250,9 +2250,9 @@ fn build_unsafe_script_entry_point_name() -> Result<()> {
 
     ----- stderr -----
     Building wheel (uv build backend)...
-      × Failed to build `[TEMP_DIR]/`
-      ├─▶ Invalid project metadata
-      ╰─▶ Script entry point name `../script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Invalid project metadata
+      Caused by: Script entry point name `../script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())
@@ -2294,9 +2294,9 @@ fn build_dot_script_entry_point_name() -> Result<()> {
 
     ----- stderr -----
     Building wheel (uv build backend)...
-      × Failed to build `[TEMP_DIR]/`
-      ├─▶ Invalid project metadata
-      ╰─▶ Script entry point name `.` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Invalid project metadata
+      Caused by: Script entry point name `.` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())
@@ -2338,9 +2338,9 @@ fn build_nested_script_entry_point_name() -> Result<()> {
 
     ----- stderr -----
     Building wheel (uv build backend)...
-      × Failed to build `[TEMP_DIR]/`
-      ├─▶ Invalid project metadata
-      ╰─▶ Script entry point name `nested/script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Invalid project metadata
+      Caused by: Script entry point name `nested/script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())
@@ -2515,8 +2515,8 @@ fn build_list_files_errors() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-      × Failed to build `[WORKSPACE]/test/packages/anyio_local`
-      ╰─▶ Can only use `--list` with a compatible uv build backend, but `[WORKSPACE]/test/packages/anyio_local` is not compatible because `build_system.build-backend` is not `uv_build`, but `flit_core.buildapi`
+    error: Failed to build `[WORKSPACE]/test/packages/anyio_local`
+      Caused by: Can only use `--list` with a compatible uv build backend, but `[WORKSPACE]/test/packages/anyio_local` is not compatible because `build_system.build-backend` is not `uv_build`, but `flit_core.buildapi`
     ");
     Ok(())
 }
@@ -2549,8 +2549,8 @@ fn build_version_mismatch() -> Result<()> {
 
     ----- stderr -----
     Building wheel from source distribution...
-      × Failed to build `[TEMP_DIR]/anyio-1.2.3.tar.gz`
-      ╰─▶ The source distribution declares version 1.2.3, but the wheel declares version 4.3.0+foo
+    error: Failed to build `[TEMP_DIR]/anyio-1.2.3.tar.gz`
+      Caused by: The source distribution declares version 1.2.3, but the wheel declares version 4.3.0+foo
     ");
     Ok(())
 }
@@ -2784,8 +2784,8 @@ fn force_pep517() -> Result<()> {
 
     ----- stderr -----
     Building source distribution (uv build backend)...
-      × Failed to build `[TEMP_DIR]/`
-      ╰─▶ Expected a Python module at: src/does_not_exist/__init__.py
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Expected a Python module at: src/does_not_exist/__init__.py
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--force-pep517").env(EnvVars::RUST_BACKTRACE, "0"), @"
@@ -2796,9 +2796,9 @@ fn force_pep517() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     Error: Missing source directory at: `src`
-      × Failed to build `[TEMP_DIR]/`
-      ├─▶ The build backend returned an error
-      ╰─▶ Call to `uv_build.build_sdist` failed (exit status: 1)
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: The build backend returned an error
+      Caused by: Call to `uv_build.build_sdist` failed (exit status: 1)
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -2855,11 +2855,34 @@ fn venv_included_in_sdist() -> Result<()> {
 
     ----- stderr -----
     Building source distribution...
-      × Failed to build `[TEMP_DIR]/`
-      ├─▶ Invalid tar file
-      ├─▶ failed to unpack `[CACHE_DIR]/sdists-v9/[TMP]/python`
-      ╰─▶ symlink path `[PYTHON-3.12]` is absolute, but external symlinks are not allowed
-      help: This file seems to be part of a virtual environment. Virtual environments must be excluded from source distributions.
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Invalid tar file
+      Caused by: failed to unpack `[CACHE_DIR]/sdists-v9/[TMP]/python`
+      Caused by: symlink path `[PYTHON-3.12]` is absolute, but external symlinks are not allowed
+
+    hint: The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.
+    ");
+
+    uv_snapshot!(context.filters(), context.build().arg("-q"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Invalid tar file
+      Caused by: failed to unpack `[CACHE_DIR]/sdists-v9/[TMP]/python`
+      Caused by: symlink path `[PYTHON-3.12]` is absolute, but external symlinks are not allowed
+
+    hint: The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.
+    ");
+
+    uv_snapshot!(context.filters(), context.build().arg("-qq"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
     ");
 
     Ok(())

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -1405,12 +1405,12 @@ fn build_sha() -> Result<()> {
       Caused by: Failed to download `hatchling==1.22.4`
       Caused by: Hash mismatch for `hatchling==1.22.4`
 
-    Expected:
-      sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
-      sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+        Expected:
+          sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
+          sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
 
-    Computed:
-      sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+        Computed:
+          sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
     ");
 
     project
@@ -1437,12 +1437,12 @@ fn build_sha() -> Result<()> {
       Caused by: Failed to download `hatchling==1.22.4`
       Caused by: Hash mismatch for `hatchling==1.22.4`
 
-    Expected:
-      sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
-      sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+        Expected:
+          sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
+          sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
 
-    Computed:
-      sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+        Computed:
+          sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
     ");
 
     project

--- a/crates/uv/tests/build/build_backend.rs
+++ b/crates/uv/tests/build/build_backend.rs
@@ -1016,8 +1016,8 @@ fn error_on_relative_module_root_outside_project_root() -> Result<()> {
 
     ----- stderr -----
     Building source distribution (uv build backend)...
-      × Failed to build `[TEMP_DIR]/`
-      ╰─▶ Module root must be inside the project: ..
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Module root must be inside the project: ..
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--wheel"), @"
@@ -1027,8 +1027,8 @@ fn error_on_relative_module_root_outside_project_root() -> Result<()> {
 
     ----- stderr -----
     Building wheel (uv build backend)...
-      × Failed to build `[TEMP_DIR]/`
-      ╰─▶ Module root must be inside the project: ..
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Module root must be inside the project: ..
     ");
 
     Ok(())
@@ -1071,8 +1071,8 @@ fn error_on_relative_data_dir_outside_project_root() -> Result<()> {
 
     ----- stderr -----
     Building source distribution (uv build backend)...
-      × Failed to build `[TEMP_DIR]/project`
-      ╰─▶ The path for the data directory headers must be inside the project: ../header
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: The path for the data directory headers must be inside the project: ../header
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("project").arg("--wheel"), @"
@@ -1082,8 +1082,8 @@ fn error_on_relative_data_dir_outside_project_root() -> Result<()> {
 
     ----- stderr -----
     Building wheel (uv build backend)...
-      × Failed to build `[TEMP_DIR]/project`
-      ╰─▶ The path for the data directory headers must be inside the project: ../header
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: The path for the data directory headers must be inside the project: ../header
     ");
 
     Ok(())
@@ -1115,8 +1115,8 @@ fn venv_in_source_tree() {
 
     ----- stderr -----
     Building source distribution (uv build backend)...
-      × Failed to build `[TEMP_DIR]/`
-      ╰─▶ Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: src/foo/.venv
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: src/foo/.venv
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--wheel"), @"
@@ -1126,8 +1126,8 @@ fn venv_in_source_tree() {
 
     ----- stderr -----
     Building wheel (uv build backend)...
-      × Failed to build `[TEMP_DIR]/`
-      ╰─▶ Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: src/foo/.venv
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: src/foo/.venv
     ");
 }
 
@@ -1224,13 +1224,13 @@ fn invalid_pyproject_toml() -> Result<()> {
 
     ----- stderr -----
     Building source distribution (uv build backend)...
-      × Failed to build `[TEMP_DIR]/child`
-      ├─▶ Invalid metadata format in: child/pyproject.toml
-      ╰─▶ TOML parse error at line 2, column 8
-            |
-          2 | name = 1
-            |        ^
-          invalid type: integer `1`, expected a string
+    error: Failed to build `[TEMP_DIR]/child`
+      Caused by: Invalid metadata format in: child/pyproject.toml
+      Caused by: TOML parse error at line 2, column 8
+          |
+        2 | name = 1
+          |        ^
+        invalid type: integer `1`, expected a string
     ");
 
     Ok(())


### PR DESCRIPTION
Replace the build command’s local miette diagnostic with the standard error-chain renderer, including build-specific hints such as the source-distribution virtual-environment hint.