### PR TITLE
Fix preview schema in schemastore

### DIFF
--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -2924,6 +2924,10 @@ impl schemars::JsonSchema for PreviewOption {
         schema.insert(
             "not".to_string(),
             schemars::json_schema!({
+                "properties": {
+                    "preview": {},
+                    "preview-features": {},
+                },
                 "required": ["preview", "preview-features"],
             })
             .into(),

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -594,6 +594,10 @@
   },
   "additionalProperties": false,
   "not": {
+    "properties": {
+      "preview": {},
+      "preview-features": {}
+    },
     "required": ["preview", "preview-features"]
   },
   "definitions": {
@@ -1762,7 +1766,8 @@
             "packaged-init",
             "centralized-project-envs",
             "tool-install-locks",
-            "workspace-list-scripts"
+            "workspace-list-scripts",
+            "no-distutils-patch"
           ]
         },
         {


### PR DESCRIPTION
SchemaStore validates `uv.json` with Ajv strict mode, which rejects the generated `not` constraint because it requires `preview` and `preview-features` without declaring them in the same subschema.

This adds empty property declarations alongside `required`. Regenerating `uv.schema.json` also adds the existing `no-distutils-patch` preview feature, which was missing from the checked-in schema.
