### PR TITLE
Explain empty root requirement ranges

### DIFF
--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -14,6 +14,7 @@ use uv_pypi_types::{
 };
 
 use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner};
+use crate::resolver::UnsatisfiableRequirement;
 
 /// The source constraint carried by a single dependency edge.
 ///
@@ -109,12 +110,39 @@ pub(crate) struct PubGrubDependency {
 }
 
 impl PubGrubDependency {
-    pub(crate) fn from_requirement<'a>(
+    /// Convert flattened requirements into PubGrub dependency edges.
+    ///
+    /// An empty range cannot retain the specifiers that produced it, so return the source
+    /// requirement details instead. The resolver attaches them to the parent package as the
+    /// reason that package cannot be selected.
+    pub(crate) fn from_requirements<'a>(
+        conflicts: &Conflicts,
+        requirements: impl IntoIterator<Item = Cow<'a, Requirement>>,
+        group_name: Option<&'a GroupName>,
+        parent_package: Option<&'a PubGrubPackage>,
+    ) -> Result<Vec<Self>, UnsatisfiableRequirement> {
+        let mut dependencies = Vec::new();
+        for requirement in requirements {
+            dependencies.extend(Self::from_requirement(
+                conflicts,
+                requirement,
+                group_name,
+                parent_package,
+            )?);
+        }
+        Ok(dependencies)
+    }
+
+    fn from_requirement<'a>(
         conflicts: &Conflicts,
         requirement: Cow<'a, Requirement>,
         group_name: Option<&'a GroupName>,
         parent_package: Option<&'a PubGrubPackage>,
-    ) -> impl Iterator<Item = Self> + 'a {
+    ) -> Result<impl Iterator<Item = Self> + 'a, UnsatisfiableRequirement> {
+        if let Some(requirement) = UnsatisfiableRequirement::from_requirement(&requirement) {
+            return Err(requirement);
+        }
+
         let parent_name = parent_package.and_then(|package| package.name_no_root());
         let is_normal_parent = parent_package
             .is_some_and(|parent| parent.extra().is_none() && parent.group().is_none());
@@ -165,7 +193,7 @@ impl PubGrubDependency {
         };
 
         // Add the package, plus any extra variants.
-        iter.map(move |(extra, group)| {
+        Ok(iter.map(move |(extra, group)| {
             let pubgrub_requirement =
                 PubGrubRequirement::from_requirement(&requirement, extra, group);
             let PubGrubRequirement {
@@ -228,7 +256,7 @@ impl PubGrubDependency {
                 }
                 PubGrubPackageInner::System(_) => unreachable!("System package in dependencies"),
             }
-        })
+        }))
     }
 
     /// Extracts a possible conflicting item from this dependency.

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -304,6 +304,14 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                 }
             }
             External::Custom(package, set, reason) => {
+                if let UnavailableReason::Version(UnavailableVersion::UnsatisfiableDependency(
+                    requirement,
+                )) = reason
+                    && let Some(root) = self.format_root_requires(package)
+                {
+                    return format!("{root} {requirement}");
+                }
+
                 if let Some(root) = self.format_root(package) {
                     format!("{root} cannot be used because {reason}")
                 } else {
@@ -756,6 +764,13 @@ impl PubGrubReportFormatter<'_> {
         while let Some((derivation_tree, inherited_exclude_newer_ranges)) = pending.pop() {
             match derivation_tree {
                 DerivationTree::External(External::Custom(package, set, reason)) => {
+                    if matches!(
+                        reason,
+                        UnavailableReason::Version(UnavailableVersion::UnsatisfiableDependency(_))
+                    ) {
+                        continue;
+                    }
+
                     if let Some(name) = package.name_no_root() {
                         // Check for no versions due to pre-release options.
                         if !fork_urls.contains_key(name) {

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -3,9 +3,11 @@ use std::fmt::{Display, Formatter};
 use std::iter;
 use std::sync::Arc;
 
+use pubgrub::Ranges;
 use reqwest::StatusCode;
 
-use uv_distribution_types::IncompatibleDist;
+use uv_distribution_types::{IncompatibleDist, Requirement, RequirementSource};
+use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_platform_tags::{AbiTag, Tags};
 
@@ -29,6 +31,63 @@ impl Display for UnavailableReason {
     }
 }
 
+/// A requirement whose version specifiers resolve to an empty range.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnsatisfiableRequirement {
+    name: PackageName,
+    extras: Box<[ExtraName]>,
+    version_specifiers: VersionSpecifiers,
+}
+
+impl UnsatisfiableRequirement {
+    /// Preserve a requirement whose specifiers collapse to an empty PubGrub range.
+    ///
+    /// PubGrub ranges do not retain the specifiers that produced them, but the original
+    /// requirement is needed to explain the conflict in the resolution report.
+    pub(crate) fn from_requirement(requirement: &Requirement) -> Option<Self> {
+        let RequirementSource::Registry { specifier, .. } = &requirement.source else {
+            return None;
+        };
+        Ranges::from(specifier.clone()).is_empty().then(|| Self {
+            name: requirement.name.clone(),
+            extras: requirement.extras.clone(),
+            version_specifiers: specifier.clone(),
+        })
+    }
+
+    fn fmt_package(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.name, f)?;
+        if !self.extras.is_empty() {
+            f.write_str("[")?;
+            for (index, extra) in self.extras.iter().enumerate() {
+                if index > 0 {
+                    f.write_str(",")?;
+                }
+                Display::fmt(extra, f)?;
+            }
+            f.write_str("]")?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for UnsatisfiableRequirement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (index, specifier) in self.version_specifiers.iter().enumerate() {
+            if index > 0 {
+                f.write_str(" and ")?;
+            }
+            self.fmt_package(f)?;
+            Display::fmt(specifier, f)?;
+        }
+        if self.version_specifiers.len() > 1 {
+            f.write_str(", which are incompatible")
+        } else {
+            f.write_str(", which does not allow any versions")
+        }
+    }
+}
+
 /// The package version is unavailable and cannot be used. Unlike [`MetadataUnavailable`], this
 /// applies to a single version of the package.
 ///
@@ -36,6 +95,8 @@ impl Display for UnavailableReason {
 /// the source and we want to merge unavailable messages across versions.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum UnavailableVersion {
+    /// The version has a dependency whose version specifiers resolve to an empty range.
+    UnsatisfiableDependency(UnsatisfiableRequirement),
     /// Version is incompatible because it has no usable distributions
     IncompatibleDist(IncompatibleDist),
     /// The wheel metadata was found, but could not be parsed.
@@ -56,6 +117,7 @@ pub enum UnavailableVersion {
 impl UnavailableVersion {
     fn message(&self) -> Cow<'static, str> {
         match self {
+            Self::UnsatisfiableDependency(requirement) => Cow::Owned(requirement.to_string()),
             Self::IncompatibleDist(invalid_dist) => Cow::Owned(format!("{invalid_dist}")),
             Self::InvalidMetadata => Cow::Borrowed("invalid metadata"),
             Self::InconsistentMetadata => Cow::Borrowed("inconsistent metadata"),
@@ -70,6 +132,9 @@ impl UnavailableVersion {
 
     pub(crate) fn singular_message(&self) -> String {
         match self {
+            Self::UnsatisfiableDependency(requirement) => {
+                format!("depends on {requirement}")
+            }
             Self::IncompatibleDist(invalid_dist) => invalid_dist.singular_message(),
             Self::InvalidMetadata => format!("has {self}"),
             Self::InconsistentMetadata => format!("has {self}"),
@@ -82,6 +147,7 @@ impl UnavailableVersion {
 
     pub(crate) fn plural_message(&self) -> String {
         match self {
+            Self::UnsatisfiableDependency(requirement) => format!("depend on {requirement}"),
             Self::IncompatibleDist(invalid_dist) => invalid_dist.plural_message(),
             Self::InvalidMetadata => format!("have {self}"),
             Self::InconsistentMetadata => format!("have {self}"),
@@ -98,6 +164,7 @@ impl UnavailableVersion {
         requires_python: Option<AbiTag>,
     ) -> Option<String> {
         match self {
+            Self::UnsatisfiableDependency(_) => None,
             Self::IncompatibleDist(invalid_dist) => {
                 invalid_dist.context_message(tags, requires_python)
             }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -59,7 +59,7 @@ use crate::resolution::ResolverOutput;
 use crate::resolution_mode::ResolutionStrategy;
 pub(crate) use crate::resolver::availability::{
     ResolverVersion, UnavailableErrorChain, UnavailablePackage, UnavailableReason,
-    UnavailableVersion,
+    UnavailableVersion, UnsatisfiableRequirement,
 };
 use crate::resolver::batch_prefetch::BatchPrefetcher;
 use crate::resolver::derivation::DerivationChainBuilder;
@@ -1829,16 +1829,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     python_requirement,
                 );
 
-                requirements
-                    .flat_map(move |requirement| {
-                        PubGrubDependency::from_requirement(
-                            &self.conflicts,
-                            requirement,
-                            None,
-                            Some(package),
-                        )
-                    })
-                    .collect()
+                PubGrubDependency::from_requirements(
+                    &self.conflicts,
+                    requirements,
+                    None,
+                    Some(package),
+                )
             }
 
             PubGrubPackageInner::Package {
@@ -1960,17 +1956,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     python_requirement,
                 );
 
-                requirements
-                    .flat_map(|requirement| {
-                        PubGrubDependency::from_requirement(
-                            &self.conflicts,
-                            requirement,
-                            group.as_ref(),
-                            Some(package),
-                        )
-                    })
-                    .chain(system_dependencies)
-                    .collect()
+                PubGrubDependency::from_requirements(
+                    &self.conflicts,
+                    requirements,
+                    group.as_ref(),
+                    Some(package),
+                )
+                .map(|mut dependencies| {
+                    dependencies.extend(system_dependencies);
+                    dependencies
+                })
             }
 
             PubGrubPackageInner::Python(_) => return Ok(Dependencies::Unforkable(Vec::default())),
@@ -2051,7 +2046,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 ));
             }
         };
-        Ok(Dependencies::Available(dependencies))
+        Ok(match dependencies {
+            Ok(dependencies) => Dependencies::Available(dependencies),
+            Err(requirement) => {
+                Dependencies::Unavailable(UnavailableVersion::UnsatisfiableDependency(requirement))
+            }
+        })
     }
 
     /// The regular and dev dependencies filtered by Python version and the markers of this fork,

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -13788,7 +13788,7 @@ fn emit_index_annotation_multiple_indexes() -> Result<()> {
     Ok(())
 }
 
-/// Test error message when direct dependency is an empty set.
+/// Test error message when a direct dependency has incompatible version specifiers.
 #[test]
 fn no_version_for_direct_dependency() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13806,7 +13806,7 @@ fn no_version_for_direct_dependency() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ your requirements for pypyp cannot be satisfied
+      ╰─▶ you require pypyp==1 and pypyp>=1.2, which are incompatible
     "
     );
 


### PR DESCRIPTION
## Summary

This builds on #20227 by preserving the requirement that produced an empty version range instead of formatting the normalized empty set generically after resolution fails.

Detect unsatisfiable version specifiers while converting requirements to PubGrub dependencies, then attach a structured `UnsatisfiableRequirement` as the reason the parent version is unavailable. The derivation tree retains the package, extras, and original specifiers, so root requirements can explain the exact conflict and transitive requirements use the same mechanism without a separate reporting side channel. Availability hints are skipped for this reason because the parent package itself is not unavailable.

For example, `pypyp==1,>=1.2` now reports `you require pypyp==1 and pypyp>=1.2, which are incompatible`.
