### PR TITLE
Make pre-release proxy selection self-contained

### DIFF
--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -53,6 +53,7 @@ mod tests {
 
     #[test]
     fn priority_size() {
+        assert_eq!(size_of::<PubGrubTiebreaker>(), 4);
         assert_eq!(
             size_of::<<UvDependencyProvider as DependencyProvider>::Priority>(),
             24

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -114,7 +114,7 @@ impl PubGrubPriorities {
         &self,
         package: &PubGrubPackage,
     ) -> <UvDependencyProvider as DependencyProvider>::Priority {
-        let name = match &**package {
+        let (name, prerelease) = match &**package {
             // There is only a single root package despite the value. The priorities on root don't
             // matter for the resolution output, since the Pythons don't have dependencies
             // themselves and are only used when the package is incompatible.
@@ -130,13 +130,16 @@ impl PubGrubPriorities {
             PubGrubPackageInner::System(_) => {
                 return (PubGrubPriority::Root, PubGrubTiebreaker::from(3));
             }
-            PubGrubPackageInner::Prerelease { package } => package
-                .name_no_root()
-                .expect("pre-release proxy should wrap a registry package"),
+            PubGrubPackageInner::Prerelease { package } => (
+                package
+                    .name_no_root()
+                    .expect("pre-release proxy should wrap a registry package"),
+                true,
+            ),
             PubGrubPackageInner::Marker { name, .. }
             | PubGrubPackageInner::Extra { name, .. }
             | PubGrubPackageInner::Group { name, .. }
-            | PubGrubPackageInner::Package { name, .. } => name,
+            | PubGrubPackageInner::Package { name, .. } => (name, false),
         };
         // To ensure deterministic resolution, each (virtual) package needs to be registered on
         // discovery (as dependency of another package), before we query it for prioritization.
@@ -157,9 +160,14 @@ impl PubGrubPriorities {
                 if cfg!(debug_assertions) {
                     panic!("Package not registered in prioritization: `{package:?}`")
                 } else {
-                    PubGrubTiebreaker(Reverse(u32::MAX))
+                    PubGrubTiebreaker::from(u32::MAX)
                 }
             }
+        };
+        let package_tiebreaker = if prerelease {
+            package_tiebreaker.prioritize_prerelease()
+        } else {
+            package_tiebreaker
         };
 
         (package_priority, package_tiebreaker)
@@ -271,10 +279,22 @@ pub(crate) enum PubGrubPriority {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct PubGrubTiebreaker(Reverse<u32>);
+pub(crate) enum PubGrubTiebreaker {
+    Normal(Reverse<u32>),
+    Prerelease(Reverse<u32>),
+}
+
+impl PubGrubTiebreaker {
+    /// Prioritize a pre-release proxy over other virtual packages for the same distribution.
+    fn prioritize_prerelease(self) -> Self {
+        match self {
+            Self::Normal(order) | Self::Prerelease(order) => Self::Prerelease(order),
+        }
+    }
+}
 
 impl From<u32> for PubGrubTiebreaker {
     fn from(value: u32) -> Self {
-        Self(Reverse(value))
+        Self::Normal(Reverse(value))
     }
 }

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -40,11 +40,10 @@ impl PubGrubPriorities {
         urls: &ForkUrls,
     ) {
         let len = self.virtual_package_tiebreaker.len();
+        let prerelease = matches!(&**package, PubGrubPackageInner::Prerelease { .. });
         self.virtual_package_tiebreaker
             .entry_ref(package)
-            .or_insert_with(|| {
-                PubGrubTiebreaker::from(u32::try_from(len).expect("Less than 2**32 packages"))
-            });
+            .or_insert_with(|| PubGrubTiebreaker::from_package_order(len, prerelease));
 
         // The root package and Python constraints have no explicit priority, the root package is
         // always first and the Python version (range) is fixed.
@@ -114,7 +113,7 @@ impl PubGrubPriorities {
         &self,
         package: &PubGrubPackage,
     ) -> <UvDependencyProvider as DependencyProvider>::Priority {
-        let (name, prerelease) = match &**package {
+        let name = match &**package {
             // There is only a single root package despite the value. The priorities on root don't
             // matter for the resolution output, since the Pythons don't have dependencies
             // themselves and are only used when the package is incompatible.
@@ -130,16 +129,13 @@ impl PubGrubPriorities {
             PubGrubPackageInner::System(_) => {
                 return (PubGrubPriority::Root, PubGrubTiebreaker::from(3));
             }
-            PubGrubPackageInner::Prerelease { package } => (
-                package
-                    .name_no_root()
-                    .expect("pre-release proxy should wrap a registry package"),
-                true,
-            ),
+            PubGrubPackageInner::Prerelease { package } => package
+                .name_no_root()
+                .expect("pre-release proxy should wrap a registry package"),
             PubGrubPackageInner::Marker { name, .. }
             | PubGrubPackageInner::Extra { name, .. }
             | PubGrubPackageInner::Group { name, .. }
-            | PubGrubPackageInner::Package { name, .. } => (name, false),
+            | PubGrubPackageInner::Package { name, .. } => name,
         };
         // To ensure deterministic resolution, each (virtual) package needs to be registered on
         // discovery (as dependency of another package), before we query it for prioritization.
@@ -164,12 +160,6 @@ impl PubGrubPriorities {
                 }
             }
         };
-        let package_tiebreaker = if prerelease {
-            package_tiebreaker.prioritize_prerelease()
-        } else {
-            package_tiebreaker
-        };
-
         (package_priority, package_tiebreaker)
     }
 
@@ -279,22 +269,23 @@ pub(crate) enum PubGrubPriority {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum PubGrubTiebreaker {
-    Normal(Reverse<u32>),
-    Prerelease(Reverse<u32>),
-}
+pub(crate) struct PubGrubTiebreaker(Reverse<u32>);
 
 impl PubGrubTiebreaker {
-    /// Prioritize a pre-release proxy over other virtual packages for the same distribution.
-    fn prioritize_prerelease(self) -> Self {
-        match self {
-            Self::Normal(order) | Self::Prerelease(order) => Self::Prerelease(order),
-        }
+    const NORMAL_PACKAGE_START: u32 = 1 << 31;
+
+    /// Create a tiebreaker that prioritizes pre-release proxies, then preserves discovery order.
+    fn from_package_order(index: usize, prerelease: bool) -> Self {
+        let index = u32::try_from(index).expect("Less than 2**32 packages");
+        let normal_order = index
+            .checked_add(Self::NORMAL_PACKAGE_START)
+            .expect("Less than 2**31 packages");
+        Self(Reverse(if prerelease { index } else { normal_order }))
     }
 }
 
 impl From<u32> for PubGrubTiebreaker {
     fn from(value: u32) -> Self {
-        Self::Normal(Reverse(value))
+        Self(Reverse(value))
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -13,7 +13,7 @@ use either::Either;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use papaya::{HashMap, ResizeMode};
-use pubgrub::{Id, IncompId, Incompatibility, Kind, Ranges, State, Term};
+use pubgrub::{Id, IncompId, Incompatibility, Kind, Ranges, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
@@ -514,18 +514,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         .expect("a package was chosen but we don't have a term");
                     let range = term_intersection.unwrap_positive();
                     let explicit_prerelease =
-                        matches!(&**next_package, PubGrubPackageInner::Prerelease { .. })
-                            || state.has_active_prerelease_proxy(next_package);
+                        matches!(&**next_package, PubGrubPackageInner::Prerelease { .. });
 
                     // Within a fixed resolver environment, an implicit registry candidate is
                     // stable for a given range and pre-release policy. Avoid repeating candidate
                     // selection when PubGrub revisits an identical decision after backtracking.
                     let cache_selected_version = url.is_none() && index.is_none();
                     let decision = if cache_selected_version
-                        && let Some((selected_range, selected_prerelease, version)) =
+                        && let Some((selected_range, version)) =
                             state.selected_versions.get(&next_id)
                         && selected_range == range
-                        && *selected_prerelease == explicit_prerelease
                     {
                         Some(ResolverVersion::Unforked(version.clone()))
                     } else {
@@ -548,10 +546,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         if cache_selected_version
                             && let Some(ResolverVersion::Unforked(version)) = &decision
                         {
-                            state.selected_versions.insert(
-                                next_id,
-                                (range.clone(), explicit_prerelease, version.clone()),
-                            );
+                            state
+                                .selected_versions
+                                .insert(next_id, (range.clone(), version.clone()));
                         }
 
                         decision
@@ -3067,9 +3064,8 @@ pub(crate) struct ForkState {
     added_dependencies: FxHashMap<Id<PubGrubPackage>, FxHashSet<Version>>,
     /// The last range scheduled for prefetch for each undecided package.
     pre_visited: FxHashMap<Id<PubGrubPackage>, Range<Version>>,
-    /// The last version selected for each package, range, and explicit pre-release authorization
-    /// state in a specific environment.
-    selected_versions: FxHashMap<Id<PubGrubPackage>, (Range<Version>, bool, Version)>,
+    /// The last version selected for each package and range in a specific environment.
+    selected_versions: FxHashMap<Id<PubGrubPackage>, (Range<Version>, Version)>,
     /// All known versions for each package, from the version maps and the installed packages,
     /// used to keep the version sets in the partial solution minimal.
     ///
@@ -3108,11 +3104,6 @@ pub(crate) struct ForkState {
     ///
     /// Tracked on the fork state to avoid counting each identical version between forks as new try.
     prefetcher: BatchPrefetcher,
-    /// Reverse index of pre-release proxy package IDs discovered for each package name.
-    ///
-    /// Entries are not removed on backtracking. This map only avoids scanning PubGrub's package
-    /// graph; whether a proxy is active is always derived from the current partial solution.
-    prerelease_by_name: FxHashMap<PackageName, Vec<Id<PubGrubPackage>>>,
 }
 
 impl ForkState {
@@ -3139,30 +3130,7 @@ impl ForkState {
             python_requirement,
             conflict_tracker: ConflictTracker::default(),
             prefetcher,
-            prerelease_by_name: FxHashMap::default(),
         }
-    }
-
-    /// Returns `true` if an active pre-release proxy authorizes this package in the current fork.
-    fn has_active_prerelease_proxy(&self, package: &PubGrubPackage) -> bool {
-        if self.prerelease_by_name.is_empty() {
-            return false;
-        }
-        let Some(name) = package.name_no_root() else {
-            return false;
-        };
-        self.prerelease_by_name
-            .get(name)
-            .into_iter()
-            .flatten()
-            .any(|proxy| {
-                matches!(
-                    self.pubgrub
-                        .partial_solution
-                        .term_intersection_for_package(*proxy),
-                    Some(Term::Positive(_))
-                )
-            })
     }
 
     /// Visit the dependencies for the selected version of the current package, incorporating any
@@ -3286,17 +3254,6 @@ impl ForkState {
                 parent: _,
                 source: _,
             } = dependency;
-
-            if let PubGrubPackageInner::Prerelease { package: wrapped } = &**package {
-                let Some(name) = wrapped.name_no_root() else {
-                    continue;
-                };
-                let proxy = self.pubgrub.package_store.alloc(package.clone());
-                let proxy_ids = self.prerelease_by_name.entry(name.clone()).or_default();
-                if !proxy_ids.contains(&proxy) {
-                    proxy_ids.push(proxy);
-                }
-            }
 
             let Some(base_package) = package.base_package() else {
                 continue;


### PR DESCRIPTION
## Summary

Stacked on #19993.

The parent PR currently checks whether a matching pre-release proxy is active in PubGrub's partial solution before selecting a version for the underlying package. That makes selection for a package identity depend on mutable solver state and requires a reverse index synchronized with package discovery.

This PR instead prioritizes pre-release proxies over other virtual packages for the same distribution. The proxy applies normal version ordering, selects a version, and pins the wrapped package to that exact version. The wrapped package can retain its stable-first policy: when pinned to a pre-release, its exact range contains no stable candidate, so it naturally falls back to the selected pre-release.

As a result, candidate-selection policy is invariant per package identity. This removes the partial-solution lookup, the reverse index, and the authorization bit from the selected-version cache while preserving authorization and backtracking behavior. The focused pre-release scenarios and the `uv-resolver` test suite pass with the proxy-first ordering.
