### PR TITLE
Check locked tools for malware before cache reuse

### DIFF
--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -491,6 +491,7 @@ pub(crate) async fn check(
         Some(venv.root().to_owned())
     } else if let Some(project) = &project {
         let extras = extras.with_defaults(DefaultExtras::default());
+        let mut malware_context = project::sync::MalwareCheckContext::from(&malware_settings);
 
         let venv = if let Some(venv) = isolated_venv {
             venv
@@ -646,6 +647,7 @@ pub(crate) async fn check(
                         .build_constraints(project.workspace().install_path()),
                     &base_interpreter,
                     &settings,
+                    &malware_settings,
                     &client_builder,
                     &ty_state,
                     Box::new(SummaryInstallLogger),
@@ -665,6 +667,7 @@ pub(crate) async fn check(
                     }
                     Err(err) => return Err(err.into()),
                 };
+                malware_context.record_resolution(&resolution);
                 PythonEnvironment::from(environment)
                     .scripts()
                     .join(format!("ty{}", std::env::consts::EXE_SUFFIX))
@@ -695,7 +698,7 @@ pub(crate) async fn check(
                 DryRun::Disabled,
                 printer,
                 preview,
-                &malware_settings,
+                malware_context,
             )
             .await
             {

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -21,6 +21,7 @@ use uv_distribution_types::{
 };
 use uv_preview::Preview;
 use uv_python::{Interpreter, PythonEnvironment, canonicalize_executable};
+use uv_settings::MalwareCheckSettings;
 use uv_types::{HashStrategy, SourceTreeEditablePolicy};
 use uv_workspace::WorkspaceCache;
 
@@ -197,14 +198,16 @@ impl CachedEnvironment {
     /// Prefer [`Self::from_spec`] when starting from unresolved requirements; it selects the base
     /// interpreter and resolves the requirements for that interpreter before delegating here.
     ///
-    /// This method verifies the hashes recorded in `resolution`. `interpreter` must be the base
-    /// interpreter for which `resolution` was produced. In particular, callers materializing a
-    /// universal lock must derive its markers and tags from the same interpreter.
+    /// This method checks `resolution` for malware when enabled and verifies its recorded hashes.
+    /// Both checks run before cache lookup. `interpreter` must be the base interpreter for which
+    /// `resolution` was produced. In particular, callers materializing a universal lock must derive
+    /// its markers and tags from the same interpreter.
     pub(crate) async fn from_locked_resolution(
         resolution: &Resolution,
         build_constraints: Constraints,
         interpreter: &Interpreter,
         settings: &ResolverInstallerSettings,
+        malware_settings: &MalwareCheckSettings,
         client_builder: &BaseClientBuilder<'_>,
         state: &PlatformState,
         install: Box<dyn InstallLogger>,
@@ -214,6 +217,19 @@ impl CachedEnvironment {
         printer: Printer,
         preview: Preview,
     ) -> Result<Self, ProjectError> {
+        let malware_check_client_builder = client_builder
+            .clone()
+            .keyring(settings.resolver.keyring_provider);
+        crate::commands::project::sync::check_resolution_malware(
+            resolution,
+            &malware_check_client_builder,
+            concurrency,
+            malware_settings,
+            cache,
+            preview,
+        )
+        .await?;
+
         let hash_strategy = HashStrategy::from_resolution(resolution, HashCheckingMode::Verify)?;
         Self::from_resolution(
             resolution,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -20,7 +20,9 @@ use uv_configuration::{
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::LoweredExtraBuildDependencies;
-use uv_distribution_types::{Dist, Index, Name, Requirement, Resolution, ResolvedDist, SourceDist};
+use uv_distribution_types::{
+    Dist, Index, IndexUrl, Name, Requirement, Resolution, ResolvedDist, SourceDist,
+};
 use uv_fs::{PortablePathBuf, Simplified};
 use uv_installer::{InstallationStrategy, SitePackages};
 use uv_normalize::{DefaultExtras, DefaultGroups, PackageName};
@@ -634,7 +636,7 @@ impl Deref for SyncEnvironment {
 }
 
 /// Sync a lockfile with an environment.
-pub(crate) async fn do_sync(
+pub(crate) async fn do_sync<'a>(
     target: InstallTarget<'_>,
     venv: &PythonEnvironment,
     extras: &ExtrasSpecificationWithDefaults,
@@ -654,8 +656,10 @@ pub(crate) async fn do_sync(
     dry_run: DryRun,
     printer: Printer,
     preview: Preview,
-    malware_settings: &MalwareCheckSettings,
+    malware_settings: impl Into<MalwareCheckContext<'a>>,
 ) -> Result<Changelog, ProjectError> {
+    let malware_context = malware_settings.into();
+
     // Extract the project settings.
     let InstallerSettingsRef {
         index_locations,
@@ -836,7 +840,7 @@ pub(crate) async fn do_sync(
             concurrency,
             cache,
             preview,
-            malware_settings,
+            &malware_context,
         )
         .await?;
 
@@ -918,7 +922,7 @@ pub(crate) async fn do_sync(
         concurrency,
         cache,
         preview,
-        malware_settings,
+        &malware_context,
     )
     .await?;
 
@@ -949,6 +953,81 @@ pub(crate) async fn do_sync(
     Ok(changelog)
 }
 
+
+pub(crate) struct MalwareCheckContext<'a> {
+    settings: &'a MalwareCheckSettings,
+    checked_dependencies: Vec<Dependency>,
+    preview_warning_emitted: bool,
+}
+
+impl MalwareCheckContext<'_> {
+    pub(super) fn record_resolution(&mut self, resolution: &Resolution) {
+        if self.settings.enabled {
+            self.checked_dependencies
+                .extend(malware_dependencies_from_resolution(resolution));
+            self.preview_warning_emitted = true;
+        }
+    }
+}
+
+impl<'a> From<&'a MalwareCheckSettings> for MalwareCheckContext<'a> {
+    fn from(settings: &'a MalwareCheckSettings) -> Self {
+        Self {
+            settings,
+            checked_dependencies: Vec::new(),
+            preview_warning_emitted: false,
+        }
+    }
+}
+
+/// Run a malware check against OSV before reusing or materializing a locked [`Resolution`].
+pub(super) async fn check_resolution_malware(
+    resolution: &Resolution,
+    client_builder: &BaseClientBuilder<'_>,
+    concurrency: &Concurrency,
+    malware_settings: &MalwareCheckSettings,
+    cache: &Cache,
+    preview: Preview,
+) -> Result<(), ProjectError> {
+    if !malware_settings.enabled {
+        return Ok(());
+    }
+    warn_malware_check_preview(preview);
+
+    let dependencies = malware_dependencies_from_resolution(resolution);
+    let installed_dependencies = dependencies.iter().cloned().collect();
+
+    check_malware_dependencies(
+        &dependencies,
+        &installed_dependencies,
+        client_builder,
+        concurrency,
+        malware_settings.malware_check_url.clone(),
+        cache,
+    )
+    .await
+}
+
+fn malware_dependencies_from_resolution(resolution: &Resolution) -> Vec<Dependency> {
+    resolution
+        .distributions()
+        .filter(|dist| matches!(dist.index(), Some(IndexUrl::Pypi(_))))
+        .filter_map(|dist| {
+            dist.version()
+                .map(|version| Dependency::new(dist.name().clone(), version.clone()))
+        })
+        .collect()
+}
+
+fn warn_malware_check_preview(preview: Preview) {
+    if !preview.is_enabled(PreviewFeature::MalwareCheck) {
+        warn_user!(
+            "Malware checks are experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
+            PreviewFeature::MalwareCheck
+        );
+    }
+}
+
 /// Run a malware check against OSV if malware checking is enabled.
 async fn maybe_check_malware(
     target: &InstallTarget<'_>,
@@ -957,24 +1036,22 @@ async fn maybe_check_malware(
     concurrency: &Concurrency,
     cache: &Cache,
     preview: Preview,
-    malware_settings: &MalwareCheckSettings,
+    malware_context: &MalwareCheckContext<'_>,
 ) -> Result<(), ProjectError> {
-    if !malware_settings.enabled {
+    if !malware_context.settings.enabled {
         return Ok(());
     }
 
-    if !preview.is_enabled(PreviewFeature::MalwareCheck) {
-        warn_user!(
-            "Malware checks are experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
-            PreviewFeature::MalwareCheck
-        );
+    if !malware_context.preview_warning_emitted {
+        warn_malware_check_preview(preview);
     }
     check_malware(
         target,
         resolution,
+        &malware_context.checked_dependencies,
         client_builder,
         concurrency,
-        malware_settings.malware_check_url.clone(),
+        malware_context.settings.malware_check_url.clone(),
         cache,
     )
     .await
@@ -988,6 +1065,7 @@ async fn maybe_check_malware(
 async fn check_malware(
     target: &InstallTarget<'_>,
     resolution: &Resolution,
+    checked_dependencies: &[Dependency],
     client_builder: &BaseClientBuilder<'_>,
     concurrency: &Concurrency,
     malware_check_url: Option<DisplaySafeUrl>,
@@ -995,7 +1073,10 @@ async fn check_malware(
 ) -> Result<(), ProjectError> {
     let installed_dependencies: FxHashSet<_> = resolution
         .distributions()
-        .filter_map(|dist| dist.version().map(|version| (dist.name(), version)))
+        .filter_map(|dist| {
+            dist.version()
+                .map(|version| Dependency::new(dist.name().clone(), version.clone()))
+        })
         .collect();
 
     let all_extras = ExtrasSpecification::from_all_extras().with_defaults(DefaultExtras::All);
@@ -1021,8 +1102,28 @@ async fn check_malware(
     let dependencies: Vec<Dependency> = auditable
         .packages()
         .map(|(name, version)| Dependency::new((*name).clone(), (*version).clone()))
+        .filter(|dependency| !checked_dependencies.contains(dependency))
         .collect();
 
+    check_malware_dependencies(
+        &dependencies,
+        &installed_dependencies,
+        client_builder,
+        concurrency,
+        malware_check_url,
+        cache,
+    )
+    .await
+}
+
+async fn check_malware_dependencies(
+    dependencies: &[Dependency],
+    installed_dependencies: &FxHashSet<Dependency>,
+    client_builder: &BaseClientBuilder<'_>,
+    concurrency: &Concurrency,
+    malware_check_url: Option<DisplaySafeUrl>,
+    cache: &Cache,
+) -> Result<(), ProjectError> {
     let osv_url = malware_check_url.unwrap_or_else(|| osv::API_BASE.clone());
 
     let base_client = client_builder.build()?;
@@ -1039,7 +1140,7 @@ async fn check_malware(
     // seems fine while we're in preview since it'll help us shake out
     // any reliability risks with OSV.
     let identifiers = service
-        .query_identifiers(&dependencies, Filter::Malware)
+        .query_identifiers(dependencies, Filter::Malware)
         .await?;
 
     let malware_findings: Vec<_> = identifiers
@@ -1056,9 +1157,9 @@ async fn check_malware(
             MalwareFindings(malware_findings.clone())
         );
 
-        let has_installed_malware = malware_findings.iter().any(|(dependency, _)| {
-            installed_dependencies.contains(&(dependency.name(), dependency.version()))
-        });
+        let has_installed_malware = malware_findings
+            .iter()
+            .any(|(dependency, _)| installed_dependencies.contains(dependency));
 
         if has_installed_malware {
             Err(ProjectError::MalwareFound)

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -959,7 +959,7 @@ pub(crate) async fn do_sync<'a>(
 /// were already checked instead of querying OSV twice.
 pub(crate) struct MalwareCheckContext<'a> {
     settings: &'a MalwareCheckSettings,
-    checked_dependencies: Vec<Dependency>,
+    checked_dependencies: FxHashSet<Dependency>,
 }
 
 impl MalwareCheckContext<'_> {
@@ -975,7 +975,7 @@ impl<'a> From<&'a MalwareCheckSettings> for MalwareCheckContext<'a> {
     fn from(settings: &'a MalwareCheckSettings) -> Self {
         Self {
             settings,
-            checked_dependencies: Vec::new(),
+            checked_dependencies: FxHashSet::default(),
         }
     }
 }
@@ -1063,7 +1063,7 @@ async fn maybe_check_malware(
 async fn check_malware(
     target: &InstallTarget<'_>,
     resolution: &Resolution,
-    checked_dependencies: &[Dependency],
+    checked_dependencies: &FxHashSet<Dependency>,
     client_builder: &BaseClientBuilder<'_>,
     concurrency: &Concurrency,
     malware_check_url: Option<DisplaySafeUrl>,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -39,7 +39,7 @@ use uv_resolver::{
 use uv_scripts::Pep723Script;
 use uv_settings::{MalwareCheckSettings, PythonInstallMirrors};
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
-use uv_warnings::warn_user;
+use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::pyproject::Source;
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, VirtualProject, Workspace, WorkspaceCache};
 
@@ -953,11 +953,13 @@ pub(crate) async fn do_sync<'a>(
     Ok(changelog)
 }
 
-
+/// Carries dependencies checked during a locked-tool preflight into a following project sync.
+///
+/// The locked tool and project resolutions can overlap, so the later sync skips dependencies that
+/// were already checked instead of querying OSV twice.
 pub(crate) struct MalwareCheckContext<'a> {
     settings: &'a MalwareCheckSettings,
     checked_dependencies: Vec<Dependency>,
-    preview_warning_emitted: bool,
 }
 
 impl MalwareCheckContext<'_> {
@@ -965,7 +967,6 @@ impl MalwareCheckContext<'_> {
         if self.settings.enabled {
             self.checked_dependencies
                 .extend(malware_dependencies_from_resolution(resolution));
-            self.preview_warning_emitted = true;
         }
     }
 }
@@ -975,7 +976,6 @@ impl<'a> From<&'a MalwareCheckSettings> for MalwareCheckContext<'a> {
         Self {
             settings,
             checked_dependencies: Vec::new(),
-            preview_warning_emitted: false,
         }
     }
 }
@@ -1021,7 +1021,7 @@ fn malware_dependencies_from_resolution(resolution: &Resolution) -> Vec<Dependen
 
 fn warn_malware_check_preview(preview: Preview) {
     if !preview.is_enabled(PreviewFeature::MalwareCheck) {
-        warn_user!(
+        warn_user_once!(
             "Malware checks are experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
             PreviewFeature::MalwareCheck
         );
@@ -1042,9 +1042,7 @@ async fn maybe_check_malware(
         return Ok(());
     }
 
-    if !malware_context.preview_warning_emitted {
-        warn_malware_check_preview(preview);
-    }
+    warn_malware_check_preview(preview);
     check_malware(
         target,
         resolution,

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -5,6 +5,9 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::indoc;
 use insta::assert_snapshot;
+use serde_json::json;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use uv_static::EnvVars;
 use uv_test::packse::PackseServer;
@@ -982,9 +985,9 @@ fn check_no_sync_isolated_does_not_write_lock_or_sync() -> Result<()> {
     Ok(())
 }
 
-#[test]
+#[tokio::test]
 #[cfg(feature = "test-pypi")]
-fn check_uses_exact_ty_version_from_selected_included_group() -> Result<()> {
+async fn check_uses_exact_ty_version_from_selected_included_group() -> Result<()> {
     let context =
         uv_test::test_context!("3.12").with_filter((r"ty 0\.0\.17(?: \([^)]*\))?", "ty 0.0.17"));
 
@@ -1033,8 +1036,20 @@ fn check_uses_exact_ty_version_from_selected_included_group() -> Result<()> {
     assert!(context.temp_dir.child("uv.lock").exists());
     assert!(context.site_packages().join("ty").exists());
 
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .and(body_string_contains("ty"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": []}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
     // The preferred `dev` group is not enabled, so the tool uses a cached environment even though
-    // the enabled `typing` group selects the same package.
+    // the enabled `typing` group selects the same package. The cached environment and normal sync
+    // should share the malware result instead of querying OSV twice.
     uv_snapshot!(
         context.filters(),
         context
@@ -1044,7 +1059,9 @@ fn check_uses_exact_ty_version_from_selected_included_group() -> Result<()> {
             .arg("typing")
             .arg("--exclude-newer")
             .arg("2026-02-15T00:00:00Z")
-            .arg("--show-version"),
+            .arg("--show-version")
+            .env(EnvVars::UV_MALWARE_CHECK, "1")
+            .env(EnvVars::UV_MALWARE_CHECK_URL, server.uri()),
         @"
     exit_code: 0 (success)
     ----- stdout -----
@@ -1052,6 +1069,7 @@ fn check_uses_exact_ty_version_from_selected_included_group() -> Result<()> {
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    warning: Malware checks are experimental and may change without warning. Pass `--preview-features malware-check` to disable this warning.
     Installed 1 package in [TIME]
     Using ty 0.0.17
     "
@@ -1120,6 +1138,77 @@ fn check_locked_tool_rejects_invalid_hash() -> Result<()> {
 
           Computed:
             sha256:[HASH]
+    "
+    );
+
+    Ok(())
+}
+
+/// Ensure that a cached environment for a locked tool is checked for malware before reuse.
+#[tokio::test]
+#[cfg(feature = "test-pypi")]
+async fn check_locked_tool_rejects_malware_from_warm_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [dependency-groups]
+        dev = ["ty==0.0.17"]
+    "#})?;
+    context.temp_dir.child("main.py").write_str("x = 1")?;
+
+    context
+        .lock()
+        .arg("--exclude-newer")
+        .arg("2026-02-15T00:00:00Z")
+        .assert()
+        .success();
+
+    // Populate the locked tool environment without a malware check.
+    context
+        .check()
+        .arg("--no-sync")
+        .arg("--frozen")
+        .env(EnvVars::UV_MALWARE_CHECK, "0")
+        .assert()
+        .success();
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .and(body_string_contains("ty"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "MAL-2026-1234"}]}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--no-sync")
+            .arg("--frozen")
+            .arg("--preview-features")
+            .arg("malware-check")
+            .env(EnvVars::UV_MALWARE_CHECK, "1")
+            .env(EnvVars::UV_MALWARE_CHECK_URL, server.uri()),
+        @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    warning: Malware detected in locked dependencies:
+      - `ty==0.0.17`: MAL-2026-1234 (https://osv.dev/vulnerability/MAL-2026-1234)
+    error: Malware detected in one or more dependencies that would be installed; aborting sync. Set `UV_MALWARE_CHECK=0` to bypass this check.
     "
     );
 


### PR DESCRIPTION
`UV_MALWARE_CHECK` runs during normal project synchronization, but `uv check` can materialize a locked `ty` subgraph through `CachedEnvironment::from_locked_resolution`. That path previously bypassed malware checks, including when reusing a warm cache entry or running with `--no-sync`.

This adds the malware preflight to the shared locked-environment code, before cache lookup or materialization. When project synchronization follows, `MalwareCheckContext` carries the already-checked dependencies forward so uv does not query OSV or emit the preview warning twice. Explicit tool paths and standalone download paths remain outside this flow.
