### PR TITLE
fix(workspace): canonicalize workspace root to resolve symlinks

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -316,6 +316,11 @@ impl Workspace {
             .clone();
         let path = normalize_path(&path);
 
+        // Canonicalize to resolve symlinks, ensuring the workspace root path is
+        // consistent regardless of how it's accessed (e.g. via `/symlink/to/project`
+        // vs `/real/path/to/project`).
+        let path = fs_err::canonicalize(&path).map_err(WorkspaceErrorKind::Normalize)?;
+
         let project_path = path
             .ancestors()
             .find(|path| path.join("pyproject.toml").is_file())

--- a/crates/uv/tests/workspace/workspace.rs
+++ b/crates/uv/tests/workspace/workspace.rs
@@ -2547,3 +2547,4 @@ fn workspace_discovery_with_symlinked_root() -> Result<()> {
     ");
 
     Ok(())
+}

--- a/crates/uv/tests/workspace/workspace.rs
+++ b/crates/uv/tests/workspace/workspace.rs
@@ -10,6 +10,7 @@ use indoc::indoc;
 use insta::{assert_json_snapshot, assert_snapshot};
 use serde::{Deserialize, Serialize};
 
+use uv_fs::create_symlink;
 use uv_test::{copy_dir_ignore, make_project, uv_snapshot};
 
 fn workspaces_dir() -> PathBuf {
@@ -2518,3 +2519,31 @@ fn workspace_unmanaged_member_no_project() -> Result<()> {
 
     Ok(())
 }
+
+/// Verify that workspace discovery works when the project root is reached through
+/// a symlink. `Workspace::discover` canonicalizes the path early, so symlinked
+/// paths resolve to the real project root.
+#[test]
+fn workspace_discovery_with_symlinked_root() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    // Create a project at a real directory.
+    let real = context.temp_dir.join("real");
+    make_project(&real, "project", "dependencies = []")?;
+
+    // Create a symlink pointing to the real project.
+    let link = context.temp_dir.join("link");
+    create_symlink(&real, &link)?;
+
+    // Run `uv lock` from the symlinked path — the canonicalize fix ensures
+    // workspace discovery resolves symlinks and finds the project root.
+    uv_snapshot!(context.filters(), context.lock().current_dir(&link), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 1 package in [TIME]
+    ");
+
+    Ok(())


### PR DESCRIPTION

## Summary

When the workspace root path contains a symlink (e.g., \/symlink/to/project\), \Workspace::discover\ could fail or produce inconsistent results because it compared symlinked paths against real paths. This adds an early \s_err::canonicalize\ call so the workspace root is always resolved to its real path before discovery continues.

## Test Plan

Added integration test \workspace_discovery_with_symlinked_root\ that creates a project, symlinks to it, and runs \uv lock\ from the symlinked path.

Closes #19222
