### PR TITLE
fix(uv): preserve extra and group names in dependency conflict error messages

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1749,31 +1749,31 @@ mod tests {
         let extra = PubGrubPackage::from(PubGrubPackageInner::Extra {
             name: PackageName::from_owned("pkg".to_string()).unwrap(),
             extra: ExtraName::from_owned("my-extra".to_string()).unwrap(),
-            marker: None,
+            marker: None.into(),
         });
         let group = PubGrubPackage::from(PubGrubPackageInner::Group {
             name: PackageName::from_owned("pkg".to_string()).unwrap(),
             group: "my-group".parse::<GroupName>().unwrap(),
-            marker: None,
+            marker: None.into(),
         });
         let dep = PubGrubPackage::from(PubGrubPackageInner::Package {
             name: PackageName::from_owned("dep".to_string()).unwrap(),
             extra: None,
-            marker: None,
+            marker: None.into(),
             group: None,
         });
 
         let extra_leaf = ErrorTree::External(External::FromDependencyOf(
             extra,
-            pubgrub::Range::any(),
+            pubgrub::Range::full(),
             dep.clone(),
-            pubgrub::Range::any(),
+            pubgrub::Range::full(),
         ));
         let group_leaf = ErrorTree::External(External::FromDependencyOf(
             group,
-            pubgrub::Range::any(),
+            pubgrub::Range::full(),
             dep,
-            pubgrub::Range::any(),
+            pubgrub::Range::full(),
         ));
         // Combine them into a small tree so both survive the transformation.
         let tree = ErrorTree::Derived(Derived {
@@ -1788,11 +1788,11 @@ mod tests {
         // Both the Extra and Group proxies should still be present.
         let packages: Vec<_> = derivation_tree_packages(&collapsed).collect();
         assert!(
-            packages.iter().any(|p| matches!(&**p, PubGrubPackageInner::Extra { .. })),
+            packages.iter().any(|p| matches!(&***p, PubGrubPackageInner::Extra { .. })),
             "Extra proxy should be preserved after collapse_proxies"
         );
         assert!(
-            packages.iter().any(|p| matches!(&**p, PubGrubPackageInner::Group { .. })),
+            packages.iter().any(|p| matches!(&***p, PubGrubPackageInner::Group { .. })),
             "Group proxy should be preserved after collapse_proxies"
         );
     }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -481,13 +481,20 @@ impl NoSolutionError {
     }
 
     /// Given a [`DerivationTree`], collapse any [`External::FromDependencyOf`] incompatibilities
-    /// wrap an [`PubGrubPackageInner::Extra`] package.
+    /// that wrap a [`PubGrubPackageInner::Marker`] proxy. Extra and group proxies are preserved
+    /// since they carry user-meaningful information about which optional dependencies are involved.
     pub(crate) fn collapse_proxies(derivation_tree: ErrorTree) -> ErrorTree {
         fn is_proxy(tree: &ErrorTree) -> bool {
+            // Returns `true` if the package is a marker-only proxy (not extra or
+            // group, which carry user-meaningful information).
+            fn is_proxy_package(package: &PubGrubPackage) -> bool {
+                matches!(&**package, PubGrubPackageInner::Marker { .. })
+            }
+
             matches!(
                 tree,
                 DerivationTree::External(External::FromDependencyOf(package, ..))
-                    if package.is_proxy()
+                    if is_proxy_package(package)
             )
         }
 

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1666,6 +1666,7 @@ fn simplify_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uv_normalize::GroupName;
 
     fn deep_derivation_tree() -> ErrorTree {
         let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
@@ -1739,6 +1740,61 @@ mod tests {
 
         assert!(thread.join().is_ok());
         Ok(())
+    }
+
+    #[test]
+    fn collapse_proxies_preserves_extra_and_group() {
+        // Build a tree with Extra and Group proxies. They should survive
+        // `collapse_proxies` since they carry user-meaningful information.
+        let extra = PubGrubPackage::from(PubGrubPackageInner::Extra {
+            name: PackageName::from_owned("pkg".to_string()).unwrap(),
+            extra: ExtraName::from_owned("my-extra".to_string()).unwrap(),
+            marker: None,
+        });
+        let group = PubGrubPackage::from(PubGrubPackageInner::Group {
+            name: PackageName::from_owned("pkg".to_string()).unwrap(),
+            group: "my-group".parse::<GroupName>().unwrap(),
+            marker: None,
+        });
+        let dep = PubGrubPackage::from(PubGrubPackageInner::Package {
+            name: PackageName::from_owned("dep".to_string()).unwrap(),
+            extra: None,
+            marker: None,
+            group: None,
+        });
+
+        let extra_leaf = ErrorTree::External(External::FromDependencyOf(
+            extra,
+            pubgrub::Range::any(),
+            dep.clone(),
+            pubgrub::Range::any(),
+        ));
+        let group_leaf = ErrorTree::External(External::FromDependencyOf(
+            group,
+            pubgrub::Range::any(),
+            dep,
+            pubgrub::Range::any(),
+        ));
+        // Combine them into a small tree so both survive the transformation.
+        let tree = ErrorTree::Derived(Derived {
+            terms: pubgrub::Map::default(),
+            shared_id: None,
+            cause1: Arc::new(extra_leaf),
+            cause2: Arc::new(group_leaf),
+        });
+
+        let collapsed = NoSolutionError::collapse_proxies(tree);
+
+        // Both the Extra and Group proxies should still be present.
+        let packages: Vec<_> = derivation_tree_packages(&collapsed).collect();
+        assert!(
+            packages.iter().any(|p| matches!(&**p, PubGrubPackageInner::Extra { .. })),
+            "Extra proxy should be preserved after collapse_proxies"
+        );
+        assert!(
+            packages.iter().any(|p| matches!(&**p, PubGrubPackageInner::Group { .. })),
+            "Group proxy should be preserved after collapse_proxies"
+        );
     }
 
     #[test]


### PR DESCRIPTION

## Summary

\collapse_proxies\ in the error reporting was collapsing all proxy nodes including \Extra\ and \Group\ proxies. This caused dependency conflict error messages to lose the extra/group name context (e.g. showing \package[A]\ as just \package\) when the extra appeared in a \FromDependencyOf\ chain.

Changed \collapse_proxies\ to only collapse \Marker\ proxies while preserving \Extra\ and \Group\ proxies, since those carry user-meaningful dependency context.

## Test Plan

Added unit test \collapse_proxies_preserves_extra_and_group\ in \error.rs\.

Closes #19525
