### PR TITLE
Use Rust 1.95 features

### DIFF
--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -459,16 +459,13 @@ impl Osv {
                 // TODO: Warn on a malformed version string rather than silently skipping it.
                 // Alternatively, we could propagate the raw version string in the finding and
                 // leave it to the callsite to process into PEP 440 versions.
+                Event::Fixed(fixed) if let Ok(version) = Version::from_str(fixed) => Some(version),
                 Event::Fixed(fixed) => {
-                    if let Ok(fixed) = Version::from_str(fixed) {
-                        Some(fixed)
-                    } else {
-                        trace!(
-                            "Skipping invalid (non-PEP 440) version in OSV record {id}: {fixed}",
-                            id = vuln.id,
-                        );
-                        None
-                    }
+                    trace!(
+                        "Skipping invalid (non-PEP 440) version in OSV record {id}: {fixed}",
+                        id = vuln.id,
+                    );
+                    None
                 }
                 _ => None,
             })

--- a/crates/uv-cache-info/src/cache_info.rs
+++ b/crates/uv-cache-info/src/cache_info.rs
@@ -168,18 +168,20 @@ impl CacheInfo {
                         );
                     } else {
                         // Fall back to the inode.
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::MetadataExt;
-                            directories
-                                .insert(dir, Some(DirectoryTimestamp::Inode(metadata.ino())));
-                        }
-                        #[cfg(not(unix))]
-                        {
-                            warn!(
-                                "Failed to read creation time for directory: `{}`",
-                                path.display()
-                            );
+                        cfg_select! {
+                            unix => {
+                                use std::os::unix::fs::MetadataExt;
+                                directories.insert(
+                                    dir,
+                                    Some(DirectoryTimestamp::Inode(metadata.ino())),
+                                );
+                            },
+                            _ => {
+                                warn!(
+                                    "Failed to read creation time for directory: `{}`",
+                                    path.display()
+                                );
+                            },
                         }
                     }
                 }

--- a/crates/uv-cache-info/src/timestamp.rs
+++ b/crates/uv-cache-info/src/timestamp.rs
@@ -21,21 +21,21 @@ impl Timestamp {
 
     /// Return the [`Timestamp`] for the given metadata.
     pub fn from_metadata(metadata: &std::fs::Metadata) -> Self {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt;
+        cfg_select! {
+            unix => {
+                use std::os::unix::fs::MetadataExt;
 
-            let ctime = u64::try_from(metadata.ctime()).expect("ctime to be representable as u64");
-            let ctime_nsec = u32::try_from(metadata.ctime_nsec())
-                .expect("ctime_nsec to be representable as u32");
-            let duration = std::time::Duration::new(ctime, ctime_nsec);
-            Self(std::time::UNIX_EPOCH + duration)
-        }
-
-        #[cfg(not(unix))]
-        {
-            let modified = metadata.modified().expect("modified time to be available");
-            Self(modified)
+                let ctime =
+                    u64::try_from(metadata.ctime()).expect("ctime to be representable as u64");
+                let ctime_nsec = u32::try_from(metadata.ctime_nsec())
+                    .expect("ctime_nsec to be representable as u32");
+                let duration = std::time::Duration::new(ctime, ctime_nsec);
+                Self(std::time::UNIX_EPOCH + duration)
+            },
+            _ => {
+                let modified = metadata.modified().expect("modified time to be available");
+                Self(modified)
+            },
         }
     }
 

--- a/crates/uv-cache/src/removal.rs
+++ b/crates/uv-cache/src/removal.rs
@@ -76,20 +76,19 @@ impl Removal {
             // Remove the file.
             self.total_bytes += metadata.len();
             if metadata.is_symlink() {
-                #[cfg(windows)]
-                {
-                    use std::os::windows::fs::FileTypeExt;
+                cfg_select! {
+                    windows => {
+                        use std::os::windows::fs::FileTypeExt;
 
-                    if metadata.file_type().is_symlink_dir() {
-                        remove_dir(&path)?;
-                    } else {
+                        if metadata.file_type().is_symlink_dir() {
+                            remove_dir(&path)?;
+                        } else {
+                            remove_file(&path)?;
+                        }
+                    },
+                    _ => {
                         remove_file(&path)?;
-                    }
-                }
-
-                #[cfg(not(windows))]
-                {
-                    remove_file(&path)?;
+                    },
                 }
             } else {
                 remove_file(&path)?;

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -675,13 +675,12 @@ impl CachedClient {
 
             match result {
                 Ok(ok) => return Ok(ok),
-                Err(err) => {
-                    if let Some(backoff) = retry_state.should_retry(err.error(), err.retries()) {
-                        retry_state.sleep_backoff(backoff).await;
-                        continue;
-                    }
-                    return Err(err.with_retries(retry_state.total_retries()));
+                Err(err)
+                    if let Some(backoff) = retry_state.should_retry(err.error(), err.retries()) =>
+                {
+                    retry_state.sleep_backoff(backoff).await;
                 }
+                Err(err) => return Err(err.with_retries(retry_state.total_retries())),
             }
         }
     }
@@ -714,13 +713,12 @@ impl CachedClient {
 
             match result {
                 Ok(ok) => return Ok(ok),
-                Err(err) => {
-                    if let Some(backoff) = retry_state.should_retry(err.error(), err.retries()) {
-                        retry_state.sleep_backoff(backoff).await;
-                        continue;
-                    }
-                    return Err(err.with_retries(retry_state.total_retries()));
+                Err(err)
+                    if let Some(backoff) = retry_state.should_retry(err.error(), err.retries()) =>
+                {
+                    retry_state.sleep_backoff(backoff).await;
                 }
+                Err(err) => return Err(err.with_retries(retry_state.total_retries())),
             }
         }
     }

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -305,64 +305,61 @@ impl Error {
 
             // The server returned a "Method Not Allowed" error, indicating it doesn't support
             // HEAD requests, so we can't check for range requests.
-            ErrorKind::WrappedReqwestError(_, err) => {
-                if let Some(status) = err.status() {
-                    // If the server doesn't support HEAD requests, we can't check for range
-                    // requests.
-                    if status == reqwest::StatusCode::METHOD_NOT_ALLOWED {
-                        return true;
-                    }
+            ErrorKind::WrappedReqwestError(_, err) if let Some(status) = err.status() => {
+                // If the server doesn't support HEAD requests, we can't check for range
+                // requests.
+                if status == reqwest::StatusCode::METHOD_NOT_ALLOWED {
+                    return true;
+                }
 
-                    // In some cases, registries return a 404 for HEAD requests when they're not
-                    // supported. In the worst case, we'll now just proceed to attempt to stream the
-                    // entire file, so it's fine to be somewhat lenient here.
-                    if status == reqwest::StatusCode::NOT_FOUND {
-                        return true;
-                    }
+                // In some cases, registries return a 404 for HEAD requests when they're not
+                // supported. In the worst case, we'll now just proceed to attempt to stream the
+                // entire file, so it's fine to be somewhat lenient here.
+                if status == reqwest::StatusCode::NOT_FOUND {
+                    return true;
+                }
 
-                    // In some cases, registries (like PyPICloud) return a 403 for HEAD requests
-                    // when they're not supported. Again, it's better to be lenient here.
-                    if status == reqwest::StatusCode::FORBIDDEN {
-                        return true;
-                    }
+                // In some cases, registries (like PyPICloud) return a 403 for HEAD requests
+                // when they're not supported. Again, it's better to be lenient here.
+                if status == reqwest::StatusCode::FORBIDDEN {
+                    return true;
+                }
 
-                    // In some cases, registries (like Alibaba Cloud) return a 400 for HEAD requests
-                    // when they're not supported. Again, it's better to be lenient here.
-                    if status == reqwest::StatusCode::BAD_REQUEST {
-                        return true;
-                    }
+                // In some cases, registries (like Alibaba Cloud) return a 400 for HEAD requests
+                // when they're not supported. Again, it's better to be lenient here.
+                if status == reqwest::StatusCode::BAD_REQUEST {
+                    return true;
                 }
             }
 
             // The server doesn't support range requests, but we only discovered this while
             // unzipping due to erroneous server behavior.
-            ErrorKind::Zip(_, ZipError::UpstreamReadError(err)) => {
+            ErrorKind::Zip(_, ZipError::UpstreamReadError(err))
                 if let Some(inner) = err.get_ref()
                     && let Some(range_reader_error) =
-                        inner.downcast_ref::<AsyncHttpRangeReaderError>()
-                {
-                    match range_reader_error {
-                        AsyncHttpRangeReaderError::HttpRangeRequestUnsupported
-                        | AsyncHttpRangeReaderError::ContentLengthMissing
-                        | AsyncHttpRangeReaderError::ContentRangeMissing => {
-                            return true;
-                        }
-                        AsyncHttpRangeReaderError::RangeMismatch { .. }
-                        | AsyncHttpRangeReaderError::ResponseTooShort { .. }
-                        | AsyncHttpRangeReaderError::ResponseTooLong { .. } => {
-                            let url = if let Some(index) = index {
-                                index.url()
-                            } else {
-                                url
-                            };
-                            warn!(
-                                "Invalid range request response from server that declares HTTP \
-                                range request support, falling back to streaming: {url}"
-                            );
-                            return true;
-                        }
-                        _ => {}
+                        inner.downcast_ref::<AsyncHttpRangeReaderError>() =>
+            {
+                match range_reader_error {
+                    AsyncHttpRangeReaderError::HttpRangeRequestUnsupported
+                    | AsyncHttpRangeReaderError::ContentLengthMissing
+                    | AsyncHttpRangeReaderError::ContentRangeMissing => {
+                        return true;
                     }
+                    AsyncHttpRangeReaderError::RangeMismatch { .. }
+                    | AsyncHttpRangeReaderError::ResponseTooShort { .. }
+                    | AsyncHttpRangeReaderError::ResponseTooLong { .. } => {
+                        let url = if let Some(index) = index {
+                            index.url()
+                        } else {
+                            url
+                        };
+                        warn!(
+                            "Invalid range request response from server that declares HTTP \
+                            range request support, falling back to streaming: {url}"
+                        );
+                        return true;
+                    }
+                    _ => {}
                 }
             }
 

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -526,17 +526,16 @@ impl RegistryClient {
             format!("{package_name}.rkyv"),
         );
         let cache_control = match self.connectivity {
-            Connectivity::Online => {
-                if let Some(header) = self.indexes.simple_api_cache_control_for(index) {
-                    CacheControl::Override(header)
-                } else {
-                    CacheControl::from(
-                        self.cache
-                            .freshness(&cache_entry, Some(package_name), None)
-                            .map_err(ErrorKind::Io)?,
-                    )
-                }
+            Connectivity::Online
+                if let Some(header) = self.indexes.simple_api_cache_control_for(index) =>
+            {
+                CacheControl::Override(header)
             }
+            Connectivity::Online => CacheControl::from(
+                self.cache
+                    .freshness(&cache_entry, Some(package_name), None)
+                    .map_err(ErrorKind::Io)?,
+            ),
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
@@ -800,17 +799,16 @@ impl RegistryClient {
             "index.html.rkyv",
         );
         let cache_control = match self.connectivity {
-            Connectivity::Online => {
-                if let Some(header) = self.indexes.simple_api_cache_control_for(index) {
-                    CacheControl::Override(header)
-                } else {
-                    CacheControl::from(
-                        self.cache
-                            .freshness(&cache_entry, None, None)
-                            .map_err(ErrorKind::Io)?,
-                    )
-                }
+            Connectivity::Online
+                if let Some(header) = self.indexes.simple_api_cache_control_for(index) =>
+            {
+                CacheControl::Override(header)
             }
+            Connectivity::Online => CacheControl::from(
+                self.cache
+                    .freshness(&cache_entry, None, None)
+                    .map_err(ErrorKind::Io)?,
+            ),
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
@@ -1104,17 +1102,16 @@ impl RegistryClient {
                 format!("{}.msgpack", filename.cache_key()),
             );
             let cache_control = match self.connectivity {
-                Connectivity::Online => {
-                    if let Some(header) = self.indexes.artifact_cache_control_for(index) {
-                        CacheControl::Override(header)
-                    } else {
-                        CacheControl::from(
-                            self.cache
-                                .freshness(&cache_entry, Some(&filename.name), None)
-                                .map_err(ErrorKind::Io)?,
-                        )
-                    }
+                Connectivity::Online
+                    if let Some(header) = self.indexes.artifact_cache_control_for(index) =>
+                {
+                    CacheControl::Override(header)
                 }
+                Connectivity::Online => CacheControl::from(
+                    self.cache
+                        .freshness(&cache_entry, Some(&filename.name), None)
+                        .map_err(ErrorKind::Io)?,
+                ),
                 Connectivity::Offline => CacheControl::AllowStale,
             };
 
@@ -1181,25 +1178,17 @@ impl RegistryClient {
             format!("{}.msgpack", filename.cache_key()),
         );
         let cache_control = match self.connectivity {
-            Connectivity::Online => {
-                if let Some(index) = index {
-                    if let Some(header) = self.indexes.artifact_cache_control_for(index) {
-                        CacheControl::Override(header)
-                    } else {
-                        CacheControl::from(
-                            self.cache
-                                .freshness(&cache_entry, Some(&filename.name), None)
-                                .map_err(ErrorKind::Io)?,
-                        )
-                    }
-                } else {
-                    CacheControl::from(
-                        self.cache
-                            .freshness(&cache_entry, Some(&filename.name), None)
-                            .map_err(ErrorKind::Io)?,
-                    )
-                }
+            Connectivity::Online
+                if let Some(index) = index
+                    && let Some(header) = self.indexes.artifact_cache_control_for(index) =>
+            {
+                CacheControl::Override(header)
             }
+            Connectivity::Online => CacheControl::from(
+                self.cache
+                    .freshness(&cache_entry, Some(&filename.name), None)
+                    .map_err(ErrorKind::Io)?,
+            ),
             Connectivity::Offline => CacheControl::AllowStale,
         };
 

--- a/crates/uv-dirs/src/lib.rs
+++ b/crates/uv-dirs/src/lib.rs
@@ -161,32 +161,31 @@ fn locate_system_config_windows(system_drive: impl AsRef<Path>) -> Option<PathBu
 ///
 /// On Windows, uses `%SYSTEMDRIVE%\ProgramData\uv\uv.toml`.
 pub fn system_config_file() -> Option<PathBuf> {
-    #[cfg(windows)]
-    {
-        env::var(EnvVars::SYSTEMDRIVE)
-            .ok()
-            .and_then(|system_drive| locate_system_config_windows(format!("{system_drive}\\")))
-    }
-
-    #[cfg(not(windows))]
-    {
-        if let Some(path) =
-            locate_system_config_xdg(env::var(EnvVars::XDG_CONFIG_DIRS).ok().as_deref())
-        {
-            return Some(path);
-        }
-
-        // Fallback to `/etc/uv/uv.toml` if `XDG_CONFIG_DIRS` is not set or no valid
-        // path is found.
-        let candidate = Path::new("/etc/uv/uv.toml");
-        match candidate.try_exists() {
-            Ok(true) => Some(candidate.to_path_buf()),
-            Ok(false) => None,
-            Err(err) => {
-                tracing::warn!("Failed to query system configuration file: {err}");
-                None
+    cfg_select! {
+        windows => {
+            env::var(EnvVars::SYSTEMDRIVE)
+                .ok()
+                .and_then(|system_drive| locate_system_config_windows(format!("{system_drive}\\")))
+        },
+        _ => {
+            if let Some(path) =
+                locate_system_config_xdg(env::var(EnvVars::XDG_CONFIG_DIRS).ok().as_deref())
+            {
+                return Some(path);
             }
-        }
+
+            // Fallback to `/etc/uv/uv.toml` if `XDG_CONFIG_DIRS` is not set or no valid
+            // path is found.
+            let candidate = Path::new("/etc/uv/uv.toml");
+            match candidate.try_exists() {
+                Ok(true) => Some(candidate.to_path_buf()),
+                Ok(false) => None,
+                Err(err) => {
+                    tracing::warn!("Failed to query system configuration file: {err}");
+                    None
+                }
+            }
+        },
     }
 }
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -802,22 +802,21 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // Determine the cache control policy for the URL.
         let cache_control = match self.client.unmanaged.connectivity() {
-            Connectivity::Online => {
+            Connectivity::Online
                 if let Some(header) = index.and_then(|index| {
                     self.build_context
                         .locations()
                         .artifact_cache_control_for(index)
-                }) {
-                    CacheControl::Override(header)
-                } else {
-                    CacheControl::from(
-                        self.build_context
-                            .cache()
-                            .freshness(&http_entry, Some(&filename.name), None)
-                            .map_err(Error::CacheRead)?,
-                    )
-                }
+                }) =>
+            {
+                CacheControl::Override(header)
             }
+            Connectivity::Online => CacheControl::from(
+                self.build_context
+                    .cache()
+                    .freshness(&http_entry, Some(&filename.name), None)
+                    .map_err(Error::CacheRead)?,
+            ),
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
@@ -978,22 +977,21 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // Determine the cache control policy for the URL.
         let cache_control = match self.client.unmanaged.connectivity() {
-            Connectivity::Online => {
+            Connectivity::Online
                 if let Some(header) = index.and_then(|index| {
                     self.build_context
                         .locations()
                         .artifact_cache_control_for(index)
-                }) {
-                    CacheControl::Override(header)
-                } else {
-                    CacheControl::from(
-                        self.build_context
-                            .cache()
-                            .freshness(&http_entry, Some(&filename.name), None)
-                            .map_err(Error::CacheRead)?,
-                    )
-                }
+                }) =>
+            {
+                CacheControl::Override(header)
             }
+            Connectivity::Online => CacheControl::from(
+                self.build_context
+                    .cache()
+                    .freshness(&http_entry, Some(&filename.name), None)
+                    .map_err(Error::CacheRead)?,
+            ),
             Connectivity::Offline => CacheControl::AllowStale,
         };
 

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -955,22 +955,21 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // Determine the cache control policy for the request.
         let cache_control = match client.unmanaged.connectivity() {
-            Connectivity::Online => {
+            Connectivity::Online
                 if let Some(header) = index.and_then(|index| {
                     self.build_context
                         .locations()
                         .artifact_cache_control_for(index)
-                }) {
-                    CacheControl::Override(header)
-                } else {
-                    CacheControl::from(
-                        self.build_context
-                            .cache()
-                            .freshness(&cache_entry, source.name(), source.source_tree())
-                            .map_err(Error::CacheRead)?,
-                    )
-                }
+                }) =>
+            {
+                CacheControl::Override(header)
             }
+            Connectivity::Online => CacheControl::from(
+                self.build_context
+                    .cache()
+                    .freshness(&cache_entry, source.name(), source.source_tree())
+                    .map_err(Error::CacheRead)?,
+            ),
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
@@ -2731,22 +2730,21 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // Determine the cache control policy for the request.
         let cache_control = match client.unmanaged.connectivity() {
-            Connectivity::Online => {
+            Connectivity::Online
                 if let Some(header) = index.and_then(|index| {
                     self.build_context
                         .locations()
                         .artifact_cache_control_for(index)
-                }) {
-                    CacheControl::Override(header)
-                } else {
-                    CacheControl::from(
-                        self.build_context
-                            .cache()
-                            .freshness(&cache_entry, source.name(), source.source_tree())
-                            .map_err(Error::CacheRead)?,
-                    )
-                }
+                }) =>
+            {
+                CacheControl::Override(header)
             }
+            Connectivity::Online => CacheControl::from(
+                self.build_context
+                    .cache()
+                    .freshness(&cache_entry, source.name(), source.source_tree())
+                    .map_err(Error::CacheRead)?,
+            ),
             Connectivity::Offline => CacheControl::AllowStale,
         };
 

--- a/crates/uv-extract/src/error.rs
+++ b/crates/uv-extract/src/error.rs
@@ -142,12 +142,8 @@ impl Error {
     pub fn is_http_streaming_failed(&self) -> bool {
         match self {
             Self::AsyncZip(async_zip::error::ZipError::UpstreamReadError(_)) => true,
-            Self::Io(err) => {
-                if let Some(inner) = err.get_ref() {
-                    inner.downcast_ref::<reqwest::Error>().is_some()
-                } else {
-                    false
-                }
+            Self::Io(err) if let Some(inner) = err.get_ref() => {
+                inner.downcast_ref::<reqwest::Error>().is_some()
             }
             _ => false,
         }

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -350,13 +350,13 @@ mod windows_tests {
 /// This function should only be used for files. If targeting a directory, use [`replace_symlink`]
 /// instead; it will use a junction on Windows, which is more performant.
 pub fn symlink_or_copy_file(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    #[cfg(windows)]
-    {
-        fs_err::copy(src.as_ref(), dst.as_ref())?;
-    }
-    #[cfg(unix)]
-    {
-        fs_err::os::unix::fs::symlink(src.as_ref(), dst.as_ref())?;
+    cfg_select! {
+        windows => {
+            fs_err::copy(src.as_ref(), dst.as_ref())?;
+        },
+        unix => {
+            fs_err::os::unix::fs::symlink(src.as_ref(), dst.as_ref())?;
+        },
     }
 
     Ok(())

--- a/crates/uv-macros/src/lib.rs
+++ b/crates/uv-macros/src/lib.rs
@@ -135,15 +135,14 @@ pub fn attribute_env_vars_metadata(_attr: TokenStream, input: TokenStream) -> To
                 let name = lit.value();
                 Some((name, doc, added_in, item.ident.span()))
             }
-            ImplItem::Fn(item) if !is_hidden(&item.attrs) => {
+            ImplItem::Fn(item)
+                if !is_hidden(&item.attrs)
+                    && let Some(pattern) = get_env_var_pattern_from_attr(&item.attrs) =>
+            {
                 // Extract the environment variable patterns.
-                if let Some(pattern) = get_env_var_pattern_from_attr(&item.attrs) {
-                    let doc = get_doc_comment(&item.attrs);
-                    let added_in = get_added_in(&item.attrs);
-                    Some((pattern, doc, added_in, item.sig.span()))
-                } else {
-                    None // Skip if pattern extraction fails.
-                }
+                let doc = get_doc_comment(&item.attrs);
+                let added_in = get_added_in(&item.attrs);
+                Some((pattern, doc, added_in, item.sig.span()))
             }
             _ => None,
         })

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -390,33 +390,34 @@ impl Pep508Url for VerbatimUrl {
                 // Ex) `file:///home/ferris/project/scripts/...`, `file://localhost/home/ferris/project/scripts/...`, or `file:../ferris/`
                 Some(Scheme::File) => {
                     // Strip the leading slashes, along with the `localhost` host, if present.
+                    cfg_select! {
+                        feature = "non-pep508-extensions" => {
+                            // Transform, e.g., `/C:/Users/ferris/wheel-0.42.0.tar.gz` to `C:\Users\ferris\wheel-0.42.0.tar.gz`.
+                            let (path, fragment) = path
+                                .split_once('#')
+                                .map_or((path, None), |(path, fragment)| (path, Some(fragment)));
+                            let path = strip_host(path);
 
-                    // Transform, e.g., `/C:/Users/ferris/wheel-0.42.0.tar.gz` to `C:\Users\ferris\wheel-0.42.0.tar.gz`.
-                    #[cfg(feature = "non-pep508-extensions")]
-                    {
-                        let (path, fragment) = path
-                            .split_once('#')
-                            .map_or((path, None), |(path, fragment)| (path, Some(fragment)));
-                        let path = strip_host(path);
+                            let path = normalize_url_path(path);
 
-                        let path = normalize_url_path(path);
+                            if let Some(working_dir) = working_dir {
+                                return Ok(Self::from_path(path.as_ref(), working_dir)?
+                                    .with_url_fragment(fragment)
+                                    .with_given(url)
+                                    .with_expanded(vars_expanded));
+                            }
 
-                        if let Some(working_dir) = working_dir {
-                            return Ok(Self::from_path(path.as_ref(), working_dir)?
+                            Ok(Self::from_absolute_path(path.as_ref())?
                                 .with_url_fragment(fragment)
                                 .with_given(url)
-                                .with_expanded(vars_expanded));
-                        }
-
-                        Ok(Self::from_absolute_path(path.as_ref())?
-                            .with_url_fragment(fragment)
-                            .with_given(url)
-                            .with_expanded(vars_expanded))
+                                .with_expanded(vars_expanded))
+                        },
+                        _ => {
+                            Ok(Self::parse_url(expanded)?
+                                .with_given(url)
+                                .with_expanded(vars_expanded))
+                        },
                     }
-                    #[cfg(not(feature = "non-pep508-extensions"))]
-                    Ok(Self::parse_url(expanded)?
-                        .with_given(url)
-                        .with_expanded(vars_expanded))
                 }
 
                 // Ex) `https://download.pytorch.org/whl/torch_stable.html`
@@ -427,31 +428,30 @@ impl Pep508Url for VerbatimUrl {
 
                 // Ex) `C:\Users\ferris\wheel-0.42.0.tar.gz`
                 _ => {
-                    #[cfg(feature = "non-pep508-extensions")]
-                    {
-                        Ok(
-                            Self::from_path_with_fragment(expanded.as_ref(), working_dir)?
-                                .with_given(url)
-                                .with_expanded(vars_expanded),
-                        )
+                    cfg_select! {
+                        feature = "non-pep508-extensions" => {
+                            Ok(
+                                Self::from_path_with_fragment(expanded.as_ref(), working_dir)?
+                                    .with_given(url)
+                                    .with_expanded(vars_expanded),
+                            )
+                        },
+                        _ => Err(Self::Err::NotAUrl(expanded.to_string())),
                     }
-                    #[cfg(not(feature = "non-pep508-extensions"))]
-                    Err(Self::Err::NotAUrl(expanded.to_string()))
                 }
             }
         } else {
             // Ex) `../editable/`
-            #[cfg(feature = "non-pep508-extensions")]
-            {
-                Ok(
-                    Self::from_path_with_fragment(expanded.as_ref(), working_dir)?
-                        .with_given(url)
-                        .with_expanded(vars_expanded),
-                )
+            cfg_select! {
+                feature = "non-pep508-extensions" => {
+                    Ok(
+                        Self::from_path_with_fragment(expanded.as_ref(), working_dir)?
+                            .with_given(url)
+                            .with_expanded(vars_expanded),
+                    )
+                },
+                _ => Err(Self::Err::NotAUrl(expanded.to_string())),
             }
-
-            #[cfg(not(feature = "non-pep508-extensions"))]
-            Err(Self::Err::NotAUrl(expanded.to_string()))
         }
     }
 

--- a/crates/uv-platform/src/host.rs
+++ b/crates/uv-platform/src/host.rs
@@ -20,23 +20,15 @@ impl OsType {
     ///
     /// Returns `None` on unsupported platforms.
     pub fn from_env() -> Option<Self> {
-        #[cfg(target_os = "linux")]
-        {
-            fs_err::read_to_string("/proc/sys/kernel/ostype")
-                .ok()
-                .map(|s| Self::Linux(s.trim().to_string()))
-        }
-        #[cfg(target_os = "macos")]
-        {
-            Some(Self::Darwin)
-        }
-        #[cfg(target_os = "windows")]
-        {
-            Some(Self::Windows)
-        }
-        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-        {
-            None
+        cfg_select! {
+            target_os = "linux" => {
+                fs_err::read_to_string("/proc/sys/kernel/ostype")
+                    .ok()
+                    .map(|s| Self::Linux(s.trim().to_string()))
+            },
+            target_os = "macos" => Some(Self::Darwin),
+            target_os = "windows" => Some(Self::Windows),
+            _ => None,
         }
     }
 }
@@ -70,25 +62,22 @@ impl OsRelease {
     ///
     /// Returns `None` on unsupported platforms or if the release cannot be read.
     pub fn from_env() -> Option<Self> {
-        #[cfg(unix)]
-        {
-            let uname = rustix::system::uname();
-            let release = uname.release().to_str().ok()?;
-            Some(Self::Unix(release.to_string()))
-        }
-        #[cfg(windows)]
-        {
-            let os_version = windows_version::OsVersion::current();
-            Some(Self::Windows {
-                major: os_version.major,
-                minor: os_version.minor,
-                build: os_version.build,
-                revision: windows_version::revision(),
-            })
-        }
-        #[cfg(not(any(unix, windows)))]
-        {
-            None
+        cfg_select! {
+            unix => {
+                let uname = rustix::system::uname();
+                let release = uname.release().to_str().ok()?;
+                Some(Self::Unix(release.to_string()))
+            },
+            windows => {
+                let os_version = windows_version::OsVersion::current();
+                Some(Self::Windows {
+                    major: os_version.major,
+                    minor: os_version.minor,
+                    build: os_version.build,
+                    revision: windows_version::revision(),
+                })
+            },
+            _ => None,
         }
     }
 }
@@ -125,16 +114,14 @@ impl LinuxOsRelease {
     ///
     /// Returns `None` on non-Linux platforms or if the file cannot be read.
     pub fn from_env() -> Option<Self> {
-        #[cfg(target_os = "linux")]
-        {
-            let content = fs_err::read_to_string("/etc/os-release")
-                .or_else(|_| fs_err::read_to_string("/usr/lib/os-release"))
-                .ok()?;
-            Some(content.parse().unwrap())
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            None
+        cfg_select! {
+            target_os = "linux" => {
+                let content = fs_err::read_to_string("/etc/os-release")
+                    .or_else(|_| fs_err::read_to_string("/usr/lib/os-release"))
+                    .ok()?;
+                Some(content.parse().unwrap())
+            },
+            _ => None,
         }
     }
 }
@@ -240,21 +227,22 @@ VERSION_ID=40
     fn test_os_type_returns_value() {
         let os_type =
             OsType::from_env().expect("OsType should be available on supported platforms");
-        #[cfg(target_os = "linux")]
-        assert!(matches!(os_type, OsType::Linux(_)));
-        #[cfg(target_os = "macos")]
-        assert_eq!(os_type, OsType::Darwin);
-        #[cfg(target_os = "windows")]
-        assert_eq!(os_type, OsType::Windows);
+        cfg_select! {
+            target_os = "linux" => { assert!(matches!(os_type, OsType::Linux(_))); },
+            target_os = "macos" => { assert_eq!(os_type, OsType::Darwin); },
+            target_os = "windows" => { assert_eq!(os_type, OsType::Windows); },
+            _ => {},
+        }
     }
 
     #[test]
     fn test_os_release_returns_value() {
         let os_release =
             OsRelease::from_env().expect("OsRelease should be available on supported platforms");
-        #[cfg(unix)]
-        assert!(matches!(os_release, OsRelease::Unix(_)));
-        #[cfg(windows)]
-        assert!(matches!(os_release, OsRelease::Windows { .. }));
+        cfg_select! {
+            unix => { assert!(matches!(os_release, OsRelease::Unix(_))); },
+            windows => { assert!(matches!(os_release, OsRelease::Windows { .. })); },
+            _ => {},
+        }
     }
 }

--- a/crates/uv-platform/src/libc.rs
+++ b/crates/uv-platform/src/libc.rs
@@ -64,36 +64,30 @@ pub enum Libc {
 impl Libc {
     pub(crate) fn from_env() -> Result<Self, crate::Error> {
         match env::consts::OS {
-            "linux" => {
-                if let Ok(libc) = env::var(EnvVars::UV_LIBC) {
-                    if !libc.is_empty() {
-                        return Self::from_str(&libc);
-                    }
-                }
-
-                Ok(Self::Some(match detect_linux_libc()? {
-                    LibcVersion::Manylinux { .. } => match env::consts::ARCH {
-                        "arm" | "armv5te" | "armv7" => {
-                            match detect_hardware_floating_point_support() {
-                                Ok(true) => target_lexicon::Environment::Gnueabihf,
-                                Ok(false) => target_lexicon::Environment::Gnueabi,
-                                Err(_) => target_lexicon::Environment::Gnu,
-                            }
-                        }
-                        _ => target_lexicon::Environment::Gnu,
-                    },
-                    LibcVersion::Musllinux { .. } => match env::consts::ARCH {
-                        "arm" | "armv5te" | "armv7" => {
-                            match detect_hardware_floating_point_support() {
-                                Ok(true) => target_lexicon::Environment::Musleabihf,
-                                Ok(false) => target_lexicon::Environment::Musleabi,
-                                Err(_) => target_lexicon::Environment::Musl,
-                            }
-                        }
-                        _ => target_lexicon::Environment::Musl,
-                    },
-                }))
+            "linux"
+                if let Ok(libc) = env::var(EnvVars::UV_LIBC)
+                    && !libc.is_empty() =>
+            {
+                Self::from_str(&libc)
             }
+            "linux" => Ok(Self::Some(match detect_linux_libc()? {
+                LibcVersion::Manylinux { .. } => match env::consts::ARCH {
+                    "arm" | "armv5te" | "armv7" => match detect_hardware_floating_point_support() {
+                        Ok(true) => target_lexicon::Environment::Gnueabihf,
+                        Ok(false) => target_lexicon::Environment::Gnueabi,
+                        Err(_) => target_lexicon::Environment::Gnu,
+                    },
+                    _ => target_lexicon::Environment::Gnu,
+                },
+                LibcVersion::Musllinux { .. } => match env::consts::ARCH {
+                    "arm" | "armv5te" | "armv7" => match detect_hardware_floating_point_support() {
+                        Ok(true) => target_lexicon::Environment::Musleabihf,
+                        Ok(false) => target_lexicon::Environment::Musleabi,
+                        Err(_) => target_lexicon::Environment::Musl,
+                    },
+                    _ => target_lexicon::Environment::Musl,
+                },
+            })),
             "windows" | "macos" => Ok(Self::None),
             // Use `None` on platforms without explicit support.
             _ => Ok(Self::None),

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -830,23 +830,23 @@ impl PythonMinorVersionLink {
                 .is_ok_and(|target| verbatim_path(&target) == verbatim_path(&self.target_directory))
         };
 
-        #[cfg(unix)]
-        {
-            self.symlink_directory
-                .symlink_metadata()
-                .is_ok_and(|metadata| metadata.file_type().is_symlink())
-                && points_to_target()
-        }
-        #[cfg(windows)]
-        {
-            self.symlink_directory
-                .symlink_metadata()
-                .is_ok_and(|metadata| {
-                    // Check that this is a reparse point, which indicates this
-                    // is a symlink or junction.
-                    (metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0) != 0
-                })
-                && points_to_target()
+        cfg_select! {
+            unix => {
+                self.symlink_directory
+                    .symlink_metadata()
+                    .is_ok_and(|metadata| metadata.file_type().is_symlink())
+                    && points_to_target()
+            },
+            windows => {
+                self.symlink_directory
+                    .symlink_metadata()
+                    .is_ok_and(|metadata| {
+                        // Check that this is a reparse point, which indicates this
+                        // is a symlink or junction.
+                        (metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0) != 0
+                    })
+                    && points_to_target()
+            },
         }
     }
 }

--- a/crates/uv-test/src/vendor.rs
+++ b/crates/uv-test/src/vendor.rs
@@ -244,20 +244,18 @@ async fn ensure_cached_artifact(artifact: &VendorArtifact, path: &Path) -> Resul
 
     match persist_with_retry_sync(temp, path) {
         Ok(()) => Ok(()),
-        Err(error) => {
+        Err(_)
             if let Ok(bytes) = fs_err::read(path)
-                && verify_bytes(artifact, &bytes).is_ok()
-            {
-                Ok(())
-            } else {
-                Err(error).with_context(|| {
-                    format!(
-                        "failed to persist cached vendor artifact `{}`",
-                        path.display()
-                    )
-                })
-            }
+                && verify_bytes(artifact, &bytes).is_ok() =>
+        {
+            Ok(())
         }
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "failed to persist cached vendor artifact `{}`",
+                path.display()
+            )
+        }),
     }
 }
 

--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -118,26 +118,26 @@ pub struct ToolEntrypoint {
 
 impl Display for ToolEntrypoint {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        #[cfg(windows)]
-        {
-            write!(
-                f,
-                "{} ({})",
-                self.name,
-                self.install_path
-                    .simplified_display()
-                    .to_string()
-                    .replace('/', "\\")
-            )
-        }
-        #[cfg(unix)]
-        {
-            write!(
-                f,
-                "{} ({})",
-                self.name,
-                self.install_path.simplified_display()
-            )
+        cfg_select! {
+            windows => {
+                write!(
+                    f,
+                    "{} ({})",
+                    self.name,
+                    self.install_path
+                        .simplified_display()
+                        .to_string()
+                        .replace('/', "\\")
+                )
+            },
+            unix => {
+                write!(
+                    f,
+                    "{} ({})",
+                    self.name,
+                    self.install_path.simplified_display()
+                )
+            },
         }
     }
 }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1752,18 +1752,15 @@ impl Source {
             RequirementSource::Registry { index: Some(_), .. } => {
                 return Ok(None);
             }
-            RequirementSource::Registry { index: None, .. } => {
-                if let Some(index) = index {
-                    Self::Registry {
-                        index,
-                        marker: MarkerTree::TRUE,
-                        extra: None,
-                        group: None,
-                    }
-                } else {
-                    return Ok(None);
+            RequirementSource::Registry { index: None, .. } if let Some(index) = index => {
+                Self::Registry {
+                    index,
+                    marker: MarkerTree::TRUE,
+                    extra: None,
+                    group: None,
                 }
             }
+            RequirementSource::Registry { index: None, .. } => return Ok(None),
             RequirementSource::Path { install_path, .. } => Self::Path {
                 editable: None,
                 package: None,

--- a/crates/uv/src/bin/uvw.rs
+++ b/crates/uv/src/bin/uvw.rs
@@ -6,15 +6,13 @@ use std::process::{Command, ExitCode, ExitStatus};
 
 /// Spawns a command exec style.
 fn exec_spawn(cmd: &mut Command) -> std::io::Result<Infallible> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        let err = cmd.exec();
-        Err(err)
-    }
-    #[cfg(windows)]
-    {
-        uv_windows::spawn_child(cmd, true)
+    cfg_select! {
+        unix => {
+            use std::os::unix::process::CommandExt;
+            let err = cmd.exec();
+            Err(err)
+        },
+        windows => uv_windows::spawn_child(cmd, true),
     }
 }
 

--- a/crates/uv/src/bin/uvx.rs
+++ b/crates/uv/src/bin/uvx.rs
@@ -7,15 +7,13 @@ use std::{
 
 /// Spawns a command exec style.
 fn exec_spawn(cmd: &mut Command) -> std::io::Result<Infallible> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        let err = cmd.exec();
-        Err(err)
-    }
-    #[cfg(windows)]
-    {
-        uv_windows::spawn_child(cmd, false)
+    cfg_select! {
+        unix => {
+            use std::os::unix::process::CommandExt;
+            let err = cmd.exec();
+            Err(err)
+        },
+        windows => uv_windows::spawn_child(cmd, false),
     }
 }
 

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -104,15 +104,14 @@ impl OperationDiagnostic {
                 dist_error(kind, dist, &chain, Arc::new(*err));
                 None
             }
+            pip::operations::Error::Requirements(err) if let Some(context) = self.context => {
+                let err = miette::Report::msg(format!("{err}"))
+                    .context(format!("Failed to resolve {context} requirement"));
+                anstream::eprint!("{err:?}");
+                None
+            }
             pip::operations::Error::Requirements(err) => {
-                if let Some(context) = self.context {
-                    let err = miette::Report::msg(format!("{err}"))
-                        .context(format!("Failed to resolve {context} requirement"));
-                    anstream::eprint!("{err:?}");
-                    None
-                } else {
-                    Some(pip::operations::Error::Requirements(err))
-                }
+                Some(pip::operations::Error::Requirements(err))
             }
             err @ pip::operations::Error::OutdatedEnvironment(..) => {
                 anstream::eprintln!("{}", err);

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -4,6 +4,8 @@ use std::ffi::OsString;
 use std::fmt::Write;
 use std::io;
 use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, anyhow, bail};
@@ -1765,16 +1767,15 @@ impl RunCommand {
                 let mut process = Command::new(interpreter.sys_executable());
                 process.arg("-c");
 
-                #[cfg(unix)]
-                {
-                    use std::os::unix::ffi::OsStringExt;
-                    process.arg(OsString::from_vec(script.clone()));
-                }
-
-                #[cfg(not(unix))]
-                {
-                    let script = String::from_utf8(script.clone()).expect("script is valid UTF-8");
-                    process.arg(script);
+                cfg_select! {
+                    unix => {
+                        process.arg(OsString::from_vec(script.clone()));
+                    },
+                    _ => {
+                        let script =
+                            String::from_utf8(script.clone()).expect("script is valid UTF-8");
+                        process.arg(script);
+                    },
                 }
                 process.args(args);
 
@@ -1797,16 +1798,15 @@ impl RunCommand {
                 let mut process = Command::new(&pythonw_executable);
                 process.arg("-c");
 
-                #[cfg(unix)]
-                {
-                    use std::os::unix::ffi::OsStringExt;
-                    process.arg(OsString::from_vec(script.clone()));
-                }
-
-                #[cfg(not(unix))]
-                {
-                    let script = String::from_utf8(script.clone()).expect("script is valid UTF-8");
-                    process.arg(script);
+                cfg_select! {
+                    unix => {
+                        process.arg(OsString::from_vec(script.clone()));
+                    },
+                    _ => {
+                        let script =
+                            String::from_utf8(script.clone()).expect("script is valid UTF-8");
+                        process.arg(script);
+                    },
                 }
                 process.args(args);
 

--- a/crates/uv/src/commands/tool/mod.rs
+++ b/crates/uv/src/commands/tool/mod.rs
@@ -132,14 +132,13 @@ impl<'a> Target<'a> {
             // e.g., `ruff@latest`
             "latest" => Self::Latest(executable, name, extras),
             // e.g., `ruff@0.6.0`
+            version if let Ok(version) = Version::from_str(version) => {
+                Self::Version(executable, name, extras, version)
+            }
             version => {
-                if let Ok(version) = Version::from_str(version) {
-                    Self::Version(executable, name, extras, version)
-                } else {
-                    // e.g. `ruff@invalid`, warn and treat the whole thing as the command
-                    debug!("Ignoring invalid version request `{version}` in command");
-                    Self::Unspecified(target)
-                }
+                // e.g. `ruff@invalid`, warn and treat the whole thing as the command
+                debug!("Ignoring invalid version request `{version}` in command");
+                Self::Unspecified(target)
             }
         }
     }

--- a/crates/uv/src/commands/workspace/dir.rs
+++ b/crates/uv/src/commands/workspace/dir.rs
@@ -30,12 +30,9 @@ pub(crate) async fn dir(
 
     let dir = match package_name {
         None => workspace.install_path(),
+        Some(package) if let Some(project) = workspace.packages().get(&package) => project.root(),
         Some(package) => {
-            if let Some(p) = workspace.packages().get(&package) {
-                p.root()
-            } else {
-                bail!("Package `{package}` not found in workspace.")
-            }
+            bail!("Package `{package}` not found in workspace.")
         }
     };
 

--- a/crates/uv/tests/sync/centralized_project_envs.rs
+++ b/crates/uv/tests/sync/centralized_project_envs.rs
@@ -595,19 +595,18 @@ fn sync_centralized_env_with_existing_file() -> Result<()> {
         .assert()
         .success();
 
-    #[cfg(unix)]
-    {
-        let target = fs_err::read_link(environment.path())?;
-        insta::with_settings!({ filters => context.filters() }, {
-            assert_snapshot!(target.portable_display(), @"[CACHE_DIR]/environments-v2/project-cp3.12.[X]-[HASH]");
-        });
-    }
-
-    #[cfg(windows)]
-    {
-        // TODO(tk): This changes once `.venv` can store an environment path.
-        assert_eq!(fs_err::read_to_string(environment.path())?, "user-data");
-        assert!(context.cache_dir.child("environments-v2").is_dir());
+    cfg_select! {
+        unix => {
+            let target = fs_err::read_link(environment.path())?;
+            insta::with_settings!({ filters => context.filters() }, {
+                assert_snapshot!(target.portable_display(), @"[CACHE_DIR]/environments-v2/project-cp3.12.[X]-[HASH]");
+            });
+        },
+        windows => {
+            // TODO(tk): This changes once `.venv` can store an environment path.
+            assert_eq!(fs_err::read_to_string(environment.path())?, "user-data");
+            assert!(context.cache_dir.child("environments-v2").is_dir());
+        },
     }
     Ok(())
 }

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -15,6 +15,8 @@ use assert_fs::{
 use indoc::indoc;
 use insta::assert_snapshot;
 use predicates::prelude::predicate;
+#[cfg(windows)]
+use uv_fs::Simplified;
 use uv_fs::copy_dir_all;
 use uv_static::EnvVars;
 
@@ -6384,8 +6386,6 @@ fn tool_install_removed_python() {
                 .unwrap();
         },
         windows => {
-            use uv_fs::Simplified;
-
             let pyvenv_cfg = tool_root.child("pyvenv.cfg");
             let broken_home = context.temp_dir.join("missing-python");
             let contents = fs_err::read_to_string(&pyvenv_cfg).unwrap();

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -6376,33 +6376,32 @@ fn tool_install_removed_python() {
 
     // Simulate the tool's interpreter disappearing without copying an arbitrary system prefix
     // like `/usr` into the test directory.
-    #[cfg(unix)]
-    {
-        let tool_python = tool_root.child("bin").child("python");
-        fs_err::remove_file(&tool_python).unwrap();
-        fs_err::os::unix::fs::symlink(context.temp_dir.join("missing-python"), &tool_python)
-            .unwrap();
-    }
+    cfg_select! {
+        unix => {
+            let tool_python = tool_root.child("bin").child("python");
+            fs_err::remove_file(&tool_python).unwrap();
+            fs_err::os::unix::fs::symlink(context.temp_dir.join("missing-python"), &tool_python)
+                .unwrap();
+        },
+        windows => {
+            use uv_fs::Simplified;
 
-    #[cfg(windows)]
-    {
-        use uv_fs::Simplified;
-
-        let pyvenv_cfg = tool_root.child("pyvenv.cfg");
-        let broken_home = context.temp_dir.join("missing-python");
-        let contents = fs_err::read_to_string(&pyvenv_cfg).unwrap();
-        let contents = contents
-            .lines()
-            .map(|line| {
-                if line.starts_with("home = ") {
-                    format!("home = {}", broken_home.simplified_display())
-                } else {
-                    line.to_string()
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs_err::write(&pyvenv_cfg, format!("{contents}\n")).unwrap();
+            let pyvenv_cfg = tool_root.child("pyvenv.cfg");
+            let broken_home = context.temp_dir.join("missing-python");
+            let contents = fs_err::read_to_string(&pyvenv_cfg).unwrap();
+            let contents = contents
+                .lines()
+                .map(|line| {
+                    if line.starts_with("home = ") {
+                        format!("home = {}", broken_home.simplified_display())
+                    } else {
+                        line.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            fs_err::write(&pyvenv_cfg, format!("{contents}\n")).unwrap();
+        },
     }
 
     // Reinstalling should skip the broken Python install.


### PR DESCRIPTION
Adopts Rust 1.95’s `cfg_select!` macro and if-let match guards now that uv’s MSRV has been raised. This removes repetitive compile-time branches and nested conditional matches without changing behavior.