### PR TITLE
Don't install venv distutils monkeypatch (`_virtualenv.pth`) for Python 3.10+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,6 +7514,7 @@ dependencies = [
  "uv-errors",
  "uv-fs",
  "uv-platform-tags",
+ "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-shell",

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -262,6 +262,7 @@ pub enum PreviewFeature {
     CentralizedProjectEnvs = 1 << 35,
     ToolInstallLocks = 1 << 36,
     WorkspaceListScripts = 1 << 37,
+    NoDistutilsPatch = 1 << 38,
 }
 
 impl PreviewFeature {
@@ -306,6 +307,7 @@ impl PreviewFeature {
             Self::CentralizedProjectEnvs => "centralized-project-envs",
             Self::ToolInstallLocks => "tool-install-locks",
             Self::WorkspaceListScripts => "workspace-list-scripts",
+            Self::NoDistutilsPatch => "no-distutils-patch",
         }
     }
 }
@@ -363,6 +365,7 @@ impl FromStr for PreviewFeature {
             "centralized-project-envs" => Self::CentralizedProjectEnvs,
             "tool-install-locks" => Self::ToolInstallLocks,
             "workspace-list-scripts" => Self::WorkspaceListScripts,
+            "no-distutils-patch" => Self::NoDistutilsPatch,
             _ => return Err(PreviewFeatureParseError),
         })
     }
@@ -669,6 +672,10 @@ mod tests {
         assert_eq!(
             PreviewFeature::WorkspaceListScripts.as_str(),
             "workspace-list-scripts"
+        );
+        assert_eq!(
+            PreviewFeature::NoDistutilsPatch.as_str(),
+            "no-distutils-patch"
         );
     }
 

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -23,6 +23,7 @@ uv-console = { workspace = true }
 uv-errors = { workspace = true }
 uv-fs = { workspace = true }
 uv-platform-tags = { workspace = true }
+uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
 uv-shell = { workspace = true }

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -17,6 +17,7 @@ use tracing::{debug, trace};
 use crate::{Error, Prompt};
 use uv_fs::{CWD, Simplified, cachedir};
 use uv_platform_tags::Os;
+use uv_preview::PreviewFeature;
 use uv_pypi_types::Scheme;
 use uv_python::managed::{
     ManagedPythonInstallation, PythonMinorVersionLink, replace_link_to_executable,
@@ -42,6 +43,15 @@ const ACTIVATE_TEMPLATES: &[(&str, &str)] = &[
     ),
 ];
 const VIRTUALENV_PATCH: &str = include_str!("_virtualenv.py");
+
+/// Python 3.10 and later already ignore the distutils install config keys this hook guards
+/// against, while the last pip release supporting Python 3.9 still needs the workaround.
+///
+/// See <https://github.com/pypa/virtualenv/issues/3181>
+fn install_distutils_patch(interpreter: &Interpreter) -> bool {
+    interpreter.python_tuple() < (3, 10)
+        || !uv_preview::is_enabled(PreviewFeature::NoDistutilsPatch)
+}
 
 /// Very basic `.cfg` file format writer.
 fn write_cfg(f: &mut impl Write, data: &[(String, String)]) -> io::Result<()> {
@@ -576,9 +586,10 @@ pub(crate) fn create(
         }
     }
 
-    // Populate `site-packages` with a `_virtualenv.py` file.
-    fs_err::write(site_packages.join("_virtualenv.py"), VIRTUALENV_PATCH)?;
-    fs_err::write(site_packages.join("_virtualenv.pth"), "import _virtualenv")?;
+    if install_distutils_patch(interpreter) {
+        fs_err::write(site_packages.join("_virtualenv.py"), VIRTUALENV_PATCH)?;
+        fs_err::write(site_packages.join("_virtualenv.pth"), "import _virtualenv")?;
+    }
 
     Ok(VirtualEnvironment {
         scheme: Scheme {

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -11,7 +11,7 @@ use uv_static::EnvVars;
 #[cfg(unix)]
 use fs_err::os::unix::fs::symlink;
 
-use uv_test::uv_snapshot;
+use uv_test::{site_packages_path, uv_snapshot};
 
 #[test]
 fn create_venv() {
@@ -72,6 +72,61 @@ fn create_venv() {
     );
 
     context.venv.assert(predicates::path::is_dir());
+}
+
+#[test]
+fn create_venv_preview_skips_distutils_patch_on_py310_plus() {
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+
+    uv_snapshot!(context.filters(), context.venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.12")
+        .arg("--preview-features")
+        .arg("no-distutils-patch"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    Activate with: source .venv/[BIN]/activate
+    "
+    );
+
+    context.venv.assert(predicates::path::is_dir());
+    let site_packages = site_packages_path(context.venv.path(), "python3.12");
+    assert!(!site_packages.join("_virtualenv.py").exists());
+    assert!(!site_packages.join("_virtualenv.pth").exists());
+}
+
+#[test]
+#[cfg(feature = "test-python-eol")]
+fn create_venv_preview_keeps_distutils_patch_on_py39() {
+    let context = uv_test::test_context_with_versions!(&["3.9"]);
+
+    uv_snapshot!(context.filters(), context.venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.9")
+        .arg("--preview-features")
+        .arg("no-distutils-patch"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.9.[X] interpreter at: [PYTHON-3.9]
+    Creating virtual environment at: .venv
+    Activate with: source .venv/[BIN]/activate
+    "
+    );
+
+    context.venv.assert(predicates::path::is_dir());
+    let site_packages = site_packages_path(context.venv.path(), "python3.9");
+    assert!(site_packages.join("_virtualenv.py").is_file());
+    assert!(site_packages.join("_virtualenv.pth").is_file());
 }
 
 #[test]

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3056,6 +3056,7 @@ fn preview_features() {
     +            CentralizedProjectEnvs,
     +            ToolInstallLocks,
     +            WorkspaceListScripts,
+    +            NoDistutilsPatch,
     +        ],
          },
          python_preference: Managed,

--- a/docs/concepts/preview.md
+++ b/docs/concepts/preview.md
@@ -73,6 +73,8 @@ The following preview features are available:
 - `centralized-project-envs`: Stores
   [project virtual environments](./projects/layout.md#centralized-project-environments) in the uv
   cache.
+- `no-distutils-patch`: Stops installing the `_virtualenv.py` / `_virtualenv.pth` distutils
+  configuration monkeypatch in virtual environments for Python 3.10 and later.
 - `json-output`: Allows `--output-format json` for various uv commands.
 - `package-conflicts`: Allows defining workspace conflicts at the package level.
 - `pylock`: Allows installing from `pylock.toml` files.


### PR DESCRIPTION
Don't install `_virtualenv.pth` and `_virtualenv.py` into venvs for Python 3.10+.

See https://github.com/astral-sh/uv/issues/6426#issuecomment-4892705791. The performance impact is notable (generated benchmarking script: https://gist.github.com/konstin/d3c35119fd5620db68d895d3411cf712):

`python -c pass`
```
Benchmark 1: with _virtualenv.pth
  Time (mean ± σ):       8.4 ms ±   0.4 ms    [User: 6.3 ms, System: 2.0 ms]
  Range (min … max):     7.5 ms …  11.8 ms    1000 runs
 
Benchmark 2: no .pth
  Time (mean ± σ):       6.4 ms ±   0.4 ms    [User: 4.6 ms, System: 1.6 ms]
  Range (min … max):     5.7 ms …  10.0 ms    1000 runs
```

For fairness: Startup when the app imports contextlib anyway.
```
Benchmark 1: with _virtualenv.pth
  Time (mean ± σ):       8.4 ms ±   0.4 ms    [User: 6.4 ms, System: 2.0 ms]
  Range (min … max):     7.5 ms …  12.0 ms    1000 runs
 
Benchmark 2: no .pth
  Time (mean ± σ):       8.1 ms ±   0.4 ms    [User: 6.1 ms, System: 1.9 ms]
  Range (min … max):     7.2 ms …  11.8 ms    1000 runs
```


We do this on Python 3.10+ to mirror https://github.com/pypa/virtualenv/issues/3181.

Fixes https://github.com/astral-sh/uv/issues/6426