### PR TITLE
Abort panics in release builds for smaller binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,6 +388,8 @@ large_stack_arrays = "allow"
 [profile.release]
 strip = true
 lto = "fat"
+# This will still show a panic message, we only skip the unwind.
+panic = "abort"
 
 # This profile is meant to mimic the `release` profile as closely as
 # possible, but using settings that are more beneficial for iterative
@@ -450,8 +452,6 @@ strip = "debuginfo"
 [profile.minimal-size]
 inherits = "release"
 opt-level = "z"
-# This will still show a panic message, we only skip the unwind
-panic = "abort"
 codegen-units = 1
 
 # The profile that 'cargo dist' will build with.


### PR DESCRIPTION
Replace unwinding on panics with aborting on panics, to shrink the uv binary.

The stripped fat-LTO release binary goes from 63.6MB to 53.0MB (-17%), a zipped wheel from 26.1 MiB to 21.3 MiB (-18%). The release build process itself sees a similar speedup.

This speeds up the installation of uv and is smaller on disk and in images. Surprisingly, it does not speed up uv itself.

The windows handler is still respected: https://doc.rust-lang.org/beta/nightly-rustc/src/rustc_session/session.rs.html#796-799

The drawback is that if a panic happens while uv is using a temporary directory, we don't clean that temp dir up. This is similar to when uv gets killed for other reasons, e.g. an OOM. Those temp dirs should also generally be in a location such as the cache or `dist`, i.e. we don't litter in random (project) directories. We already may leave the venv in a half-finished state even with unwinding since writing to venvs isn't atomic. Another drawback is that `catch_unwind` isn't respected anymore.

Given how rare panics are (we barely see any reports), I think the tradeoff is worth it. Or put the other way round: I couldn't justify a 5MB/23% larger wheel for the better behavior with unwinding.