### PR TITLE
Use standard rendering for tool requirement errors

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use anstream::eprint;
 use anyhow::{Context, bail};
 use console::Term;
 use itertools::Itertools;
@@ -55,7 +54,9 @@ use crate::commands::project::{
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::tool::common::{ToolPython, matching_packages, refine_interpreter};
 use crate::commands::tool::{Target, ToolRequest};
-use crate::commands::{diagnostics, project::environment::CachedEnvironment, read_env_files};
+use crate::commands::{
+    UvError, diagnostics, project::environment::CachedEnvironment, read_env_files,
+};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 use crate::settings::ResolverSettings;
@@ -301,10 +302,8 @@ pub(crate) async fn run(
         }
 
         Err(ProjectError::Requirements(err)) => {
-            let err = miette::Report::msg(format!("{err}"))
-                .context("Failed to resolve `--with` requirement");
-            eprint!("{err:?}");
-            return Ok(ExitStatus::Failure);
+            let err = anyhow::Error::new(err).context("Failed to resolve `--with` requirement");
+            return Err(UvError::user(err).into());
         }
         Err(err) => return Err(err.into()),
     };

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -1910,7 +1910,16 @@ fn tool_run_with_editable() -> anyhow::Result<()> {
      + werkzeug==3.0.1
     ");
 
-    // If invalid, we should reference `--with`.
+    Ok(())
+}
+
+/// Invalid `--with` requirements should use the standard user-error renderer.
+#[test]
+fn tool_run_invalid_with() {
+    let context = uv_test::test_context!("3.12");
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
     uv_snapshot!(context.filters(), context
         .tool_run()
         .arg("--with")
@@ -1924,11 +1933,9 @@ fn tool_run_with_editable() -> anyhow::Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-      × Failed to resolve `--with` requirement
-      ╰─▶ Distribution not found at: file://[TEMP_DIR]/foo
+    error: Failed to resolve `--with` requirement
+      Caused by: Distribution not found at: file://[TEMP_DIR]/foo
     ");
-
-    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
Classify invalid `uv tool run --with` requirements as `UvError::User` so the entrypoint owns final rendering and exit-status selection instead of printing a local miette report. The expected error retains exit code 1 and its full cause chain. Builds on the user-error renderer from #20217.

Part of #17110.