### PR TITLE
Use 16x32 Windows test runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,7 +205,7 @@ jobs:
 
   cargo-test-windows:
     timeout-minutes: 15
-    runs-on: namespace-profile-windows-2022-x86-64-16
+    runs-on: nscloud-windows-2022-amd64-16x32
     name: "cargo test on windows ${{ matrix.partition }} of 3"
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,7 +205,7 @@ jobs:
 
   cargo-test-windows:
     timeout-minutes: 15
-    runs-on: nscloud-windows-2022-amd64-16x32
+    runs-on: namespace-profile-windows-2022-x86-64-16x32
     name: "cargo test on windows ${{ matrix.partition }} of 3"
     strategy:
       fail-fast: false


### PR DESCRIPTION
Use Namespace's standard 16 vCPU / 32 GB Windows Server 2022 runner for the partitioned Windows test jobs. The previous custom 16 vCPU / 64 GB profile exhausted the workspace memory quota while leaving CPU capacity unused; the leaner shape preserves CPU capacity per job and allows twice as many of these jobs to run concurrently within the same resource limits.

Runtime samples average the three test partitions within each workflow run. The comparison uses 20 successful `main` runs on 16x64 and 10 runs on this branch on 16x32. Queue time is excluded. “Whole job” covers the job from start to completion, including setup, cache restoration, compilation, tests, and teardown; “Compile and test” covers the `Cargo test` step, including compilation, linking, and test execution.

| Metric           | `main` 16x64 mean (95% CI) | Branch 16x32 mean (95% CI) |         Difference (95% CI) |
| ---------------- | -------------------------: | -------------------------: | --------------------------: |
| Whole job        |           4:04 (3:57–4:11) |           4:28 (4:06–4:49) |  +24s / +9.7% (+1s to +46s) |
| Compile and test |           2:55 (2:48–3:02) |           3:18 (2:57–3:39) | +23s / +13.3% (+2s to +45s) |

| Metric           | `main` 16x64 median | Branch 16x32 median |    Difference |
| ---------------- | ------------------: | ------------------: | ------------: |
| Whole job        |                4:01 |                4:28 | +27s / +11.1% |
| Compile and test |                2:52 |                3:19 | +27s / +15.6% |
