### PR TITLE
Update Rust toolchain to 1.97 and MSRV to 1.95

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -16,7 +16,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   # renovate: datasource=github-releases depName=astral-sh/hawk
-  HAWK_VERSION: 0.1.5
+  HAWK_VERSION: 0.1.6
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
@@ -161,13 +161,13 @@ jobs:
         with:
           persist-credentials: false
       - name: "Install Rust toolchain"
-        run: rustup toolchain install 1.96.1
+        run: rustup toolchain install 1.97.0
       - name: "Install Hawk"
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
       - name: "Hawk"
-        run: cargo +1.96.1 hawk -D warnings
+        run: cargo +1.97.0 hawk -D warnings
 
   shear:
     name: "cargo shear"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.94.0"
+rust-version = "1.95.0"
 homepage = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"
 authors = ["uv"]

--- a/crates/uv-build/rust-toolchain.toml
+++ b/crates/uv-build/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.0"

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -715,8 +715,8 @@ if __name__ == "__main__":
             .expect("We should succeed at reading the launcher")
             .expect("The launcher should be valid");
 
-        assert!(launcher.kind == LauncherKind::Script);
-        assert!(launcher.python_path == python_executable_path);
+        assert_eq!(launcher.kind, LauncherKind::Script);
+        assert_eq!(launcher.python_path, python_executable_path);
 
         // Now code-sign the launcher and verify that it still works.
         sign_authenticode(console_bin_path.path());
@@ -766,8 +766,8 @@ if __name__ == "__main__":
             .expect("We should succeed at reading the launcher")
             .expect("The launcher should be valid");
 
-        assert!(launcher.kind == LauncherKind::Python);
-        assert!(launcher.python_path == python_executable_path);
+        assert_eq!(launcher.kind, LauncherKind::Python);
+        assert_eq!(launcher.python_path, python_executable_path);
 
         // Now code-sign the launcher and verify that it still works.
         sign_authenticode(console_bin_path.path());

--- a/crates/uv-trampoline/rust-toolchain.toml
+++ b/crates/uv-trampoline/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-12-12"
+channel = "nightly-2026-01-21"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.0"


### PR DESCRIPTION
## Summary

Update the MSRV to Rust 1.95.0 and the pinned Rust toolchain to Rust 1.97.0. The Windows trampoline uses a nightly toolchain, so update it to `nightly-2026-01-21`, which is new enough to compile workspace dependencies with the new MSRV.
