### PR TITLE
Use Packse for no-sources editable switch test

### DIFF
--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -16897,7 +16897,12 @@ fn only_group_and_extra_conflict() -> Result<()> {
 /// See: <https://github.com/astral-sh/uv/issues/15190>
 #[test]
 fn sync_no_sources_editable_to_package_switch() -> Result<()> {
+    let server = PackseServer::new("simple/single-package.toml");
     let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("uv.toml")
+        .write_str(&format!("index-url = \"{}\"", server.index_url()))?;
 
     // Create a local package that will be used as editable dependency.
     let local_dep = context.temp_dir.child("local_dep");
@@ -16907,9 +16912,9 @@ fn sync_no_sources_editable_to_package_switch() -> Result<()> {
     local_dep_pyproject.write_str(
         r#"
         [project]
-        name = "anyio"
-        version = "4.3.0"
-        description = "Local test package mimicking anyio"
+        name = "a"
+        version = "2.0.0"
+        description = "Local test package"
         requires-python = ">=3.8"
 
         [build-system]
@@ -16926,10 +16931,10 @@ fn sync_no_sources_editable_to_package_switch() -> Result<()> {
         name = "test_no_sources"
         version = "0.0.1"
         requires-python = ">=3.12"
-        dependencies = ["anyio"]
+        dependencies = ["a"]
 
         [tool.uv.sources]
-        anyio = { path = "./local_dep", editable = true }
+        a = { path = "./local_dep", editable = true }
 
         [build-system]
         requires = ["setuptools>=67"]
@@ -16940,19 +16945,17 @@ fn sync_no_sources_editable_to_package_switch() -> Result<()> {
         "#,
     )?;
 
-    // Step 1: `uv sync --no-sources` should install `anyio` from PyPI.
+    // Step 1: `uv sync --no-sources` should install `a` from the registry.
     uv_snapshot!(context.filters(), context.sync().arg("--no-sources"), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 4 packages in [TIME]
-    Prepared 4 packages in [TIME]
-    Installed 4 packages in [TIME]
-     + anyio==4.3.0
-     + idna==3.6
-     + sniffio==1.3.1
+    Resolved 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + a==2.0.0
      + test-no-sources==0.0.1 (from file://[TEMP_DIR]/)
     ");
 
@@ -16965,28 +16968,24 @@ fn sync_no_sources_editable_to_package_switch() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
-    Uninstalled 3 packages in [TIME]
+    Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
-     - anyio==4.3.0
-     + anyio==4.3.0 (from file://[TEMP_DIR]/local_dep)
-     - idna==3.6
-     - sniffio==1.3.1
+     - a==2.0.0
+     + a==2.0.0 (from file://[TEMP_DIR]/local_dep)
     ");
 
-    // Step 3: `uv sync --no-sources` again should switch back to PyPI package.
+    // Step 3: `uv sync --no-sources` again should switch back to the registry package.
     uv_snapshot!(context.filters(), context.sync().arg("--no-sources"), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 4 packages in [TIME]
+    Resolved 2 packages in [TIME]
     Uninstalled 1 package in [TIME]
-    Installed 3 packages in [TIME]
-     - anyio==4.3.0 (from file://[TEMP_DIR]/local_dep)
-     + anyio==4.3.0
-     + idna==3.6
-     + sniffio==1.3.1
+    Installed 1 package in [TIME]
+     - a==2.0.0 (from file://[TEMP_DIR]/local_dep)
+     + a==2.0.0
     ");
 
     Ok(())


### PR DESCRIPTION
Replace the live `anyio` dependency graph in `sync_no_sources_editable_to_package_switch` with Packse’s generated `a` package. The test still switches repeatedly between an editable path source and a registry distribution under `--no-sources`, while keeping registry and build-dependency resolution local.

In [CI](https://github.com/astral-sh/uv/actions/runs/28971856341), JUnit time fell from 2.107s to 1.866s on Linux (1.1x faster) and rose from 4.464s to 4.900s on Windows (1.1x slower).