### PR TITLE
Compress embedded Python download metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7032,6 +7032,7 @@ dependencies = [
  "clap",
  "configparser",
  "dunce",
+ "flate2",
  "fs-err",
  "futures",
  "indexmap",

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -44,6 +44,7 @@ clap = { workspace = true, optional = true }
 configparser = { workspace = true }
 dunce = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
+flate2 = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
@@ -88,4 +89,5 @@ test-log = { workspace = true }
 [build-dependencies]
 uv-static = { workspace = true }
 
+flate2 = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/uv-python/build.rs
+++ b/crates/uv-python/build.rs
@@ -4,6 +4,8 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::{env, fs};
 
+use flate2::{Compression, GzBuilder};
+
 use uv_static::EnvVars;
 
 fn process_json(data: &serde_json::Value) -> serde_json::Value {
@@ -26,7 +28,7 @@ fn main() {
 
     let version_metadata_minified = PathBuf::from_iter([
         env::var(EnvVars::OUT_DIR).unwrap(),
-        "download-metadata-minified.json".into(),
+        "download-metadata-minified.json.gz".into(),
     ]);
 
     println!(
@@ -48,16 +50,22 @@ fn main() {
     let filtered_data = process_json(&json_data);
 
     #[expect(clippy::disallowed_types)]
-    let mut out_file = File::create(version_metadata_minified)
-        .expect("failed to open download-metadata-minified.json");
+    let out_file = File::create(version_metadata_minified)
+        .expect("failed to open download-metadata-minified.json.gz");
+    let mut encoder = GzBuilder::new()
+        .mtime(0)
+        .write(out_file, Compression::best());
 
-    out_file
+    encoder
         .write_all(
             serde_json::to_string(&filtered_data)
                 .expect("Failed to serialize JSON")
                 .as_bytes(),
         )
-        .expect("Failed to write minified JSON");
+        .expect("Failed to compress minified JSON");
+    let out_file = encoder
+        .finish()
+        .expect("Failed to finish compressing minified JSON");
 
     // Cargo uses the modified times of the paths specified in
     // `rerun-if-changed`, so fetch the current file times and set them the same
@@ -72,5 +80,5 @@ fn main() {
                 .set_accessed(meta.accessed().unwrap())
                 .set_modified(meta.modified().unwrap()),
         )
-        .expect("failed to write file times to download-metadata-minified.json");
+        .expect("failed to write file times to download-metadata-minified.json.gz");
 }

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
@@ -8,6 +9,7 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant, SystemTimeError};
 use std::{env, io};
 
+use flate2::read::GzDecoder;
 use futures::TryStreamExt;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
@@ -946,8 +948,18 @@ impl FromStr for PythonDownloadRequest {
     }
 }
 
-const BUILTIN_PYTHON_DOWNLOADS_JSON: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/download-metadata-minified.json"));
+const BUILTIN_PYTHON_DOWNLOADS_GZIP: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/download-metadata-minified.json.gz"
+));
+
+/// Decompress the built-in Python download catalog.
+fn builtin_python_downloads_json() -> Result<Vec<u8>, Error> {
+    let mut decoder = GzDecoder::new(BUILTIN_PYTHON_DOWNLOADS_GZIP);
+    let mut json = Vec::new();
+    decoder.read_to_end(&mut json)?;
+    Ok(json)
+}
 
 pub struct ManagedPythonDownloadList {
     downloads: Vec<ManagedPythonDownload>,
@@ -1052,10 +1064,10 @@ impl ManagedPythonDownloadList {
         };
 
         let json_downloads = match json_source {
-            Source::BuiltIn => parse_downloads_json(
-                BUILTIN_PYTHON_DOWNLOADS_JSON,
-                "EMBEDDED IN THE BINARY".to_owned(),
-            )?,
+            Source::BuiltIn => {
+                let json = builtin_python_downloads_json()?;
+                parse_downloads_json(&json, "EMBEDDED IN THE BINARY".to_owned())?
+            }
             Source::Path(ref path) => parse_downloads_json(
                 &fs_err::read(path.as_ref())?,
                 path.to_string_lossy().to_string(),
@@ -1083,8 +1095,9 @@ impl ManagedPythonDownloadList {
     /// Load available Python distributions from the compiled-in list only.
     /// for testing purposes.
     pub fn new_only_embedded() -> Result<Self, Error> {
-        let json_downloads: HashMap<String, JsonPythonDownload> =
-            serde_json::from_slice(BUILTIN_PYTHON_DOWNLOADS_JSON).map_err(|e| {
+        let json = builtin_python_downloads_json()?;
+        let json_downloads: HashMap<String, JsonPythonDownload> = serde_json::from_slice(&json)
+            .map_err(|e| {
                 Error::InvalidPythonDownloadsJSON("EMBEDDED IN THE BINARY".to_owned(), e)
             })?;
         let result = parse_json_downloads(json_downloads);


### PR DESCRIPTION
The release binary embeds the managed-Python download catalog as 2,400,105 bytes of plain JSON. Compressing that static payload at build time removes the largest single read-only object without removing any Python download metadata.

## Summary

- Emit a deterministic gzip stream from the `uv-python` build script.
- Decompress the embedded catalog before parsing it through the existing built-in paths.

The generated payload is 283,981 bytes. With the same stripped fat-LTO `cargo build --release --bin uv` profile, the binary falls from 65,682,352 bytes to 63,649,008 bytes: 2,033,344 bytes smaller (-3.10%).

The focused embedded-catalog tests pass, `uv-python` clippy and formatting pass, and the release binary passes `--help`, `--version`, and built-in Python catalog listing smoke checks.
