### PR TITLE
Use Packse for sync override package test

### DIFF
--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -8593,7 +8593,12 @@ fn sync_wheel_path_source_error() -> Result<()> {
 
 #[test]
 fn sync_override_package() -> Result<()> {
+    let server = PackseServer::empty();
     let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("uv.toml")
+        .write_str(&format!("index-url = \"{}\"", server.index_url()))?;
 
     // Create a dependency.
     let pyproject_toml = context.temp_dir.child("core").child("pyproject.toml");


### PR DESCRIPTION
Replace live PyPI build-dependency resolution in `sync_override_package` with Packse’s cached Hatchling dependency index. The test still exercises every transition between package and virtual path sources while keeping its repeated local builds off the network.

In [CI](https://github.com/astral-sh/uv/actions/runs/28971436076), JUnit time fell from 2.342s to 1.896s on Linux (1.2x faster) and was effectively unchanged on Windows (4.836s to 4.767s).