### PR TITLE
Canonicalize PEP 440 ranges for PubGrub

### DIFF
--- a/crates/uv-pep440/src/lib.rs
+++ b/crates/uv-pep440/src/lib.rs
@@ -25,7 +25,8 @@
 
 #[cfg(feature = "version-ranges")]
 pub use version_ranges::{
-    LowerBound, UpperBound, release_specifier_to_range, release_specifiers_to_ranges,
+    LowerBound, UpperBound, canonicalize_version_ranges, release_specifier_to_range,
+    release_specifiers_to_ranges,
 };
 pub use {
     version::{

--- a/crates/uv-pep440/src/lib.rs
+++ b/crates/uv-pep440/src/lib.rs
@@ -26,7 +26,7 @@
 #[cfg(feature = "version-ranges")]
 pub use version_ranges::{
     LowerBound, UpperBound, canonicalize_version_ranges, release_specifier_to_range,
-    release_specifiers_to_ranges,
+    release_specifiers_to_ranges, strip_local_version_sentinels,
 };
 pub use {
     version::{

--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -436,7 +436,7 @@ impl Version {
     /// The version `1.0min0` is smaller than all other `1.0` versions,
     /// like `1.0a1`, `1.0dev0`, etc.
     #[inline]
-    fn min(&self) -> Option<u64> {
+    pub(crate) fn min(&self) -> Option<u64> {
         match self.inner {
             VersionInner::Small { ref small } => small.min(),
             VersionInner::Full { ref full } => full.min,
@@ -449,7 +449,7 @@ impl Version {
     /// The version `1.0max0` is larger than all other `1.0` versions,
     /// like `1.0.post1`, `1.0+local`, etc.
     #[inline]
-    fn max(&self) -> Option<u64> {
+    pub(crate) fn max(&self) -> Option<u64> {
         match self.inner {
             VersionInner::Small { ref small } => small.max(),
             VersionInner::Full { ref full } => full.max,

--- a/crates/uv-pep440/src/version_ranges.rs
+++ b/crates/uv-pep440/src/version_ranges.rs
@@ -696,14 +696,7 @@ mod tests {
                 .expect("valid version for canonicalization test")
         });
 
-        for specifiers in [
-            "==1.0",
-            "!=1.0",
-            "<1.0",
-            "<=1.0",
-            ">1.0a1",
-            "<1.0.post1",
-        ] {
+        for specifiers in ["==1.0", "!=1.0", "<1.0", "<=1.0", ">1.0a1", "<1.0.post1"] {
             let range = Ranges::from(
                 specifiers
                     .parse::<VersionSpecifiers>()

--- a/crates/uv-pep440/src/version_ranges.rs
+++ b/crates/uv-pep440/src/version_ranges.rs
@@ -15,6 +15,39 @@ use crate::{
 static PEP440_MIN_VERSION: LazyLock<Version> =
     LazyLock::new(|| Version::new([0]).with_dev(Some(0)));
 
+/// Rewrite internal local-version sentinels into bounds suitable for diagnostics.
+pub fn strip_local_version_sentinels(ranges: &Ranges<Version>) -> Ranges<Version> {
+    ranges
+        .iter()
+        .map(|(lower, upper)| {
+            let lower_is_included = matches!(lower, Bound::Included(_));
+            let lower = match lower.cloned() {
+                Bound::Included(version) | Bound::Excluded(version)
+                    if version.local() == LocalVersionSlice::Max =>
+                {
+                    Bound::Excluded(version.without_local())
+                }
+                lower => lower,
+            };
+            let upper = match upper.cloned() {
+                Bound::Included(version) if version.local() == LocalVersionSlice::Max => {
+                    Bound::Included(version.without_local())
+                }
+                Bound::Excluded(version)
+                    if version.local() == LocalVersionSlice::Max && lower_is_included =>
+                {
+                    Bound::Included(version.without_local())
+                }
+                Bound::Excluded(version) if version.local() == LocalVersionSlice::Max => {
+                    Bound::Excluded(version.without_local())
+                }
+                upper => upper,
+            };
+            (lower, upper)
+        })
+        .collect()
+}
+
 /// Canonicalize the internal sentinel bounds in a version range over the PEP 440 version universe.
 ///
 /// [`Ranges`] treats its coordinate type as continuous, while PEP 440 has known least successors

--- a/crates/uv-pep440/src/version_ranges.rs
+++ b/crates/uv-pep440/src/version_ranges.rs
@@ -3,12 +3,147 @@
 use std::cmp::Ordering;
 use std::collections::Bound;
 use std::ops::Deref;
+use std::sync::LazyLock;
 use version_ranges::Ranges;
 
 use crate::{
     LocalVersion, LocalVersionSlice, Operator, Prerelease, Version, VersionSpecifier,
     VersionSpecifiers,
 };
+
+/// The smallest valid PEP 440 version.
+static PEP440_MIN_VERSION: LazyLock<Version> =
+    LazyLock::new(|| Version::new([0]).with_dev(Some(0)));
+
+/// Canonicalize the internal sentinel bounds in a version range over the PEP 440 version universe.
+///
+/// [`Ranges`] treats its coordinate type as continuous, while PEP 440 has known least successors
+/// for some otherwise-impossible internal boundary versions. Folding those boundaries onto their
+/// successor gives membership-equivalent ranges the same equality and hash representation.
+///
+/// Returns `None` when the range is already canonical.
+pub fn canonicalize_version_ranges(ranges: &Ranges<Version>) -> Option<Ranges<Version>> {
+    if !ranges.iter().any(|(lower, upper)| {
+        lower_bound_needs_canonicalization(lower) || upper_bound_needs_canonicalization(upper)
+    }) {
+        return None;
+    }
+
+    Some(
+        ranges
+            .clone()
+            .into_iter()
+            .filter_map(|(lower, upper)| {
+                let mut lower = canonicalize_lower_bound(lower);
+                let upper = canonicalize_upper_bound(upper);
+
+                match &lower {
+                    Bound::Included(version) if version <= &*PEP440_MIN_VERSION => {
+                        lower = Bound::Unbounded;
+                    }
+                    Bound::Excluded(version) if version < &*PEP440_MIN_VERSION => {
+                        lower = Bound::Unbounded;
+                    }
+                    Bound::Included(_) | Bound::Excluded(_) | Bound::Unbounded => {}
+                }
+
+                let below_floor = match &upper {
+                    Bound::Included(version) => version < &*PEP440_MIN_VERSION,
+                    Bound::Excluded(version) => version <= &*PEP440_MIN_VERSION,
+                    Bound::Unbounded => false,
+                };
+                (!below_floor).then_some((lower, upper))
+            })
+            .collect(),
+    )
+}
+
+fn lower_bound_needs_canonicalization(bound: Bound<&Version>) -> bool {
+    match bound {
+        Bound::Included(version) => {
+            version <= &*PEP440_MIN_VERSION || sentinel_successor(version).is_some()
+        }
+        Bound::Excluded(version) => {
+            version < &*PEP440_MIN_VERSION || sentinel_successor(version).is_some()
+        }
+        Bound::Unbounded => false,
+    }
+}
+
+fn upper_bound_needs_canonicalization(bound: Bound<&Version>) -> bool {
+    match bound {
+        Bound::Included(version) => {
+            version < &*PEP440_MIN_VERSION || sentinel_successor(version).is_some()
+        }
+        Bound::Excluded(version) => {
+            version <= &*PEP440_MIN_VERSION || sentinel_successor(version).is_some()
+        }
+        Bound::Unbounded => false,
+    }
+}
+
+fn canonicalize_lower_bound(bound: Bound<Version>) -> Bound<Version> {
+    match bound {
+        Bound::Included(version) => {
+            sentinel_successor(&version).map_or(Bound::Included(version), Bound::Included)
+        }
+        Bound::Excluded(version) => {
+            sentinel_successor(&version).map_or(Bound::Excluded(version), Bound::Included)
+        }
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+fn canonicalize_upper_bound(bound: Bound<Version>) -> Bound<Version> {
+    match bound {
+        Bound::Included(version) => {
+            sentinel_successor(&version).map_or(Bound::Included(version), Bound::Excluded)
+        }
+        Bound::Excluded(version) => {
+            sentinel_successor(&version).map_or(Bound::Excluded(version), Bound::Excluded)
+        }
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+/// Return the least real PEP 440 version above an internal sentinel boundary.
+fn sentinel_successor(version: &Version) -> Option<Version> {
+    if version.local() == LocalVersionSlice::Max {
+        let version = version.clone().without_local();
+        return if let Some(dev) = version.dev() {
+            Some(version.with_dev(Some(dev.checked_add(1)?)))
+        } else if let Some(post) = version.post() {
+            Some(
+                version
+                    .with_post(Some(post.checked_add(1)?))
+                    .with_dev(Some(0)),
+            )
+        } else {
+            Some(version.with_post(Some(0)).with_dev(Some(0)))
+        };
+    }
+
+    if version.min().is_some() {
+        return Some(version.clone().with_min(None).with_dev(Some(0)));
+    }
+
+    if version.max().is_some()
+        && let Some(prerelease) = version.pre()
+    {
+        return Some(
+            version
+                .clone()
+                .with_max(None)
+                .with_pre(Some(Prerelease {
+                    kind: prerelease.kind,
+                    number: prerelease.number.checked_add(1)?,
+                }))
+                .with_dev(Some(0)),
+        );
+    }
+
+    None
+}
 
 impl From<VersionSpecifiers> for Ranges<Version> {
     /// Convert [`VersionSpecifiers`] to a PubGrub-compatible version range, using PEP 440
@@ -498,6 +633,101 @@ impl From<UpperBound> for Bound<Version> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonicalizes_known_pep440_successor_boundaries() {
+        let range = |specifier: &str| {
+            let range = Ranges::from(specifier.parse::<VersionSpecifiers>().unwrap());
+            canonicalize_version_ranges(&range).unwrap_or(range)
+        };
+
+        assert_eq!(range(">1.0a1"), range(">=1.0a2.dev0"));
+        assert_eq!(range("<=1.0"), range("<1.0.post0.dev0"));
+        assert_eq!(range("==1.0"), range(">=1.0,<1.0.post0.dev0"));
+        assert_eq!(range(">=0.dev0"), Ranges::full());
+        assert_eq!(range("<0.dev0"), Ranges::empty());
+    }
+
+    #[test]
+    fn canonicalization_preserves_pep440_floor_membership() {
+        let versions = ["0.dev0", "0a0.dev0"].map(|version| {
+            version
+                .parse::<Version>()
+                .expect("valid version for floor test")
+        });
+
+        for specifiers in ["==0.dev0", "!=0.dev0", ">=0a0.dev0", "<0a0.dev0"] {
+            let range = Ranges::from(
+                specifiers
+                    .parse::<VersionSpecifiers>()
+                    .expect("valid specifiers for floor test"),
+            );
+            let canonical = canonicalize_version_ranges(&range).unwrap_or_else(|| range.clone());
+
+            for version in &versions {
+                assert_eq!(
+                    range.contains(version),
+                    canonical.contains(version),
+                    "canonicalizing `{specifiers}` changed membership for `{version}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn canonicalization_preserves_real_version_membership() {
+        let versions = [
+            "0.dev0",
+            "0a0.dev0",
+            "0.9",
+            "1.0.dev0",
+            "1.0a1.dev0",
+            "1.0a1",
+            "1.0a2.dev0",
+            "1.0",
+            "1.0+local",
+            "1.0.post0.dev0",
+            "1.0.post1.dev0",
+            "2.0",
+        ]
+        .map(|version| {
+            version
+                .parse::<Version>()
+                .expect("valid version for canonicalization test")
+        });
+
+        for specifiers in [
+            "==1.0",
+            "!=1.0",
+            "<1.0",
+            "<=1.0",
+            ">1.0a1",
+            "<1.0.post1",
+        ] {
+            let range = Ranges::from(
+                specifiers
+                    .parse::<VersionSpecifiers>()
+                    .expect("valid specifiers for canonicalization test"),
+            );
+            let canonical = canonicalize_version_ranges(&range)
+                .expect("the specifier should contain an internal sentinel");
+
+            for version in &versions {
+                assert_eq!(
+                    range.contains(version),
+                    canonical.contains(version),
+                    "canonicalizing `{specifiers}` changed membership for `{version}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn skips_ranges_without_internal_sentinels() {
+        let range = Ranges::singleton("1.0".parse::<Version>().expect("valid version"));
+
+        assert!(canonicalize_version_ranges(&range).is_none());
+    }
 
     /// Test that `<V.postN` excludes pre-releases of the base version but includes
     /// earlier post-releases and the final release.

--- a/crates/uv-pep440/src/version_ranges.rs
+++ b/crates/uv-pep440/src/version_ranges.rs
@@ -634,10 +634,18 @@ impl From<UpperBound> for Bound<Version> {
 mod tests {
     use super::*;
 
+    fn range(specifiers: &str) -> Ranges<Version> {
+        Ranges::from(specifiers.parse::<VersionSpecifiers>().unwrap())
+    }
+
+    fn version(version: &str) -> Version {
+        version.parse().unwrap()
+    }
+
     #[test]
     fn canonicalizes_known_pep440_successor_boundaries() {
-        let range = |specifier: &str| {
-            let range = Ranges::from(specifier.parse::<VersionSpecifiers>().unwrap());
+        let range = |specifiers| {
+            let range = range(specifiers);
             canonicalize_version_ranges(&range).unwrap_or(range)
         };
 
@@ -650,18 +658,10 @@ mod tests {
 
     #[test]
     fn canonicalization_preserves_pep440_floor_membership() {
-        let versions = ["0.dev0", "0a0.dev0"].map(|version| {
-            version
-                .parse::<Version>()
-                .expect("valid version for floor test")
-        });
+        let versions = ["0.dev0", "0a0.dev0"].map(version);
 
         for specifiers in ["==0.dev0", "!=0.dev0", ">=0a0.dev0", "<0a0.dev0"] {
-            let range = Ranges::from(
-                specifiers
-                    .parse::<VersionSpecifiers>()
-                    .expect("valid specifiers for floor test"),
-            );
+            let range = range(specifiers);
             let canonical = canonicalize_version_ranges(&range).unwrap_or_else(|| range.clone());
 
             for version in &versions {
@@ -690,18 +690,10 @@ mod tests {
             "1.0.post1.dev0",
             "2.0",
         ]
-        .map(|version| {
-            version
-                .parse::<Version>()
-                .expect("valid version for canonicalization test")
-        });
+        .map(version);
 
         for specifiers in ["==1.0", "!=1.0", "<1.0", "<=1.0", ">1.0a1", "<1.0.post1"] {
-            let range = Ranges::from(
-                specifiers
-                    .parse::<VersionSpecifiers>()
-                    .expect("valid specifiers for canonicalization test"),
-            );
+            let range = range(specifiers);
             let canonical = canonicalize_version_ranges(&range)
                 .expect("the specifier should contain an internal sentinel");
 
@@ -717,7 +709,7 @@ mod tests {
 
     #[test]
     fn skips_ranges_without_internal_sentinels() {
-        let range = Ranges::singleton("1.0".parse::<Version>().expect("valid version"));
+        let range = Ranges::singleton(version("1.0"));
 
         assert!(canonicalize_version_ranges(&range).is_none());
     }

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -3,7 +3,6 @@ use std::ops::Bound;
 
 use either::Either;
 use itertools::Itertools;
-use pubgrub::Range;
 use smallvec::SmallVec;
 use tracing::{debug, trace};
 
@@ -17,6 +16,7 @@ use uv_types::InstalledPackagesProvider;
 
 use crate::preferences::{Entry, PreferenceSource, Preferences};
 use crate::prerelease::{AllowPrerelease, PrereleaseStrategy};
+use crate::pubgrub::Range;
 use crate::resolution_mode::ResolutionStrategy;
 use crate::version_map::{VersionMap, VersionMapDistHandle};
 use crate::{Exclusions, Manifest, Options, ResolverEnvironment};

--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -1,10 +1,10 @@
 use std::convert::Infallible;
 
-use pubgrub::{Dependencies, DependencyProvider, PackageResolutionStatistics, Range};
+use pubgrub::{Dependencies, DependencyProvider, PackageResolutionStatistics};
 
 use uv_pep440::Version;
 
-use crate::pubgrub::{PubGrubPackage, PubGrubPriority, PubGrubTiebreaker};
+use crate::pubgrub::{PubGrubPackage, PubGrubPriority, PubGrubTiebreaker, Range};
 use crate::resolver::UnavailableReason;
 
 /// We don't use a dependency provider, we interact with state directly, but we still need this one

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, OnceLock};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use pubgrub::{DerivationTree, Derived, External, Map, Range, Ranges, Term};
+use pubgrub::{DerivationTree, Derived, External, Map, Ranges, Term};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::trace;
 
@@ -27,7 +27,7 @@ use crate::fork_indexes::ForkIndexes;
 use crate::fork_urls::ForkUrls;
 use crate::prerelease::AllowPrerelease;
 use crate::pubgrub::{
-    PubGrubHint, PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter,
+    PubGrubHint, PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter, Range,
     report_derivation_tree,
 };
 use crate::python_requirement::PythonRequirement;
@@ -526,20 +526,26 @@ impl NoSolutionError {
 
                     let versions = SentinelRange::from(&versions).strip();
                     Some(DerivationTree::External(External::NoVersions(
-                        package, versions,
+                        package,
+                        versions.into(),
                     )))
                 }
                 External::FromDependencyOf(package1, versions1, package2, versions2) => {
                     let versions1 = SentinelRange::from(&versions1).strip();
                     let versions2 = SentinelRange::from(&versions2).strip();
                     Some(DerivationTree::External(External::FromDependencyOf(
-                        package1, versions1, package2, versions2,
+                        package1,
+                        versions1.into(),
+                        package2,
+                        versions2.into(),
                     )))
                 }
                 External::Custom(package, versions, reason) => {
                     let versions = SentinelRange::from(&versions).strip();
                     Some(DerivationTree::External(External::Custom(
-                        package, versions, reason,
+                        package,
+                        versions.into(),
+                        reason,
                     )))
                 }
             },
@@ -550,10 +556,10 @@ impl NoSolutionError {
                     .map(|(package, term)| {
                         let term = match term {
                             Term::Positive(versions) => {
-                                Term::Positive(SentinelRange::from(&versions).strip())
+                                Term::Positive(SentinelRange::from(&versions).strip().into())
                             }
                             Term::Negative(versions) => {
-                                Term::Negative(SentinelRange::from(&versions).strip())
+                                Term::Negative(SentinelRange::from(&versions).strip().into())
                             }
                         };
                         (package, term)
@@ -1331,10 +1337,16 @@ fn drop_root_dependency_on_project(tree: ErrorTree, project: &PackageName) -> Er
 
 /// A version range that may include local version sentinels (`+[max]`).
 #[derive(Debug)]
-pub struct SentinelRange<'range>(&'range Range<Version>);
+pub struct SentinelRange<'range>(&'range Ranges<Version>);
 
 impl<'range> From<&'range Range<Version>> for SentinelRange<'range> {
     fn from(range: &'range Range<Version>) -> Self {
+        Self(range.versions())
+    }
+}
+
+impl<'range> From<&'range Ranges<Version>> for SentinelRange<'range> {
+    fn from(range: &'range Ranges<Version>) -> Self {
         Self(range)
     }
 }
@@ -1670,7 +1682,7 @@ fn simplify_range(
     let versions = included_versions.get(name)?;
 
     // If this is a full range, there's nothing to simplify
-    if range == &Range::full() {
+    if range.versions() == &Ranges::full() {
         return None;
     }
 
@@ -1702,20 +1714,22 @@ fn simplify_range(
     });
 
     // Simplify the range, as implemented in PubGrub
-    Some(range.simplify(versions.iter().filter(|version| {
-        // If there are pre-releases in the range segments, we need to include pre-releases
-        if any_prerelease {
-            return true;
-        }
+    Some(Range::from_versions(range.simplify(
+        versions.iter().filter(|version| {
+            // If there are pre-releases in the range segments, we need to include pre-releases
+            if any_prerelease {
+                return true;
+            }
 
-        // If pre-releases are not allowed, filter out pre-releases
-        if prereleases_not_allowed && version.any_prerelease() {
-            return false;
-        }
+            // If pre-releases are not allowed, filter out pre-releases
+            if prereleases_not_allowed && version.any_prerelease() {
+                return false;
+            }
 
-        // Otherwise, include the version
-        true
-    })))
+            // Otherwise, include the version
+            true
+        }),
+    )))
 }
 
 #[cfg(test)]

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -14,7 +14,7 @@ use uv_distribution_types::{
     DerivationChain, DistErrorKind, IndexCapabilities, IndexLocations, IndexUrl, RequestedDist,
 };
 use uv_normalize::{ExtraName, InvalidNameError, PackageName};
-use uv_pep440::{LocalVersionSlice, LowerBound, Version};
+use uv_pep440::{LowerBound, Version};
 use uv_pep508::MarkerEnvironment;
 use uv_platform_tags::Tags;
 use uv_pypi_types::ParsedUrl;
@@ -520,32 +520,26 @@ impl NoSolutionError {
             |external| match external {
                 external @ External::NotRoot(_, _) => Some(DerivationTree::External(external)),
                 External::NoVersions(package, versions) => {
-                    if SentinelRange::from(&versions).is_complement() {
+                    if versions.is_local_version_complement() {
                         return None;
                     }
 
-                    let versions = SentinelRange::from(&versions).strip();
+                    let versions = versions.without_local_version_sentinels();
                     Some(DerivationTree::External(External::NoVersions(
-                        package,
-                        versions.into(),
+                        package, versions,
                     )))
                 }
                 External::FromDependencyOf(package1, versions1, package2, versions2) => {
-                    let versions1 = SentinelRange::from(&versions1).strip();
-                    let versions2 = SentinelRange::from(&versions2).strip();
+                    let versions1 = versions1.without_local_version_sentinels();
+                    let versions2 = versions2.without_local_version_sentinels();
                     Some(DerivationTree::External(External::FromDependencyOf(
-                        package1,
-                        versions1.into(),
-                        package2,
-                        versions2.into(),
+                        package1, versions1, package2, versions2,
                     )))
                 }
                 External::Custom(package, versions, reason) => {
-                    let versions = SentinelRange::from(&versions).strip();
+                    let versions = versions.without_local_version_sentinels();
                     Some(DerivationTree::External(External::Custom(
-                        package,
-                        versions.into(),
-                        reason,
+                        package, versions, reason,
                     )))
                 }
             },
@@ -556,10 +550,10 @@ impl NoSolutionError {
                     .map(|(package, term)| {
                         let term = match term {
                             Term::Positive(versions) => {
-                                Term::Positive(SentinelRange::from(&versions).strip().into())
+                                Term::Positive(versions.without_local_version_sentinels())
                             }
                             Term::Negative(versions) => {
-                                Term::Negative(SentinelRange::from(&versions).strip().into())
+                                Term::Negative(versions.without_local_version_sentinels())
                             }
                         };
                         (package, term)
@@ -1335,140 +1329,6 @@ fn drop_root_dependency_on_project(tree: ErrorTree, project: &PackageName) -> Er
         .into_inner()
 }
 
-/// A version range that may include local version sentinels (`+[max]`).
-#[derive(Debug)]
-pub struct SentinelRange<'range>(&'range Ranges<Version>);
-
-impl<'range> From<&'range Range<Version>> for SentinelRange<'range> {
-    fn from(range: &'range Range<Version>) -> Self {
-        Self(range.raw_versions())
-    }
-}
-
-impl<'range> From<&'range Ranges<Version>> for SentinelRange<'range> {
-    fn from(range: &'range Ranges<Version>) -> Self {
-        Self(range)
-    }
-}
-
-impl SentinelRange<'_> {
-    /// Returns `true` if the range appears to be, e.g., `>=1.0.0, <1.0.0+[max]`.
-    pub(crate) fn is_sentinel(&self) -> bool {
-        self.0.iter().all(|(lower, upper)| {
-            let (Bound::Included(lower), Bound::Excluded(upper)) = (lower, upper) else {
-                return false;
-            };
-            if !lower.local().is_empty() {
-                return false;
-            }
-            if upper.local() != LocalVersionSlice::Max {
-                return false;
-            }
-            *lower == upper.clone().without_local()
-        })
-    }
-
-    /// Returns `true` if the range appears to be, e.g., `>1.0.0, <1.0.0+[max]` (i.e., a sentinel
-    /// range with the non-local version removed).
-    fn is_complement(&self) -> bool {
-        self.0.iter().all(|(lower, upper)| {
-            let (Bound::Excluded(lower), Bound::Excluded(upper)) = (lower, upper) else {
-                return false;
-            };
-            if !lower.local().is_empty() {
-                return false;
-            }
-            if upper.local() != LocalVersionSlice::Max {
-                return false;
-            }
-            *lower == upper.clone().without_local()
-        })
-    }
-
-    /// Remove local versions sentinels (`+[max]`) from the version ranges.
-    pub fn strip(&self) -> Ranges<Version> {
-        self.0
-            .iter()
-            .map(|(lower, upper)| Self::strip_sentinel(lower.cloned(), upper.cloned()))
-            .collect()
-    }
-
-    /// Remove local versions sentinels (`+[max]`) from the interval.
-    fn strip_sentinel(
-        mut lower: Bound<Version>,
-        mut upper: Bound<Version>,
-    ) -> (Bound<Version>, Bound<Version>) {
-        match (&lower, &upper) {
-            (Bound::Unbounded, Bound::Unbounded) => {}
-            (Bound::Unbounded, Bound::Included(v)) => {
-                // `<=1.0.0+[max]` is equivalent to `<=1.0.0`
-                if v.local() == LocalVersionSlice::Max {
-                    upper = Bound::Included(v.clone().without_local());
-                }
-            }
-            (Bound::Unbounded, Bound::Excluded(v)) => {
-                // `<1.0.0+[max]` is equivalent to `<1.0.0`
-                if v.local() == LocalVersionSlice::Max {
-                    upper = Bound::Excluded(v.clone().without_local());
-                }
-            }
-            (Bound::Included(v), Bound::Unbounded) => {
-                // `>=1.0.0+[max]` is equivalent to `>1.0.0`
-                if v.local() == LocalVersionSlice::Max {
-                    lower = Bound::Excluded(v.clone().without_local());
-                }
-            }
-            (Bound::Included(v), Bound::Included(b)) => {
-                // `>=1.0.0+[max]` is equivalent to `>1.0.0`
-                if v.local() == LocalVersionSlice::Max {
-                    lower = Bound::Excluded(v.clone().without_local());
-                }
-                // `<=1.0.0+[max]` is equivalent to `<=1.0.0`
-                if b.local() == LocalVersionSlice::Max {
-                    upper = Bound::Included(b.clone().without_local());
-                }
-            }
-            (Bound::Included(v), Bound::Excluded(b)) => {
-                // `>=1.0.0+[max]` is equivalent to `>1.0.0`
-                if v.local() == LocalVersionSlice::Max {
-                    lower = Bound::Excluded(v.clone().without_local());
-                }
-                // `<1.0.0+[max]` is equivalent to `<1.0.0`
-                if b.local() == LocalVersionSlice::Max {
-                    upper = Bound::Included(b.clone().without_local());
-                }
-            }
-            (Bound::Excluded(v), Bound::Unbounded) => {
-                // `>1.0.0+[max]` is equivalent to `>1.0.0`
-                if v.local() == LocalVersionSlice::Max {
-                    lower = Bound::Excluded(v.clone().without_local());
-                }
-            }
-            (Bound::Excluded(v), Bound::Included(b)) => {
-                // `>1.0.0+[max]` is equivalent to `>1.0.0`
-                if v.local() == LocalVersionSlice::Max {
-                    lower = Bound::Excluded(v.clone().without_local());
-                }
-                // `<=1.0.0+[max]` is equivalent to `<=1.0.0`
-                if b.local() == LocalVersionSlice::Max {
-                    upper = Bound::Included(b.clone().without_local());
-                }
-            }
-            (Bound::Excluded(v), Bound::Excluded(b)) => {
-                // `>1.0.0+[max]` is equivalent to `>1.0.0`
-                if v.local() == LocalVersionSlice::Max {
-                    lower = Bound::Excluded(v.clone().without_local());
-                }
-                // `<1.0.0+[max]` is equivalent to `<1.0.0`
-                if b.local() == LocalVersionSlice::Max {
-                    upper = Bound::Excluded(b.clone().without_local());
-                }
-            }
-        }
-        (lower, upper)
-    }
-}
-
 /// A prefix match, e.g., `==2.4.*`, which is desugared to a range like `>=2.4.dev0,<2.5.dev0`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PrefixMatch<'a> {
@@ -1682,7 +1542,7 @@ fn simplify_range(
     let versions = included_versions.get(name)?;
 
     // If this is a full range, there's nothing to simplify
-    if range.raw_versions() == &Ranges::full() {
+    if range.encoded_versions() == &Ranges::full() {
         return None;
     }
 

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1341,7 +1341,7 @@ pub struct SentinelRange<'range>(&'range Ranges<Version>);
 
 impl<'range> From<&'range Range<Version>> for SentinelRange<'range> {
     fn from(range: &'range Range<Version>) -> Self {
-        Self(range.versions())
+        Self(range.raw_versions())
     }
 }
 
@@ -1682,7 +1682,7 @@ fn simplify_range(
     let versions = included_versions.get(name)?;
 
     // If this is a full range, there's nothing to simplify
-    if range.versions() == &Ranges::full() {
+    if range.raw_versions() == &Ranges::full() {
         return None;
     }
 

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -1,5 +1,5 @@
 pub use dependency_mode::DependencyMode;
-pub use error::{ErrorTree, NoSolutionError, NoSolutionHeader, ResolveError, SentinelRange};
+pub use error::{ErrorTree, NoSolutionError, NoSolutionHeader, ResolveError};
 pub use exclude_newer::{
     ExcludeNewer, ExcludeNewerChange, ExcludeNewerOverrideChange, ExcludeNewerPackage,
     ExcludeNewerPackageChange, ExcludeNewerPackageEntry, ExcludeNewerValueChange,

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::iter;
 
 use either::Either;
-use pubgrub::Ranges;
 
 use uv_distribution_types::{IndexMetadata, Requirement, RequirementSource};
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -13,7 +12,7 @@ use uv_pypi_types::{
     ParsedGitPathUrl, ParsedPathUrl, ParsedUrl, VerbatimParsedUrl,
 };
 
-use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner};
+use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, Range};
 use crate::resolver::UnsatisfiableRequirement;
 
 /// The source constraint carried by a single dependency edge.
@@ -84,7 +83,7 @@ impl DependencySource {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct PubGrubDependency {
     pub(crate) package: PubGrubPackage,
-    pub(crate) version: Ranges<Version>,
+    pub(crate) version: Range<Version>,
 
     /// When the parent that created this dependency is a "normal" package
     /// (non-extra non-group), this corresponds to its name.
@@ -272,7 +271,7 @@ impl PubGrubDependency {
 #[derive(Debug, Clone)]
 struct PubGrubRequirement {
     package: PubGrubPackage,
-    version: Ranges<Version>,
+    version: Range<Version>,
     source: DependencySource,
 }
 
@@ -363,7 +362,7 @@ impl PubGrubRequirement {
 
         Self {
             package: Self::package_for_requirement(requirement, extra, group),
-            version: Ranges::full(),
+            version: Range::full(),
             source: DependencySource::Url(Box::new(VerbatimParsedUrl {
                 parsed_url,
                 verbatim: verbatim_url.clone(),
@@ -380,7 +379,7 @@ impl PubGrubRequirement {
         Self {
             package: Self::package_for_requirement(requirement, extra, group),
             source: DependencySource::from_requirement(requirement),
-            version: Ranges::from(specifier.clone()),
+            version: Range::from(specifier.clone()),
         }
     }
 }

--- a/crates/uv-resolver/src/pubgrub/mod.rs
+++ b/crates/uv-resolver/src/pubgrub/mod.rs
@@ -1,10 +1,12 @@
 pub(crate) use crate::pubgrub::dependencies::{DependencySource, PubGrubDependency};
 pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
 pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority, PubGrubTiebreaker};
+pub(crate) use crate::pubgrub::range::Range;
 pub use crate::pubgrub::report::PubGrubHint;
 pub(crate) use crate::pubgrub::report::{PubGrubReportFormatter, report as report_derivation_tree};
 
 mod dependencies;
 mod package;
 mod priority;
+mod range;
 mod report;

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -1,7 +1,7 @@
 use std::cmp::Reverse;
 
 use hashbrown::hash_map::{EntryRef, OccupiedEntry};
-use pubgrub::{DependencyProvider, Range};
+use pubgrub::DependencyProvider;
 use rustc_hash::FxBuildHasher;
 
 use uv_normalize::PackageName;
@@ -9,7 +9,7 @@ use uv_pep440::Version;
 
 use crate::dependency_provider::UvDependencyProvider;
 use crate::fork_urls::ForkUrls;
-use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
+use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubPython, Range};
 use crate::{FxHashbrownMap, SentinelRange};
 
 /// A prioritization map to guide the PubGrub resolution process.

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -7,10 +7,10 @@ use rustc_hash::FxBuildHasher;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 
+use crate::FxHashbrownMap;
 use crate::dependency_provider::UvDependencyProvider;
 use crate::fork_urls::ForkUrls;
 use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubPython, Range};
-use crate::{FxHashbrownMap, SentinelRange};
 
 /// A prioritization map to guide the PubGrub resolution process.
 ///
@@ -61,9 +61,7 @@ impl PubGrubPriorities {
                 // Compute the priority.
                 let priority = if urls.get(name).is_some() {
                     PubGrubPriority::DirectUrl(Reverse(index))
-                } else if version.as_singleton().is_some()
-                    || SentinelRange::from(version).is_sentinel()
-                {
+                } else if version.is_singleton_constraint() {
                     PubGrubPriority::Singleton(Reverse(index))
                 } else {
                     // Keep the conflict-causing packages to avoid loops where we seesaw between
@@ -86,9 +84,7 @@ impl PubGrubPriorities {
                 // Compute the priority.
                 let priority = if urls.get(name).is_some() {
                     PubGrubPriority::DirectUrl(Reverse(len))
-                } else if version.as_singleton().is_some()
-                    || SentinelRange::from(version).is_sentinel()
-                {
+                } else if version.is_singleton_constraint() {
                     PubGrubPriority::Singleton(Reverse(len))
                 } else {
                     PubGrubPriority::Unspecified(Reverse(len))

--- a/crates/uv-resolver/src/pubgrub/range.rs
+++ b/crates/uv-resolver/src/pubgrub/range.rs
@@ -1,0 +1,295 @@
+use std::fmt::{Debug, Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::ops::{Bound, Deref, RangeBounds};
+
+use pubgrub::{Ranges, SetRelation, VersionSet};
+
+use uv_pep440::{Version, VersionSpecifiers, canonicalize_version_ranges};
+
+/// A PEP 440 version range with separate representations for diagnostics and PubGrub reasoning.
+///
+/// `versions` retains the original sentinel bounds used to format PEP 440 constraints, while
+/// `canonical_versions` folds those sentinels onto their least valid successors. PubGrub uses the
+/// canonical representation for equality, hashing, and set relations.
+#[derive(Clone, Debug)]
+pub struct Range<T> {
+    versions: Ranges<T>,
+    canonical_versions: Option<Box<Ranges<T>>>,
+}
+
+impl<T> Range<T> {
+    fn logical_versions(&self) -> &Ranges<T> {
+        self.canonical_versions.as_deref().unwrap_or(&self.versions)
+    }
+}
+
+impl<T: PartialEq> PartialEq for Range<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.logical_versions() == other.logical_versions()
+    }
+}
+
+impl<T: Eq> Eq for Range<T> {}
+
+impl<T: Hash> Hash for Range<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.logical_versions().hash(state);
+    }
+}
+
+impl<T> Deref for Range<T> {
+    type Target = Ranges<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.versions
+    }
+}
+
+impl Range<Version> {
+    fn from_parts(versions: Ranges<Version>, canonical_versions: Option<Ranges<Version>>) -> Self {
+        let canonical_versions = canonical_versions
+            .filter(|canonical| canonical != &versions)
+            .map(Box::new);
+        Self {
+            versions,
+            canonical_versions,
+        }
+    }
+
+    fn from_canonical_versions(versions: Ranges<Version>) -> Self {
+        Self {
+            versions,
+            canonical_versions: None,
+        }
+    }
+
+    /// Create a range from its diagnostic representation.
+    pub(crate) fn from_versions(versions: Ranges<Version>) -> Self {
+        let canonical_versions = canonicalize_version_ranges(&versions);
+        Self::from_parts(versions, canonical_versions)
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self::from_canonical_versions(Ranges::empty())
+    }
+
+    pub(crate) fn full() -> Self {
+        Self::from_canonical_versions(Ranges::full())
+    }
+
+    pub(crate) fn singleton(version: Version) -> Self {
+        Self::from_versions(Ranges::singleton(version))
+    }
+
+    pub(crate) fn from_range_bounds(range: impl RangeBounds<Version>) -> Self {
+        Self::from_versions(Ranges::from_range_bounds(range))
+    }
+
+    pub(crate) fn strictly_lower_than(version: Version) -> Self {
+        Self::from_versions(Ranges::strictly_lower_than(version))
+    }
+
+    pub(crate) fn strictly_higher_than(version: Version) -> Self {
+        Self::from_versions(Ranges::strictly_higher_than(version))
+    }
+
+    /// Return the original PEP 440 bounds used for candidate iteration and diagnostics.
+    pub(crate) fn versions(&self) -> &Ranges<Version> {
+        &self.versions
+    }
+
+    pub(crate) fn complement(&self) -> Self {
+        Self::from_parts(
+            self.versions.complement(),
+            self.canonical_versions.as_deref().map(Ranges::complement),
+        )
+    }
+
+    pub(crate) fn intersection(&self, other: &Self) -> Self {
+        self.binary_op(other, Ranges::intersection)
+    }
+
+    pub(crate) fn union(&self, other: &Self) -> Self {
+        self.binary_op(other, Ranges::union)
+    }
+
+    fn binary_op(
+        &self,
+        other: &Self,
+        operation: impl Fn(&Ranges<Version>, &Ranges<Version>) -> Ranges<Version>,
+    ) -> Self {
+        let versions = operation(&self.versions, &other.versions);
+        let canonical_versions = (self.canonical_versions.is_some()
+            || other.canonical_versions.is_some())
+        .then(|| operation(self.logical_versions(), other.logical_versions()));
+        Self::from_parts(versions, canonical_versions)
+    }
+}
+
+impl From<Ranges<Version>> for Range<Version> {
+    fn from(versions: Ranges<Version>) -> Self {
+        Self::from_versions(versions)
+    }
+}
+
+impl FromIterator<(Bound<Version>, Bound<Version>)> for Range<Version> {
+    fn from_iter<I: IntoIterator<Item = (Bound<Version>, Bound<Version>)>>(iter: I) -> Self {
+        Self::from_versions(iter.into_iter().collect())
+    }
+}
+
+impl From<VersionSpecifiers> for Range<Version> {
+    fn from(specifiers: VersionSpecifiers) -> Self {
+        Self::from_versions(Ranges::from(specifiers))
+    }
+}
+
+impl VersionSet for Range<Version> {
+    type V = Version;
+
+    fn empty() -> Self {
+        Self::empty()
+    }
+
+    fn singleton(version: Self::V) -> Self {
+        Self::singleton(version)
+    }
+
+    fn complement(&self) -> Self {
+        Self::complement(self)
+    }
+
+    fn intersection(&self, other: &Self) -> Self {
+        Self::intersection(self, other)
+    }
+
+    fn contains(&self, version: &Self::V) -> bool {
+        self.versions.contains(version)
+    }
+
+    fn full() -> Self {
+        Self::full()
+    }
+
+    fn union(&self, other: &Self) -> Self {
+        Self::union(self, other)
+    }
+
+    fn is_disjoint(&self, other: &Self) -> bool {
+        self.logical_versions()
+            .is_disjoint(other.logical_versions())
+    }
+
+    fn subset_of(&self, other: &Self) -> bool {
+        self.logical_versions().subset_of(other.logical_versions())
+    }
+
+    fn relation(&self, other: &Self) -> SetRelation {
+        self.logical_versions().relation(other.logical_versions())
+    }
+}
+
+impl<T: Debug + Display + Clone + Eq + Ord> Display for Range<T> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.versions, formatter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::str::FromStr;
+
+    use pubgrub::{Ranges, VersionSet};
+
+    use super::Range;
+    use uv_pep440::{Version, VersionSpecifiers, canonicalize_version_ranges};
+
+    fn range(specifiers: &str) -> Range<Version> {
+        Range::from(
+            VersionSpecifiers::from_str(specifiers).expect("valid version specifiers for test"),
+        )
+    }
+
+    fn version(version: &str) -> Version {
+        Version::from_str(version).expect("valid version")
+    }
+
+    fn hash(range: &Range<Version>) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        range.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn equivalent_pep440_ranges_have_canonical_identity() {
+        for (left, right) in [
+            (">1.0a1", ">=1.0a2.dev0"),
+            ("<=1.0", "<1.0.post0.dev0"),
+            ("==1.0", ">=1.0,<1.0.post0.dev0"),
+        ] {
+            let left = range(left);
+            let right = range(right);
+
+            assert_eq!(left, right);
+            assert_eq!(hash(&left), hash(&right));
+            assert!(left.subset_of(&right));
+            assert!(right.subset_of(&left));
+        }
+    }
+
+    #[test]
+    fn canonical_identity_preserves_original_bounds() {
+        let raw = Ranges::from(
+            VersionSpecifiers::from_str("<=1.0").expect("valid version specifiers for test"),
+        );
+        let range = Range::from(raw.clone());
+
+        assert_eq!(range.versions(), &raw);
+        assert_eq!(range.to_string(), raw.to_string());
+        assert_ne!(range.versions(), range.logical_versions());
+    }
+
+    #[test]
+    fn range_algebra_preserves_canonical_identity() {
+        let ranges = [
+            "==0.dev0",
+            "!=0.dev0",
+            "<=1.0",
+            "<1.0.post0.dev0",
+            "<1.0",
+            "<1.0.dev0",
+            ">1.0a1",
+            ">=1.0a2.dev0",
+            "==1.0",
+            ">=2.0b1,<3",
+            ">=3.5,<4",
+        ]
+        .map(range);
+
+        for left in &ranges {
+            assert_matches_recanonicalized(&left.complement());
+            for right in &ranges {
+                assert_matches_recanonicalized(&left.intersection(right));
+                assert_matches_recanonicalized(&left.union(right));
+            }
+        }
+    }
+
+    fn assert_matches_recanonicalized(range: &Range<Version>) {
+        let canonical_versions =
+            canonicalize_version_ranges(&range.versions).unwrap_or_else(|| range.versions.clone());
+        assert_eq!(range.logical_versions(), &canonical_versions);
+    }
+
+    #[test]
+    fn pep440_floor_is_not_logically_empty() {
+        let floor = version("0.dev0");
+        let range = range("==0.dev0");
+
+        assert!(range.contains(&floor));
+        assert!(!range.is_disjoint(&Range::singleton(floor)));
+        assert_ne!(range, Range::empty());
+    }
+}

--- a/crates/uv-resolver/src/pubgrub/range.rs
+++ b/crates/uv-resolver/src/pubgrub/range.rs
@@ -107,6 +107,16 @@ impl Range<Version> {
         Self::from_versions(Ranges::strictly_higher_than(version))
     }
 
+    /// Widen this range across gaps in the known versions while preserving canonical identity.
+    pub(crate) fn widen_versions(&self, versions: &[Version]) -> Self {
+        Self::from_versions(self.encoded_versions.widen_versions(versions))
+    }
+
+    /// Narrow this range onto the known versions while preserving canonical identity.
+    pub(crate) fn narrow_versions(&self, versions: &[Version]) -> Self {
+        Self::from_versions(self.encoded_versions.narrow_versions(versions))
+    }
+
     /// Return the internal PEP 440 bounds used for candidate iteration.
     pub(crate) fn encoded_versions(&self) -> &Ranges<Version> {
         &self.encoded_versions
@@ -361,6 +371,26 @@ mod tests {
                 assert_matches_recanonicalized(&left.union(right));
             }
         }
+    }
+
+    #[test]
+    fn known_version_projection_preserves_canonical_identity() {
+        let versions = [version("0.dev0"), version("1.0"), version("2.0")];
+        let encoded = range("<=1.0");
+        let canonical = range("<1.0.post0.dev0");
+
+        assert_eq!(
+            encoded.widen_versions(&versions),
+            canonical.widen_versions(&versions)
+        );
+        assert_eq!(
+            encoded.narrow_versions(&versions),
+            canonical.narrow_versions(&versions)
+        );
+
+        let empty = range("<0.dev0");
+        assert_eq!(empty.widen_versions(&versions), Range::empty());
+        assert_eq!(empty.narrow_versions(&versions), Range::empty());
     }
 
     fn assert_matches_recanonicalized(range: &Range<Version>) {

--- a/crates/uv-resolver/src/pubgrub/range.rs
+++ b/crates/uv-resolver/src/pubgrub/range.rs
@@ -4,27 +4,31 @@ use std::ops::{Bound, Deref, RangeBounds};
 
 use pubgrub::{Ranges, SetRelation, VersionSet};
 
-use uv_pep440::{Version, VersionSpecifiers, canonicalize_version_ranges};
+use uv_pep440::{
+    LocalVersionSlice, Version, VersionSpecifiers, canonicalize_version_ranges,
+    strip_local_version_sentinels,
+};
 
-/// A PEP 440 version range with separate representations for diagnostics and PubGrub reasoning.
+/// A PEP 440 version range with encoded and canonical representations.
 ///
-/// `raw_versions` retains the original sentinel bounds used to format PEP 440 constraints, while
-/// `canonical_versions` folds those sentinels onto their least valid successors. PubGrub uses the
-/// canonical representation for equality, hashing, and set relations.
+/// `encoded_versions` retains the internal sentinel bounds required for candidate membership and
+/// as the source for a lossy diagnostic projection. `canonical_versions` folds those sentinels
+/// onto their least valid successors. PubGrub uses the canonical representation for equality,
+/// hashing, and set relations.
 #[derive(Clone, Debug)]
 pub struct Range<T> {
-    raw_versions: Ranges<T>,
+    encoded_versions: Ranges<T>,
     canonical_versions: Option<Box<Ranges<T>>>,
 }
 
 impl<T> Range<T> {
     /// Return the canonical set used for identity and set relationships.
     ///
-    /// Ranges that do not need canonicalization reuse their raw representation.
+    /// Ranges that do not need canonicalization reuse their encoded representation.
     fn logical_versions(&self) -> &Ranges<T> {
         self.canonical_versions
             .as_deref()
-            .unwrap_or(&self.raw_versions)
+            .unwrap_or(&self.encoded_versions)
     }
 }
 
@@ -46,34 +50,34 @@ impl<T> Deref for Range<T> {
     type Target = Ranges<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.raw_versions
+        &self.encoded_versions
     }
 }
 
 impl Range<Version> {
     /// Construct a [`Range`], omitting a redundant canonical representation.
     fn from_parts(
-        raw_versions: Ranges<Version>,
+        encoded_versions: Ranges<Version>,
         canonical_versions: Option<Ranges<Version>>,
     ) -> Self {
         let canonical_versions = canonical_versions
-            .filter(|canonical| canonical != &raw_versions)
+            .filter(|canonical| canonical != &encoded_versions)
             .map(Box::new);
         Self {
-            raw_versions,
+            encoded_versions,
             canonical_versions,
         }
     }
 
-    /// Construct a [`Range`] whose raw representation is already canonical.
+    /// Construct a [`Range`] whose encoded representation is already canonical.
     fn from_canonical_versions(versions: Ranges<Version>) -> Self {
         Self {
-            raw_versions: versions,
+            encoded_versions: versions,
             canonical_versions: None,
         }
     }
 
-    /// Create a range from its diagnostic representation.
+    /// Create a range from its internal PEP 440 encoding.
     pub(crate) fn from_versions(versions: Ranges<Version>) -> Self {
         let canonical_versions = canonicalize_version_ranges(&versions);
         Self::from_parts(versions, canonical_versions)
@@ -103,14 +107,51 @@ impl Range<Version> {
         Self::from_versions(Ranges::strictly_higher_than(version))
     }
 
-    /// Return the original PEP 440 bounds used for candidate iteration and diagnostics.
-    pub(crate) fn raw_versions(&self) -> &Ranges<Version> {
-        &self.raw_versions
+    /// Return the internal PEP 440 bounds used for candidate iteration.
+    pub(crate) fn encoded_versions(&self) -> &Ranges<Version> {
+        &self.encoded_versions
+    }
+
+    /// Return `true` if this range represents a single PEP 440 version constraint.
+    ///
+    /// A constraint like `==1.0` includes local versions such as `1.0+local`, so its encoded range
+    /// is not a singleton even though it should be prioritized like a pinned requirement.
+    pub(crate) fn is_singleton_constraint(&self) -> bool {
+        self.encoded_versions.as_singleton().is_some() || self.is_local_version_sentinel()
+    }
+
+    /// Return `true` if this range represents one or more exact public-version constraints.
+    fn is_local_version_sentinel(&self) -> bool {
+        self.encoded_versions.iter().all(|(lower, upper)| {
+            let (Bound::Included(lower), Bound::Excluded(upper)) = (lower, upper) else {
+                return false;
+            };
+            lower.local().is_empty()
+                && upper.local() == LocalVersionSlice::Max
+                && *lower == upper.clone().without_local()
+        })
+    }
+
+    /// Return `true` if this range contains only local versions of the same public version.
+    pub(crate) fn is_local_version_complement(&self) -> bool {
+        self.encoded_versions.iter().all(|(lower, upper)| {
+            let (Bound::Excluded(lower), Bound::Excluded(upper)) = (lower, upper) else {
+                return false;
+            };
+            lower.local().is_empty()
+                && upper.local() == LocalVersionSlice::Max
+                && *lower == upper.clone().without_local()
+        })
+    }
+
+    /// Rewrite internal local-version sentinels into bounds suitable for diagnostics.
+    pub(crate) fn without_local_version_sentinels(&self) -> Self {
+        Self::from_versions(strip_local_version_sentinels(&self.encoded_versions))
     }
 
     pub(crate) fn complement(&self) -> Self {
         Self::from_parts(
-            self.raw_versions.complement(),
+            self.encoded_versions.complement(),
             self.canonical_versions.as_deref().map(Ranges::complement),
         )
     }
@@ -125,18 +166,19 @@ impl Range<Version> {
 
     /// Apply a set operation to both representations while preserving their equivalence.
     ///
-    /// The raw result retains sentinel bounds for iteration and diagnostics, while the logical
-    /// result keeps subsequent PubGrub operations congruent with canonical equality.
+    /// The encoded result retains sentinel bounds for candidate membership and diagnostic
+    /// projection, while the logical result keeps subsequent PubGrub operations congruent with
+    /// canonical equality.
     fn binary_op(
         &self,
         other: &Self,
         operation: impl Fn(&Ranges<Version>, &Ranges<Version>) -> Ranges<Version>,
     ) -> Self {
-        let raw_versions = operation(&self.raw_versions, &other.raw_versions);
+        let encoded_versions = operation(&self.encoded_versions, &other.encoded_versions);
         let canonical_versions = (self.canonical_versions.is_some()
             || other.canonical_versions.is_some())
         .then(|| operation(self.logical_versions(), other.logical_versions()));
-        Self::from_parts(raw_versions, canonical_versions)
+        Self::from_parts(encoded_versions, canonical_versions)
     }
 }
 
@@ -178,7 +220,7 @@ impl VersionSet for Range<Version> {
     }
 
     fn contains(&self, version: &Self::V) -> bool {
-        self.raw_versions.contains(version)
+        self.encoded_versions.contains(version)
     }
 
     fn full() -> Self {
@@ -205,7 +247,7 @@ impl VersionSet for Range<Version> {
 
 impl<T: Debug + Display + Clone + Eq + Ord> Display for Range<T> {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.raw_versions, formatter)
+        Display::fmt(&self.encoded_versions, formatter)
     }
 }
 
@@ -255,14 +297,38 @@ mod tests {
 
     #[test]
     fn canonical_identity_preserves_original_bounds() {
-        let raw = Ranges::from(
+        let encoded = Ranges::from(
             VersionSpecifiers::from_str("<=1.0").expect("valid version specifiers for test"),
         );
-        let range = Range::from(raw.clone());
+        let range = Range::from(encoded.clone());
 
-        assert_eq!(range.raw_versions(), &raw);
-        assert_eq!(range.to_string(), raw.to_string());
-        assert_ne!(range.raw_versions(), range.logical_versions());
+        assert_eq!(range.encoded_versions(), &encoded);
+        assert_eq!(range.to_string(), encoded.to_string());
+        assert_ne!(range.encoded_versions(), range.logical_versions());
+    }
+
+    #[test]
+    fn diagnostic_ranges_hide_local_version_sentinels() {
+        let equality = range("==1.0");
+        assert_eq!(equality.encoded_versions().to_string(), ">=1.0, <1.0+");
+        assert_eq!(
+            equality.without_local_version_sentinels().to_string(),
+            "==1.0"
+        );
+
+        let upper_bound = range("<=1.0");
+        assert_eq!(upper_bound.encoded_versions().to_string(), "<=1.0+");
+        assert_eq!(
+            upper_bound.without_local_version_sentinels().to_string(),
+            "<=1.0"
+        );
+    }
+
+    #[test]
+    fn public_version_equality_is_a_singleton_constraint() {
+        assert!(range("==1.0").is_singleton_constraint());
+        assert!(Range::singleton(version("1.0+local")).is_singleton_constraint());
+        assert!(!range(">=1.0").is_singleton_constraint());
     }
 
     #[test]
@@ -292,8 +358,8 @@ mod tests {
     }
 
     fn assert_matches_recanonicalized(range: &Range<Version>) {
-        let canonical_versions = canonicalize_version_ranges(&range.raw_versions)
-            .unwrap_or_else(|| range.raw_versions.clone());
+        let canonical_versions = canonicalize_version_ranges(&range.encoded_versions)
+            .unwrap_or_else(|| range.encoded_versions.clone());
         assert_eq!(range.logical_versions(), &canonical_versions);
     }
 

--- a/crates/uv-resolver/src/pubgrub/range.rs
+++ b/crates/uv-resolver/src/pubgrub/range.rs
@@ -8,18 +8,20 @@ use uv_pep440::{Version, VersionSpecifiers, canonicalize_version_ranges};
 
 /// A PEP 440 version range with separate representations for diagnostics and PubGrub reasoning.
 ///
-/// `versions` retains the original sentinel bounds used to format PEP 440 constraints, while
+/// `raw_versions` retains the original sentinel bounds used to format PEP 440 constraints, while
 /// `canonical_versions` folds those sentinels onto their least valid successors. PubGrub uses the
 /// canonical representation for equality, hashing, and set relations.
 #[derive(Clone, Debug)]
 pub struct Range<T> {
-    versions: Ranges<T>,
+    raw_versions: Ranges<T>,
     canonical_versions: Option<Box<Ranges<T>>>,
 }
 
 impl<T> Range<T> {
     fn logical_versions(&self) -> &Ranges<T> {
-        self.canonical_versions.as_deref().unwrap_or(&self.versions)
+        self.canonical_versions
+            .as_deref()
+            .unwrap_or(&self.raw_versions)
     }
 }
 
@@ -41,24 +43,27 @@ impl<T> Deref for Range<T> {
     type Target = Ranges<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.versions
+        &self.raw_versions
     }
 }
 
 impl Range<Version> {
-    fn from_parts(versions: Ranges<Version>, canonical_versions: Option<Ranges<Version>>) -> Self {
+    fn from_parts(
+        raw_versions: Ranges<Version>,
+        canonical_versions: Option<Ranges<Version>>,
+    ) -> Self {
         let canonical_versions = canonical_versions
-            .filter(|canonical| canonical != &versions)
+            .filter(|canonical| canonical != &raw_versions)
             .map(Box::new);
         Self {
-            versions,
+            raw_versions,
             canonical_versions,
         }
     }
 
     fn from_canonical_versions(versions: Ranges<Version>) -> Self {
         Self {
-            versions,
+            raw_versions: versions,
             canonical_versions: None,
         }
     }
@@ -94,13 +99,13 @@ impl Range<Version> {
     }
 
     /// Return the original PEP 440 bounds used for candidate iteration and diagnostics.
-    pub(crate) fn versions(&self) -> &Ranges<Version> {
-        &self.versions
+    pub(crate) fn raw_versions(&self) -> &Ranges<Version> {
+        &self.raw_versions
     }
 
     pub(crate) fn complement(&self) -> Self {
         Self::from_parts(
-            self.versions.complement(),
+            self.raw_versions.complement(),
             self.canonical_versions.as_deref().map(Ranges::complement),
         )
     }
@@ -118,11 +123,11 @@ impl Range<Version> {
         other: &Self,
         operation: impl Fn(&Ranges<Version>, &Ranges<Version>) -> Ranges<Version>,
     ) -> Self {
-        let versions = operation(&self.versions, &other.versions);
+        let raw_versions = operation(&self.raw_versions, &other.raw_versions);
         let canonical_versions = (self.canonical_versions.is_some()
             || other.canonical_versions.is_some())
         .then(|| operation(self.logical_versions(), other.logical_versions()));
-        Self::from_parts(versions, canonical_versions)
+        Self::from_parts(raw_versions, canonical_versions)
     }
 }
 
@@ -164,7 +169,7 @@ impl VersionSet for Range<Version> {
     }
 
     fn contains(&self, version: &Self::V) -> bool {
-        self.versions.contains(version)
+        self.raw_versions.contains(version)
     }
 
     fn full() -> Self {
@@ -191,7 +196,7 @@ impl VersionSet for Range<Version> {
 
 impl<T: Debug + Display + Clone + Eq + Ord> Display for Range<T> {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.versions, formatter)
+        Display::fmt(&self.raw_versions, formatter)
     }
 }
 
@@ -246,9 +251,9 @@ mod tests {
         );
         let range = Range::from(raw.clone());
 
-        assert_eq!(range.versions(), &raw);
+        assert_eq!(range.raw_versions(), &raw);
         assert_eq!(range.to_string(), raw.to_string());
-        assert_ne!(range.versions(), range.logical_versions());
+        assert_ne!(range.raw_versions(), range.logical_versions());
     }
 
     #[test]
@@ -278,8 +283,8 @@ mod tests {
     }
 
     fn assert_matches_recanonicalized(range: &Range<Version>) {
-        let canonical_versions =
-            canonicalize_version_ranges(&range.versions).unwrap_or_else(|| range.versions.clone());
+        let canonical_versions = canonicalize_version_ranges(&range.raw_versions)
+            .unwrap_or_else(|| range.raw_versions.clone());
         assert_eq!(range.logical_versions(), &canonical_versions);
     }
 

--- a/crates/uv-resolver/src/pubgrub/range.rs
+++ b/crates/uv-resolver/src/pubgrub/range.rs
@@ -116,19 +116,25 @@ impl Range<Version> {
     ///
     /// A constraint like `==1.0` includes local versions such as `1.0+local`, so its encoded range
     /// is not a singleton even though it should be prioritized like a pinned requirement.
+    #[inline]
     pub(crate) fn is_singleton_constraint(&self) -> bool {
         self.encoded_versions.as_singleton().is_some() || self.is_local_version_sentinel()
     }
 
     /// Return `true` if this range represents one or more exact public-version constraints.
+    #[inline]
     fn is_local_version_sentinel(&self) -> bool {
         self.encoded_versions.iter().all(|(lower, upper)| {
             let (Bound::Included(lower), Bound::Excluded(upper)) = (lower, upper) else {
                 return false;
             };
-            lower.local().is_empty()
-                && upper.local() == LocalVersionSlice::Max
-                && *lower == upper.clone().without_local()
+            if !lower.local().is_empty() {
+                return false;
+            }
+            if upper.local() != LocalVersionSlice::Max {
+                return false;
+            }
+            *lower == upper.clone().without_local()
         })
     }
 

--- a/crates/uv-resolver/src/pubgrub/range.rs
+++ b/crates/uv-resolver/src/pubgrub/range.rs
@@ -18,6 +18,9 @@ pub struct Range<T> {
 }
 
 impl<T> Range<T> {
+    /// Return the canonical set used for identity and set relationships.
+    ///
+    /// Ranges that do not need canonicalization reuse their raw representation.
     fn logical_versions(&self) -> &Ranges<T> {
         self.canonical_versions
             .as_deref()
@@ -48,6 +51,7 @@ impl<T> Deref for Range<T> {
 }
 
 impl Range<Version> {
+    /// Construct a [`Range`], omitting a redundant canonical representation.
     fn from_parts(
         raw_versions: Ranges<Version>,
         canonical_versions: Option<Ranges<Version>>,
@@ -61,6 +65,7 @@ impl Range<Version> {
         }
     }
 
+    /// Construct a [`Range`] whose raw representation is already canonical.
     fn from_canonical_versions(versions: Ranges<Version>) -> Self {
         Self {
             raw_versions: versions,
@@ -118,6 +123,10 @@ impl Range<Version> {
         self.binary_op(other, Ranges::union)
     }
 
+    /// Apply a set operation to both representations while preserving their equivalence.
+    ///
+    /// The raw result retains sentinel bounds for iteration and diagnostics, while the logical
+    /// result keeps subsequent PubGrub operations congruent with canonical equality.
     fn binary_op(
         &self,
         other: &Self,

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -8,7 +8,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use jiff::Timestamp;
 use owo_colors::OwoColorize;
-use pubgrub::{DerivationTree, Derived, External, Map, Range, ReportFormatter, Term};
+use pubgrub::{DerivationTree, Derived, External, Map, ReportFormatter, Term};
 use reqwest::StatusCode;
 use rustc_hash::FxHashMap;
 
@@ -28,7 +28,7 @@ use crate::exclude_newer::EffectiveExcludeNewerSource;
 use crate::fork_indexes::ForkIndexes;
 use crate::fork_urls::ForkUrls;
 use crate::prerelease::AllowPrerelease;
-use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
+use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubPython, Range};
 use crate::python_requirement::{PythonRequirement, PythonRequirementSource};
 use crate::resolver::{
     MetadataUnavailable, UnavailableErrorChain, UnavailablePackage, UnavailableReason,

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -3,7 +3,6 @@ use std::fmt::{Display, Formatter};
 use std::iter;
 use std::sync::Arc;
 
-use pubgrub::Ranges;
 use reqwest::StatusCode;
 
 use uv_distribution_types::{IncompatibleDist, Requirement, RequirementSource};
@@ -11,6 +10,7 @@ use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_platform_tags::{AbiTag, Tags};
 
+use crate::pubgrub::Range;
 use crate::resolver::{MetadataUnavailable, VersionFork};
 
 /// The reason why a package or a version cannot be used.
@@ -48,7 +48,7 @@ impl UnsatisfiableRequirement {
         let RequirementSource::Registry { specifier, .. } = &requirement.source else {
             return None;
         };
-        Ranges::from(specifier.clone()).is_empty().then(|| Self {
+        (Range::from(specifier.clone()) == Range::empty()).then(|| Self {
             name: requirement.name.clone(),
             extras: requirement.extras.clone(),
             version_specifiers: specifier.clone(),

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -2,13 +2,13 @@ use std::cmp::min;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use pubgrub::{Range, Ranges, Term};
+use pubgrub::Term;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, trace};
 
 use crate::candidate_selector::CandidateSelector;
-use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner};
+use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, Range};
 use crate::resolver::Request;
 use crate::{
     InMemoryIndex, PythonRequirement, ResolveError, ResolverEnvironment, VersionsResponse,
@@ -209,7 +209,7 @@ impl BatchPrefetcherRunner {
     fn send_prefetch(
         &self,
         name: &PackageName,
-        unchangeable_constraints: Option<&Term<Ranges<Version>>>,
+        unchangeable_constraints: Option<&Term<Range<Version>>>,
         total_prefetch: usize,
         versions_response: &Arc<VersionsResponse>,
         mut phase: BatchPrefetchStrategy,

--- a/crates/uv-resolver/src/resolver/derivation.rs
+++ b/crates/uv-resolver/src/resolver/derivation.rs
@@ -1,11 +1,11 @@
-use pubgrub::{Id, Kind, Ranges, State};
+use pubgrub::{Id, Kind, State};
 use rustc_hash::FxHashMap;
 
 use uv_distribution_types::{DerivationChain, DerivationStep};
 use uv_pep440::Version;
 
 use crate::dependency_provider::UvDependencyProvider;
-use crate::pubgrub::PubGrubPackage;
+use crate::pubgrub::{PubGrubPackage, Range};
 
 /// Build a [`DerivationChain`] from the pubgrub state, which is available in `uv-resolver`, but not
 /// in `uv-distribution-types`.
@@ -42,7 +42,7 @@ impl DerivationChainBuilder {
                         continue;
                     };
                     let dependency_versions =
-                        dependency_versions.cloned().unwrap_or_else(Ranges::empty);
+                        dependency_versions.cloned().unwrap_or_else(Range::empty);
                     if id == *id2 && dependency_versions.contains(version) {
                         if let Some(version) = solution.get(id1) {
                             let p1 = &state.package_store[*id1];
@@ -60,7 +60,7 @@ impl DerivationChainBuilder {
                                     p1.extra().cloned(),
                                     p1.group().cloned(),
                                     Some(version.clone()),
-                                    dependency_versions,
+                                    dependency_versions.versions().clone(),
                                 ));
 
                                 // Recursively search the next package.

--- a/crates/uv-resolver/src/resolver/derivation.rs
+++ b/crates/uv-resolver/src/resolver/derivation.rs
@@ -60,7 +60,7 @@ impl DerivationChainBuilder {
                                     p1.extra().cloned(),
                                     p1.group().cloned(),
                                     Some(version.clone()),
-                                    dependency_versions.versions().clone(),
+                                    dependency_versions.raw_versions().clone(),
                                 ));
 
                                 // Recursively search the next package.

--- a/crates/uv-resolver/src/resolver/derivation.rs
+++ b/crates/uv-resolver/src/resolver/derivation.rs
@@ -60,7 +60,7 @@ impl DerivationChainBuilder {
                                     p1.extra().cloned(),
                                     p1.group().cloned(),
                                     Some(version.clone()),
-                                    dependency_versions.raw_versions().clone(),
+                                    dependency_versions.encoded_versions().clone(),
                                 ));
 
                                 // Recursively search the next package.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -13,7 +13,7 @@ use either::Either;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use papaya::{HashMap, ResizeMode};
-use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
+use pubgrub::{Id, IncompId, Incompatibility, Kind, Ranges, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
@@ -52,7 +52,7 @@ use crate::pins::FilePins;
 use crate::preferences::{PreferenceSource, Preferences};
 use crate::pubgrub::{
     DependencySource, PubGrubDependency, PubGrubPackage, PubGrubPackageInner, PubGrubPriorities,
-    PubGrubPython,
+    PubGrubPython, Range,
 };
 use crate::python_requirement::PythonRequirement;
 use crate::resolution::ResolverOutput;
@@ -3292,7 +3292,7 @@ impl ForkState {
         &mut self,
         affected: Id<PubGrubPackage>,
         version: Option<&Version>,
-        incompatibility: IncompId<PubGrubPackage, Ranges<Version>, UnavailableReason>,
+        incompatibility: IncompId<PubGrubPackage, Range<Version>, UnavailableReason>,
     ) {
         let mut culprit_is_real = false;
         for (incompatible, _term) in self.pubgrub.incompatibility_store[incompatibility].iter() {
@@ -3366,7 +3366,10 @@ impl ForkState {
                 .add_incompatibility(Incompatibility::from_dependency(
                     *package,
                     Range::singleton(version.clone()),
-                    (python, release_specifiers_to_ranges(requires_python)),
+                    (
+                        python,
+                        Range::from_versions(release_specifiers_to_ranges(requires_python)),
+                    ),
                 ));
             self.pubgrub
                 .partial_solution
@@ -3439,7 +3442,7 @@ impl ForkState {
                     continue;
                 };
                 let dependency_range =
-                    dependency_range.map_or_else(|| Cow::Owned(Ranges::empty()), Cow::Borrowed);
+                    dependency_range.map_or_else(|| Cow::Owned(Range::empty()), Cow::Borrowed);
                 if *package != self_package {
                     continue;
                 }

--- a/crates/uv-resolver/src/resolver/system.rs
+++ b/crates/uv-resolver/src/resolver/system.rs
@@ -1,13 +1,13 @@
 use std::str::FromStr;
 
-use pubgrub::Ranges;
-
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_redacted::DisplaySafeUrl;
 use uv_torch::TorchBackend;
 
-use crate::pubgrub::{DependencySource, PubGrubDependency, PubGrubPackage, PubGrubPackageInner};
+use crate::pubgrub::{
+    DependencySource, PubGrubDependency, PubGrubPackage, PubGrubPackageInner, Range,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SystemDependency {
@@ -47,7 +47,7 @@ impl From<SystemDependency> for PubGrubDependency {
     fn from(value: SystemDependency) -> Self {
         Self {
             package: PubGrubPackage::from(PubGrubPackageInner::System(value.name)),
-            version: Ranges::singleton(value.version),
+            version: Range::singleton(value.version),
             parent: None,
             source: DependencySource::Unspecified,
         }

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -10,8 +10,7 @@ use uv_distribution_types::{
 };
 use uv_errors::{Hint, Hints};
 use uv_normalize::PackageName;
-use uv_pep440::Version;
-use uv_resolver::SentinelRange;
+use uv_pep440::{Version, strip_local_version_sentinels};
 
 use crate::commands::pip;
 use crate::commands::pip::install::ExternallyManagedError;
@@ -413,7 +412,7 @@ fn format_chain(name: &PackageName, version: Option<&Version>, chain: &Derivatio
         } else {
             message = format!("{message} {} depends on", format_step(step, range));
         }
-        range = Some(SentinelRange::from(&step.range).strip());
+        range = Some(strip_local_version_sentinels(&step.range));
     }
     if let Some(range) = range.filter(|range| *range != Ranges::empty() && *range != Ranges::full())
     {

--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -3436,7 +3436,7 @@ fn canonical_empty_requirement() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ you require a ∅
+      ╰─▶ you require a<0.dev0, which does not allow any versions
     ");
 
     context.assert_not_installed("a");

--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -3410,6 +3410,38 @@ fn single_package() {
     context.assert_installed("a", "2.0.0");
 }
 
+/// A requirement that canonicalizes to the empty PEP 440 set is reported as empty.
+///
+/// ```text
+/// canonical-empty-requirement
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   └── requires a<0.dev0
+/// │       └── unsatisfied: no matching version
+/// └── a
+///     └── a-0.dev0
+/// ```
+#[test]
+fn canonical_empty_requirement() {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("version_ranges/canonical-empty-requirement.toml");
+
+    uv_snapshot!(context.filters(), command(&context, &server)
+        .arg("a<0.dev0")
+        , @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ you require a ∅
+    ");
+
+    context.assert_not_installed("a");
+}
+
 /// Two versions of a package use differently spelled but PEP 440-equivalent dependency ranges.
 ///
 /// ```text

--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -3410,6 +3410,53 @@ fn single_package() {
     context.assert_installed("a", "2.0.0");
 }
 
+/// Two versions of a package use differently spelled but PEP 440-equivalent dependency ranges.
+///
+/// ```text
+/// equivalent-dependency-ranges
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   ├── requires a
+/// │   │   ├── satisfied by a-1.0.0
+/// │   │   └── satisfied by a-2.0.0
+/// │   └── requires c>=2.0
+/// │       └── satisfied by c-2.0.0
+/// ├── a
+/// │   ├── a-1.0.0
+/// │   │   └── requires c<=1.0
+/// │   │       └── satisfied by c-1.0.0
+/// │   └── a-2.0.0
+/// │       └── requires c<1.0.post0.dev0
+/// │           └── satisfied by c-1.0.0
+/// └── c
+///     ├── c-1.0.0
+///     └── c-2.0.0
+/// ```
+#[test]
+fn equivalent_dependency_ranges() {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("version_ranges/equivalent-dependency-ranges.toml");
+
+    uv_snapshot!(context.filters(), command(&context, &server)
+        .arg("a")
+        .arg("c>=2.0")
+        , @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because all versions of a depend on c<=1.0 and you require a, we can conclude that you require c<=1.0.
+          And because you require c>=2.0, we can conclude that your requirements are unsatisfiable.
+    ");
+
+    // Both versions of `a` require the same logical range of `c`, which conflicts with the root requirement.
+    context.assert_not_installed("a");
+    context.assert_not_installed("c");
+}
+
 /// Both wheels and source distributions are available, and the user has disabled binaries.
 ///
 /// ```text

--- a/test/scenarios/version_ranges/canonical-empty-requirement.toml
+++ b/test/scenarios/version_ranges/canonical-empty-requirement.toml
@@ -1,0 +1,10 @@
+name = "canonical-empty-requirement"
+description = "A requirement that canonicalizes to the empty PEP 440 set is reported as empty."
+
+[root]
+requires = ["a<0.dev0"]
+
+[expected]
+satisfiable = false
+
+[packages.a.versions."0.dev0"]

--- a/test/scenarios/version_ranges/equivalent-dependency-ranges.toml
+++ b/test/scenarios/version_ranges/equivalent-dependency-ranges.toml
@@ -1,0 +1,19 @@
+name = "equivalent-dependency-ranges"
+description = "Two versions of a package use differently spelled but PEP 440-equivalent dependency ranges."
+
+[root]
+requires = ["a", "c>=2.0"]
+
+[expected]
+satisfiable = false
+explanation = "Both versions of `a` require the same logical range of `c`, which conflicts with the root requirement."
+
+[packages.a.versions."1.0.0"]
+requires = ["c<=1.0"]
+
+[packages.a.versions."2.0.0"]
+requires = ["c<1.0.post0.dev0"]
+
+[packages.c.versions."1.0.0"]
+
+[packages.c.versions."2.0.0"]


### PR DESCRIPTION
## Summary

To represent PEP 440 specifiers as generic version ranges, we use synthetic internal versions as interval boundaries. For example, because `==1.0` also matches versions such as `1.0+local`, its range extends to a synthetic maximum local version of `1.0`. These boundaries are not valid package versions; they are implementation details of our PEP 440 range conversion.

This creates cases where two generic ranges have different endpoints but contain exactly the same set of valid PEP 440 versions. For example, the ranges derived from `<=1.0` and `<1.0.post0.dev0` are equivalent over valid versions, but the generic range implementation treats its coordinate space as continuous and considers them different. This prevents PubGrub from merging equivalent dependency incompatibilities and can produce unnecessarily long derivations.

This PR introduces a PEP 440-aware range wrapper with separate encoded and canonical representations. The encoded representation retains the sentinel bounds needed for candidate membership and diagnostic projection, while the canonical representation folds those boundaries onto their least valid successors and drives equality, hashing, and set relations. Local-version sentinel projection is centralized with the PEP 440 range logic rather than error reporting.

As a concrete example, this scenario gives two versions of `a` equivalent constraints on `c`:

```text
a==1.0.0 -> c<=1.0
a==2.0.0 -> c<1.0.post0.dev0
```

Previously, the error explained each version separately. With canonical identity, PubGrub merges them and reports that all versions of `a` depend on `c<=1.0`.
