### PR TITLE
Cache Hawk dependencies

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -160,6 +160,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: ". -> target/hawk"
+          cache-workspace-crates: "false"
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
       - name: "Install Rust toolchain"
         run: rustup toolchain install 1.97.0
       - name: "Install Hawk"
@@ -167,7 +172,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 -LsSf \
             "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
       - name: "Hawk"
-        run: cargo +1.97.0 hawk -D warnings
+        run: cargo +1.97.0 hawk --target-dir target/hawk -D warnings
 
   shear:
     name: "cargo shear"


### PR DESCRIPTION
## Summary

Give the Hawk job its own Rust cache and target directory so dependency artifacts can be reused across CI runs.

Keep workspace crate outputs out of the cache so Hawk still recompiles uv and emits fresh analysis fragments. Cache writes continue to follow the workflow’s existing `save-rust-cache` input.

After rebasing onto Hawk 0.1.7 and package-scoped doctest analysis, [warm-cache CI on this branch](https://github.com/astral-sh/uv/actions/runs/29043777639/job/86207386980) reduced the Hawk step from 4:18 on the [exact base commit](https://github.com/astral-sh/uv/actions/runs/29043681659/job/86207094292) to 3:05, saving 1:13 (28%). Complete job time fell from 4:31 to 3:34, saving 57 seconds (21%). The 1.03 GB cache restored in 23 seconds and reduced the first production Cargo pass from 2:06 to 0:56; the other two Cargo passes and the scoped rustdoc and final-analysis phase remained within two seconds of the exact base, confirming that workspace analysis still runs fresh.