### PR TITLE
move "Project dependencies" and "Dependency specifiers" text into a new standards page

### DIFF
--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -4,7 +4,8 @@
 
 Dependencies of the project are defined in several fields:
 
-- [`project.dependencies`](#project-dependencies): Published dependencies.
+- [`project.dependencies`](../../reference/standards.md#project-dependencies): Published
+  dependencies.
 - [`project.optional-dependencies`](#optional-dependencies): Published optional dependencies, or
   "extras".
 - [`dependency-groups`](#dependency-groups): Local dependencies for development.
@@ -165,37 +166,6 @@ documentation for a complete enumeration of the available markers and operators.
 !!! tip
 
     Dependency sources can also be [changed per-platform](#platform-specific-sources).
-
-## Project dependencies
-
-The `project.dependencies` table represents the dependencies that are used when uploading to PyPI or
-building a wheel. Individual dependencies are specified using
-[dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
-syntax, and the table follows the
-[PEP 621](https://packaging.python.org/en/latest/specifications/pyproject-toml/) standard.
-
-`project.dependencies` defines the list of packages that are required for the project, along with
-the version constraints that should be used when installing them. Each entry includes a dependency
-name and version. An entry may include extras or environment markers for platform-specific packages.
-For example:
-
-```toml title="pyproject.toml"
-[project]
-name = "albatross"
-version = "0.1.0"
-dependencies = [
-  # Any version in this range
-  "tqdm >=4.66.2,<5",
-  # Exactly this version of torch
-  "torch ==2.2.2",
-  # Install transformers with the torch extra
-  "transformers[torch] >=4.39.3,<5",
-  # Only install this package on older python versions
-  # See "Environment Markers" for more information
-  "importlib_metadata >=7.1.0,<8; python_version < '3.10'",
-  "mollymawk ==0.1.0"
-]
-```
 
 ## Dependency sources
 
@@ -568,8 +538,8 @@ installation of Excel parsers and `matplotlib` unless someone explicitly require
 requested with the `package[<extra>]` syntax, e.g., `pandas[plot, excel]`.
 
 Optional dependencies are specified in `[project.optional-dependencies]`, a TOML table that maps
-from extra name to its dependencies, following [dependency specifiers](#dependency-specifiers)
-syntax.
+from extra name to its dependencies, following
+[dependency specifiers](../../reference/standards.md#dependency-specifiers) syntax.
 
 Optional dependencies can have entries in `tool.uv.sources` the same as normal dependencies.
 
@@ -930,38 +900,3 @@ members = ["child"]
 ```
 
 Then `child` would be built and installed.
-
-## Dependency specifiers
-
-uv uses standard
-[dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/),
-originally defined in [PEP 508](https://peps.python.org/pep-0508/). A dependency specifier is
-composed of, in order:
-
-- The dependency name
-- The extras you want (optional)
-- The version specifier
-- An environment marker (optional)
-
-The version specifiers are comma separated and added together, e.g., `foo >=1.2.3,<2,!=1.4.0` is
-interpreted as "a version of `foo` that's at least 1.2.3, but less than 2, and not 1.4.0".
-
-Specifiers are padded with trailing zeros if required, so `foo ==2` matches foo 2.0.0, too.
-
-A star can be used for the last digit with equals, e.g., `foo ==2.1.*` will accept any release from
-the 2.1 series. Similarly, `~=` matches where the last digit is equal or higher, e.g., `foo ~=1.2`
-is equal to `foo >=1.2,<2`, and `foo ~=1.2.3` is equal to `foo >=1.2.3,<1.3`.
-
-Extras are comma-separated in square bracket between name and version, e.g.,
-`pandas[excel,plot] ==2.2`. Whitespace between extra names is ignored.
-
-Some dependencies are only required in specific environments, e.g., a specific Python version or
-operating system. For example to install the `importlib-metadata` backport for the
-`importlib.metadata` module, use `importlib-metadata >=7.1.0,<8; python_version < '3.10'`. To
-install `colorama` on Windows (but omit it on other platforms), use
-`colorama >=0.4.6,<5; platform_system == "Windows"`.
-
-Markers are combined with `and`, `or`, and parentheses, e.g.,
-`aiohttp >=3.7.4,<4; (sys_platform != 'win32' or implementation_name != 'pypy') and python_version >= '3.10'`.
-Note that versions within markers must be quoted, while versions _outside_ of markers must _not_ be
-quoted.

--- a/docs/guides/integration/renovate.md
+++ b/docs/guides/integration/renovate.md
@@ -15,7 +15,7 @@ uv is supported by [Renovate](https://github.com/renovatebot/renovate).
 
 Renovate uses the presence of a `uv.lock` file to determine that uv is used for managing
 dependencies, and will suggest upgrades to
-[project dependencies](../../concepts/projects/dependencies.md#project-dependencies),
+[project dependencies](../../reference/standards.md/#project-dependencies),
 [optional dependencies](../../concepts/projects/dependencies.md#optional-dependencies) and
 [development dependencies](../../concepts/projects/dependencies.md#development-dependencies).
 Renovate will update both the `pyproject.toml` and `uv.lock` files.

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -79,7 +79,9 @@ document$.subscribe(function () {
     "concepts/projects/#build-isolation":
       "concepts/projects/config/#build-isolation",
     "concepts/projects/dependencies/#dependency-specifiers-pep-508":
-      "concepts/projects/dependencies/#dependency-specifiers",
+      "reference/standards/#dependency-specifiers",
+    "concepts/projects/dependencies/#dependency-specifiers":
+      "reference/standards/#dependency-specifiers",
     "concepts/projects/dependencies/#importing-dependencies":
       "concepts/projects/dependencies/#importing-dependencies-from-requirements-files",
     "concepts/projects/layout/#pylock-toml":

--- a/docs/reference/standards.md
+++ b/docs/reference/standards.md
@@ -1,0 +1,65 @@
+## Project dependencies
+
+The `project.dependencies` table represents the dependencies that are used when uploading to PyPI or
+building a wheel. Individual dependencies are specified using
+[dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
+syntax, and the table follows the
+[PEP 621](https://packaging.python.org/en/latest/specifications/pyproject-toml/) standard.
+
+`project.dependencies` defines the list of packages that are required for the project, along with
+the version constraints that should be used when installing them. Each entry includes a dependency
+name and version. An entry may include extras or environment markers for platform-specific packages.
+For example:
+
+```toml title="pyproject.toml"
+[project]
+name = "albatross"
+version = "0.1.0"
+dependencies = [
+  # Any version in this range
+  "tqdm >=4.66.2,<5",
+  # Exactly this version of torch
+  "torch ==2.2.2",
+  # Install transformers with the torch extra
+  "transformers[torch] >=4.39.3,<5",
+  # Only install this package on older python versions
+  # See "Environment Markers" for more information
+  "importlib_metadata >=7.1.0,<8; python_version < '3.10'",
+  "mollymawk ==0.1.0"
+]
+```
+
+## Dependency specifiers
+
+uv uses standard
+[dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/),
+originally defined in [PEP 508](https://peps.python.org/pep-0508/). A dependency specifier is
+composed of, in order:
+
+- The dependency name
+- The extras you want (optional)
+- The version specifier
+- An environment marker (optional)
+
+The version specifiers are comma separated and added together, e.g., `foo >=1.2.3,<2,!=1.4.0` is
+interpreted as "a version of `foo` that's at least 1.2.3, but less than 2, and not 1.4.0".
+
+Specifiers are padded with trailing zeros if required, so `foo ==2` matches foo 2.0.0, too.
+
+A star can be used for the last digit with equals, e.g., `foo ==2.1.*` will accept any release from
+the 2.1 series. Similarly, `~=` matches where the last digit is equal or higher, e.g., `foo ~=1.2`
+is equal to `foo >=1.2,<2`, and `foo ~=1.2.3` is equal to `foo >=1.2.3,<1.3`.
+
+Extras are comma-separated in square bracket between name and version, e.g.,
+`pandas[excel,plot] ==2.2`. Whitespace between extra names is ignored.
+
+Some dependencies are only required in specific environments, e.g., a specific Python version or
+operating system. For example to install the `importlib-metadata` backport for the
+`importlib.metadata` module, use `importlib-metadata >=7.1.0,<8; python_version < '3.10'`. To
+install `colorama` on Windows (but omit it on other platforms), use
+`colorama >=0.4.6,<5; platform_system == "Windows"`.
+
+Markers are combined with `and`, `or`, and parentheses, e.g.,
+`aiohttp >=3.7.4,<4; (sys_platform != 'win32' or implementation_name != 'pypy') and python_version >= '3.10'`.
+Note that versions within markers must be quoted, while versions _outside_ of markers must _not_ be
+quoted.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -274,6 +274,7 @@ nav:
           - Python support: reference/policies/python.md
           - Rust support: reference/policies/rust.md
           - License: reference/policies/license.md
+      - Standards: reference/standards.md
 validation:
   omitted_files: warn
   absolute_links: warn


### PR DESCRIPTION
Resolves #15408
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
This PR moves the documentation sections "Project dependencies" and "Dependency specifiers" that were previously in uv/concepts/projects/dependencies into a new page, uv/reference/standards, as specified by #15408.

Due to changing the documentation "tree" I had to modify references to the moved sections, as well as the extra.js script. 

I also added the new "Standards" page to the mkdocs.yml nav section and formatted the files using Prettier.


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
I tested the changes in a local documentation instance built by the recommended command in CONTRIBUTING.md.
The new page is visible in the sidebar and contains the correct contents, the two sections that were moved were no longer visible in their old parent page.

I tested all references to the moved pages and they behave as expected.

