### PR TITLE
Skip universal tests on macOS and Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           cargo nextest run \
             --cargo-profile fast-build \
-            --features test-python-patch,native-auth,secret-service \
+            --features test-python-patch,test-universal,native-auth,secret-service \
             --workspace \
             --profile ci-linux
 

--- a/crates/uv-dev/src/generate_scenarios.rs
+++ b/crates/uv-dev/src/generate_scenarios.rs
@@ -416,6 +416,9 @@ fn render_compile_case(output: &mut String, case: &ScenarioCase) -> Result<()> {
     if case.scenario.name.contains("patch") {
         output.push_str("#[cfg(feature = \"test-python-patch\")]\n");
     }
+    if case.scenario.resolver_options.universal {
+        output.push_str("#[cfg(feature = \"test-universal\")]\n");
+    }
     output.push_str("#[test]\n");
     writeln!(
         output,
@@ -923,7 +926,7 @@ fn requirement_specifiers(requirement: &Requirement) -> Option<&uv_pep440::Versi
 mod tests {
     use super::{
         TemplateKind, check_generated_file, compile_requirements, load_scenarios,
-        load_scenarios_from, render,
+        load_scenarios_from, module_name, render, scenarios_for_template,
     };
 
     #[test]
@@ -958,6 +961,26 @@ mod tests {
                 .find(|line| line.starts_with("#![cfg"))
                 .expect("scenario suite should contain a feature gate");
             assert_eq!(gate, expected_gate);
+        }
+    }
+
+    #[test]
+    fn universal_compile_scenarios_are_feature_gated() {
+        let scenarios = load_scenarios().expect("vendored scenarios should parse");
+        let cases = scenarios_for_template(TemplateKind::Compile, &scenarios);
+        let output =
+            render(TemplateKind::Compile, &cases).expect("compile scenario suite should render");
+        let mut universal_cases = cases
+            .into_iter()
+            .filter(|case| case.scenario.resolver_options.universal)
+            .peekable();
+
+        assert!(universal_cases.peek().is_some());
+        for case in universal_cases {
+            assert!(output.contains(&format!(
+                "#[cfg(feature = \"test-universal\")]\n#[test]\nfn {}()",
+                module_name(&case.scenario.name)
+            )));
         }
     }
 

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -182,7 +182,8 @@ test-defaults = [
   "test-python-managed",
   "test-python-eol",
   "test-slow",
-  "test-ecosystem"
+  "test-ecosystem",
+  "test-universal"
 ]
 # Introduces a testing dependency on crates.io.
 test-crates-io = []
@@ -206,6 +207,8 @@ test-python-managed = []
 test-slow = []
 # Includes test cases that require ecosystem packages
 test-ecosystem = []
+# Includes test cases for universal, platform-independent behavior.
+test-universal = []
 # Includes test cases that write to the Windows registry. These tests mutate
 # global state (the Windows registry).
 # We don't run these tests by default locally; the CI for Windows enables them.

--- a/crates/uv/tests/it/main.rs
+++ b/crates/uv/tests/it/main.rs
@@ -4,6 +4,7 @@ use uv_test::pypi_proxy;
 
 mod auth;
 
+#[cfg(all(feature = "test-pypi", feature = "test-universal"))]
 mod branching_urls;
 
 #[cfg(all(

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1,17 +1,24 @@
 use anyhow::Result;
+#[cfg(feature = "test-universal")]
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
+#[cfg(feature = "test-universal")]
 use url::Url;
 
 use uv_fs::Simplified;
+#[cfg(feature = "test-universal")]
 use uv_static::EnvVars;
+#[cfg(feature = "test-universal")]
 use uv_test::packse::PackseServer;
-#[cfg(feature = "test-git")]
+use uv_test::uv_snapshot;
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 use uv_test::{READ_ONLY_GITHUB_TOKEN, decode_token};
-use uv_test::{download_to_disk, uv_snapshot, venv_bin_path};
+#[cfg(feature = "test-universal")]
+use uv_test::{download_to_disk, venv_bin_path};
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_wheel_registry() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -144,6 +151,7 @@ fn lock_wheel_registry() -> Result<()> {
 }
 
 /// Lock a requirement from PyPI.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_sdist_registry() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-29T00:00:00Z");
@@ -238,8 +246,8 @@ fn lock_sdist_registry() -> Result<()> {
 }
 
 /// Lock a Git requirement using `tool.uv.sources`.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_sdist_git() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -508,8 +516,8 @@ fn lock_sdist_git() -> Result<()> {
 }
 
 /// Lock a Git requirement using PEP 508.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_sdist_git_subdirectory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -602,8 +610,8 @@ fn lock_sdist_git_subdirectory() -> Result<()> {
 }
 
 /// Lock a Git requirement using PEP 508.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_sdist_git_pep508() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -837,8 +845,8 @@ fn lock_sdist_git_pep508() -> Result<()> {
 }
 
 /// Lock a Git requirement using `tool.uv.sources` with a short revision.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_sdist_git_short_rev() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -945,8 +953,8 @@ fn lock_sdist_git_short_rev() -> Result<()> {
 }
 
 /// Lock a Git requirement that points to a pre-built source archive within a repository.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_sdist_git_archive() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1064,8 +1072,8 @@ fn lock_sdist_git_archive() -> Result<()> {
 }
 
 /// Reject a Git source archive when Git LFS was requested but could not be initialized.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_sdist_git_archive_missing_lfs() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1104,8 +1112,8 @@ fn lock_sdist_git_archive_missing_lfs() -> Result<()> {
 }
 
 /// Lock a Git requirement that points to a pre-built wheel within a repository.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_wheel_git_archive() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1225,8 +1233,8 @@ fn lock_wheel_git_archive() -> Result<()> {
 }
 
 /// Reject a Git wheel archive when Git LFS was requested but could not be initialized.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_wheel_git_archive_missing_lfs() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1265,6 +1273,7 @@ fn lock_wheel_git_archive_missing_lfs() -> Result<()> {
 }
 
 /// Lock a requirement from a direct URL to a wheel.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_wheel_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1419,6 +1428,7 @@ fn lock_wheel_url() -> Result<()> {
 }
 
 /// Lock a requirement from a direct URL to a source distribution.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_sdist_url() -> Result<()> {
     let server = PackseServer::new("simple/single-package.toml");
@@ -1526,6 +1536,7 @@ fn lock_sdist_url() -> Result<()> {
 }
 
 /// Lock a requirement from a direct URL to a source distribution, with a subdirectory.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_sdist_url_subdirectory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1663,6 +1674,7 @@ fn lock_sdist_url_subdirectory() -> Result<()> {
 }
 
 /// Lock a requirement from a direct URL to a source distribution, with a subdirectory.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_sdist_url_subdirectory_pep508() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1797,6 +1809,7 @@ fn lock_sdist_url_subdirectory_pep508() -> Result<()> {
 }
 
 /// Lock a project with an extra. When resolving, all extras should be included.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1941,6 +1954,7 @@ fn lock_project_extra() -> Result<()> {
 }
 
 /// Lock a project with `uv.tool.override-dependencies`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_overrides() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2000,6 +2014,7 @@ fn lock_project_with_overrides() -> Result<()> {
 }
 
 /// Lock a project with `tool.uv.override-dependencies` scoped to a package version.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_scoped_overrides() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2187,6 +2202,7 @@ fn lock_project_with_scoped_overrides() -> Result<()> {
 }
 
 /// Reject conflicting overrides scoped to the same package version.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_conflicting_scoped_overrides() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2223,6 +2239,7 @@ fn lock_project_with_conflicting_scoped_overrides() -> Result<()> {
 }
 
 /// Lock a project with `uv.tool.override-dependencies` that reference `tool.uv.sources`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_override_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2281,6 +2298,7 @@ fn lock_project_with_override_sources() -> Result<()> {
 }
 
 /// Reject a URL override scoped to a package version.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_scoped_override_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2314,6 +2332,7 @@ fn lock_project_with_scoped_override_url() -> Result<()> {
 }
 
 /// Lock a project with a pre-release pin from a scoped override.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_scoped_override_prerelease() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2026-01-01T00:00:00Z");
@@ -2354,6 +2373,7 @@ fn lock_project_with_scoped_override_prerelease() -> Result<()> {
 }
 
 /// Do not allow an excluded scoped override to opt a direct dependency into pre-releases.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_excluded_scoped_override_prerelease() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2026-01-01T00:00:00Z");
@@ -2397,6 +2417,7 @@ fn lock_project_with_excluded_scoped_override_prerelease() -> Result<()> {
 }
 
 /// Lock a project with an explicitly pinned yanked release from a scoped override.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_scoped_override_yank() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2432,6 +2453,7 @@ fn lock_project_with_scoped_override_yank() -> Result<()> {
 }
 
 /// Reject a scoped override from an explicit index.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_scoped_override_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2473,6 +2495,7 @@ fn lock_project_with_scoped_override_index() -> Result<()> {
 }
 
 /// Lock a project with `uv.tool.exclude-dependencies`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_excludes() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2672,6 +2695,7 @@ fn lock_project_with_excludes() -> Result<()> {
 }
 
 /// Lock a project with `uv.tool.constraint-dependencies`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_constraints() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2727,6 +2751,7 @@ fn lock_project_with_constraints() -> Result<()> {
 }
 
 /// Lock a project with `uv.tool.constraint-dependencies` that reference `tool.uv.sources`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_constraint_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2785,6 +2810,7 @@ fn lock_project_with_constraint_sources() -> Result<()> {
 }
 
 /// Lock a project with `uv.tool.build-constraint-dependencies`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_build_constraints() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2870,6 +2896,7 @@ fn lock_project_with_build_constraints() -> Result<()> {
 }
 
 /// Lock a project with `uv.tool.build-constraint-dependencies` that reference `tool.uv.sources`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_project_with_build_constraint_sources() -> Result<()> {
     let context = uv_test::test_context!("3.9");
@@ -2926,6 +2953,7 @@ fn lock_project_with_build_constraint_sources() -> Result<()> {
 }
 
 /// Lock a project with a dependency that has an extra.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dependency_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3122,7 +3150,7 @@ fn lock_dependency_extra() -> Result<()> {
 }
 
 /// Lock a project with a dependency that has a conditional extra.
-#[cfg(feature = "test-python-eol")]
+#[cfg(all(feature = "test-universal", feature = "test-python-eol"))]
 #[test]
 fn lock_conditional_dependency_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3424,6 +3452,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
 }
 
 /// Lock a project with a dependency that requests a non-existent extra.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dependency_non_existent_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3607,6 +3636,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
 
 /// This tests a "basic" case for specifying a group that conflicts with the
 /// project itself.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_project_basic1() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3801,6 +3831,7 @@ fn lock_conflicting_project_basic1() -> Result<()> {
 }
 
 /// This tests a case where workspace members conflict with each other.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_workspace_members() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3985,6 +4016,7 @@ fn lock_conflicting_workspace_members() -> Result<()> {
 
 /// Like [`lock_conflicting_workspace_members`], but the root project depends on the conflicting
 /// workspace member
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_workspace_members_depends_direct() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4058,6 +4090,7 @@ fn lock_conflicting_workspace_members_depends_direct() -> Result<()> {
 
 /// Like [`lock_conflicting_workspace_members_depends_direct`], but the root project depends on the
 /// conflicting workspace member via a direct optional dependency.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_workspace_members_depends_direct_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4259,6 +4292,7 @@ fn lock_conflicting_workspace_members_depends_direct_extra() -> Result<()> {
 
 /// Like [`lock_conflicting_workspace_members_depends_direct`], but the dependency is through an
 /// intermediate package without conflict.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_workspace_members_depends_transitive() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4356,6 +4390,7 @@ fn lock_conflicting_workspace_members_depends_transitive() -> Result<()> {
 
 /// Like [`lock_conflicting_workspace_members_depends_transitive`], but the dependency is through an
 /// intermediate package without conflict.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_workspace_members_depends_transitive_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4573,6 +4608,7 @@ fn lock_conflicting_workspace_members_depends_transitive_extra() -> Result<()> {
 
 /// This tests another "basic" case for specifying a group that conflicts with
 /// the project itself.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_project_basic2() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4766,6 +4802,7 @@ fn lock_conflicting_project_basic2() -> Result<()> {
 }
 
 /// This tests a case where we declare an extra and a group as conflicting.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_mixed() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4972,6 +5009,7 @@ fn lock_conflicting_mixed() -> Result<()> {
 }
 
 /// Show updated dependencies on `lock --upgrade`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_upgrade_log() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5142,6 +5180,7 @@ fn lock_upgrade_log() -> Result<()> {
 
 /// Show updated dependencies on `lock --upgrade`, with a package that resolves to multiple
 /// versions.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_upgrade_log_multi_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5305,6 +5344,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
 /// fork markers.
 ///
 /// Regression test for: <https://github.com/astral-sh/uv/issues/16839>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_upgrade_dry_run_multi_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5349,6 +5389,7 @@ fn lock_upgrade_dry_run_multi_version() -> Result<()> {
 /// canonical for workspace conflicts.
 ///
 /// Regression test for: <https://github.com/astral-sh/uv/issues/18553>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_check_refresh_workspace_conflicts() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5518,6 +5559,7 @@ fn lock_check_refresh_workspace_conflicts() -> Result<()> {
 }
 
 /// Respect the locked version in an existing lockfile.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_preference() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5690,8 +5732,8 @@ fn lock_preference() -> Result<()> {
 }
 
 /// If the user includes `git+` in a `tool.uv.sources` entry, we shouldn't fail.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_git_plus_prefix() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -5776,8 +5818,8 @@ fn lock_git_plus_prefix() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_partial_git() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -5934,6 +5976,7 @@ fn lock_partial_git() -> Result<()> {
 }
 
 /// See: <https://github.com/astral-sh/uv/issues/10654#issuecomment-2594022975>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_unsupported_tag() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -6017,8 +6060,8 @@ fn lock_unsupported_tag() -> Result<()> {
 }
 
 /// Respect locked versions with `uv lock`, unless `--upgrade` is passed.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_git_sha() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -6134,6 +6177,7 @@ fn lock_git_sha() -> Result<()> {
 }
 
 /// Lock a requirement from PyPI, respecting the `Requires-Python` metadata.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -6820,6 +6864,7 @@ fn lock_requires_python() -> Result<()> {
 
 /// Lock a requirement from PyPI, ignoring any dependencies that exceed the `requires-python`
 /// upper-bound.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_upper() -> Result<()> {
     let context = uv_test::test_context!("3.11").with_exclude_newer("2024-08-29T00:00:00Z");
@@ -6944,7 +6989,7 @@ fn lock_requires_python_upper() -> Result<()> {
 }
 
 /// Lock a requirement from PyPI with an exact Python bound.
-#[cfg(feature = "test-python-patch")]
+#[cfg(all(feature = "test-universal", feature = "test-python-patch"))]
 #[test]
 fn lock_requires_python_exact() -> Result<()> {
     let context = uv_test::test_context!("3.13.0");
@@ -7024,7 +7069,7 @@ fn lock_requires_python_exact() -> Result<()> {
 }
 
 /// Lock a requirement from PyPI with a compatible release Python bound.
-#[cfg(feature = "test-python-patch")]
+#[cfg(all(feature = "test-universal", feature = "test-python-patch"))]
 #[test]
 fn lock_requires_python_compatible_specifier() -> Result<()> {
     let context = uv_test::test_context!("3.13.0");
@@ -7088,6 +7133,7 @@ fn lock_requires_python_compatible_specifier() -> Result<()> {
 }
 
 /// Fork, even with a single dependency, if the minimum Python version is increased.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_fork() -> Result<()> {
     let context = uv_test::test_context!("3.11").with_exclude_newer("2024-08-29T00:00:00Z");
@@ -7181,6 +7227,7 @@ fn lock_requires_python_fork() -> Result<()> {
 }
 
 /// Lock a requirement from PyPI, respecting the `Requires-Python` metadata
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_wheels() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
@@ -7362,6 +7409,7 @@ fn lock_requires_python_wheels() -> Result<()> {
 
 /// Lock a requirement from PyPI, respecting the `Requires-Python` metadata. In this case,
 /// `Requires-Python` uses the equals-star syntax.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_star() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -7484,6 +7532,7 @@ fn lock_requires_python_star() -> Result<()> {
 
 /// Lock a requirement from PyPI, respecting the `Requires-Python` metadata. In this case,
 /// `Requires-Python` uses the != operator.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_not_equal() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -7563,6 +7612,7 @@ fn lock_requires_python_not_equal() -> Result<()> {
 /// Lock a requirement from PyPI, respecting the `Requires-Python` metadata. In this case,
 /// `Requires-Python` uses a pre-release specifier, but it's effectively ignored, as `>=3.11.0b1`
 /// is interpreted as equivalent to `>=3.11.0`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_pre() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -7684,6 +7734,7 @@ fn lock_requires_python_pre() -> Result<()> {
 }
 
 /// Warn if `Requires-Python` does not include a lower bound.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_unbounded() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -7783,6 +7834,7 @@ fn lock_requires_python_unbounded() -> Result<()> {
 }
 
 /// Error if `Requires-Python` is disjoint across the workspace.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_disjoint() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -7826,6 +7878,7 @@ fn lock_requires_python_disjoint() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_maximum_version() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -7982,6 +8035,7 @@ fn lock_requires_python_maximum_version() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_fewest_versions() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -8095,6 +8149,7 @@ fn lock_requires_python_fewest_versions() -> Result<()> {
 /// However, `python_full_version` should use PubGrub semantics, as (e.g.)
 /// `python_full_version >= '3.10' or python_full_version < '3.10'` will actually exclude versions
 /// like `3.10.0b0`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_python_version_marker_complement() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -8212,6 +8267,7 @@ fn lock_python_version_marker_complement() -> Result<()> {
 }
 
 /// Lock the development dependencies for a project.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dev() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8333,6 +8389,7 @@ fn lock_dev() -> Result<()> {
 }
 
 /// Lock a package that's included both conditionally and unconditionally in the lockfile.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conditional_unconditional() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8411,6 +8468,7 @@ fn lock_conditional_unconditional() -> Result<()> {
 }
 
 /// Lock a package that's included twice with different markers.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8607,6 +8665,7 @@ fn lock_relative_and_absolute_paths() -> Result<()> {
 }
 
 /// Check PEP 508 URL handling when they contain variables
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_pep508_urls_with_vars() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8938,6 +8997,7 @@ fn lock_index_absolute_path_from_config() -> Result<()> {
 }
 
 /// Lock a project that includes cyclic dependencies.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_cycles() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9141,6 +9201,7 @@ fn lock_cycles() -> Result<()> {
 }
 
 /// Ensures that stale lockfile metadata is detected.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_new_extras() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9414,6 +9475,7 @@ fn lock_new_extras() -> Result<()> {
 /// Ensure that the installer rejects invalid hashes from the lockfile.
 ///
 /// In this case, the hashes for `idna` have all been incremented by one in the left-most digit.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_invalid_hash() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9518,6 +9580,7 @@ fn lock_invalid_hash() -> Result<()> {
 /// Ensure that we can install from a lockfile when the index switches hash algorithms.
 /// First lock and sync with SHA256 hashes, then switch to SHA512 and lock/sync again
 /// without clearing the cache.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_mixed_hashes() -> Result<()> {
     let context = uv_test::test_context!("3.13");
@@ -9735,6 +9798,7 @@ fn lock_mixed_hashes() -> Result<()> {
 }
 
 /// Lock with an index which serves zstd-compressed wheels.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_zstd_wheel() -> Result<()> {
     use serde_json::json;
@@ -9862,6 +9926,7 @@ async fn lock_zstd_wheel() -> Result<()> {
 }
 
 /// Vary the `--resolution-mode`, and ensure that the lockfile is updated.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_resolution_mode() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10042,6 +10107,7 @@ fn lock_resolution_mode() -> Result<()> {
 
 /// Lock a requirement from PyPI, filtering out wheels that target an ABI that is non-overlapping
 /// with the `Requires-Python` constraint.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_requires_python_no_wheels() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10074,6 +10140,7 @@ fn lock_requires_python_no_wheels() -> Result<()> {
 
 /// In this case, a package is included twice at the same version, but pointing to different direct
 /// URLs.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_same_version_multiple_urls() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10258,6 +10325,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
 
 /// When locking with `--resolution-mode=lowest`, we should warn on unbounded direct
 /// dependencies.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_unsafe_lowest() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10301,6 +10369,7 @@ fn lock_unsafe_lowest() -> Result<()> {
 }
 
 /// Lock a package that's excluded from the parent workspace, but depends on that parent.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclusion() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10398,6 +10467,7 @@ fn lock_exclusion() -> Result<()> {
 }
 
 /// See: <https://github.com/astral-sh/uv/issues/9832#issuecomment-2539121761>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_relative_lock_deserialization() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10500,6 +10570,7 @@ fn lock_relative_lock_deserialization() -> Result<()> {
 }
 
 /// Lock a workspace member with a non-workspace source.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_non_workspace_source() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10554,6 +10625,7 @@ fn lock_non_workspace_source() -> Result<()> {
 }
 
 /// Lock a workspace member with a non-workspace source.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_no_workspace_source() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10608,6 +10680,7 @@ fn lock_no_workspace_source() -> Result<()> {
 ///
 /// Lock a workspace with a member that also supports standalone installation via platform-specific
 /// path sources.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_workspace_member_with_standalone_path_source() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10718,6 +10791,7 @@ fn lock_workspace_member_with_standalone_path_source() -> Result<()> {
 }
 
 /// Lock a workspace with a member that's a peer to the root.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_peer_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10823,6 +10897,7 @@ fn lock_peer_member() -> Result<()> {
 }
 
 /// Lock a workspace with a member whose directory contains a URL fragment delimiter.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_workspace_member_with_fragment_delimiter() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10905,6 +10980,7 @@ fn lock_workspace_member_with_fragment_delimiter() -> Result<()> {
 }
 
 /// Lock a workspace in which a member defines an explicit index that requires authentication.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_index_workspace_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -11049,6 +11125,7 @@ async fn lock_index_workspace_member() -> Result<()> {
 
 /// Ensure that development dependencies are omitted for non-workspace members. Below, `bar` depends
 /// on `foo`, but `bar/uv.lock` should omit `anyio`, but should include `typing-extensions`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dev_transitive() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -11227,6 +11304,7 @@ fn lock_dev_transitive() -> Result<()> {
 }
 
 /// Avoid persisting registry credentials in `uv.lock`.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_redact_http() -> Result<()> {
     // This test in particular seems to prompt a link mode warning
@@ -11425,6 +11503,7 @@ async fn lock_redact_http() -> Result<()> {
 }
 
 /// Test that packages aren't unnecessarily updated when an index URL contains a username.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_index_url_username_change_no_update() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -11502,8 +11581,8 @@ fn lock_index_url_username_change_no_update() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_redact_git_pep508() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_link_mode_warning();
     let token = decode_token(READ_ONLY_GITHUB_TOKEN);
@@ -11587,8 +11666,8 @@ fn lock_redact_git_pep508() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_redact_git_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_link_mode_warning();
     let token = decode_token(READ_ONLY_GITHUB_TOKEN);
@@ -11675,8 +11754,8 @@ fn lock_redact_git_sources() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_redact_git_pep508_non_project() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_link_mode_warning();
     let token = decode_token(READ_ONLY_GITHUB_TOKEN);
@@ -11756,6 +11835,7 @@ fn lock_redact_git_pep508_non_project() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_redact_index_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_link_mode_warning();
@@ -11851,6 +11931,7 @@ async fn lock_redact_index_sources() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_redact_url_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_link_mode_warning();
@@ -11940,6 +12021,7 @@ async fn lock_redact_url_sources() -> Result<()> {
 }
 
 /// Pass credentials for a named index via environment variables.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_env_credentials() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -12031,6 +12113,7 @@ async fn lock_env_credentials() -> Result<()> {
 /// Test solving for packages that are pinned to separate indexes in the same realm.
 /// This requires the credentials to be cached at the URL-level instead of the realm-level, or
 /// credentials for one index will be used for both indexes and the request will fail.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_multiple_indexes_same_realm_different_credentials() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -12079,6 +12162,7 @@ async fn lock_multiple_indexes_same_realm_different_credentials() -> Result<()> 
 
 // Same as [`lock_multiple_indexes_same_realm_different_credentials`], but with trailing slashes
 // on the index URL
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_multiple_indexes_same_realm_different_credentials_trailing_slash() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -12126,6 +12210,7 @@ async fn lock_multiple_indexes_same_realm_different_credentials_trailing_slash()
 }
 
 /// Resolve against an index that uses relative links.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_relative_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -12218,6 +12303,7 @@ async fn lock_relative_index() -> Result<()> {
 }
 
 /// Lock a package that's excluded from the parent workspace, but depends on that parent.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_no_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -12450,6 +12536,7 @@ fn lock_no_sources() -> Result<()> {
 }
 
 /// Lock a project that has an existing lockfile with a deprecated schema.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_migrate() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -12593,6 +12680,7 @@ fn lock_migrate() -> Result<()> {
 }
 
 /// Upgrade a specific package with `--upgrade-package`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_upgrade_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -12876,6 +12964,7 @@ fn lock_upgrade_package() -> Result<()> {
 }
 
 /// Upgrade all packages in a dependency group with `--upgrade-group`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_upgrade_group() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -12935,6 +13024,7 @@ fn lock_upgrade_group() -> Result<()> {
 }
 
 /// `--upgrade-group` only upgrades direct dependencies of the group, not transitive dependencies.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_upgrade_group_transitive() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13048,6 +13138,7 @@ fn lock_upgrade_group_transitive() -> Result<()> {
 
 /// `--upgrade-group` works for projects without a `[project]` table (e.g., virtual workspace
 /// roots), where dependency groups are stored in the lock manifest rather than on a package.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_upgrade_group_no_project_table() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13102,6 +13193,7 @@ fn lock_upgrade_group_no_project_table() -> Result<()> {
 }
 
 /// Check that we discard the fork marker from the lockfile when using `--upgrade`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_upgrade_drop_fork_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13146,6 +13238,7 @@ fn lock_upgrade_drop_fork_markers() -> Result<()> {
 }
 
 /// Warn when there are missing bounds on transitive dependencies with `--resolution lowest`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_warn_missing_transitive_lower_bounds() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13177,6 +13270,7 @@ fn lock_warn_missing_transitive_lower_bounds() -> Result<()> {
 }
 
 /// Lock a local wheel via `--find-links`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_local_wheel() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13291,6 +13385,7 @@ fn lock_find_links_local_wheel() -> Result<()> {
 }
 
 /// Prefer an explicit index over any `--find-links` entries.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_ignore_explicit_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13412,6 +13507,7 @@ fn lock_find_links_ignore_explicit_index() -> Result<()> {
 
 /// Ensure that `[[tool.uv.index]]` entries with `format = "flat"` can use relative paths in the
 /// `url` field.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_relative_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13528,6 +13624,7 @@ fn lock_find_links_relative_url() -> Result<()> {
 }
 
 /// Lock a local source distribution via `--find-links`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_local_sdist() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13640,6 +13737,7 @@ fn lock_find_links_local_sdist() -> Result<()> {
 }
 
 /// Lock a wheel over HTTP via `--find-links`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_http_wheel() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13734,6 +13832,7 @@ fn lock_find_links_http_wheel() -> Result<()> {
 }
 
 /// Lock a source distribution over HTTP via `--find-links`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_http_sdist() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13826,6 +13925,7 @@ fn lock_find_links_http_sdist() -> Result<()> {
 }
 
 /// Use an explicit `--find-links` index.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_explicit_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13932,6 +14032,7 @@ fn lock_find_links_explicit_index() -> Result<()> {
 }
 
 /// Use the same index priority rules, interchangeably, for `--find-links` and Simple API indexes.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_higher_priority_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -14023,6 +14124,7 @@ fn lock_find_links_higher_priority_index() -> Result<()> {
 }
 
 /// Use the same index priority rules, interchangeably, for `--find-links` and Simple API indexes.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_find_links_lower_priority_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -14131,6 +14233,7 @@ fn lock_find_links_lower_priority_index() -> Result<()> {
 }
 
 /// Lock against a local directory laid out as a PEP 503-compatible index.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_local_index() -> Result<()> {
     let context = uv_test::test_context!("3.13");
@@ -14278,6 +14381,7 @@ fn lock_local_index() -> Result<()> {
 /// `anyio`).
 ///
 /// When resolving, we should ignore the `tool.uv.sources` and instead pull in `anyio` from PyPI.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_sources_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -14402,6 +14506,7 @@ fn lock_sources_url() -> Result<()> {
 }
 
 /// Skip direct URL freshness checks while offline without skipping mutable transitive sources.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_sources_url_offline_validates_transitive_source_tree() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -14477,6 +14582,7 @@ fn lock_sources_url_offline_validates_transitive_source_tree() -> Result<()> {
 /// `anyio`).
 ///
 /// When resolving, we should ignore the `tool.uv.sources` and instead pull in `anyio` from PyPI.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_sources_archive() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -14613,6 +14719,7 @@ fn lock_sources_archive() -> Result<()> {
 /// `anyio`).
 ///
 /// When resolving, we should respect the `tool.uv.sources` and pull in the stub `anyio`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_sources_source_tree() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -14732,6 +14839,7 @@ fn lock_sources_source_tree() -> Result<()> {
 
 /// Lock a project in which a given dependency is requested from two different members, once as
 /// editable, and once as non-editable. This should trigger a conflicting URL error.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_editable() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -14888,6 +14996,7 @@ fn lock_editable() -> Result<()> {
 
 /// Lock a project in which a given dependency is requested from two different members, once as
 /// editable, and once as non-editable.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_mixed_extras() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15123,6 +15232,7 @@ fn lock_mixed_extras() -> Result<()> {
 
 /// Lock a project in which a given dependency is requested from two different members, once as
 /// editable, and once as non-editable.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_transitive_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15298,8 +15408,8 @@ fn lock_transitive_extra() -> Result<()> {
 
 /// If a source is provided via `tool.uv.sources` _and_ a URL is provided in `project.dependencies`,
 /// we accept the source in `tool.uv.sources`, unless `--no-sources` is provided.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_mismatched_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -15412,8 +15522,8 @@ fn lock_mismatched_sources() -> Result<()> {
 /// version is satisfied.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/4604>
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_mismatched_versions() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -15499,8 +15609,8 @@ fn lock_mismatched_versions() -> Result<()> {
 }
 
 /// Test that `--no-sources-package` allows selectively disabling sources for specific packages.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_no_sources_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -15604,8 +15714,8 @@ fn lock_no_sources_package() -> Result<()> {
 }
 
 /// Test that `--no-sources-package` works with multiple packages.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_no_sources_package_multiple() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -15722,8 +15832,8 @@ fn lock_no_sources_package_multiple() -> Result<()> {
 }
 
 /// Test that `--no-sources` takes precedence over `--no-sources-package`.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_no_sources_with_no_sources_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -15832,8 +15942,8 @@ fn lock_no_sources_with_no_sources_package() -> Result<()> {
 }
 
 /// Test that `UV_NO_SOURCES_PACKAGE` environment variable works.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_no_sources_package_env_var() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -15942,6 +16052,7 @@ fn lock_no_sources_package_env_var() -> Result<()> {
 
 /// This checks that overlapping marker expressions with disjoint
 /// version constraints fails to resolve.
+#[cfg(feature = "test-universal")]
 #[test]
 fn unconditional_overlapping_marker_disjoint_version_constraints() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15974,6 +16085,7 @@ fn unconditional_overlapping_marker_disjoint_version_constraints() -> Result<()>
 }
 
 /// Checks the output of `uv lock --check` when there isn't a lock
+#[cfg(feature = "test-universal")]
 #[test]
 fn check_no_lock() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -16002,6 +16114,7 @@ fn check_no_lock() -> Result<()> {
 }
 
 /// Checks the output of `uv lock --check` when the lock is outdated
+#[cfg(feature = "test-universal")]
 #[test]
 fn check_outdated_lock() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -16082,6 +16195,7 @@ fn check_outdated_lock() -> Result<()> {
 /// This checks that markers that normalize to 'false', which are serialized
 /// to the lockfile as `python_full_version < '0'`, get read back as false.
 /// Otherwise `uv lock --check` will always fail.
+#[cfg(feature = "test-universal")]
 #[test]
 fn normalize_false_marker_dependency_groups() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -16151,6 +16265,7 @@ fn normalize_false_marker_dependency_groups() -> Result<()> {
 /// This checks that markers that normalize to 'false', which are serialized
 /// to the lockfile as `python_full_version < '0'`, get read back as false.
 /// Otherwise `uv lock --check` will always fail.
+#[cfg(feature = "test-universal")]
 #[test]
 fn normalize_false_marker_requires_dist() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -16215,6 +16330,7 @@ fn normalize_false_marker_requires_dist() -> Result<()> {
 }
 
 /// Change indexes between locking operations.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_change_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -16339,6 +16455,7 @@ async fn lock_change_index() -> Result<()> {
 
 /// Lock a `pyproject.toml`, add a remove a workspace member, and ensure that the lockfile is
 /// updated on the next run.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_remove_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -16645,6 +16762,7 @@ fn lock_remove_member() -> Result<()> {
 ///
 /// This test would fail if we didn't write the list of workspace members to the lockfile, since
 /// we wouldn't be able to determine that a new member was added.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_add_member_with_build_system() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -16859,6 +16977,7 @@ fn lock_add_member_with_build_system() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_add_member_without_build_system() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17199,6 +17318,7 @@ fn lock_add_member_without_build_system() -> Result<()> {
 /// Lock a `pyproject.toml`, then add a dependency that's already included in the resolution.
 /// In theory, we shouldn't need to re-resolve, but based on our current strategy, we don't accept
 /// the existing lockfile.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_redundant_add_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17402,6 +17522,7 @@ fn lock_redundant_add_member() -> Result<()> {
 
 /// Lock a `pyproject.toml`, add a new constraint, and ensure that the lockfile is updated on the
 /// next run.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_new_constraints() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17602,6 +17723,7 @@ fn lock_new_constraints() -> Result<()> {
 
 /// Lock a `pyproject.toml`, add a new constraint, and ensure that the lockfile is updated on the
 /// next run.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_remove_member_non_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17773,6 +17895,7 @@ fn lock_remove_member_non_project() -> Result<()> {
 
 /// Lock a `pyproject.toml`, then rename the project, and ensure that the lockfile is updated on
 /// the next run.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_rename_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17922,6 +18045,7 @@ fn lock_rename_project() -> Result<()> {
 }
 
 /// Test backwards compatibility for `[package.metadata]`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_missing_metadata() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18064,6 +18188,7 @@ fn lock_missing_metadata() -> Result<()> {
 /// accidentally renamed to `package.dependency-groups` in v0.4.27, which is technically out of
 /// compliance with our lockfile versioning policy. In v0.4.28, we renamed it back to
 /// `package.dev-dependencies`, with backwards compatibility for `package.dependency-groups`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dev_dependencies_alias() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18211,6 +18336,7 @@ fn lock_dev_dependencies_alias() -> Result<()> {
 
 /// Lock a `pyproject.toml`, reorder the dependencies, and ensure that the lockfile is _not_ updated
 /// on the next run.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_reorder() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18342,6 +18468,7 @@ fn lock_reorder() -> Result<()> {
 }
 
 /// Ensure that `requires-python` bounds are correctly narrowed in the presence of upper-bound caps.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_narrowed_python_version_upper() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18452,6 +18579,7 @@ fn lock_narrowed_python_version_upper() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_narrowed_python_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18569,6 +18697,7 @@ fn lock_narrowed_python_version() -> Result<()> {
 /// our `requires-python` constraint.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/6059>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_unnecessary_python_forks() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18676,6 +18805,7 @@ fn lock_exclude_unnecessary_python_forks() -> Result<()> {
 }
 
 /// Lock with a user-provided constraint on the space of supported environments.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_constrained_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18994,6 +19124,7 @@ fn lock_constrained_environment() -> Result<()> {
 
 /// Lock with a user-provided constraint on the space of supported environments, using a
 /// non-project workspace root.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_constrained_environment_non_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -19158,6 +19289,7 @@ fn lock_constrained_environment_non_project() -> Result<()> {
 }
 
 /// User-provided constraints must be disjoint.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_overlapping_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -19191,6 +19323,7 @@ fn lock_overlapping_environment() -> Result<()> {
 }
 
 /// Lock a non-project workspace root with forked dev dependencies.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_non_project_fork() -> Result<()> {
     let context = uv_test::test_context!("3.10");
@@ -19387,6 +19520,7 @@ fn lock_non_project_fork() -> Result<()> {
 }
 
 /// Lock a non-project workspace root with a conditional dependency.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_non_project_conditional() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -19492,6 +19626,7 @@ fn lock_non_project_conditional() -> Result<()> {
 }
 
 /// Lock a non-project workspace root with `dependency-groups`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_non_project_group() -> Result<()> {
     let context = uv_test::test_context!("3.10");
@@ -19638,6 +19773,7 @@ fn lock_non_project_group() -> Result<()> {
 /// Here instead of leaning on `tool.uv.workspace` we use the
 /// officially blessed "pyproject.toml with no `[project]` that
 /// declares `[dependency-groups]`".
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_non_project_group_standard() -> Result<()> {
     let context = uv_test::test_context!("3.10");
@@ -19729,6 +19865,7 @@ fn lock_non_project_group_standard() -> Result<()> {
 }
 
 /// Lock a non-project workspace root with `tool.uv.sources`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_non_project_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -19814,6 +19951,7 @@ fn lock_non_project_sources() -> Result<()> {
 }
 
 /// Lock a non-project workspace root with conflicts declared between members.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_non_project_member_conflicts() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -19985,6 +20123,7 @@ fn lock_non_project_member_conflicts() -> Result<()> {
 
 /// Locking a non-project workspace root should reject conflicts that omit
 /// `package = ...`, since there is no root project name to infer.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_non_project_member_conflicts_missing_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -20034,6 +20173,7 @@ fn lock_non_project_member_conflicts_missing_package() -> Result<()> {
 }
 
 /// `coverage` defines a `toml` extra, but it doesn't enable any dependencies after Python 3.11.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dropped_dev_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -20151,6 +20291,7 @@ fn lock_dropped_dev_extra() -> Result<()> {
 }
 
 /// Lock with an empty (but existent) `tool.uv.dev-dependencies` group.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_empty_dev_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -20259,6 +20400,7 @@ fn lock_empty_dev_dependencies() -> Result<()> {
 }
 
 /// Lock with an empty (but existent) `dependency-groups` group.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_empty_dependency_group() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -20363,6 +20505,7 @@ fn lock_empty_dependency_group() -> Result<()> {
 }
 
 /// Add and remove an empty dependency group.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_add_empty_dependency_group() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -20606,6 +20749,7 @@ fn lock_add_empty_dependency_group() -> Result<()> {
 }
 
 /// Use a trailing slash on the declared index.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_trailing_slash_index_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -20730,6 +20874,7 @@ fn lock_trailing_slash_index_url() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_invalid_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -20777,6 +20922,7 @@ fn lock_invalid_index() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_explicit_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -20884,6 +21030,7 @@ fn lock_explicit_index() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_explicit_default_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21049,6 +21196,7 @@ fn lock_explicit_default_index() -> Result<()> {
 }
 
 /// Error when an explicit index does not have a name.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_unnamed_explicit_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21093,6 +21241,7 @@ fn lock_unnamed_explicit_index() -> Result<()> {
 }
 
 /// Error when an index cache-control override is not a valid HTTP header value.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_invalid_index_cache_control() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21139,6 +21288,7 @@ fn lock_invalid_index_cache_control() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_named_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21218,6 +21368,7 @@ async fn lock_named_index() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_default_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21350,6 +21501,7 @@ fn lock_default_index() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_named_index_cli() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -21442,6 +21594,7 @@ fn lock_named_index_cli() -> Result<()> {
 
 /// If a named index is referenced in `tool.uv.sources` but only defined in `uv.toml`, we should
 /// provide a hint that the index was found in a configuration file.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_named_index_config_file_hint() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21490,6 +21643,7 @@ fn lock_named_index_config_file_hint() -> Result<()> {
 /// If a named index is referenced in `tool.uv.sources` but only defined in a user-level `uv.toml`
 /// (e.g., `~/.config/uv/uv.toml`), we should provide a hint that the index was found in a
 /// configuration file.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg_attr(
     windows,
@@ -21544,6 +21698,7 @@ fn lock_named_index_user_config_file_hint() -> Result<()> {
 }
 
 /// If a name is reused, within a single file, we should raise an error.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_repeat_named_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21585,6 +21740,7 @@ fn lock_repeat_named_index() -> Result<()> {
 }
 
 /// If multiple indexes are marked as default within a single file, we should raise an error.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_default_indexes() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21628,6 +21784,7 @@ fn lock_multiple_default_indexes() -> Result<()> {
 }
 
 /// If a name is defined in both the workspace root and the member, prefer the index in the member.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_repeat_named_index_member() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -21742,6 +21899,7 @@ fn lock_repeat_named_index_member() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_unique_named_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -21817,6 +21975,7 @@ fn lock_unique_named_index() -> Result<()> {
 
 /// If a name is reused, the higher-priority index should "overwrite" the lower-priority index.
 /// This includes names passed in via the CLI.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_repeat_named_index_cli() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -21985,6 +22144,7 @@ fn lock_repeat_named_index_cli() -> Result<()> {
 /// index on other platforms.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/11776>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_named_index_overlap() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -22064,6 +22224,7 @@ fn lock_named_index_overlap() -> Result<()> {
 }
 
 /// Lock a project with `package = false`, making it a virtual project.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_explicit_virtual_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -22291,6 +22452,7 @@ fn lock_explicit_virtual_project() -> Result<()> {
 }
 
 /// Lock a project that is implicitly virtual (by way of omitting `build-system`).
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_implicit_virtual_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -22514,6 +22676,7 @@ fn lock_implicit_virtual_project() -> Result<()> {
 
 /// Lock a project that has a path dependency that is implicitly non-virtual (despite
 /// omitting `build-system`).
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_implicit_package_path() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -22675,6 +22838,7 @@ fn lock_implicit_package_path() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflicting_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -22705,6 +22869,7 @@ fn lock_conflicting_environment() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_split_python_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -22823,6 +22988,7 @@ fn lock_split_python_environment() -> Result<()> {
 /// Correctly narrow the Python requirement when upper bounds are present.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/6911>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_python_upper_bound() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -23189,6 +23355,7 @@ fn lock_python_upper_bound() -> Result<()> {
 }
 
 /// See: <https://github.com/astral-sh/uv/issues/7876>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_simplified_environments() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -23300,6 +23467,7 @@ fn lock_simplified_environments() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dependency_metadata() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -23538,8 +23706,8 @@ fn lock_dependency_metadata() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_dependency_metadata_git() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -23660,6 +23828,7 @@ fn lock_dependency_metadata_git() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_strip_fragment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -23744,6 +23913,7 @@ fn lock_strip_fragment() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_request_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -23788,6 +23958,7 @@ fn lock_request_requires_python() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_duplicate_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -23858,6 +24029,7 @@ fn lock_duplicate_sources() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_invalid_project_table() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -23903,6 +24075,7 @@ fn lock_invalid_project_table() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_missing_name() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -23934,6 +24107,7 @@ fn lock_missing_name() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_missing_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -23965,6 +24139,7 @@ fn lock_missing_version() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_unsupported_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -24056,6 +24231,7 @@ fn lock_unsupported_version() -> Result<()> {
 }
 
 /// See: <https://github.com/astral-sh/uv/issues/7618>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_change_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -24284,6 +24460,7 @@ fn lock_change_requires_python() -> Result<()> {
 }
 
 /// Retrieve credentials for a named index from the keyring.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_keyring_credentials() -> Result<()> {
     let keyring_context = uv_test::test_context!("3.12");
@@ -24381,6 +24558,7 @@ async fn lock_keyring_credentials() -> Result<()> {
 }
 
 /// Get credentials from the keyring with `explicit = true` and `authenticate = always`
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_keyring_explicit_always() -> Result<()> {
     let keyring_context = uv_test::test_context!("3.12");
@@ -24469,6 +24647,7 @@ async fn lock_keyring_explicit_always() -> Result<()> {
 
 /// Fetch credentials (including a username) for a named index via the keyring using `authenticate =
 /// always`
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_keyring_credentials_always_authenticate_fetches_username() -> Result<()> {
     let keyring_context = uv_test::test_context!("3.12");
@@ -24576,6 +24755,7 @@ async fn lock_keyring_credentials_always_authenticate_fetches_username() -> Resu
 
 /// Fetch credentials (including a username) for a named index via the keyring using `authenticate =
 /// always` — but the keyring version installed does not support `--mode creds`
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_keyring_credentials_always_authenticate_unsupported_mode() -> Result<()> {
     let keyring_context = uv_test::test_context!("3.12");
@@ -24633,6 +24813,7 @@ async fn lock_keyring_credentials_always_authenticate_unsupported_mode() -> Resu
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -24732,6 +24913,7 @@ fn lock_multiple_sources() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_conflict() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -24769,6 +24951,7 @@ fn lock_multiple_sources_conflict() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_no_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -24804,6 +24987,7 @@ fn lock_multiple_sources_no_marker() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_index_disjoint_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -24939,6 +25123,7 @@ fn lock_multiple_sources_index_disjoint_markers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_index_mixed() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -25077,6 +25262,7 @@ fn lock_multiple_sources_index_mixed() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_index_non_total() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -25177,6 +25363,7 @@ fn lock_multiple_sources_index_non_total() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_index_explicit() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -25328,6 +25515,7 @@ fn lock_multiple_sources_index_explicit() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_non_total() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -25429,6 +25617,7 @@ fn lock_multiple_sources_non_total() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_respect_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -25508,6 +25697,7 @@ fn lock_multiple_sources_respect_marker() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -25595,6 +25785,7 @@ fn lock_multiple_sources_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_index_overlapping_extras() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -25649,6 +25840,7 @@ fn lock_multiple_sources_index_overlapping_extras() -> Result<()> {
 }
 
 /// Sources will be ignored when an `extra` is applied, but references a non-existent extra.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_index_with_missing_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -25689,6 +25881,7 @@ fn lock_multiple_index_with_missing_extra() -> Result<()> {
 
 /// Sources will be ignored when an `extra` is applied, but the dependency isn't in an optional
 /// group.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_index_with_absent_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -25731,6 +25924,7 @@ fn lock_multiple_index_with_absent_extra() -> Result<()> {
 }
 
 /// Sources will be ignored when a `group` is applied, but references a non-existent group.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_index_with_missing_group() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -25771,6 +25965,7 @@ fn lock_multiple_index_with_missing_group() -> Result<()> {
 
 /// Sources will be ignored when a `group` is applied, but the dependency isn't in a dependency
 /// group.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_index_with_absent_group() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -25812,6 +26007,7 @@ fn lock_multiple_index_with_absent_group() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dry_run() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -25879,6 +26075,7 @@ fn lock_dry_run() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dry_run_noop() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -25942,6 +26139,7 @@ fn lock_dry_run_noop() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_include() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26126,6 +26324,7 @@ fn lock_group_include() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26244,6 +26443,7 @@ fn lock_group_requires_python() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_includes_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26395,6 +26595,7 @@ fn lock_group_includes_requires_python() -> Result<()> {
 }
 
 /// Referring to a dependency-group with group-requires-python that does not exist
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_requires_undefined_group() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26429,6 +26630,7 @@ fn lock_group_requires_undefined_group() -> Result<()> {
 }
 
 /// The legacy dev-dependencies cannot be referred to by group-requires-python
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_requires_dev_dep() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26463,6 +26665,7 @@ fn lock_group_requires_dev_dep() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_includes_requires_python_contradiction() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26586,6 +26789,7 @@ fn lock_group_includes_requires_python_contradiction() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_include_cycle() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26619,6 +26823,7 @@ fn lock_group_include_cycle() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_include_dev() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26654,6 +26859,7 @@ fn lock_group_include_dev() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_include_missing() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26685,6 +26891,7 @@ fn lock_group_include_missing() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_invalid_entry_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26732,6 +26939,7 @@ fn lock_group_invalid_entry_package() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_invalid_entry_group_name() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26767,6 +26975,7 @@ fn lock_group_invalid_entry_group_name() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_invalid_duplicate_group_name() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26803,6 +27012,7 @@ fn lock_group_invalid_duplicate_group_name() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_invalid_entry_table() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26834,6 +27044,7 @@ fn lock_group_invalid_entry_table() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_include_with_extra_key() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26866,6 +27077,7 @@ fn lock_group_include_with_extra_key() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_invalid_entry_type() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26901,6 +27113,7 @@ fn lock_group_invalid_entry_type() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_empty_entry_table() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -26936,6 +27149,7 @@ fn lock_group_empty_entry_table() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_group_workspace() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -27153,8 +27367,8 @@ fn lock_group_workspace() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_transitive_git() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -27297,6 +27511,7 @@ fn lock_transitive_git() -> Result<()> {
 }
 
 /// Lock a package with a dynamic version.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -27408,6 +27623,7 @@ fn lock_dynamic_version() -> Result<()> {
 }
 
 /// Lock a package with a dynamic version and dynamic dependencies.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_version_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -27519,6 +27735,7 @@ fn lock_dynamic_version_dependencies() -> Result<()> {
 
 /// Validating a lockfile with a dynamic version (but static dependencies) shouldn't require
 /// building the package.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_version_no_build() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -27585,6 +27802,7 @@ fn lock_dynamic_version_no_build() -> Result<()> {
 }
 
 /// Lock a package that depends on a package with a dynamic version using a `workspace` source.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_version_workspace_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -27776,6 +27994,7 @@ fn lock_dynamic_version_workspace_member() -> Result<()> {
 
 /// Lock a package that depends on a package with a dynamic version using a `path` source (as
 /// opposed to a workspace).
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_version_path_dependency() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -27953,6 +28172,7 @@ fn lock_dynamic_version_path_dependency() -> Result<()> {
 /// See: <https://github.com/astral-sh/uv/issues/10776>
 ///
 /// N.B. `hatchling` "flattens" recursive extras.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_version_self_extra_hatchling() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-01T00:00:00Z");
@@ -28107,6 +28327,7 @@ fn lock_dynamic_version_self_extra_hatchling() -> Result<()> {
 /// See: <https://github.com/astral-sh/uv/issues/10776>
 ///
 /// N.B. `setuptools` does not "flatten" recursive extras.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_version_self_extra_setuptools() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-01T00:00:00Z");
@@ -28265,6 +28486,7 @@ fn lock_dynamic_version_self_extra_setuptools() -> Result<()> {
 }
 
 /// See: <https://github.com/astral-sh/uv/issues/11047>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_built_cache() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -28386,6 +28608,7 @@ fn lock_dynamic_built_cache() -> Result<()> {
 }
 
 /// See: <https://github.com/astral-sh/uv/issues/11047>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_shared_build_dependency() -> Result<()> {
     let context = uv_test::test_context!("3.13").with_exclude_newer("2025-01-28T00:00:00Z");
@@ -28668,6 +28891,7 @@ fn lock_shared_build_dependency() -> Result<()> {
 }
 
 /// Re-lock after converting a package from dynamic to static.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_dynamic_to_static() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -28800,6 +29024,7 @@ fn lock_dynamic_to_static() -> Result<()> {
 }
 
 /// Re-lock after converting a package from static to dynamic.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_static_to_dynamic() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -28931,6 +29156,7 @@ fn lock_static_to_dynamic() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_bump_static_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29036,6 +29262,7 @@ fn lock_bump_static_version() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_derivation_chain_prod() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29093,6 +29320,7 @@ fn lock_derivation_chain_prod() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_derivation_chain_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29151,6 +29379,7 @@ fn lock_derivation_chain_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_derivation_chain_group() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29211,6 +29440,7 @@ fn lock_derivation_chain_group() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_derivation_chain_extended() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29284,6 +29514,7 @@ fn lock_derivation_chain_extended() -> Result<()> {
 
 /// The project itself is marked as an editable dependency, but under the wrong name. The project
 /// itself isn't a package.
+#[cfg(feature = "test-universal")]
 #[test]
 fn mismatched_name_self_editable() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29319,6 +29550,7 @@ fn mismatched_name_self_editable() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_relative_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29421,6 +29653,7 @@ fn lock_relative_project() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_recursive_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29530,6 +29763,7 @@ fn lock_recursive_extra() -> Result<()> {
 /// ```
 /// uv pip install dist/pymatgen-2024.10.3.tar.gz pymatgen[ci,optional] --resolution=lowest
 /// ```
+#[cfg(feature = "test-universal")]
 #[test]
 fn no_lowest_warning_with_name_and_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29567,6 +29801,7 @@ fn no_lowest_warning_with_name_and_url() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_no_build_static_metadata() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29664,6 +29899,7 @@ fn lock_no_build_static_metadata() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_no_build_dynamic_metadata() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29692,6 +29928,7 @@ fn lock_no_build_dynamic_metadata() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_compatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29792,6 +30029,7 @@ fn lock_self_compatible() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_exact() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29892,6 +30130,7 @@ fn lock_self_exact() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_incompatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -29922,6 +30161,7 @@ fn lock_self_incompatible() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_extra_to_extra_compatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30026,6 +30266,7 @@ fn lock_self_extra_to_extra_compatible() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_extra_to_same_extra_incompatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30059,6 +30300,7 @@ fn lock_self_extra_to_same_extra_incompatible() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_extra_to_other_extra_incompatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30093,6 +30335,7 @@ fn lock_self_extra_to_other_extra_incompatible() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_extra_compatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30197,6 +30440,7 @@ fn lock_self_extra_compatible() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_extra_incompatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30230,6 +30474,7 @@ fn lock_self_extra_incompatible() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_marker_compatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30330,6 +30575,7 @@ fn lock_self_marker_compatible() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_self_marker_incompatible() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30362,6 +30608,7 @@ fn lock_self_marker_incompatible() -> Result<()> {
 
 /// When resolving `PyQt5-Qt5`, we choose the latest version, even though it doesn't support
 /// Windows. This may change in the future.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_split_on_windows() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-12-18T00:00:00Z");
@@ -30453,8 +30700,8 @@ fn lock_split_on_windows() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn lock_missing_git_prefix() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -30486,6 +30733,7 @@ fn lock_missing_git_prefix() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_arm() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30561,6 +30809,7 @@ fn lock_arm() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_x86_64() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30637,6 +30886,7 @@ fn lock_x86_64() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_x86() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30710,6 +30960,7 @@ fn lock_x86() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_script() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30827,6 +31078,7 @@ fn lock_script() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_script_path() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -30966,6 +31218,7 @@ fn lock_script_path() -> Result<()> {
 ///
 /// `uv lock --script` should invalidate a script lockfile when a local editable dependency's
 /// `pyproject.toml` changes.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_script_editable_path_dependency_change() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -31139,6 +31392,7 @@ fn lock_script_editable_path_dependency_change() -> Result<()> {
 }
 
 /// `uv lock --script` should add a PEP 723 tag, if it doesn't exist already.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_script_initialize() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_missing_file_error();
@@ -31187,6 +31441,7 @@ fn lock_script_initialize() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_pytorch_cpu() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -31872,6 +32127,7 @@ fn lock_pytorch_cpu() -> Result<()> {
 /// in the PyTorch forks.
 ///
 /// Regression test for: <https://github.com/astral-sh/uv/issues/10772>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_pytorch_index_preferences() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -32366,6 +32622,7 @@ fn lock_pytorch_index_preferences() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_intel_mac() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-12-18T00:00:00Z");
@@ -32745,6 +33002,7 @@ fn lock_intel_mac() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_pytorch_local_preference() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -33091,6 +33349,7 @@ fn lock_pytorch_local_preference() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn windows_arm() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -33168,6 +33427,7 @@ fn windows_arm() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn windows_amd64_required() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -33243,6 +33503,7 @@ fn windows_amd64_required() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn windows_arm64_required() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -33316,6 +33577,7 @@ fn windows_arm64_required() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_empty_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -33511,6 +33773,7 @@ fn lock_empty_extra() -> Result<()> {
 
 /// The fork markers in the lockfile don't cover the supported environments (here: universal). We
 /// need to discard the lockfile.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_invalid_fork_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -33590,6 +33853,7 @@ fn lock_invalid_fork_markers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_omit_wheels_exclude_newer() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-08-01T00:00:00Z");
@@ -33681,6 +33945,7 @@ fn lock_omit_wheels_exclude_newer() -> Result<()> {
 }
 
 /// Check that we hint if the resolution failed in a different Python version.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflict_for_disjoint_python_version() -> Result<()> {
     let context = uv_test::test_context!("3.9");
@@ -33739,7 +34004,7 @@ fn lock_conflict_for_disjoint_python_version() -> Result<()> {
 }
 
 /// Check that we hint if the resolution failed for a different platform.
-#[cfg(feature = "test-python-patch")]
+#[cfg(all(feature = "test-universal", feature = "test-python-patch"))]
 #[test]
 fn lock_requires_python_empty_lock_file() -> Result<()> {
     // N.B. These versions were selected based on what was
@@ -33903,6 +34168,7 @@ fn lock_requires_python_empty_lock_file() -> Result<()> {
 }
 
 /// Check that we hint if the resolution failed for a different platform.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_conflict_for_disjoint_platform() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -33966,6 +34232,7 @@ fn lock_conflict_for_disjoint_platform() -> Result<()> {
 
 /// Add a package with an `--index` URL with no trailing slash while an index with the same URL
 /// exists with a trailing slash in the `pyproject.toml`.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_trailing_slash_index_url_in_pyproject_not_index_argument() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34099,6 +34366,7 @@ async fn lock_trailing_slash_index_url_in_pyproject_not_index_argument() -> Resu
 
 /// Run `uv lock --locked` with a lockfile with trailing slashes on the index URL but a
 /// `pyproject.toml` without a trailing slash on the index URL.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_trailing_slash_index_url_in_lockfile_not_pyproject() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34194,6 +34462,7 @@ async fn lock_trailing_slash_index_url_in_lockfile_not_pyproject() -> Result<()>
 
 /// Run `uv lock --locked` with `pyproject.toml` with trailing slashes on the index URL but a
 /// lockfile without trailing slashes on the index URL.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_trailing_slash_index_url_in_pyproject_and_not_lockfile() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34289,6 +34558,7 @@ async fn lock_trailing_slash_index_url_in_pyproject_and_not_lockfile() -> Result
 
 /// Run `uv lock --locked` with a lockfile and `pyproject.toml` with trailing slashes on the index
 /// URL.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_trailing_slash_index_url_in_lockfile_and_pyproject_toml() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34379,6 +34649,7 @@ async fn lock_trailing_slash_index_url_in_lockfile_and_pyproject_toml() -> Resul
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_trailing_slash_find_links() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34527,6 +34798,7 @@ fn lock_trailing_slash_find_links() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_prefix_match() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34556,6 +34828,7 @@ fn lock_prefix_match() -> Result<()> {
 }
 
 /// Regression test for <https://github.com/astral-sh/uv/issues/14231>.
+#[cfg(feature = "test-universal")]
 #[test]
 fn test_tilde_equals_python_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34587,6 +34860,7 @@ fn test_tilde_equals_python_version() -> Result<()> {
 }
 
 /// Test that a configured exclude-newer value can be disabled via the CLI.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_newer_disable_cli() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34637,6 +34911,7 @@ fn lock_exclude_newer_disable_cli() -> Result<()> {
 }
 
 /// Test that a configured exclude-newer value can be disabled via the environment.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_newer_disable_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34685,6 +34960,7 @@ fn lock_exclude_newer_disable_environment() -> Result<()> {
 }
 
 /// Test that exclude-newer can be disabled in configuration.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_newer_disable_config() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34733,6 +35009,7 @@ fn lock_exclude_newer_disable_config() -> Result<()> {
 }
 
 /// Test that exclude-newer-package can be disabled for specific packages using `false`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_newer_package_disable() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34821,6 +35098,7 @@ fn lock_exclude_newer_package_disable() -> Result<()> {
 }
 
 /// Test that exclude-newer-package is properly serialized in the lockfile.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_newer_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34965,6 +35243,7 @@ fn lock_exclude_newer_package() -> Result<()> {
 /// Test that the resolver emits a hint when all versions are excluded by `--exclude-newer`.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/18014>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_newer_hint() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35004,6 +35283,7 @@ fn lock_exclude_newer_hint() -> Result<()> {
 /// Regression test for:
 /// - <https://github.com/astral-sh/uv/issues/16813>
 /// - <https://github.com/astral-sh/uv/issues/18799>
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_exclude_newer_index_disable() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35089,6 +35369,7 @@ async fn lock_exclude_newer_index_disable() -> Result<()> {
 }
 
 /// Test that an index can set its own `exclude-newer` value, and package overrides still win.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_exclude_newer_index_value() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35186,6 +35467,7 @@ async fn lock_exclude_newer_index_value() -> Result<()> {
 /// even though older versions of the same package are still available.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/18949>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_newer_hint_pinned_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35225,6 +35507,7 @@ fn lock_exclude_newer_hint_pinned_version() -> Result<()> {
 /// release upper bound is excluded by `--exclude-newer`.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/19266>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_exclude_newer_hint_compatible_release() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35262,6 +35545,7 @@ fn lock_exclude_newer_hint_compatible_release() -> Result<()> {
 
 /// Test that lockfile validation includes explicit indexes from path dependencies.
 /// <https://github.com/astral-sh/uv/issues/11419>
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_path_dependency_explicit_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35340,6 +35624,7 @@ async fn lock_path_dependency_explicit_index() -> Result<()> {
 
 /// Test that lockfile validation includes explicit indexes from path dependencies
 /// defined in a non-root workspace member.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_path_dependency_explicit_index_workspace_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35440,6 +35725,7 @@ async fn lock_path_dependency_explicit_index_workspace_member() -> Result<()> {
 
 /// Test that lockfile validation works correctly when path dependency has
 /// both explicit and non-explicit indexes.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_path_dependency_mixed_indexes() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35522,6 +35808,7 @@ async fn lock_path_dependency_mixed_indexes() -> Result<()> {
 }
 
 /// Test that path dependencies without an index don't affect validation.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_path_dependency_no_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35586,6 +35873,7 @@ fn lock_path_dependency_no_index() -> Result<()> {
 /// child's `requires-python` is stricter than the root but compatible with the marker.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/18199>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_path_dependency_marker_gated_requires_python() -> Result<()> {
     // Use Python 3.9 as the interpreter to reproduce the issue: the installed Python (3.9)
@@ -35643,6 +35931,7 @@ fn lock_path_dependency_marker_gated_requires_python() -> Result<()> {
 }
 
 /// Test that a nested path dependency with an explicit index validates correctly.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_nested_path_dependency_explicit_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35738,6 +36027,7 @@ async fn lock_nested_path_dependency_explicit_index() -> Result<()> {
 }
 
 /// Test that validating circular path dependency indexes doesn't cause an infinite loop.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_circular_path_dependency_explicit_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35817,6 +36107,7 @@ async fn lock_circular_path_dependency_explicit_index() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_android() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-06-01T00:00:00Z");
@@ -35914,6 +36205,7 @@ fn lock_android() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_required_intersection() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -36017,6 +36309,7 @@ fn lock_required_intersection() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_refresh() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -36244,6 +36537,7 @@ fn lock_refresh() -> Result<()> {
 }
 
 /// Ensure conflicts on virtual packages (such as markers) give good error messages.
+#[cfg(feature = "test-universal")]
 #[test]
 fn collapsed_error_with_marker_packages() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -36279,6 +36573,7 @@ fn collapsed_error_with_marker_packages() -> Result<()> {
 }
 
 /// <https://github.com/astral-sh/uv/issues/16148>
+#[cfg(feature = "test-universal")]
 #[test]
 fn no_warning_without_and_with_lower_bound() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -36309,6 +36604,7 @@ fn no_warning_without_and_with_lower_bound() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_unsupported_wheel_url_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -36338,6 +36634,7 @@ fn lock_unsupported_wheel_url_requires_python() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_unsupported_wheel_url_supported_platform() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -36380,6 +36677,7 @@ fn lock_unsupported_wheel_url_supported_platform() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_unsupported_wheel_url_required_platform() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -36412,6 +36710,7 @@ fn lock_unsupported_wheel_url_required_platform() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_required_environment_cycle_reports_resolution_error() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -36500,6 +36799,7 @@ fn lock_required_environment_cycle_reports_resolution_error() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_supported_environment_wheel_only_package_requires_compatible_wheels() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -36565,6 +36865,7 @@ fn lock_supported_environment_wheel_only_package_requires_compatible_wheels() ->
 /// above the tag's version. When `tool.uv.environments` constrains to a specific Python version
 /// (e.g., 3.12), the resolver should recognize that a `cp37-abi3` wheel covers that environment
 /// rather than treating the `cp37` tag as an exact Python 3.7 requirement.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_supported_environment_abi3_wheel() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -36681,6 +36982,7 @@ fn lock_supported_environment_abi3_wheel() -> Result<()> {
 /// it's defined in a dependency group or the top-level `project.dependencies` field.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/16843>
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_check_multiple_default_indexes_explicit_assignment_dependency_group() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -36731,6 +37033,7 @@ async fn lock_check_multiple_default_indexes_explicit_assignment_dependency_grou
 }
 
 /// Do not panic with `u64::MAX` causing an `u64::MAX + 1` overflow.
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_tilde_equal_version_u64_max_rejected() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -36763,6 +37066,7 @@ fn lock_tilde_equal_version_u64_max_rejected() -> Result<()> {
 /// Test that `uv lock --frozen` and `UV_FROZEN=1` show a warning.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/12783>
+#[cfg(feature = "test-universal")]
 #[test]
 fn lock_frozen_warning() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/lock/main.rs
+++ b/crates/uv/tests/lock/main.rs
@@ -1,7 +1,15 @@
 //! Integration tests for `uv lock`.
 
-#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+#[cfg(all(
+    feature = "test-python",
+    feature = "test-pypi",
+    feature = "test-universal"
+))]
 use uv_test::pypi_proxy;
 
-#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+#[cfg(all(
+    feature = "test-python",
+    feature = "test-pypi",
+    feature = "test-universal"
+))]
 mod lock;

--- a/crates/uv/tests/lock/main.rs
+++ b/crates/uv/tests/lock/main.rs
@@ -7,9 +7,5 @@
 ))]
 use uv_test::pypi_proxy;
 
-#[cfg(all(
-    feature = "test-python",
-    feature = "test-pypi",
-    feature = "test-universal"
-))]
+#[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod lock;

--- a/crates/uv/tests/lock_scenarios/main.rs
+++ b/crates/uv/tests/lock_scenarios/main.rs
@@ -1,9 +1,18 @@
 //! Integration tests for lock scenarios and conflicts.
 
-#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+#[cfg(all(
+    feature = "test-python",
+    feature = "test-pypi",
+    feature = "test-universal"
+))]
 mod lock_conflict;
 
-#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+#[cfg(all(
+    feature = "test-python",
+    feature = "test-pypi",
+    feature = "test-universal"
+))]
 mod lock_exclude_newer_relative;
 
+#[cfg(feature = "test-universal")]
 mod lock_scenarios;

--- a/crates/uv/tests/pip/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip/pip_compile_scenarios.rs
@@ -67,6 +67,7 @@ fn command(context: &TestContext, python_versions: &[&str], server: &PackseServe
 ///         │   └── satisfied by forkleaf-1.1.0
 ///         └── requires python>=0
 /// ```
+#[cfg(feature = "test-universal")]
 #[test]
 fn lowest_direct_fork_max_python() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -140,6 +141,7 @@ fn lowest_direct_fork_max_python() -> Result<()> {
 ///         │   └── satisfied by forkleaf-1.1.0
 ///         └── requires python>=0
 /// ```
+#[cfg(feature = "test-universal")]
 #[test]
 fn lowest_direct_fork_min_python() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -218,6 +220,7 @@ fn lowest_direct_fork_min_python() -> Result<()> {
 ///         │   └── satisfied by forkleaf-1.1.0
 ///         └── requires python>=0
 /// ```
+#[cfg(feature = "test-universal")]
 #[test]
 fn lowest_fork_max_python() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -291,6 +294,7 @@ fn lowest_fork_max_python() -> Result<()> {
 ///         │   └── satisfied by forkleaf-1.1.0
 ///         └── requires python>=0
 /// ```
+#[cfg(feature = "test-universal")]
 #[test]
 fn lowest_fork_min_python() -> Result<()> {
     let context = uv_test::test_context!("3.11");

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -589,6 +589,7 @@ fn compile_constraint_extra() -> Result<()> {
 /// to false (for example, `python_version < '0'`).
 ///
 /// See: <https://github.com/astral-sh/uv/issues/8676>
+#[cfg(feature = "test-universal")]
 #[test]
 fn compile_constraints_omit_impossible_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2671,6 +2672,7 @@ fn compile_git_subdirectory_static_metadata() -> Result<()> {
 /// when re-running `uv pip compile`.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/18224>
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-git")]
 fn pep_751_compile_git_preferences() -> Result<()> {
@@ -8324,6 +8326,7 @@ fn no_strip_markers_transitive_marker() -> Result<()> {
 }
 
 /// Perform a universal resolution with a package that has a marker.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8369,6 +8372,7 @@ fn universal() -> Result<()> {
 }
 
 /// Perform a universal resolution with conflicting versions and markers.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_conflicting() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8418,6 +8422,7 @@ fn universal_conflicting() -> Result<()> {
 }
 
 /// Perform a universal resolution with a package that contains cycles in its dependency graph.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_cycles() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8476,6 +8481,7 @@ fn universal_cycles() -> Result<()> {
 }
 
 /// Perform a universal resolution with a constraint.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_constraint() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8517,6 +8523,7 @@ fn universal_constraint() -> Result<()> {
 }
 
 /// Perform a universal resolution with a constraint, where the constraint itself has a marker.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_constraint_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8563,6 +8570,7 @@ fn universal_constraint_marker() -> Result<()> {
 /// This currently fails, but should succeed.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/4640>
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_multi_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -8601,6 +8609,7 @@ fn universal_multi_version() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_platform_fork() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -8663,6 +8672,7 @@ fn universal_platform_fork() -> Result<()> {
 }
 
 /// Requested distinct local versions with disjoint markers.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_locals() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -8721,6 +8731,7 @@ fn universal_disjoint_locals() -> Result<()> {
 
 /// Requested distinct local versions with disjoint markers of a package
 /// that is also present as a transitive dependency.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_transitive_disjoint_locals() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -8802,6 +8813,7 @@ fn universal_transitive_disjoint_locals() -> Result<()> {
 }
 
 /// Prefer local versions for dependencies of path requirements.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_local_path_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -8873,6 +8885,7 @@ fn universal_local_path_requirement() -> Result<()> {
 
 /// If a dependency requests a local version with an overlapping marker expression,
 /// we should prefer the local in both forks.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_overlapping_local_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -8944,6 +8957,7 @@ fn universal_overlapping_local_requirement() -> Result<()> {
 
 /// If a dependency requests distinct local versions with disjoint marker expressions,
 /// we should fork the root requirement.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_local_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -9022,6 +9036,7 @@ fn universal_disjoint_local_requirement() -> Result<()> {
 
 /// If a dependency requests distinct local versions and non-local versions with disjoint marker
 /// expressions, we should fork the root requirement.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_base_or_local_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.10").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -9106,6 +9121,7 @@ fn universal_disjoint_base_or_local_requirement() -> Result<()> {
 /// If a dependency requests a local version with an overlapping marker expression
 /// that form a nested fork, we should prefer the local in both children of the outer
 /// fork.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_nested_overlapping_local_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -9267,6 +9283,7 @@ fn universal_nested_overlapping_local_requirement() -> Result<()> {
 
 /// If a dependency requests distinct local versions with disjoint marker expressions
 /// that form a nested fork, we should create a nested fork.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_nested_disjoint_local_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -9397,6 +9414,7 @@ fn existing_prerelease_preference() -> Result<()> {
 }
 
 /// Requested distinct pre-release strategies with disjoint markers.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_prereleases() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-07-17T00:00:00Z");
@@ -9428,6 +9446,7 @@ fn universal_disjoint_prereleases() -> Result<()> {
 }
 
 /// Requested distinct pre-release strategies with disjoint markers.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_prereleases_preference() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-07-17T00:00:00Z");
@@ -9469,6 +9488,7 @@ fn universal_disjoint_prereleases_preference() -> Result<()> {
 /// Requested distinct pre-release strategies with disjoint markers.
 ///
 /// TODO(charlie): This should resolve to two different `cffi` versions, one for each fork.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_prereleases_preference_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-07-17T00:00:00Z");
@@ -9510,6 +9530,7 @@ fn universal_disjoint_prereleases_preference_marker() -> Result<()> {
 
 /// Resolve to a single version as `--prerelease=allow` is provided, even though the first branch
 /// doesn't include a pre-release marker.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_prereleases_allow() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-07-17T00:00:00Z");
@@ -9546,6 +9567,7 @@ fn universal_disjoint_prereleases_allow() -> Result<()> {
 
 /// Requested distinct pre-release strategies with disjoint markers for a package
 /// that is also present as a transitive dependency.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_transitive_disjoint_prerelease_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-07-17T00:00:00Z");
@@ -9586,6 +9608,7 @@ fn universal_transitive_disjoint_prerelease_requirement() -> Result<()> {
 }
 
 /// Ensure that the global pre-release mode is respected across forks.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_prerelease_mode() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-07-17T00:00:00Z");
@@ -9619,6 +9642,7 @@ fn universal_prerelease_mode() -> Result<()> {
 
 /// If a dependency requests a pre-release version with an overlapping marker expression,
 /// we should prefer the pre-release version in both forks.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_overlapping_prerelease_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-07-17T00:00:00Z");
@@ -9667,6 +9691,7 @@ fn universal_overlapping_prerelease_requirement() -> Result<()> {
 
 /// If a dependency requests distinct pre-release strategies with disjoint marker expressions,
 /// we should fork the root requirement.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_prerelease_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-07-17T00:00:00Z");
@@ -9722,6 +9747,7 @@ fn universal_disjoint_prerelease_requirement() -> Result<()> {
 
 /// Perform a universal resolution that requires narrowing the supported Python range in one of the
 /// fork branches.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9756,6 +9782,7 @@ fn universal_requires_python() -> Result<()> {
 }
 
 /// Perform a universal resolution that requires narrowing the supported Python range in a non-fork.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_requires_python_incomplete() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9792,6 +9819,7 @@ fn universal_requires_python_incomplete() -> Result<()> {
 /// [1]: https://github.com/astral-sh/uv/issues/4885
 /// [2]: https://github.com/astral-sh/uv/pull/4707
 /// [3]: https://github.com/astral-sh/uv/pull/5597
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_no_repeated_unconditional_distributions_1() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9910,6 +9938,7 @@ fn universal_no_repeated_unconditional_distributions_1() -> Result<()> {
 /// This test captures a case[1] that was broken by marker normalization.
 ///
 /// [1]: https://github.com/astral-sh/uv/issues/6064
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_no_repeated_unconditional_distributions_2() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9963,6 +9992,7 @@ fn universal_no_repeated_unconditional_distributions_2() -> Result<()> {
 
 /// Solve for upper bounds before solving for lower bounds. A solution that satisfies `pylint < 3`
 /// can also work for `pylint > 2`, but the inverse isn't true (due to maximum version selection).
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_prefer_upper_bounds() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10019,6 +10049,7 @@ fn universal_prefer_upper_bounds() -> Result<()> {
 }
 
 /// Remove `python_version` markers that are always true.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_unnecessary_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10060,6 +10091,7 @@ fn universal_unnecessary_python() -> Result<()> {
 /// versions of `torch`.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/5086>
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_marker_propagation() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10159,6 +10191,7 @@ fn universal_marker_propagation() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10205,6 +10238,7 @@ fn universal_disjoint_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_extra_no_strip() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10256,6 +10290,7 @@ fn universal_disjoint_extra_no_strip() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_overlap_extra_base() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10302,6 +10337,7 @@ fn universal_overlap_extra_base() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_overlap_extra_base_no_strip() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10351,6 +10387,7 @@ fn universal_overlap_extra_base_no_strip() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_overlap_extras() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10397,6 +10434,7 @@ fn universal_overlap_extras() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_overlap_extras_no_strip() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10446,6 +10484,7 @@ fn universal_overlap_extras_no_strip() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_identical_extras() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -10492,6 +10531,7 @@ fn universal_identical_extras() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_identical_extras_no_strip() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -11090,6 +11130,7 @@ dev = [
 }
 
 /// Resolve from a `pyproject.toml` file with a recursive extra, with a marker attached.
+#[cfg(feature = "test-universal")]
 #[test]
 fn compile_pyproject_toml_recursive_extra_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -11141,6 +11182,7 @@ dev = [
 }
 
 /// Resolve from a `pyproject.toml` file with multiple recursive extras.
+#[cfg(feature = "test-universal")]
 #[test]
 fn compile_pyproject_toml_deeply_recursive_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -13374,6 +13416,7 @@ fn compile_index_url_first_match_base() -> Result<()> {
 ///
 /// If the package exists on the "extra" index, but at an incompatible version, the resolution
 /// should fail by default (even though a compatible version exists on the "primary" index).
+#[cfg(feature = "test-universal")]
 #[test]
 fn compile_index_url_first_match_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -14953,6 +14996,7 @@ fn symlink() -> Result<()> {
 
 /// Resolve with `--universal`, applying user-provided constraints to the space of supported
 /// environments.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_constrained_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15001,6 +15045,7 @@ fn universal_constrained_environment() -> Result<()> {
 }
 
 /// Resolve with `--universal`, requiring artifact coverage for user-provided environments.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_required_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15117,6 +15162,7 @@ fn compile_requires_txt() -> Result<()> {
 }
 
 /// Regression test for: <https://github.com/astral-sh/uv/issues/6269>
+#[cfg(feature = "test-universal")]
 #[test]
 fn astroid_not_repeated() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15254,6 +15300,7 @@ exceptiongroup==1.0.0rc8
 }
 
 /// Regression test for: <https://github.com/astral-sh/uv/issues/6412>
+#[cfg(feature = "test-universal")]
 #[test]
 fn tomli_less_than_python311() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15364,6 +15411,7 @@ matplotlib
 }
 
 /// Regression test for: <https://github.com/astral-sh/uv/issues/6836>
+#[cfg(feature = "test-universal")]
 #[test]
 fn importlib_metadata_not_repeated() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15426,6 +15474,7 @@ fn importlib_metadata_not_repeated() -> Result<()> {
 }
 
 /// Regression test for: <https://github.com/astral-sh/uv/issues/6836>
+#[cfg(feature = "test-universal")]
 #[test]
 fn prune_unreachable() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15472,6 +15521,7 @@ fn prune_unreachable() -> Result<()> {
 /// includes static metadata.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/8767>
+#[cfg(feature = "test-universal")]
 #[test]
 fn unsupported_requires_python_static_metadata() -> Result<()> {
     let context = uv_test::test_context!("3.11").with_exclude_newer("2024-11-04T00:00:00Z");
@@ -15502,6 +15552,7 @@ fn unsupported_requires_python_static_metadata() -> Result<()> {
 ///
 /// See: <https://github.com/astral-sh/uv/issues/8767>
 #[cfg(feature = "test-python-eol")]
+#[cfg(feature = "test-universal")]
 #[test]
 fn unsupported_requires_python_dynamic_metadata() -> Result<()> {
     let context = uv_test::test_context!("3.8").with_exclude_newer("2024-11-04T00:00:00Z");
@@ -15718,6 +15769,7 @@ fn invalid_platform() -> Result<()> {
 }
 
 /// Treat `sys_platform` and `sys.platform` as equivalent markers in the marker algebra.
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_deprecated_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15750,6 +15802,7 @@ fn universal_disjoint_deprecated_markers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_disjoint_override_urls() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15795,6 +15848,7 @@ fn universal_disjoint_override_urls() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn universal_conflicting_override_urls() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -15874,6 +15928,7 @@ fn compile_lowest_extra_unpinned_warning() -> Result<()> {
 }
 
 #[cfg(feature = "test-python-eol")]
+#[cfg(feature = "test-universal")]
 #[test]
 fn disjoint_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.8").with_exclude_newer("2025-01-29T00:00:00Z");
@@ -15968,6 +16023,7 @@ fn dynamic_version_source_dist() -> Result<()> {
 }
 
 #[cfg(feature = "test-python-eol")]
+#[cfg(feature = "test-universal")]
 #[test]
 fn max_python_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.8").with_exclude_newer("2024-12-18T00:00:00Z");
@@ -17011,6 +17067,7 @@ fn group_target_does_not_exist() -> Result<()> {
 
 /// See: <https://github.com/astral-sh/uv/issues/10957>
 #[cfg(feature = "test-python-eol")]
+#[cfg(feature = "test-universal")]
 #[test]
 fn compile_preserve_requires_python_split() -> Result<()> {
     let context = uv_test::test_context!("3.8").with_exclude_newer("2025-01-01T00:00:00Z");
@@ -17066,6 +17123,7 @@ fn compile_preserve_requires_python_split() -> Result<()> {
 }
 
 /// Regression test for <https://github.com/astral-sh/uv/issues/11279#issuecomment-2640270189>
+#[cfg(feature = "test-universal")]
 #[test]
 fn markers_on_extra_packages() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17100,6 +17158,7 @@ fn markers_on_extra_packages() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn respect_non_local_preference() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -17152,6 +17211,7 @@ fn respect_non_local_preference() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn omit_wheels_exclude_newer() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2024-08-01T00:00:00Z");
@@ -17217,6 +17277,7 @@ fn omit_wheels_exclude_newer() -> Result<()> {
 }
 
 /// See: <https://github.com/astral-sh/uv/issues/12260>
+#[cfg(feature = "test-universal")]
 #[test]
 fn compile_quotes() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17279,6 +17340,7 @@ fn compile_invalid_output_file() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_filename() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17305,6 +17367,7 @@ fn pep_751_filename() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_registry_wheel() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17354,6 +17417,7 @@ fn pep_751_compile_registry_wheel() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_registry_sdist() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-29T00:00:00Z");
@@ -17402,6 +17466,7 @@ fn pep_751_compile_registry_sdist() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17506,6 +17571,7 @@ fn pep_751_compile_directory() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-git")]
 fn pep_751_compile_git() -> Result<()> {
@@ -17557,6 +17623,7 @@ fn pep_751_compile_git() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_url_wheel() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17621,6 +17688,7 @@ fn pep_751_compile_url_wheel() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_url_sdist() -> Result<()> {
     let server = PackseServer::new("simple/single-package.toml");
@@ -17675,6 +17743,7 @@ fn pep_751_compile_url_sdist() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_path_wheel() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17754,6 +17823,7 @@ fn pep_751_compile_path_wheel() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_path_sdist() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -17834,6 +17904,7 @@ fn pep_751_compile_path_sdist() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_preferences() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18004,6 +18075,7 @@ fn pep_751_compile_preferences() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_warn() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18179,6 +18251,7 @@ fn pep_751_compile_non_universal() -> Result<()> {
 }
 
 /// Test that `--only-binary` excludes source distributions from pylock.toml output.
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_only_binary() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18217,6 +18290,7 @@ fn pep_751_compile_only_binary() -> Result<()> {
 }
 
 /// Test that `--no-binary` excludes wheels from pylock.toml output.
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_no_binary() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18254,6 +18328,7 @@ fn pep_751_compile_no_binary() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_compile_no_emit_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -18572,6 +18647,7 @@ fn git_path_transitive_dependency() -> Result<()> {
 }
 
 /// Ensure that `--emit-index-annotation` plays nicely with `--annotation-style=line`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn omit_python_patch_universal() -> Result<()> {
     let context = uv_test::test_context!("3.11");
@@ -18723,6 +18799,7 @@ fn post_release_less_than() -> Result<()> {
 /// The main test (first snapshot) builds a Windows wheel, and targets macOS. If we run this test on
 /// Linux, the wheel tag is neither host nor target, but we don't have a reason to reject the
 /// Windows tag either.
+#[cfg(feature = "test-universal")]
 #[test]
 fn compile_with_python_platform_and_built_wheel_for_different_platform() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -14,7 +14,9 @@ use fs_err::File;
 use futures::executor::block_on;
 use futures::io::AllowStdIo;
 use http::StatusCode;
-use indoc::{formatdoc, indoc};
+#[cfg(feature = "test-universal")]
+use indoc::formatdoc;
+use indoc::indoc;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use url::Url;
 use wiremock::matchers::{method, path};

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -2672,9 +2672,8 @@ fn compile_git_subdirectory_static_metadata() -> Result<()> {
 /// when re-running `uv pip compile`.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/18224>
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-git", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn pep_751_compile_git_preferences() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -17571,9 +17570,8 @@ fn pep_751_compile_directory() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-git", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn pep_751_compile_git() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/project/export.rs
+++ b/crates/uv/tests/project/export.rs
@@ -3,18 +3,24 @@
 use anyhow::{Ok, Result};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
+#[cfg(feature = "test-universal")]
 use indoc::{formatdoc, indoc};
+#[cfg(feature = "test-universal")]
 use insta::assert_snapshot;
-#[cfg(feature = "test-git")]
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 use std::path::Path;
 use std::process::Stdio;
-#[cfg(feature = "test-git")]
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 use uv_fs::Simplified;
+#[cfg(feature = "test-universal")]
 use uv_static::EnvVars;
-#[cfg(feature = "test-git")]
+#[cfg(feature = "test-universal")]
+use uv_test::copy_dir_ignore;
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 use uv_test::{READ_ONLY_GITHUB_SSH_DEPLOY_KEY, READ_ONLY_GITHUB_TOKEN, decode_token};
-use uv_test::{apply_filters, copy_dir_ignore, uv_snapshot};
+use uv_test::{apply_filters, uv_snapshot};
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_dependency() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -63,6 +69,7 @@ fn requirements_txt_dependency() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_export_no_header() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -109,6 +116,7 @@ fn requirements_txt_export_no_header() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_dependency_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -195,6 +203,7 @@ fn requirements_txt_dependency_extra() -> Result<()> {
 /// An optional dependency's marker can be omitted from the lockfile when the extra is only active
 /// in environments that satisfy the same marker. Ensure export restores the extra's activation
 /// marker instead of making the dependency unconditional.
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_conditional_transitive_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2026-05-12T00:00:00Z");
@@ -233,6 +242,7 @@ fn requirements_txt_conditional_transitive_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_project_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -385,6 +395,7 @@ fn requirements_txt_project_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_simplifies_selected_root_extra_markers_from_lock() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -460,6 +471,7 @@ fn requirements_txt_simplifies_selected_root_extra_markers_from_lock() -> Result
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_prune() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -525,6 +537,7 @@ fn requirements_txt_prune() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_dependency_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -577,6 +590,7 @@ fn requirements_txt_dependency_marker() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_dependency_multiple_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -660,6 +674,7 @@ fn requirements_txt_dependency_multiple_markers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_dependency_conflicting_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -904,6 +919,7 @@ fn requirements_txt_dependency_conflicting_markers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_non_root() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -965,6 +981,7 @@ fn requirements_txt_non_root() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn allrequirements_txt_() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1040,6 +1057,7 @@ fn allrequirements_txt_() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_frozen() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1128,6 +1146,7 @@ fn requirements_txt_frozen() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_create_missing_dir() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1206,6 +1225,7 @@ fn requirements_txt_create_missing_dir() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_non_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1261,6 +1281,7 @@ fn requirements_txt_non_project() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn virtual_empty() -> Result<()> {
     // testing how `uv export` reacts to a pyproject with no `[project]` and nothing useful to it
@@ -1287,6 +1308,7 @@ fn virtual_empty() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn virtual_dependency_group() -> Result<()> {
     // testing basic `uv export --group` functionality
@@ -1357,7 +1379,7 @@ fn virtual_dependency_group() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "test-git")]
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
 fn requirements_txt_https_git_credentials() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1422,7 +1444,7 @@ fn reduce_ssh_key_file_permissions(key_file: &Path) -> Result<()> {
 }
 
 /// Don't redact the username `git` in SSH URLs.
-#[cfg(feature = "test-git")]
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
 fn requirements_txt_ssh_git_username() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1511,6 +1533,7 @@ fn requirements_txt_ssh_git_username() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn requirements_txt_https_credentials() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1546,6 +1569,7 @@ async fn requirements_txt_https_credentials() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_non_project_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1601,6 +1625,7 @@ fn requirements_txt_non_project_marker() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_non_project_workspace() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1679,6 +1704,7 @@ fn requirements_txt_non_project_workspace() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_non_project_fork() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2003,6 +2029,7 @@ fn requirements_txt_relative_path() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn devrequirements_txt_() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2098,6 +2125,7 @@ fn devrequirements_txt_() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_no_hashes() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2140,6 +2168,7 @@ fn requirements_txt_no_hashes() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_output_file() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2207,6 +2236,7 @@ fn requirements_txt_output_file() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_no_emit() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2420,6 +2450,7 @@ fn requirements_txt_no_emit() -> Result<()> {
 /// even if the workspace has a single member (i.e., no additional packages).
 ///
 /// See: <https://github.com/astral-sh/uv/issues/18070>
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_no_emit_workspace_all_packages() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2466,6 +2497,7 @@ fn requirements_txt_no_emit_workspace_all_packages() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_only_emit() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2552,6 +2584,7 @@ fn requirements_txt_only_emit() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_no_editable() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2657,6 +2690,7 @@ fn requirements_txt_no_editable() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_export_group() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2834,6 +2868,7 @@ fn requirements_txt_export_group() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_script() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3097,6 +3132,7 @@ fn requirements_txt_script() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_conflicts() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3199,6 +3235,7 @@ fn requirements_txt_conflicts() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_simple_conflict_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3284,6 +3321,7 @@ fn requirements_txt_simple_conflict_markers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_complex_conflict_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -3659,6 +3697,7 @@ fn requirements_txt_complex_conflict_markers() -> Result<()> {
 }
 
 /// Export requirements in the presence of a cycle.
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_cyclic_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3744,6 +3783,7 @@ fn requirements_txt_cyclic_dependencies() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pylock_workspace_member_conflict_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
@@ -3953,6 +3993,7 @@ fn pylock_workspace_member_conflict_markers() -> Result<()> {
 }
 
 /// Export requirements in the presence of a cycle, with conflicts enabled.
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_cyclic_dependencies_conflict() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4052,6 +4093,7 @@ fn requirements_txt_cyclic_dependencies_conflict() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_dependency() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4116,6 +4158,7 @@ fn pep_751_dependency() -> Result<()> {
 }
 
 /// `packages` is a required key in PEP 751, even when there are no packages to export.
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_no_packages() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4150,6 +4193,7 @@ fn pep_751_no_packages() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_export_no_header() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4211,6 +4255,7 @@ fn pep_751_export_no_header() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_export_no_editable() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4274,6 +4319,7 @@ fn pep_751_export_no_editable() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_dependency_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4391,6 +4437,7 @@ fn pep_751_dependency_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_project_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4621,8 +4668,8 @@ fn pep_751_project_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn pep_751_git_dependency() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -4664,6 +4711,7 @@ fn pep_751_git_dependency() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_wheel_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4717,6 +4765,7 @@ fn pep_751_wheel_url() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_sdist_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4770,6 +4819,7 @@ fn pep_751_sdist_url() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_sdist_url_subdirectory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4833,6 +4883,7 @@ fn pep_751_sdist_url_subdirectory() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_infer_output_format() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -4969,6 +5020,7 @@ fn pep_751_infer_output_format() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_filename() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5003,7 +5055,7 @@ fn pep_751_filename() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "test-git")]
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
 fn pep_751_https_git_credentials() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5043,6 +5095,7 @@ fn pep_751_https_git_credentials() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn pep_751_https_credentials() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5086,6 +5139,7 @@ async fn pep_751_https_credentials() -> Result<()> {
 /// Check that relative and absolute paths are preserved in pylock.toml export.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/16514>
+#[cfg(feature = "test-universal")]
 #[test]
 fn pep_751_relative_and_absolute_paths() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5176,6 +5230,7 @@ fn pep_751_relative_and_absolute_paths() -> Result<()> {
 /// Support `UV_NO_EDITABLE=1 uv export`.
 ///
 /// <https://github.com/astral-sh/uv/issues/15103>
+#[cfg(feature = "test-universal")]
 #[test]
 fn no_editable_env_var() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5216,6 +5271,7 @@ fn no_editable_env_var() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn export_only_group_and_extra_conflict() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5269,6 +5325,7 @@ fn export_only_group_and_extra_conflict() -> Result<()> {
 }
 
 /// The members in the workspace (`foo`) and in the lockfile (`bar`) mismatch.
+#[cfg(feature = "test-universal")]
 #[test]
 fn export_lock_workspace_mismatch_with_frozen() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5313,6 +5370,7 @@ fn export_lock_workspace_mismatch_with_frozen() -> Result<()> {
 }
 
 /// Export multiple packages within a workspace.
+#[cfg(feature = "test-universal")]
 #[test]
 fn multiple_packages() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -5456,6 +5514,7 @@ fn multiple_packages() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_basic() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -5536,6 +5595,7 @@ fn cyclonedx_export_basic() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_direct_url() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -5617,7 +5677,7 @@ fn cyclonedx_export_direct_url() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "test-git")]
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
 fn cyclonedx_export_git_dependency() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -5699,6 +5759,7 @@ fn cyclonedx_export_git_dependency() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_no_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -5766,7 +5827,7 @@ fn cyclonedx_export_no_dependencies() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "test-git")]
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
 fn cyclonedx_export_mixed_source_types() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -5874,6 +5935,7 @@ fn cyclonedx_export_mixed_source_types() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_project_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -5959,6 +6021,7 @@ fn cyclonedx_export_project_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_project_extra_with_optional_flag() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -6066,6 +6129,7 @@ fn cyclonedx_export_project_extra_with_optional_flag() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_with_workspace_member() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -6229,6 +6293,7 @@ fn cyclonedx_export_with_workspace_member() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_workspace_non_root() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -6331,6 +6396,7 @@ fn cyclonedx_export_workspace_non_root() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_workspace_with_extras() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -6552,6 +6618,7 @@ fn cyclonedx_export_workspace_with_extras() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_workspace_frozen() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -6714,6 +6781,7 @@ fn cyclonedx_export_workspace_frozen() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_workspace_all_packages() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -6903,6 +6971,7 @@ fn cyclonedx_export_workspace_all_packages() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_all_packages_non_workspace_root_dependency() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -7002,6 +7071,7 @@ fn cyclonedx_export_all_packages_non_workspace_root_dependency() -> Result<()> {
 }
 
 // Contains a combination of combination of workspace and registry deps, with another workspace dep not depended on by the root
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_workspace_mixed_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -7180,6 +7250,7 @@ fn cyclonedx_export_workspace_mixed_dependencies() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_dependency_marker() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -7281,6 +7352,7 @@ fn cyclonedx_export_dependency_marker() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_multiple_dependency_markers() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -7409,6 +7481,7 @@ fn cyclonedx_export_multiple_dependency_markers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_dependency_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -7539,6 +7612,7 @@ fn cyclonedx_export_dependency_extra() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_prune() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -7723,6 +7797,7 @@ fn cyclonedx_export_prune() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_group() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -7955,6 +8030,7 @@ fn cyclonedx_export_group() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_non_project() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -8074,6 +8150,7 @@ fn cyclonedx_export_non_project() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_no_emit() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -8275,6 +8352,7 @@ fn cyclonedx_export_no_emit() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_relative_path() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -8387,6 +8465,7 @@ fn cyclonedx_export_relative_path() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_cyclic_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -8580,6 +8659,7 @@ fn cyclonedx_export_cyclic_dependencies() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_dev_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -8789,6 +8869,7 @@ fn cyclonedx_export_dev_dependencies() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_all_packages_conflicting_workspace_members() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -8967,6 +9048,7 @@ fn cyclonedx_export_all_packages_conflicting_workspace_members() -> Result<()> {
 }
 
 /// See: <https://github.com/astral-sh/uv/issues/18608>
+#[cfg(feature = "test-universal")]
 #[test]
 fn export_package_conflicting_workspace_members() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9109,6 +9191,7 @@ fn export_package_conflicting_workspace_members() -> Result<()> {
 /// should include its dependencies (not produce empty output).
 ///
 /// See: <https://github.com/astral-sh/uv/issues/18608>
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_conflicting_workspace_member_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9282,6 +9365,7 @@ fn requirements_txt_conflicting_workspace_member_package() -> Result<()> {
 
 /// Exporting the workspace root package should continue to include its dependencies
 /// even when it conflicts with another workspace member.
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_conflicting_workspace_root_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9375,6 +9459,7 @@ fn requirements_txt_conflicting_workspace_root_package() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_alternative_registry() -> Result<()> {
     let context = uv_test::test_context!("3.12")
@@ -9600,6 +9685,7 @@ fn cyclonedx_export_alternative_registry() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cyclonedx_export_virtual_workspace_fixture() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_cyclonedx_filters();
@@ -9769,6 +9855,7 @@ fn cyclonedx_export_virtual_workspace_fixture() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn pylock_toml_filter_by_requires_python() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -9827,6 +9914,7 @@ fn pylock_toml_filter_by_requires_python() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn requirements_txt_emit_indexes() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/project/export.rs
+++ b/crates/uv/tests/project/export.rs
@@ -1415,7 +1415,7 @@ fn requirements_txt_https_git_credentials() -> Result<()> {
 
 /// SSH blocks too permissive key files, so we need to scope permissions for the file to the current
 /// user.
-#[cfg(feature = "test-git")]
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
 fn reduce_ssh_key_file_permissions(key_file: &Path) -> Result<()> {
     #[cfg(unix)]
     {

--- a/crates/uv/tests/project/main.rs
+++ b/crates/uv/tests/project/main.rs
@@ -9,11 +9,7 @@ mod check;
 #[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod edit;
 
-#[cfg(all(
-    feature = "test-python",
-    feature = "test-pypi",
-    feature = "test-universal"
-))]
+#[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod export;
 
 #[cfg(all(feature = "test-python", feature = "test-r2"))]

--- a/crates/uv/tests/project/main.rs
+++ b/crates/uv/tests/project/main.rs
@@ -9,7 +9,11 @@ mod check;
 #[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod edit;
 
-#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+#[cfg(all(
+    feature = "test-python",
+    feature = "test-pypi",
+    feature = "test-universal"
+))]
 mod export;
 
 #[cfg(all(feature = "test-python", feature = "test-r2"))]

--- a/crates/uv/tests/project/tree.rs
+++ b/crates/uv/tests/project/tree.rs
@@ -5,6 +5,7 @@ use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
 use url::Url;
 
+#[cfg(feature = "test-universal")]
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
 
@@ -42,6 +43,7 @@ fn tree_centralized_environment_no_cache() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn nested_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -83,6 +85,7 @@ fn nested_dependencies() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn nested_platform_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -212,6 +215,7 @@ fn invert() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn frozen() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -274,6 +278,7 @@ fn frozen() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn outdated() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -312,6 +317,7 @@ fn outdated() -> Result<()> {
 /// Uses idna which has releases at:
 /// - 3.6: 2023-11-25
 /// - 3.7: 2024-04-11
+#[cfg(feature = "test-universal")]
 #[test]
 fn outdated_exclude_newer_relative() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -451,6 +457,7 @@ fn scoped_exclude_dependencies() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn platform_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -576,6 +583,7 @@ fn platform_dependencies_inverted() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn repeated_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -622,6 +630,7 @@ fn repeated_dependencies() -> Result<()> {
 
 /// In this case, a package is included twice at the same version, but pointing to different direct
 /// URLs.
+#[cfg(feature = "test-universal")]
 #[test]
 fn repeated_version() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -748,6 +757,7 @@ fn dev_dependencies() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn dev_dependencies_inverted() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -805,6 +815,7 @@ fn dev_dependencies_inverted() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn optional_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -855,6 +866,7 @@ fn optional_dependencies() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn optional_dependencies_inverted() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -920,6 +932,7 @@ fn optional_dependencies_inverted() -> Result<()> {
 /// When a package is required both as a plain dep and as a dep with extras (e.g., from a
 /// dependency group), `uv tree` should not display extra-conditional dependencies for the plain
 /// occurrence.
+#[cfg(feature = "test-universal")]
 #[test]
 fn dep_and_group_extras() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1334,6 +1347,7 @@ fn group() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cycle() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1420,6 +1434,7 @@ fn cycle() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cycle_no_orphaned_roots() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1452,6 +1467,7 @@ fn cycle_no_orphaned_roots() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cycle_no_infinite_loop() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1495,6 +1511,7 @@ fn cycle_no_infinite_loop() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cycle_invert() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1539,6 +1556,7 @@ fn cycle_invert() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cycle_depth_boundary_no_premature_dedupe() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1585,6 +1603,7 @@ fn cycle_depth_boundary_no_premature_dedupe() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cycle_invert_deep() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1637,6 +1656,7 @@ fn cycle_invert_deep() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn cycle_depth_no_dedupe() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1679,6 +1699,7 @@ fn cycle_depth_no_dedupe() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_dev() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1759,6 +1780,7 @@ fn workspace_dev() -> Result<()> {
 }
 
 /// An inverted tree should only follow consumers that activate the extra required by the path.
+#[cfg(feature = "test-universal")]
 #[test]
 fn invert_preserves_extra_attribution() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1840,6 +1862,7 @@ fn invert_preserves_extra_attribution() -> Result<()> {
 }
 
 /// Member dependency groups describe the root member, not consumers of that member.
+#[cfg(feature = "test-universal")]
 #[test]
 fn invert_preserves_dependency_group_attribution() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1906,6 +1929,7 @@ fn invert_preserves_dependency_group_attribution() -> Result<()> {
 }
 
 /// Universal inverted trees should not join edges from mutually exclusive environments.
+#[cfg(feature = "test-universal")]
 #[test]
 fn invert_preserves_marker_attribution() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1986,6 +2010,7 @@ fn invert_preserves_marker_attribution() -> Result<()> {
 
 /// Universal inverted trees should include every version that directly depends on a package in a
 /// satisfiable marker environment.
+#[cfg(feature = "test-universal")]
 #[test]
 fn invert_preserves_marker_split_versions() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2069,6 +2094,7 @@ fn invert_preserves_marker_split_versions() -> Result<()> {
 }
 
 /// Declared conflicts are world knowledge for the encoded extra and group markers.
+#[cfg(feature = "test-universal")]
 #[test]
 fn invert_preserves_conflict_marker_attribution() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2190,6 +2216,7 @@ fn invert_preserves_conflict_marker_attribution() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn non_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2228,6 +2255,7 @@ fn non_project() -> Result<()> {
 
 /// A pyproject.toml with only `[dependency-groups]` (no `[project]`, no `[tool.uv.workspace]`)
 /// is valid per PEP 735, and `uv tree` must handle it.
+#[cfg(feature = "test-universal")]
 #[test]
 fn dependency_groups_only() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2353,6 +2381,7 @@ fn non_project_group_selection_with_extras() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn non_project_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2826,6 +2855,7 @@ fn script() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn only_group() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2908,6 +2938,7 @@ fn only_group() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn show_sizes() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/workspace/workspace.rs
+++ b/crates/uv/tests/workspace/workspace.rs
@@ -586,9 +586,8 @@ fn test_uv_run_with_package_root_workspace() -> Result<()> {
 }
 
 /// Check that `uv run --isolated` creates isolated virtual environments.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-pypi", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-pypi")]
 fn test_uv_run_isolate() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let work_dir = context.temp_dir.join("albatross-root-workspace");
@@ -1588,9 +1587,8 @@ fn workspace_inherit_sources() -> Result<()> {
 }
 
 /// Tests error messages when a workspace member's dependencies cannot be resolved.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-pypi", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1645,9 +1643,8 @@ fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
 
 /// Tests error messages when a workspace member's dependencies conflict with
 /// another member's.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-pypi", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies_conflicting() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1714,9 +1711,8 @@ fn workspace_unsatisfiable_member_dependencies_conflicting() -> Result<()> {
 
 /// Tests error messages when a workspace member's dependencies conflict with
 /// two other member's.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-pypi", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies_conflicting_threeway() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1798,9 +1794,8 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_threeway() -> Result<
 
 /// Tests error messages when a workspace member's dependencies conflict with
 /// another member's optional dependencies.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-pypi", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies_conflicting_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1869,9 +1864,8 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_extra() -> Result<()>
 
 /// Tests error messages when a workspace member's dependencies conflict with
 /// another member's development dependencies.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-pypi", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies_conflicting_dev() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1941,9 +1935,8 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_dev() -> Result<()> {
 
 /// Tests error messages when a workspace member's name shadows a dependency of
 /// another member.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-pypi", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-pypi")]
 fn workspace_member_name_shadows_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -2073,9 +2066,8 @@ fn test_path_hopping() -> Result<()> {
 /// `c` is a package in a git workspace, and it has a workspace dependency to `d`. Check that we
 /// are correctly resolving `d` to a git dependency with a subdirectory and not relative to the
 /// checkout directory.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-git", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn transitive_dep_in_git_workspace_no_root() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -2149,9 +2141,8 @@ fn transitive_dep_in_git_workspace_no_root() -> Result<()> {
 /// `workspace-member-in-subdir` is a package in a git workspace, and it has a workspace dependency
 /// to `uv-git-workspace-in-root`. Check that we are correctly resolving `uv-git-workspace-in-root`
 /// to a git dependency without a subdirectory and not relative to the checkout directory.
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-git", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn transitive_dep_in_git_workspace_with_root() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -2223,9 +2214,8 @@ fn transitive_dep_in_git_workspace_with_root() -> Result<()> {
 /// checkout's root package.
 ///
 /// See: <https://github.com/astral-sh/uv/pull/18311#discussion_r3340828264>
-#[cfg(feature = "test-universal")]
+#[cfg(all(feature = "test-git", feature = "test-universal"))]
 #[test]
-#[cfg(feature = "test-git")]
 fn transitive_dep_in_git_workspace_with_cache_inside_workspace() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/workspace/workspace.rs
+++ b/crates/uv/tests/workspace/workspace.rs
@@ -5,9 +5,12 @@ use std::path::PathBuf;
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileWriteStr, PathChild};
+#[cfg(feature = "test-universal")]
 use assert_fs::prelude::FileTouch;
 use indoc::indoc;
-use insta::{assert_json_snapshot, assert_snapshot};
+use insta::assert_json_snapshot;
+#[cfg(feature = "test-universal")]
+use insta::assert_snapshot;
 use serde::{Deserialize, Serialize};
 
 use uv_test::{copy_dir_ignore, make_project, uv_snapshot};
@@ -583,6 +586,7 @@ fn test_uv_run_with_package_root_workspace() -> Result<()> {
 }
 
 /// Check that `uv run --isolated` creates isolated virtual environments.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-pypi")]
 fn test_uv_run_isolate() -> Result<()> {
@@ -757,6 +761,7 @@ struct Package {
 ///
 /// We have a main workspace with packages `a` and `b`, and a second workspace with `c`, `d` and
 /// `e`. We have `a -> b`, `b -> c`, `c -> d`. `e` should not be installed.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_to_workspace_paths_dependencies() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -853,6 +858,7 @@ fn workspace_to_workspace_paths_dependencies() -> Result<()> {
 }
 
 /// Ensure that workspace discovery skips an empty directory that matches a member glob.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_empty_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -896,6 +902,7 @@ fn workspace_empty_member() -> Result<()> {
 }
 
 /// Ensure that workspace discovery skips directories that only contain gitignored files.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_gitignored_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -964,6 +971,7 @@ fn workspace_gitignored_member() -> Result<()> {
 
 /// Ensure that workspace discovery skips directories that only contain gitignored
 /// files even if they're nested inside non-ignored directories.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_gitignored_member_in_subdirectory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1039,6 +1047,7 @@ fn workspace_gitignored_member_in_subdirectory() -> Result<()> {
 
 /// Ensure that workspace discovery skips directories that only contain files ignored via
 /// `.ignore` (not just `.gitignore`).
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_ignored_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1107,6 +1116,7 @@ fn workspace_ignored_member() -> Result<()> {
 
 /// Ensure that workspace discovery still errors for non-empty, non-gitignored directories
 /// missing a `pyproject.toml`.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_nonempty_member_no_pyproject() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1156,6 +1166,7 @@ fn workspace_nonempty_member_no_pyproject() -> Result<()> {
 }
 
 /// Ensure that workspace discovery ignores hidden directories.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_hidden_files() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1212,6 +1223,7 @@ fn workspace_hidden_files() -> Result<()> {
 }
 
 /// Ensure that workspace discovery accepts valid hidden directories.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_hidden_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1278,6 +1290,7 @@ fn workspace_hidden_member() -> Result<()> {
 }
 
 /// Ensure that workspace discovery accepts valid hidden directories.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_non_included_member() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1341,6 +1354,7 @@ fn workspace_non_included_member() -> Result<()> {
 ///
 /// In such cases, relative paths should be resolved relative to the workspace root, rather than
 /// relative to the member.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_inherit_sources() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -1574,6 +1588,7 @@ fn workspace_inherit_sources() -> Result<()> {
 }
 
 /// Tests error messages when a workspace member's dependencies cannot be resolved.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
@@ -1630,6 +1645,7 @@ fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
 
 /// Tests error messages when a workspace member's dependencies conflict with
 /// another member's.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies_conflicting() -> Result<()> {
@@ -1698,6 +1714,7 @@ fn workspace_unsatisfiable_member_dependencies_conflicting() -> Result<()> {
 
 /// Tests error messages when a workspace member's dependencies conflict with
 /// two other member's.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies_conflicting_threeway() -> Result<()> {
@@ -1781,6 +1798,7 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_threeway() -> Result<
 
 /// Tests error messages when a workspace member's dependencies conflict with
 /// another member's optional dependencies.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies_conflicting_extra() -> Result<()> {
@@ -1851,6 +1869,7 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_extra() -> Result<()>
 
 /// Tests error messages when a workspace member's dependencies conflict with
 /// another member's development dependencies.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-pypi")]
 fn workspace_unsatisfiable_member_dependencies_conflicting_dev() -> Result<()> {
@@ -1922,6 +1941,7 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_dev() -> Result<()> {
 
 /// Tests error messages when a workspace member's name shadows a dependency of
 /// another member.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-pypi")]
 fn workspace_member_name_shadows_dependencies() -> Result<()> {
@@ -1995,6 +2015,7 @@ fn workspace_member_name_shadows_dependencies() -> Result<()> {
 ///
 /// Each package is its own workspace. We put the other projects into a separate directory `libs` so
 /// the paths don't line up by accident.
+#[cfg(feature = "test-universal")]
 #[test]
 fn test_path_hopping() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2052,6 +2073,7 @@ fn test_path_hopping() -> Result<()> {
 /// `c` is a package in a git workspace, and it has a workspace dependency to `d`. Check that we
 /// are correctly resolving `d` to a git dependency with a subdirectory and not relative to the
 /// checkout directory.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-git")]
 fn transitive_dep_in_git_workspace_no_root() -> Result<()> {
@@ -2127,6 +2149,7 @@ fn transitive_dep_in_git_workspace_no_root() -> Result<()> {
 /// `workspace-member-in-subdir` is a package in a git workspace, and it has a workspace dependency
 /// to `uv-git-workspace-in-root`. Check that we are correctly resolving `uv-git-workspace-in-root`
 /// to a git dependency without a subdirectory and not relative to the checkout directory.
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-git")]
 fn transitive_dep_in_git_workspace_with_root() -> Result<()> {
@@ -2200,6 +2223,7 @@ fn transitive_dep_in_git_workspace_with_root() -> Result<()> {
 /// checkout's root package.
 ///
 /// See: <https://github.com/astral-sh/uv/pull/18311#discussion_r3340828264>
+#[cfg(feature = "test-universal")]
 #[test]
 #[cfg(feature = "test-git")]
 fn transitive_dep_in_git_workspace_with_cache_inside_workspace() -> Result<()> {
@@ -2382,6 +2406,7 @@ fn workspace_members_with_leading_dot_slash() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_members_with_parent_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2427,6 +2452,7 @@ fn workspace_members_with_parent_directory() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_members_with_complex_relative_paths() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2476,6 +2502,7 @@ fn workspace_members_with_complex_relative_paths() -> Result<()> {
 ///
 /// Uses `--verbose` to exercise the `debug!` log path, which previously panicked on
 /// `.unwrap()` when the `[project]` section was missing.
+#[cfg(feature = "test-universal")]
 #[test]
 fn workspace_unmanaged_member_no_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

This PR adds a `test-universal` feature for test cases whose results do not depend on the host platform. It remains in `test-defaults` and is explicitly enabled on Linux, but omitted on macOS and Windows (which continue to use `--no-default-features` without opting in).

The dedicated lock and lock-scenario suites, export and branching URL tests, universal `pip compile` and `uv tree` cases, and lock-only workspace cases are all gated under this flag. The sync and install tests are omitted (i.e., still run on each platform) since they install platform-specific artifacts. In the macOS CI feature configuration, this removes 660 tests from the affected binaries.

In [CI on this branch](https://github.com/astral-sh/uv/actions/runs/28961560957) compared with [CI for the exact base commit](https://github.com/astral-sh/uv/actions/runs/28961428604), macOS nextest wall time fell from 6:29 to 4:31 (30%) and the full `Cargo test` step fell from 9:42 to 7:03, saving 2:39 (27%). Windows ran 616 fewer tests; nextest's critical partition fell from 1:26 to 1:17 (10%) and aggregate test-case time across the three partitions fell by 7:04 (13%), although compilation and cache variance masked that gain in the full `Cargo test` step, which was 9 seconds slower in this sample.
