### PR TITLE
Use Packse for dependency group tests

### DIFF
--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -3373,6 +3373,61 @@ fn python_version_does_not_exist() {
     context.assert_not_installed("a");
 }
 
+/// Three independent packages used to test dependency-group selection.
+///
+/// ```text
+/// dependency-groups
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   ├── requires iniconfig==2.0.0
+/// │   │   └── satisfied by iniconfig-2.0.0
+/// │   ├── requires sniffio==1.3.1
+/// │   │   └── satisfied by sniffio-1.3.1
+/// │   ├── requires sortedcontainers==2.4.0
+/// │   │   └── satisfied by sortedcontainers-2.4.0
+/// │   └── requires typing-extensions==4.10.0
+/// │       └── satisfied by typing-extensions-4.10.0
+/// ├── iniconfig
+/// │   └── iniconfig-2.0.0
+/// ├── sniffio
+/// │   └── sniffio-1.3.1
+/// ├── sortedcontainers
+/// │   └── sortedcontainers-2.4.0
+/// └── typing-extensions
+///     └── typing-extensions-4.10.0
+/// ```
+#[test]
+fn dependency_groups() {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("simple/dependency-groups.toml");
+
+    uv_snapshot!(context.filters(), command(&context, &server)
+        .arg("iniconfig==2.0.0")
+        .arg("sniffio==1.3.1")
+        .arg("sortedcontainers==2.4.0")
+        .arg("typing-extensions==4.10.0")
+        , @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + iniconfig==2.0.0
+     + sniffio==1.3.1
+     + sortedcontainers==2.4.0
+     + typing-extensions==4.10.0
+    ");
+
+    context.assert_installed("iniconfig", "2.0.0");
+    context.assert_installed("sniffio", "1.3.1");
+    context.assert_installed("sortedcontainers", "2.4.0");
+    context.assert_installed("typing_extensions", "4.10.0");
+}
+
 /// A single package with two stable versions.
 ///
 /// ```text

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -16144,8 +16144,6 @@ fn respect_index_preference() -> Result<()> {
 
 #[test]
 fn dependency_group() -> Result<()> {
-    let server = PackseServer::new("simple/dependency-groups.toml");
-
     // uv pip compile --group tests, with a single pyproject.toml
     fn new_context() -> Result<TestContext> {
         let context = uv_test::test_context!("3.12");
@@ -16174,6 +16172,7 @@ fn dependency_group() -> Result<()> {
         command
     }
 
+    let server = PackseServer::new("simple/dependency-groups.toml");
     let mut context;
 
     // Passing --group should add just that group's contents from ./pyproject.toml

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::env::current_dir;
 use std::fs;
 use std::io::Cursor;
+use std::process::Command;
 use std::str::FromStr;
 
 use anyhow::Result;
@@ -16143,6 +16144,8 @@ fn respect_index_preference() -> Result<()> {
 
 #[test]
 fn dependency_group() -> Result<()> {
+    let server = PackseServer::new("simple/dependency-groups.toml");
+
     // uv pip compile --group tests, with a single pyproject.toml
     fn new_context() -> Result<TestContext> {
         let context = uv_test::test_context!("3.12");
@@ -16165,11 +16168,17 @@ fn dependency_group() -> Result<()> {
         Ok(context)
     }
 
+    fn command(context: &TestContext, server: &PackseServer) -> Command {
+        let mut command = context.pip_compile();
+        command.arg("--index-url").arg(server.index_url());
+        command
+    }
+
     let mut context;
 
     // Passing --group should add just that group's contents from ./pyproject.toml
     context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_compile()
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("--group").arg("bar"), @"
     success: true
     exit_code: 0
@@ -16187,7 +16196,7 @@ fn dependency_group() -> Result<()> {
     // (This is a "try to confuse the internals" test, as this file is logically
     // imported twice, but with two different semantics.)
     context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_compile()
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("pyproject.toml")
         .arg("--group").arg("bar"), @"
     success: true
@@ -16206,7 +16215,7 @@ fn dependency_group() -> Result<()> {
 
     // Another "try to confuse the internals" test with an absolute path
     context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_compile()
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg(context.temp_dir.child("pyproject.toml").path())
         .arg("--group").arg("bar"), @"
     success: true
@@ -16225,7 +16234,7 @@ fn dependency_group() -> Result<()> {
 
     // An explicit use of `<path>:<group>` syntax, here using what the default is anyway
     context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_compile()
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("--group").arg("pyproject.toml:bar"), @"
     success: true
     exit_code: 0
@@ -16241,7 +16250,7 @@ fn dependency_group() -> Result<()> {
 
     // "try to confuse the internals" with an explicit path for the group
     context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_compile()
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("pyproject.toml")
         .arg("--group").arg("pyproject.toml:bar"), @"
     success: true
@@ -16260,7 +16269,7 @@ fn dependency_group() -> Result<()> {
 
     // Let's check that the other group works fine individually
     context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_compile()
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("--group").arg("foo"), @"
     success: true
     exit_code: 0
@@ -16276,7 +16285,7 @@ fn dependency_group() -> Result<()> {
 
     // Now let's do both of the groups together
     context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_compile()
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("--group").arg("foo")
         .arg("--group").arg("bar"), @"
     success: true
@@ -16295,7 +16304,7 @@ fn dependency_group() -> Result<()> {
 
     // And finally put it all together
     context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_compile()
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("pyproject.toml")
         .arg("--group").arg("foo")
         .arg("--group").arg("bar"), @"

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -11411,8 +11411,6 @@ fn direct_url_json_direct_url() -> Result<()> {
 
 #[test]
 fn dependency_group() -> Result<()> {
-    let server = PackseServer::new("simple/dependency-groups.toml");
-
     // testing basic `uv pip install --group` functionality
     fn new_context(server: &PackseServer) -> Result<TestContext> {
         let context = uv_test::test_context!("3.12");
@@ -11447,6 +11445,7 @@ fn dependency_group() -> Result<()> {
         command
     }
 
+    let server = PackseServer::new("simple/dependency-groups.toml");
     let mut context;
 
     // 'bar' using path sugar

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -11411,8 +11411,10 @@ fn direct_url_json_direct_url() -> Result<()> {
 
 #[test]
 fn dependency_group() -> Result<()> {
+    let server = PackseServer::new("simple/dependency-groups.toml");
+
     // testing basic `uv pip install --group` functionality
-    fn new_context() -> Result<TestContext> {
+    fn new_context(server: &PackseServer) -> Result<TestContext> {
         let context = uv_test::test_context!("3.12");
 
         let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -11430,15 +11432,26 @@ fn dependency_group() -> Result<()> {
             "#,
         )?;
 
-        context.lock().assert().success();
+        context
+            .lock()
+            .arg("--index-url")
+            .arg(server.index_url())
+            .assert()
+            .success();
         Ok(context)
+    }
+
+    fn command(context: &TestContext, server: &PackseServer) -> Command {
+        let mut command = context.pip_install();
+        command.arg("--index-url").arg(server.index_url());
+        command
     }
 
     let mut context;
 
     // 'bar' using path sugar
-    context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_install()
+    context = new_context(&server)?;
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("--group").arg("bar"), @"
     success: true
     exit_code: 0
@@ -11453,8 +11466,8 @@ fn dependency_group() -> Result<()> {
 
     // 'bar' using path sugar
     // and also pulling in the same pyproject.toml with -r
-    context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_install()
+    context = new_context(&server)?;
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("-r").arg("pyproject.toml")
         .arg("--group").arg("bar"), @"
     success: true
@@ -11470,8 +11483,8 @@ fn dependency_group() -> Result<()> {
     ");
 
     // 'bar' with an explicit path
-    context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_install()
+    context = new_context(&server)?;
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("--group").arg("pyproject.toml:bar"), @"
     success: true
     exit_code: 0
@@ -11486,8 +11499,8 @@ fn dependency_group() -> Result<()> {
 
     // 'bar' using explicit path
     // and also pulling in the same pyproject.toml with -r
-    context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_install()
+    context = new_context(&server)?;
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("-r").arg("pyproject.toml")
         .arg("--group").arg("pyproject.toml:bar"), @"
     success: true
@@ -11503,8 +11516,8 @@ fn dependency_group() -> Result<()> {
     ");
 
     // 'bar' using path sugar
-    context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_install()
+    context = new_context(&server)?;
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("--group").arg("foo"), @"
     success: true
     exit_code: 0
@@ -11519,8 +11532,8 @@ fn dependency_group() -> Result<()> {
 
     // 'foo' using path sugar
     // 'bar' using path sugar
-    context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_install()
+    context = new_context(&server)?;
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("--group").arg("foo")
         .arg("--group").arg("bar"), @"
     success: true
@@ -11536,8 +11549,8 @@ fn dependency_group() -> Result<()> {
     ");
 
     // all together now!
-    context = new_context()?;
-    uv_snapshot!(context.filters(), context.pip_install()
+    context = new_context(&server)?;
+    uv_snapshot!(context.filters(), command(&context, &server)
         .arg("-r").arg("pyproject.toml")
         .arg("--group").arg("foo")
         .arg("--group").arg("bar"), @"

--- a/test/scenarios/simple/dependency-groups.toml
+++ b/test/scenarios/simple/dependency-groups.toml
@@ -1,0 +1,27 @@
+name = "dependency-groups"
+description = "Three independent packages used to test dependency-group selection."
+
+[root]
+requires = [
+  "iniconfig==2.0.0",
+  "sniffio==1.3.1",
+  "sortedcontainers==2.4.0",
+  "typing-extensions==4.10.0",
+]
+
+[expected]
+satisfiable = true
+
+[expected.packages]
+iniconfig = "2.0.0"
+sniffio = "1.3.1"
+sortedcontainers = "2.4.0"
+typing-extensions = "4.10.0"
+
+[packages.iniconfig.versions."2.0.0"]
+
+[packages.sniffio.versions."1.3.1"]
+
+[packages.sortedcontainers.versions."2.4.0"]
+
+[packages.typing-extensions.versions."4.10.0"]


### PR DESCRIPTION
Replace the live-PyPI packages in the `pip install` and `pip compile` dependency-group tests with a local Packse scenario. The tests still cover path syntax, combining project and group dependencies, and selecting multiple groups.

In [CI](https://github.com/astral-sh/uv/actions/runs/28959621503), total affected JUnit time (including the added generated scenario on Linux) fell from 4.19s to 3.50s on Linux (16% faster) and from 13.69s to 7.40s on Windows (46% faster).