### PR TITLE
Use Packse for direct URL sdist tests

### DIFF
--- a/crates/uv-test/src/packse/server.rs
+++ b/crates/uv-test/src/packse/server.rs
@@ -103,6 +103,11 @@ impl PackseServer {
     pub fn index_url(&self) -> String {
         format!("{}/simple/", self.server.url())
     }
+
+    /// Return the URL for a generated distribution file.
+    pub fn file_url(&self, filename: &str) -> String {
+        format!("{}/files/{filename}", self.server.url())
+    }
 }
 
 /// Build the complete [`ServerIndex`] from a scenario and cached build dependencies.

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1421,26 +1421,28 @@ fn lock_wheel_url() -> Result<()> {
 /// Lock a requirement from a direct URL to a source distribution.
 #[test]
 fn lock_sdist_url() -> Result<()> {
+    let server = PackseServer::new("simple/single-package.toml");
     let context = uv_test::test_context!("3.12");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(
+    pyproject_toml.write_str(&formatdoc! {
         r#"
         [project]
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = ["anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz"]
+        dependencies = ["a @ {sdist_url}"]
         "#,
-    )?;
+        sdist_url = server.file_url("a-1.0.0.tar.gz"),
+    })?;
 
-    uv_snapshot!(context.filters(), context.lock(), @"
+    uv_snapshot!(context.filters(), context.lock().arg("--index-url").arg(server.index_url()), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 4 packages in [TIME]
+    Resolved 2 packages in [TIME]
     ");
 
     let lock = context.read("uv.lock");
@@ -1458,66 +1460,21 @@ fn lock_sdist_url() -> Result<()> {
         exclude-newer = "2024-03-25T00:00:00Z"
 
         [[package]]
-        name = "anyio"
-        version = "4.3.0"
-        source = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz" }
-        dependencies = [
-            { name = "idna" },
-            { name = "sniffio" },
-        ]
-        sdist = { hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" }
-
-        [package.metadata]
-        requires-dist = [
-            { name = "anyio", extras = ["trio"], marker = "extra == 'test'" },
-            { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7" },
-            { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.0.2" },
-            { name = "exceptiongroup", marker = "extra == 'test'", specifier = ">=1.2.0" },
-            { name = "hypothesis", marker = "extra == 'test'", specifier = ">=4.0" },
-            { name = "idna", specifier = ">=2.8" },
-            { name = "packaging", marker = "extra == 'doc'" },
-            { name = "psutil", marker = "extra == 'test'", specifier = ">=5.9" },
-            { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
-            { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.6.1" },
-            { name = "sniffio", specifier = ">=1.1" },
-            { name = "sphinx", marker = "extra == 'doc'", specifier = ">=7" },
-            { name = "sphinx-autodoc-typehints", marker = "extra == 'doc'", specifier = ">=1.2.0" },
-            { name = "sphinx-rtd-theme", marker = "extra == 'doc'" },
-            { name = "trio", marker = "extra == 'trio'", specifier = ">=0.23" },
-            { name = "trustme", marker = "extra == 'test'" },
-            { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1" },
-            { name = "uvloop", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32' and extra == 'test'", specifier = ">=0.17" },
-        ]
-        provides-extras = ["doc", "test", "trio"]
-
-        [[package]]
-        name = "idna"
-        version = "3.6"
-        source = { registry = "https://pypi.org/simple" }
-        sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426, upload-time = "2023-11-25T15:40:54.902Z" }
-        wheels = [
-            { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567, upload-time = "2023-11-25T15:40:52.604Z" },
-        ]
+        name = "a"
+        version = "1.0.0"
+        source = { url = "http://[LOCALHOST]/files/a-1.0.0.tar.gz" }
+        sdist = { hash = "sha256:3d2b4c28a4e112f3a1cef1db4dc5efa33fcbbcc38bc11ccc80321097db86c097" }
 
         [[package]]
         name = "project"
         version = "0.1.0"
         source = { virtual = "." }
         dependencies = [
-            { name = "anyio" },
+            { name = "a" },
         ]
 
         [package.metadata]
-        requires-dist = [{ name = "anyio", url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz" }]
-
-        [[package]]
-        name = "sniffio"
-        version = "1.3.1"
-        source = { registry = "https://pypi.org/simple" }
-        sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-        wheels = [
-            { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-        ]
+        requires-dist = [{ name = "a", url = "http://[LOCALHOST]/files/a-1.0.0.tar.gz" }]
         "#
         );
     });
@@ -1529,7 +1486,7 @@ fn lock_sdist_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 4 packages in [TIME]
+    Resolved 2 packages in [TIME]
     ");
 
     // Re-run with `--check --offline`. We cannot refresh direct URL metadata without network
@@ -1540,7 +1497,7 @@ fn lock_sdist_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 4 packages in [TIME]
+    Resolved 2 packages in [TIME]
     ");
 
     // Install from the lockfile.
@@ -1550,11 +1507,9 @@ fn lock_sdist_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 3 packages in [TIME]
-    Installed 3 packages in [TIME]
-     + anyio==4.3.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
-     + idna==3.6
-     + sniffio==1.3.1
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + a==1.0.0 (from http://[LOCALHOST]/files/a-1.0.0.tar.gz)
     ");
 
     // Re-install from the lockfile.
@@ -1564,7 +1519,7 @@ fn lock_sdist_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Checked 3 packages in [TIME]
+    Checked 1 package in [TIME]
     ");
 
     Ok(())

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -14,7 +14,7 @@ use fs_err::File;
 use futures::executor::block_on;
 use futures::io::AllowStdIo;
 use http::StatusCode;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use url::Url;
 use wiremock::matchers::{method, path};
@@ -17623,16 +17623,20 @@ fn pep_751_compile_url_wheel() -> Result<()> {
 
 #[test]
 fn pep_751_compile_url_sdist() -> Result<()> {
+    let server = PackseServer::new("simple/single-package.toml");
     let context = uv_test::test_context!("3.12");
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
-    requirements_txt.write_str(
-        "anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz",
-    )?;
+    requirements_txt.write_str(&formatdoc! {
+        "a @ {sdist_url}",
+        sdist_url = server.file_url("a-1.0.0.tar.gz"),
+    })?;
 
     uv_snapshot!(context.filters(), context
         .pip_compile()
         .arg("requirements.txt")
+        .arg("--index-url")
+        .arg(server.index_url())
         .arg("--universal")
         .arg("-o")
         .arg("pylock.toml"), @r#"
@@ -17646,24 +17650,12 @@ fn pep_751_compile_url_sdist() -> Result<()> {
     requires-python = ">=3.12"
 
     [[packages]]
-    name = "anyio"
-    version = "4.3.0"
-    archive = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hashes = { sha256 = "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" } }
-
-    [[packages]]
-    name = "idna"
-    version = "3.6"
-    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
-    wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
-
-    [[packages]]
-    name = "sniffio"
-    version = "1.3.1"
-    sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
-    wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
+    name = "a"
+    version = "1.0.0"
+    archive = { url = "http://[LOCALHOST]/files/a-1.0.0.tar.gz", hashes = { sha256 = "3d2b4c28a4e112f3a1cef1db4dc5efa33fcbbcc38bc11ccc80321097db86c097" } }
 
     ----- stderr -----
-    Resolved 3 packages in [TIME]
+    Resolved 1 package in [TIME]
     "#);
 
     uv_snapshot!(context.filters(), context.pip_sync()
@@ -17674,11 +17666,9 @@ fn pep_751_compile_url_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 3 packages in [TIME]
-    Installed 3 packages in [TIME]
-     + anyio==4.3.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
-     + idna==3.6
-     + sniffio==1.3.1
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + a==1.0.0 (from http://[LOCALHOST]/files/a-1.0.0.tar.gz)
     "
     );
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13314,27 +13314,33 @@ fn pep_751_install_url_wheel() -> Result<()> {
 
 #[test]
 fn pep_751_install_url_sdist() -> Result<()> {
+    let server = PackseServer::new("simple/single-package.toml");
     let context = uv_test::test_context!("3.12");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(
+    pyproject_toml.write_str(&formatdoc! {
         r#"
         [project]
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = ["anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz"]
+        dependencies = ["a @ {sdist_url}"]
         "#,
-    )?;
+        sdist_url = server.file_url("a-1.0.0.tar.gz"),
+    })?;
 
     context
         .export()
+        .arg("--index-url")
+        .arg(server.index_url())
         .arg("-o")
         .arg("pylock.toml")
         .assert()
         .success();
 
     uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--index-url")
+        .arg(server.index_url())
         .arg("--preview")
         .arg("-r")
         .arg("pylock.toml"), @"
@@ -13343,15 +13349,15 @@ fn pep_751_install_url_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 3 packages in [TIME]
-    Installed 3 packages in [TIME]
-     + anyio==4.3.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
-     + idna==3.6
-     + sniffio==1.3.1
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + a==1.0.0 (from http://[LOCALHOST]/files/a-1.0.0.tar.gz)
     "
     );
 
     uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--index-url")
+        .arg(server.index_url())
         .arg("--preview")
         .arg("-r")
         .arg("pylock.toml"), @"
@@ -13360,7 +13366,7 @@ fn pep_751_install_url_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Checked 3 packages in [TIME]
+    Checked 1 package in [TIME]
     "
     );
 


### PR DESCRIPTION
Replace live `files.pythonhosted.org` sdists in the lock and PEP 751 direct-URL tests with Packse’s generated `a` sdist. A small Packse helper exposes generated artifact URLs so the tests continue exercising direct URLs while keeping package metadata and build dependencies local.

In [CI](https://github.com/astral-sh/uv/actions/runs/28964587124), combined JUnit time fell from 6.604s to 2.263s on Linux (2.9x faster) and from 13.448s to 3.532s on Windows (3.8x faster).