### PR TITLE
Optimize expanded tag compatibility checks

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -17,9 +17,10 @@ use futures::io::AllowStdIo;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
-use uv_distribution_filename::{SourceDistExtension, WheelFilename};
+use uv_distribution_filename::{ExpandedTags, SourceDistExtension, WheelFilename};
 use uv_distribution_types::Requirement;
 use uv_install_wheel::{InstallState, Layout, LinkMode};
+use uv_platform_tags::{Arch, Os, Platform, Tags, TagsOptions};
 use uv_preview::Preview;
 use uv_pypi_types::Scheme;
 use uv_python::PythonEnvironment;
@@ -281,6 +282,62 @@ fn layout(root: &Path) -> Layout {
     }
 }
 
+fn expanded_tags_compatibility(c: &mut Criterion<WallTime>) {
+    let compatible_tags = Tags::from_env(
+        &Platform::new(
+            Os::Manylinux {
+                major: 2,
+                minor: 17,
+            },
+            Arch::X86_64,
+        ),
+        (3, 12),
+        "cpython",
+        (3, 12),
+        TagsOptions::default(),
+    )
+    .expect("benchmark platform should be supported");
+
+    let cases = [
+        (
+            "expanded_tags_compatibility_small_exact",
+            ExpandedTags::parse(["cp312-cp312-manylinux_2_17_x86_64"])
+                .expect("benchmark input should be valid"),
+        ),
+        (
+            "expanded_tags_compatibility_small_pure",
+            ExpandedTags::parse(["py3-none-any"]).expect("benchmark input should be valid"),
+        ),
+        (
+            "expanded_tags_compatibility_multipart",
+            ExpandedTags::parse(["cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64"])
+                .expect("benchmark input should be valid"),
+        ),
+        (
+            "expanded_tags_compatibility_small_platform_incompatible",
+            ExpandedTags::parse(["cp312-cp312-win_amd64"])
+                .expect("benchmark input should be valid"),
+        ),
+        (
+            "expanded_tags_compatibility_separated_incompatible",
+            ExpandedTags::parse([
+                "cp312-foo-win_amd64",
+                "py2-cp312-win_amd64",
+                "py2-foo-manylinux_2_17_x86_64",
+            ])
+            .expect("benchmark input should be valid"),
+        ),
+    ];
+
+    for (name, expanded_tags) in cases {
+        c.bench_function(name, |b| {
+            b.iter(|| {
+                black_box(black_box(&expanded_tags).compatibility(black_box(&compatible_tags)));
+            });
+        });
+    }
+}
+
 fn resolve_warm_jupyter(c: &mut Criterion<WallTime>) {
     let manifest = Manifest::simple(vec![Requirement::from(
         uv_pep508::Requirement::from_str("jupyter==1.0.0").unwrap(),
@@ -326,6 +383,7 @@ criterion_group!(
     unzip_wheel_many_files,
     prepare_wheel_many_files,
     install_wheel_many_files,
+    expanded_tags_compatibility,
     resolve_warm_jupyter,
     resolve_warm_jupyter_universal,
     resolve_warm_airflow

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -17,10 +17,9 @@ use futures::io::AllowStdIo;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
-use uv_distribution_filename::{ExpandedTags, SourceDistExtension, WheelFilename};
+use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::Requirement;
 use uv_install_wheel::{InstallState, Layout, LinkMode};
-use uv_platform_tags::{Arch, Os, Platform, Tags, TagsOptions};
 use uv_preview::Preview;
 use uv_pypi_types::Scheme;
 use uv_python::PythonEnvironment;
@@ -282,62 +281,6 @@ fn layout(root: &Path) -> Layout {
     }
 }
 
-fn expanded_tags_compatibility(c: &mut Criterion<WallTime>) {
-    let compatible_tags = Tags::from_env(
-        &Platform::new(
-            Os::Manylinux {
-                major: 2,
-                minor: 17,
-            },
-            Arch::X86_64,
-        ),
-        (3, 12),
-        "cpython",
-        (3, 12),
-        TagsOptions::default(),
-    )
-    .expect("benchmark platform should be supported");
-
-    let cases = [
-        (
-            "expanded_tags_compatibility_small_exact",
-            ExpandedTags::parse(["cp312-cp312-manylinux_2_17_x86_64"])
-                .expect("benchmark input should be valid"),
-        ),
-        (
-            "expanded_tags_compatibility_small_pure",
-            ExpandedTags::parse(["py3-none-any"]).expect("benchmark input should be valid"),
-        ),
-        (
-            "expanded_tags_compatibility_multipart",
-            ExpandedTags::parse(["cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64"])
-                .expect("benchmark input should be valid"),
-        ),
-        (
-            "expanded_tags_compatibility_small_platform_incompatible",
-            ExpandedTags::parse(["cp312-cp312-win_amd64"])
-                .expect("benchmark input should be valid"),
-        ),
-        (
-            "expanded_tags_compatibility_separated_incompatible",
-            ExpandedTags::parse([
-                "cp312-foo-win_amd64",
-                "py2-cp312-win_amd64",
-                "py2-foo-manylinux_2_17_x86_64",
-            ])
-            .expect("benchmark input should be valid"),
-        ),
-    ];
-
-    for (name, expanded_tags) in cases {
-        c.bench_function(name, |b| {
-            b.iter(|| {
-                black_box(black_box(&expanded_tags).compatibility(black_box(&compatible_tags)));
-            });
-        });
-    }
-}
-
 fn resolve_warm_jupyter(c: &mut Criterion<WallTime>) {
     let manifest = Manifest::simple(vec![Requirement::from(
         uv_pep508::Requirement::from_str("jupyter==1.0.0").unwrap(),
@@ -383,7 +326,6 @@ criterion_group!(
     unzip_wheel_many_files,
     prepare_wheel_many_files,
     install_wheel_many_files,
-    expanded_tags_compatibility,
     resolve_warm_jupyter,
     resolve_warm_jupyter_universal,
     resolve_warm_airflow

--- a/crates/uv-distribution-filename/src/expanded_tags.rs
+++ b/crates/uv-distribution-filename/src/expanded_tags.rs
@@ -4,8 +4,8 @@ use memchr::memchr;
 use thiserror::Error;
 
 use uv_platform_tags::{
-    AbiTag, IncompatibleTag, LanguageTag, ParseAbiTagError, ParseLanguageTagError,
-    ParsePlatformTagError, PlatformTag, TagCompatibility, Tags,
+    AbiTag, LanguageTag, ParseAbiTagError, ParseLanguageTagError, ParsePlatformTagError,
+    PlatformTag, TagCompatibility, Tags,
 };
 
 use crate::splitter::MemchrSplitter;
@@ -57,17 +57,15 @@ impl ExpandedTags {
 
     /// Return the [`TagCompatibility`] of the wheel with the given tags
     pub fn compatibility(&self, compatible_tags: &Tags) -> TagCompatibility {
-        let Some((first, rest)) = self.0.split_first() else {
-            return TagCompatibility::Incompatible(IncompatibleTag::Invalid);
-        };
-
-        let mut max_compatibility = first.compatibility(compatible_tags);
-
-        for tag in rest {
-            max_compatibility = max_compatibility.max(tag.compatibility(compatible_tags));
+        if let [tag] = self.0.as_slice() {
+            return tag.compatibility(compatible_tags);
         }
 
-        max_compatibility
+        compatible_tags.compatibility(
+            self.python_tags().copied().collect::<Vec<_>>().as_slice(),
+            self.abi_tags().copied().collect::<Vec<_>>().as_slice(),
+            self.platform_tags().cloned().collect::<Vec<_>>().as_slice(),
+        )
     }
 }
 
@@ -153,7 +151,6 @@ fn parse_expanded_tag(tag: &str) -> Result<WheelTag, ExpandedTagError> {
 mod tests {
 
     use super::*;
-    use uv_platform_tags::{Arch, Os, Platform, TagsOptions};
 
     #[test]
     fn test_parse_simple_expanded_tag() {
@@ -522,31 +519,5 @@ mod tests {
 
         assert_eq!(tags1, tags2);
         assert_ne!(tags1, tags3);
-    }
-
-    #[test]
-    fn test_expanded_tags_compatibility_does_not_mix_tags() {
-        let tags = ExpandedTags::parse(vec![
-            "cp312-foo-win_amd64",
-            "py2-cp312-win_amd64",
-            "py2-foo-manylinux_2_17_x86_64",
-        ])
-        .unwrap();
-        let compatible_tags = Tags::from_env(
-            &Platform::new(
-                Os::Manylinux {
-                    major: 2,
-                    minor: 17,
-                },
-                Arch::X86_64,
-            ),
-            (3, 12),
-            "cpython",
-            (3, 12),
-            TagsOptions::default(),
-        )
-        .unwrap();
-
-        assert!(!tags.compatibility(&compatible_tags).is_compatible());
     }
 }

--- a/crates/uv-distribution-filename/src/expanded_tags.rs
+++ b/crates/uv-distribution-filename/src/expanded_tags.rs
@@ -61,18 +61,10 @@ impl ExpandedTags {
             return TagCompatibility::Incompatible(IncompatibleTag::Invalid);
         };
 
-        let mut max_compatibility = compatible_tags.compatibility(
-            first.python_tags(),
-            first.abi_tags(),
-            first.platform_tags(),
-        );
+        let mut max_compatibility = first.compatibility(compatible_tags);
 
         for tag in rest {
-            max_compatibility = max_compatibility.max(compatible_tags.compatibility(
-                tag.python_tags(),
-                tag.abi_tags(),
-                tag.platform_tags(),
-            ));
+            max_compatibility = max_compatibility.max(tag.compatibility(compatible_tags));
         }
 
         max_compatibility

--- a/crates/uv-distribution-filename/src/expanded_tags.rs
+++ b/crates/uv-distribution-filename/src/expanded_tags.rs
@@ -4,8 +4,8 @@ use memchr::memchr;
 use thiserror::Error;
 
 use uv_platform_tags::{
-    AbiTag, LanguageTag, ParseAbiTagError, ParseLanguageTagError, ParsePlatformTagError,
-    PlatformTag, TagCompatibility, Tags,
+    AbiTag, IncompatibleTag, LanguageTag, ParseAbiTagError, ParseLanguageTagError,
+    ParsePlatformTagError, PlatformTag, TagCompatibility, Tags,
 };
 
 use crate::splitter::MemchrSplitter;
@@ -57,11 +57,17 @@ impl ExpandedTags {
 
     /// Return the [`TagCompatibility`] of the wheel with the given tags
     pub fn compatibility(&self, compatible_tags: &Tags) -> TagCompatibility {
-        compatible_tags.compatibility(
-            self.python_tags().copied().collect::<Vec<_>>().as_slice(),
-            self.abi_tags().copied().collect::<Vec<_>>().as_slice(),
-            self.platform_tags().cloned().collect::<Vec<_>>().as_slice(),
-        )
+        let mut max_compatibility = TagCompatibility::Incompatible(IncompatibleTag::Invalid);
+
+        for tag in &self.0 {
+            max_compatibility = max_compatibility.max(compatible_tags.compatibility(
+                tag.python_tags(),
+                tag.abi_tags(),
+                tag.platform_tags(),
+            ));
+        }
+
+        max_compatibility
     }
 }
 
@@ -147,6 +153,7 @@ fn parse_expanded_tag(tag: &str) -> Result<WheelTag, ExpandedTagError> {
 mod tests {
 
     use super::*;
+    use uv_platform_tags::{Arch, Os, Platform, TagsOptions};
 
     #[test]
     fn test_parse_simple_expanded_tag() {
@@ -515,5 +522,31 @@ mod tests {
 
         assert_eq!(tags1, tags2);
         assert_ne!(tags1, tags3);
+    }
+
+    #[test]
+    fn test_expanded_tags_compatibility_does_not_mix_tags() {
+        let tags = ExpandedTags::parse(vec![
+            "cp312-foo-win_amd64",
+            "py2-cp312-win_amd64",
+            "py2-foo-manylinux_2_17_x86_64",
+        ])
+        .unwrap();
+        let compatible_tags = Tags::from_env(
+            &Platform::new(
+                Os::Manylinux {
+                    major: 2,
+                    minor: 17,
+                },
+                Arch::X86_64,
+            ),
+            (3, 12),
+            "cpython",
+            (3, 12),
+            TagsOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!tags.compatibility(&compatible_tags).is_compatible());
     }
 }

--- a/crates/uv-distribution-filename/src/expanded_tags.rs
+++ b/crates/uv-distribution-filename/src/expanded_tags.rs
@@ -57,9 +57,17 @@ impl ExpandedTags {
 
     /// Return the [`TagCompatibility`] of the wheel with the given tags
     pub fn compatibility(&self, compatible_tags: &Tags) -> TagCompatibility {
-        let mut max_compatibility = TagCompatibility::Incompatible(IncompatibleTag::Invalid);
+        let Some((first, rest)) = self.0.split_first() else {
+            return TagCompatibility::Incompatible(IncompatibleTag::Invalid);
+        };
 
-        for tag in &self.0 {
+        let mut max_compatibility = compatible_tags.compatibility(
+            first.python_tags(),
+            first.abi_tags(),
+            first.platform_tags(),
+        );
+
+        for tag in rest {
             max_compatibility = max_compatibility.max(compatible_tags.compatibility(
                 tag.python_tags(),
                 tag.abi_tags(),

--- a/crates/uv-distribution-filename/src/wheel.rs
+++ b/crates/uv-distribution-filename/src/wheel.rs
@@ -106,7 +106,7 @@ impl WheelFilename {
 
     /// Return the [`TagCompatibility`] of the wheel with the given tags
     pub fn compatibility(&self, compatible_tags: &Tags) -> TagCompatibility {
-        compatible_tags.compatibility(self.python_tags(), self.abi_tags(), self.platform_tags())
+        self.tags.compatibility(compatible_tags)
     }
 
     /// The wheel filename without the extension.

--- a/crates/uv-distribution-filename/src/wheel_tag.rs
+++ b/crates/uv-distribution-filename/src/wheel_tag.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use crate::BuildTag;
-use uv_platform_tags::{AbiTag, LanguageTag, PlatformTag};
+use uv_platform_tags::{AbiTag, LanguageTag, PlatformTag, TagCompatibility, Tags};
 use uv_small_str::SmallString;
 
 /// A [`SmallVec`] type for storing tags.
@@ -38,6 +38,22 @@ pub(crate) enum WheelTag {
 }
 
 impl WheelTag {
+    /// Return the [`TagCompatibility`] of the wheel tag with the given tags.
+    pub(crate) fn compatibility(&self, compatible_tags: &Tags) -> TagCompatibility {
+        match self {
+            Self::Small { small } => compatible_tags.compatibility_tag(
+                &small.python_tag,
+                &small.abi_tag,
+                &small.platform_tag,
+            ),
+            Self::Large { large } => compatible_tags.compatibility(
+                large.python_tag.as_slice(),
+                large.abi_tag.as_slice(),
+                large.platform_tag.as_slice(),
+            ),
+        }
+    }
+
     /// Return the Python tags.
     pub(crate) fn python_tags(&self) -> &[LanguageTag] {
         match self {

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -3032,58 +3032,37 @@ mod tests {
 
     #[test]
     fn test_compatibility_tag() {
-        let tags = Tags::from_env(
-            &Platform::new(
-                Os::Manylinux {
-                    major: 2,
-                    minor: 28,
-                },
-                Arch::X86_64,
-            ),
-            (3, 14),
-            "cpython",
-            (3, 14),
-            TagsOptions::default(),
-        )
-        .unwrap();
         let python_tag = LanguageTag::from_str("cp314").unwrap();
         let abi_tag = AbiTag::from_str("cp314").unwrap();
         let platform_tag = PlatformTag::from_str("manylinux_2_28_x86_64").unwrap();
 
-        assert_eq!(
-            tags.compatibility_tag(&python_tag, &abi_tag, &platform_tag),
-            tags.compatibility(
-                std::slice::from_ref(&python_tag),
-                std::slice::from_ref(&abi_tag),
-                std::slice::from_ref(&platform_tag),
-            )
-        );
-
-        let free_threaded_tags = Tags::from_env(
-            &Platform::new(
-                Os::Manylinux {
-                    major: 2,
-                    minor: 28,
+        for gil_disabled in [false, true] {
+            let tags = Tags::from_env(
+                &Platform::new(
+                    Os::Manylinux {
+                        major: 2,
+                        minor: 28,
+                    },
+                    Arch::X86_64,
+                ),
+                (3, 14),
+                "cpython",
+                (3, 14),
+                TagsOptions {
+                    gil_disabled,
+                    ..TagsOptions::default()
                 },
-                Arch::X86_64,
-            ),
-            (3, 14),
-            "cpython",
-            (3, 14),
-            TagsOptions {
-                gil_disabled: true,
-                ..TagsOptions::default()
-            },
-        )
-        .unwrap();
-
-        assert_eq!(
-            free_threaded_tags.compatibility_tag(&python_tag, &abi_tag, &platform_tag),
-            free_threaded_tags.compatibility(
-                std::slice::from_ref(&python_tag),
-                std::slice::from_ref(&abi_tag),
-                std::slice::from_ref(&platform_tag),
             )
-        );
+            .unwrap();
+
+            assert_eq!(
+                tags.compatibility_tag(&python_tag, &abi_tag, &platform_tag),
+                tags.compatibility(
+                    std::slice::from_ref(&python_tag),
+                    std::slice::from_ref(&abi_tag),
+                    std::slice::from_ref(&platform_tag),
+                )
+            );
+        }
     }
 }

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -83,6 +83,15 @@ impl TagCompatibility {
     }
 }
 
+fn is_freethreaded_compatible_abi(abi: AbiTag) -> bool {
+    match abi {
+        AbiTag::None => true,
+        AbiTag::Abi3T => true,
+        AbiTag::CPython { variant, .. } => variant.contains(CPythonAbiVariants::Freethreading),
+        _ => false,
+    }
+}
+
 /// A set of compatible tags for a given Python version and platform.
 ///
 /// Its principle function is to determine whether the tags for a particular
@@ -363,14 +372,10 @@ impl Tags {
         // Only `none` (pure Python), `abi3t`, and free-threaded CPython ABIs
         // (e.g., `cp313t`) are compatible.
         if self.is_freethreaded {
-            let has_compatible_abi = wheel_abi_tags.iter().any(|abi| match abi {
-                AbiTag::None => true,
-                AbiTag::Abi3T => true,
-                AbiTag::CPython { variant, .. } => {
-                    variant.contains(CPythonAbiVariants::Freethreading)
-                }
-                _ => false,
-            });
+            let has_compatible_abi = wheel_abi_tags
+                .iter()
+                .copied()
+                .any(is_freethreaded_compatible_abi);
             if !has_compatible_abi {
                 return TagCompatibility::Incompatible(IncompatibleTag::FreethreadedAbi);
             }
@@ -403,6 +408,30 @@ impl Tags {
             }
         }
         max_compatibility
+    }
+
+    /// Returns the [`TagCompatibility`] of a single wheel tag.
+    pub fn compatibility_tag(
+        &self,
+        wheel_python_tag: &LanguageTag,
+        wheel_abi_tag: &AbiTag,
+        wheel_platform_tag: &PlatformTag,
+    ) -> TagCompatibility {
+        if self.is_freethreaded && !is_freethreaded_compatible_abi(*wheel_abi_tag) {
+            return TagCompatibility::Incompatible(IncompatibleTag::FreethreadedAbi);
+        }
+
+        let Some(abis) = self.map.get(wheel_python_tag) else {
+            return TagCompatibility::Incompatible(IncompatibleTag::Python);
+        };
+        let Some(platforms) = abis.get(wheel_abi_tag) else {
+            return TagCompatibility::Incompatible(IncompatibleTag::Abi);
+        };
+        let Some(priority) = platforms.get(wheel_platform_tag).copied() else {
+            return TagCompatibility::Incompatible(IncompatibleTag::Platform);
+        };
+
+        TagCompatibility::Compatible(priority)
     }
 
     /// Return the highest-priority Python tag for the [`Tags`].
@@ -2999,5 +3028,62 @@ mod tests {
         assert!(debug_compatibility.is_compatible());
         assert!(non_debug_compatibility.is_compatible());
         assert!(debug_compatibility > non_debug_compatibility);
+    }
+
+    #[test]
+    fn test_compatibility_tag() {
+        let tags = Tags::from_env(
+            &Platform::new(
+                Os::Manylinux {
+                    major: 2,
+                    minor: 28,
+                },
+                Arch::X86_64,
+            ),
+            (3, 14),
+            "cpython",
+            (3, 14),
+            TagsOptions::default(),
+        )
+        .unwrap();
+        let python_tag = LanguageTag::from_str("cp314").unwrap();
+        let abi_tag = AbiTag::from_str("cp314").unwrap();
+        let platform_tag = PlatformTag::from_str("manylinux_2_28_x86_64").unwrap();
+
+        assert_eq!(
+            tags.compatibility_tag(&python_tag, &abi_tag, &platform_tag),
+            tags.compatibility(
+                std::slice::from_ref(&python_tag),
+                std::slice::from_ref(&abi_tag),
+                std::slice::from_ref(&platform_tag),
+            )
+        );
+
+        let free_threaded_tags = Tags::from_env(
+            &Platform::new(
+                Os::Manylinux {
+                    major: 2,
+                    minor: 28,
+                },
+                Arch::X86_64,
+            ),
+            (3, 14),
+            "cpython",
+            (3, 14),
+            TagsOptions {
+                gil_disabled: true,
+                ..TagsOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            free_threaded_tags.compatibility_tag(&python_tag, &abi_tag, &platform_tag),
+            free_threaded_tags.compatibility(
+                std::slice::from_ref(&python_tag),
+                std::slice::from_ref(&abi_tag),
+                std::slice::from_ref(&platform_tag),
+            )
+        );
     }
 }


### PR DESCRIPTION
Avoid allocating temporary tag vectors in `ExpandedTags::compatibility` by checking each wheel tag directly against the supported tag set.

This improves the focused compatibility benchmarks by ~3.8x-5.6x vs `main`:

- `small_exact`: `47.031 ns` -> `8.626 ns`
- `small_pure`: `46.330 ns` -> `8.343 ns`
- `multipart`: `55.592 ns` -> `14.776 ns`
- `small_platform_incompatible`: `46.167 ns` -> `8.308 ns`
- `separated_incompatible`: `72.540 ns` -> `17.101 ns`

Also adds a benchmark covering the common small-tag paths and incompatible multipart cases.