### PR TITLE
fix(uv): show lock mismatch error even with --quiet flag (#19326)

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -270,7 +270,7 @@ pub(crate) async fn lock(
         // Lock mismatches from `--check`/`--locked` are expected validation failures.
         // Handle them here so we return exit code 1 instead of bubbling up as an error (exit code 2).
         Err(err @ ProjectError::LockMismatch(..)) => {
-            writeln!(printer.stderr(), "{}", err.to_string().bold())?;
+            writeln!(printer.stderr_important(), "{}", err.to_string().bold())?;
             Ok(ExitStatus::Failure)
         }
         Err(ProjectError::Operation(err)) => {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -380,7 +380,7 @@ pub(crate) async fn sync(
                 Outcome::LockMismatch(prev, cur, lock_source)
             } else {
                 writeln!(
-                    printer.stderr(),
+                    printer.stderr_important(),
                     "{}",
                     ProjectError::LockMismatch(prev, cur, lock_source)
                         .to_string()
@@ -485,7 +485,7 @@ pub(crate) async fn sync(
         Outcome::Success(..) => Ok(ExitStatus::Success),
         Outcome::LockMismatch(prev, cur, lock_source) => {
             writeln!(
-                printer.stderr(),
+                printer.stderr_important(),
                 "{}",
                 ProjectError::LockMismatch(prev, cur, lock_source)
                     .to_string()


### PR DESCRIPTION
## Summary

When running `uv sync --locked --quiet`, the lock mismatch error is silently suppressed. The user sees exit code 1 but no message explaining what went wrong.

## Root Cause

`printer.stderr()` returns `Stderr::Disabled` in `--quiet` mode. The `LockMismatch` error in both `sync.rs` and `lock.rs` writes through this channel, so the message is discarded.

## Fix

Replace `printer.stderr()` with `printer.stderr_important()` in all 3 sites where `LockMismatch` is caught and displayed. `stderr_important()` is enabled in both `Quiet` and `Default` modes (only disabled in `Silent`), matching the established pattern used by `self_update.rs`.

Closes #19326