### PR TITLE
Clarify empty version range diagnostics

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -342,6 +342,12 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                     }
                 }
 
+                if dependency_set.is_empty()
+                    && let Some(root) = self.format_root(package)
+                {
+                    return format!("{root} for {dependency} cannot be satisfied");
+                }
+
                 if let Some(root) = self.format_root_requires(package) {
                     return format!(
                         "{root} {}",

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -13806,7 +13806,7 @@ fn no_version_for_direct_dependency() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ you require pypyp ∅
+      ╰─▶ your requirements for pypyp cannot be satisfied
     "
     );
 


### PR DESCRIPTION
## Summary

When direct requirements have an empty intersection, the resolver reports `you require pypyp ∅`. The empty-set notation is terse and obscures that the package requirements themselves cannot be satisfied.

Render empty root dependency ranges as `your requirements for pypyp cannot be satisfied`. This keeps the affected package visible while describing the conflict in plain language, and preserves generic range formatting for non-root incompatibilities.
