### PR TITLE
fix(uv): handle leaf cycles in uv tree --invert

### DIFF
--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -5,6 +5,7 @@ use std::fmt::Write;
 use either::Either;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use petgraph::algo::tarjan_scc;
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::prelude::EdgeRef;
 use petgraph::{Direction, Graph};
@@ -436,8 +437,8 @@ impl<'env> TreeDisplay<'env> {
             } else {
                 let mut roots = if invert {
                     // For inverted trees, find leaf packages (nodes with no incoming
-                    // edges).
-                    graph
+                    // edges after reversal).
+                    let mut roots: Vec<_> = graph
                         .node_indices()
                         .filter(|index| {
                             graph
@@ -445,7 +446,34 @@ impl<'env> TreeDisplay<'env> {
                                 .next()
                                 .is_none()
                         })
-                        .collect::<Vec<_>>()
+                        .collect();
+
+                    // If no node has zero incoming edges (e.g., a leaf cycle), fall
+                    // back to treating each root SCC as a root. A root SCC is one
+                    // whose nodes have no incoming edges from outside the SCC.
+                    if roots.is_empty() {
+                        let sccs = tarjan_scc(&graph);
+                        for scc in &sccs {
+                            let has_external_incoming = scc.iter().any(|node| {
+                                graph
+                                    .edges_directed(*node, Direction::Incoming)
+                                    .any(|edge| !scc.contains(&edge.source()))
+                            });
+                            if !has_external_incoming {
+                                // Pick the best node in the SCC as root: prefer
+                                // packages over Root nodes.
+                                let root = scc
+                                    .iter()
+                                    .find(|n| matches!(graph[**n], Node::Package(_)))
+                                    .or_else(|| scc.first());
+                                if let Some(root) = root {
+                                    roots.push(*root);
+                                }
+                            }
+                        }
+                    }
+
+                    roots
                 } else {
                     // For non-inverted trees, use the root node directly.
                     graph

--- a/crates/uv/tests/project/tree.rs
+++ b/crates/uv/tests/project/tree.rs
@@ -2998,3 +2998,92 @@ fn workspace_circular_dependencies() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn invert_leaf_cycle() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    // Create a lockfile with a leaf cycle: bar ↔ baz form a cycle where no
+    // node in the reversed graph has zero incoming edges. Without the SCC
+    // fallback, `--invert` would produce no output.
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [project]
+            name = "foo"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            dependencies = ["bar==1.0.0"]
+        "#})?;
+
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(indoc! {r#"
+            version = 1
+            revision = 3
+            requires-python = ">=3.12"
+
+            [[package]]
+            name = "foo"
+            version = "1.0.0"
+            source = { virtual = "." }
+            dependencies = [
+                { name = "bar" },
+            ]
+
+            [[package]]
+            name = "bar"
+            version = "1.0.0"
+            source = { registry = "https://pypi.org/simple" }
+            dependencies = [
+                { name = "baz" },
+            ]
+
+            [[package]]
+            name = "baz"
+            version = "1.0.0"
+            source = { registry = "https://pypi.org/simple" }
+            dependencies = [
+                { name = "bar" },
+            ]
+        "#})?;
+
+    // Normal tree — no issue; the cycle is displayed as usual.
+    uv_snapshot!(context.filters(), context.tree().arg("--frozen"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    foo v1.0.0
+    └── bar v1.0.0
+        └── baz v1.0.0
+            └── bar v1.0.0 (*)
+    (*) Package tree already displayed
+
+    ----- stderr -----
+
+    "
+    );
+
+    // Inverted tree — without the SCC fallback every node in the reversed
+    // graph has incoming edges, yielding an empty root set and no output.
+    // With the fix, the SCC {bar, baz} is detected as a root SCC.
+    uv_snapshot!(context.filters(), context.tree().arg("--frozen").arg("--invert"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    bar v1.0.0
+    ├── baz v1.0.0
+    │   └── bar v1.0.0 (*)
+    └── foo v1.0.0
+
+    (*) Package tree already displayed
+
+    ----- stderr -----
+
+    "
+    );
+
+    Ok(())
+}

--- a/crates/uv/tests/project/tree.rs
+++ b/crates/uv/tests/project/tree.rs
@@ -3017,10 +3017,7 @@ fn invert_leaf_cycle() -> Result<()> {
             dependencies = ["bar==1.0.0"]
         "#})?;
 
-    context
-        .temp_dir
-        .child("uv.lock")
-        .write_str(indoc! {r#"
+    context.temp_dir.child("uv.lock").write_str(indoc! {r#"
             version = 1
             revision = 3
             requires-python = ">=3.12"


### PR DESCRIPTION

## Summary

When running \uv tree --invert\ on a dependency graph with leaf cycles (cycles where the cycle nodes have no outgoing edges to non-cycle nodes), the previous root selection logic would fail to find a valid root, silently dropping parts of the dependency tree.

Fix uses \petgraph::algo::tarjan_scc\ to detect strongly connected components, then picks one node per SCC with no external incoming edges as the root for that cycle.

## Test Plan

Added integration test \invert_leaf_cycle\ with a lockfile fixture containing a leaf cycle plus a leaf-cycle fixture.

Closes #19972
