### PR TITLE
Route proxy artifacts through physical endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6279,6 +6279,7 @@ dependencies = [
  "uv-distribution-filename",
  "uv-distribution-types",
  "uv-errors",
+ "uv-extract",
  "uv-fs",
  "uv-git",
  "uv-metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7224,6 +7224,7 @@ dependencies = [
  "toml_writer",
  "tracing",
  "url",
+ "uv-cache",
  "uv-cache-key",
  "uv-client",
  "uv-configuration",
@@ -7254,6 +7255,7 @@ dependencies = [
  "uv-version",
  "uv-warnings",
  "uv-workspace",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/uv-audit/src/service/project_status.rs
+++ b/crates/uv-audit/src/service/project_status.rs
@@ -80,17 +80,16 @@ impl<'a> ProjectStatusAudit<'a> {
                 return None;
             }
         };
-
-        let archive = results
+        let Some(archive) = results
             .into_iter()
-            .map(|(_, format)| match format {
-                MetadataFormat::Simple(archive) => archive,
-                MetadataFormat::Flat(_) => {
-                    unreachable!("Flat metadata should not be returned by `simple_detail`")
-                }
+            .find_map(|response| match response.format {
+                MetadataFormat::Simple(archive) => Some(archive),
+                MetadataFormat::Flat(_) => None,
             })
-            .next()?;
-
+        else {
+            trace!("Skipping project-status check for `{name}`: no Simple API response");
+            return None;
+        };
         let project_status: PypiProjectStatus =
             match rkyv::deserialize::<PypiProjectStatus, rkyv::rancor::Error>(
                 archive.project_status(),

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -26,6 +26,7 @@ uv-configuration = { workspace = true }
 uv-distribution-filename = { workspace = true }
 uv-distribution-types = { workspace = true }
 uv-errors = { workspace = true }
+uv-extract = { workspace = true }
 uv-fs = { workspace = true, features = ["tokio"] }
 uv-git = { workspace = true }
 uv-metadata = { workspace = true }
@@ -73,6 +74,7 @@ x509-parser = { workspace = true }
 serde_json = { workspace = true }
 uv-platform = { workspace = true }
 thiserror = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
@@ -88,7 +90,6 @@ insta = { workspace = true }
 rcgen = { workspace = true }
 regex = { workspace = true }
 temp-env = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 wiremock = { workspace = true }

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -71,6 +71,8 @@ pub enum ClientBuildError {
     Credentials(#[from] CredentialsFromUrlError),
     #[error(transparent)]
     IndexCredentials(#[from] IndexCredentialsError),
+    #[error(transparent)]
+    ProxyIndex(#[from] uv_distribution_types::ProxyIndexError),
 }
 
 /// Selectively skip parts or the entire auth middleware.

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -436,6 +436,38 @@ pub enum ErrorKind {
     #[error("Package `{0}` was not found in the registry")]
     RemotePackageNotFound(PackageName),
 
+    #[error(
+        "Locked artifact `{filename}` from `{canonical}` has no digest and cannot be fetched through proxy index `{proxy}`; regenerate the lockfile"
+    )]
+    ProxyArtifactMissingDigest {
+        filename: String,
+        canonical: IndexUrl,
+        proxy: IndexUrl,
+    },
+
+    #[error("Artifact `{filename}` from `{canonical}` was not found on proxy index `{proxy}`")]
+    ProxyArtifactNotFound {
+        filename: String,
+        canonical: IndexUrl,
+        proxy: IndexUrl,
+    },
+
+    #[error(
+        "Artifact `{filename}` from proxy index `{proxy}` does not match the locked digest from `{canonical}`"
+    )]
+    ProxyArtifactDigestMismatch {
+        filename: String,
+        canonical: IndexUrl,
+        proxy: IndexUrl,
+    },
+
+    #[error("Proxy artifact `{filename}` from `{proxy}` uses unsupported local URL `{url}`")]
+    ProxyArtifactLocalUrl {
+        filename: String,
+        proxy: IndexUrl,
+        url: DisplaySafeUrl,
+    },
+
     /// The package was not found in the local (file-based) index.
     #[error("Package `{0}` was not found in the local index")]
     LocalPackageNotFound(PackageName),

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -8,8 +8,8 @@ pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithC
 pub use error::{Error, ErrorKind, ProblemDetails, WrappedReqwestError};
 pub use flat_index::{FlatIndexClient, FlatIndexEntries, FlatIndexEntry, FlatIndexError};
 pub use registry_client::{
-    Connectivity, MetadataFormat, RegistryClient, RegistryClientBuilder, SimpleDetailMetadata,
-    SimpleDetailMetadatum, SimpleIndexMetadata, VersionFiles,
+    Connectivity, IndexMetadataResponse, MetadataFormat, RegistryClient, RegistryClientBuilder,
+    SimpleDetailMetadata, SimpleDetailMetadatum, SimpleIndexMetadata, VersionFiles,
 };
 pub(crate) use retry::UvRetryableStrategy;
 pub use retry::{RetriableError, RetryState, retryable_on_request_failure};

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -8,8 +8,9 @@ pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithC
 pub use error::{Error, ErrorKind, ProblemDetails, WrappedReqwestError};
 pub use flat_index::{FlatIndexClient, FlatIndexEntries, FlatIndexEntry, FlatIndexError};
 pub use registry_client::{
-    Connectivity, IndexMetadataResponse, MetadataFormat, RegistryClient, RegistryClientBuilder,
-    SimpleDetailMetadata, SimpleDetailMetadatum, SimpleIndexMetadata, VersionFiles,
+    Connectivity, IndexMetadataResponse, MetadataFormat, ProxyArtifact, RegistryClient,
+    RegistryClientBuilder, SimpleDetailMetadata, SimpleDetailMetadatum, SimpleIndexMetadata,
+    VersionFiles,
 };
 pub(crate) use retry::UvRetryableStrategy;
 pub use retry::{RetriableError, RetryState, retryable_on_request_failure};

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Formatter};
+use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -10,20 +11,24 @@ use http::{HeaderMap, StatusCode};
 use itertools::Either;
 use reqwest::{Proxy, Response};
 use rustc_hash::FxHashMap;
+use tokio::io::AsyncSeekExt;
 use tokio::sync::{Mutex, Semaphore};
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 use url::Url;
 
 use uv_auth::{CredentialsCache, Indexes, PyxTokenStore};
 use uv_cache::{Cache, CacheBucket, CacheEntry, WheelCache};
+use uv_cache_key::cache_digest;
 use uv_configuration::IndexStrategy;
 use uv_configuration::KeyringProviderType;
 use uv_distribution_filename::{DistFilename, WheelFilename};
 use uv_distribution_types::{
     BuiltDist, File, FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations,
     IndexMetadataRef, IndexRoute, IndexRoutes, IndexStatusCodeDecision, IndexStatusCodeStrategy,
-    IndexUrl, Name, RegistryBuiltWheel, Zstd,
+    IndexUrl, Name, Zstd,
 };
+use uv_extract::hash::{HashReader, Hasher};
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
 use uv_normalize::PackageName;
@@ -266,6 +271,18 @@ pub struct IndexMetadataResponse<'index> {
     pub format: MetadataFormat,
 }
 
+/// A locked artifact rediscovered through a proxy index.
+#[derive(Debug)]
+pub struct ProxyArtifact {
+    pub physical_index: IndexUrl,
+    pub file: File,
+    /// Whether the lockfile and proxy index advertise a shared digest.
+    ///
+    /// If false, the full artifact must be downloaded and validated against the locked digest
+    /// before its metadata can be trusted.
+    pub has_shared_hash: bool,
+}
+
 impl RegistryClient {
     /// Return the [`CachedClient`] used by this client.
     pub fn cached_client(&self) -> &CachedClient {
@@ -299,6 +316,129 @@ impl RegistryClient {
 
     pub fn credentials_cache(&self) -> &CredentialsCache {
         self.client.uncached().credentials_cache()
+    }
+
+    /// Rediscover a locked artifact through the proxy configured for its canonical index.
+    pub async fn proxy_artifact(
+        &self,
+        package_name: &PackageName,
+        canonical: &IndexUrl,
+        filename: &str,
+        locked_hashes: &HashDigests,
+        capabilities: &IndexCapabilities,
+    ) -> Result<Option<ProxyArtifact>, Error> {
+        let route = self.routes.route_for(canonical);
+        if !route.is_proxy() {
+            return Ok(None);
+        }
+        let proxy = route.physical.clone();
+        if locked_hashes.is_empty() {
+            return Err(ErrorKind::ProxyArtifactMissingDigest {
+                filename: filename.to_string(),
+                canonical: canonical.clone(),
+                proxy,
+            }
+            .into());
+        }
+
+        let response = match self
+            .simple_detail(
+                package_name,
+                Some(IndexMetadataRef::from(canonical)),
+                capabilities,
+                &Semaphore::new(1),
+            )
+            .await
+        {
+            Ok(mut responses) => {
+                responses
+                    .pop()
+                    .ok_or_else(|| ErrorKind::ProxyArtifactNotFound {
+                        filename: filename.to_string(),
+                        canonical: canonical.clone(),
+                        proxy: proxy.clone(),
+                    })?
+            }
+            Err(err) if matches!(err.kind(), ErrorKind::RemotePackageNotFound(_)) => {
+                return Err(ErrorKind::ProxyArtifactNotFound {
+                    filename: filename.to_string(),
+                    canonical: canonical.clone(),
+                    proxy,
+                }
+                .into());
+            }
+            Err(err) => return Err(err),
+        };
+        let proxy = response.index_route.physical.clone();
+        let metadata = match response.format {
+            MetadataFormat::Simple(metadata) => OwnedArchive::deserialize(&metadata),
+            MetadataFormat::Flat(_) => {
+                return Err(ErrorKind::ProxyArtifactNotFound {
+                    filename: filename.to_string(),
+                    canonical: canonical.clone(),
+                    proxy,
+                }
+                .into());
+            }
+        };
+        let mut hashless_candidate = None;
+        let mut found_filename = false;
+        for (_, file) in metadata
+            .into_iter()
+            .flat_map(|version| version.files.all(package_name))
+        {
+            if file.filename.as_ref() != filename {
+                continue;
+            }
+            validate_proxy_artifact_url(
+                filename,
+                &file.url.to_url().map_err(ErrorKind::InvalidUrl)?,
+                &proxy,
+            )?;
+            found_filename = true;
+            let comparable = file.hashes.iter().any(|proxy_hash| {
+                locked_hashes
+                    .iter()
+                    .any(|locked_hash| locked_hash.algorithm() == proxy_hash.algorithm())
+            });
+            let has_shared_hash = file.hashes.iter().any(|proxy_hash| {
+                locked_hashes
+                    .iter()
+                    .any(|locked_hash| locked_hash == proxy_hash)
+            });
+            if has_shared_hash {
+                return Ok(Some(ProxyArtifact {
+                    physical_index: proxy,
+                    file,
+                    has_shared_hash,
+                }));
+            }
+            if !comparable && hashless_candidate.is_none() {
+                hashless_candidate = Some(file);
+            }
+        }
+        if let Some(file) = hashless_candidate {
+            return Ok(Some(ProxyArtifact {
+                physical_index: proxy,
+                file,
+                has_shared_hash: false,
+            }));
+        }
+        if found_filename {
+            Err(ErrorKind::ProxyArtifactDigestMismatch {
+                filename: filename.to_string(),
+                canonical: canonical.clone(),
+                proxy,
+            }
+            .into())
+        } else {
+            Err(ErrorKind::ProxyArtifactNotFound {
+                filename: filename.to_string(),
+                canonical: canonical.clone(),
+                proxy,
+            }
+            .into())
+        }
     }
 
     /// Return the appropriate index URLs for the given [`PackageName`].
@@ -1004,8 +1144,31 @@ impl RegistryClient {
                 }
 
                 let wheel = wheels.best_wheel();
+                let proxy_artifact = if wheel.proxy.is_none() {
+                    self.proxy_artifact(
+                        &wheel.filename.name,
+                        &wheel.index,
+                        &wheel.file.filename,
+                        &wheel.file.hashes,
+                        capabilities,
+                    )
+                    .await?
+                } else {
+                    None
+                };
+                let (physical_index, file) = if let Some(proxy_artifact) = &proxy_artifact {
+                    (&proxy_artifact.physical_index, &proxy_artifact.file)
+                } else {
+                    (wheel.physical_index(), wheel.file.as_ref())
+                };
+                let requires_full_verification = proxy_artifact
+                    .as_ref()
+                    .is_some_and(|proxy_artifact| !proxy_artifact.has_shared_hash);
 
-                let url = wheel.file.url.to_url().map_err(ErrorKind::InvalidUrl)?;
+                let url = file.url.to_url().map_err(ErrorKind::InvalidUrl)?;
+                if wheel.proxy.is_some() || proxy_artifact.is_some() {
+                    validate_proxy_artifact_url(&wheel.filename.to_string(), &url, physical_index)?;
+                }
                 let location = if url.scheme() == "file" {
                     let path = url
                         .to_file_path()
@@ -1035,8 +1198,25 @@ impl RegistryClient {
                         })?
                     }
                     WheelLocation::Url(url) => {
-                        self.wheel_metadata_registry(wheel, &url, capabilities)
+                        if requires_full_verification {
+                            self.wheel_metadata_verified_proxy(
+                                &wheel.filename,
+                                &url,
+                                &wheel.index,
+                                physical_index,
+                                &wheel.file.hashes,
+                            )
                             .await?
+                        } else {
+                            self.wheel_metadata_registry_at(
+                                &wheel.filename,
+                                physical_index,
+                                file,
+                                &url,
+                                capabilities,
+                            )
+                            .await?
+                        }
                     }
                 }
             }
@@ -1125,25 +1305,6 @@ impl RegistryClient {
         Ok(metadata)
     }
 
-    /// Fetch the metadata from a wheel file.
-    async fn wheel_metadata_registry(
-        &self,
-        wheel: &RegistryBuiltWheel,
-        url: &DisplaySafeUrl,
-        capabilities: &IndexCapabilities,
-    ) -> Result<ResolutionMetadata, Error> {
-        let RegistryBuiltWheel {
-            filename,
-            file,
-            index,
-            ..
-        } = wheel;
-
-        let route = self.routes.route_for(index);
-        self.wheel_metadata_registry_at(filename, route.physical, file, url, capabilities)
-            .await
-    }
-
     async fn wheel_metadata_registry_at(
         &self,
         filename: &WheelFilename,
@@ -1223,6 +1384,119 @@ impl RegistryClient {
             )
             .await
         }
+    }
+
+    /// Download a proxy wheel and verify it against its locked hashes before reading metadata.
+    async fn wheel_metadata_verified_proxy(
+        &self,
+        filename: &WheelFilename,
+        url: &DisplaySafeUrl,
+        canonical: &IndexUrl,
+        proxy: &IndexUrl,
+        locked_hashes: &HashDigests,
+    ) -> Result<ResolutionMetadata, Error> {
+        let mut locked_hashes_cache_key = locked_hashes
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        locked_hashes_cache_key.sort_unstable();
+        let cache_entry = self.cache.entry(
+            CacheBucket::Wheels,
+            WheelCache::Index(proxy).wheel_dir(filename.name.as_ref()),
+            format!(
+                "{}-artifact-{}.msgpack",
+                filename.cache_key(),
+                cache_digest(&locked_hashes_cache_key)
+            ),
+        );
+        let cache_control = match self.connectivity {
+            Connectivity::Online => {
+                if let Some(header) = self.indexes.artifact_cache_control_for(proxy) {
+                    CacheControl::Override(header)
+                } else {
+                    CacheControl::from(
+                        self.cache
+                            .freshness(&cache_entry, Some(&filename.name), None)
+                            .map_err(ErrorKind::Io)?,
+                    )
+                }
+            }
+            Connectivity::Offline => CacheControl::AllowStale,
+        };
+
+        // Acquire an advisory lock, to guard against concurrent writes.
+        #[cfg(windows)]
+        let _lock = {
+            let lock_entry = cache_entry.with_file(format!("{}.lock", filename.stem()));
+            lock_entry.lock().await.map_err(ErrorKind::CacheLock)?
+        };
+
+        let expected_hashes = locked_hashes.clone();
+        let response_callback = async |response: Response| {
+            let reader = response
+                .bytes_stream()
+                .map_err(|err| self.handle_response_errors(err))
+                .into_async_read();
+            let mut hashers = expected_hashes
+                .iter()
+                .map(|hash| Hasher::from(hash.algorithm()))
+                .collect::<Vec<_>>();
+            let mut reader = HashReader::new(reader.compat(), &mut hashers);
+
+            let temp_file = tempfile::tempfile_in(self.cache.root()).map_err(ErrorKind::Io)?;
+            let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
+                fs_err::File::from_parts(temp_file, self.cache.root()),
+            ));
+            tokio::io::copy(&mut reader, &mut writer)
+                .await
+                .map_err(ErrorKind::Io)?;
+
+            let computed_hashes = hashers
+                .into_iter()
+                .map(HashDigest::from)
+                .collect::<Vec<_>>();
+            if !computed_hashes
+                .iter()
+                .any(|computed| expected_hashes.iter().any(|expected| expected == computed))
+            {
+                return Err(ErrorKind::ProxyArtifactDigestMismatch {
+                    filename: filename.to_string(),
+                    canonical: canonical.clone(),
+                    proxy: proxy.clone(),
+                }
+                .into());
+            }
+
+            let mut file = writer.into_inner();
+            file.seek(io::SeekFrom::Start(0))
+                .await
+                .map_err(ErrorKind::Io)?;
+            let contents = read_metadata_async_seek(filename, file)
+                .await
+                .map_err(|err| ErrorKind::Metadata(url.to_string(), err))?;
+            ResolutionMetadata::parse_metadata(&contents).map_err(|err| {
+                Error::from(ErrorKind::MetadataParseError(
+                    filename.clone(),
+                    url.to_string(),
+                    Box::new(err),
+                ))
+            })
+        };
+        let req = self
+            .uncached_client(url)
+            .get(Url::from(url.clone()))
+            .header(
+                "accept-encoding",
+                http::HeaderValue::from_static("identity"),
+            )
+            .build()
+            .map_err(|err| {
+                ErrorKind::from_reqwest(url.clone(), err, self.client.certificate_source())
+            })?;
+        self.cached_client()
+            .get_serde_with_retry(req, &cache_entry, cache_control, response_callback)
+            .await
+            .map_err(crate::Error::from)
     }
 
     /// Get the wheel metadata if it isn't available in an index through PEP 658
@@ -1400,6 +1674,22 @@ impl RegistryClient {
             std::io::Error::other(err)
         }
     }
+}
+
+fn validate_proxy_artifact_url(
+    filename: &str,
+    url: &DisplaySafeUrl,
+    proxy: &IndexUrl,
+) -> Result<(), Error> {
+    if url.scheme() == "file" {
+        return Err(ErrorKind::ProxyArtifactLocalUrl {
+            filename: filename.to_string(),
+            proxy: proxy.clone(),
+            url: url.clone(),
+        }
+        .into());
+    }
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -1994,11 +2284,14 @@ impl Connectivity {
 mod tests {
     use std::str::FromStr;
 
-    use serde_json::from_str as deserialize_json;
+    use async_zip::base::write::ZipFileWriter;
+    use async_zip::{Compression as ZipCompression, ZipEntryBuilder};
+    use serde_json::{from_str as deserialize_json, json};
     use tokio::sync::Semaphore;
     use url::Url;
+    use uv_extract::hash::{HashReader, Hasher};
     use uv_normalize::PackageName;
-    use uv_pypi_types::PypiSimpleDetail;
+    use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, PypiSimpleDetail};
     use uv_redacted::DisplaySafeUrl;
     use uv_torch::{TorchBackend, TorchSource, TorchStrategy};
 
@@ -2007,11 +2300,14 @@ mod tests {
         RegistryClient, RegistryClientBuilder, SimpleDetailMetadata, SimpleDetailMetadatum,
         html::SimpleDetailHTML,
     };
-    use uv_cache::Cache;
+    use uv_cache::{Cache, CacheBucket, WheelCache};
+    use uv_distribution_filename::WheelFilename;
     use uv_distribution_types::{
-        FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-        IndexReference, IndexUrl, ProxyIndex, ToUrlError,
+        BuiltDist, File, FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations,
+        IndexMetadataRef, IndexReference, IndexUrl, ProxyIndex, RegistryBuiltDist,
+        RegistryBuiltWheel, ToUrlError,
     };
+    use uv_git::GitResolver;
     use uv_small_str::SmallString;
     use wiremock::matchers::{basic_auth, method, path, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -2384,6 +2680,532 @@ mod tests {
 
         assert!(capabilities.unauthorized(&proxy));
         assert!(!capabilities.unauthorized(&canonical));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_artifact_uses_exact_filename_and_locked_digest() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        let filename = "example-1.0.0-py3-none-any.whl";
+        let digest = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3";
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path("/simple/example/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(
+                    json!({
+                        "name": "example",
+                        "files": [{
+                            "filename": filename,
+                            "url": format!("https://artifacts.example.com/files/{filename}"),
+                            "hashes": {
+                                "sha256": digest.strip_prefix("sha256:").unwrap_or_default()
+                            },
+                            "core-metadata": true
+                        }]
+                    })
+                    .to_string(),
+                    "application/vnd.pypi.simple.v1+json",
+                ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let canonical = IndexUrl::from_str("https://pypi.org/simple")?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(canonical.clone()),
+            url: proxy,
+        }]);
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations)
+            .build()?;
+        let hashes = HashDigests::from(vec![HashDigest::from_str(digest)?]);
+
+        let artifact = client
+            .proxy_artifact(
+                &PackageName::from_str("example")?,
+                &canonical,
+                filename,
+                &hashes,
+                &IndexCapabilities::default(),
+            )
+            .await?
+            .ok_or("expected a proxy artifact")?;
+        assert_eq!(
+            artifact.file.url.to_url()?.as_str(),
+            format!("https://artifacts.example.com/files/{filename}")
+        );
+        assert!(artifact.file.dist_info_metadata);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_artifact_attributes_authentication_failure_to_proxy() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path("/simple/example/"))
+            .respond_with(ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let canonical = IndexUrl::from_str("https://canonical.example.com/simple")?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(canonical.clone()),
+            url: proxy.clone(),
+        }]);
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations)
+            .build()?;
+        let capabilities = IndexCapabilities::default();
+        let locked_hashes = HashDigests::from(HashDigest::from_str(
+            "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+        )?);
+
+        let error = client
+            .proxy_artifact(
+                &PackageName::from_str("example")?,
+                &canonical,
+                "example-1.0.0-py3-none-any.whl",
+                &locked_hashes,
+                &capabilities,
+            )
+            .await
+            .expect_err("an unauthorized proxy lookup should fail");
+
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::ProxyArtifactNotFound {
+                canonical: error_canonical,
+                proxy: error_proxy,
+                ..
+            } if error_canonical == &canonical && error_proxy == &proxy
+        ));
+        assert!(capabilities.unauthorized(&proxy));
+        assert!(!capabilities.unauthorized(&canonical));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn locked_wheel_metadata_routes_through_proxy_artifact() -> Result<(), Error> {
+        let canonical_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&canonical_server)
+            .await;
+
+        let proxy_server = MockServer::start().await;
+        let filename = "example-1.0.0-py3-none-any.whl";
+        let digest = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3";
+        let metadata = "Metadata-Version: 2.3\nName: example\nVersion: 1.0.0\n";
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path("/simple/example/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(
+                    json!({
+                        "name": "example",
+                        "files": [{
+                            "filename": filename,
+                            "url": format!("{}/files/{filename}", proxy_server.uri()),
+                            "hashes": {
+                                "sha256": digest.strip_prefix("sha256:").unwrap_or_default()
+                            },
+                            "core-metadata": true
+                        }]
+                    })
+                    .to_string(),
+                    "application/vnd.pypi.simple.v1+json",
+                ),
+            )
+            .expect(1)
+            .mount(&proxy_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path(format!(
+                "/files/{filename}.metadata"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_string(metadata))
+            .expect(1)
+            .mount(&proxy_server)
+            .await;
+
+        let canonical = IndexUrl::from_str(&format!("{}/simple", canonical_server.uri()))?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", proxy_server.uri()))?;
+        let locations =
+            IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
+                .with_proxy_indexes(vec![ProxyIndex {
+                    index: IndexReference::Url(canonical.clone()),
+                    url: proxy,
+                }]);
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations)
+            .build()?;
+        let locked_hashes = HashDigests::from(vec![HashDigest::from_str(digest)?]);
+        let locked_file = File {
+            dist_info_metadata: true,
+            filename: SmallString::from(filename),
+            hashes: locked_hashes,
+            requires_python: None,
+            size: None,
+            upload_time_utc_ms: None,
+            url: FileLocation::new(
+                SmallString::from(format!("{}/files/{filename}", canonical_server.uri())),
+                &SmallString::from(canonical_server.uri()),
+            ),
+            yanked: None,
+            zstd: None,
+        };
+        let built_dist = BuiltDist::Registry(RegistryBuiltDist {
+            wheels: vec![RegistryBuiltWheel {
+                filename: WheelFilename::from_str(filename)?,
+                file: Box::new(locked_file),
+                index: canonical,
+                proxy: None,
+            }],
+            best_wheel_index: 0,
+            sdist: None,
+        });
+
+        let metadata = client
+            .wheel_metadata(
+                &built_dist,
+                &GitResolver::default(),
+                &IndexCapabilities::default(),
+                None,
+            )
+            .await?;
+
+        assert_eq!(metadata.name, PackageName::from_str("example")?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hashless_proxy_artifact_metadata_requires_verified_wheel() -> Result<(), Error> {
+        let canonical_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&canonical_server)
+            .await;
+
+        let filename = "example-1.0.0-py3-none-any.whl";
+        let mut wheel = ZipFileWriter::new(Vec::new());
+        let padding_entry = ZipEntryBuilder::new(
+            "example/padding.bin".to_string().into(),
+            ZipCompression::Stored,
+        );
+        let padding = vec![0; 64 * 1024];
+        wheel.write_entry_whole(padding_entry, &padding).await?;
+        let metadata_entry = ZipEntryBuilder::new(
+            "example-1.0.0.dist-info/METADATA".to_string().into(),
+            ZipCompression::Stored,
+        );
+        wheel
+            .write_entry_whole(
+                metadata_entry,
+                b"Metadata-Version: 2.3\nName: example\nVersion: 1.0.0\n",
+            )
+            .await?;
+        let wheel_bytes = wheel.close().await?;
+        let mut hashers = vec![Hasher::from(HashAlgorithm::Sha256)];
+        let mut reader = HashReader::new(std::io::Cursor::new(&wheel_bytes), &mut hashers);
+        reader.finish().await?;
+        let locked_digest = hashers
+            .into_iter()
+            .next()
+            .map(HashDigest::from)
+            .ok_or("expected a wheel digest")?;
+
+        let proxy_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path("/simple/example/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("cache-control", "max-age=3600")
+                    .set_body_raw(
+                        json!({
+                            "name": "example",
+                            "files": [{
+                                "filename": filename,
+                                "url": format!("{}/files/{filename}", proxy_server.uri()),
+                                "hashes": {},
+                                "core-metadata": true
+                            }]
+                        })
+                        .to_string(),
+                        "application/vnd.pypi.simple.v1+json",
+                    ),
+            )
+            .expect(1)
+            .mount(&proxy_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path(format!(
+                "/files/{filename}.metadata"
+            )))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("Metadata-Version: 2.3\nName: example\nVersion: 2.0.0\n"),
+            )
+            .expect(0)
+            .mount(&proxy_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path(format!("/files/{filename}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("cache-control", "max-age=3600")
+                    .set_body_bytes(wheel_bytes),
+            )
+            .expect(3)
+            .mount(&proxy_server)
+            .await;
+
+        let canonical = IndexUrl::from_str(&format!("{}/simple", canonical_server.uri()))?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", proxy_server.uri()))?;
+        let locations =
+            IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
+                .with_proxy_indexes(vec![ProxyIndex {
+                    index: IndexReference::Url(canonical.clone()),
+                    url: proxy.clone(),
+                }]);
+        let cache = Cache::temp()?;
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache.clone())
+            .index_locations(locations)
+            .build()?;
+        let built_dist = |hashes: HashDigests| -> Result<BuiltDist, Error> {
+            let locked_file = File {
+                dist_info_metadata: true,
+                filename: SmallString::from(filename),
+                hashes,
+                requires_python: None,
+                size: None,
+                upload_time_utc_ms: None,
+                url: FileLocation::new(
+                    SmallString::from(format!("{}/files/{filename}", canonical_server.uri())),
+                    &SmallString::from(canonical_server.uri()),
+                ),
+                yanked: None,
+                zstd: None,
+            };
+            Ok(BuiltDist::Registry(RegistryBuiltDist {
+                wheels: vec![RegistryBuiltWheel {
+                    filename: WheelFilename::from_str(filename)?,
+                    file: Box::new(locked_file),
+                    index: canonical.clone(),
+                    proxy: None,
+                }],
+                best_wheel_index: 0,
+                sdist: None,
+            }))
+        };
+
+        let metadata = client
+            .wheel_metadata(
+                &built_dist(HashDigests::from(locked_digest.clone()))?,
+                &GitResolver::default(),
+                &IndexCapabilities::default(),
+                None,
+            )
+            .await?;
+        assert_eq!(metadata.version.to_string(), "1.0.0");
+
+        let wheel_filename = WheelFilename::from_str(filename)?;
+        let locked_hashes_cache_key = vec![locked_digest.to_string()];
+        let cache_file = format!(
+            "{}-artifact-{}.msgpack",
+            wheel_filename.cache_key(),
+            super::cache_digest(&locked_hashes_cache_key)
+        );
+        let canonical_entry = cache.entry(
+            CacheBucket::Wheels,
+            WheelCache::Index(&canonical).wheel_dir(wheel_filename.name.as_ref()),
+            &cache_file,
+        );
+        let proxy_entry = cache.entry(
+            CacheBucket::Wheels,
+            WheelCache::Index(&proxy).wheel_dir(wheel_filename.name.as_ref()),
+            &cache_file,
+        );
+        assert!(!canonical_entry.path().exists());
+        assert!(proxy_entry.path().exists());
+
+        let invalid_hashes = HashDigests::from(HashDigest::from_str(
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        )?);
+        for _ in 0..2 {
+            let error = client
+                .wheel_metadata(
+                    &built_dist(invalid_hashes.clone())?,
+                    &GitResolver::default(),
+                    &IndexCapabilities::default(),
+                    None,
+                )
+                .await
+                .expect_err("the proxy wheel should fail its locked digest");
+            assert!(matches!(
+                error.kind(),
+                crate::ErrorKind::ProxyArtifactDigestMismatch {
+                    canonical: error_canonical,
+                    proxy: error_proxy,
+                    ..
+                } if error_canonical == &canonical && error_proxy == &proxy
+            ));
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_artifact_requires_exact_filename() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        let locked_filename = "example-1.1.0-py3-none-any.whl";
+        let proxy_filename = "example-1.01.0-py3-none-any.whl";
+        let digest = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3";
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path("/simple/example/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(
+                    json!({
+                        "name": "example",
+                        "files": [{
+                            "filename": proxy_filename,
+                            "url": format!("https://artifacts.example.com/files/{proxy_filename}"),
+                            "hashes": {
+                                "sha256": digest.strip_prefix("sha256:").unwrap_or_default()
+                            }
+                        }]
+                    })
+                    .to_string(),
+                    "application/vnd.pypi.simple.v1+json",
+                ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let canonical = IndexUrl::from_str("https://pypi.org/simple")?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(canonical.clone()),
+            url: proxy.clone(),
+        }]);
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations)
+            .build()?;
+        let hashes = HashDigests::from(vec![HashDigest::from_str(digest)?]);
+
+        let error = client
+            .proxy_artifact(
+                &PackageName::from_str("example")?,
+                &canonical,
+                locked_filename,
+                &hashes,
+                &IndexCapabilities::default(),
+            )
+            .await
+            .expect_err("an equivalent parsed filename should not match");
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::ProxyArtifactNotFound {
+                filename,
+                canonical: error_canonical,
+                proxy: error_proxy,
+            } if filename == locked_filename && error_canonical == &canonical && error_proxy == &proxy
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_artifact_rejects_hashless_lock_entry() -> Result<(), Error> {
+        let canonical = IndexUrl::from_str("https://canonical.example.com/simple")?;
+        let proxy = IndexUrl::from_str("https://proxy.example.com/simple")?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(canonical.clone()),
+            url: proxy.clone(),
+        }]);
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations)
+            .build()?;
+
+        let error = client
+            .proxy_artifact(
+                &PackageName::from_str("example")?,
+                &canonical,
+                "example-1.0.0-py3-none-any.whl",
+                &HashDigests::empty(),
+                &IndexCapabilities::default(),
+            )
+            .await
+            .expect_err("a hashless lock artifact should fail before proxy lookup");
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::ProxyArtifactMissingDigest {
+                canonical: error_canonical,
+                proxy: error_proxy,
+                ..
+            } if error_canonical == &canonical && error_proxy == &proxy
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_artifact_rejects_local_url() -> Result<(), Error> {
+        let server = MockServer::start().await;
+        let filename = "example-1.0.0-py3-none-any.whl";
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path("/simple/example/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(
+                    json!({
+                        "name": "example",
+                        "files": [{
+                            "filename": filename,
+                            "url": format!("file:///tmp/{filename}"),
+                            "hashes": {}
+                        }]
+                    })
+                    .to_string(),
+                    "application/vnd.pypi.simple.v1+json",
+                ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let canonical = IndexUrl::from_str("https://canonical.example.com/simple")?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(canonical.clone()),
+            url: proxy.clone(),
+        }]);
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations)
+            .build()?;
+        let locked_hashes = HashDigests::from(HashDigest::from_str(
+            "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+        )?);
+
+        let error = client
+            .proxy_artifact(
+                &PackageName::from_str("example")?,
+                &canonical,
+                filename,
+                &locked_hashes,
+                &IndexCapabilities::default(),
+            )
+            .await
+            .expect_err("proxy artifacts must not use local URLs");
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::ProxyArtifactLocalUrl {
+                filename: error_filename,
+                proxy: error_proxy,
+                ..
+            } if error_filename == filename && error_proxy == &proxy
+        ));
         Ok(())
     }
 

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -20,9 +20,9 @@ use uv_configuration::IndexStrategy;
 use uv_configuration::KeyringProviderType;
 use uv_distribution_filename::{DistFilename, WheelFilename};
 use uv_distribution_types::{
-    BuiltDist, File, FileLocation, IndexCapabilities, IndexFormat, IndexLocations,
-    IndexMetadataRef, IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
-    RegistryBuiltWheel, Zstd,
+    BuiltDist, File, FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations,
+    IndexMetadataRef, IndexRoute, IndexRoutes, IndexStatusCodeDecision, IndexStatusCodeStrategy,
+    IndexUrl, Name, RegistryBuiltWheel, Zstd,
 };
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
@@ -142,7 +142,7 @@ impl<'a> RegistryClientBuilder<'a> {
     }
 
     /// Add all authenticated sources to the cache.
-    fn cache_index_credentials(&mut self) -> Result<(), ClientBuildError> {
+    fn cache_index_credentials(&self) -> Result<(), ClientBuildError> {
         for index in self.index_locations.known_indexes() {
             if let Some(credentials) = index.credentials()? {
                 trace!(
@@ -153,6 +153,18 @@ impl<'a> RegistryClientBuilder<'a> {
                         .map(ToString::to_string)
                         .unwrap_or_else(|| index.url.to_string())
                 );
+                if let Some(root_url) = index.root_url() {
+                    self.base_client_builder
+                        .store_credentials(&root_url, credentials.clone());
+                }
+                self.base_client_builder
+                    .store_credentials(index.raw_url(), credentials);
+            }
+        }
+        for proxy_index in self.index_locations.proxy_indexes() {
+            let index = Index::from(proxy_index.url.clone());
+            if let Some(credentials) = index.credentials()? {
+                trace!("Read credentials for proxy index {}", index.url);
                 if let Some(root_url) = index.root_url() {
                     self.base_client_builder
                         .store_credentials(&root_url, credentials.clone());
@@ -174,9 +186,10 @@ impl<'a> RegistryClientBuilder<'a> {
     }
 
     fn build_inner(
-        mut self,
+        self,
         existing: Option<&BaseClient>,
     ) -> Result<RegistryClient, ClientBuildError> {
+        let routes = IndexRoutes::try_from(&self.index_locations)?;
         self.cache_index_credentials()?;
 
         // Wrap in any relevant middleware and handle connectivity.
@@ -197,6 +210,7 @@ impl<'a> RegistryClientBuilder<'a> {
 
         Ok(RegistryClient {
             indexes: self.index_locations,
+            routes,
             index_strategy: self.index_strategy,
             torch_backend: self.torch_backend,
             cache: self.cache,
@@ -214,6 +228,8 @@ impl<'a> RegistryClientBuilder<'a> {
 pub struct RegistryClient {
     /// The indexes to use for fetching packages.
     indexes: IndexLocations,
+    /// Validated routes from canonical indexes to physical metadata endpoints.
+    routes: IndexRoutes,
     /// The strategy to use when fetching across multiple indexes.
     index_strategy: IndexStrategy,
     /// The strategy to use when selecting a PyTorch backend, if any.
@@ -242,10 +258,23 @@ pub enum MetadataFormat {
     Flat(Vec<FlatIndexEntry>),
 }
 
+/// Package metadata returned for an index.
+#[derive(Debug)]
+pub struct IndexMetadataResponse<'index> {
+    /// The index route used to fetch this metadata.
+    pub index_route: IndexRoute<'index>,
+    pub format: MetadataFormat,
+}
+
 impl RegistryClient {
     /// Return the [`CachedClient`] used by this client.
     pub fn cached_client(&self) -> &CachedClient {
         &self.client
+    }
+
+    /// Return the validated [`IndexRoutes`] used by this client.
+    pub fn index_routes(&self) -> &IndexRoutes {
+        &self.routes
     }
 
     /// Return the [`BaseClient`] used by this client.
@@ -317,7 +346,7 @@ impl RegistryClient {
         index: Option<IndexMetadataRef<'index>>,
         capabilities: &IndexCapabilities,
         download_concurrency: &Semaphore,
-    ) -> Result<Vec<(&'index IndexUrl, MetadataFormat)>, Error> {
+    ) -> Result<Vec<IndexMetadataResponse<'index>>, Error> {
         // If `--no-index` is specified, avoid fetching regardless of whether the index is implicit,
         // explicit, etc.
         if self.indexes.no_index() {
@@ -339,19 +368,23 @@ impl RegistryClient {
                     let _permit = download_concurrency.acquire().await;
                     match index.format {
                         IndexFormat::Simple => {
+                            let index_route = self.routes.route_for(index.url);
                             let status_code_strategy =
-                                self.indexes.status_code_strategy_for(index.url);
+                                self.indexes.status_code_strategy_for(index_route.physical);
                             match self
                                 .simple_detail_single_index(
                                     package_name,
-                                    index.url,
+                                    index_route.physical,
                                     capabilities,
                                     &status_code_strategy,
                                 )
                                 .await?
                             {
                                 SimpleMetadataSearchOutcome::Found(metadata) => {
-                                    results.push((index.url, MetadataFormat::Simple(metadata)));
+                                    results.push(IndexMetadataResponse {
+                                        index_route,
+                                        format: MetadataFormat::Simple(metadata),
+                                    });
                                     break;
                                 }
                                 // Package not found, so we will continue on to the next index (if there is one)
@@ -369,7 +402,13 @@ impl RegistryClient {
                         IndexFormat::Flat => {
                             let entries = self.flat_single_index(package_name, index.url).await?;
                             if !entries.is_empty() {
-                                results.push((index.url, MetadataFormat::Flat(entries)));
+                                results.push(IndexMetadataResponse {
+                                    index_route: IndexRoute {
+                                        canonical: index.url,
+                                        physical: index.url,
+                                    },
+                                    format: MetadataFormat::Flat(entries),
+                                });
                                 break;
                             }
                         }
@@ -384,13 +423,14 @@ impl RegistryClient {
                         let _permit = download_concurrency.acquire().await;
                         match index.format {
                             IndexFormat::Simple => {
+                                let index_route = self.routes.route_for(index.url);
                                 // For unsafe matches, ignore authentication failures.
                                 let status_code_strategy =
                                     IndexStatusCodeStrategy::ignore_authentication_error_codes();
                                 let metadata = match self
                                     .simple_detail_single_index(
                                         package_name,
-                                        index.url,
+                                        index_route.physical,
                                         capabilities,
                                         &status_code_strategy,
                                     )
@@ -399,21 +439,26 @@ impl RegistryClient {
                                     SimpleMetadataSearchOutcome::Found(metadata) => Some(metadata),
                                     _ => None,
                                 };
-                                Ok((index.url, metadata.map(MetadataFormat::Simple)))
+                                Ok(metadata.map(|metadata| IndexMetadataResponse {
+                                    index_route,
+                                    format: MetadataFormat::Simple(metadata),
+                                }))
                             }
                             IndexFormat::Flat => {
                                 let entries =
                                     self.flat_single_index(package_name, index.url).await?;
-                                Ok((index.url, Some(MetadataFormat::Flat(entries))))
+                                Ok(Some(IndexMetadataResponse {
+                                    index_route: IndexRoute {
+                                        canonical: index.url,
+                                        physical: index.url,
+                                    },
+                                    format: MetadataFormat::Flat(entries),
+                                }))
                             }
                         }
                     })
                     .buffered(8)
-                    .filter_map(async |result: Result<_, Error>| match result {
-                        Ok((index, Some(metadata))) => Some(Ok((index, metadata))),
-                        Ok((_, None)) => None,
-                        Err(err) => Some(Err(err)),
-                    })
+                    .filter_map(async |result: Result<_, Error>| result.transpose())
                     .try_collect::<Vec<_>>()
                     .await?;
             }
@@ -757,6 +802,8 @@ impl RegistryClient {
         &self,
         index_url: &IndexUrl,
     ) -> Result<SimpleIndexMetadata, Error> {
+        let route = self.routes.route_for(index_url);
+        let index_url = route.physical;
         // Format the URL for PyPI.
         let mut url = index_url.url().clone();
         url.path_segments_mut()
@@ -1089,8 +1136,22 @@ impl RegistryClient {
             filename,
             file,
             index,
+            ..
         } = wheel;
 
+        let route = self.routes.route_for(index);
+        self.wheel_metadata_registry_at(filename, route.physical, file, url, capabilities)
+            .await
+    }
+
+    async fn wheel_metadata_registry_at(
+        &self,
+        filename: &WheelFilename,
+        index: &IndexUrl,
+        file: &File,
+        url: &DisplaySafeUrl,
+        capabilities: &IndexCapabilities,
+    ) -> Result<ResolutionMetadata, Error> {
         // If the metadata file is available at its own url (PEP 658), download it from there.
         if file.dist_info_metadata {
             let mut url = url.clone();
@@ -1933,6 +1994,7 @@ impl Connectivity {
 mod tests {
     use std::str::FromStr;
 
+    use serde_json::from_str as deserialize_json;
     use tokio::sync::Semaphore;
     use url::Url;
     use uv_normalize::PackageName;
@@ -1941,16 +2003,17 @@ mod tests {
     use uv_torch::{TorchBackend, TorchSource, TorchStrategy};
 
     use crate::{
-        BaseClientBuilder, Connectivity, RegistryClient, RegistryClientBuilder,
-        SimpleDetailMetadata, SimpleDetailMetadatum, html::SimpleDetailHTML,
+        BaseClientBuilder, ClientBuildError, Connectivity, IndexMetadataResponse, MetadataFormat,
+        RegistryClient, RegistryClientBuilder, SimpleDetailMetadata, SimpleDetailMetadatum,
+        html::SimpleDetailHTML,
     };
     use uv_cache::Cache;
     use uv_distribution_types::{
         FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-        IndexUrl, ToUrlError,
+        IndexReference, IndexUrl, ProxyIndex, ToUrlError,
     };
     use uv_small_str::SmallString;
-    use wiremock::matchers::{basic_auth, method, path_regex};
+    use wiremock::matchers::{basic_auth, method, path, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     type Error = Box<dyn std::error::Error>;
@@ -2010,6 +2073,40 @@ mod tests {
                 .expect("request recording should be enabled")
                 .is_empty()
         );
+    }
+
+    fn proxy_index_locations(canonical: &IndexUrl, proxy: &IndexUrl) -> IndexLocations {
+        IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
+            .with_proxy_indexes(vec![ProxyIndex {
+                index: IndexReference::Url(canonical.clone()),
+                url: proxy.clone(),
+            }])
+    }
+
+    fn proxy_registry_client(
+        canonical: &IndexUrl,
+        proxy: &IndexUrl,
+    ) -> Result<RegistryClient, Error> {
+        Ok(
+            RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+                .index_locations(proxy_index_locations(canonical, proxy))
+                .build()?,
+        )
+    }
+
+    async fn fetch_simple_detail<'index>(
+        client: &'index RegistryClient,
+        index: &'index IndexUrl,
+        capabilities: &IndexCapabilities,
+    ) -> Result<Vec<IndexMetadataResponse<'index>>, crate::Error> {
+        client
+            .simple_detail(
+                &PackageName::from_str("example").expect("valid package name"),
+                Some(IndexMetadataRef::from(index)),
+                capabilities,
+                &Semaphore::new(1),
+            )
+            .await
     }
 
     #[tokio::test]
@@ -2081,6 +2178,212 @@ mod tests {
 
         assert_no_index(&registry_client, "validation", None).await?;
         assert_no_requests(&server).await;
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_proxy_index_rejected_by_all_build_paths() -> Result<(), Error> {
+        let index = IndexUrl::from_str("https://pypi.org/simple")?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(index.clone()),
+            url: index,
+        }]);
+        let builder = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations);
+
+        assert!(matches!(
+            builder.clone().build(),
+            Err(ClientBuildError::ProxyIndex(_))
+        ));
+        let base_client = BaseClientBuilder::default().build()?;
+        assert!(matches!(
+            builder.wrap_existing(&base_client),
+            Err(ClientBuildError::ProxyIndex(_))
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn simple_detail_routes_through_proxy() -> Result<(), Error> {
+        let canonical_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&canonical_server)
+            .await;
+
+        let proxy_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/simple/example/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"{"files": []}"#, "application/vnd.pypi.simple.v1+json"),
+            )
+            .expect(1)
+            .mount(&proxy_server)
+            .await;
+
+        let canonical = IndexUrl::from_str(&format!("{}/simple", canonical_server.uri()))?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", proxy_server.uri()))?;
+        let client = proxy_registry_client(&canonical, &proxy)?;
+
+        let response = fetch_simple_detail(&client, &canonical, &IndexCapabilities::default())
+            .await?
+            .into_iter()
+            .next()
+            .ok_or("expected proxy metadata")?;
+        assert_eq!(response.index_route.canonical, &canonical);
+        assert_eq!(response.index_route.physical, &proxy);
+        assert!(matches!(response.format, MetadataFormat::Simple(_)));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn simple_detail_does_not_route_flat_index_through_proxy() -> Result<(), Error> {
+        let canonical_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<a href="example-1.0.0-py3-none-any.whl">example</a>"#,
+                "text/html",
+            ))
+            .expect(1)
+            .mount(&canonical_server)
+            .await;
+
+        let proxy_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&proxy_server)
+            .await;
+
+        let canonical = IndexUrl::from_str(&canonical_server.uri())?;
+        let proxy = IndexUrl::from_str(&proxy_server.uri())?;
+        let client = proxy_registry_client(&canonical, &proxy)?;
+
+        let response = client
+            .simple_detail(
+                &PackageName::from_str("example")?,
+                Some(IndexMetadataRef {
+                    url: &canonical,
+                    format: IndexFormat::Flat,
+                }),
+                &IndexCapabilities::default(),
+                &Semaphore::new(1),
+            )
+            .await?
+            .into_iter()
+            .next()
+            .ok_or("expected flat-index metadata")?;
+
+        assert_eq!(response.index_route.canonical, &canonical);
+        assert_eq!(response.index_route.physical, &canonical);
+        assert!(matches!(response.format, MetadataFormat::Flat(_)));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn simple_detail_authenticates_to_proxy() -> Result<(), Error> {
+        let proxy_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/simple/example/"))
+            .and(basic_auth("proxy-user", "proxy-secret"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"{"files": []}"#, "application/vnd.pypi.simple.v1+json"),
+            )
+            .expect(1)
+            .mount(&proxy_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/simple/example/"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&proxy_server)
+            .await;
+        let proxy = IndexUrl::from_str(&format!(
+            "http://proxy-user:proxy-secret@{}/simple",
+            proxy_server.address()
+        ))?;
+        let canonical = IndexUrl::from_str("https://canonical.example.com/simple")?;
+        let client = proxy_registry_client(&canonical, &proxy)?;
+
+        let response = fetch_simple_detail(&client, &canonical, &IndexCapabilities::default())
+            .await?
+            .into_iter()
+            .next()
+            .ok_or("expected authenticated proxy metadata")?;
+
+        assert_eq!(response.index_route.canonical, &canonical);
+        assert_eq!(response.index_route.physical, &proxy);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn simple_detail_uses_proxy_status_code_policy() -> Result<(), Error> {
+        let proxy_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/simple/example/"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&proxy_server)
+            .await;
+
+        let canonical = IndexUrl::from_str("https://canonical.example.com/simple")?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", proxy_server.uri()))?;
+        let canonical_index = Index::from(canonical.clone());
+        let mut proxy_index = Index::from(proxy.clone());
+        proxy_index.explicit = true;
+        proxy_index.ignore_error_codes = Some(vec![deserialize_json("500")?]);
+        let locations = IndexLocations::new(vec![canonical_index, proxy_index], Vec::new(), false)
+            .with_proxy_indexes(vec![ProxyIndex {
+                index: IndexReference::Url(canonical.clone()),
+                url: proxy,
+            }]);
+        let client =
+            RegistryClientBuilder::new(BaseClientBuilder::default().retries(0), Cache::temp()?)
+                .index_locations(locations)
+                .build()?;
+
+        let error = fetch_simple_detail(&client, &canonical, &IndexCapabilities::default())
+            .await
+            .expect_err("the proxy response should be ignored by its status-code policy");
+
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::RemotePackageNotFound(package) if package.as_ref() == "example"
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn simple_detail_attributes_authentication_failure_to_proxy() -> Result<(), Error> {
+        let canonical_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&canonical_server)
+            .await;
+
+        let proxy_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/simple/example/"))
+            .respond_with(ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&proxy_server)
+            .await;
+
+        let canonical = IndexUrl::from_str(&format!("{}/simple", canonical_server.uri()))?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", proxy_server.uri()))?;
+        let client = proxy_registry_client(&canonical, &proxy)?;
+        let capabilities = IndexCapabilities::default();
+
+        fetch_simple_detail(&client, &canonical, &capabilities)
+            .await
+            .expect_err("the proxy should reject the request");
+
+        assert!(capabilities.unauthorized(&proxy));
+        assert!(!capabilities.unauthorized(&canonical));
         Ok(())
     }
 

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -279,6 +279,57 @@ pub struct IndexCredentialsError {
     source: CredentialsFromUrlError,
 }
 
+/// A configured index name or URL.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
+#[serde(untagged)]
+pub enum IndexReference {
+    /// The name of a configured index.
+    Name(IndexName),
+    /// The URL of an index.
+    Url(IndexUrl),
+}
+
+impl<'de> Deserialize<'de> for IndexReference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if let Ok(name) = IndexName::from_str(&value) {
+            Ok(Self::Name(name))
+        } else {
+            IndexUrl::from_str(&value)
+                .map(Self::Url)
+                .map_err(serde::de::Error::custom)
+        }
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for IndexReference {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("IndexReference")
+    }
+
+    fn json_schema(_generator: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "description": "The name or URL of a package index."
+        })
+    }
+}
+
+/// A proxy endpoint used to access a canonical package index.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub struct ProxyIndex {
+    /// The canonical index, identified by name or URL.
+    pub index: IndexReference,
+    /// The proxy index URL.
+    pub url: IndexUrl,
+}
+
 impl PartialEq for Index {
     fn eq(&self, other: &Self) -> bool {
         let Self {

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -17,7 +17,10 @@ use uv_pypi_types::HashAlgorithm;
 use uv_redacted::DisplaySafeUrl;
 use uv_warnings::warn_user;
 
-use crate::{ExcludeNewerOverride, Index, IndexStatusCodeStrategy, Verbatim};
+use crate::{
+    ExcludeNewerOverride, Index, IndexFormat, IndexReference, IndexStatusCodeStrategy, ProxyIndex,
+    Verbatim,
+};
 
 pub static PYPI_URL: LazyLock<DisplaySafeUrl> =
     LazyLock::new(|| DisplaySafeUrl::parse("https://pypi.org/simple").unwrap());
@@ -258,12 +261,29 @@ impl Deref for IndexUrl {
 ///
 /// This type merges the legacy `--index-url`, `--extra-index-url`, and `--find-links` options,
 /// along with the uv-specific `--index` and `--default-index`.
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct IndexLocations {
     indexes: Vec<Index>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    proxy_indexes: Vec<ProxyIndex>,
     flat_index: Vec<Index>,
     no_index: bool,
+}
+
+/// Preserve the existing output when no proxy indexes are configured.
+impl std::fmt::Debug for IndexLocations {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = formatter.debug_struct("IndexLocations");
+        debug.field("indexes", &self.indexes);
+        if !self.proxy_indexes.is_empty() {
+            debug.field("proxy_indexes", &self.proxy_indexes);
+        }
+        debug
+            .field("flat_index", &self.flat_index)
+            .field("no_index", &self.no_index)
+            .finish()
+    }
 }
 
 impl IndexLocations {
@@ -271,9 +291,17 @@ impl IndexLocations {
     pub fn new(indexes: Vec<Index>, flat_index: Vec<Index>, no_index: bool) -> Self {
         Self {
             indexes,
+            proxy_indexes: Vec::new(),
             flat_index,
             no_index,
         }
+    }
+
+    /// Configure proxy indexes for canonical package indexes.
+    #[must_use]
+    pub fn with_proxy_indexes(mut self, proxy_indexes: Vec<ProxyIndex>) -> Self {
+        self.proxy_indexes = proxy_indexes;
+        self
     }
 
     /// Combine a set of index locations.
@@ -286,6 +314,7 @@ impl IndexLocations {
     pub fn combine(self, indexes: Vec<Index>, flat_index: Vec<Index>, no_index: bool) -> Self {
         Self {
             indexes: self.indexes.into_iter().chain(indexes).collect(),
+            proxy_indexes: self.proxy_indexes,
             flat_index: self.flat_index.into_iter().chain(flat_index).collect(),
             no_index: self.no_index || no_index,
         }
@@ -302,6 +331,17 @@ impl IndexLocations {
 fn is_same_index(a: &IndexUrl, b: &IndexUrl) -> bool {
     RealmRef::from(&**b.url()) == RealmRef::from(&**a.url())
         && CanonicalUrl::new(a.url().clone()) == CanonicalUrl::new(b.url().clone())
+}
+
+/// Return user-defined indexes in priority order, excluding shadowed names.
+fn prioritized_defined_indexes(indexes: &[Index]) -> impl Iterator<Item = &Index> {
+    let mut seen = FxHashSet::default();
+    let (non_default, default) = indexes
+        .iter()
+        .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
+        .partition::<Vec<_>, _>(|index| !index.default);
+
+    non_default.into_iter().chain(default)
 }
 
 impl<'a> IndexLocations {
@@ -406,6 +446,11 @@ impl<'a> IndexLocations {
         self.no_index
     }
 
+    /// Return the configured proxy indexes.
+    pub fn proxy_indexes(&self) -> impl Iterator<Item = &ProxyIndex> {
+        self.proxy_indexes.iter()
+    }
+
     /// Return a vector containing all allowed [`Index`] entries.
     ///
     /// This includes explicit indexes, implicit indexes, flat indexes, and the default index.
@@ -477,20 +522,7 @@ impl<'a> IndexLocations {
             return Either::Left(std::iter::empty());
         }
 
-        let mut seen = FxHashSet::default();
-        let (non_default, default) = self
-            .indexes
-            .iter()
-            .filter(move |index| {
-                if let Some(name) = &index.name {
-                    seen.insert(name)
-                } else {
-                    true
-                }
-            })
-            .partition::<Vec<_>, _>(|index| !index.default);
-
-        Either::Right(non_default.into_iter().chain(default))
+        Either::Right(prioritized_defined_indexes(&self.indexes))
     }
 
     /// Return the configured index matching the given URL.
@@ -538,22 +570,150 @@ impl<'a> IndexLocations {
     }
 }
 
+/// Convert an index URL into an authentication scope without retaining credentials.
+fn authentication_index(index: &IndexUrl, auth_policy: uv_auth::AuthPolicy) -> uv_auth::Index {
+    let mut url = index.url().clone();
+    url.set_username("").ok();
+    url.set_password(None).ok();
+    let mut root_url = index.root().unwrap_or_else(|| url.clone());
+    root_url.set_username("").ok();
+    root_url.set_password(None).ok();
+    uv_auth::Index {
+        url,
+        root_url,
+        auth_policy,
+    }
+}
+
 impl From<&IndexLocations> for uv_auth::Indexes {
     fn from(index_locations: &IndexLocations) -> Self {
-        Self::from_indexes(index_locations.allowed_indexes().into_iter().map(|index| {
-            let mut url = index.url().url().clone();
-            url.set_username("").ok();
-            url.set_password(None).ok();
-            let mut root_url = index.url().root().unwrap_or_else(|| url.clone());
-            root_url.set_username("").ok();
-            root_url.set_password(None).ok();
-            uv_auth::Index {
-                url,
-                root_url,
-                auth_policy: index.authenticate,
-            }
-        }))
+        let configured_indexes = index_locations.allowed_indexes();
+        let indexes = configured_indexes
+            .iter()
+            .map(|index| authentication_index(index.url(), index.authenticate))
+            .chain(
+                index_locations
+                    .proxy_indexes()
+                    .filter(|proxy_index| {
+                        !configured_indexes
+                            .iter()
+                            .any(|index| is_same_index(index.url(), &proxy_index.url))
+                    })
+                    .map(|proxy_index| {
+                        authentication_index(&proxy_index.url, uv_auth::AuthPolicy::Auto)
+                    }),
+            );
+        Self::from_indexes(indexes)
     }
+}
+
+/// Validated routes from canonical indexes to physical metadata endpoints.
+#[derive(Debug, Clone, Default)]
+pub struct IndexRoutes {
+    routes: Vec<(IndexUrl, IndexUrl)>,
+}
+
+impl IndexRoutes {
+    /// Return the logical and physical endpoints for a canonical index.
+    pub fn route_for<'index>(&'index self, canonical: &'index IndexUrl) -> IndexRoute<'index> {
+        let physical = self
+            .routes
+            .iter()
+            .find(|(route_canonical, _)| is_same_index(route_canonical, canonical))
+            .map_or(canonical, |(_, physical)| physical);
+        IndexRoute {
+            canonical,
+            physical,
+        }
+    }
+
+    /// Return the configured proxy routes.
+    pub fn proxy_routes(&self) -> impl Iterator<Item = IndexRoute<'_>> {
+        self.routes.iter().map(|(canonical, physical)| IndexRoute {
+            canonical,
+            physical,
+        })
+    }
+}
+
+impl TryFrom<&IndexLocations> for IndexRoutes {
+    type Error = ProxyIndexError;
+
+    fn try_from(index_locations: &IndexLocations) -> Result<Self, Self::Error> {
+        let effective_indexes =
+            prioritized_defined_indexes(&index_locations.indexes).collect::<Vec<_>>();
+        let mut routes =
+            Vec::<(IndexUrl, IndexUrl)>::with_capacity(index_locations.proxy_indexes.len());
+        for proxy_index in &index_locations.proxy_indexes {
+            let canonical = match &proxy_index.index {
+                IndexReference::Name(name) => effective_indexes
+                    .iter()
+                    .copied()
+                    .find(|index| index.name.as_ref() == Some(name))
+                    .map(|index| index.url().clone())
+                    .ok_or_else(|| ProxyIndexError::UnknownIndex { name: name.clone() })?,
+                IndexReference::Url(url) => url.clone(),
+            };
+            if effective_indexes
+                .iter()
+                .copied()
+                .chain(&index_locations.flat_index)
+                .any(|index| {
+                    index.format == IndexFormat::Flat && is_same_index(index.url(), &canonical)
+                })
+            {
+                return Err(ProxyIndexError::FlatIndex { index: canonical });
+            }
+            if matches!(canonical, IndexUrl::Path(_)) {
+                return Err(ProxyIndexError::PathIndex { index: canonical });
+            }
+            if matches!(proxy_index.url, IndexUrl::Path(_)) {
+                return Err(ProxyIndexError::PathIndex {
+                    index: proxy_index.url.clone(),
+                });
+            }
+            if is_same_index(&canonical, &proxy_index.url) {
+                return Err(ProxyIndexError::SelfProxy { index: canonical });
+            }
+            if routes
+                .iter()
+                .any(|(route_canonical, _)| is_same_index(route_canonical, &canonical))
+            {
+                return Err(ProxyIndexError::Duplicate { index: canonical });
+            }
+            routes.push((canonical, proxy_index.url.clone()));
+        }
+        Ok(Self { routes })
+    }
+}
+
+/// The logical and physical endpoints for an index request.
+#[derive(Debug, Clone, Copy)]
+pub struct IndexRoute<'index> {
+    pub canonical: &'index IndexUrl,
+    pub physical: &'index IndexUrl,
+}
+
+impl IndexRoute<'_> {
+    /// Return `true` if the index request is routed through a proxy.
+    pub fn is_proxy(self) -> bool {
+        !is_same_index(self.canonical, self.physical)
+    }
+}
+
+/// An invalid proxy-index configuration.
+#[derive(Debug, Clone, Eq, PartialEq, Error)]
+pub enum ProxyIndexError {
+    #[error("Proxy index references unknown index `{name}`")]
+    UnknownIndex { name: crate::IndexName },
+    #[error("Multiple proxy indexes are configured for `{index}`")]
+    Duplicate { index: IndexUrl },
+    #[error("Proxy index for `{index}` points to the canonical index itself")]
+    SelfProxy { index: IndexUrl },
+    #[error("Proxy index for `{index}` references a flat index")]
+    FlatIndex { index: IndexUrl },
+    #[error("Proxy index mappings do not support path-backed index `{index}`")]
+    PathIndex { index: IndexUrl },
 }
 
 bitflags::bitflags! {
@@ -639,7 +799,7 @@ impl IndexCapabilities {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{IndexCacheControl, IndexFormat, IndexName};
+    use crate::{IndexCacheControl, IndexFormat, IndexName, IndexReference, ProxyIndex};
     use http::HeaderValue;
 
     #[test]
@@ -687,6 +847,144 @@ mod tests {
 
         assert_eq!(locations.indexes().count(), 2);
         assert_eq!(locations.fetch_indexes().count(), 1);
+    }
+
+    #[test]
+    fn proxy_index_resolves_name() -> Result<(), Box<dyn std::error::Error>> {
+        let canonical = IndexUrl::from_str("https://pypi.org/simple")?;
+        let proxy = IndexUrl::from_str("https://packages.example.com/simple")?;
+        let mut index = Index::from(canonical.clone());
+        index.name = Some(IndexName::from_str("pypi")?);
+        let locations =
+            IndexLocations::new(vec![index], Vec::new(), false).with_proxy_indexes(vec![
+                ProxyIndex {
+                    index: IndexReference::Name(IndexName::from_str("pypi")?),
+                    url: proxy.clone(),
+                },
+            ]);
+
+        let routes = IndexRoutes::try_from(&locations)?;
+        let route = routes.route_for(&canonical);
+        assert_eq!(route.canonical, &canonical);
+        assert_eq!(route.physical, &proxy);
+        assert!(route.is_proxy());
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_index_matches_url_without_credentials() -> Result<(), Box<dyn std::error::Error>> {
+        let authenticated = IndexUrl::from_str("https://user:secret@pypi.org/simple")?;
+        let canonical = IndexUrl::from_str("https://pypi.org/simple")?;
+        let proxy = IndexUrl::from_str("https://packages.example.com/simple")?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(authenticated),
+            url: proxy.clone(),
+        }]);
+
+        let routes = IndexRoutes::try_from(&locations)?;
+        assert_eq!(routes.route_for(&canonical).physical, &proxy);
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_index_preserves_configured_never_authentication_policy()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let canonical = IndexUrl::from_str("https://pypi.org/simple")?;
+        let proxy =
+            IndexUrl::from_str("https://proxy-user:proxy-secret@packages.example.com/simple")?;
+        let mut configured_proxy = Index::from(proxy.clone());
+        configured_proxy.explicit = true;
+        configured_proxy.authenticate = uv_auth::AuthPolicy::Never;
+        assert!(configured_proxy.credentials()?.is_some());
+
+        let locations = IndexLocations::new(
+            vec![Index::from(canonical.clone()), configured_proxy],
+            Vec::new(),
+            false,
+        )
+        .with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(canonical),
+            url: proxy,
+        }]);
+        let configured_indexes = locations.allowed_indexes();
+        let expected = uv_auth::Indexes::from_indexes(
+            configured_indexes
+                .iter()
+                .map(|index| authentication_index(index.url(), index.authenticate)),
+        );
+
+        assert_eq!(uv_auth::Indexes::from(&locations), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_index_rejects_duplicate_and_self_mappings() -> Result<(), Box<dyn std::error::Error>> {
+        let canonical = IndexUrl::from_str("https://pypi.org/simple")?;
+        let duplicate = IndexLocations::default().with_proxy_indexes(vec![
+            ProxyIndex {
+                index: IndexReference::Url(canonical.clone()),
+                url: IndexUrl::from_str("https://one.example.com/simple")?,
+            },
+            ProxyIndex {
+                index: IndexReference::Url(IndexUrl::from_str("https://pypi.org/simple/")?),
+                url: IndexUrl::from_str("https://two.example.com/simple")?,
+            },
+        ]);
+        assert!(matches!(
+            IndexRoutes::try_from(&duplicate),
+            Err(ProxyIndexError::Duplicate { .. })
+        ));
+
+        let self_proxy = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(canonical),
+            url: IndexUrl::from_str("https://pypi.org/simple/")?,
+        }]);
+        assert!(matches!(
+            IndexRoutes::try_from(&self_proxy),
+            Err(ProxyIndexError::SelfProxy { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_index_rejects_unknown_and_flat_indexes() -> Result<(), Box<dyn std::error::Error>> {
+        let unknown = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Name(IndexName::from_str("unknown")?),
+            url: IndexUrl::from_str("https://proxy.example.com/simple")?,
+        }]);
+        assert!(matches!(
+            IndexRoutes::try_from(&unknown),
+            Err(ProxyIndexError::UnknownIndex { .. })
+        ));
+
+        let canonical = IndexUrl::from_str("https://canonical.example.com/packages")?;
+        let mut index = Index::from(canonical);
+        index.name = Some(IndexName::from_str("canonical")?);
+        index.format = IndexFormat::Flat;
+        let flat = IndexLocations::new(vec![index], Vec::new(), false).with_proxy_indexes(vec![
+            ProxyIndex {
+                index: IndexReference::Name(IndexName::from_str("canonical")?),
+                url: IndexUrl::from_str("https://proxy.example.com/packages")?,
+            },
+        ]);
+        assert!(matches!(
+            IndexRoutes::try_from(&flat),
+            Err(ProxyIndexError::FlatIndex { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_index_rejects_path_indexes() -> Result<(), Box<dyn std::error::Error>> {
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(IndexUrl::from_str("https://pypi.org/simple")?),
+            url: IndexUrl::from_str("./proxy")?,
+        }]);
+        assert!(matches!(
+            IndexRoutes::try_from(&locations),
+            Err(ProxyIndexError::PathIndex { .. })
+        ));
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -687,7 +687,7 @@ impl BuiltDist {
     }
 
     /// Returns the [`IndexUrl`], if the distribution is from a registry.
-    pub fn index(&self) -> Option<&IndexUrl> {
+    fn index(&self) -> Option<&IndexUrl> {
         match self {
             Self::Registry(registry) => Some(&registry.best_wheel().index),
             Self::DirectUrl(_) => None,

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -225,6 +225,15 @@ pub struct RegistryBuiltWheel {
     pub filename: WheelFilename,
     pub file: Box<File>,
     pub index: IndexUrl,
+    /// The physical proxy endpoint used to discover this wheel, if any.
+    pub proxy: Option<IndexUrl>,
+}
+
+impl RegistryBuiltWheel {
+    /// Return the physical index from which this wheel should be fetched.
+    pub fn physical_index(&self) -> &IndexUrl {
+        self.proxy.as_ref().unwrap_or(&self.index)
+    }
 }
 
 /// A built distribution (wheel) that exists in a registry, like `PyPI`.
@@ -300,6 +309,8 @@ pub struct RegistrySourceDist {
     /// The file extension, e.g. `tar.gz`, `zip`, etc.
     pub ext: SourceDistExtension,
     pub index: IndexUrl,
+    /// The physical proxy endpoint used to discover this source distribution, if any.
+    pub proxy: Option<IndexUrl>,
     /// When an sdist is selected, it may be the case that there were
     /// available wheels too. There are many reasons why a wheel might not
     /// have been chosen (maybe none available are compatible with the

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -27,7 +27,7 @@ use uv_fs::write_atomic;
 use uv_git::{GIT_LFS, GitError};
 use uv_install_wheel::validate_and_heal_record;
 use uv_platform_tags::Tags;
-use uv_pypi_types::{HashDigest, HashDigests, PyProjectToml};
+use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, PyProjectToml};
 use uv_python::PythonVariant;
 use uv_redacted::DisplaySafeUrl;
 use uv_types::{BuildContext, BuildStack};
@@ -185,16 +185,52 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         match dist {
             BuiltDist::Registry(wheels) => {
                 let wheel = wheels.best_wheel();
+                let filename = wheel.filename.to_string();
+                let proxy_artifact = if wheel.proxy.is_none() {
+                    self.client
+                        .managed(|client| {
+                            client.proxy_artifact(
+                                wheel.name(),
+                                &wheel.index,
+                                &filename,
+                                &wheel.file.hashes,
+                                self.build_context.capabilities(),
+                            )
+                        })
+                        .await?
+                } else {
+                    None
+                };
+                let proxied = wheel.proxy.is_some() || proxy_artifact.is_some();
+                let mut hashes = WheelHashPolicy::from(hashes);
+                if proxied {
+                    hashes.validation = if wheel.file.hashes.is_empty() {
+                        hashes.required
+                    } else {
+                        HashPolicy::Any(wheel.file.hashes.as_slice())
+                    };
+                }
+                let (target, physical_index) = if let Some(proxy) = &wheel.proxy {
+                    (WheelTarget::from_wheel(&wheel.file)?, proxy)
+                } else if let Some(proxy_artifact) = &proxy_artifact {
+                    (
+                        WheelTarget::from_wheel(&proxy_artifact.file)?,
+                        &proxy_artifact.physical_index,
+                    )
+                } else {
+                    (WheelTarget::try_from(&*wheel.file)?, &wheel.index)
+                };
                 let WheelTarget {
                     url,
                     extension,
                     size,
-                } = WheelTarget::try_from(&*wheel.file)?;
+                } = target;
+                validate_proxy_artifact_url(proxied, &filename, &url)?;
 
                 // Create a cache entry for the wheel.
                 let wheel_entry = self.build_context.cache().entry(
                     CacheBucket::Wheels,
-                    WheelCache::Index(&wheel.index).wheel_dir(wheel.name().as_ref()),
+                    WheelCache::Index(physical_index).wheel_dir(wheel.name().as_ref()),
                     wheel.filename.cache_key(),
                 );
 
@@ -207,10 +243,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         .load_wheel(
                             &path,
                             &wheel.filename,
-                            WheelExtension::Whl,
+                            extension,
                             wheel_entry,
                             dist,
-                            hashes,
+                            hashes.required,
                         )
                         .await;
                 }
@@ -219,7 +255,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 match self
                     .stream_wheel(
                         url.clone(),
-                        dist.index(),
+                        Some(physical_index),
                         &wheel.filename,
                         extension,
                         size,
@@ -257,7 +293,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         let archive = self
                             .download_wheel(
                                 url,
-                                dist.index(),
+                                Some(physical_index),
                                 &wheel.filename,
                                 extension,
                                 size,
@@ -302,7 +338,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         None,
                         &wheel_entry,
                         dist,
-                        hashes,
+                        hashes.into(),
                     )
                     .await
                 {
@@ -340,7 +376,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                                 None,
                                 &wheel_entry,
                                 dist,
-                                hashes,
+                                hashes.into(),
                             )
                             .await?;
                         Ok(LocalWheel {
@@ -702,7 +738,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: WheelHashPolicy<'_>,
     ) -> Result<Archive, Error> {
         // Acquire an advisory lock, to guard against concurrent writes.
         #[cfg(windows)]
@@ -731,7 +767,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .into_async_read();
 
                 // Create a hasher for each hash algorithm.
-                let algorithms = http_hash_algorithms(hashes);
+                let algorithms = hashes.http_algorithms();
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
@@ -770,6 +806,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 };
                 // Exhaust the reader to compute the hashes.
                 hasher.finish().await.map_err(Error::HashExhaustion)?;
+                let computed_hashes = validate_hashes(hashers, hashes.validation, dist)?;
 
                 // Before we make the wheel accessible by persisting it, ensure that the RECORD is
                 // valid.
@@ -788,11 +825,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
-                Ok(Archive::new(
-                    id,
-                    hashers.into_iter().map(HashDigest::from).collect(),
-                    filename.clone(),
-                ))
+                Ok(Archive::new(id, computed_hashes.into(), filename.clone()))
             }
             .instrument(info_span!("wheel", wheel = %dist))
         };
@@ -838,7 +871,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // If the archive is missing the required hashes, or has since been removed, force a refresh.
         let archive = Some(archive)
-            .filter(|archive| archive.has_digests(hashes))
+            .filter(|archive| hashes.is_reusable(archive))
             .filter(|archive| archive.exists(self.build_context.cache()));
 
         let archive = if let Some(archive) = archive {
@@ -876,7 +909,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: WheelHashPolicy<'_>,
     ) -> Result<Archive, Error> {
         // Acquire an advisory lock, to guard against concurrent writes.
         #[cfg(windows)]
@@ -901,7 +934,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .bytes_stream()
                     .map_err(|err| self.handle_response_errors(err))
                     .into_async_read();
-                let algorithms = http_hash_algorithms(hashes);
+                let algorithms = hashes.http_algorithms();
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
@@ -948,7 +981,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     WheelExtension::WhlZst => uv_extract::stream::untar_zst(file, &target).await,
                 }
                 .map_err(|err| Error::Extract(filename.to_string(), err))?;
-                let hashes = hashers.into_iter().map(HashDigest::from).collect();
+                let computed_hashes = validate_hashes(hashers, hashes.validation, dist)?;
 
                 // Before we make the wheel accessible by persisting it, ensure that the RECORD is
                 // valid.
@@ -967,7 +1000,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
-                Ok(Archive::new(id, hashes, filename.clone()))
+                Ok(Archive::new(id, computed_hashes.into(), filename.clone()))
             }
             .instrument(info_span!("wheel", wheel = %dist))
         };
@@ -1013,7 +1046,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // If the archive is missing the required hashes, or has since been removed, force a refresh.
         let archive = Some(archive)
-            .filter(|archive| archive.has_digests(hashes))
+            .filter(|archive| hashes.is_reusable(archive))
             .filter(|archive| archive.exists(self.build_context.cache()));
 
         let archive = if let Some(archive) = archive {
@@ -1291,6 +1324,20 @@ fn content_length(response: &reqwest::Response) -> Option<u64> {
         .and_then(|val| val.parse::<u64>().ok())
 }
 
+pub(crate) fn validate_proxy_artifact_url(
+    proxied: bool,
+    filename: &str,
+    url: &DisplaySafeUrl,
+) -> Result<(), Error> {
+    if proxied && url.scheme() == "file" {
+        return Err(Error::ProxyArtifactLocalUrl {
+            filename: filename.to_string(),
+            url: url.clone(),
+        });
+    }
+    Ok(())
+}
+
 /// An asynchronous reader that reports progress as bytes are read.
 struct ProgressReader<'a, R> {
     reader: R,
@@ -1412,6 +1459,41 @@ impl PathArchivePointer {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct WheelHashPolicy<'a> {
+    /// The hashes that the physical artifact must match before cache admission.
+    validation: HashPolicy<'a>,
+    /// The hashes that the caller will require on the returned archive.
+    required: HashPolicy<'a>,
+}
+
+impl<'a> WheelHashPolicy<'a> {
+    fn new(validation: HashPolicy<'a>, required: HashPolicy<'a>) -> Self {
+        Self {
+            validation,
+            required,
+        }
+    }
+
+    fn http_algorithms(self) -> Vec<HashAlgorithm> {
+        let mut algorithms = http_hash_algorithms(self.validation);
+        algorithms.extend(self.required.algorithms());
+        algorithms.sort_unstable();
+        algorithms.dedup();
+        algorithms
+    }
+
+    fn is_reusable(self, archive: &impl Hashed) -> bool {
+        archive.satisfies(self.validation) && archive.has_digests(self.required)
+    }
+}
+
+impl<'a> From<HashPolicy<'a>> for WheelHashPolicy<'a> {
+    fn from(hashes: HashPolicy<'a>) -> Self {
+        Self::new(HashPolicy::None, hashes)
+    }
+}
+
 #[derive(Debug, Clone)]
 struct WheelTarget {
     /// The URL from which the wheel can be downloaded.
@@ -1422,24 +1504,29 @@ struct WheelTarget {
     size: Option<u64>,
 }
 
+impl WheelTarget {
+    fn from_wheel(file: &File) -> Result<Self, ToUrlError> {
+        Ok(Self {
+            url: file.url.to_url()?,
+            extension: WheelExtension::Whl,
+            size: file.size,
+        })
+    }
+}
+
 impl TryFrom<&File> for WheelTarget {
     type Error = ToUrlError;
 
     /// Determine the [`WheelTarget`] from a [`File`].
     fn try_from(file: &File) -> Result<Self, Self::Error> {
-        let url = file.url.to_url()?;
         if let Some(zstd) = file.zstd.as_ref() {
             Ok(Self {
-                url: add_tar_zst_extension(url),
+                url: add_tar_zst_extension(file.url.to_url()?),
                 extension: WheelExtension::WhlZst,
                 size: zstd.size,
             })
         } else {
-            Ok(Self {
-                url,
-                extension: WheelExtension::Whl,
-                size: file.size,
-            })
+            Self::from_wheel(file)
         }
     }
 }
@@ -1450,6 +1537,25 @@ enum WheelExtension {
     Whl,
     /// A `.whl.tar.zst` file.
     WhlZst,
+}
+
+fn validate_hashes(
+    hashers: Vec<Hasher>,
+    hashes: HashPolicy<'_>,
+    dist: &BuiltDist,
+) -> Result<Vec<HashDigest>, Error> {
+    let computed_hashes = hashers
+        .into_iter()
+        .map(HashDigest::from)
+        .collect::<Vec<_>>();
+    if !hashes.matches(&computed_hashes) {
+        return Err(Error::hash_mismatch(
+            dist.to_string(),
+            hashes.digests(),
+            &computed_hashes,
+        ));
+    }
+    Ok(computed_hashes)
 }
 
 /// Add `.tar.zst` to the end of the URL path, if it doesn't already exist.
@@ -1468,6 +1574,54 @@ fn add_tar_zst_extension(mut url: DisplaySafeUrl) -> DisplaySafeUrl {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn proxy_wheel_hash_policy_preserves_validation_algorithms()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let canonical_hashes = HashDigests::from(vec![
+            "sha512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .parse()?,
+        ]);
+        let hashes = WheelHashPolicy::new(
+            HashPolicy::Any(canonical_hashes.as_slice()),
+            HashPolicy::None,
+        );
+
+        assert_eq!(
+            hashes.http_algorithms(),
+            vec![HashAlgorithm::Sha256, HashAlgorithm::Sha512]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_wheel_hash_policy_rejects_wrong_cached_digest()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let canonical_hashes = HashDigests::from(vec![
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
+        ]);
+        let cached_hashes = vec![
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse()?,
+        ];
+        let hashes = WheelHashPolicy::new(
+            HashPolicy::Any(canonical_hashes.as_slice()),
+            HashPolicy::None,
+        );
+
+        assert!(!hashes.is_reusable(&cached_hashes));
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_artifact_rejects_local_url() -> Result<(), Box<dyn std::error::Error>> {
+        let url = DisplaySafeUrl::parse("file:///tmp/example.whl")?;
+        assert!(matches!(
+            validate_proxy_artifact_url(true, "example.whl", &url),
+            Err(Error::ProxyArtifactLocalUrl { .. })
+        ));
+        assert!(validate_proxy_artifact_url(false, "example.whl", &url).is_ok());
+        Ok(())
+    }
 
     #[test]
     fn test_add_tar_zst_extension() {

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -8,7 +8,7 @@ use crate::metadata::MetadataError;
 use uv_cache::Error as CacheError;
 use uv_client::WrappedReqwestError;
 use uv_distribution_filename::{WheelFilename, WheelFilenameError};
-use uv_distribution_types::{InstalledDist, InstalledDistError, IsBuildBackendError};
+use uv_distribution_types::{IndexUrl, InstalledDist, InstalledDistError, IsBuildBackendError};
 use uv_fs::Simplified;
 use uv_git::GitError;
 use uv_normalize::PackageName;
@@ -44,6 +44,19 @@ pub enum Error {
     InvalidUrl(#[from] uv_distribution_types::ToUrlError),
     #[error("Expected a file URL, but received: {0}")]
     NonFileUrl(DisplaySafeUrl),
+    #[error("Proxy artifact `{filename}` uses unsupported local URL `{url}`")]
+    ProxyArtifactLocalUrl {
+        filename: String,
+        url: DisplaySafeUrl,
+    },
+    #[error(
+        "Locked artifact `{filename}` from `{canonical}` has no digest and cannot be fetched through proxy index `{proxy}`; regenerate the lockfile"
+    )]
+    ProxyArtifactMissingDigest {
+        filename: String,
+        canonical: IndexUrl,
+        proxy: IndexUrl,
+    },
     #[error(transparent)]
     Git(#[from] uv_git::GitResolverError),
     #[error(transparent)]

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -8,13 +8,15 @@ use uv_cache_info::CacheInfo;
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
     BuildInfo, BuildVariables, CachedRegistryDist, ConfigSettings, ExtraBuildRequirement,
-    ExtraBuildRequires, ExtraBuildVariables, Hashed, Index, IndexLocations, IndexUrl,
-    PackageConfigSettings, RegistryBuiltDist, RegistrySourceDist,
+    ExtraBuildRequires, ExtraBuildVariables, HashPolicy, Hashed, Index, IndexLocations, IndexRoute,
+    IndexRoutes, IndexUrl, PackageConfigSettings, ProxyIndexError, RegistryBuiltDist,
+    RegistrySourceDist,
 };
 use uv_fs::{directories, files};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_platform_tags::Tags;
+use uv_pypi_types::HashDigest;
 use uv_types::HashStrategy;
 
 use crate::index::cached_wheel::{CachedWheel, ResolvedWheel};
@@ -46,42 +48,63 @@ impl IndexEntry<'_> {
     pub fn dist(&self) -> &CachedRegistryDist {
         &self.dist
     }
+}
 
-    fn matches_wheel(
-        &self,
-        index: &IndexUrl,
-        filename: &WheelFilename,
-        no_build: bool,
-        no_binary: bool,
-    ) -> bool {
-        self.matches_index_and_build_policy(index, no_build, no_binary)
-            && self.dist.filename == *filename
+/// An entry loaded from one selected physical cache shard.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct PhysicalIndexEntry {
+    /// The cached distribution.
+    dist: CachedRegistryDist,
+    /// Whether the wheel was built from source (true), or downloaded from the registry directly (false).
+    built: bool,
+}
+
+impl PhysicalIndexEntry {
+    fn allowed_by_build_options(&self, no_build: bool, no_binary: bool) -> bool {
+        !(self.built && no_build || !self.built && no_binary)
+    }
+
+    fn matches_wheel(&self, filename: &WheelFilename, no_build: bool, no_binary: bool) -> bool {
+        self.allowed_by_build_options(no_build, no_binary) && self.dist.filename == *filename
     }
 
     fn matches_source(
         &self,
-        index: &IndexUrl,
         name: &PackageName,
         version: &Version,
         no_build: bool,
         no_binary: bool,
     ) -> bool {
-        self.matches_index_and_build_policy(index, no_build, no_binary)
+        self.allowed_by_build_options(no_build, no_binary)
             && self.dist.filename.name == *name
             && self.dist.filename.version == *version
     }
+}
 
-    fn matches_index_and_build_policy(
-        &self,
-        index: &IndexUrl,
-        no_build: bool,
-        no_binary: bool,
-    ) -> bool {
-        if *self.index.url() != *index {
-            return false;
-        }
-        if self.built { !no_build } else { !no_binary }
+/// Return the hashes required to admit an artifact from a proxy cache.
+///
+/// Hashless artifacts discovered through a proxy can use the ordinary cache path, while
+/// lock-derived artifacts without proxy provenance require digest evidence.
+fn proxy_validation_hashes<'hashes>(
+    filename: &impl std::fmt::Display,
+    hashes: &'hashes [HashDigest],
+    artifact_proxy: Option<&IndexUrl>,
+    route: IndexRoute<'_>,
+) -> Result<Option<&'hashes [HashDigest]>, crate::Error> {
+    if !route.is_proxy() {
+        return Ok(None);
     }
+    if hashes.is_empty() {
+        if artifact_proxy.is_some() {
+            return Ok(None);
+        }
+        return Err(crate::Error::ProxyArtifactMissingDigest {
+            filename: filename.to_string(),
+            canonical: route.canonical.clone(),
+            proxy: route.physical.clone(),
+        });
+    }
+    Ok(Some(hashes))
 }
 
 /// A local index of distributions that originate from a registry, like `PyPI`.
@@ -90,8 +113,10 @@ pub struct RegistryWheelIndex<'a> {
     cache: &'a Cache,
     tags: &'a Tags,
     index_locations: &'a IndexLocations,
+    index_routes: IndexRoutes,
     hasher: &'a HashStrategy,
     index: FxHashMap<&'a PackageName, Vec<IndexEntry<'a>>>,
+    physical_index: FxHashMap<(&'a PackageName, IndexUrl), Vec<PhysicalIndexEntry>>,
     config_settings: &'a ConfigSettings,
     config_settings_package: &'a PackageConfigSettings,
     extra_build_requires: &'a ExtraBuildRequires,
@@ -109,53 +134,78 @@ impl<'a> RegistryWheelIndex<'a> {
         config_settings_package: &'a PackageConfigSettings,
         extra_build_requires: &'a ExtraBuildRequires,
         extra_build_variables: &'a ExtraBuildVariables,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, ProxyIndexError> {
+        let index_routes = IndexRoutes::try_from(index_locations)?;
+        Ok(Self {
             cache,
             tags,
             index_locations,
+            index_routes,
             hasher,
             config_settings,
             config_settings_package,
             extra_build_requires,
             extra_build_variables,
             index: FxHashMap::default(),
-        }
+            physical_index: FxHashMap::default(),
+        })
     }
 
-    /// Return a cached wheel that satisfies a registry wheel requirement.
-    pub fn wheel(
+    /// Return a cached wheel that satisfies a registry wheel requirement, failing if its proxy
+    /// route cannot safely admit a cached artifact.
+    pub fn try_wheel(
         &mut self,
         wheel: &'a RegistryBuiltDist,
         no_build: bool,
         no_binary: bool,
-    ) -> Option<&CachedRegistryDist> {
+    ) -> Result<Option<&CachedRegistryDist>, crate::Error> {
         let wheel = wheel.best_wheel();
-        self.get(&wheel.filename.name).find_map(|entry| {
-            entry
-                .matches_wheel(&wheel.index, &wheel.filename, no_build, no_binary)
-                .then_some(&entry.dist)
-        })
+        let route = self.index_routes.route_for(&wheel.index);
+        let validation = proxy_validation_hashes(
+            &wheel.filename,
+            wheel.file.hashes.as_slice(),
+            wheel.proxy.as_ref(),
+            route,
+        )?;
+        let physical_index = route.physical.clone();
+        Ok(self
+            .get_physical(&wheel.filename.name, &physical_index)
+            .find_map(|entry| {
+                if validation.is_some_and(|hashes| !entry.dist.satisfies(HashPolicy::Any(hashes)))
+                    || !entry.matches_wheel(&wheel.filename, no_build, no_binary)
+                {
+                    return None;
+                }
+                Some(&entry.dist)
+            }))
     }
 
-    /// Return a cached wheel that satisfies a registry source distribution requirement.
-    pub fn source(
+    /// Return a cached wheel that satisfies a registry source distribution requirement, failing
+    /// if its proxy route cannot safely admit a cached artifact.
+    pub fn try_source(
         &mut self,
         source: &'a RegistrySourceDist,
         no_build: bool,
         no_binary: bool,
-    ) -> Option<&CachedRegistryDist> {
-        self.get(&source.name).find_map(|entry| {
-            entry
-                .matches_source(
-                    &source.index,
-                    &source.name,
-                    &source.version,
-                    no_build,
-                    no_binary,
-                )
-                .then_some(&entry.dist)
-        })
+    ) -> Result<Option<&CachedRegistryDist>, crate::Error> {
+        let route = self.index_routes.route_for(&source.index);
+        let validation = proxy_validation_hashes(
+            &source.file.filename,
+            source.file.hashes.as_slice(),
+            source.proxy.as_ref(),
+            route,
+        )?;
+        let physical_index = route.physical.clone();
+        Ok(self
+            .get_physical(&source.name, &physical_index)
+            .find_map(|entry| {
+                if validation.is_some_and(|hashes| !entry.dist.satisfies(HashPolicy::Any(hashes)))
+                    || !entry.matches_source(&source.name, &source.version, no_build, no_binary)
+                {
+                    return None;
+                }
+                Some(&entry.dist)
+            }))
     }
 
     /// Return an iterator over available wheels for a given package.
@@ -165,7 +215,7 @@ impl<'a> RegistryWheelIndex<'a> {
         self.get_impl(name).iter().rev()
     }
 
-    /// Get an entry in the index.
+    /// Get the public entries for a package across the configured indexes.
     fn get_impl(&mut self, name: &'a PackageName) -> &[IndexEntry<'_>] {
         (match self.index.entry(name) {
             Entry::Occupied(entry) => entry.into_mut(),
@@ -183,7 +233,41 @@ impl<'a> RegistryWheelIndex<'a> {
         }) as _
     }
 
-    /// Add a package to the index by reading from the cache.
+    /// Return an iterator over available wheels for a package and physical index.
+    ///
+    /// If the package is not yet indexed for this endpoint, this will index the package by reading
+    /// only that endpoint's cache shard.
+    fn get_physical(
+        &mut self,
+        name: &'a PackageName,
+        index: &IndexUrl,
+    ) -> impl Iterator<Item = &PhysicalIndexEntry> {
+        self.get_physical_impl(name, index).iter().rev()
+    }
+
+    /// Get the entries for one physical cache shard.
+    fn get_physical_impl(
+        &mut self,
+        name: &'a PackageName,
+        index: &IndexUrl,
+    ) -> &[PhysicalIndexEntry] {
+        (match self.physical_index.entry((name, index.clone())) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(Self::index_physical(
+                name,
+                index,
+                self.cache,
+                self.tags,
+                self.hasher,
+                self.config_settings,
+                self.config_settings_package,
+                self.extra_build_requires,
+                self.extra_build_variables,
+            )),
+        }) as _
+    }
+
+    /// Add a package from all configured indexes for the public cache-enumeration API.
     fn index<'index>(
         package: &PackageName,
         cache: &Cache,
@@ -196,23 +280,77 @@ impl<'a> RegistryWheelIndex<'a> {
         extra_build_variables: &ExtraBuildVariables,
     ) -> Vec<IndexEntry<'index>> {
         let mut entries = vec![];
-
         let mut seen = FxHashSet::default();
+
         for index in index_locations.allowed_indexes() {
             if !seen.insert(index.url()) {
                 continue;
             }
+            entries.extend(
+                Self::index_physical(
+                    package,
+                    index.url(),
+                    cache,
+                    tags,
+                    hasher,
+                    config_settings,
+                    config_settings_package,
+                    extra_build_requires,
+                    extra_build_variables,
+                )
+                .into_iter()
+                .map(|entry| IndexEntry {
+                    dist: entry.dist,
+                    built: entry.built,
+                    index,
+                }),
+            );
+        }
 
+        // Preserve the public API's ordering across all configured indexes.
+        entries.sort_unstable_by(|a, b| {
+            a.dist
+                .filename
+                .version
+                .cmp(&b.dist.filename.version)
+                .then_with(|| {
+                    a.dist
+                        .filename
+                        .compatibility(tags)
+                        .cmp(&b.dist.filename.compatibility(tags))
+                        .then_with(|| a.built.cmp(&b.built))
+                })
+        });
+
+        entries
+    }
+
+    /// Add a package from one physical endpoint to the index by reading from the cache.
+    fn index_physical(
+        package: &PackageName,
+        index: &IndexUrl,
+        cache: &Cache,
+        tags: &Tags,
+        hasher: &HashStrategy,
+        config_settings: &ConfigSettings,
+        config_settings_package: &PackageConfigSettings,
+        extra_build_requires: &ExtraBuildRequires,
+        extra_build_variables: &ExtraBuildVariables,
+    ) -> Vec<PhysicalIndexEntry> {
+        let mut entries = vec![];
+
+        // Read exactly the selected physical endpoint's shard.
+        {
             // Index all the wheels that were downloaded directly from the registry.
             let wheel_dir = cache.shard(
                 CacheBucket::Wheels,
-                WheelCache::Index(index.url()).wheel_dir(package.as_ref()),
+                WheelCache::Index(index).wheel_dir(package.as_ref()),
             );
 
             // For registry wheels, the cache structure is: `<index>/<package-name>/<wheel>.http`
             // or `<index>/<package-name>/<version>/<wheel>.rev`.
             for file in files(&wheel_dir).ok().into_iter().flatten() {
-                match index.url() {
+                match index {
                     // Add files from remote registries.
                     IndexUrl::Pypi(_) | IndexUrl::Url(_) => {
                         if file
@@ -230,9 +368,8 @@ impl<'a> RegistryWheelIndex<'a> {
                                             &wheel.filename.version,
                                         ),
                                     ) {
-                                        entries.push(IndexEntry {
+                                        entries.push(PhysicalIndexEntry {
                                             dist: wheel.into_registry_dist(),
-                                            index,
                                             built: false,
                                         });
                                     }
@@ -257,9 +394,8 @@ impl<'a> RegistryWheelIndex<'a> {
                                             &wheel.filename.version,
                                         ),
                                     ) {
-                                        entries.push(IndexEntry {
+                                        entries.push(PhysicalIndexEntry {
                                             dist: wheel.into_registry_dist(),
-                                            index,
                                             built: false,
                                         });
                                     }
@@ -274,7 +410,7 @@ impl<'a> RegistryWheelIndex<'a> {
             // from the registry.
             let cache_shard = cache.shard(
                 CacheBucket::SourceDistributions,
-                WheelCache::Index(index.url()).wheel_dir(package.as_ref()),
+                WheelCache::Index(index).wheel_dir(package.as_ref()),
             );
 
             // For registry source distributions, the cache structure is: `<index>/<package-name>/<version>/`.
@@ -282,7 +418,7 @@ impl<'a> RegistryWheelIndex<'a> {
                 let cache_shard = cache_shard.shard(shard);
 
                 // Read the revision from the cache.
-                let revision = match index.url() {
+                let revision = match index {
                     // Add files from remote registries.
                     IndexUrl::Pypi(_) | IndexUrl::Url(_) => {
                         let revision_entry = cache_shard.entry(HTTP_REVISION);
@@ -348,9 +484,8 @@ impl<'a> RegistryWheelIndex<'a> {
                                         CacheInfo::default(),
                                         build_info.clone(),
                                     );
-                                    entries.push(IndexEntry {
+                                    entries.push(PhysicalIndexEntry {
                                         dist: wheel.into_registry_dist(),
-                                        index,
                                         built: true,
                                     });
                                 }
@@ -411,5 +546,307 @@ impl<'a> RegistryWheelIndex<'a> {
         extra_build_variables: &'settings ExtraBuildVariables,
     ) -> Option<&'settings BuildVariables> {
         extra_build_variables.get(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::str::FromStr;
+
+    use anyhow::anyhow;
+    use uv_distribution_filename::SourceDistExtension;
+    use uv_distribution_types::{
+        File, FileLocation, Index, IndexReference, ProxyIndex, RegistryBuiltWheel,
+    };
+    use uv_platform_tags::{Arch, Os, Platform, TagsOptions};
+    use uv_pypi_types::HashDigests;
+
+    use super::*;
+
+    fn entry(
+        filename: &WheelFilename,
+        built: bool,
+        path: &str,
+        hashes: &HashDigests,
+    ) -> PhysicalIndexEntry {
+        PhysicalIndexEntry {
+            dist: CachedRegistryDist {
+                filename: filename.clone(),
+                path: PathBuf::from(path).into_boxed_path(),
+                hashes: hashes.clone(),
+                cache_info: CacheInfo::default(),
+                build_info: None,
+            },
+            built,
+        }
+    }
+
+    fn registry_file(filename: &str, hashes: &HashDigests) -> File {
+        let base = "https://canonical.example/simple/example/".into();
+        File {
+            dist_info_metadata: false,
+            filename: filename.into(),
+            hashes: hashes.clone(),
+            requires_python: None,
+            size: None,
+            upload_time_utc_ms: None,
+            url: FileLocation::new(filename.into(), &base),
+            yanked: None,
+            zstd: None,
+        }
+    }
+
+    fn registry_wheel(
+        canonical: &IndexUrl,
+        previous_proxy: Option<&IndexUrl>,
+        filename: &WheelFilename,
+        hashes: &HashDigests,
+    ) -> RegistryBuiltDist {
+        RegistryBuiltDist {
+            wheels: vec![RegistryBuiltWheel {
+                filename: filename.clone(),
+                file: Box::new(registry_file(&filename.to_string(), hashes)),
+                index: canonical.clone(),
+                proxy: previous_proxy.cloned(),
+            }],
+            best_wheel_index: 0,
+            sdist: None,
+        }
+    }
+
+    fn registry_source(
+        canonical: &IndexUrl,
+        previous_proxy: Option<&IndexUrl>,
+        name: &PackageName,
+        version: &Version,
+        hashes: &HashDigests,
+    ) -> RegistrySourceDist {
+        RegistrySourceDist {
+            name: name.clone(),
+            version: version.clone(),
+            file: Box::new(registry_file("example-1.0.tar.gz", hashes)),
+            ext: SourceDistExtension::TarGz,
+            index: canonical.clone(),
+            proxy: previous_proxy.cloned(),
+            wheels: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn proxy_cache_isolated_to_current_route() -> anyhow::Result<()> {
+        let canonical = IndexUrl::from_str("https://canonical.example/simple")?;
+        let proxy_a = IndexUrl::from_str("https://proxy-a.example/simple")?;
+        let proxy_b = IndexUrl::from_str("https://proxy-b.example/simple")?;
+        let wheel_filename = WheelFilename::from_str("example-1.0-py3-none-any.whl")?;
+        let built_filename = WheelFilename::from_str("example-1.0-py2-none-any.whl")?;
+        let other_filename = WheelFilename::from_str("example-2.0-py3-none-any.whl")?;
+        let package_name = PackageName::from_str("example")?;
+        let version = Version::from_str("1.0")?;
+        let hashes = HashDigests::from(HashDigest::from_str(
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )?);
+        let wrong_hashes = HashDigests::from(HashDigest::from_str(
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        )?);
+        let empty_hashes = HashDigests::empty();
+
+        let wheel = registry_wheel(&canonical, Some(&proxy_a), &wheel_filename, &hashes);
+        let source = registry_source(&canonical, Some(&proxy_a), &package_name, &version, &hashes);
+        let live_hashless_wheel =
+            registry_wheel(&canonical, Some(&proxy_a), &wheel_filename, &empty_hashes);
+        let live_hashless_source = registry_source(
+            &canonical,
+            Some(&proxy_a),
+            &package_name,
+            &version,
+            &empty_hashes,
+        );
+        let locked_hashless_wheel =
+            registry_wheel(&canonical, None, &wheel_filename, &empty_hashes);
+        let locked_hashless_source =
+            registry_source(&canonical, None, &package_name, &version, &empty_hashes);
+
+        let index_locations =
+            IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
+                .with_proxy_indexes(vec![ProxyIndex {
+                    index: IndexReference::Url(canonical.clone()),
+                    url: proxy_b.clone(),
+                }]);
+        let platform = Platform::new(
+            Os::Manylinux {
+                major: 2,
+                minor: 28,
+            },
+            Arch::X86_64,
+        );
+        let tags = Tags::from_env(
+            platform,
+            (3, 12),
+            "cpython",
+            (3, 12),
+            TagsOptions::default(),
+        )?;
+        let cache = Cache::temp()?;
+        let hasher = HashStrategy::default();
+        let config_settings = ConfigSettings::default();
+        let config_settings_package = PackageConfigSettings::default();
+        let extra_build_requires = ExtraBuildRequires::default();
+        let extra_build_variables = ExtraBuildVariables::default();
+        let mut wheel_index = RegistryWheelIndex::new(
+            &cache,
+            &tags,
+            &index_locations,
+            &hasher,
+            &config_settings,
+            &config_settings_package,
+            &extra_build_requires,
+            &extra_build_variables,
+        )?;
+
+        wheel_index.physical_index.insert(
+            (&package_name, canonical.clone()),
+            vec![
+                entry(&wheel_filename, false, "canonical", &hashes),
+                entry(&built_filename, true, "canonical-source", &hashes),
+            ],
+        );
+        wheel_index.physical_index.insert(
+            (&package_name, proxy_a.clone()),
+            vec![
+                entry(&wheel_filename, false, "proxy-a", &hashes),
+                entry(&built_filename, true, "proxy-a-source", &hashes),
+            ],
+        );
+        wheel_index.physical_index.insert(
+            (&package_name, proxy_b.clone()),
+            vec![
+                entry(
+                    &wheel_filename,
+                    false,
+                    "proxy-b-wrong-digest",
+                    &wrong_hashes,
+                ),
+                entry(
+                    &built_filename,
+                    true,
+                    "proxy-b-source-wrong-digest",
+                    &wrong_hashes,
+                ),
+            ],
+        );
+
+        assert!(wheel_index.try_wheel(&wheel, true, false)?.is_none());
+        assert!(wheel_index.try_source(&source, false, true)?.is_none());
+
+        wheel_index.physical_index.insert(
+            (&package_name, proxy_b.clone()),
+            vec![
+                entry(
+                    &wheel_filename,
+                    false,
+                    "proxy-b-wrong-digest",
+                    &wrong_hashes,
+                ),
+                entry(&wheel_filename, false, "proxy-b-wheel", &hashes),
+                entry(&built_filename, true, "proxy-b-source", &hashes),
+                entry(&other_filename, false, "proxy-b-wrong-version", &hashes),
+            ],
+        );
+
+        let downloaded = wheel_index
+            .try_wheel(&wheel, true, false)?
+            .ok_or_else(|| anyhow!("expected the current proxy wheel"))?;
+        assert_eq!(downloaded.path.as_ref(), Path::new("proxy-b-wheel"));
+        assert!(wheel_index.try_wheel(&wheel, false, true)?.is_none());
+
+        let built = wheel_index
+            .try_source(&source, false, true)?
+            .ok_or_else(|| anyhow!("expected the current proxy source build"))?;
+        assert_eq!(built.path.as_ref(), Path::new("proxy-b-source"));
+        let downloaded_for_source = wheel_index
+            .try_source(&source, true, false)?
+            .ok_or_else(|| anyhow!("expected the current proxy wheel for the source"))?;
+        assert_eq!(
+            downloaded_for_source.path.as_ref(),
+            Path::new("proxy-b-wheel")
+        );
+        assert!(wheel_index.try_source(&source, true, true)?.is_none());
+
+        let live_downloaded = wheel_index
+            .try_wheel(&live_hashless_wheel, true, false)?
+            .ok_or_else(|| anyhow!("expected the live hashless proxy wheel"))?;
+        assert_eq!(live_downloaded.path.as_ref(), Path::new("proxy-b-wheel"));
+        let live_built = wheel_index
+            .try_source(&live_hashless_source, false, true)?
+            .ok_or_else(|| anyhow!("expected the live hashless proxy source build"))?;
+        assert_eq!(live_built.path.as_ref(), Path::new("proxy-b-source"));
+
+        let error = wheel_index
+            .try_wheel(&locked_hashless_wheel, true, false)
+            .expect_err("a hashless locked proxy wheel lookup should fail");
+        assert!(matches!(
+            error,
+            crate::Error::ProxyArtifactMissingDigest {
+                canonical: error_canonical,
+                proxy: error_proxy,
+                ..
+            } if error_canonical == canonical && error_proxy == proxy_b
+        ));
+        let error = wheel_index
+            .try_source(&locked_hashless_source, false, true)
+            .expect_err("a hashless locked proxy source lookup should fail");
+        assert!(matches!(
+            error,
+            crate::Error::ProxyArtifactMissingDigest {
+                canonical: error_canonical,
+                proxy: error_proxy,
+                ..
+            } if error_canonical == canonical && error_proxy == proxy_b
+        ));
+        let direct_locations =
+            IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false);
+        let direct_wheel = registry_wheel(&canonical, None, &wheel_filename, &empty_hashes);
+        let canonical_index = Index::from(canonical.clone());
+        let mut direct_index = RegistryWheelIndex::new(
+            &cache,
+            &tags,
+            &direct_locations,
+            &hasher,
+            &config_settings,
+            &config_settings_package,
+            &extra_build_requires,
+            &extra_build_variables,
+        )?;
+        direct_index.physical_index.insert(
+            (&package_name, canonical.clone()),
+            vec![entry(&wheel_filename, false, "canonical", &empty_hashes)],
+        );
+        let direct = direct_index
+            .try_wheel(&direct_wheel, true, false)?
+            .ok_or_else(|| anyhow!("expected the direct index cache entry"))?;
+        assert_eq!(direct.path.as_ref(), Path::new("canonical"));
+
+        let public_entry = entry(&wheel_filename, false, "canonical-public", &empty_hashes);
+        direct_index.index.insert(
+            &package_name,
+            vec![IndexEntry {
+                dist: public_entry.dist,
+                built: public_entry.built,
+                index: &canonical_index,
+            }],
+        );
+        let public_entry = direct_index
+            .get(&package_name)
+            .next()
+            .ok_or_else(|| anyhow!("expected the public canonical cache entry"))?;
+        assert_eq!(public_entry.index().url(), &canonical);
+        assert!(!public_entry.is_built());
+        assert_eq!(
+            public_entry.dist().path.as_ref(),
+            Path::new("canonical-public")
+        );
+
+        Ok(())
     }
 }

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -33,7 +33,7 @@ use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::{
     BuildInfo, BuildVariables, BuildableSource, ConfigSettings, DirectorySourceUrl,
     ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, HashPolicy, Hashed, IndexUrl,
-    PathSourceUrl, RequirementSource, RequiresPython, SourceDist, SourceUrl,
+    PathSourceUrl, RegistrySourceDist, RequirementSource, RequiresPython, SourceDist, SourceUrl,
 };
 use uv_extract::hash::Hasher;
 use uv_fs::{Simplified, rename_with_retry, write_atomic};
@@ -213,6 +213,74 @@ pub(crate) struct SourceDistributionBuilder<'a, T: BuildContext> {
     reporter: Option<Arc<dyn Reporter>>,
 }
 
+struct RegistrySourceTarget<'a> {
+    url: DisplaySafeUrl,
+    physical_index: Cow<'a, IndexUrl>,
+    validation_hashes: Option<&'a HashDigests>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SourceHashPolicy<'a> {
+    required: HashPolicy<'a>,
+    validation: Option<&'a [HashDigest]>,
+}
+
+impl<'a> SourceHashPolicy<'a> {
+    fn new(required: HashPolicy<'a>, validation: Option<&'a HashDigests>) -> Self {
+        Self {
+            required,
+            validation: validation.map(HashDigests::as_slice),
+        }
+    }
+
+    fn http_algorithms(self) -> Vec<HashAlgorithm> {
+        let mut algorithms = http_hash_algorithms(self.required);
+        if let Some(validation) = self.validation {
+            algorithms.extend(validation.iter().map(HashDigest::algorithm));
+        }
+        algorithms.sort_unstable();
+        algorithms.dedup();
+        algorithms
+    }
+
+    fn admits_cached_revision(self, revision: &impl Hashed) -> bool {
+        self.validation
+            .is_none_or(|hashes| revision.satisfies(HashPolicy::Any(hashes)))
+            && revision.has_digests(self.required)
+    }
+
+    fn validate_artifact(
+        self,
+        source: &BuildableSource<'_>,
+        hashes: &[HashDigest],
+    ) -> Result<(), Error> {
+        if let Some(validation) = self.validation
+            && !HashPolicy::Any(validation).matches(hashes)
+        {
+            return Err(Error::hash_mismatch(source.to_string(), validation, hashes));
+        }
+        Ok(())
+    }
+
+    fn validate(self, source: &BuildableSource<'_>, hashes: &impl Hashed) -> Result<(), Error> {
+        self.validate_artifact(source, hashes.hashes())?;
+        if !hashes.satisfies(self.required) {
+            return Err(Error::hash_mismatch(
+                source.to_string(),
+                self.required.digests(),
+                hashes.hashes(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl<'a> From<HashPolicy<'a>> for SourceHashPolicy<'a> {
+    fn from(required: HashPolicy<'a>) -> Self {
+        Self::new(required, None)
+    }
+}
+
 /// The name of the file that contains the revision ID for a remote distribution, encoded via `MsgPack`.
 pub(crate) const HTTP_REVISION: &str = "revision.http";
 
@@ -229,6 +297,51 @@ const METADATA: &str = "metadata.msgpack";
 const SOURCE: &str = "src";
 
 impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
+    async fn registry_source_target<'data>(
+        &self,
+        dist: &'data RegistrySourceDist,
+        client: &ManagedClient<'_>,
+    ) -> Result<RegistrySourceTarget<'data>, Error> {
+        let (url, physical_index, validation_hashes) = if let Some(proxy) = dist.proxy.as_ref() {
+            (
+                dist.file.url.to_url()?,
+                Cow::Borrowed(proxy),
+                (!dist.file.hashes.is_empty()).then_some(&dist.file.hashes),
+            )
+        } else {
+            let artifact = client
+                .managed(|client| {
+                    client.proxy_artifact(
+                        &dist.name,
+                        &dist.index,
+                        dist.file.filename.as_ref(),
+                        &dist.file.hashes,
+                        self.build_context.capabilities(),
+                    )
+                })
+                .await?;
+            if let Some(artifact) = artifact {
+                (
+                    artifact.file.url.to_url()?,
+                    Cow::Owned(artifact.physical_index),
+                    Some(&dist.file.hashes),
+                )
+            } else {
+                (dist.file.url.to_url()?, Cow::Borrowed(&dist.index), None)
+            }
+        };
+        crate::distribution_database::validate_proxy_artifact_url(
+            physical_index.as_ref() != &dist.index,
+            dist.file.filename.as_ref(),
+            &url,
+        )?;
+        Ok(RegistrySourceTarget {
+            url,
+            physical_index,
+            validation_hashes,
+        })
+    }
+
     /// Initialize a [`SourceDistributionBuilder`] from a [`BuildContext`].
     pub(crate) fn new(build_context: &'a T) -> Self {
         Self {
@@ -266,16 +379,17 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     ) -> Result<BuiltWheelMetadata, Error> {
         let built_wheel_metadata = match &source {
             BuildableSource::Dist(SourceDist::Registry(dist)) => {
+                let target = self.registry_source_target(dist, client).await?;
                 // For registry source distributions, shard by package, then version, for
                 // convenience in debugging.
                 let cache_shard = self.build_context.cache().shard(
                     CacheBucket::SourceDistributions,
-                    WheelCache::Index(&dist.index)
+                    WheelCache::Index(target.physical_index.as_ref())
                         .wheel_dir(dist.name.as_ref())
                         .join(dist.version.to_string()),
                 );
 
-                let url = dist.file.url.to_url()?;
+                let url = target.url;
 
                 // If the URL is a file URL, use the local path directly.
                 if url.scheme() == "file" {
@@ -301,12 +415,12 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 self.url(
                     source,
                     &url,
-                    Some(&dist.index),
+                    Some(&target.physical_index),
                     &cache_shard,
                     None,
                     dist.ext,
                     tags,
-                    hashes,
+                    SourceHashPolicy::new(hashes, target.validation_hashes),
                     client,
                 )
                 .boxed_local()
@@ -327,7 +441,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     dist.subdirectory.as_deref(),
                     dist.ext,
                     tags,
-                    hashes,
+                    hashes.into(),
                     client,
                 )
                 .boxed_local()
@@ -384,7 +498,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     resource.subdirectory,
                     resource.ext,
                     tags,
-                    hashes,
+                    hashes.into(),
                     client,
                 )
                 .boxed_local()
@@ -430,15 +544,16 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     ) -> Result<ArchiveMetadata, Error> {
         let metadata = match &source {
             BuildableSource::Dist(SourceDist::Registry(dist)) => {
+                let target = self.registry_source_target(dist, client).await?;
                 // For registry source distributions, shard by package, then version.
                 let cache_shard = self.build_context.cache().shard(
                     CacheBucket::SourceDistributions,
-                    WheelCache::Index(&dist.index)
+                    WheelCache::Index(target.physical_index.as_ref())
                         .wheel_dir(dist.name.as_ref())
                         .join(dist.version.to_string()),
                 );
 
-                let url = dist.file.url.to_url()?;
+                let url = target.url;
 
                 // If the URL is a file URL, use the local path directly.
                 if url.scheme() == "file" {
@@ -463,11 +578,11 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 self.url_metadata(
                     source,
                     &url,
-                    Some(&dist.index),
+                    Some(&target.physical_index),
                     &cache_shard,
                     None,
                     dist.ext,
-                    hashes,
+                    SourceHashPolicy::new(hashes, target.validation_hashes),
                     client,
                 )
                 .boxed_local()
@@ -487,7 +602,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     &cache_shard,
                     dist.subdirectory.as_deref(),
                     dist.ext,
-                    hashes,
+                    hashes.into(),
                     client,
                 )
                 .boxed_local()
@@ -542,7 +657,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     &cache_shard,
                     resource.subdirectory,
                     resource.ext,
-                    hashes,
+                    hashes.into(),
                     client,
                 )
                 .boxed_local()
@@ -631,7 +746,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         subdirectory: Option<&'data Path>,
         ext: SourceDistExtension,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: SourceHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
@@ -642,13 +757,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .await?;
 
         // Before running the build, check that the hashes match.
-        if !revision.satisfies(hashes) {
-            return Err(Error::hash_mismatch(
-                source.to_string(),
-                hashes.digests(),
-                revision.hashes(),
-            ));
-        }
+        hashes.validate(source, &revision)?;
 
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
@@ -764,7 +873,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         cache_shard: &CacheShard,
         subdirectory: Option<&'data Path>,
         ext: SourceDistExtension,
-        hashes: HashPolicy<'_>,
+        hashes: SourceHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
@@ -775,13 +884,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .await?;
 
         // Before running the build, check that the hashes match.
-        if !revision.satisfies(hashes) {
-            return Err(Error::hash_mismatch(
-                source.to_string(),
-                hashes.digests(),
-                revision.hashes(),
-            ));
-        }
+        hashes.validate(source, &revision)?;
 
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
@@ -948,7 +1051,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         url: &DisplaySafeUrl,
         index: Option<&IndexUrl>,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: SourceHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<Revision, Error> {
         let cache_entry = cache_shard.entry(HTTP_REVISION);
@@ -984,12 +1087,20 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 // Download the source distribution.
                 debug!("Downloading source distribution: {source}");
                 let entry = cache_shard.shard(revision.id()).entry(SOURCE);
-                let algorithms = http_hash_algorithms(hashes);
-                let hashes = self
-                    .download_archive(query_url, response, source, ext, entry.path(), &algorithms)
+                let algorithms = hashes.http_algorithms();
+                let computed_hashes = self
+                    .download_archive(
+                        query_url,
+                        response,
+                        source,
+                        ext,
+                        entry.path(),
+                        &algorithms,
+                        hashes,
+                    )
                     .await?;
 
-                Ok(revision.with_hashes(HashDigests::from(hashes)))
+                Ok(revision.with_hashes(HashDigests::from(computed_hashes)))
             }
             .boxed_local()
             .instrument(info_span!("download", source_dist = %source))
@@ -1011,7 +1122,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             })?;
 
         // If the archive is missing the required hashes, force a refresh.
-        if revision.has_digests(hashes) {
+        if hashes.admits_cached_revision(&revision) {
             Ok(revision)
         } else {
             client
@@ -2722,7 +2833,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         index: Option<&IndexUrl>,
         entry: &CacheEntry,
         revision: Revision,
-        hashes: HashPolicy<'_>,
+        hashes: SourceHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<Revision, Error> {
         warn!("Re-downloading missing source distribution: {source}");
@@ -2754,7 +2865,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             async {
                 // Take the union of the requested and existing hash algorithms.
                 let algorithms = {
-                    let mut algorithms = http_hash_algorithms(hashes);
+                    let mut algorithms = hashes.http_algorithms();
                     for digest in revision.hashes() {
                         algorithms.push(digest.algorithm());
                     }
@@ -2763,15 +2874,27 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     algorithms
                 };
 
-                let hashes = self
-                    .download_archive(query_url, response, source, ext, entry.path(), &algorithms)
+                let computed_hashes = self
+                    .download_archive(
+                        query_url,
+                        response,
+                        source,
+                        ext,
+                        entry.path(),
+                        &algorithms,
+                        hashes,
+                    )
                     .await?;
                 for existing in revision.hashes() {
-                    if !hashes.contains(existing) {
+                    if !computed_hashes.contains(existing) {
                         return Err(Error::CacheHeal(source.to_string(), existing.algorithm()));
                     }
                 }
-                Ok(revision.clone().with_hashes(HashDigests::from(hashes)))
+                let revision = revision
+                    .clone()
+                    .with_hashes(HashDigests::from(computed_hashes));
+                hashes.validate(source, &revision)?;
+                Ok(revision)
             }
             .boxed_local()
             .instrument(info_span!("download", source_dist = %source))
@@ -2804,6 +2927,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         ext: SourceDistExtension,
         target: &Path,
         algorithms: &[HashAlgorithm],
+        policy: SourceHashPolicy<'_>,
     ) -> Result<Vec<HashDigest>, Error> {
         let temp_dir = tempfile::tempdir_in(
             self.build_context
@@ -2837,7 +2961,11 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             hasher.finish().await.map_err(Error::HashExhaustion)?;
         }
 
-        let hashes = hashers.into_iter().map(HashDigest::from).collect();
+        let hashes = hashers
+            .into_iter()
+            .map(HashDigest::from)
+            .collect::<Vec<_>>();
+        policy.validate_artifact(source, &hashes)?;
 
         // Extract the top-level directory.
         let extracted = match uv_extract::strip_component(temp_dir.path()) {
@@ -3724,4 +3852,40 @@ fn read_wheel_metadata(
     let dist_info = read_archive_metadata(filename, reader)
         .map_err(|err| Error::WheelMetadata(wheel.to_path_buf(), Box::new(err)))?;
     Ok(ResolutionMetadata::parse_metadata(&dist_info)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_source_hash_policy_preserves_validation_algorithms()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let validation = HashDigests::from(vec![
+            "sha512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .parse()?,
+        ]);
+        let hashes = SourceHashPolicy::new(HashPolicy::None, Some(&validation));
+
+        assert_eq!(
+            hashes.http_algorithms(),
+            vec![HashAlgorithm::Sha256, HashAlgorithm::Sha512]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_source_hash_policy_rejects_wrong_cached_digest()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let validation = HashDigests::from(vec![
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
+        ]);
+        let cached_hashes = vec![
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse()?,
+        ];
+        let hashes = SourceHashPolicy::new(HashPolicy::None, Some(&validation));
+
+        assert!(!hashes.admits_cached_revision(&cached_hashes));
+        Ok(())
+    }
 }

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -280,7 +280,7 @@ impl<'a> Planner<'a> {
             config_settings_package,
             extra_build_requires,
             extra_build_variables,
-        );
+        )?;
         let built_index = BuiltWheelIndex::new(
             cache,
             tags,
@@ -399,7 +399,9 @@ impl<'a> Planner<'a> {
             // Identify any cached distributions that satisfy the requirement.
             match dist.as_ref() {
                 Dist::Built(BuiltDist::Registry(wheel)) => {
-                    if let Some(distribution) = registry_index.wheel(wheel, no_build, no_binary) {
+                    if let Some(distribution) =
+                        registry_index.try_wheel(wheel, no_build, no_binary)?
+                    {
                         debug!("Registry requirement already cached: {distribution}");
                         cached.push(CachedDist::Registry(distribution.clone()));
                         continue;
@@ -593,7 +595,9 @@ impl<'a> Planner<'a> {
                     }
                 }
                 Dist::Source(SourceDist::Registry(sdist)) => {
-                    if let Some(distribution) = registry_index.source(sdist, no_build, no_binary) {
+                    if let Some(distribution) =
+                        registry_index.try_source(sdist, no_build, no_binary)?
+                    {
                         debug!("Registry requirement already cached: {distribution}");
                         cached.push(CachedDist::Registry(distribution.clone()));
                         continue;

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -26,8 +26,8 @@ use url::Url;
 use uv_auth::{Credentials, PyxTokenStore, Realm};
 use uv_cache::{Cache, Refresh};
 use uv_client::{
-    BaseClient, ClientBuildError, DEFAULT_MAX_REDIRECTS, MetadataFormat, OwnedArchive,
-    RegistryClientBuilder, RequestBuilder, RetryParsingError, RetryState,
+    BaseClient, ClientBuildError, DEFAULT_MAX_REDIRECTS, IndexMetadataResponse, MetadataFormat,
+    OwnedArchive, RegistryClientBuilder, RequestBuilder, RetryParsingError, RetryState,
 };
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
 use uv_distribution_filename::{DistFilename, SourceDistExtension, SourceDistFilename};
@@ -990,7 +990,13 @@ pub async fn check_url(
             };
         }
     };
-    let [(_, MetadataFormat::Simple(simple_metadata))] = response.as_slice() else {
+    let [
+        IndexMetadataResponse {
+            format: MetadataFormat::Simple(simple_metadata),
+            ..
+        },
+    ] = response.as_slice()
+    else {
         unreachable!("We queried a single index, we must get a single response");
     };
     let simple_metadata = OwnedArchive::deserialize(simple_metadata);

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -83,6 +83,8 @@ url = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 toml = { workspace = true }
+uv-cache = { workspace = true }
+wiremock = { workspace = true }
 
 [features]
 schemars = ["dep:schemars", "uv-distribution-types/schemars"]

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -116,6 +116,7 @@ impl FlatDistributions {
                     filename,
                     file: Box::new(file),
                     index,
+                    proxy: None,
                 };
                 match self.0.entry(version) {
                     Entry::Occupied(mut entry) => {
@@ -139,6 +140,7 @@ impl FlatDistributions {
                     ext: filename.extension,
                     file: Box::new(file),
                     index,
+                    proxy: None,
                     wheels: vec![],
                 };
                 match self.0.entry(filename.version) {

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1492,6 +1492,7 @@ impl PylockTomlWheel {
             filename,
             file,
             index,
+            proxy: None,
         })
     }
 }
@@ -1655,6 +1656,7 @@ impl PylockTomlSdist {
             file,
             ext,
             index,
+            proxy: None,
             wheels: vec![],
         })
     }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -28,10 +28,10 @@ use uv_distribution_filename::{
 use uv_distribution_types::{
     BuiltDist, DependencyMetadata, DirectUrlBuiltDist, DirectUrlSourceDist, DirectorySourceDist,
     Dist, FileLocation, GitDirectorySourceDist, GitPathBuiltDist, GitPathSourceDist, Identifier,
-    IndexLocations, IndexMetadata, IndexUrl, Name, PYPI_URL, PathBuiltDist, PathSourceDist,
-    RegistryBuiltDist, RegistryBuiltWheel, RegistrySourceDist, RemoteSource, Requirement,
-    RequirementSource, RequiresPython, ResolvedDist, SimplifiedMarkerTree, StaticMetadata,
-    ToUrlError, UrlString,
+    IndexLocations, IndexMetadata, IndexRoutes, IndexUrl, Name, PYPI_URL, PathBuiltDist,
+    PathSourceDist, ProxyIndexError, RegistryBuiltDist, RegistryBuiltWheel, RegistrySourceDist,
+    RemoteSource, Requirement, RequirementSource, RequiresPython, ResolvedDist,
+    SimplifiedMarkerTree, StaticMetadata, ToUrlError, UrlString,
 };
 use uv_fs::{
     PortablePath, PortablePathBuf, Simplified, normalize_path, relative_to, try_relative_to_if,
@@ -1850,18 +1850,7 @@ impl Lock {
         }
 
         // Collect the set of available indexes (both `--index-url` and `--find-links` entries).
-        let mut remotes = indexes.map(|locations| {
-            locations
-                .allowed_indexes()
-                .into_iter()
-                .filter_map(|index| match index.url() {
-                    IndexUrl::Pypi(_) | IndexUrl::Url(_) => {
-                        Some(UrlString::from(index.url().without_credentials().as_ref()))
-                    }
-                    IndexUrl::Path(_) => None,
-                })
-                .collect::<BTreeSet<_>>()
-        });
+        let mut remotes = indexes.map(available_remote_indexes).transpose()?;
 
         let mut locals = indexes.map(|locations| {
             locations
@@ -2446,6 +2435,30 @@ impl<'tags> TagPolicy<'tags> {
             Self::Required(tags) | Self::Preferred(tags) => tags,
         }
     }
+}
+
+/// Collect the remote indexes that can satisfy an existing lock.
+fn available_remote_indexes(
+    locations: &IndexLocations,
+) -> Result<BTreeSet<UrlString>, ProxyIndexError> {
+    let routes = IndexRoutes::try_from(locations)?;
+    let mut remotes = locations
+        .allowed_indexes()
+        .into_iter()
+        .filter_map(|index| match index.url() {
+            IndexUrl::Pypi(_) | IndexUrl::Url(_) => {
+                Some(UrlString::from(index.url().without_credentials().as_ref()))
+            }
+            IndexUrl::Path(_) => None,
+        })
+        .collect::<BTreeSet<_>>();
+
+    for route in routes.proxy_routes() {
+        remotes.insert(UrlString::from(
+            route.canonical.without_credentials().as_ref(),
+        ));
+    }
+    Ok(remotes)
 }
 
 /// The result of checking if a lockfile satisfies a set of requirements.
@@ -6215,6 +6228,9 @@ impl std::fmt::Display for WheelTagHint {
 /// is with the caller somewhere in such cases.
 #[derive(Debug, thiserror::Error)]
 enum LockErrorKind {
+    /// An error that occurs when proxy-index configuration is invalid.
+    #[error(transparent)]
+    ProxyIndex(#[from] ProxyIndexError),
     /// An error that occurs when multiple packages with the same
     /// ID were found.
     #[error("Found duplicate package `{id}`", id = id.cyan())]
@@ -6938,6 +6954,7 @@ pub(crate) fn is_wheel_unreachable(
 
 #[cfg(test)]
 mod tests {
+    use uv_distribution_types::{IndexReference, ProxyIndex};
     use uv_pep440::VersionSpecifiers;
     use uv_pep508::MarkerEnvironmentBuilder;
     use uv_warnings::anstream;
@@ -7111,6 +7128,27 @@ source = { registry = "https://example.com/simple" }
             .dependency_selection(Some(&project_name), &dependency_name, &marker_environment)
             .expect_err("ambiguous production selection");
         insta::assert_snapshot!(error, @"found multiple packages matching production dependency `ty` for `project`");
+    }
+
+    #[test]
+    fn url_proxy_indexes_are_not_resolution_indexes() -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str("https://canonical.example.com/simple")?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(canonical.clone()),
+            url: IndexUrl::from_str("https://proxy.example.com/simple")?,
+        }]);
+
+        assert!(
+            locations
+                .allowed_indexes()
+                .iter()
+                .all(|index| index.url() != &canonical)
+        );
+        assert!(
+            available_remote_indexes(&locations)?
+                .contains(&UrlString::from(canonical.without_credentials().as_ref()))
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3434,6 +3434,7 @@ impl Package {
                     file,
                     ext,
                     index,
+                    proxy: None,
                     wheels: vec![],
                 };
                 uv_distribution_types::SourceDist::Registry(reg_dist)
@@ -3510,6 +3511,7 @@ impl Package {
                     file,
                     ext,
                     index,
+                    proxy: None,
                     wheels: vec![],
                 };
                 uv_distribution_types::SourceDist::Registry(reg_dist)
@@ -5156,6 +5158,7 @@ impl Wheel {
                     filename,
                     file,
                     index,
+                    proxy: None,
                 })
             }
             RegistrySource::Path(index_path) => {
@@ -5207,6 +5210,7 @@ impl Wheel {
                     filename,
                     file,
                     index,
+                    proxy: None,
                 })
             }
         }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap;
 use uv_configuration::{IndexStrategy, NoBinary, NoBuild};
 use uv_distribution_types::{
     IncompatibleDist, IncompatibleSource, IncompatibleWheel, Index, IndexCapabilities,
-    IndexLocations, IndexMetadata, IndexUrl, RequiresPython,
+    IndexLocations, IndexMetadata, IndexRoutes, IndexUrl, RequiresPython,
 };
 use uv_normalize::PackageName;
 use uv_pep440::{Version, VersionSpecifier, VersionSpecifiers};
@@ -742,6 +742,8 @@ impl PubGrubReportFormatter<'_> {
         inherited_exclude_newer_ranges: &FxHashMap<PackageName, Range<Version>>,
         output_hints: &mut IndexSet<PubGrubHint>,
     ) {
+        let index_routes = IndexRoutes::try_from(index_locations).ok();
+
         // Check for disjoint target hints (only applicable to universal resolution).
         if let Some(markers) = env.fork_markers() {
             // TODO(konsti): This is a crude approximation to telling the user the difference
@@ -783,6 +785,7 @@ impl PubGrubReportFormatter<'_> {
                             set,
                             selector,
                             index_locations,
+                            index_routes.as_ref(),
                             index_capabilities,
                             available_indexes,
                             unavailable_packages,
@@ -841,6 +844,7 @@ impl PubGrubReportFormatter<'_> {
                             set,
                             selector,
                             index_locations,
+                            index_routes.as_ref(),
                             index_capabilities,
                             available_indexes,
                             unavailable_packages,
@@ -1178,6 +1182,7 @@ impl PubGrubReportFormatter<'_> {
         set: &Range<Version>,
         selector: &CandidateSelector,
         index_locations: &IndexLocations,
+        index_routes: Option<&IndexRoutes>,
         index_capabilities: &IndexCapabilities,
         available_indexes: &FxHashMap<PackageName, BTreeSet<IndexUrl>>,
         unavailable_packages: &FxHashMap<PackageName, UnavailablePackage>,
@@ -1298,18 +1303,50 @@ impl PubGrubReportFormatter<'_> {
         }
 
         // Add hints due to an index returning an unauthorized response.
-        for index in index_locations.allowed_indexes() {
-            if index_capabilities.unauthorized(&index.url) {
+        if let Some(index_routes) = index_routes {
+            Self::authentication_hints(
+                index_locations,
+                index_routes,
+                index_capabilities,
+                available_indexes,
+                hints,
+            );
+        }
+    }
+
+    fn authentication_hints(
+        index_locations: &IndexLocations,
+        index_routes: &IndexRoutes,
+        index_capabilities: &IndexCapabilities,
+        available_indexes: &FxHashMap<PackageName, BTreeSet<IndexUrl>>,
+        hints: &mut IndexSet<PubGrubHint>,
+    ) {
+        let mut physical_indexes = BTreeMap::<&IndexUrl, bool>::new();
+        for route in index_locations
+            .allowed_indexes()
+            .into_iter()
+            .map(|index| index_routes.route_for(&index.url))
+            .chain(index_routes.proxy_routes())
+        {
+            physical_indexes.entry(route.physical).or_default();
+        }
+        for canonical_index in available_indexes.values().flatten() {
+            let physical_index = index_routes.route_for(canonical_index).physical;
+            if let Some(any_successful_response) = physical_indexes.get_mut(physical_index) {
+                *any_successful_response = true;
+            }
+        }
+
+        for (physical_index, any_successful_response) in physical_indexes {
+            if index_capabilities.unauthorized(physical_index) {
                 hints.insert(PubGrubHint::UnauthorizedIndex {
-                    index: index.url.clone(),
+                    index: physical_index.clone(),
                 });
             }
-            if index_capabilities.forbidden(&index.url) {
+            if index_capabilities.forbidden(physical_index) {
                 hints.insert(PubGrubHint::ForbiddenIndex {
-                    index: index.url.clone(),
-                    any_successful_response: available_indexes
-                        .values()
-                        .any(|indexes| indexes.contains(&index.url)),
+                    index: physical_index.clone(),
+                    any_successful_response,
                 });
             }
         }
@@ -2688,8 +2725,13 @@ fn padded<'a, T: std::fmt::Display + ?Sized>(
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::str::FromStr;
+
     use pubgrub::{DefaultStringReporter, Reporter};
-    use uv_distribution_types::RequiresPython;
+    use uv_distribution_types::{
+        IndexReference, IndexStatusCodeStrategy, ProxyIndex, RequiresPython,
+    };
     use uv_pep508::{MarkerEnvironment, MarkerEnvironmentBuilder};
 
     use super::*;
@@ -2750,6 +2792,99 @@ mod tests {
                 tags: None,
             }
         }
+    }
+
+    #[test]
+    fn url_proxy_routes_are_included_in_authentication_hints()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let canonical_without_response =
+            IndexUrl::from_str("https://canonical-a.example.com/simple")?;
+        let canonical_with_response =
+            IndexUrl::from_str("https://user:secret@canonical-b.example.com/simple")?;
+        let redacted_canonical_with_response =
+            IndexUrl::from_str("https://canonical-b.example.com/simple")?;
+        let physical = IndexUrl::from_str("https://proxy.example.com/simple")?;
+        let index_locations = IndexLocations::default().with_proxy_indexes(vec![
+            ProxyIndex {
+                index: IndexReference::Url(canonical_without_response.clone()),
+                url: physical.clone(),
+            },
+            ProxyIndex {
+                index: IndexReference::Url(canonical_with_response.clone()),
+                url: physical.clone(),
+            },
+        ]);
+        // URL-form routes that are otherwise unconfigured can satisfy existing locks, but they
+        // must not become fresh-resolution indexes.
+        assert!(index_locations.allowed_indexes().iter().all(|index| {
+            index.url() != &canonical_without_response && index.url() != &canonical_with_response
+        }));
+
+        let index_routes = IndexRoutes::try_from(&index_locations)?;
+        assert_eq!(
+            index_routes
+                .route_for(&redacted_canonical_with_response)
+                .physical,
+            &physical
+        );
+        let index_capabilities = IndexCapabilities::default();
+        let _ = IndexStatusCodeStrategy::Default.handle_status_code(
+            StatusCode::UNAUTHORIZED,
+            &physical,
+            &index_capabilities,
+        );
+        let _ = IndexStatusCodeStrategy::Default.handle_status_code(
+            StatusCode::FORBIDDEN,
+            &physical,
+            &index_capabilities,
+        );
+        let available_indexes = FxHashMap::from_iter([(
+            PackageName::from_str("example")?,
+            BTreeSet::from([redacted_canonical_with_response]),
+        )]);
+        let mut hints = IndexSet::new();
+        PubGrubReportFormatter::authentication_hints(
+            &index_locations,
+            &index_routes,
+            &index_capabilities,
+            &available_indexes,
+            &mut hints,
+        );
+        let hints = hints
+            .iter()
+            .map(|hint| match hint {
+                PubGrubHint::UnauthorizedIndex { index } => {
+                    Ok(("unauthorized", index.to_string(), None))
+                }
+                PubGrubHint::ForbiddenIndex {
+                    index,
+                    any_successful_response,
+                } => Ok((
+                    "forbidden",
+                    index.to_string(),
+                    Some(*any_successful_response),
+                )),
+                _ => Err(io::Error::other("unexpected authentication hint")),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        insta::assert_debug_snapshot!(hints, @r#"
+        [
+            (
+                "unauthorized",
+                "https://proxy.example.com/simple",
+                None,
+            ),
+            (
+                "forbidden",
+                "https://proxy.example.com/simple",
+                Some(
+                    true,
+                ),
+            ),
+        ]
+        "#);
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -288,8 +288,9 @@ impl BatchPrefetcherRunner {
 
             // Avoid prefetching built distributions that don't support _either_ PEP 658 (`.metadata`)
             // or range requests.
+            let physical_index = wheel.physical_index();
             if !(wheel.file.dist_info_metadata
-                || self.capabilities.supports_range_requests(&wheel.index))
+                || self.capabilities.supports_range_requests(physical_index))
             {
                 debug!("Abandoning prefetch for {wheel} due to missing registry capabilities");
                 return Ok(());

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 
 use reqwest::StatusCode;
 
-use uv_client::MetadataFormat;
+use uv_client::{IndexMetadataResponse, MetadataFormat};
 use uv_configuration::BuildOptions;
 use uv_distribution::{ArchiveMetadata, DistributionDatabase, Reporter};
 use uv_distribution_types::{
-    Dist, IndexCapabilities, IndexLocations, IndexMetadata, IndexMetadataRef, InstalledDist,
-    RequestedDist, RequiresPython,
+    BuiltDist, Dist, IndexCapabilities, IndexLocations, IndexMetadata, IndexMetadataRef,
+    IndexRoutes, InstalledDist, RequestedDist, RequiresPython, SourceDist,
 };
 use uv_normalize::PackageName;
 use uv_pep440::{Version, VersionSpecifiers};
@@ -129,6 +129,41 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext> {
     capabilities: &'a IndexCapabilities,
 }
 
+/// Return whether a failed metadata request should be ignored for the physical index that served
+/// the artifact.
+fn ignores_metadata_error(
+    dist: &Dist,
+    index_locations: &IndexLocations,
+    index_routes: &IndexRoutes,
+    status: StatusCode,
+) -> bool {
+    let physical_index = match dist {
+        Dist::Built(BuiltDist::Registry(dist)) => {
+            let wheel = dist.best_wheel();
+            Some(
+                wheel
+                    .proxy
+                    .as_ref()
+                    .unwrap_or_else(|| index_routes.route_for(&wheel.index).physical),
+            )
+        }
+        Dist::Source(SourceDist::Registry(dist)) => Some(
+            dist.proxy
+                .as_ref()
+                .unwrap_or_else(|| index_routes.route_for(&dist.index).physical),
+        ),
+        Dist::Built(BuiltDist::DirectUrl(_) | BuiltDist::Path(_) | BuiltDist::GitPath(_))
+        | Dist::Source(
+            SourceDist::DirectUrl(_)
+            | SourceDist::GitDirectory(_)
+            | SourceDist::GitPath(_)
+            | SourceDist::Path(_)
+            | SourceDist::Directory(_),
+        ) => None,
+    };
+    physical_index.is_some_and(|index| index_locations.ignores_error_code_for(index, status))
+}
+
 impl<'a, Context: BuildContext> DefaultResolverProvider<'a, Context> {
     /// Reads the flat index entries and builds the provider.
     pub fn new(
@@ -199,19 +234,24 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
             Ok(results) => Ok(VersionsResponse::Found(
                 results
                     .into_iter()
-                    .map(|(index, metadata)| {
+                    .map(|response| {
+                        let IndexMetadataResponse {
+                            index_route,
+                            format,
+                        } = response;
                         let included_version_cutoff =
-                            self.effective_exclude_newer(package_name, index);
+                            self.effective_exclude_newer(package_name, index_route.canonical);
                         let available_version_cutoff = included_version_cutoff
                             .is_none()
                             .then_some(self.available_version_cutoff)
                             .flatten();
 
-                        match metadata {
+                        match format {
                             MetadataFormat::Simple(metadata) => VersionMap::from_simple_metadata(
                                 metadata,
                                 package_name,
-                                index.clone(),
+                                index_route.canonical.clone(),
+                                index_route.physical.clone(),
                                 self.tags.clone(),
                                 self.requires_python.clone(),
                                 self.allowed_yanks.clone(),
@@ -299,9 +339,12 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                         }
                         uv_client::ErrorKind::WrappedReqwestError(url, err) => {
                             let Some(status) = err.status().filter(|status| {
-                                dist.index().is_some_and(|index| {
-                                    self.index_locations.ignores_error_code_for(index, *status)
-                                })
+                                ignores_metadata_error(
+                                    dist,
+                                    self.index_locations,
+                                    self.fetcher.client().unmanaged.index_routes(),
+                                    *status,
+                                )
                             }) else {
                                 return Err(uv_client::Error::new(
                                     uv_client::ErrorKind::WrappedReqwestError(url, err),
@@ -366,5 +409,98 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
             fetcher: self.fetcher.with_reporter(reporter),
             ..self
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use uv_distribution_filename::WheelFilename;
+    use uv_distribution_types::{
+        File, FileLocation, Index, IndexReference, IndexUrl, ProxyIndex, RegistryBuiltDist,
+        RegistryBuiltWheel, SerializableStatusCode,
+    };
+    use uv_pypi_types::HashDigests;
+    use uv_small_str::SmallString;
+
+    use super::*;
+
+    #[test]
+    fn ignored_metadata_error_uses_physical_proxy_index() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let canonical = IndexUrl::from_str("https://canonical.example.com/simple")?;
+        let proxy = IndexUrl::from_str("https://proxy.example.com/simple")?;
+        let mut canonical_index = Index::from(canonical.clone());
+        canonical_index.ignore_error_codes = Some(vec![serde_json::from_value::<
+            SerializableStatusCode,
+        >(serde_json::json!(403))?]);
+        let mut proxy_index = Index::from(proxy.clone());
+        proxy_index.ignore_error_codes = Some(vec![serde_json::from_value::<
+            SerializableStatusCode,
+        >(serde_json::json!(401))?]);
+        let index_locations =
+            IndexLocations::new(vec![canonical_index, proxy_index], Vec::new(), false)
+                .with_proxy_indexes(vec![ProxyIndex {
+                    index: IndexReference::Url(canonical.clone()),
+                    url: proxy.clone(),
+                }]);
+        let index_routes = IndexRoutes::try_from(&index_locations)?;
+
+        let filename = WheelFilename::from_str("example-1.0.0-py3-none-any.whl")?;
+        let file_url =
+            SmallString::from("https://files.example.com/packages/example-1.0.0-py3-none-any.whl");
+        let dist = Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+            wheels: vec![RegistryBuiltWheel {
+                filename: filename.clone(),
+                file: Box::new(File {
+                    dist_info_metadata: false,
+                    filename: SmallString::from(filename.to_string()),
+                    hashes: HashDigests::empty(),
+                    requires_python: None,
+                    size: None,
+                    upload_time_utc_ms: None,
+                    url: FileLocation::new(file_url.clone(), &file_url),
+                    yanked: None,
+                    zstd: None,
+                }),
+                index: canonical,
+                proxy: Some(proxy),
+            }],
+            best_wheel_index: 0,
+            sdist: None,
+        }));
+        let mut locked_dist = dist.clone();
+        if let Dist::Built(BuiltDist::Registry(registry_dist)) = &mut locked_dist {
+            for wheel in &mut registry_dist.wheels {
+                wheel.proxy = None;
+            }
+        }
+
+        assert!(ignores_metadata_error(
+            &dist,
+            &index_locations,
+            &index_routes,
+            StatusCode::UNAUTHORIZED
+        ));
+        assert!(!ignores_metadata_error(
+            &dist,
+            &index_locations,
+            &index_routes,
+            StatusCode::FORBIDDEN
+        ));
+        assert!(ignores_metadata_error(
+            &locked_dist,
+            &index_locations,
+            &index_routes,
+            StatusCode::UNAUTHORIZED
+        ));
+        assert!(!ignores_metadata_error(
+            &locked_dist,
+            &index_locations,
+            &index_routes,
+            StatusCode::FORBIDDEN
+        ));
+        Ok(())
     }
 }

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -47,6 +47,7 @@ impl VersionMap {
         simple_metadata: OwnedArchive<SimpleDetailMetadata>,
         package_name: &PackageName,
         index: IndexUrl,
+        physical_index: IndexUrl,
         tags: Option<Tags>,
         requires_python: RequiresPython,
         allowed_yanks: AllowedYanks,
@@ -59,6 +60,7 @@ impl VersionMap {
         let mut stable = false;
         let mut local = false;
         let mut entries = Vec::with_capacity(simple_metadata.iter().size_hint().0);
+        let proxy = (physical_index != index).then_some(physical_index);
         // Create stubs for each entry in simple metadata. The full conversion
         // from a `VersionFiles` to a PrioritizedDist for each version
         // isn't done until that specific version is requested.
@@ -102,6 +104,7 @@ impl VersionMap {
                 no_binary: build_options.no_binary_package(package_name),
                 no_build: build_options.no_build_package(package_name),
                 index,
+                proxy,
                 tags,
                 allowed_yanks,
                 hasher,
@@ -508,6 +511,8 @@ struct VersionMapLazy {
     no_build: bool,
     /// The URL of the index where this package came from.
     index: IndexUrl,
+    /// The physical proxy endpoint used to retrieve this package, if any.
+    proxy: Option<IndexUrl>,
     /// The set of compatibility tags that determines whether a wheel is usable
     /// in the current environment.
     tags: Option<Tags>,
@@ -527,6 +532,11 @@ struct VersionMapLazy {
 impl VersionMapLazy {
     /// Returns the registry-provided metadata for the given version, if it exists.
     fn get_metadata(&self, version: &Version) -> Option<ResolutionMetadata> {
+        // Version-level metadata is not bound to an artifact. When routing through a proxy,
+        // use artifact metadata so canonicalization can validate its provenance.
+        if self.proxy.is_some() {
+            return None;
+        }
         let archived = self
             .map
             .get(version)
@@ -706,6 +716,7 @@ impl VersionMapLazy {
                             filename,
                             file: Box::new(file),
                             index: self.index.clone(),
+                            proxy: self.proxy.clone(),
                         };
                         priority_dist.insert_built(dist, hashes, compatibility);
                     }
@@ -724,6 +735,7 @@ impl VersionMapLazy {
                             ext: filename.extension,
                             file: Box::new(file),
                             index: self.index.clone(),
+                            proxy: self.proxy.clone(),
                             wheels: vec![],
                         };
                         priority_dist.insert_source(dist, hashes, compatibility);
@@ -904,5 +916,107 @@ impl<'a> RangeBounds<Version> for BoundingRange<'a> {
 
     fn end_bound(&self) -> Bound<&'a Version> {
         self.max
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use serde_json::json;
+    use tokio::sync::Semaphore;
+    use uv_cache::Cache;
+    use uv_client::{BaseClientBuilder, MetadataFormat, RegistryClientBuilder};
+    use uv_distribution_types::{
+        Index, IndexCapabilities, IndexLocations, IndexMetadataRef, IndexReference, ProxyIndex,
+    };
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    type Error = Box<dyn std::error::Error>;
+
+    #[tokio::test]
+    async fn proxied_resolution_metadata_is_bound_to_artifacts() -> Result<(), Error> {
+        let proxy_server = MockServer::start().await;
+        let filename = "example-1.0.0-py3-none-any.whl";
+        Mock::given(method("GET"))
+            .and(path("/simple/example/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(
+                    json!({
+                        "files": [{
+                            "filename": filename,
+                            "url": format!("https://artifacts.example.com/{filename}"),
+                            "hashes": {},
+                            "core-metadata": true
+                        }],
+                        "core-metadata": {
+                            "1.0.0": {}
+                        }
+                    })
+                    .to_string(),
+                    "application/vnd.pyx.simple.v1+json",
+                ),
+            )
+            .expect(1)
+            .mount(&proxy_server)
+            .await;
+
+        let canonical = IndexUrl::from_str("https://canonical.example.com/simple")?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", proxy_server.uri()))?;
+        let locations =
+            IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
+                .with_proxy_indexes(vec![ProxyIndex {
+                    index: IndexReference::Url(canonical.clone()),
+                    url: proxy.clone(),
+                }]);
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(locations)
+            .build()?;
+        let package = PackageName::from_str("example")?;
+        let response = client
+            .simple_detail(
+                &package,
+                Some(IndexMetadataRef::from(&canonical)),
+                &IndexCapabilities::default(),
+                &Semaphore::new(1),
+            )
+            .await?
+            .into_iter()
+            .next()
+            .ok_or("expected proxy metadata")?;
+        let MetadataFormat::Simple(simple_metadata) = response.format else {
+            return Err("expected Simple API metadata".into());
+        };
+
+        let version = Version::from_str("1.0.0")?;
+        let requires_python =
+            RequiresPython::greater_than_equal_version(&Version::from_str("3.8")?);
+        let version_map = VersionMap::from_simple_metadata(
+            simple_metadata,
+            &package,
+            response.index_route.canonical.clone(),
+            response.index_route.physical.clone(),
+            None,
+            requires_python,
+            AllowedYanks::default(),
+            HashStrategy::default(),
+            None,
+            None,
+            None,
+            &BuildOptions::default(),
+        );
+
+        assert!(version_map.get_metadata(&version).is_none());
+        let (wheel, _) = version_map
+            .get(&version)
+            .and_then(PrioritizedDist::best_wheel)
+            .ok_or("expected a proxied wheel")?;
+        assert_eq!(wheel.index, canonical);
+        assert_eq!(wheel.proxy.as_ref(), Some(&proxy));
+        assert_eq!(wheel.physical_index(), &proxy);
+        Ok(())
     }
 }

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -1,7 +1,7 @@
 use tokio::sync::Semaphore;
 use tracing::debug;
 
-use uv_client::{MetadataFormat, RegistryClient, VersionFiles};
+use uv_client::{IndexMetadataResponse, MetadataFormat, RegistryClient, VersionFiles};
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{
     File, IndexCapabilities, IndexLocations, IndexMetadataRef, IndexUrl, RequiresPython,
@@ -144,8 +144,12 @@ impl LatestClient<'_> {
             Err(err) => return Err(err),
         };
 
-        for (index, archive) in archives {
-            let exclude_newer = self.effective_exclude_newer(package, index);
+        for IndexMetadataResponse {
+            index_route,
+            format: archive,
+        } in archives
+        {
+            let exclude_newer = self.effective_exclude_newer(package, index_route.canonical);
 
             match archive {
                 MetadataFormat::Simple(archive) => {


### PR DESCRIPTION
Existing locks retain canonical registry artifact identities. When that canonical index is routed through a proxy, uv needs to rediscover the exact locked file through the current physical endpoint; otherwise metadata requests and downloads can bypass the proxy or use the wrong cache shard.

This PR adds locked artifact rediscovery by exact filename and digest. When the proxy advertises one of the locked hashes, uv uses the normal metadata path. If it does not advertise a comparable hash, uv streams the full wheel to a temporary file and validates it against the lock before parsing its metadata. The canonical index owns the resolution and lock identity, while the physical endpoint takes care of request URLs, authentication, status and cache-control policy, capability attribution, redirects, and errors.

Artifact reads and writes use only the current physical endpoint’s cache shard (for now; this might be a future optimization opportunity, or rendered moot by #19693). Direct indexes retain their existing behavior because their physical and canonical endpoints are identical. Since proxies are not configurable as of this PR, all indexes are direct.

URL-form proxy indexes can satisfy existing locks but remain excluded from fresh resolution. Lock canonicalization, artifact URL mapping, and proxy configuration remain separate follow-ups.