### PR TITLE
Add rustc version information to linehaul

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -37,7 +37,7 @@ use uv_static::EnvVars;
 use uv_version::version;
 use uv_warnings::warn_user_once;
 
-use crate::linehaul::LineHaul;
+use crate::linehaul::{LineHaul, RustcVersion};
 use crate::middleware::OfflineMiddleware;
 use crate::tls::{Certificates, read_identity};
 use crate::{Connectivity, RetriableError, RetryState, UvRetryableStrategy};
@@ -117,6 +117,8 @@ pub struct BaseClientBuilder<'a> {
     custom_client: Option<Client>,
     /// uv subcommand in which this client is being used
     subcommand: Option<Vec<String>>,
+    /// The version of `rustc` available for this uv invocation.
+    rustc_version: Option<RustcVersion>,
     /// Optional name for this client, used in debug logging.
     client_name: Option<&'static str>,
     /// Whether to disable retry delays (for testing).
@@ -183,6 +185,7 @@ impl Default for BaseClientBuilder<'_> {
             cross_origin_credential_policy: CrossOriginCredentialsPolicy::Secure,
             custom_client: None,
             subcommand: None,
+            rustc_version: None,
             client_name: None,
             no_retry_delay: env::var_os(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY).is_some(),
         }
@@ -349,6 +352,12 @@ impl<'a> BaseClientBuilder<'a> {
     }
 
     #[must_use]
+    pub fn rustc_version(mut self, rustc_version: RustcVersion) -> Self {
+        self.rustc_version = Some(rustc_version);
+        self
+    }
+
+    #[must_use]
     pub fn client_name(mut self, name: &'static str) -> Self {
         self.client_name = Some(name);
         self
@@ -471,7 +480,13 @@ impl<'a> BaseClientBuilder<'a> {
         let mut user_agent_string = format!("uv/{}", version());
 
         // Add linehaul metadata.
-        let linehaul = LineHaul::new(self.markers, self.platform, self.subcommand.clone());
+        let rustc_version = self.rustc_version.as_ref().and_then(RustcVersion::get);
+        let linehaul = LineHaul::new(
+            self.markers,
+            self.platform,
+            self.subcommand.clone(),
+            rustc_version,
+        );
         if let Ok(output) = serde_json::to_string(&linehaul) {
             let _ = write!(user_agent_string, " {output}");
         }

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -7,6 +7,7 @@ pub use base_client::{
 pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithCachePolicy};
 pub use error::{Error, ErrorKind, ProblemDetails, WrappedReqwestError};
 pub use flat_index::{FlatIndexClient, FlatIndexEntries, FlatIndexEntry, FlatIndexError};
+pub use linehaul::RustcVersion;
 pub use registry_client::{
     Connectivity, MetadataFormat, RegistryClient, RegistryClientBuilder, SimpleDetailMetadata,
     SimpleDetailMetadatum, SimpleIndexMetadata, VersionFiles,

--- a/crates/uv-client/src/linehaul.rs
+++ b/crates/uv-client/src/linehaul.rs
@@ -1,12 +1,147 @@
 use std::env;
+use std::io::{Read, Seek, SeekFrom};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tracing::instrument;
 
+use uv_fs::tempfile_in;
 use uv_pep508::MarkerEnvironment;
 use uv_platform_tags::{Os, Platform};
 use uv_static::EnvVars;
 use uv_version::version;
+
+const RUSTC_VERSION_TIMEOUT: Duration = Duration::from_millis(50);
+const RUSTC_VERSION_POLL_INTERVAL: Duration = Duration::from_millis(2);
+
+/// A wrapper for a background worker (in a thread) that queries `rustc --version`.
+#[derive(Debug, Clone)]
+pub struct RustcVersion(Arc<RustcVersionInner>);
+
+#[derive(Debug)]
+struct RustcVersionInner {
+    result: OnceLock<Option<String>>,
+    deadline: Instant,
+}
+
+impl RustcVersion {
+    /// Spawn a background query for `rustc --version`.
+    #[must_use]
+    pub fn spawn() -> Self {
+        let deadline = Instant::now() + RUSTC_VERSION_TIMEOUT;
+        let inner = Arc::new(RustcVersionInner {
+            result: OnceLock::new(),
+            deadline,
+        });
+        let worker = Arc::clone(&inner);
+        if thread::Builder::new()
+            .name("uv-rustc-version".to_string())
+            .spawn(move || {
+                let version = Self::query_version(deadline);
+                let _ = worker.result.set(version);
+            })
+            .is_err()
+        {
+            let _ = inner.result.set(None);
+        }
+        Self(inner)
+    }
+
+    /// Create an already-resolved `rustc` version.
+    #[must_use]
+    pub fn ready(version: String) -> Self {
+        Self(Arc::new(RustcVersionInner {
+            result: OnceLock::from(Some(version)),
+            deadline: Instant::now(),
+        }))
+    }
+
+    fn query_version(deadline: Instant) -> Option<String> {
+        if Instant::now() >= deadline {
+            return None;
+        }
+        // Capture stdout in a regular file instead of a pipe. Since we only read after waiting
+        // for `rustc`, a pipe could deadlock if its buffer fills or hang if a descendant inherits
+        // the write end and keeps it open.
+        let mut output = tempfile_in(&env::temp_dir()).ok()?;
+        let mut child = Command::new("rustc")
+            .arg("--version")
+            .stdin(Stdio::null())
+            .stdout(output.reopen().ok()?)
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+
+        let status = loop {
+            if Instant::now() >= deadline {
+                Self::kill_and_reap(&mut child);
+                return None;
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) => {}
+                Err(_) => {
+                    Self::kill_and_reap(&mut child);
+                    return None;
+                }
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            thread::sleep(remaining.min(RUSTC_VERSION_POLL_INTERVAL));
+        };
+        if !status.success() {
+            return None;
+        }
+
+        let output_file = output.as_file_mut();
+        output_file.seek(SeekFrom::Start(0)).ok()?;
+        let mut stdout = Vec::new();
+        output_file.read_to_end(&mut stdout).ok()?;
+        if Instant::now() >= deadline {
+            return None;
+        }
+        Self::parse_version(&stdout)
+    }
+
+    fn kill_and_reap(child: &mut Child) {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    fn parse_version(output: &[u8]) -> Option<String> {
+        let output = output.strip_prefix(b"rustc ")?;
+        let version_length = output
+            .iter()
+            .position(u8::is_ascii_whitespace)
+            .unwrap_or(output.len());
+        if version_length == 0 {
+            return None;
+        }
+        std::str::from_utf8(&output[..version_length])
+            .ok()
+            .map(str::to_owned)
+    }
+
+    pub(crate) fn get(&self) -> Option<&str> {
+        loop {
+            if let Some(version) = self.0.result.get() {
+                return version.as_deref();
+            }
+            let now = Instant::now();
+            if now >= self.0.deadline {
+                return self.0.result.get_or_init(|| None).as_deref();
+            }
+            thread::sleep(
+                self.0
+                    .deadline
+                    .duration_since(now)
+                    .min(RUSTC_VERSION_POLL_INTERVAL),
+            );
+        }
+    }
+}
 
 #[derive(Serialize)]
 struct Installer {
@@ -68,6 +203,7 @@ impl LineHaul {
         markers: Option<&MarkerEnvironment>,
         platform: Option<&Platform>,
         subcommand: Option<Vec<String>>,
+        rustc_version: Option<&str>,
     ) -> Self {
         // https://github.com/pypa/pip/blob/24.0/src/pip/_internal/network/session.py#L87
         let looks_like_ci = [
@@ -145,9 +281,29 @@ impl LineHaul {
             openssl_version: None,
             // Should probably always be None in uv.
             setuptools_version: None,
-            // Calling rustc --version is likely too slow.
-            rustc_version: None,
+            rustc_version: rustc_version.map(str::to_owned),
             ci: looks_like_ci,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RustcVersion;
+
+    #[test]
+    fn parse_rustc_version_output() {
+        assert_eq!(
+            RustcVersion::parse_version(b"rustc 1.90.0 (1159e78c4 2024-09-02)\n"),
+            Some("1.90.0".to_string())
+        );
+        assert_eq!(
+            RustcVersion::parse_version(b"rustc 1.90.0\n"),
+            Some("1.90.0".to_string())
+        );
+        assert_eq!(RustcVersion::parse_version(b"rust 1.90.0\n"), None);
+        assert_eq!(RustcVersion::parse_version(b"rustc\n1.90.0\n"), None);
+        assert_eq!(RustcVersion::parse_version(b"rustc \n"), None);
+        assert_eq!(RustcVersion::parse_version(b"rustc \xff\n"), None);
     }
 }

--- a/crates/uv-client/tests/it/user_agent_version.rs
+++ b/crates/uv-client/tests/it/user_agent_version.rs
@@ -5,8 +5,7 @@ use insta::{assert_json_snapshot, assert_snapshot, with_settings};
 use url::Url;
 
 use uv_cache::Cache;
-use uv_client::BaseClientBuilder;
-use uv_client::RegistryClientBuilder;
+use uv_client::{BaseClientBuilder, RegistryClientBuilder, RustcVersion};
 use uv_pep508::{MarkerEnvironment, MarkerEnvironmentBuilder};
 use uv_platform_tags::{Arch, Os, Platform};
 use uv_redacted::DisplaySafeUrl;
@@ -158,8 +157,11 @@ async fn test_user_agent_has_linehaul() -> Result<()> {
 
     // Initialize uv-client
     let cache = Cache::temp()?.init().await?;
-    let mut builder =
-        RegistryClientBuilder::new(BaseClientBuilder::default(), cache).markers(&markers);
+    let mut builder = RegistryClientBuilder::new(
+        BaseClientBuilder::default().rustc_version(RustcVersion::ready("1.90.0".to_string())),
+        cache,
+    )
+    .markers(&markers);
 
     let linux = Platform::new(
         Os::Manylinux {
@@ -236,7 +238,7 @@ async fn test_user_agent_has_linehaul() -> Result<()> {
           },
           "openssl_version": null,
           "python": "3.12.2",
-          "rustc_version": null,
+          "rustc_version": "1.90.0",
           "setuptools_version": null,
           "system": {
             "name": "Linux",

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 use uv_cache::Cache;
 use uv_cli::{ExternalCommand, GlobalArgs};
-use uv_client::BaseClientBuilder;
+use uv_client::{BaseClientBuilder, RustcVersion};
 use uv_configuration::{
     Concurrency, Constraints, DependencyGroups, DryRun, EditableMode, EnvFile, ExtrasSpecification,
     InstallOptions, TargetTriple,
@@ -1455,6 +1455,7 @@ impl ParsedRunCommand {
         global_args: &GlobalArgs,
         filesystem: Option<&FilesystemOptions>,
         environment: &EnvironmentOptions,
+        rustc_version: &RustcVersion,
     ) -> anyhow::Result<(Option<Pep723Item>, RunCommand)> {
         match self {
             Self::Ready(run_command) => {
@@ -1472,6 +1473,7 @@ impl ParsedRunCommand {
                     settings.network_settings.connect_timeout,
                     settings.network_settings.retries,
                 )
+                .rustc_version(rustc_version.clone())
                 .http_proxy(settings.network_settings.http_proxy)
                 .https_proxy(settings.network_settings.https_proxy)
                 .no_proxy(settings.network_settings.no_proxy);

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -32,7 +32,7 @@ use uv_cli::{
     PythonNamespace, SelfCommand, SelfNamespace, ToolCommand, ToolNamespace, TopLevelArgs,
     WorkspaceCommand, WorkspaceNamespace, compat::CompatArgs,
 };
-use uv_client::BaseClientBuilder;
+use uv_client::{BaseClientBuilder, RustcVersion};
 use uv_configuration::min_stack_size;
 use uv_flags::EnvironmentFlags;
 use uv_fs::{CWD, Simplified, normalize_path};
@@ -125,6 +125,9 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
     if let Some(directory) = directory.as_ref() {
         std::env::set_current_dir(directory)?;
     }
+
+    // Spawn our `rustc --version` worker.
+    let rustc_version = RustcVersion::spawn();
 
     // Parse the external command, if necessary.
     let parsed_run_command = if let Commands::Project(command) = &*cli.command
@@ -342,6 +345,7 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
                 &cli.top_level.global_args,
                 filesystem.as_ref(),
                 &environment,
+                &rustc_version,
             )
             .await?;
         (script, Some(run_command))
@@ -627,6 +631,7 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
         globals.network_settings.connect_timeout,
         globals.network_settings.retries,
     )
+    .rustc_version(rustc_version)
     .http_proxy(globals.network_settings.http_proxy.clone())
     .https_proxy(globals.network_settings.https_proxy.clone())
     .no_proxy(globals.network_settings.no_proxy.clone());

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild};
 use bytes::Bytes;
 use http::StatusCode;
+use http::header::USER_AGENT;
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, StreamBody};
 use hyper::body::Frame;
@@ -12,7 +13,7 @@ use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
 use serde_json::json;
 use tokio_stream::wrappers::ReceiverStream;
-use wiremock::matchers::{any, method};
+use wiremock::matchers::{any, method, path};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 use uv_static::EnvVars;
@@ -120,6 +121,47 @@ async fn mock_simple_api(server: &MockServer) {
         )
         .mount(server)
         .await;
+}
+
+/// Check that index requests include the version reported by the real `rustc` executable.
+#[tokio::test]
+async fn index_user_agent_includes_rustc_version() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/linehaul-user-agent-test/"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut command = context.pip_install();
+    command
+        .arg("linehaul-user-agent-test")
+        .arg("--default-index")
+        .arg(server.uri());
+
+    let output = command.output()?;
+    anyhow::ensure!(
+        !output.status.success(),
+        "installing an unavailable package unexpectedly succeeded"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let request = requests.first().unwrap();
+    let user_agent = request.headers.get(USER_AGENT).unwrap().to_str().unwrap();
+
+    let (_, linehaul) = user_agent.split_once(' ').unwrap();
+    let linehaul: serde_json::Value = serde_json::from_str(linehaul).unwrap();
+    let rustc_version = linehaul["rustc_version"].as_str().unwrap();
+
+    // NOTE: Intentionally not performing an exact match so that we don't have
+    // to churn this on every MSRV bump.
+    let version_pattern = regex::Regex::new(r"\d+\.\d+\.\d+").unwrap();
+    assert!(version_pattern.is_match(rustc_version));
+
+    Ok(())
 }
 
 fn connection_reset(_request: &wiremock::Request) -> io::Error {


### PR DESCRIPTION
## Summary

Closes #20127.

~~WIP, still iterating on this.~~

The basic idea here is to spawn a dedicated thread for `rustc --version` early in uv's lifecycle, and strictly bound it (currently 50ms, which should be more than enough).

Like with pip, we consider the version from `rustc --version` to be the second "word" segment in the output, e.g. `1.0.0` in `rustc 1.0.0 (abc def...)`.

## Test Plan

Added unit and integration tests.