### PR TITLE
Fix build backend compatible-version safeguard never firing

### DIFF
--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -2201,15 +2201,16 @@ mod tests {
         // Versions are ordered from oldest to latest
         let last_compatible =
             Version::from_str(COMPATIBLE_VERSIONS[COMPATIBLE_VERSIONS.len() - 1]).unwrap();
-        if last_compatible.release()[0] != current_version.release()[0]
-            && last_compatible.release()[0] != current_version.release()[1]
-        {
-            panic!(
-                "Please update the list of compatible versions for the uv build backend: \
-                If there was no breaking change in uv-build, add the last release before the \
-                breaking release to `COMPATIBLE_VERSIONS`, otherwise reset `COMPATIBLE_VERSIONS` \
-                to an empty list"
-            );
-        }
+        // uv is versioned as `0.<minor>.<patch>`, so a breaking release bumps the minor segment.
+        // The list is kept one minor behind the current release, so if the newest compatible
+        // version isn't the immediately preceding minor, we likely missed updating the list on a
+        // breaking release.
+        assert!(
+            last_compatible.release()[1] + 1 == current_version.release()[1],
+            "Please update the list of compatible versions for the uv build backend: \
+            If there was no breaking change in uv-build, add the last release before the \
+            breaking release to `COMPATIBLE_VERSIONS`, otherwise reset `COMPATIBLE_VERSIONS` \
+            to an empty list"
+        );
     }
 }


### PR DESCRIPTION


The `update_compatibility_for_breaking_release` test in the uv build backend is
meant to fail on a breaking-version bump when `COMPATIBLE_VERSIONS` has not been
updated (it was added in #18821 as an oversight guard). Right now its check is
dead code, so it can never fail and the guard does nothing.

The condition is:

```rust
if last_compatible.release()[0] != current_version.release()[0]
    && last_compatible.release()[0] != current_version.release()[1]
{
    panic!(...);
}
```

The second `&&` operand reuses `last_compatible.release()[0]` where it looks like
it was meant to compare the minor segment `[1]`. Since uv is versioned
`0.<minor>.<patch>`, the major segment `release()[0]` is always `0`, so the first
operand `0 != 0` is always false and the `&&` makes the whole condition false no
matter what. The `panic!` is unreachable, so the test always passes.

I looked at how `COMPATIBLE_VERSIONS` is actually maintained to work out what the
check was trying to express. The list is kept exactly one minor behind the current
release: the 0.11.0 bump (`1f31f0e9f`) changed it from `["0.9.30"]` to
`["0.9.30", "0.10.12"]`, adding the last release of the previous minor. So I
replaced the guard with an assertion of that invariant: the newest compatible
version's minor plus one equals the current minor.

```rust
assert!(
    last_compatible.release()[1] + 1 == current_version.release()[1],
    "..."
);
```

This passes on the current state (last compatible `0.10.12`, current `0.11.x`) and
fails, as intended, when a breaking minor bump lands without the list being
updated. I used `assert!` instead of `if ... { panic! }` to match the assertion
style and keep clippy happy.

One thing worth flagging: this is a judgment call about the intended heuristic, and
it is slightly stricter than the original (broken) code. The comment above the test
already says "Feel free to update the heuristic if it doesn't suit the current
compatibility rules anymore," so please adjust if you had something different in
mind. I deliberately did not touch `COMPATIBLE_VERSIONS` itself, since whether any
given release is a breaking build-backend change is a maintainer call and the fixed
test passes as-is.

## Test Plan

- `cargo test -p uv-build-backend --lib update_compatibility_for_breaking_release`
  passes; the full `cargo test -p uv-build-backend --lib` is green (61 tests).
- `cargo clippy -p uv-build-backend --all-targets --all-features -- -D warnings` is
  clean.
- `cargo fmt -p uv-build-backend -- --check` is clean.
- To confirm the guard now actually fires, I temporarily set `COMPATIBLE_VERSIONS`
  to `["0.9.30"]` (simulating a missed breaking bump): the test fails with the
  intended panic. Setting it to `[]` returns early and passes (the reset case).
  Restored to the real list, it passes again.
