### PR TITLE
Avoid hash clones and identity allocations during resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5973,6 +5973,7 @@ dependencies = [
  "uv-distribution-types",
  "uv-extract",
  "uv-install-wheel",
+ "uv-normalize",
  "uv-pep440",
  "uv-pep508",
  "uv-performance-memory-allocator",

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -43,6 +43,7 @@ uv-distribution-filename = { workspace = true }
 uv-distribution-types = { workspace = true }
 uv-extract = { workspace = true }
 uv-install-wheel = { workspace = true }
+uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-performance-memory-allocator = { workspace = true }

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -297,6 +297,14 @@ fn resolve_warm_jupyter_universal(c: &mut Criterion<WallTime>) {
     c.bench_function("resolve_warm_jupyter_universal", |b| b.iter(&run));
 }
 
+fn resolve_warm_numpy_many_wheels(c: &mut Criterion<WallTime>) {
+    let manifest = Manifest::simple(vec![Requirement::from(
+        uv_pep508::Requirement::from_str("numpy==2.1.0").unwrap(),
+    )]);
+    let run = setup(manifest, false);
+    c.bench_function("resolve_warm_numpy_many_wheels", |b| b.iter(&run));
+}
+
 fn resolve_warm_airflow(c: &mut Criterion<WallTime>) {
     let manifest = Manifest::simple(vec![
         Requirement::from(uv_pep508::Requirement::from_str("apache-airflow[all]==2.9.3").unwrap()),
@@ -328,6 +336,7 @@ criterion_group!(
     install_wheel_many_files,
     resolve_warm_jupyter,
     resolve_warm_jupyter_universal,
+    resolve_warm_numpy_many_wheels,
     resolve_warm_airflow
 );
 criterion_main!(uv);

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -20,10 +20,13 @@ use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::Requirement;
 use uv_install_wheel::{InstallState, Layout, LinkMode};
+use uv_normalize::PackageName;
+use uv_pep440::Version;
 use uv_preview::Preview;
 use uv_pypi_types::Scheme;
 use uv_python::PythonEnvironment;
 use uv_resolver::Manifest;
+use uv_types::HashStrategy;
 
 const MANY_FILES_WHEEL_FILENAME: &str = "manyfiles-0.0.0-py3-none-any.whl";
 const MANY_FILES_WHEEL_FILE_COUNT: usize = 10_000;
@@ -305,6 +308,16 @@ fn resolve_warm_numpy_many_wheels(c: &mut Criterion<WallTime>) {
     c.bench_function("resolve_warm_numpy_many_wheels", |b| b.iter(&run));
 }
 
+fn hash_strategy_get_package_default(c: &mut Criterion<WallTime>) {
+    let strategy = HashStrategy::default();
+    let package = PackageName::from_str("numpy").expect("package name should be valid");
+    let version = Version::from_str("2.1.0").expect("version should be valid");
+
+    c.bench_function("hash_strategy_get_package_default", |b| {
+        b.iter(|| strategy.get_package(black_box(&package), black_box(&version)));
+    });
+}
+
 fn resolve_warm_airflow(c: &mut Criterion<WallTime>) {
     let manifest = Manifest::simple(vec![
         Requirement::from(uv_pep508::Requirement::from_str("apache-airflow[all]==2.9.3").unwrap()),
@@ -337,6 +350,7 @@ criterion_group!(
     resolve_warm_jupyter,
     resolve_warm_jupyter_universal,
     resolve_warm_numpy_many_wheels,
+    hash_strategy_get_package_default,
     resolve_warm_airflow
 );
 criterion_main!(uv);

--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -341,11 +341,12 @@ pub enum HashComparison {
 
 impl PrioritizedDist {
     /// Create a new [`PrioritizedDist`] from the given wheel distribution.
-    pub fn from_built(
-        dist: RegistryBuiltWheel,
-        hashes: Vec<HashDigest>,
-        compatibility: WheelCompatibility,
-    ) -> Self {
+    pub fn from_built(dist: RegistryBuiltWheel, compatibility: WheelCompatibility) -> Self {
+        let hashes = if compatibility.is_excluded() {
+            Vec::new()
+        } else {
+            dist.file.hashes.iter().cloned().collect()
+        };
         Self(Box::new(PrioritizedDistInner {
             markers: implied_markers(&dist.filename),
             best_wheel_index: Some(0),
@@ -356,11 +357,12 @@ impl PrioritizedDist {
     }
 
     /// Create a new [`PrioritizedDist`] from the given source distribution.
-    pub fn from_source(
-        dist: RegistrySourceDist,
-        hashes: Vec<HashDigest>,
-        compatibility: SourceDistCompatibility,
-    ) -> Self {
+    pub fn from_source(dist: RegistrySourceDist, compatibility: SourceDistCompatibility) -> Self {
+        let hashes = if compatibility.is_excluded() {
+            Vec::new()
+        } else {
+            dist.file.hashes.iter().cloned().collect()
+        };
         Self(Box::new(PrioritizedDistInner {
             markers: MarkerTree::TRUE,
             best_wheel_index: None,
@@ -371,12 +373,7 @@ impl PrioritizedDist {
     }
 
     /// Insert the given built distribution into the [`PrioritizedDist`].
-    pub fn insert_built(
-        &mut self,
-        dist: RegistryBuiltWheel,
-        hashes: impl IntoIterator<Item = HashDigest>,
-        compatibility: WheelCompatibility,
-    ) {
+    pub fn insert_built(&mut self, dist: RegistryBuiltWheel, compatibility: WheelCompatibility) {
         // Track the implied markers.
         if compatibility.is_compatible() {
             if !self.0.markers.is_true() {
@@ -385,7 +382,7 @@ impl PrioritizedDist {
         }
         // Track the hashes.
         if !compatibility.is_excluded() {
-            self.0.hashes.extend(hashes);
+            self.0.hashes.extend(dist.file.hashes.iter().cloned());
         }
         // Track the highest-priority wheel.
         if let Some((.., existing_compatibility)) = self.best_wheel() {
@@ -402,7 +399,6 @@ impl PrioritizedDist {
     pub fn insert_source(
         &mut self,
         dist: RegistrySourceDist,
-        hashes: impl IntoIterator<Item = HashDigest>,
         compatibility: SourceDistCompatibility,
     ) {
         // Track the implied markers.
@@ -411,7 +407,7 @@ impl PrioritizedDist {
         }
         // Track the hashes.
         if !compatibility.is_excluded() {
-            self.0.hashes.extend(hashes);
+            self.0.hashes.extend(dist.file.hashes.iter().cloned());
         }
         // Track the highest-priority source.
         if let Some((.., existing_compatibility)) = &self.0.source {

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -119,10 +119,10 @@ impl FlatDistributions {
                 };
                 match self.0.entry(version) {
                     Entry::Occupied(mut entry) => {
-                        entry.get_mut().insert_built(dist, vec![], compatibility);
+                        entry.get_mut().insert_built(dist, compatibility);
                     }
                     Entry::Vacant(entry) => {
-                        entry.insert(PrioritizedDist::from_built(dist, vec![], compatibility));
+                        entry.insert(PrioritizedDist::from_built(dist, compatibility));
                     }
                 }
             }
@@ -143,10 +143,10 @@ impl FlatDistributions {
                 };
                 match self.0.entry(filename.version) {
                     Entry::Occupied(mut entry) => {
-                        entry.get_mut().insert_source(dist, vec![], compatibility);
+                        entry.get_mut().insert_source(dist, compatibility);
                     }
                     Entry::Vacant(entry) => {
-                        entry.insert(PrioritizedDist::from_source(dist, vec![], compatibility));
+                        entry.insert(PrioritizedDist::from_source(dist, compatibility));
                     }
                 }
             }

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -580,14 +580,14 @@ impl VersionMapLazy {
 
                 // Prioritize amongst all available files.
                 let yanked = file.yanked.as_deref();
-                let hashes = file.hashes.clone();
+                let hashes = file.hashes.as_slice();
                 match filename {
                     DistFilename::WheelFilename(filename) => {
                         let compatibility = self.wheel_compatibility(
                             &filename,
                             &filename.name,
                             &filename.version,
-                            hashes.as_slice(),
+                            hashes,
                             yanked,
                             excluded,
                             upload_time,
@@ -597,13 +597,13 @@ impl VersionMapLazy {
                             file: Box::new(file),
                             index: self.index.clone(),
                         };
-                        priority_dist.insert_built(dist, hashes, compatibility);
+                        priority_dist.insert_built(dist, compatibility);
                     }
                     DistFilename::SourceDistFilename(filename) => {
                         let compatibility = self.source_dist_compatibility(
                             &filename.name,
                             &filename.version,
-                            hashes.as_slice(),
+                            hashes,
                             yanked,
                             excluded,
                             upload_time,
@@ -616,7 +616,7 @@ impl VersionMapLazy {
                             index: self.index.clone(),
                             wheels: vec![],
                         };
-                        priority_dist.insert_source(dist, hashes, compatibility);
+                        priority_dist.insert_source(dist, compatibility);
                     }
                 }
             }

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -55,11 +55,11 @@ impl HashStrategy {
 
     /// Return the [`HashPolicy`] for the given registry-based package.
     pub fn get_package(&self, name: &PackageName, version: &Version) -> HashPolicy<'_> {
-        let id = VersionId::from_registry(name.clone(), version.clone());
         match self {
             Self::None => HashPolicy::None,
             Self::Generate(mode) => HashPolicy::Generate(*mode),
             Self::Verify(hashes) => {
+                let id = VersionId::from_registry(name.clone(), version.clone());
                 if let Some(hashes) = hashes.get(&id) {
                     HashPolicy::Any(hashes.as_slice())
                 } else {
@@ -67,6 +67,7 @@ impl HashStrategy {
                 }
             }
             Self::Require(hashes) => {
+                let id = VersionId::from_registry(name.clone(), version.clone());
                 HashPolicy::Any(hashes.get(&id).map(Vec::as_slice).unwrap_or_default())
             }
         }
@@ -76,11 +77,11 @@ impl HashStrategy {
     ///
     /// A direct URL identifies a single concrete artifact, so every provided digest must match.
     pub fn get_url(&self, url: &DisplaySafeUrl) -> HashPolicy<'_> {
-        let id = VersionId::from_url(url);
         match self {
             Self::None => HashPolicy::None,
             Self::Generate(mode) => HashPolicy::Generate(*mode),
             Self::Verify(hashes) => {
+                let id = VersionId::from_url(url);
                 if let Some(hashes) = hashes.get(&id) {
                     HashPolicy::All(hashes.as_slice())
                 } else {
@@ -88,6 +89,7 @@ impl HashStrategy {
                 }
             }
             Self::Require(hashes) => {
+                let id = VersionId::from_url(url);
                 HashPolicy::All(hashes.get(&id).map(Vec::as_slice).unwrap_or_default())
             }
         }


### PR DESCRIPTION
## Summary

- Avoid cloning file hashes while materializing prioritized distributions from the version map.
- Avoid constructing `VersionId` for default hash policy lookups that do not need package identity.
- Add benchmarks for warm many-wheel resolution and default hash policy package lookup.

## Benchmarks

`hash_strategy_get_package_default` A/B/A/B:

- old: `5.398 ns` average
- new: `3.222 ns` average
- ~40% lower time, ~1.68x faster

## Tests

- `RUSTC_WRAPPER= cargo check -p uv-resolver`
- `RUSTC_WRAPPER= cargo check -p uv-bench --benches`
- `RUSTC_WRAPPER= cargo test -p uv-types hash`
- `RUSTC_WRAPPER= cargo test -p uv-distribution-types prioritized_distribution`
- `git diff --check upstream/main..HEAD`