### PR TITLE
fix(uv): uv lock --upgrade ignored when upgrade-package set in config (#19954)

### DIFF
--- a/crates/uv-configuration/src/package_options.rs
+++ b/crates/uv-configuration/src/package_options.rs
@@ -255,9 +255,10 @@ impl Upgrade {
     /// Combine a set of [`Upgrade`] values.
     #[must_use]
     pub fn combine(self, other: Self) -> Self {
-        // For `strategy`: `other` takes precedence for an explicit `All` or `None`; otherwise,
-        // merge.
+        // For `strategy`: `self` (CLI) takes precedence over `other` (config) for `All`;
+        // `other` takes precedence for `None`; otherwise merge.
         let strategy = match (self.strategy, other.strategy) {
+            (UpgradeStrategy::All, _) => UpgradeStrategy::All,
             (_, UpgradeStrategy::All) => UpgradeStrategy::All,
             (_, UpgradeStrategy::None) => UpgradeStrategy::None,
             (


### PR DESCRIPTION
## Summary

`uv lock --upgrade` was being ignored when `upgrade-package` was set in pyproject.toml via `[tool.uv]`.

## Root Cause

In `Upgrade::combine()`, the match arms checked `(_, UpgradeStrategy::All)` first, which meant the config file's `UpgradeStrategy::All` (set when `upgrade-package` is configured) would take precedence over the CLI's `UpgradeStrategy::All` (set by `--upgrade`). Since match arms are evaluated top-to-bottom, `(UpgradeStrategy::All, _)` needed to come first.

## Changes

- `crates/uv-configuration/src/package_options.rs`: Add `(UpgradeStrategy::All, _) => UpgradeStrategy::All` as the first arm in `Upgrade::combine()`

Closes #19954