### PR TITLE
Upgrade Hawk to 0.1.7

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -16,7 +16,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   # renovate: datasource=github-releases depName=astral-sh/hawk
-  HAWK_VERSION: 0.1.6
+  HAWK_VERSION: 0.1.7
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/hawk.toml
+++ b/hawk.toml
@@ -12,6 +12,17 @@ package = "uv-dev"
 bin = "uv-dev"
 reason = "developer binary shipped from this workspace"
 
+# Keep this list in sync with workspace packages that define doctests.
+
+[[doctest]]
+package = "uv-pep440"
+
+[[doctest]]
+package = "uv-pep508"
+
+[[doctest]]
+package = "uv-redacted"
+
 # Keep public APIs that are consumed by downstream Rust integrations.
 
 [[override]]


### PR DESCRIPTION
## Summary

Upgrade Hawk from 0.1.6 to 0.1.7, which adds package-scoped doctest analysis.

Configure Hawk to compile doctests only for `uv-pep440`, `uv-pep508`, and `uv-redacted`. These are the three workspace packages that currently define executable doctests—five in total—so we retain the existing doctest consumer coverage without compiling rustdoc across the full workspace. A configuration comment records that the package list must stay synchronized as new doctests are added.

In [CI on this branch](https://github.com/astral-sh/uv/actions/runs/29042482462/job/86203126073) compared with [CI for the exact base commit](https://github.com/astral-sh/uv/actions/runs/29035164064/job/86178621474), the rustdoc and final-analysis phase fell from 3:34 to 0:48, saving 2:46 (78%). The full Hawk step fell from 6:33 to 4:34, saving 1:59 (30%), and the complete job fell from 6:47 to 4:50, saving 1:57 (29%). The exact-base run was unusually fast; against the 8:25 median of the three immediately preceding main runs with the same Rust and Hawk setup, the complete job saves 3:35 (43%).