### PR TITLE
Run parser microbenchmarks in simulation only

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -48,7 +48,7 @@ jobs:
           cargo run --bin uv -- pip compile test/requirements/airflow.in --universal --exclude-newer 2024-08-08 --cache-dir .cache
 
       - name: "Build benchmarks"
-        run: cargo codspeed build -m walltime --profile profiling -p uv-bench
+        run: cargo codspeed build -m walltime --profile profiling -p uv-bench --bench uv --bench workspace_discovery
 
       - name: "Create artifact archive"
         run: tar -cvf benchmarks-walltime.tar target/codspeed target/debug/uv .cache

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -29,8 +29,8 @@ path = "benches/workspace_discovery.rs"
 harness = false
 
 [[bench]]
-name = "simulation"
-path = "benches/simulation.rs"
+name = "uv_pep440"
+path = "benches/uv_pep440.rs"
 harness = false
 
 [dev-dependencies]

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -28,6 +28,11 @@ name = "workspace_discovery"
 path = "benches/workspace_discovery.rs"
 harness = false
 
+[[bench]]
+name = "simulation"
+path = "benches/simulation.rs"
+harness = false
+
 [dev-dependencies]
 uv-cache = { workspace = true }
 uv-client = { workspace = true }

--- a/crates/uv-bench/benches/simulation.rs
+++ b/crates/uv-bench/benches/simulation.rs
@@ -1,0 +1,20 @@
+use std::hint::black_box;
+use std::str::FromStr;
+
+use criterion::{Criterion, criterion_group, criterion_main, measurement::WallTime};
+use uv_pep440::VersionSpecifiers;
+
+fn parse_version_specifiers(c: &mut Criterion<WallTime>) {
+    for specifiers in [">=3.8", ">=3.8,<4", ">=2.5, !=3.0.*, !=3.1.*, !=3.2.*, <4"] {
+        let name = format!("parse_version_specifiers {specifiers}");
+        c.bench_function(&name, |benchmark| {
+            benchmark.iter(|| {
+                VersionSpecifiers::from_str(black_box(specifiers))
+                    .expect("benchmark input should be valid")
+            });
+        });
+    }
+}
+
+criterion_group!(simulation, parse_version_specifiers);
+criterion_main!(simulation);

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -20,7 +20,6 @@ use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::Requirement;
 use uv_install_wheel::{InstallState, Layout, LinkMode};
-use uv_pep440::VersionSpecifiers;
 use uv_preview::Preview;
 use uv_pypi_types::Scheme;
 use uv_python::PythonEnvironment;
@@ -309,19 +308,6 @@ fn resolve_warm_airflow(c: &mut Criterion<WallTime>) {
     c.bench_function("resolve_warm_airflow", |b| b.iter(&run));
 }
 
-fn parse_version_specifiers(c: &mut Criterion<WallTime>) {
-    let mut group = c.benchmark_group("parse_version_specifiers");
-    for specifiers in [">=3.8", ">=3.8,<4", ">=2.5, !=3.0.*, !=3.1.*, !=3.2.*, <4"] {
-        group.bench_with_input(specifiers, specifiers, |benchmark, specifiers| {
-            benchmark.iter(|| {
-                VersionSpecifiers::from_str(black_box(specifiers))
-                    .expect("benchmark input should be valid")
-            });
-        });
-    }
-    group.finish();
-}
-
 // This takes >5m to run in CodSpeed.
 // fn resolve_warm_airflow_universal(c: &mut Criterion<WallTime>) {
 //     let manifest = Manifest::simple(vec![
@@ -342,8 +328,7 @@ criterion_group!(
     install_wheel_many_files,
     resolve_warm_jupyter,
     resolve_warm_jupyter_universal,
-    resolve_warm_airflow,
-    parse_version_specifiers
+    resolve_warm_airflow
 );
 criterion_main!(uv);
 

--- a/crates/uv-bench/benches/uv_pep440.rs
+++ b/crates/uv-bench/benches/uv_pep440.rs
@@ -16,5 +16,5 @@ fn parse_version_specifiers(c: &mut Criterion<WallTime>) {
     }
 }
 
-criterion_group!(simulation, parse_version_specifiers);
-criterion_main!(simulation);
+criterion_group!(uv_pep440, parse_version_specifiers);
+criterion_main!(uv_pep440);


### PR DESCRIPTION
## Summary

The `VersionSpecifiers` parser microbenchmarks are short enough that wall-time measurements are noisy and have been flaking on recent pull requests.

Move those benchmarks into a dedicated `uv_pep440` target, which remains part of the simulation build, and explicitly restrict the wall-time build to the existing `uv` and `workspace_discovery` targets. Give each case a descriptive leaf name like `parse_version_specifiers >=3.8` instead of relying on the Criterion group name appearing in CodSpeed.