### PR TITLE
fix(uv): gracefully handle corrupt tool receipts on uninstall (#19630)

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,24 +133,28 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
-                // If the tool is not installed properly, attempt to remove the environment anyway.
-                match installed_tools.remove_environment(&name) {
-                    Ok(()) => {
-                        dangling = true;
-                        writeln!(
-                            printer.stderr(),
-                            "Removed dangling environment for `{name}`"
-                        )?;
-                        continue;
-                    }
-                    Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
-                        if err.kind() == std::io::ErrorKind::NotFound =>
-                    {
-                        bail!("`{name}` is not installed");
-                    }
-                    Err(err) => {
-                        return Err(err.into());
+            let receipt = match installed_tools.get_tool_receipt(&name) {
+                Ok(Some(receipt)) => receipt,
+                Ok(None) | Err(_) => {
+                    // If the tool is not installed properly (e.g., corrupt receipt),
+                    // attempt to remove the environment anyway with a warning.
+                    match installed_tools.remove_environment(&name) {
+                        Ok(()) => {
+                            dangling = true;
+                            writeln!(
+                                printer.stderr(),
+                                "Removed dangling environment for `{name}`"
+                            )?;
+                            continue;
+                        }
+                        Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
+                            if err.kind() == std::io::ErrorKind::NotFound =>
+                        {
+                            bail!("`{name}` is not installed");
+                        }
+                        Err(err) => {
+                            return Err(err.into());
+                        }
                     }
                 }
             };

--- a/crates/uv/tests/tool/tool_uninstall.rs
+++ b/crates/uv/tests/tool/tool_uninstall.rs
@@ -1,5 +1,6 @@
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::PathChild;
+use assert_fs::prelude::*;
 
 use uv_static::EnvVars;
 
@@ -228,6 +229,40 @@ fn tool_uninstall_all_missing_receipt() {
     fs_err::remove_file(tool_dir.join("black").join("uv-receipt.toml")).unwrap();
 
     uv_snapshot!(context.filters(), context.tool_uninstall().arg("--all")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed dangling environment for `black`
+    ");
+}
+
+#[test]
+fn tool_uninstall_corrupt_receipt() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black`
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    // Corrupt the receipt by writing invalid TOML content
+    tool_dir
+        .child("black")
+        .child("uv-receipt.toml")
+        .write_str("this is not valid toml = = = corrupt")
+        .unwrap();
+
+    uv_snapshot!(context.filters(), context.tool_uninstall().arg("black")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
     success: true


### PR DESCRIPTION
## Summary

`uv tool uninstall <name>` fails with a raw error when the tool's receipt file is corrupt. Users who see `uv tool list` warning about a malformed installation then try `uv tool uninstall` to clean it up, but that also errors out.

## Changes

- `crates/uv/src/commands/tool/uninstall.rs`: Changed `let Some(receipt) = get_tool_receipt(&name)?` (hard propagate on error) to a `match` that treats both `Ok(None)` (no receipt) and `Err` (corrupt receipt) as a dangling environment, removing it with a warning instead of crashing.

Closes #19630