### PR TITLE
Preserve deprecated explicit pre-release mode

### DIFF
--- a/crates/uv-resolver/src/manifest.rs
+++ b/crates/uv-resolver/src/manifest.rs
@@ -120,12 +120,13 @@ impl Manifest {
             .chain(self.overrides(env, mode))
     }
 
-    /// Return all requirements that affect manifest-wide yanked-version candidate selection.
+    /// Return all requirements that affect manifest-wide candidate selection policy initialized
+    /// before resolution begins.
     ///
     /// Scoped overrides are included even when their scope is not selected. Whether a scoped
-    /// override applies is only known during resolution, after yanked-version policy has already
-    /// been initialized.
-    pub(crate) fn yanked_version_requirements<'a>(
+    /// override applies is only known during resolution, after explicit pre-release and
+    /// yanked-version policy has already been initialized.
+    pub(crate) fn candidate_selection_requirements<'a>(
         &'a self,
         env: &'a ResolverEnvironment,
         mode: DependencyMode,

--- a/crates/uv-resolver/src/manifest.rs
+++ b/crates/uv-resolver/src/manifest.rs
@@ -120,12 +120,11 @@ impl Manifest {
             .chain(self.overrides(env, mode))
     }
 
-    /// Return all requirements that affect manifest-wide candidate selection policy initialized
-    /// before resolution begins.
+    /// Return all requirements that affect manifest-wide candidate selection policy.
     ///
     /// Scoped overrides are included even when their scope is not selected. Whether a scoped
-    /// override applies is only known during resolution, after explicit pre-release and
-    /// yanked-version policy has already been initialized.
+    /// override applies is only known during resolution, after pre-release and yanked-version
+    /// policy has already been initialized.
     pub(crate) fn candidate_selection_requirements<'a>(
         &'a self,
         env: &'a ResolverEnvironment,

--- a/crates/uv-resolver/src/prerelease.rs
+++ b/crates/uv-resolver/src/prerelease.rs
@@ -1,4 +1,6 @@
-use uv_distribution_types::RequirementSource;
+use std::borrow::Cow;
+
+use uv_distribution_types::{Requirement, RequirementSource};
 use uv_normalize::PackageName;
 use uv_pep440::{Operator, VersionSpecifiers};
 
@@ -77,33 +79,27 @@ impl PrereleaseStrategy {
             PrereleaseMode::Disallow => Self::Disallow,
             PrereleaseMode::Allow => Self::Allow,
             PrereleaseMode::IfNecessary => Self::IfNecessary,
-            PrereleaseMode::Explicit => {
-                let mut packages = ForkSet::default();
-                for requirement in manifest.candidate_selection_requirements(env, dependencies) {
-                    let RequirementSource::Registry { specifier, .. } = &requirement.source else {
-                        continue;
-                    };
+            PrereleaseMode::Explicit => Self::Explicit(Self::explicit_packages(
+                manifest.candidate_selection_requirements(env, dependencies),
+            )),
+            PrereleaseMode::IfNecessaryOrExplicit => Self::IfNecessaryOrExplicit(
+                Self::explicit_packages(manifest.requirements(env, dependencies)),
+            ),
+        }
+    }
 
-                    if contains_prerelease(specifier) {
-                        packages.add(&requirement, ());
-                    }
-                }
-                Self::Explicit(packages)
-            }
-            PrereleaseMode::IfNecessaryOrExplicit => {
-                let mut packages = ForkSet::default();
-                for requirement in manifest.requirements(env, dependencies) {
-                    let RequirementSource::Registry { specifier, .. } = &requirement.source else {
-                        continue;
-                    };
+    fn explicit_packages<'a>(requirements: impl Iterator<Item = Cow<'a, Requirement>>) -> ForkSet {
+        let mut packages = ForkSet::default();
+        for requirement in requirements {
+            let RequirementSource::Registry { specifier, .. } = &requirement.source else {
+                continue;
+            };
 
-                    if contains_prerelease(specifier) {
-                        packages.add(&requirement, ());
-                    }
-                }
-                Self::IfNecessaryOrExplicit(packages)
+            if contains_prerelease(specifier) {
+                packages.add(&requirement, ());
             }
         }
+        packages
     }
 
     /// Returns the pre-release candidate selection policy for a package.

--- a/crates/uv-resolver/src/prerelease.rs
+++ b/crates/uv-resolver/src/prerelease.rs
@@ -19,20 +19,25 @@ pub enum PrereleaseMode {
     /// Allow pre-release versions when no stable candidate satisfies the active constraints.
     IfNecessary,
 
+    /// Allow pre-release versions for first-party packages with explicit pre-release specifiers in
+    /// their version requirements.
+    #[deprecated(note = "use `if-necessary-or-explicit` instead")]
+    Explicit,
+
     /// Allow pre-release versions when no stable candidate satisfies the active constraints, or
     /// when an active direct or transitive requirement contains an explicit pre-release specifier.
     #[default]
-    #[serde(alias = "explicit")]
-    #[cfg_attr(feature = "clap", value(alias("explicit")))]
     IfNecessaryOrExplicit,
 }
 
+#[allow(deprecated)]
 impl std::fmt::Display for PrereleaseMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Disallow => write!(f, "disallow"),
             Self::Allow => write!(f, "allow"),
             Self::IfNecessary => write!(f, "if-necessary"),
+            Self::Explicit => write!(f, "explicit"),
             Self::IfNecessaryOrExplicit => write!(f, "if-necessary-or-explicit"),
         }
     }
@@ -51,12 +56,17 @@ pub(crate) enum PrereleaseStrategy {
     /// Allow pre-release versions when no stable candidate satisfies the active constraints.
     IfNecessary,
 
+    /// Allow pre-release versions for first-party packages with explicit pre-release specifiers in
+    /// their version requirements.
+    Explicit(ForkSet),
+
     /// Allow pre-release versions when no stable candidate satisfies the active constraints, or
     /// when an active requirement contains an explicit pre-release specifier.
     IfNecessaryOrExplicit(ForkSet),
 }
 
 impl PrereleaseStrategy {
+    #[allow(deprecated)]
     pub(crate) fn from_mode(
         mode: PrereleaseMode,
         manifest: &Manifest,
@@ -67,6 +77,19 @@ impl PrereleaseStrategy {
             PrereleaseMode::Disallow => Self::Disallow,
             PrereleaseMode::Allow => Self::Allow,
             PrereleaseMode::IfNecessary => Self::IfNecessary,
+            PrereleaseMode::Explicit => {
+                let mut packages = ForkSet::default();
+                for requirement in manifest.candidate_selection_requirements(env, dependencies) {
+                    let RequirementSource::Registry { specifier, .. } = &requirement.source else {
+                        continue;
+                    };
+
+                    if contains_prerelease(specifier) {
+                        packages.add(&requirement, ());
+                    }
+                }
+                Self::Explicit(packages)
+            }
             PrereleaseMode::IfNecessaryOrExplicit => {
                 let mut packages = ForkSet::default();
                 for requirement in manifest.requirements(env, dependencies) {
@@ -100,6 +123,13 @@ impl PrereleaseStrategy {
             Self::Disallow => PrereleaseSelection::Disallow,
             Self::Allow => PrereleaseSelection::Allow,
             Self::IfNecessary => PrereleaseSelection::PreferStable,
+            Self::Explicit(packages) => {
+                if packages.contains(package_name, env) {
+                    PrereleaseSelection::Allow
+                } else {
+                    PrereleaseSelection::Disallow
+                }
+            }
             Self::IfNecessaryOrExplicit(packages) => {
                 if explicit_prerelease || packages.contains(package_name, env) {
                     PrereleaseSelection::Allow

--- a/crates/uv-resolver/src/yanks.rs
+++ b/crates/uv-resolver/src/yanks.rs
@@ -22,7 +22,7 @@ impl AllowedYanks {
         let mut allowed_yanks = FxHashMap::<PackageName, FxHashSet<Version>>::default();
 
         // Allow yanks for any pinned input requirements.
-        for requirement in manifest.yanked_version_requirements(env, dependencies) {
+        for requirement in manifest.candidate_selection_requirements(env, dependencies) {
             let RequirementSource::Registry { specifier, .. } = &requirement.source else {
                 continue;
             };

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -4311,6 +4311,16 @@ pub(crate) struct ResolverSettings {
     pub(crate) upgrade: Upgrade,
 }
 
+#[allow(deprecated)]
+fn warn_if_deprecated_prerelease_mode(prerelease: PrereleaseMode) -> PrereleaseMode {
+    if matches!(prerelease, PrereleaseMode::Explicit) {
+        warn_user_once!(
+            "The `explicit` pre-release mode is deprecated and will be removed in a future release. Use `if-necessary-or-explicit` instead."
+        );
+    }
+    prerelease
+}
+
 impl ResolverSettings {
     /// Resolve the [`ResolverSettings`] from the CLI and filesystem configuration.
     fn combine(
@@ -4366,7 +4376,7 @@ impl From<ResolverOptions> for ResolverSettings {
         Self {
             index_locations,
             resolution: value.resolution.unwrap_or_default(),
-            prerelease: value.prerelease.unwrap_or_default(),
+            prerelease: warn_if_deprecated_prerelease_mode(value.prerelease.unwrap_or_default()),
             fork_strategy: value.fork_strategy.unwrap_or_default(),
             dependency_metadata: DependencyMetadata::from_entries(
                 value.dependency_metadata.into_iter().flatten(),
@@ -4509,7 +4519,9 @@ impl From<ResolverInstallerOptions> for ResolverInstallerSettings {
                 build_isolation: value.build_isolation.unwrap_or_default(),
                 extra_build_dependencies: value.extra_build_dependencies.unwrap_or_default(),
                 extra_build_variables: value.extra_build_variables.unwrap_or_default(),
-                prerelease: value.prerelease.unwrap_or_default(),
+                prerelease: warn_if_deprecated_prerelease_mode(
+                    value.prerelease.unwrap_or_default(),
+                ),
                 resolution: value.resolution.unwrap_or_default(),
                 sources: NoSources::from_args(
                     value.no_sources,
@@ -4783,7 +4795,9 @@ impl PipSettings {
                 DependencyMode::Transitive
             },
             resolution: args.resolution.combine(resolution).unwrap_or_default(),
-            prerelease: args.prerelease.combine(prerelease).unwrap_or_default(),
+            prerelease: warn_if_deprecated_prerelease_mode(
+                args.prerelease.combine(prerelease).unwrap_or_default(),
+            ),
             fork_strategy: args
                 .fork_strategy
                 .combine(fork_strategy)

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -10085,10 +10085,9 @@ fn lock_resolution_mode() -> Result<()> {
     Ok(())
 }
 
-/// Accept the removed `explicit` pre-release mode in existing lockfiles, configuration, and CLI
-/// arguments, while treating it as `if-necessary-or-explicit`.
+/// Accept the `explicit` pre-release mode in lockfiles, configuration, and CLI arguments.
 #[test]
-fn lock_legacy_explicit_prerelease_mode() -> Result<()> {
+fn lock_explicit_prerelease_mode() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
     context
@@ -10127,6 +10126,7 @@ fn lock_legacy_explicit_prerelease_mode() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: The `explicit` pre-release mode is deprecated and will be removed in a future release. Use `if-necessary-or-explicit` instead.
     Resolved 1 package in [TIME]
     ");
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -4803,9 +4803,10 @@ fn build_transitive_prerelease() -> Result<()> {
     Ok(())
 }
 
-/// The legacy `--prerelease=explicit` spelling should use the default range-relative fallback.
+/// `--prerelease=explicit` should not fall back to a pre-release without a direct pre-release
+/// specifier.
 #[test]
-fn legacy_explicit_prerelease_falls_back_if_necessary() {
+fn explicit_prerelease_does_not_fall_back_if_necessary() {
     let context = uv_test::test_context!("3.12");
     let server = PackseServer::new("prereleases/package-only-prereleases-in-range.toml");
 
@@ -4814,18 +4815,73 @@ fn legacy_explicit_prerelease_falls_back_if_necessary() {
         .arg(server.index_url())
         .arg("--prerelease=explicit")
         .arg("a>0.1.0"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: The `explicit` pre-release mode is deprecated and will be removed in a future release. Use `if-necessary-or-explicit` instead.
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only a<=0.1.0 is available and you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
+
+    hint: Pre-releases are available for `a` in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)
+    ");
+}
+
+/// `--prerelease=explicit` should allow a pre-release for a direct requirement with a pre-release
+/// specifier.
+#[test]
+fn explicit_prerelease_allows_direct_marker() {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new(
+        "prereleases/package-prerelease-specified-only-prerelease-available.toml",
+    );
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--index-url")
+        .arg(server.index_url())
+        .arg("--prerelease=explicit")
+        .arg("a>=0.1.0a1"), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
+    warning: The `explicit` pre-release mode is deprecated and will be removed in a future release. Use `if-necessary-or-explicit` instead.
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
-     + a==1.0.0a1
+     + a==0.3.0a1
     ");
 
-    context.assert_installed("a", "1.0.0a1");
+    context.assert_installed("a", "0.3.0a1");
+}
+
+/// `--prerelease=explicit` should not allow a pre-release based only on a transitive pre-release
+/// specifier.
+#[test]
+fn explicit_prerelease_disallows_transitive_marker() {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("prereleases/transitive-prerelease-and-stable-dependency.toml");
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--index-url")
+        .arg(server.index_url())
+        .arg("--prerelease=explicit")
+        .arg("a")
+        .arg("b"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: The `explicit` pre-release mode is deprecated and will be removed in a future release. Use `if-necessary-or-explicit` instead.
+      × No solution found when resolving dependencies:
+      ╰─▶ Because there is no version of c==2.0.0b1 and all versions of a depend on c==2.0.0b1, we can conclude that all versions of a cannot be used.
+          And because you require a, we can conclude that your requirements are unsatisfiable.
+
+    hint: `c` was requested with a pre-release marker (e.g., c==2.0.0b1), but pre-releases weren't enabled (try: `--prerelease=allow`)
+    ");
 }
 
 /// `--prerelease=disallow` should continue to reject explicitly requested transitive

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -333,15 +333,11 @@ selected according to uv's ordinary [package priorities](../pip/compatibility.md
 If uv selects a compatible stable version before discovering a later requirement that authorizes
 pre-releases, it may retain that stable version even when a newer pre-release becomes eligible.
 
-Use `--prerelease if-necessary` to prefer stable candidates even when a requirement contains a
-pre-release identifier, while still falling back to pre-releases when no stable candidate works. Use
-`--prerelease explicit` to consider pre-releases only for first-party requirements that contain a
-pre-release identifier, without falling back for other packages. Use `--prerelease allow` to
+Use `--prerelease explicit` to consider pre-releases only for first-party requirements that contain
+a pre-release identifier, without falling back for other packages. This mode is deprecated and will
+be removed in a future release; use `if-necessary-or-explicit` instead. Use `--prerelease allow` to
 consider pre-releases for every package without preferring stable candidates first, or
 `--prerelease disallow` to exclude them entirely.
-
-The `explicit` mode is deprecated and will be removed in a future release. Use
-`if-necessary-or-explicit` instead.
 
 For more details, see
 [Pre-release compatibility](../pip/compatibility.md#pre-release-compatibility).
@@ -440,13 +436,11 @@ including Git sources, and explicit indexes are not supported.
 
 Under the default pre-release policy, an explicit pre-release specifier in a scoped override
 authorizes pre-release candidates only while that scope is selected. If resolution backtracks away
-from the package version to which the override applies, the authorization is removed with it. Under
-`--prerelease explicit`, pre-release permissions are determined before uv knows which scoped
-overrides will apply, so a pre-release specifier in any scoped override opts that package into
-pre-release candidate selection for the entire resolution, even if the scope is not selected.
-Yanked-version permissions are also determined before uv knows which scoped overrides will apply. As
-a result, an exact yanked-version pin in any scoped override opts that package into yanked-version
-candidate selection for the entire resolution, even if the scope is not selected.
+from the package version to which the override applies, the authorization is removed with it. The
+legacy `explicit` mode and yanked-version handling instead determine permissions before uv knows
+which scoped overrides will apply. As a result, a pre-release specifier or exact yanked-version pin
+in any scoped override makes the corresponding candidates eligible for the entire resolution, even
+if the scope is not selected.
 
 If multiple overrides are provided for the same package, they must be differentiated with
 [markers](#platform-markers). If a package has a dependency with a marker, it is replaced

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -333,8 +333,15 @@ selected according to uv's ordinary [package priorities](../pip/compatibility.md
 If uv selects a compatible stable version before discovering a later requirement that authorizes
 pre-releases, it may retain that stable version even when a newer pre-release becomes eligible.
 
-Use `--prerelease allow` to consider pre-releases for every package without preferring stable
-candidates first, or `--prerelease disallow` to exclude them entirely.
+Use `--prerelease if-necessary` to prefer stable candidates even when a requirement contains a
+pre-release identifier, while still falling back to pre-releases when no stable candidate works. Use
+`--prerelease explicit` to consider pre-releases only for first-party requirements that contain a
+pre-release identifier, without falling back for other packages. Use `--prerelease allow` to
+consider pre-releases for every package without preferring stable candidates first, or
+`--prerelease disallow` to exclude them entirely.
+
+The `explicit` mode is deprecated and will be removed in a future release. Use
+`if-necessary-or-explicit` instead.
 
 For more details, see
 [Pre-release compatibility](../pip/compatibility.md#pre-release-compatibility).
@@ -431,12 +438,15 @@ for the same dependency.
 Scoped overrides currently support registry version specifiers only. Direct URL and path sources,
 including Git sources, and explicit indexes are not supported.
 
-An explicit pre-release specifier in a scoped override authorizes pre-release candidates only while
-that scope is selected. If resolution backtracks away from the package version to which the override
-applies, the authorization is removed with it. Yanked-version permissions are still determined
-before uv knows which scoped overrides will apply. As a result, an exact yanked-version pin in any
-scoped override opts that package into yanked-version candidate selection for the entire resolution,
-even if the scope is not selected.
+Under the default pre-release policy, an explicit pre-release specifier in a scoped override
+authorizes pre-release candidates only while that scope is selected. If resolution backtracks away
+from the package version to which the override applies, the authorization is removed with it. Under
+`--prerelease explicit`, pre-release permissions are determined before uv knows which scoped
+overrides will apply, so a pre-release specifier in any scoped override opts that package into
+pre-release candidate selection for the entire resolution, even if the scope is not selected.
+Yanked-version permissions are also determined before uv knows which scoped overrides will apply. As
+a result, an exact yanked-version pin in any scoped override opts that package into yanked-version
+candidate selection for the entire resolution, even if the scope is not selected.
 
 If multiple overrides are provided for the same package, they must be differentiated with
 [markers](#platform-markers). If a package has a dependency with a marker, it is replaced

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -333,11 +333,12 @@ selected according to uv's ordinary [package priorities](../pip/compatibility.md
 If uv selects a compatible stable version before discovering a later requirement that authorizes
 pre-releases, it may retain that stable version even when a newer pre-release becomes eligible.
 
-Use `--prerelease explicit` to consider pre-releases only for first-party requirements that contain
-a pre-release identifier, without falling back for other packages. This mode is deprecated and will
-be removed in a future release; use `if-necessary-or-explicit` instead. Use `--prerelease allow` to
-consider pre-releases for every package without preferring stable candidates first, or
-`--prerelease disallow` to exclude them entirely.
+Use `--prerelease allow` to consider pre-releases for every package without preferring stable
+candidates first, or `--prerelease disallow` to exclude them entirely.
+
+The `explicit` mode is deprecated and will be removed in a future release; use
+`if-necessary-or-explicit` instead. It considers pre-releases only for first-party requirements that
+contain a pre-release identifier, without falling back for other packages.
 
 For more details, see
 [Pre-release compatibility](../pip/compatibility.md#pre-release-compatibility).
@@ -434,13 +435,12 @@ for the same dependency.
 Scoped overrides currently support registry version specifiers only. Direct URL and path sources,
 including Git sources, and explicit indexes are not supported.
 
-Under the default pre-release policy, an explicit pre-release specifier in a scoped override
-authorizes pre-release candidates only while that scope is selected. If resolution backtracks away
-from the package version to which the override applies, the authorization is removed with it. The
-legacy `explicit` mode and yanked-version handling instead determine permissions before uv knows
-which scoped overrides will apply. As a result, a pre-release specifier or exact yanked-version pin
-in any scoped override makes the corresponding candidates eligible for the entire resolution, even
-if the scope is not selected.
+An explicit pre-release specifier in a scoped override authorizes pre-release candidates only while
+that scope is selected. If resolution backtracks away from the package version to which the override
+applies, the authorization is removed with it. Yanked-version permissions are still determined
+before uv knows which scoped overrides will apply. As a result, an exact yanked-version pin in any
+scoped override opts that package into yanked-version candidate selection for the entire resolution,
+even if the scope is not selected.
 
 If multiple overrides are provided for the same package, they must be differentiated with
 [markers](#platform-markers). If a package has a dependency with a marker, it is replaced

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -57,11 +57,12 @@ is selected, `c==2.0a1` participates in normal version order and is preferred as
 version. A later requirement that excludes `c==1.0` forces uv to reconsider it. In every case, the
 selected version satisfies all active requirements.
 
-Use `--prerelease explicit` to consider pre-releases only for first-party requirements that contain
-a pre-release identifier, without falling back for other packages. This mode is deprecated and will
-be removed in a future release; use `if-necessary-or-explicit` instead. Use `--prerelease allow` to
-consider pre-releases for every package without preferring stable candidates first, or
-`--prerelease disallow` to exclude them entirely.
+Use `--prerelease allow` to consider pre-releases for every package without preferring stable
+candidates first, or `--prerelease disallow` to exclude them entirely.
+
+The `explicit` mode is deprecated and will be removed in a future release; use
+`if-necessary-or-explicit` instead. It considers pre-releases only for first-party requirements that
+contain a pre-release identifier, without falling back for other packages.
 
 !!! note
 
@@ -69,11 +70,9 @@ consider pre-releases for every package without preferring stable candidates fir
 
 Pre-releases are
 [notoriously difficult](https://pubgrub-rs-guide.pages.dev/limitations/prerelease_versions) to model
-because dependency requirements are discovered incrementally during resolution. Under the default
-policy, uv tracks pre-release authorization with the dependencies that introduced it, so the
-authorization is removed if resolution backtracks away from those dependencies. The legacy
-`explicit` policy instead determines authorization from first-party requirements before resolution
-begins.
+because dependency requirements are discovered incrementally during resolution. uv tracks
+pre-release authorization with the dependencies that introduced it, so the authorization is removed
+if resolution backtracks away from those dependencies.
 
 ## Packages that exist on multiple indexes
 

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -57,8 +57,15 @@ is selected, `c==2.0a1` participates in normal version order and is preferred as
 version. A later requirement that excludes `c==1.0` forces uv to reconsider it. In every case, the
 selected version satisfies all active requirements.
 
-Use `--prerelease allow` to consider pre-releases for every package without preferring stable
-candidates first, or `--prerelease disallow` to exclude them entirely.
+Use `--prerelease if-necessary` to prefer stable candidates even when a requirement contains a
+pre-release identifier, while still falling back to pre-releases when no stable candidate works. Use
+`--prerelease explicit` to consider pre-releases only for first-party requirements that contain a
+pre-release identifier, without falling back for other packages. Use `--prerelease allow` to
+consider pre-releases for every package without preferring stable candidates first, or
+`--prerelease disallow` to exclude them entirely.
+
+The `explicit` mode is deprecated and will be removed in a future release. Use
+`if-necessary-or-explicit` instead.
 
 !!! note
 
@@ -66,9 +73,11 @@ candidates first, or `--prerelease disallow` to exclude them entirely.
 
 Pre-releases are
 [notoriously difficult](https://pubgrub-rs-guide.pages.dev/limitations/prerelease_versions) to model
-because dependency requirements are discovered incrementally during resolution. uv tracks
-pre-release authorization with the dependencies that introduced it, so the authorization is removed
-if resolution backtracks away from those dependencies.
+because dependency requirements are discovered incrementally during resolution. Under the default
+policy, uv tracks pre-release authorization with the dependencies that introduced it, so the
+authorization is removed if resolution backtracks away from those dependencies. The legacy
+`explicit` policy instead determines authorization from first-party requirements before resolution
+begins.
 
 ## Packages that exist on multiple indexes
 

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -57,15 +57,11 @@ is selected, `c==2.0a1` participates in normal version order and is preferred as
 version. A later requirement that excludes `c==1.0` forces uv to reconsider it. In every case, the
 selected version satisfies all active requirements.
 
-Use `--prerelease if-necessary` to prefer stable candidates even when a requirement contains a
-pre-release identifier, while still falling back to pre-releases when no stable candidate works. Use
-`--prerelease explicit` to consider pre-releases only for first-party requirements that contain a
-pre-release identifier, without falling back for other packages. Use `--prerelease allow` to
+Use `--prerelease explicit` to consider pre-releases only for first-party requirements that contain
+a pre-release identifier, without falling back for other packages. This mode is deprecated and will
+be removed in a future release; use `if-necessary-or-explicit` instead. Use `--prerelease allow` to
 consider pre-releases for every package without preferring stable candidates first, or
 `--prerelease disallow` to exclude them entirely.
-
-The `explicit` mode is deprecated and will be removed in a future release. Use
-`if-necessary-or-explicit` instead.
 
 !!! note
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1709,6 +1709,12 @@
           "const": "if-necessary"
         },
         {
+          "description": "Allow pre-release versions for first-party packages with explicit pre-release specifiers in\ntheir version requirements.",
+          "type": "string",
+          "const": "explicit",
+          "deprecated": true
+        },
+        {
           "description": "Allow pre-release versions when no stable candidate satisfies the active constraints, or\nwhen an active direct or transitive requirement contains an explicit pre-release specifier.",
           "type": "string",
           "const": "if-necessary-or-explicit"


### PR DESCRIPTION
## Summary

The parent PR currently treats `explicit` as an alias for `if-necessary-or-explicit`, which changes existing configurations to fall back to pre-releases when no stable candidate satisfies the active constraints.

This restores the standalone `explicit` policy with its legacy solve-static behavior: only first-party requirements with explicit pre-release specifiers authorize pre-releases, packages without that authorization do not fall back, and transitive pre-release requirements do not enable the mode dynamically. Keeping the authorization set fixed before resolution preserves PubGrub's candidate-universe assumptions, including the legacy scoped-override behavior.

(The mode remains deprecated, but we warn rather than failing.)