### PR TITLE
Canonicalize proxy artifact URLs for lock construction

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -2303,8 +2303,8 @@ mod tests {
     use uv_cache::{Cache, CacheBucket, WheelCache};
     use uv_distribution_filename::WheelFilename;
     use uv_distribution_types::{
-        BuiltDist, File, FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations,
-        IndexMetadataRef, IndexReference, IndexUrl, ProxyIndex, RegistryBuiltDist,
+        ArtifactUrlMap, BuiltDist, File, FileLocation, Index, IndexCapabilities, IndexFormat,
+        IndexLocations, IndexMetadataRef, IndexReference, IndexUrl, ProxyIndex, RegistryBuiltDist,
         RegistryBuiltWheel, ToUrlError,
     };
     use uv_git::GitResolver;
@@ -2339,6 +2339,13 @@ mod tests {
         )
     }
 
+    fn artifact_url_map() -> Result<ArtifactUrlMap, Error> {
+        Ok(ArtifactUrlMap::single(
+            DisplaySafeUrl::parse("https://proxy.example/files")?,
+            DisplaySafeUrl::parse("https://canonical.example/files")?,
+        ))
+    }
+
     async fn assert_no_index(
         client: &RegistryClient,
         package: &str,
@@ -2371,12 +2378,18 @@ mod tests {
         );
     }
 
-    fn proxy_index_locations(canonical: &IndexUrl, proxy: &IndexUrl) -> IndexLocations {
-        IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
-            .with_proxy_indexes(vec![ProxyIndex {
-                index: IndexReference::Url(canonical.clone()),
-                url: proxy.clone(),
-            }])
+    fn proxy_index_locations(
+        canonical: &IndexUrl,
+        proxy: &IndexUrl,
+    ) -> Result<IndexLocations, Error> {
+        Ok(
+            IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
+                .with_proxy_indexes(vec![ProxyIndex {
+                    index: IndexReference::Url(canonical.clone()),
+                    url: proxy.clone(),
+                    artifact_url_map: artifact_url_map()?,
+                }]),
+        )
     }
 
     fn proxy_registry_client(
@@ -2385,7 +2398,7 @@ mod tests {
     ) -> Result<RegistryClient, Error> {
         Ok(
             RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
-                .index_locations(proxy_index_locations(canonical, proxy))
+                .index_locations(proxy_index_locations(canonical, proxy)?)
                 .build()?,
         )
     }
@@ -2483,6 +2496,7 @@ mod tests {
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(index.clone()),
             url: index,
+            artifact_url_map: artifact_url_map()?,
         }]);
         let builder = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
             .index_locations(locations);
@@ -2635,6 +2649,7 @@ mod tests {
             .with_proxy_indexes(vec![ProxyIndex {
                 index: IndexReference::Url(canonical.clone()),
                 url: proxy,
+                artifact_url_map: artifact_url_map()?,
             }]);
         let client =
             RegistryClientBuilder::new(BaseClientBuilder::default().retries(0), Cache::temp()?)
@@ -2716,6 +2731,7 @@ mod tests {
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(canonical.clone()),
             url: proxy,
+            artifact_url_map: artifact_url_map()?,
         }]);
         let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
             .index_locations(locations)
@@ -2755,6 +2771,7 @@ mod tests {
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(canonical.clone()),
             url: proxy.clone(),
+            artifact_url_map: artifact_url_map()?,
         }]);
         let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
             .index_locations(locations)
@@ -2839,6 +2856,7 @@ mod tests {
                 .with_proxy_indexes(vec![ProxyIndex {
                     index: IndexReference::Url(canonical.clone()),
                     url: proxy,
+                    artifact_url_map: artifact_url_map()?,
                 }]);
         let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
             .index_locations(locations)
@@ -2971,6 +2989,7 @@ mod tests {
                 .with_proxy_indexes(vec![ProxyIndex {
                     index: IndexReference::Url(canonical.clone()),
                     url: proxy.clone(),
+                    artifact_url_map: artifact_url_map()?,
                 }]);
         let cache = Cache::temp()?;
         let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache.clone())
@@ -3091,6 +3110,7 @@ mod tests {
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(canonical.clone()),
             url: proxy.clone(),
+            artifact_url_map: artifact_url_map()?,
         }]);
         let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
             .index_locations(locations)
@@ -3125,6 +3145,7 @@ mod tests {
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(canonical.clone()),
             url: proxy.clone(),
+            artifact_url_map: artifact_url_map()?,
         }]);
         let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
             .index_locations(locations)
@@ -3180,6 +3201,7 @@ mod tests {
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(canonical.clone()),
             url: proxy.clone(),
+            artifact_url_map: artifact_url_map()?,
         }]);
         let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
             .index_locations(locations)

--- a/crates/uv-distribution-types/src/artifact_url.rs
+++ b/crates/uv-distribution-types/src/artifact_url.rs
@@ -1,0 +1,850 @@
+use std::collections::{BTreeMap, btree_map::Entry};
+use std::fmt;
+
+use serde::de::{Error as _, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
+
+use crate::{FileLocation, UrlString};
+
+/// A one-way mapping from physical proxy artifact URL prefixes to canonical URL prefixes.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(transparent)]
+pub struct ArtifactUrlMap(BTreeMap<DisplaySafeUrl, DisplaySafeUrl>);
+
+impl<'de> Deserialize<'de> for ArtifactUrlMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ArtifactUrlMapVisitor;
+
+        impl<'de> Visitor<'de> for ArtifactUrlMapVisitor {
+            type Value = ArtifactUrlMap;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a physical-to-canonical artifact URL map")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut mappings = BTreeMap::new();
+                while let Some((physical, canonical)) = map.next_entry::<String, String>()? {
+                    let physical = parse_artifact_url::<A::Error>(&physical)?;
+                    let canonical = parse_artifact_url::<A::Error>(&canonical)?;
+                    match mappings.entry(physical) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(canonical);
+                        }
+                        Entry::Occupied(entry) => {
+                            let physical = diagnostic_safe(entry.key());
+                            return Err(A::Error::custom(format_args!(
+                                "duplicate physical artifact URL prefix `{physical}`"
+                            )));
+                        }
+                    }
+                }
+                Ok(ArtifactUrlMap(mappings))
+            }
+        }
+
+        deserializer.deserialize_map(ArtifactUrlMapVisitor)
+    }
+}
+
+impl ArtifactUrlMap {
+    /// Create an artifact URL map from physical-to-canonical prefix mappings.
+    #[cfg(test)]
+    pub(crate) fn new(mappings: BTreeMap<DisplaySafeUrl, DisplaySafeUrl>) -> Self {
+        Self(mappings)
+    }
+
+    /// Create an artifact URL map containing one physical-to-canonical prefix mapping.
+    pub fn single(physical: DisplaySafeUrl, canonical: DisplaySafeUrl) -> Self {
+        Self(BTreeMap::from([(physical, canonical)]))
+    }
+
+    pub(crate) fn validate(&self) -> Result<ValidatedArtifactUrlMap, ArtifactUrlMapError> {
+        if self.0.is_empty() {
+            return Err(ArtifactUrlMapError::Empty);
+        }
+
+        let mut mappings = Vec::<ArtifactUrlMapping>::with_capacity(self.0.len());
+        for (physical, canonical) in &self.0 {
+            validate_configured_prefix(physical)?;
+            validate_configured_prefix(canonical)?;
+
+            let physical = normalize_prefix(physical);
+            let canonical = normalize_prefix(canonical);
+            for mapping in &mappings {
+                if same_origin(&mapping.physical, &physical)
+                    && (path_suffix(mapping.physical.path(), physical.path()).is_some()
+                        || path_suffix(physical.path(), mapping.physical.path()).is_some())
+                {
+                    return Err(ArtifactUrlMapError::OverlappingPhysicalPrefixes {
+                        first: Box::new(mapping.physical.clone()),
+                        second: Box::new(physical),
+                    });
+                }
+            }
+            mappings.push(ArtifactUrlMapping {
+                physical,
+                canonical,
+            });
+        }
+        Ok(ValidatedArtifactUrlMap { mappings })
+    }
+}
+
+impl FromIterator<(DisplaySafeUrl, DisplaySafeUrl)> for ArtifactUrlMap {
+    fn from_iter<T: IntoIterator<Item = (DisplaySafeUrl, DisplaySafeUrl)>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub(crate) struct ValidatedArtifactUrlMap {
+    mappings: Vec<ArtifactUrlMapping>,
+}
+
+impl ValidatedArtifactUrlMap {
+    pub(crate) fn canonical_artifact_url(
+        &self,
+        location: &FileLocation,
+        filename: &str,
+    ) -> Result<FileLocation, ArtifactUrlMapError> {
+        let mut physical = location
+            .to_url()
+            .map_err(|_| ArtifactUrlMapError::InvalidArtifactUrl)?;
+
+        // Simple API hash fragments have already been captured in [`crate::File::hashes`].
+        physical.set_fragment(None);
+
+        let physical = DisplaySafeUrl::parse(physical.as_str())
+            .map_err(|_| ArtifactUrlMapError::InvalidArtifactUrl)?;
+
+        validate_http_url(&physical)?;
+        if has_credentials(&physical) {
+            return Err(ArtifactUrlMapError::Credentials {
+                url: Box::new(diagnostic_safe(&physical)),
+            });
+        }
+        if physical.query().is_some() {
+            return Err(ArtifactUrlMapError::Query {
+                url: Box::new(diagnostic_safe(&physical)),
+            });
+        }
+
+        let mut matched = None;
+        for mapping in &self.mappings {
+            if same_origin(&mapping.physical, &physical)
+                && let Some(suffix) = path_suffix(mapping.physical.path(), physical.path())
+            {
+                if matched.is_some() {
+                    return Err(ArtifactUrlMapError::Ambiguous {
+                        url: Box::new(physical),
+                    });
+                }
+                matched = Some((mapping, suffix));
+            }
+        }
+        let Some((mapping, suffix)) = matched else {
+            return Err(ArtifactUrlMapError::Unmapped {
+                url: Box::new(physical),
+            });
+        };
+
+        let mut canonical = mapping.canonical.clone();
+        canonical.set_path(&mapped_path(mapping.canonical.path(), suffix));
+        let Some(encoded_filename) = canonical
+            .path_segments()
+            .and_then(|mut segments| segments.next_back())
+        else {
+            return Err(ArtifactUrlMapError::MissingFilename {
+                url: Box::new(canonical),
+            });
+        };
+        let mapped_filename = percent_encoding::percent_decode_str(encoded_filename)
+            .decode_utf8()
+            .map_err(|source| ArtifactUrlMapError::InvalidFilenameEncoding {
+                url: Box::new(canonical.clone()),
+                source,
+            })?
+            .into_owned();
+        if mapped_filename != filename {
+            return Err(ArtifactUrlMapError::FilenameChanged {
+                url: Box::new(canonical),
+                expected: filename.to_string(),
+                actual: mapped_filename,
+            });
+        }
+
+        Ok(FileLocation::AbsoluteUrl(UrlString::from(canonical)))
+    }
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+struct ArtifactUrlMapping {
+    physical: DisplaySafeUrl,
+    canonical: DisplaySafeUrl,
+}
+
+/// An invalid artifact URL mapping or application.
+#[derive(Debug, Clone, Eq, PartialEq, Error)]
+pub enum ArtifactUrlMapError {
+    #[error("Artifact URL map must contain at least one physical-to-canonical prefix mapping")]
+    Empty,
+    #[error("Artifact URL `{url}` must use the HTTP or HTTPS scheme")]
+    UnsupportedScheme { url: Box<DisplaySafeUrl> },
+    #[error("Artifact URL `{url}` cannot be used as a URL base")]
+    CannotBeABase { url: Box<DisplaySafeUrl> },
+    #[error("Artifact URL `{url}` must not contain credentials")]
+    Credentials { url: Box<DisplaySafeUrl> },
+    #[error("Artifact URL `{url}` must not contain a query string")]
+    Query { url: Box<DisplaySafeUrl> },
+    #[error("Configured artifact URL prefix `{url}` must not contain a fragment")]
+    Fragment { url: Box<DisplaySafeUrl> },
+    #[error("Physical artifact URL prefixes `{first}` and `{second}` overlap")]
+    OverlappingPhysicalPrefixes {
+        first: Box<DisplaySafeUrl>,
+        second: Box<DisplaySafeUrl>,
+    },
+    // Do not retain the failed parse input or source here. Unlike a [`DisplaySafeUrl`], both can
+    // contain unredacted credentials or query parameters from an untrusted proxy response.
+    #[error("Failed to resolve proxy artifact URL")]
+    InvalidArtifactUrl,
+    #[error("Artifact URL `{url}` does not match any configured physical prefix")]
+    Unmapped { url: Box<DisplaySafeUrl> },
+    #[error("Artifact URL `{url}` matches multiple configured physical prefixes")]
+    Ambiguous { url: Box<DisplaySafeUrl> },
+    #[error("Mapped artifact URL `{url}` does not contain a filename")]
+    MissingFilename { url: Box<DisplaySafeUrl> },
+    #[error("Mapped artifact URL `{url}` has an invalid percent-encoded filename")]
+    InvalidFilenameEncoding {
+        url: Box<DisplaySafeUrl>,
+        #[source]
+        source: std::str::Utf8Error,
+    },
+    #[error(
+        "Mapped artifact URL `{url}` has filename `{actual}`, but the selected file is `{expected}`"
+    )]
+    FilenameChanged {
+        url: Box<DisplaySafeUrl>,
+        expected: String,
+        actual: String,
+    },
+}
+
+fn validate_configured_prefix(url: &DisplaySafeUrl) -> Result<(), ArtifactUrlMapError> {
+    validate_http_url(url)?;
+    if has_credentials(url) {
+        return Err(ArtifactUrlMapError::Credentials {
+            url: Box::new(diagnostic_safe(url)),
+        });
+    }
+    if url.query().is_some() {
+        return Err(ArtifactUrlMapError::Query {
+            url: Box::new(diagnostic_safe(url)),
+        });
+    }
+    if url.fragment().is_some() {
+        return Err(ArtifactUrlMapError::Fragment {
+            url: Box::new(diagnostic_safe(url)),
+        });
+    }
+    Ok(())
+}
+
+fn validate_http_url(url: &DisplaySafeUrl) -> Result<(), ArtifactUrlMapError> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(ArtifactUrlMapError::UnsupportedScheme {
+            url: Box::new(diagnostic_safe(url)),
+        });
+    }
+    if url.cannot_be_a_base() {
+        return Err(ArtifactUrlMapError::CannotBeABase {
+            url: Box::new(diagnostic_safe(url)),
+        });
+    }
+    Ok(())
+}
+
+fn diagnostic_safe(url: &DisplaySafeUrl) -> DisplaySafeUrl {
+    let mut sanitized = url.clone();
+    sanitized.remove_credentials();
+    sanitized.set_query(None);
+    sanitized.set_fragment(None);
+    sanitized
+}
+
+fn parse_artifact_url<E: serde::de::Error>(value: &str) -> Result<DisplaySafeUrl, E> {
+    DisplaySafeUrl::parse(value).map_err(|error| match error {
+        DisplaySafeUrlError::AmbiguousAuthority(_) => {
+            E::custom("ambiguous user/pass authority in artifact URL (not percent-encoded?)")
+        }
+        DisplaySafeUrlError::Url(error) => E::custom(error),
+    })
+}
+
+fn has_credentials(url: &DisplaySafeUrl) -> bool {
+    !url.username().is_empty() || url.password().is_some()
+}
+
+fn normalize_prefix(url: &DisplaySafeUrl) -> DisplaySafeUrl {
+    let mut normalized = url.clone();
+    let path = normalized_path(url.path());
+    normalized.set_path(&path);
+    normalized
+}
+
+fn normalized_path(path: &str) -> String {
+    if path.is_empty() {
+        return "/".to_string();
+    }
+    path.strip_suffix('/')
+        .filter(|prefix| !prefix.is_empty() && !prefix.ends_with('/'))
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn same_origin(left: &DisplaySafeUrl, right: &DisplaySafeUrl) -> bool {
+    left.origin() == right.origin()
+}
+
+fn path_suffix<'url>(prefix: &str, path: &'url str) -> Option<&'url str> {
+    if prefix == "/" {
+        return path.strip_prefix('/');
+    }
+    let suffix = path.strip_prefix(prefix)?;
+    if suffix.is_empty() || prefix.ends_with('/') {
+        Some(suffix)
+    } else {
+        suffix.strip_prefix('/')
+    }
+}
+
+fn mapped_path(prefix: &str, suffix: &str) -> String {
+    if suffix.is_empty() {
+        prefix.to_string()
+    } else if prefix.ends_with('/') {
+        format!("{prefix}{suffix}")
+    } else {
+        format!("{prefix}/{suffix}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use super::*;
+
+    #[test]
+    fn validates_required_http_prefixes() -> Result<(), Box<dyn Error>> {
+        assert_eq!(
+            ArtifactUrlMap::new(BTreeMap::new()).validate(),
+            Err(ArtifactUrlMapError::Empty)
+        );
+
+        let invalid = [
+            (
+                "ftp://proxy.example/files",
+                ArtifactUrlMapError::UnsupportedScheme {
+                    url: Box::new(url("ftp://proxy.example/files")?),
+                },
+            ),
+            (
+                "https://username-token@proxy.example/files",
+                ArtifactUrlMapError::Credentials {
+                    url: Box::new(url("https://proxy.example/files")?),
+                },
+            ),
+            (
+                "https://proxy.example/files?token=secret",
+                ArtifactUrlMapError::Query {
+                    url: Box::new(url("https://proxy.example/files")?),
+                },
+            ),
+            (
+                "ftp://proxy.example/files?token=secret",
+                ArtifactUrlMapError::UnsupportedScheme {
+                    url: Box::new(url("ftp://proxy.example/files")?),
+                },
+            ),
+            (
+                "https://username-token@proxy.example/files?token=secret",
+                ArtifactUrlMapError::Credentials {
+                    url: Box::new(url("https://proxy.example/files")?),
+                },
+            ),
+            (
+                "https://proxy.example/files#fragment_token=secret",
+                ArtifactUrlMapError::Fragment {
+                    url: Box::new(url("https://proxy.example/files")?),
+                },
+            ),
+        ];
+        for (physical, expected) in invalid {
+            let map =
+                ArtifactUrlMap::single(url(physical)?, url("https://canonical.example/packages")?);
+            assert_eq!(map.validate(), Err(expected));
+        }
+        let configured_query = ArtifactUrlMap::single(
+            url("https://proxy.example/files?token=secret")?,
+            url("https://canonical.example/packages")?,
+        )
+        .validate()
+        .expect_err("configured queries should be rejected");
+        assert!(
+            configured_query
+                .to_string()
+                .contains("https://proxy.example/files")
+        );
+        assert!(!configured_query.to_string().contains("token=secret"));
+
+        let invalid_canonical = ArtifactUrlMap::single(
+            url("https://proxy.example/files")?,
+            url("https://canonical.example/packages#fragment")?,
+        );
+        assert!(matches!(
+            invalid_canonical.validate(),
+            Err(ArtifactUrlMapError::Fragment { .. })
+        ));
+        let configured_fragment = ArtifactUrlMap::single(
+            url("https://proxy.example/files#fragment_token=secret")?,
+            url("https://canonical.example/packages")?,
+        )
+        .validate()
+        .expect_err("configured fragments should be rejected");
+        assert!(
+            configured_fragment
+                .to_string()
+                .contains("proxy.example/files")
+        );
+        assert!(!configured_fragment.to_string().contains("secret"));
+        assert!(!configured_fragment.to_string().contains("fragment_token"));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_normalized_duplicate_and_overlapping_prefixes() -> Result<(), Box<dyn Error>> {
+        let duplicate = artifact_url_map([
+            (
+                "https://PROXY.example:443/pypi/",
+                "https://canonical.example/one",
+            ),
+            (
+                "https://proxy.example/pypi",
+                "https://canonical.example/two",
+            ),
+        ])?;
+        assert!(matches!(
+            duplicate.validate(),
+            Err(ArtifactUrlMapError::OverlappingPhysicalPrefixes { .. })
+        ));
+
+        let parent = artifact_url_map([
+            (
+                "https://proxy.example/pypi",
+                "https://canonical.example/one",
+            ),
+            (
+                "https://proxy.example/pypi/files",
+                "https://canonical.example/two",
+            ),
+        ])?;
+        assert!(matches!(
+            parent.validate(),
+            Err(ArtifactUrlMapError::OverlappingPhysicalPrefixes { .. })
+        ));
+
+        let segment_boundary = artifact_url_map([
+            (
+                "https://proxy.example/pypi",
+                "https://canonical.example/shared",
+            ),
+            (
+                "https://proxy.example/pypi-other",
+                "https://canonical.example/shared/",
+            ),
+        ])?;
+        assert!(segment_boundary.validate().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn deserialization_rejects_normalized_duplicate_keys_and_round_trips()
+    -> Result<(), Box<dyn Error>> {
+        let duplicate = toml::from_str::<ArtifactUrlMap>(
+            r#"
+"https://PROXY.example:443/pypi" = "https://canonical.example/one"
+"https://proxy.example/pypi" = "https://canonical.example/two"
+"#,
+        )
+        .expect_err("normalized duplicate physical prefixes must be rejected");
+        assert!(
+            duplicate
+                .to_string()
+                .contains("duplicate physical artifact URL prefix")
+        );
+        let duplicate_query = toml::from_str::<ArtifactUrlMap>(
+            r#"
+"https://PROXY.example:443/pypi?token=secret" = "https://canonical.example/one"
+"https://proxy.example/pypi?token=secret" = "https://canonical.example/two"
+"#,
+        )
+        .expect_err("normalized duplicate query-bearing prefixes must be rejected");
+        assert!(
+            duplicate_query
+                .to_string()
+                .contains("https://proxy.example/pypi")
+        );
+        assert!(!duplicate_query.to_string().contains("token=secret"));
+        let duplicate_fragment = toml::from_str::<ArtifactUrlMap>(
+            r#"
+"https://PROXY.example:443/pypi#fragment_token=secret" = "https://canonical.example/one"
+"https://proxy.example/pypi#fragment_token=secret" = "https://canonical.example/two"
+"#,
+        )
+        .expect_err("normalized duplicate fragment-bearing prefixes must be rejected");
+        assert!(
+            duplicate_fragment
+                .to_string()
+                .contains("https://proxy.example/pypi")
+        );
+        assert!(!duplicate_fragment.to_string().contains("secret"));
+        assert!(!duplicate_fragment.to_string().contains("fragment_token"));
+
+        let map = toml::from_str::<ArtifactUrlMap>(
+            r#"
+"https://proxy.example/pypi" = "https://canonical.example/packages"
+"#,
+        )?;
+        let serialized = toml::to_string(&map)?;
+        assert_eq!(toml::from_str::<ArtifactUrlMap>(&serialized)?, map);
+        Ok(())
+    }
+
+    #[test]
+    fn deserialization_rejects_ambiguous_authority() {
+        for input in [
+            r#"
+"https://user/name:password@domain/files#fragment_token=secret" = "https://canonical.example/packages"
+"#,
+            r#"
+"https://proxy.example/pypi" = "https://user/name:password@domain/files#fragment_token=secret"
+"#,
+        ] {
+            let error = toml::from_str::<ArtifactUrlMap>(input)
+                .expect_err("ambiguous URL authorities must be rejected");
+            assert!(error.to_string().contains("ambiguous user/pass authority"));
+            assert!(!error.to_string().contains("secret"));
+            assert!(!error.to_string().contains("fragment_token"));
+        }
+    }
+
+    #[test]
+    fn maps_physical_prefix_and_preserves_encoded_suffix() -> Result<(), Box<dyn Error>> {
+        let map = ArtifactUrlMap::single(
+            url("https://proxy.example/pypi/")?,
+            url("https://canonical.example/packages/")?,
+        )
+        .validate()?;
+        let physical = FileLocation::new(
+            "https://proxy.example/pypi/%E2%82%AC.whl#sha256=abc".into(),
+            &"".into(),
+        );
+
+        let canonical = map.canonical_artifact_url(&physical, "€.whl")?;
+        assert_eq!(
+            canonical.to_url()?.as_str(),
+            "https://canonical.example/packages/%E2%82%AC.whl"
+        );
+        assert!(matches!(canonical, FileLocation::AbsoluteUrl(_)));
+
+        let relative = FileLocation::new(
+            "nested/example.whl".into(),
+            &"https://proxy.example/pypi/".into(),
+        );
+        assert_eq!(
+            map.canonical_artifact_url(&relative, "example.whl")?
+                .to_url()?
+                .as_str(),
+            "https://canonical.example/packages/nested/example.whl"
+        );
+
+        let reverse = FileLocation::new(
+            "https://canonical.example/packages/%E2%82%AC.whl".into(),
+            &"".into(),
+        );
+        assert!(matches!(
+            map.canonical_artifact_url(&reverse, "€.whl"),
+            Err(ArtifactUrlMapError::Unmapped { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn requires_path_segment_boundary() -> Result<(), Box<dyn Error>> {
+        let map = ArtifactUrlMap::single(
+            url("https://proxy.example/pypi")?,
+            url("https://canonical.example/packages")?,
+        )
+        .validate()?;
+        let physical = FileLocation::new(
+            "https://proxy.example/pypi-other/example.whl".into(),
+            &"".into(),
+        );
+        assert!(matches!(
+            map.canonical_artifact_url(&physical, "example.whl"),
+            Err(ArtifactUrlMapError::Unmapped { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn preserves_empty_path_segments() -> Result<(), Box<dyn Error>> {
+        let root_map = ArtifactUrlMap::single(
+            url("https://proxy.example//")?,
+            url("https://canonical.example/packages//")?,
+        )
+        .validate()?;
+        let root_artifact =
+            FileLocation::new("https://proxy.example/artifact.whl".into(), &"".into());
+        assert!(matches!(
+            root_map.canonical_artifact_url(&root_artifact, "artifact.whl"),
+            Err(ArtifactUrlMapError::Unmapped { .. })
+        ));
+
+        let empty_segment_artifact =
+            FileLocation::new("https://proxy.example//artifact.whl".into(), &"".into());
+        assert_eq!(
+            root_map
+                .canonical_artifact_url(&empty_segment_artifact, "artifact.whl")?
+                .to_url()?
+                .as_str(),
+            "https://canonical.example/packages//artifact.whl"
+        );
+
+        let nested_map = ArtifactUrlMap::single(
+            url("https://proxy.example/pypi//")?,
+            url("https://canonical.example/packages//")?,
+        )
+        .validate()?;
+        let single_separator =
+            FileLocation::new("https://proxy.example/pypi/artifact.whl".into(), &"".into());
+        assert!(matches!(
+            nested_map.canonical_artifact_url(&single_separator, "artifact.whl"),
+            Err(ArtifactUrlMapError::Unmapped { .. })
+        ));
+        let double_separator = FileLocation::new(
+            "https://proxy.example/pypi//artifact.whl".into(),
+            &"".into(),
+        );
+        assert_eq!(
+            nested_map
+                .canonical_artifact_url(&double_separator, "artifact.whl")?
+                .to_url()?
+                .as_str(),
+            "https://canonical.example/packages//artifact.whl"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn maps_to_root_without_duplicate_separator() -> Result<(), Box<dyn Error>> {
+        let map = ArtifactUrlMap::single(
+            url("https://proxy.example/pypi/")?,
+            url("https://canonical.example/")?,
+        )
+        .validate()?;
+        let physical =
+            FileLocation::new("https://proxy.example/pypi/example.whl".into(), &"".into());
+        assert_eq!(
+            map.canonical_artifact_url(&physical, "example.whl")?
+                .to_url()?
+                .as_str(),
+            "https://canonical.example/example.whl"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_selected_query_credentials_and_changed_filename() -> Result<(), Box<dyn Error>> {
+        let map = ArtifactUrlMap::single(
+            url("https://proxy.example/files")?,
+            url("https://canonical.example/packages")?,
+        )
+        .validate()?;
+
+        let query = FileLocation::new(
+            "https://proxy.example/files/example.whl?token=secret#fragment_token=secret".into(),
+            &"".into(),
+        );
+        let query_error = map
+            .canonical_artifact_url(&query, "example.whl")
+            .expect_err("selected queries should be rejected");
+        assert!(matches!(&query_error, ArtifactUrlMapError::Query { .. }));
+        assert!(
+            query_error
+                .to_string()
+                .contains("https://proxy.example/files/example.whl")
+        );
+        assert!(!query_error.to_string().contains("token=secret"));
+        assert!(!query_error.to_string().contains("fragment_token"));
+
+        let credentials_and_query = FileLocation::new(
+            "https://username-token:password-token@proxy.example/files/example.whl?token=secret#fragment_token=secret"
+                .into(),
+            &"".into(),
+        );
+        let credentials_and_query_error = map
+            .canonical_artifact_url(&credentials_and_query, "example.whl")
+            .expect_err("selected credentials should be rejected before mapping");
+        assert!(matches!(
+            &credentials_and_query_error,
+            ArtifactUrlMapError::Credentials { .. }
+        ));
+        let ArtifactUrlMapError::Credentials { url } = &credentials_and_query_error else {
+            return Err("expected credentials error".into());
+        };
+        assert_eq!(url.as_str(), "https://proxy.example/files/example.whl");
+        assert!(
+            credentials_and_query_error
+                .to_string()
+                .contains("https://proxy.example/files/example.whl")
+        );
+        for diagnostic in [
+            credentials_and_query_error.to_string(),
+            format!("{credentials_and_query_error:?}"),
+        ] {
+            assert!(!diagnostic.contains("username-token"));
+            assert!(!diagnostic.contains("password-token"));
+            assert!(!diagnostic.contains("token=secret"));
+            assert!(!diagnostic.contains("fragment_token"));
+        }
+
+        let credentials = FileLocation::new(
+            "https://user:password@proxy.example/files/example.whl".into(),
+            &"".into(),
+        );
+        assert!(matches!(
+            map.canonical_artifact_url(&credentials, "example.whl"),
+            Err(ArtifactUrlMapError::Credentials { .. })
+        ));
+
+        let local = FileLocation::new(
+            "file:///tmp/example.whl#fragment_token=secret".into(),
+            &"".into(),
+        );
+        let local_error = map
+            .canonical_artifact_url(&local, "example.whl")
+            .expect_err("non-HTTP artifact URLs should be rejected");
+        assert!(matches!(
+            &local_error,
+            ArtifactUrlMapError::UnsupportedScheme { .. }
+        ));
+        assert!(!local_error.to_string().contains("secret"));
+        assert!(!local_error.to_string().contains("fragment_token"));
+
+        let filename = FileLocation::new(
+            "https://proxy.example/files/different.whl".into(),
+            &"".into(),
+        );
+        assert!(matches!(
+            map.canonical_artifact_url(&filename, "example.whl"),
+            Err(ArtifactUrlMapError::FilenameChanged { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_artifact_url_errors_do_not_retain_unparsed_secrets() -> Result<(), Box<dyn Error>> {
+        let map = ArtifactUrlMap::single(
+            url("https://proxy.example/files")?,
+            url("https://canonical.example/packages")?,
+        )
+        .validate()?;
+        let locations = [
+            FileLocation::new(
+                "https://[invalid]/example.whl?absolute_token=secret".into(),
+                &"".into(),
+            ),
+            FileLocation::new(
+                "example.whl".into(),
+                &"https://[invalid]/files?base_token=secret".into(),
+            ),
+            FileLocation::RelativeUrl(
+                "https://proxy.example/files/".into(),
+                "https://[invalid]/example.whl?join_token=secret".into(),
+            ),
+            FileLocation::new(
+                "//username-token/name:password-secret@proxy.example/files/example.whl".into(),
+                &"https://proxy.example/simple/".into(),
+            ),
+        ];
+
+        for location in locations {
+            let error = map
+                .canonical_artifact_url(&location, "example.whl")
+                .expect_err("unparsable artifact URLs should be rejected");
+            assert_eq!(error, ArtifactUrlMapError::InvalidArtifactUrl);
+            let chain = error_chain(&error);
+            assert!(!chain.contains("secret"));
+            assert!(!chain.contains("token"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn detects_ambiguous_match_defensively() -> Result<(), Box<dyn Error>> {
+        let map = ValidatedArtifactUrlMap {
+            mappings: vec![
+                ArtifactUrlMapping {
+                    physical: url("https://proxy.example/")?,
+                    canonical: url("https://canonical.example/root")?,
+                },
+                ArtifactUrlMapping {
+                    physical: url("https://proxy.example/files")?,
+                    canonical: url("https://canonical.example/files")?,
+                },
+            ],
+        };
+        let physical =
+            FileLocation::new("https://proxy.example/files/example.whl".into(), &"".into());
+        assert!(matches!(
+            map.canonical_artifact_url(&physical, "example.whl"),
+            Err(ArtifactUrlMapError::Ambiguous { .. })
+        ));
+        Ok(())
+    }
+
+    fn artifact_url_map<const N: usize>(
+        mappings: [(&str, &str); N],
+    ) -> Result<ArtifactUrlMap, uv_redacted::DisplaySafeUrlError> {
+        mappings
+            .into_iter()
+            .map(|(physical, canonical)| Ok((url(physical)?, url(canonical)?)))
+            .collect()
+    }
+
+    fn url(value: &str) -> Result<DisplaySafeUrl, uv_redacted::DisplaySafeUrlError> {
+        DisplaySafeUrl::parse(value)
+    }
+
+    fn error_chain(mut error: &(dyn Error + 'static)) -> String {
+        let mut messages = Vec::new();
+        loop {
+            messages.push(error.to_string());
+            let Some(source) = error.source() else {
+                break;
+            };
+            error = source;
+        }
+        messages.join(": ")
+    }
+}

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -14,7 +14,9 @@ use uv_small_str::SmallString;
 use crate::exclude_newer::ExcludeNewerOverride;
 use crate::index_name::{IndexName, IndexNameError};
 use crate::origin::Origin;
-use crate::{IndexStatusCodeStrategy, IndexUrl, IndexUrlError, SerializableStatusCode};
+use crate::{
+    ArtifactUrlMap, IndexStatusCodeStrategy, IndexUrl, IndexUrlError, SerializableStatusCode,
+};
 
 /// Cache control configuration for an index.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Default)]
@@ -328,6 +330,8 @@ pub struct ProxyIndex {
     pub index: IndexReference,
     /// The proxy index URL.
     pub url: IndexUrl,
+    /// One-way physical-to-canonical URL prefixes for artifacts emitted in a new lock.
+    pub artifact_url_map: ArtifactUrlMap,
 }
 
 impl PartialEq for Index {

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -18,8 +18,8 @@ use uv_redacted::DisplaySafeUrl;
 use uv_warnings::warn_user;
 
 use crate::{
-    ExcludeNewerOverride, Index, IndexFormat, IndexReference, IndexStatusCodeStrategy, ProxyIndex,
-    Verbatim,
+    ArtifactUrlMapError, ExcludeNewerOverride, FileLocation, Index, IndexFormat, IndexReference,
+    IndexStatusCodeStrategy, ProxyIndex, ValidatedArtifactUrlMap, Verbatim,
 };
 
 pub static PYPI_URL: LazyLock<DisplaySafeUrl> =
@@ -331,6 +331,14 @@ impl IndexLocations {
 fn is_same_index(a: &IndexUrl, b: &IndexUrl) -> bool {
     RealmRef::from(&**b.url()) == RealmRef::from(&**a.url())
         && CanonicalUrl::new(a.url().clone()) == CanonicalUrl::new(b.url().clone())
+}
+
+fn diagnostic_safe_index_url(index: &IndexUrl) -> DisplaySafeUrl {
+    let mut url = index.url().clone();
+    url.remove_credentials();
+    url.set_query(None);
+    url.set_fragment(None);
+    url
 }
 
 /// Return user-defined indexes in priority order, excluding shadowed names.
@@ -701,6 +709,83 @@ impl IndexRoute<'_> {
     }
 }
 
+/// Validated output-only routes for canonicalizing proxy artifacts.
+#[derive(Debug, Clone)]
+pub struct ProxyArtifactRoutes {
+    routes: Vec<ProxyArtifactRouteData>,
+}
+
+impl ProxyArtifactRoutes {
+    /// Return the output route for a canonical proxy index.
+    pub fn route_for(&self, canonical: &IndexUrl) -> Option<ProxyArtifactRoute<'_>> {
+        self.routes
+            .iter()
+            .find(|route| is_same_index(&route.canonical, canonical))
+            .map(|route| ProxyArtifactRoute {
+                physical: &route.physical,
+                artifact_url_map: &route.artifact_url_map,
+            })
+    }
+}
+
+impl TryFrom<&IndexLocations> for ProxyArtifactRoutes {
+    type Error = ProxyIndexError;
+
+    fn try_from(index_locations: &IndexLocations) -> Result<Self, Self::Error> {
+        let index_routes = IndexRoutes::try_from(index_locations)?;
+        let routes = index_routes
+            .proxy_routes()
+            .zip(index_locations.proxy_indexes())
+            .map(|(route, proxy_index)| {
+                let artifact_url_map =
+                    proxy_index.artifact_url_map.validate().map_err(|source| {
+                        ProxyIndexError::ArtifactUrlMap {
+                            index: diagnostic_safe_index_url(&proxy_index.url),
+                            source: Box::new(source),
+                        }
+                    })?;
+                Ok(ProxyArtifactRouteData {
+                    canonical: route.canonical.clone(),
+                    physical: route.physical.clone(),
+                    artifact_url_map,
+                })
+            })
+            .collect::<Result<Vec<_>, ProxyIndexError>>()?;
+        Ok(Self { routes })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProxyArtifactRouteData {
+    canonical: IndexUrl,
+    physical: IndexUrl,
+    artifact_url_map: ValidatedArtifactUrlMap,
+}
+
+/// A validated output-only route for canonicalizing proxy artifacts.
+#[derive(Debug, Clone, Copy)]
+pub struct ProxyArtifactRoute<'route> {
+    physical: &'route IndexUrl,
+    artifact_url_map: &'route ValidatedArtifactUrlMap,
+}
+
+impl ProxyArtifactRoute<'_> {
+    /// Return `true` if the physical index identifies this proxy route.
+    pub fn matches_physical(self, physical: &IndexUrl) -> bool {
+        is_same_index(self.physical, physical)
+    }
+
+    /// Map a physical proxy artifact URL to its canonical lock representation.
+    pub fn canonical_artifact_url(
+        self,
+        physical: &FileLocation,
+        filename: &str,
+    ) -> Result<FileLocation, ArtifactUrlMapError> {
+        self.artifact_url_map
+            .canonical_artifact_url(physical, filename)
+    }
+}
+
 /// An invalid proxy-index configuration.
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
 pub enum ProxyIndexError {
@@ -714,6 +799,12 @@ pub enum ProxyIndexError {
     FlatIndex { index: IndexUrl },
     #[error("Proxy index mappings do not support path-backed index `{index}`")]
     PathIndex { index: IndexUrl },
+    #[error("Invalid artifact URL map for proxy index `{index}`")]
+    ArtifactUrlMap {
+        index: DisplaySafeUrl,
+        #[source]
+        source: Box<ArtifactUrlMapError>,
+    },
 }
 
 bitflags::bitflags! {
@@ -798,8 +889,12 @@ impl IndexCapabilities {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
-    use crate::{IndexCacheControl, IndexFormat, IndexName, IndexReference, ProxyIndex};
+    use crate::{
+        ArtifactUrlMap, IndexCacheControl, IndexFormat, IndexName, IndexReference, ProxyIndex,
+    };
     use http::HeaderValue;
 
     #[test]
@@ -860,6 +955,7 @@ mod tests {
                 ProxyIndex {
                     index: IndexReference::Name(IndexName::from_str("pypi")?),
                     url: proxy.clone(),
+                    artifact_url_map: artifact_url_map()?,
                 },
             ]);
 
@@ -879,6 +975,7 @@ mod tests {
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(authenticated),
             url: proxy.clone(),
+            artifact_url_map: artifact_url_map()?,
         }]);
 
         let routes = IndexRoutes::try_from(&locations)?;
@@ -905,6 +1002,7 @@ mod tests {
         .with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(canonical),
             url: proxy,
+            artifact_url_map: artifact_url_map()?,
         }]);
         let configured_indexes = locations.allowed_indexes();
         let expected = uv_auth::Indexes::from_indexes(
@@ -924,10 +1022,12 @@ mod tests {
             ProxyIndex {
                 index: IndexReference::Url(canonical.clone()),
                 url: IndexUrl::from_str("https://one.example.com/simple")?,
+                artifact_url_map: artifact_url_map()?,
             },
             ProxyIndex {
                 index: IndexReference::Url(IndexUrl::from_str("https://pypi.org/simple/")?),
                 url: IndexUrl::from_str("https://two.example.com/simple")?,
+                artifact_url_map: artifact_url_map()?,
             },
         ]);
         assert!(matches!(
@@ -938,6 +1038,7 @@ mod tests {
         let self_proxy = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(canonical),
             url: IndexUrl::from_str("https://pypi.org/simple/")?,
+            artifact_url_map: artifact_url_map()?,
         }]);
         assert!(matches!(
             IndexRoutes::try_from(&self_proxy),
@@ -951,6 +1052,7 @@ mod tests {
         let unknown = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Name(IndexName::from_str("unknown")?),
             url: IndexUrl::from_str("https://proxy.example.com/simple")?,
+            artifact_url_map: artifact_url_map()?,
         }]);
         assert!(matches!(
             IndexRoutes::try_from(&unknown),
@@ -965,6 +1067,7 @@ mod tests {
             ProxyIndex {
                 index: IndexReference::Name(IndexName::from_str("canonical")?),
                 url: IndexUrl::from_str("https://proxy.example.com/packages")?,
+                artifact_url_map: artifact_url_map()?,
             },
         ]);
         assert!(matches!(
@@ -979,12 +1082,136 @@ mod tests {
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(IndexUrl::from_str("https://pypi.org/simple")?),
             url: IndexUrl::from_str("./proxy")?,
+            artifact_url_map: artifact_url_map()?,
         }]);
         assert!(matches!(
             IndexRoutes::try_from(&locations),
             Err(ProxyIndexError::PathIndex { .. })
         ));
         Ok(())
+    }
+
+    #[test]
+    fn proxy_index_requires_non_empty_artifact_url_map() -> Result<(), Box<dyn std::error::Error>> {
+        let missing = toml::from_str::<ProxyIndex>(
+            r#"
+index = "https://pypi.org/simple"
+url = "https://proxy.example/simple"
+"#,
+        );
+        assert!(missing.is_err());
+
+        let empty = toml::from_str::<ProxyIndex>(
+            r#"
+index = "https://pypi.org/simple"
+url = "https://proxy.example/simple"
+artifact-url-map = {}
+"#,
+        )?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![empty]);
+        assert!(IndexRoutes::try_from(&locations).is_ok());
+        assert!(matches!(
+            ProxyArtifactRoutes::try_from(&locations),
+            Err(ProxyIndexError::ArtifactUrlMap {
+                source,
+                ..
+            }) if matches!(source.as_ref(), ArtifactUrlMapError::Empty)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_artifact_route_errors_redact_index_secrets() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
+            index: IndexReference::Url(IndexUrl::from_str("https://pypi.org/simple")?),
+            url: IndexUrl::from_str(
+                "https://username-token:password-token@proxy.example/simple?query-token=secret#fragment-token=secret",
+            )?,
+            artifact_url_map: ArtifactUrlMap::new(BTreeMap::default()),
+        }]);
+
+        let error = ProxyArtifactRoutes::try_from(&locations)
+            .expect_err("an empty artifact URL map should be rejected");
+        let ProxyIndexError::ArtifactUrlMap { index, .. } = &error else {
+            return Err("expected artifact URL map error".into());
+        };
+        assert_eq!(index.as_str(), "https://proxy.example/simple");
+        assert!(error.to_string().contains("https://proxy.example/simple"));
+        for diagnostic in [error.to_string(), format!("{error:?}")] {
+            assert!(!diagnostic.contains("username-token"));
+            assert!(!diagnostic.contains("password-token"));
+            assert!(!diagnostic.contains("query-token"));
+            assert!(!diagnostic.contains("fragment-token"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn proxy_artifact_routes_preserve_declaration_map_pairing()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let first_canonical = IndexUrl::from_str("https://one.example/simple")?;
+        let second_canonical = IndexUrl::from_str("https://two.example/simple")?;
+        let first_physical = IndexUrl::from_str("https://proxy.example/one/simple")?;
+        let second_physical = IndexUrl::from_str("https://proxy.example/two/simple")?;
+        let locations = IndexLocations::default().with_proxy_indexes(vec![
+            ProxyIndex {
+                index: IndexReference::Url(first_canonical.clone()),
+                url: first_physical,
+                artifact_url_map: ArtifactUrlMap::single(
+                    DisplaySafeUrl::parse("https://files.proxy.example/one")?,
+                    DisplaySafeUrl::parse("https://files.example/one")?,
+                ),
+            },
+            ProxyIndex {
+                index: IndexReference::Url(second_canonical.clone()),
+                url: second_physical,
+                artifact_url_map: ArtifactUrlMap::single(
+                    DisplaySafeUrl::parse("https://files.proxy.example/two")?,
+                    DisplaySafeUrl::parse("https://files.example/two")?,
+                ),
+            },
+        ]);
+
+        let routes = ProxyArtifactRoutes::try_from(&locations)?;
+        let first = routes
+            .route_for(&first_canonical)
+            .expect("first output route should exist");
+        let second = routes
+            .route_for(&second_canonical)
+            .expect("second output route should exist");
+
+        let first_artifact = FileLocation::new(
+            "https://files.proxy.example/one/example.whl".into(),
+            &"".into(),
+        );
+        assert_eq!(
+            first
+                .canonical_artifact_url(&first_artifact, "example.whl")?
+                .to_url()?
+                .as_str(),
+            "https://files.example/one/example.whl"
+        );
+
+        let second_artifact = FileLocation::new(
+            "https://files.proxy.example/two/example.tar.gz".into(),
+            &"".into(),
+        );
+        assert_eq!(
+            second
+                .canonical_artifact_url(&second_artifact, "example.tar.gz")?
+                .to_url()?
+                .as_str(),
+            "https://files.example/two/example.tar.gz"
+        );
+        Ok(())
+    }
+
+    fn artifact_url_map() -> Result<ArtifactUrlMap, uv_redacted::DisplaySafeUrlError> {
+        Ok(ArtifactUrlMap::single(
+            DisplaySafeUrl::parse("https://proxy.example/files")?,
+            DisplaySafeUrl::parse("https://canonical.example/files")?,
+        ))
     }
 
     #[test]

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -57,6 +57,7 @@ use uv_redacted::DisplaySafeUrl;
 
 pub use crate::annotation::*;
 pub use crate::any::*;
+pub use crate::artifact_url::*;
 pub use crate::build_info::*;
 pub use crate::build_requires::*;
 pub use crate::buildable::*;
@@ -89,6 +90,7 @@ pub use crate::traits::*;
 
 mod annotation;
 mod any;
+mod artifact_url;
 mod build_info;
 mod build_requires;
 mod buildable;

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -557,10 +557,11 @@ mod tests {
     use anyhow::anyhow;
     use uv_distribution_filename::SourceDistExtension;
     use uv_distribution_types::{
-        File, FileLocation, Index, IndexReference, ProxyIndex, RegistryBuiltWheel,
+        ArtifactUrlMap, File, FileLocation, Index, IndexReference, ProxyIndex, RegistryBuiltWheel,
     };
     use uv_platform_tags::{Arch, Os, Platform, TagsOptions};
     use uv_pypi_types::HashDigests;
+    use uv_redacted::DisplaySafeUrl;
 
     use super::*;
 
@@ -672,6 +673,10 @@ mod tests {
                 .with_proxy_indexes(vec![ProxyIndex {
                     index: IndexReference::Url(canonical.clone()),
                     url: proxy_b.clone(),
+                    artifact_url_map: ArtifactUrlMap::single(
+                        DisplaySafeUrl::parse("https://proxy-b.example/files")?,
+                        DisplaySafeUrl::parse("https://canonical.example/files")?,
+                    ),
                 }]);
         let platform = Platform::new(
             Os::Manylinux {

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -21,7 +21,8 @@ pub use prerelease::PrereleaseMode;
 pub use pubgrub::PubGrubHint;
 pub use python_requirement::PythonRequirement;
 pub use resolution::{
-    AnnotationStyle, ConflictingDistributionError, DisplayResolutionGraph, ResolverOutput,
+    AnnotationStyle, ConflictingDistributionError, DisplayResolutionGraph,
+    ProxyCanonicalizationError, ResolverOutput,
 };
 pub use resolution_mode::ResolutionMode;
 pub use resolver::{

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -6744,7 +6744,7 @@ fn canonical_marker_trees(
 ///
 /// Returns `true` if the wheel is definitely unreachable, and `false` if it may be reachable,
 /// including if the wheel tag isn't recognized.
-fn is_wheel_unreachable_for_marker(
+pub(crate) fn is_wheel_unreachable_for_marker(
     filename: &WheelFilename,
     requires_python: &RequiresPython,
     marker: &UniversalMarker,
@@ -6954,9 +6954,10 @@ pub(crate) fn is_wheel_unreachable(
 
 #[cfg(test)]
 mod tests {
-    use uv_distribution_types::{IndexReference, ProxyIndex};
+    use uv_distribution_types::{ArtifactUrlMap, IndexReference, ProxyIndex};
     use uv_pep440::VersionSpecifiers;
     use uv_pep508::MarkerEnvironmentBuilder;
+    use uv_redacted::DisplaySafeUrl;
     use uv_warnings::anstream;
 
     use super::*;
@@ -7136,6 +7137,10 @@ source = { registry = "https://example.com/simple" }
         let locations = IndexLocations::default().with_proxy_indexes(vec![ProxyIndex {
             index: IndexReference::Url(canonical.clone()),
             url: IndexUrl::from_str("https://proxy.example.com/simple")?,
+            artifact_url_map: ArtifactUrlMap::single(
+                DisplaySafeUrl::parse("https://proxy.example/files")?,
+                DisplaySafeUrl::parse("https://canonical.example/files")?,
+            ),
         }]);
 
         assert!(

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -2730,9 +2730,10 @@ mod tests {
 
     use pubgrub::{DefaultStringReporter, Reporter};
     use uv_distribution_types::{
-        IndexReference, IndexStatusCodeStrategy, ProxyIndex, RequiresPython,
+        ArtifactUrlMap, IndexReference, IndexStatusCodeStrategy, ProxyIndex, RequiresPython,
     };
     use uv_pep508::{MarkerEnvironment, MarkerEnvironmentBuilder};
+    use uv_redacted::DisplaySafeUrl;
 
     use super::*;
 
@@ -2808,10 +2809,18 @@ mod tests {
             ProxyIndex {
                 index: IndexReference::Url(canonical_without_response.clone()),
                 url: physical.clone(),
+                artifact_url_map: ArtifactUrlMap::single(
+                    DisplaySafeUrl::parse("https://proxy.example.com/files")?,
+                    DisplaySafeUrl::parse("https://canonical-a.example.com/files")?,
+                ),
             },
             ProxyIndex {
                 index: IndexReference::Url(canonical_with_response.clone()),
                 url: physical.clone(),
+                artifact_url_map: ArtifactUrlMap::single(
+                    DisplaySafeUrl::parse("https://proxy.example.com/files")?,
+                    DisplaySafeUrl::parse("https://canonical-b.example.com/files")?,
+                ),
             },
         ]);
         // URL-form routes that are otherwise unconfigured can satisfy existing locks, but they

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -17,7 +17,10 @@ use crate::universal_marker::UniversalMarker;
 
 mod display;
 mod output;
+mod proxy;
 mod requirements_txt;
+
+pub use proxy::ProxyCanonicalizationError;
 
 /// A pinned package with its resolved distribution and metadata. The [`ResolvedDist`] refers to a
 /// specific distribution (e.g., a specific wheel), while the [`Metadata23`] refers to the metadata

--- a/crates/uv-resolver/src/resolution/proxy.rs
+++ b/crates/uv-resolver/src/resolution/proxy.rs
@@ -1,0 +1,1110 @@
+use std::sync::Arc;
+
+use uv_distribution_types::{
+    ArtifactUrlMapError, BuiltDist, Dist, File, IndexLocations, IndexUrl, ProxyArtifactRoutes,
+    ProxyIndexError, RegistryBuiltWheel, RegistrySourceDist, ResolvedDist, SourceDist,
+};
+use uv_normalize::PackageName;
+use uv_pep508::MarkerTree;
+use uv_redacted::DisplaySafeUrl;
+
+use crate::lock::is_wheel_unreachable_for_marker;
+use crate::resolution::{ResolutionGraphNode, ResolverOutput};
+use crate::universal_marker::{ConflictMarker, UniversalMarker};
+
+/// An error encountered while canonicalizing proxy artifact URLs for a new lock.
+#[derive(Debug, thiserror::Error)]
+pub enum ProxyCanonicalizationError {
+    #[error(transparent)]
+    ProxyIndex(#[from] ProxyIndexError),
+    #[error(
+        "Cannot canonicalize `{filename}` for `{package}` because canonical index `{canonical}` has no matching proxy declaration"
+    )]
+    MissingProxyIndex {
+        package: PackageName,
+        filename: String,
+        canonical: Box<DisplaySafeUrl>,
+    },
+    #[error(
+        "Cannot canonicalize `{filename}` for `{package}` because proxy index `{physical}` does not match the configured route for `{canonical}`"
+    )]
+    RouteMismatch {
+        package: PackageName,
+        filename: String,
+        canonical: Box<DisplaySafeUrl>,
+        physical: Box<DisplaySafeUrl>,
+    },
+    #[error(
+        "Cannot lock `{filename}` for `{package}` from proxy index `{physical}` because it has no supported advertised digest"
+    )]
+    MissingDigest {
+        package: PackageName,
+        filename: String,
+        physical: Box<DisplaySafeUrl>,
+    },
+    #[error(
+        "Failed to canonicalize `{filename}` for `{package}` from proxy index `{physical}` against `{canonical}`"
+    )]
+    ArtifactUrl {
+        package: PackageName,
+        filename: String,
+        canonical: Box<DisplaySafeUrl>,
+        physical: Box<DisplaySafeUrl>,
+        #[source]
+        source: Box<ArtifactUrlMapError>,
+    },
+}
+
+fn diagnostic_safe_index_url(index: &IndexUrl) -> DisplaySafeUrl {
+    let mut url = index.url().clone();
+    url.remove_credentials();
+    url.set_query(None);
+    url.set_fragment(None);
+    url
+}
+
+impl ResolverOutput {
+    /// Canonicalize proxy artifact URLs before constructing a new lock.
+    pub fn canonicalize_proxy_artifact_urls_for_lock(
+        &mut self,
+        index_locations: &IndexLocations,
+        supported_environments: &[MarkerTree],
+    ) -> Result<(), ProxyCanonicalizationError> {
+        let artifact_routes = ProxyArtifactRoutes::try_from(index_locations)?;
+        let supported_environment = self.supported_environment(supported_environments);
+        let mut replacements = Vec::new();
+
+        for (node_index, annotated) in self.base_dists() {
+            let ResolvedDist::Installable { dist, version } = &annotated.dist else {
+                continue;
+            };
+            let selected_index = annotated.index();
+            let mut canonicalized = dist.as_ref().clone();
+            let mut wheel_marker = annotated.marker;
+            if let Some(supported_environment) = supported_environment {
+                wheel_marker.and(supported_environment);
+            }
+            if canonicalize_dist(
+                &mut canonicalized,
+                &annotated.name,
+                &artifact_routes,
+                selected_index,
+                &self.requires_python,
+                &wheel_marker,
+            )? {
+                replacements.push((
+                    node_index,
+                    ResolvedDist::Installable {
+                        dist: Arc::new(canonicalized),
+                        version: version.clone(),
+                    },
+                ));
+            }
+        }
+
+        for (node_index, replacement) in replacements {
+            if let Some(ResolutionGraphNode::Dist(annotated)) =
+                self.graph.node_weight_mut(node_index)
+            {
+                annotated.dist = replacement;
+            }
+        }
+        Ok(())
+    }
+
+    fn supported_environment(
+        &self,
+        supported_environments: &[MarkerTree],
+    ) -> Option<UniversalMarker> {
+        if supported_environments.is_empty() {
+            return None;
+        }
+        let mut combined = MarkerTree::FALSE;
+        for marker in supported_environments {
+            combined.or(self.requires_python.complexify_markers(*marker));
+        }
+        Some(UniversalMarker::new(combined, ConflictMarker::TRUE))
+    }
+}
+
+fn canonicalize_dist(
+    dist: &mut Dist,
+    package: &PackageName,
+    artifact_routes: &ProxyArtifactRoutes,
+    selected_index: Option<&IndexUrl>,
+    requires_python: &uv_distribution_types::RequiresPython,
+    wheel_marker: &UniversalMarker,
+) -> Result<bool, ProxyCanonicalizationError> {
+    match dist {
+        Dist::Built(BuiltDist::Registry(registry)) => {
+            let mut changed = false;
+            if let Some(source_dist) = registry.sdist.as_mut()
+                && selected_index.is_some_and(|index| *index == source_dist.index)
+                && canonicalize_source_dist(source_dist, package, artifact_routes)?
+            {
+                changed = true;
+            }
+            if canonicalize_wheels(
+                &mut registry.wheels,
+                package,
+                artifact_routes,
+                selected_index,
+                requires_python,
+                wheel_marker,
+            )? {
+                changed = true;
+            }
+            Ok(changed)
+        }
+        Dist::Source(SourceDist::Registry(registry)) => {
+            let mut changed = selected_index.is_some_and(|index| *index == registry.index)
+                && canonicalize_source_dist(registry, package, artifact_routes)?;
+            if canonicalize_wheels(
+                &mut registry.wheels,
+                package,
+                artifact_routes,
+                selected_index,
+                requires_python,
+                wheel_marker,
+            )? {
+                changed = true;
+            }
+            Ok(changed)
+        }
+        Dist::Built(_) | Dist::Source(_) => Ok(false),
+    }
+}
+
+fn canonicalize_wheels(
+    wheels: &mut [RegistryBuiltWheel],
+    package: &PackageName,
+    artifact_routes: &ProxyArtifactRoutes,
+    selected_index: Option<&IndexUrl>,
+    requires_python: &uv_distribution_types::RequiresPython,
+    wheel_marker: &UniversalMarker,
+) -> Result<bool, ProxyCanonicalizationError> {
+    let mut changed = false;
+    for wheel in wheels {
+        if selected_index.is_none_or(|index| *index != wheel.index) {
+            continue;
+        }
+        if is_wheel_unreachable_for_marker(&wheel.filename, requires_python, wheel_marker, None) {
+            continue;
+        }
+        let lock_filename = wheel.filename.to_string();
+        if canonicalize_registry_file(
+            wheel.file.as_mut(),
+            Some(&lock_filename),
+            &wheel.index,
+            &mut wheel.proxy,
+            package,
+            artifact_routes,
+        )? {
+            changed = true;
+        }
+    }
+    Ok(changed)
+}
+
+fn canonicalize_source_dist(
+    source_dist: &mut RegistrySourceDist,
+    package: &PackageName,
+    artifact_routes: &ProxyArtifactRoutes,
+) -> Result<bool, ProxyCanonicalizationError> {
+    canonicalize_registry_file(
+        source_dist.file.as_mut(),
+        None,
+        &source_dist.index,
+        &mut source_dist.proxy,
+        package,
+        artifact_routes,
+    )
+}
+
+fn canonicalize_registry_file(
+    file: &mut File,
+    lock_filename: Option<&str>,
+    canonical: &IndexUrl,
+    proxy: &mut Option<IndexUrl>,
+    package: &PackageName,
+    artifact_routes: &ProxyArtifactRoutes,
+) -> Result<bool, ProxyCanonicalizationError> {
+    let Some(physical) = proxy.as_ref() else {
+        return Ok(false);
+    };
+    let filename = lock_filename.unwrap_or(file.filename.as_ref());
+    if file.hashes.is_empty() {
+        return Err(ProxyCanonicalizationError::MissingDigest {
+            package: package.clone(),
+            filename: filename.to_string(),
+            physical: Box::new(diagnostic_safe_index_url(physical)),
+        });
+    }
+    let Some(artifact_route) = artifact_routes.route_for(canonical) else {
+        return Err(ProxyCanonicalizationError::MissingProxyIndex {
+            package: package.clone(),
+            filename: filename.to_string(),
+            canonical: Box::new(diagnostic_safe_index_url(canonical)),
+        });
+    };
+    if !artifact_route.matches_physical(physical) {
+        return Err(ProxyCanonicalizationError::RouteMismatch {
+            package: package.clone(),
+            filename: filename.to_string(),
+            canonical: Box::new(diagnostic_safe_index_url(canonical)),
+            physical: Box::new(diagnostic_safe_index_url(physical)),
+        });
+    }
+    let canonicalization_error = |source| ProxyCanonicalizationError::ArtifactUrl {
+        package: package.clone(),
+        filename: filename.to_string(),
+        canonical: Box::new(diagnostic_safe_index_url(canonical)),
+        physical: Box::new(diagnostic_safe_index_url(physical)),
+        source: Box::new(source),
+    };
+    let mut canonical_url = artifact_route
+        .canonical_artifact_url(&file.url, file.filename.as_ref())
+        .map_err(&canonicalization_error)?;
+    // Lock deserialization normalizes wheel filenames, while proxy rediscovery matches them
+    // exactly. Require the mapped URL to survive that round trip.
+    if let Some(lock_filename) = lock_filename
+        && lock_filename != file.filename.as_ref()
+    {
+        canonical_url = artifact_route
+            .canonical_artifact_url(&file.url, lock_filename)
+            .map_err(&canonicalization_error)?;
+    }
+    file.url = canonical_url;
+    *proxy = None;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+    use std::path::Path;
+    use std::str::FromStr;
+
+    use petgraph::{Directed, graph::Graph, graph::NodeIndex};
+    use serde_json::json;
+    use uv_cache::Cache;
+    use uv_client::{BaseClientBuilder, RegistryClientBuilder};
+    use uv_configuration::{Constraints, Overrides};
+    use uv_distribution_filename::{SourceDistExtension, WheelFilename};
+    use uv_distribution_types::{
+        ArtifactUrlMap, FileLocation, Index, IndexCapabilities, IndexReference, ProxyIndex,
+        RegistryBuiltDist, RequiresPython, UrlString, Zstd,
+    };
+    use uv_normalize::{ExtraName, PackageName};
+    use uv_pep440::{Version, VersionSpecifiers};
+    use uv_pypi_types::{HashDigest, HashDigests, Yanked};
+    use uv_redacted::DisplaySafeUrl;
+    use wiremock::matchers::{method, path as request_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::Options;
+    use crate::resolution::AnnotatedDist;
+
+    const CANONICAL_INDEX: &str = "https://canonical.example/simple";
+    const PROXY_INDEX: &str = "https://proxy.example/simple";
+    const PHYSICAL_PREFIX: &str = "https://files.proxy.example/packages";
+    const CANONICAL_PREFIX: &str = "https://files.canonical.example/artifacts";
+    const SHA256: &str = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+
+    type ResolverFixture = (ResolverOutput, Vec<NodeIndex>, Option<NodeIndex>);
+
+    #[test]
+    fn canonicalizes_wheel_without_mutating_runtime_extra_or_canonical_nodes()
+    -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        let proxy = IndexUrl::from_str(PROXY_INDEX)?;
+        let filename = "example-1.0.0-py3-none-any.whl";
+        let wheel = registry_wheel(
+            filename,
+            &format!("{PHYSICAL_PREFIX}/{filename}#sha256=ignored"),
+            &canonical,
+            Some(&proxy),
+            hashes()?,
+        )?;
+        let original_wheel = wheel.clone();
+        let canonical_filename = "canonical-1.0.0-py3-none-any.whl";
+        let canonical_wheel = registry_wheel(
+            canonical_filename,
+            &format!("https://canonical.example/files/{canonical_filename}"),
+            &canonical,
+            None,
+            HashDigests::empty(),
+        )?;
+        let original_canonical_wheel = canonical_wheel.clone();
+        let (mut resolution, base_indexes, extra_index) = resolver_output(
+            vec![
+                (
+                    PackageName::from_str("example")?,
+                    Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                        wheels: vec![wheel],
+                        best_wheel_index: 0,
+                        sdist: None,
+                    })),
+                ),
+                (
+                    PackageName::from_str("canonical")?,
+                    Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                        wheels: vec![canonical_wheel],
+                        best_wheel_index: 0,
+                        sdist: None,
+                    })),
+                ),
+            ],
+            true,
+        )?;
+        let runtime_dist = installable_dist_at(&resolution, base_indexes[0])?.clone();
+
+        let index_locations = index_locations()?;
+        resolution.canonicalize_proxy_artifact_urls_for_lock(&index_locations, &[])?;
+
+        let base_wheel = wheel_at(&resolution, base_indexes[0], 0)?;
+        let mut expected_file = original_wheel.file.as_ref().clone();
+        expected_file.url = FileLocation::AbsoluteUrl(UrlString::from(DisplaySafeUrl::parse(
+            &format!("{CANONICAL_PREFIX}/{filename}"),
+        )?));
+        assert_eq!(base_wheel.file.as_ref(), &expected_file);
+        assert_eq!(base_wheel.index, canonical);
+        assert!(base_wheel.proxy.is_none());
+        let extra_wheel = wheel_at(&resolution, extra_index.ok_or("expected an extra node")?, 0)?;
+        assert_eq!(extra_wheel, &original_wheel);
+        assert_eq!(
+            registry_wheel_from_dist(runtime_dist.as_ref(), 0)?,
+            &original_wheel
+        );
+        assert_eq!(
+            wheel_at(&resolution, base_indexes[1], 0)?,
+            &original_canonical_wheel
+        );
+        let lock = crate::Lock::from_resolution(
+            &resolution,
+            Path::new("."),
+            Vec::new(),
+            &index_locations,
+        )?;
+        let lock = lock.to_toml()?;
+        insta::assert_snapshot!(lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [[package]]
+        name = "canonical"
+        version = "1.0.0"
+        source = { registry = "https://canonical.example/simple" }
+        wheels = [
+            { url = "https://canonical.example/files/canonical-1.0.0-py3-none-any.whl", size = 42, upload-time = "1970-01-01T00:00:01.234Z", zstd = { hash = "sha256:1111111111111111111111111111111111111111111111111111111111111111", size = 21 } },
+        ]
+
+        [[package]]
+        name = "example"
+        version = "1.0.0"
+        source = { registry = "https://canonical.example/simple" }
+        wheels = [
+            { url = "https://files.canonical.example/artifacts/example-1.0.0-py3-none-any.whl", hash = "sha256:1111111111111111111111111111111111111111111111111111111111111111", size = 42, upload-time = "1970-01-01T00:00:01.234Z", zstd = { hash = "sha256:1111111111111111111111111111111111111111111111111111111111111111", size = 21 } },
+        ]
+        "#);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fresh_lock_wheel_filename_is_replay_stable() -> Result<(), Box<dyn Error>> {
+        let server = MockServer::start().await;
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        let proxy = IndexUrl::from_str(&format!("{}/simple", server.uri()))?;
+        let index_locations =
+            IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
+                .with_proxy_indexes(vec![ProxyIndex {
+                    index: IndexReference::Url(canonical.clone()),
+                    url: proxy.clone(),
+                    artifact_url_map: ArtifactUrlMap::single(
+                        DisplaySafeUrl::parse(PHYSICAL_PREFIX)?,
+                        DisplaySafeUrl::parse(CANONICAL_PREFIX)?,
+                    ),
+                }]);
+
+        let proxy_filename = "example-1.01.0-py3-none-any.whl";
+        let lock_filename = WheelFilename::from_str(proxy_filename)?.to_string();
+        assert_eq!(lock_filename, "example-1.1.0-py3-none-any.whl");
+        let unstable_wheel = registry_wheel(
+            proxy_filename,
+            &format!("{PHYSICAL_PREFIX}/{proxy_filename}"),
+            &canonical,
+            Some(&proxy),
+            hashes()?,
+        )?;
+        let (mut unstable_resolution, _, _) = resolver_output(
+            vec![(
+                PackageName::from_str("example")?,
+                Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                    wheels: vec![unstable_wheel],
+                    best_wheel_index: 0,
+                    sdist: None,
+                })),
+            )],
+            false,
+        )?;
+
+        let error = unstable_resolution
+            .canonicalize_proxy_artifact_urls_for_lock(&index_locations, &[])
+            .expect_err("an unstable wheel filename must not be emitted into a fresh lock");
+        let ProxyCanonicalizationError::ArtifactUrl { source, .. } = &error else {
+            return Err("expected artifact URL error".into());
+        };
+        let ArtifactUrlMapError::FilenameChanged {
+            expected, actual, ..
+        } = source.as_ref()
+        else {
+            return Err("expected filename stability error".into());
+        };
+        assert_eq!(expected, &lock_filename);
+        assert_eq!(actual, proxy_filename);
+
+        let stable_wheel = registry_wheel(
+            &lock_filename,
+            &format!("{PHYSICAL_PREFIX}/{lock_filename}"),
+            &canonical,
+            Some(&proxy),
+            hashes()?,
+        )?;
+        let (mut stable_resolution, _, _) = resolver_output(
+            vec![(
+                PackageName::from_str("example")?,
+                Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                    wheels: vec![stable_wheel],
+                    best_wheel_index: 0,
+                    sdist: None,
+                })),
+            )],
+            false,
+        )?;
+        stable_resolution.canonicalize_proxy_artifact_urls_for_lock(&index_locations, &[])?;
+        let lock = crate::Lock::from_resolution(
+            &stable_resolution,
+            Path::new("."),
+            Vec::new(),
+            &index_locations,
+        )?;
+        let lock_toml = lock.to_toml()?;
+        let lock_value: toml::Value = toml::from_str(&lock_toml)?;
+        let package = lock_value
+            .get("package")
+            .and_then(toml::Value::as_array)
+            .and_then(|packages| {
+                packages.iter().find(|package| {
+                    package.get("name").and_then(toml::Value::as_str) == Some("example")
+                })
+            })
+            .ok_or("expected example package in fresh lock")?;
+        let wheel = package
+            .get("wheels")
+            .and_then(toml::Value::as_array)
+            .and_then(|wheels| wheels.first())
+            .ok_or("expected wheel in fresh lock")?;
+        let locked_url = wheel
+            .get("url")
+            .and_then(toml::Value::as_str)
+            .ok_or("expected wheel URL in fresh lock")?;
+        let locked_filename = locked_url
+            .rsplit('/')
+            .next()
+            .ok_or("expected filename in fresh lock URL")?;
+        let locked_hash = wheel
+            .get("hash")
+            .and_then(toml::Value::as_str)
+            .ok_or("expected wheel digest in fresh lock")?;
+        assert_eq!(locked_filename, lock_filename);
+
+        let digest = SHA256
+            .strip_prefix("sha256:")
+            .ok_or("expected SHA-256 test digest")?;
+        Mock::given(method("GET"))
+            .and(request_path("/simple/example/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(
+                    json!({
+                        "name": "example",
+                        "files": [{
+                            "filename": lock_filename,
+                            "url": format!("{PHYSICAL_PREFIX}/{lock_filename}"),
+                            "hashes": { "sha256": digest },
+                        }],
+                    })
+                    .to_string(),
+                    "application/vnd.pypi.simple.v1+json",
+                ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
+            .index_locations(index_locations)
+            .build()?;
+        let locked_hashes = HashDigests::from(HashDigest::from_str(locked_hash)?);
+        let artifact = client
+            .proxy_artifact(
+                &PackageName::from_str("example")?,
+                &canonical,
+                locked_filename,
+                &locked_hashes,
+                &IndexCapabilities::default(),
+            )
+            .await?
+            .ok_or("expected proxy rediscovery for the fresh lock wheel")?;
+        assert_eq!(artifact.file.filename.as_ref(), locked_filename);
+        assert!(artifact.has_shared_hash);
+        Ok(())
+    }
+
+    #[test]
+    fn canonicalizes_source_and_only_retained_wheels() -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        let proxy = IndexUrl::from_str(PROXY_INDEX)?;
+        let source_filename = "example-1.0.0.tar.gz";
+        let source_file = registry_file(
+            source_filename,
+            &format!("{PHYSICAL_PREFIX}/{source_filename}"),
+            hashes()?,
+        )?;
+        let original_source_file = source_file.clone();
+        let retained_filename = "example-1.0.0-py3-none-any.whl";
+        let retained = registry_wheel(
+            retained_filename,
+            &format!("{PHYSICAL_PREFIX}/{retained_filename}"),
+            &canonical,
+            Some(&proxy),
+            hashes()?,
+        )?;
+        let omitted_filename = "example-1.0.0-cp312-cp312-win_amd64.whl";
+        let omitted = registry_wheel(
+            omitted_filename,
+            &format!("https://unmapped.example/{omitted_filename}"),
+            &canonical,
+            Some(&proxy),
+            HashDigests::empty(),
+        )?;
+        let original_omitted = omitted.clone();
+        let source = RegistrySourceDist {
+            name: PackageName::from_str("example")?,
+            version: Version::from_str("1.0.0")?,
+            file: Box::new(source_file),
+            ext: SourceDistExtension::TarGz,
+            index: canonical,
+            proxy: Some(proxy),
+            wheels: vec![retained, omitted],
+        };
+        let (mut resolution, base_indexes, _) = resolver_output(
+            vec![(
+                PackageName::from_str("example")?,
+                Dist::Source(SourceDist::Registry(source)),
+            )],
+            false,
+        )?;
+        let supported = [MarkerTree::from_str("sys_platform == 'linux'")?];
+
+        resolution.canonicalize_proxy_artifact_urls_for_lock(&index_locations()?, &supported)?;
+
+        let source = source_at(&resolution, base_indexes[0])?;
+        let mut expected_source_file = original_source_file;
+        expected_source_file.url = FileLocation::AbsoluteUrl(UrlString::from(
+            DisplaySafeUrl::parse(&format!("{CANONICAL_PREFIX}/{source_filename}"))?,
+        ));
+        assert_eq!(source.file.as_ref(), &expected_source_file);
+        assert!(source.proxy.is_none());
+        assert_eq!(
+            source.wheels[0].file.url.to_url()?.as_str(),
+            format!("{CANONICAL_PREFIX}/{retained_filename}")
+        );
+        assert!(source.wheels[0].proxy.is_none());
+        assert_eq!(source.wheels[1], original_omitted);
+        Ok(())
+    }
+
+    #[test]
+    fn skips_non_selected_registry_artifacts_before_validation() -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        let proxy = IndexUrl::from_str(PROXY_INDEX)?;
+        let non_selected = IndexUrl::from_str("https://find-links.example/packages")?;
+
+        let selected_filename = "example-1.0.0-py3-none-any.whl";
+        let selected = registry_wheel(
+            selected_filename,
+            &format!("{PHYSICAL_PREFIX}/{selected_filename}"),
+            &canonical,
+            Some(&proxy),
+            hashes()?,
+        )?;
+        let non_selected_wheel_filename = "example-1.0.0-py2-none-any.whl";
+        let non_selected_wheel = registry_wheel(
+            non_selected_wheel_filename,
+            &format!("https://unmapped.example/{non_selected_wheel_filename}"),
+            &non_selected,
+            Some(&proxy),
+            HashDigests::empty(),
+        )?;
+        let original_non_selected_wheel = non_selected_wheel.clone();
+
+        let non_selected_source_filename = "example-1.0.0.tar.gz";
+        let non_selected_source = RegistrySourceDist {
+            name: PackageName::from_str("example")?,
+            version: Version::from_str("1.0.0")?,
+            file: Box::new(registry_file(
+                non_selected_source_filename,
+                &format!("https://unmapped.example/{non_selected_source_filename}"),
+                HashDigests::empty(),
+            )?),
+            ext: SourceDistExtension::TarGz,
+            index: non_selected,
+            proxy: Some(proxy),
+            wheels: vec![],
+        };
+        let original_non_selected_source = non_selected_source.clone();
+        let (mut resolution, base_indexes, _) = resolver_output(
+            vec![(
+                PackageName::from_str("example")?,
+                Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                    wheels: vec![selected, non_selected_wheel],
+                    best_wheel_index: 0,
+                    sdist: Some(non_selected_source),
+                })),
+            )],
+            false,
+        )?;
+
+        resolution.canonicalize_proxy_artifact_urls_for_lock(&index_locations()?, &[])?;
+
+        let Dist::Built(BuiltDist::Registry(registry)) =
+            installable_dist_at(&resolution, base_indexes[0])?.as_ref()
+        else {
+            return Err("expected registry built distribution".into());
+        };
+        assert_eq!(
+            registry.wheels[0].file.url.to_url()?.as_str(),
+            format!("{CANONICAL_PREFIX}/{selected_filename}")
+        );
+        assert!(registry.wheels[0].proxy.is_none());
+        assert_eq!(registry.wheels[1], original_non_selected_wheel);
+        assert_eq!(registry.sdist.as_ref(), Some(&original_non_selected_source));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_hashless_retained_wheel_and_source() -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        let proxy = IndexUrl::from_str(PROXY_INDEX)?;
+        let wheel_filename = "wheel-1.0.0-py3-none-any.whl";
+        let wheel = registry_wheel(
+            wheel_filename,
+            &format!("{PHYSICAL_PREFIX}/{wheel_filename}"),
+            &canonical,
+            Some(&proxy),
+            HashDigests::empty(),
+        )?;
+        let (mut wheel_resolution, _, _) = resolver_output(
+            vec![(
+                PackageName::from_str("wheel")?,
+                Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                    wheels: vec![wheel],
+                    best_wheel_index: 0,
+                    sdist: None,
+                })),
+            )],
+            false,
+        )?;
+        assert!(matches!(
+            wheel_resolution.canonicalize_proxy_artifact_urls_for_lock(&index_locations()?, &[]),
+            Err(ProxyCanonicalizationError::MissingDigest { filename, .. })
+                if filename == wheel_filename
+        ));
+
+        let source_filename = "source-1.0.0.tar.gz";
+        let source = RegistrySourceDist {
+            name: PackageName::from_str("source")?,
+            version: Version::from_str("1.0.0")?,
+            file: Box::new(registry_file(
+                source_filename,
+                &format!("{PHYSICAL_PREFIX}/{source_filename}"),
+                HashDigests::empty(),
+            )?),
+            ext: SourceDistExtension::TarGz,
+            index: canonical,
+            proxy: Some(proxy),
+            wheels: vec![],
+        };
+        let (mut source_resolution, _, _) = resolver_output(
+            vec![(
+                PackageName::from_str("source")?,
+                Dist::Source(SourceDist::Registry(source)),
+            )],
+            false,
+        )?;
+        assert!(matches!(
+            source_resolution.canonicalize_proxy_artifact_urls_for_lock(
+                &index_locations()?,
+                &[]
+            ),
+            Err(ProxyCanonicalizationError::MissingDigest { filename, .. })
+                if filename == source_filename
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn canonicalization_errors_redact_index_url_secrets() -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(
+            "https://canonical-user:canonical-password@canonical.example/simple?canonical-query=secret#canonical-fragment=secret",
+        )?;
+        let physical = IndexUrl::from_str(
+            "https://proxy-user:proxy-password@proxy.example/simple?proxy-query=secret#proxy-fragment=secret",
+        )?;
+        let filename = "example-1.0.0-py3-none-any.whl";
+
+        let hashless_wheel = registry_wheel(
+            filename,
+            &format!("{PHYSICAL_PREFIX}/{filename}"),
+            &canonical,
+            Some(&physical),
+            HashDigests::empty(),
+        )?;
+        let (mut hashless_resolution, _, _) = resolver_output(
+            vec![(
+                PackageName::from_str("example")?,
+                Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                    wheels: vec![hashless_wheel],
+                    best_wheel_index: 0,
+                    sdist: None,
+                })),
+            )],
+            false,
+        )?;
+        let missing_digest = hashless_resolution
+            .canonicalize_proxy_artifact_urls_for_lock(&index_locations()?, &[])
+            .expect_err("a hashless retained wheel should fail");
+        let missing_digest_diagnostic = format!("{missing_digest}\n{missing_digest:?}");
+        assert!(missing_digest_diagnostic.contains("https://proxy.example/simple"));
+        for secret in [
+            "proxy-user",
+            "proxy-password",
+            "proxy-query",
+            "proxy-fragment",
+        ] {
+            assert!(!missing_digest_diagnostic.contains(secret));
+        }
+
+        let mapped_wheel = registry_wheel(
+            filename,
+            &format!("{PHYSICAL_PREFIX}/{filename}"),
+            &canonical,
+            Some(&physical),
+            hashes()?,
+        )?;
+        let (mut missing_proxy_resolution, _, _) = resolver_output(
+            vec![(
+                PackageName::from_str("example")?,
+                Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                    wheels: vec![mapped_wheel],
+                    best_wheel_index: 0,
+                    sdist: None,
+                })),
+            )],
+            false,
+        )?;
+        let no_proxy = IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false);
+        let missing_proxy = missing_proxy_resolution
+            .canonicalize_proxy_artifact_urls_for_lock(&no_proxy, &[])
+            .expect_err("a selected proxy artifact without a declaration should fail");
+        let missing_proxy_diagnostic = format!("{missing_proxy}\n{missing_proxy:?}");
+        assert!(missing_proxy_diagnostic.contains("https://canonical.example/simple"));
+        for secret in [
+            "canonical-user",
+            "canonical-password",
+            "canonical-query",
+            "canonical-fragment",
+        ] {
+            assert!(!missing_proxy_diagnostic.contains(secret));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn failure_does_not_partially_mutate_base_nodes() -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        let proxy = IndexUrl::from_str(PROXY_INDEX)?;
+        let first_filename = "first-1.0.0-py3-none-any.whl";
+        let first = registry_wheel(
+            first_filename,
+            &format!("{PHYSICAL_PREFIX}/{first_filename}"),
+            &canonical,
+            Some(&proxy),
+            hashes()?,
+        )?;
+        let second_filename = "second-1.0.0-py3-none-any.whl";
+        let second = registry_wheel(
+            second_filename,
+            &format!("https://unmapped.example/{second_filename}"),
+            &canonical,
+            Some(&proxy),
+            hashes()?,
+        )?;
+        let original_first = first.clone();
+        let original_second = second.clone();
+        let (mut resolution, base_indexes, _) = resolver_output(
+            vec![
+                (
+                    PackageName::from_str("first")?,
+                    Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                        wheels: vec![first],
+                        best_wheel_index: 0,
+                        sdist: None,
+                    })),
+                ),
+                (
+                    PackageName::from_str("second")?,
+                    Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                        wheels: vec![second],
+                        best_wheel_index: 0,
+                        sdist: None,
+                    })),
+                ),
+            ],
+            false,
+        )?;
+
+        assert!(matches!(
+            resolution.canonicalize_proxy_artifact_urls_for_lock(&index_locations()?, &[]),
+            Err(ProxyCanonicalizationError::ArtifactUrl {
+                source,
+                ..
+            }) if matches!(source.as_ref(), ArtifactUrlMapError::Unmapped { .. })
+        ));
+        assert_eq!(wheel_at(&resolution, base_indexes[0], 0)?, &original_first);
+        assert_eq!(wheel_at(&resolution, base_indexes[1], 0)?, &original_second);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_mismatched_physical_route() -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        let physical = IndexUrl::from_str("https://other-proxy.example/simple")?;
+        let filename = "example-1.0.0-py3-none-any.whl";
+        let wheel = registry_wheel(
+            filename,
+            &format!("{PHYSICAL_PREFIX}/{filename}"),
+            &canonical,
+            Some(&physical),
+            hashes()?,
+        )?;
+        let original = wheel.clone();
+        let (mut resolution, base_indexes, _) = resolver_output(
+            vec![(
+                PackageName::from_str("example")?,
+                Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                    wheels: vec![wheel],
+                    best_wheel_index: 0,
+                    sdist: None,
+                })),
+            )],
+            false,
+        )?;
+
+        assert!(matches!(
+            resolution.canonicalize_proxy_artifact_urls_for_lock(&index_locations()?, &[]),
+            Err(ProxyCanonicalizationError::RouteMismatch { .. })
+        ));
+        assert_eq!(wheel_at(&resolution, base_indexes[0], 0)?, &original);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_missing_proxy_declaration() -> Result<(), Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        let physical = IndexUrl::from_str(PROXY_INDEX)?;
+        let filename = "example-1.0.0-py3-none-any.whl";
+        let wheel = registry_wheel(
+            filename,
+            &format!("{PHYSICAL_PREFIX}/{filename}"),
+            &canonical,
+            Some(&physical),
+            hashes()?,
+        )?;
+        let original = wheel.clone();
+        let (mut resolution, base_indexes, _) = resolver_output(
+            vec![(
+                PackageName::from_str("example")?,
+                Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                    wheels: vec![wheel],
+                    best_wheel_index: 0,
+                    sdist: None,
+                })),
+            )],
+            false,
+        )?;
+        let index_locations = IndexLocations::new(vec![Index::from(canonical)], Vec::new(), false);
+
+        assert!(matches!(
+            resolution.canonicalize_proxy_artifact_urls_for_lock(&index_locations, &[]),
+            Err(ProxyCanonicalizationError::MissingProxyIndex { .. })
+        ));
+        assert_eq!(wheel_at(&resolution, base_indexes[0], 0)?, &original);
+        Ok(())
+    }
+
+    fn index_locations() -> Result<IndexLocations, Box<dyn Error>> {
+        let canonical = IndexUrl::from_str(CANONICAL_INDEX)?;
+        Ok(
+            IndexLocations::new(vec![Index::from(canonical.clone())], Vec::new(), false)
+                .with_proxy_indexes(vec![ProxyIndex {
+                    index: IndexReference::Url(canonical),
+                    url: IndexUrl::from_str(PROXY_INDEX)?,
+                    artifact_url_map: ArtifactUrlMap::single(
+                        DisplaySafeUrl::parse(PHYSICAL_PREFIX)?,
+                        DisplaySafeUrl::parse(CANONICAL_PREFIX)?,
+                    ),
+                }]),
+        )
+    }
+
+    fn resolver_output(
+        dists: Vec<(PackageName, Dist)>,
+        add_extra: bool,
+    ) -> Result<ResolverFixture, Box<dyn Error>> {
+        let version = Version::from_str("1.0.0")?;
+        let mut graph: Graph<ResolutionGraphNode, UniversalMarker, Directed> = Graph::new();
+        graph.add_node(ResolutionGraphNode::Root);
+        let mut base_indexes = Vec::with_capacity(dists.len());
+        let mut extra_index = None;
+        for (position, (name, dist)) in dists.into_iter().enumerate() {
+            let annotated = AnnotatedDist {
+                dist: ResolvedDist::Installable {
+                    dist: Arc::new(dist),
+                    version: Some(version.clone()),
+                },
+                name,
+                version: version.clone(),
+                extra: None,
+                group: None,
+                hashes: HashDigests::empty(),
+                metadata: None,
+                marker: UniversalMarker::TRUE,
+            };
+            base_indexes.push(graph.add_node(ResolutionGraphNode::Dist(annotated.clone())));
+            if add_extra && position == 0 {
+                extra_index = Some(graph.add_node(ResolutionGraphNode::Dist(AnnotatedDist {
+                    extra: Some(ExtraName::from_str("feature")?),
+                    ..annotated
+                })));
+            }
+        }
+        Ok((
+            ResolverOutput {
+                graph,
+                requires_python: RequiresPython::greater_than_equal_version(&Version::from_str(
+                    "3.12",
+                )?),
+                fork_markers: vec![],
+                diagnostics: vec![],
+                requirements: vec![],
+                constraints: Constraints::default(),
+                overrides: Overrides::default(),
+                options: Options::default(),
+            },
+            base_indexes,
+            extra_index,
+        ))
+    }
+
+    fn registry_wheel(
+        filename: &str,
+        url: &str,
+        canonical: &IndexUrl,
+        proxy: Option<&IndexUrl>,
+        hashes: HashDigests,
+    ) -> Result<RegistryBuiltWheel, Box<dyn Error>> {
+        Ok(RegistryBuiltWheel {
+            filename: WheelFilename::from_str(filename)?,
+            file: Box::new(registry_file(filename, url, hashes)?),
+            index: canonical.clone(),
+            proxy: proxy.cloned(),
+        })
+    }
+
+    fn registry_file(
+        filename: &str,
+        url: &str,
+        hashes: HashDigests,
+    ) -> Result<File, Box<dyn Error>> {
+        Ok(File {
+            dist_info_metadata: true,
+            filename: filename.into(),
+            hashes,
+            requires_python: Some(Arc::new(VersionSpecifiers::from_str(">=3.9")?)),
+            size: Some(42),
+            upload_time_utc_ms: Some(1234),
+            url: FileLocation::new(url.into(), &"".into()),
+            yanked: Some(Box::new(Yanked::Reason("proxy reason".into()))),
+            zstd: Some(Box::new(Zstd {
+                hashes: HashDigests::from(HashDigest::from_str(SHA256)?),
+                size: Some(21),
+            })),
+        })
+    }
+
+    fn hashes() -> Result<HashDigests, uv_pypi_types::HashError> {
+        Ok(HashDigests::from(HashDigest::from_str(SHA256)?))
+    }
+
+    fn installable_dist_at(
+        resolution: &ResolverOutput,
+        node_index: NodeIndex,
+    ) -> Result<&Arc<Dist>, Box<dyn Error>> {
+        let ResolutionGraphNode::Dist(annotated) = &resolution.graph[node_index] else {
+            return Err("expected distribution node".into());
+        };
+        let ResolvedDist::Installable { dist, .. } = &annotated.dist else {
+            return Err("expected installable distribution".into());
+        };
+        Ok(dist)
+    }
+
+    fn registry_wheel_from_dist(
+        dist: &Dist,
+        wheel_index: usize,
+    ) -> Result<&RegistryBuiltWheel, Box<dyn Error>> {
+        let Dist::Built(BuiltDist::Registry(registry)) = dist else {
+            return Err("expected registry built distribution".into());
+        };
+        registry
+            .wheels
+            .get(wheel_index)
+            .ok_or_else(|| "expected registry wheel".into())
+    }
+
+    fn wheel_at(
+        resolution: &ResolverOutput,
+        node_index: NodeIndex,
+        wheel_index: usize,
+    ) -> Result<&RegistryBuiltWheel, Box<dyn Error>> {
+        registry_wheel_from_dist(
+            installable_dist_at(resolution, node_index)?.as_ref(),
+            wheel_index,
+        )
+    }
+
+    fn source_at(
+        resolution: &ResolverOutput,
+        node_index: NodeIndex,
+    ) -> Result<&RegistrySourceDist, Box<dyn Error>> {
+        let Dist::Source(SourceDist::Registry(source)) =
+            installable_dist_at(resolution, node_index)?.as_ref()
+        else {
+            return Err("expected registry source distribution".into());
+        };
+        Ok(source)
+    }
+}

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -418,10 +418,11 @@ mod tests {
 
     use uv_distribution_filename::WheelFilename;
     use uv_distribution_types::{
-        File, FileLocation, Index, IndexReference, IndexUrl, ProxyIndex, RegistryBuiltDist,
-        RegistryBuiltWheel, SerializableStatusCode,
+        ArtifactUrlMap, File, FileLocation, Index, IndexReference, IndexUrl, ProxyIndex,
+        RegistryBuiltDist, RegistryBuiltWheel, SerializableStatusCode,
     };
     use uv_pypi_types::HashDigests;
+    use uv_redacted::DisplaySafeUrl;
     use uv_small_str::SmallString;
 
     use super::*;
@@ -444,6 +445,10 @@ mod tests {
                 .with_proxy_indexes(vec![ProxyIndex {
                     index: IndexReference::Url(canonical.clone()),
                     url: proxy.clone(),
+                    artifact_url_map: ArtifactUrlMap::single(
+                        DisplaySafeUrl::parse("https://proxy.example.com/files")?,
+                        DisplaySafeUrl::parse("https://canonical.example.com/files")?,
+                    ),
                 }]);
         let index_routes = IndexRoutes::try_from(&index_locations)?;
 

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -928,8 +928,10 @@ mod tests {
     use uv_cache::Cache;
     use uv_client::{BaseClientBuilder, MetadataFormat, RegistryClientBuilder};
     use uv_distribution_types::{
-        Index, IndexCapabilities, IndexLocations, IndexMetadataRef, IndexReference, ProxyIndex,
+        ArtifactUrlMap, Index, IndexCapabilities, IndexLocations, IndexMetadataRef, IndexReference,
+        ProxyIndex,
     };
+    use uv_redacted::DisplaySafeUrl;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -971,6 +973,10 @@ mod tests {
                 .with_proxy_indexes(vec![ProxyIndex {
                     index: IndexReference::Url(canonical.clone()),
                     url: proxy.clone(),
+                    artifact_url_map: ArtifactUrlMap::single(
+                        DisplaySafeUrl::parse("https://proxy.example/files")?,
+                        DisplaySafeUrl::parse("https://canonical.example/files")?,
+                    ),
                 }]);
         let client = RegistryClientBuilder::new(BaseClientBuilder::default(), Cache::temp()?)
             .index_locations(locations)

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -986,7 +986,7 @@ async fn do_lock(
             );
 
             // Resolve the requirements.
-            let (resolution, _) = pip::operations::resolve(
+            let (mut resolution, _) = pip::operations::resolve(
                 ExtrasResolver::new(&hasher, state.index(), database)
                     .with_reporter(Arc::new(ResolverReporter::from(printer)))
                     .resolve(target.members_requirements())
@@ -1057,10 +1057,15 @@ async fn do_lock(
             .relative_to(target.install_path())?;
 
             let previous = existing_lock.map(ValidatedLock::into_lock);
+            let supported_environments = lock_supported_environments.clone().into_markers();
+            resolution.canonicalize_proxy_artifact_urls_for_lock(
+                index_locations,
+                &supported_environments,
+            )?;
             let lock = Lock::from_resolution(
                 &resolution,
                 target.install_path(),
-                lock_supported_environments.clone().into_markers(),
+                supported_environments,
                 index_locations,
             )?
             .with_manifest(manifest)

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -326,6 +326,9 @@ pub(crate) enum ProjectError {
     Lock(#[from] uv_resolver::LockError),
 
     #[error(transparent)]
+    ProxyCanonicalization(#[from] uv_resolver::ProxyCanonicalizationError),
+
+    #[error(transparent)]
     Operation(#[from] pip::operations::Error),
 
     #[error(transparent)]

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -700,7 +700,7 @@ pub(crate) async fn install(
                 )?;
                 (resolution, tool_lock)
             } else {
-                let resolution = match resolve_environment(
+                let mut resolution = match resolve_environment(
                     tool_environment_spec(
                         spec.clone(),
                         existing_tool_lock
@@ -733,6 +733,10 @@ pub(crate) async fn install(
                     }
                     Err(err) => return Err(err.into()),
                 };
+                resolution.canonicalize_proxy_artifact_urls_for_lock(
+                    &settings.resolver.index_locations,
+                    &[],
+                )?;
                 let tool_lock = ToolLock::from_resolution(
                     &tool_dir,
                     &resolution,
@@ -930,7 +934,7 @@ pub(crate) async fn install(
             .await;
 
             // If the resolution failed, retry with the inferred `requires-python` constraint.
-            let (resolution, interpreter) = match resolution {
+            let (mut resolution, interpreter) = match resolution {
                 Ok(resolution) => (resolution, interpreter),
                 Err(err) => match err {
                     ProjectError::Operation(err) => {
@@ -1000,6 +1004,10 @@ pub(crate) async fn install(
             };
 
             if tool_locks {
+                resolution.canonicalize_proxy_artifact_urls_for_lock(
+                    &settings.resolver.index_locations,
+                    &[],
+                )?;
                 let tool_lock = ToolLock::from_resolution(
                     &tool_dir,
                     &resolution,

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -365,7 +365,7 @@ async fn upgrade_tool(
         let target_interpreter =
             requested_interpreter.unwrap_or_else(|| environment.environment().interpreter());
         let site_packages = SitePackages::from_environment(environment.environment())?;
-        let universal_resolution = resolve_environment(
+        let mut universal_resolution = resolve_environment(
             tool_environment_spec(spec, None, Some(&site_packages)),
             EnvironmentResolution::Universal,
             target_interpreter,
@@ -383,6 +383,8 @@ async fn upgrade_tool(
             preview,
         )
         .await?;
+        universal_resolution
+            .canonicalize_proxy_artifact_urls_for_lock(&settings.resolver.index_locations, &[])?;
         let tool_lock = ToolLock::from_resolution(
             &tool_dir,
             &universal_resolution,


### PR DESCRIPTION
> [!CAUTION]
> I have not looked at this code yet, it _will_ change before it's ready for review. 

Proxy indexes expose physical artifact URLs, but a new lock must retain the canonical artifact identity that the proxy represents. This PR adds a required, one-way `artifact-url-map` to each proxy declaration. Before lock construction, uv validates that its prefixes are absolute HTTP(S) URLs without credentials, queries, or fragments; rejects overlapping physical prefixes; and matches URL origins plus encoded path-segment boundaries.

Immediately before constructing a project or tool lock, uv clones the resolved base distributions and maps every retained proxied wheel and source distribution to its canonical URL. It uses the same selected-index and marker filtering as lock serialization, requires a supported advertised digest, preserves the proxy's hashes and file metadata, and updates the graph only after every artifact succeeds. Wheel filenames must also survive the lock round trip unchanged so exact proxy rediscovery can find them later.

The map is output-only. Runtime resolution, metadata and artifact requests, downloads, authentication, redirects, caches, and existing-lock installation continue to use the physical proxy route. uv does not request the canonical index or mapped artifact target to validate the map.

Proxy configuration and full CLI coverage remain follow-ups, so this establishes the lock-output primitive without changing current CLI behavior. Follows #20214.
