### PR TITLE
fix(uv): skip build-backend warning for in-tree backends (#20128)

### DIFF
--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -624,7 +624,8 @@ impl SourceBuild {
         }
 
         // Only show the warning for first party and URL dependencies, not for registry dependencies
-        // (which have sources disabled).
+        // (which have sources disabled). Skip the warning when `backend-path` is set, since that
+        // indicates an in-tree backend that wraps `uv_build` intentionally.
         if !no_sources.all()
             && pyproject_toml
                 .tool
@@ -632,6 +633,11 @@ impl SourceBuild {
                 .and_then(|tool| tool.uv.as_ref())
                 .is_some_and(|uv| uv.build_backend.is_some())
             && build_backend != Some("uv_build")
+            && pyproject_toml
+                .build_system
+                .as_ref()
+                .and_then(|build_system| build_system.backend_path.as_ref())
+                .is_none()
             && let Some(package_name) =
                 package_name.or(pyproject_toml.project.as_ref().map(|project| &project.name))
         {


### PR DESCRIPTION
## Summary

When using `uv build` with an in-tree build backend (one that uses `backend-path` in `[build-system]`), a warning is shown even though the in-tree backend wraps `uv_build` intentionally.

Example:
```
warning: `dpsprep` defines settings for `uv_build` in `tool.uv.build-backend`,
but uses `helpers.build_backend` as build backend instead
```

## Change

Skip the build-backend mismatch warning when `backend-path` is set in `[build-system]`, since that indicates an in-tree backend wrapping `uv_build` on purpose.

Closes #20128