### PR TITLE
Use saturating arithmetic for HTTP cache age computation

### DIFF
--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -908,7 +908,7 @@ impl ArchivedCachePolicy {
         let corrected_age_value = self.response.header_age().saturating_add(response_delay);
         let corrected_initial_age = apparent_age.max(corrected_age_value);
         let resident_age = unix_timestamp(now).saturating_sub(self.response.unix_timestamp.into());
-        let current_age = corrected_initial_age + resident_age;
+        let current_age = corrected_initial_age.saturating_add(resident_age);
         Duration::from_secs(current_age)
     }
 
@@ -1397,4 +1397,38 @@ fn parse_seconds(value: &[u8]) -> Option<u64> {
         return None;
     }
     std::str::from_utf8(value).ok()?.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// A server or proxy is free to send an arbitrarily large `Age` header, up
+    /// to `u64::MAX`. Combined with the resident age of a cached response, the
+    /// RFC 9111 S4.2.3 age computation must not overflow. Every term uses
+    /// saturating arithmetic, so the age saturates to `Duration::from_secs`
+    /// `(u64::MAX)` and the response is treated as stale rather than panicking
+    /// (debug) or wrapping around to a bogus "fresh" age (release).
+    #[test]
+    fn age_saturates_on_huge_age_header() {
+        let request =
+            reqwest::Request::new(http::Method::GET, "https://example.com/".parse().unwrap());
+        let http_response = http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header(http::header::AGE, u64::MAX.to_string())
+            .body(Vec::new())
+            .unwrap();
+        let response = reqwest::Response::from(http_response);
+
+        let policy = CachePolicyBuilder::new(&request).build(&response);
+        let archived = policy.to_archived();
+
+        // `now` must be strictly after the response timestamp so that
+        // `resident_age` is non-zero, which is the term that triggers the
+        // overflow when added to a `u64::MAX`-derived initial age.
+        let now = SystemTime::now() + Duration::from_secs(5);
+        assert_eq!(archived.age(now), Duration::from_secs(u64::MAX));
+    }
 }


### PR DESCRIPTION
The HTTP cache age calculation already uses saturating arithmetic for the adjacent RFC 9111 terms, but `current_age` used a plain `+`.

A very large `Age` header can make `corrected_initial_age` reach `u64::MAX`; adding any non-zero resident age then overflows. In debug builds that panics, and in release builds it wraps to a small value, which can make a stale cached response look fresh.

This switches the final addition to `saturating_add`, matching the rest of the function. Normal responses are unchanged; malformed or hostile ages now saturate and are treated as stale.

### Test Plan

Added a colocated regression test for `ArchivedCachePolicy::age` with `Age: u64::MAX`.

- `cargo test -p uv-client --lib`
- `cargo test -p uv-client --test it`
- `cargo clippy -p uv-client --all-targets -- -D warnings`
- `cargo fmt -p uv-client -- --check`
