### PR TITLE
docs: clarify that --exclude can be used multiple times

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2592,7 +2592,7 @@ pub struct PipFreezeArgs {
     #[arg(long)]
     pub exclude_editable: bool,
 
-    /// Exclude the specified package(s) from the output.
+    /// Exclude the specified package(s) from the output (can be used multiple times).
     #[arg(long)]
     pub r#exclude: Vec<PackageName>,
 
@@ -2663,7 +2663,7 @@ pub struct PipListArgs {
     #[arg(long, conflicts_with = "editable")]
     pub exclude_editable: bool,
 
-    /// Exclude the specified package(s) from the output.
+    /// Exclude the specified package(s) from the output (can be used multiple times).
     #[arg(long, value_hint = ValueHint::Other)]
     pub r#exclude: Vec<PackageName>,
 


### PR DESCRIPTION
This updates the CLI documentation for `--exclude` under `uv pip freeze` and `uv pip list` to note that it can be specified multiple times.

Refs #18429