### PR TITLE
Improve trace logs for debugging the error chain

### DIFF
--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -209,6 +209,25 @@ pub fn write_error_chain(err: &dyn Error, hints: Hints<'_>) -> fmt::Result {
     write_error_chain_with_options(err, hints, ErrorOptions::default())
 }
 
+/// Format the [`Debug`] representation of every error in an error chain.
+pub fn debug_error_chain(err: &dyn Error) -> impl fmt::Display + '_ {
+    DebugErrorChain(err)
+}
+
+struct DebugErrorChain<'a>(&'a dyn Error);
+
+impl fmt::Display for DebugErrorChain<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (index, error) in iter::successors(Some(self.0), |&error| error.source()).enumerate() {
+            if index > 0 {
+                formatter.write_str("\n")?;
+            }
+            write!(formatter, "{index}: {error:?}")?;
+        }
+        Ok(())
+    }
+}
+
 /// Formats an error or warning chain with custom options.
 ///
 /// Each hint is rendered on its own line, prefixed with the styled `hint:` label.
@@ -278,7 +297,10 @@ mod tests {
     use insta::assert_snapshot;
     use owo_colors::AnsiColors;
 
-    use super::{ErrorOptions, ErrorWithHints, HintPrefix, Hints, write_error_chain_with_options};
+    use super::{
+        ErrorOptions, ErrorWithHints, HintPrefix, Hints, debug_error_chain,
+        write_error_chain_with_options,
+    };
 
     #[test]
     fn extend_deduplicates_matching_hints() {
@@ -368,6 +390,31 @@ mod tests {
         error: Failed to write file
           Caused by: Permission denied
         ");
+    }
+
+    #[test]
+    fn formats_debug_error_chain() {
+        #[derive(Debug, thiserror::Error)]
+        #[error("inner error")]
+        struct InnerError {
+            code: u8,
+        }
+
+        #[derive(Debug, thiserror::Error)]
+        #[error("outer error")]
+        struct OuterError {
+            #[source]
+            source: InnerError,
+        }
+
+        let error = OuterError {
+            source: InnerError { code: 42 },
+        };
+
+        assert_eq!(
+            debug_error_chain(&error).to_string(),
+            "0: OuterError { source: InnerError { code: 42 } }\n1: InnerError { code: 42 }"
+        );
     }
 
     #[test]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -3058,13 +3058,18 @@ where
             };
             match error {
                 UvError::User(err) => {
-                    trace!("Error trace: {err:?}");
                     commands::diagnostics::write_error_chain(&err, printer)
                         .expect("writing to stderr should not fail");
                     ExitStatus::Failure.into()
                 }
                 UvError::Unexpected(err) => {
-                    trace!("Error trace: {err:?}");
+                    trace!(
+                        "Error chain:\n{}",
+                        uv_errors::debug_error_chain(err.as_ref())
+                    );
+                    if err.backtrace().status() == std::backtrace::BacktraceStatus::Captured {
+                        trace!("Error backtrace:\n{}", err.backtrace());
+                    }
                     commands::diagnostics::write_error_chain(&err, printer)
                         .expect("writing to stderr should not fail");
                     ExitStatus::Error.into()


### PR DESCRIPTION
Our trace log that emits a debug representation of errors is useless for `anyhow::Error` which is more common following https://github.com/astral-sh/uv/pull/20188.

For `UvError::User`, we elide the trace log entirely, I do not expect us to need to debug those error chains.

For `UvError::Unexpected`, we introduce a new `uv_errors::debug_error_chain` formatter that walks each source and renders its `Debug` representation. To retain parity with the previous implementation, we also log the backtrace if available.

e.g.:

```diff
-TRACE Error trace: Failed to create virtual environment
-
-Caused by:
-    Not a directory (os error 20)
+TRACE Error chain:
+0: Creation(Io(Os { code: 20, kind: NotADirectory, message: "Not a directory" }))
+1: Io(Os { code: 20, kind: NotADirectory, message: "Not a directory" })
 error: Failed to create virtual environment
   Caused by: Not a directory (os error 20)
```
