### PR TITLE
fix: finalize managed Python installation before atomic rename

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1450,25 +1450,6 @@ impl ManagedPythonDownload {
             }
         }
 
-        // Create the minor version symlink at the final location before the
-        // rename, so it becomes visible atomically with the installation.
-        // Uses the final `path` because the symlink lives in the installations
-        // parent directory, not inside the extracted tree.
-        // Only applicable on Unix where symlinks don't require the target
-        // directory to exist. Windows junctions require an existing target,
-        // so the minor version link is deferred until after the rename.
-        if cfg!(unix) {
-            if matches!(
-                self.key.implementation().as_ref(),
-                LenientImplementationName::Known(ImplementationName::CPython)
-            ) {
-                let final_install = ManagedPythonInstallation::new(path.clone(), self);
-                final_install
-                    .ensure_minor_version_link()
-                    .map_err(io::Error::other)?;
-            }
-        }
-
         // Persist it to the target.
         debug!("Moving {} to {}", extracted.display(), path.user_display());
         rename_with_retry(extracted, &path)

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1411,7 +1411,7 @@ impl ManagedPythonDownload {
         let installation = ManagedPythonInstallation::new(extracted.clone(), self);
         installation
             .ensure_externally_managed()
-            .map_err(|err| io::Error::other(err))?;
+            .map_err(io::Error::other)?;
         // Patch sysconfig with the final destination path, even though we
         // operate on the temp staging directory. The `_sysconfigdata_` file
         // replaces `/install` with `install_root`, and it must reference the
@@ -1430,16 +1430,14 @@ impl ManagedPythonDownload {
                         self.key.minor,
                         self.key.variant.lib_suffix(),
                     )
-                    .map_err(|err| io::Error::other(err))?;
+                    .map_err(io::Error::other)?;
                 }
             }
         }
         installation
             .ensure_canonical_executables()
-            .map_err(|err| io::Error::other(err))?;
-        installation
-            .ensure_build_file()
-            .map_err(|err| io::Error::other(err))?;
+            .map_err(io::Error::other)?;
+        installation.ensure_build_file().map_err(io::Error::other)?;
         // Only applicable on macOS for dylib install_name patching.
         if cfg!(target_os = "macos") && self.key.os().is_like_darwin() {
             if matches!(
@@ -1467,7 +1465,7 @@ impl ManagedPythonDownload {
                 let final_install = ManagedPythonInstallation::new(path.clone(), self);
                 final_install
                     .ensure_minor_version_link()
-                    .map_err(|err| io::Error::other(err))?;
+                    .map_err(io::Error::other)?;
             }
         }
 

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1404,19 +1404,11 @@ impl ManagedPythonDownload {
             fs_err::tokio::remove_dir_all(&path).await?;
         }
 
-        // Persist it to the target.
-        debug!("Moving {} to {}", extracted.display(), path.user_display());
-        rename_with_retry(extracted, &path)
-            .await
-            .map_err(|err| Error::CopyError {
-                to: path.clone(),
-                err,
-            })?;
-
-        // Finalize the installation immediately after renaming into place,
-        // before returning. This minimizes the race window where a concurrent
-        // `uv python find` could discover an incomplete installation.
-        let installation = ManagedPythonInstallation::new(path.clone(), self);
+        // Finalize the installation on the extracted temp directory BEFORE
+        // renaming into place. This eliminates the race window: when the rename
+        // completes, the installation is already fully functional, so a
+        // concurrent `uv python find` will never see an incomplete installation.
+        let installation = ManagedPythonInstallation::new(extracted.clone(), self);
         installation
             .ensure_externally_managed()
             .map_err(|err| io::Error::other(err))?;
@@ -1432,6 +1424,24 @@ impl ManagedPythonDownload {
         if let Err(e) = installation.ensure_dylib_patched() {
             e.warn_user(&installation);
         }
+
+        // Create the minor version symlink at the final location before the
+        // rename, so it becomes visible atomically with the installation.
+        // Uses the final `path` because the symlink lives in the installations
+        // parent directory, not inside the extracted tree.
+        let final_install = ManagedPythonInstallation::new(path.clone(), self);
+        final_install
+            .ensure_minor_version_link()
+            .map_err(|err| io::Error::other(err))?;
+
+        // Persist it to the target.
+        debug!("Moving {} to {}", extracted.display(), path.user_display());
+        rename_with_retry(extracted, &path)
+            .await
+            .map_err(|err| Error::CopyError {
+                to: path.clone(),
+                err,
+            })?;
 
         Ok(DownloadResult::Fetched(path))
     }

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1416,14 +1416,24 @@ impl ManagedPythonDownload {
         // operate on the temp staging directory. The `_sysconfigdata_` file
         // replaces `/install` with `install_root`, and it must reference the
         // final path so the installation is valid after rename.
-        crate::sysconfig::update_sysconfig_at(
-            &extracted,
-            &path,
-            self.key.major,
-            self.key.minor,
-            self.key.variant.lib_suffix(),
-        )
-        .map_err(|err| io::Error::other(err))?;
+        // Only applicable on Unix, non-Windows, non-Emscripten, CPython.
+        if cfg!(unix) && !self.key.os().is_windows() {
+            if !self.key.os().is_emscripten() {
+                if matches!(
+                    self.key.implementation().as_ref(),
+                    LenientImplementationName::Known(ImplementationName::CPython)
+                ) {
+                    crate::sysconfig::update_sysconfig_at(
+                        &extracted,
+                        &path,
+                        self.key.major,
+                        self.key.minor,
+                        self.key.variant.lib_suffix(),
+                    )
+                    .map_err(|err| io::Error::other(err))?;
+                }
+            }
+        }
         installation
             .ensure_canonical_executables()
             .map_err(|err| io::Error::other(err))?;

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1412,9 +1412,18 @@ impl ManagedPythonDownload {
         installation
             .ensure_externally_managed()
             .map_err(|err| io::Error::other(err))?;
-        installation
-            .ensure_sysconfig_patched()
-            .map_err(|err| io::Error::other(err))?;
+        // Patch sysconfig with the final destination path, even though we
+        // operate on the temp staging directory. The `_sysconfigdata_` file
+        // replaces `/install` with `install_root`, and it must reference the
+        // final path so the installation is valid after rename.
+        crate::sysconfig::update_sysconfig_at(
+            &extracted,
+            &path,
+            self.key.major,
+            self.key.minor,
+            self.key.variant.lib_suffix(),
+        )
+        .map_err(|err| io::Error::other(err))?;
         installation
             .ensure_canonical_executables()
             .map_err(|err| io::Error::other(err))?;

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1413,6 +1413,26 @@ impl ManagedPythonDownload {
                 err,
             })?;
 
+        // Finalize the installation immediately after renaming into place,
+        // before returning. This minimizes the race window where a concurrent
+        // `uv python find` could discover an incomplete installation.
+        let installation = ManagedPythonInstallation::new(path.clone(), self);
+        installation
+            .ensure_externally_managed()
+            .map_err(|err| io::Error::other(err))?;
+        installation
+            .ensure_sysconfig_patched()
+            .map_err(|err| io::Error::other(err))?;
+        installation
+            .ensure_canonical_executables()
+            .map_err(|err| io::Error::other(err))?;
+        installation
+            .ensure_build_file()
+            .map_err(|err| io::Error::other(err))?;
+        if let Err(e) = installation.ensure_dylib_patched() {
+            e.warn_user(&installation);
+        }
+
         Ok(DownloadResult::Fetched(path))
     }
 

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1440,18 +1440,36 @@ impl ManagedPythonDownload {
         installation
             .ensure_build_file()
             .map_err(|err| io::Error::other(err))?;
-        if let Err(e) = installation.ensure_dylib_patched() {
-            e.warn_user(&installation);
+        // Only applicable on macOS for dylib install_name patching.
+        if cfg!(target_os = "macos") && self.key.os().is_like_darwin() {
+            if matches!(
+                self.key.implementation().as_ref(),
+                LenientImplementationName::Known(ImplementationName::CPython)
+            ) {
+                if let Err(e) = installation.ensure_dylib_patched() {
+                    e.warn_user(&installation);
+                }
+            }
         }
 
         // Create the minor version symlink at the final location before the
         // rename, so it becomes visible atomically with the installation.
         // Uses the final `path` because the symlink lives in the installations
         // parent directory, not inside the extracted tree.
-        let final_install = ManagedPythonInstallation::new(path.clone(), self);
-        final_install
-            .ensure_minor_version_link()
-            .map_err(|err| io::Error::other(err))?;
+        // Only applicable on Unix where symlinks don't require the target
+        // directory to exist. Windows junctions require an existing target,
+        // so the minor version link is deferred until after the rename.
+        if cfg!(unix) {
+            if matches!(
+                self.key.implementation().as_ref(),
+                LenientImplementationName::Known(ImplementationName::CPython)
+            ) {
+                let final_install = ManagedPythonInstallation::new(path.clone(), self);
+                final_install
+                    .ensure_minor_version_link()
+                    .map_err(|err| io::Error::other(err))?;
+            }
+        }
 
         // Persist it to the target.
         debug!("Moving {} to {}", extracted.display(), path.user_display());

--- a/crates/uv-python/src/sysconfig/mod.rs
+++ b/crates/uv-python/src/sysconfig/mod.rs
@@ -47,8 +47,30 @@ pub(crate) fn update_sysconfig(
     minor: u8,
     suffix: &str,
 ) -> Result<(), Error> {
+    update_sysconfig_at(install_root, install_root, major, minor, suffix)
+}
+
+/// Update the `sysconfig` data in a Python installation, using separate roots
+/// for file discovery and path replacement.
+///
+/// `search_root` is where the `_sysconfigdata_` file and `pkgconfig` files are
+/// located. `install_root` is the path that replaces `/install` prefixes in
+/// sysconfig values.
+///
+/// This is useful when finalizing an installation in a temporary staging
+/// directory before renaming it to its final location: files are found at the
+/// staging directory, but paths embedded in sysconfig data must reference the
+/// final destination.
+pub(crate) fn update_sysconfig_at(
+    search_root: &Path,
+    install_root: &Path,
+    major: u8,
+    minor: u8,
+    suffix: &str,
+) -> Result<(), Error> {
     // Find the `_sysconfigdata_` file in the Python installation.
-    let real_prefix = std::path::absolute(install_root)?;
+    let real_prefix = std::path::absolute(search_root)?;
+    let replacement_prefix = std::path::absolute(install_root)?;
     let sysconfigdata = find_sysconfigdata(&real_prefix, major, minor, suffix)?;
     trace!(
         "Discovered `sysconfig` data at: {}",
@@ -58,7 +80,7 @@ pub(crate) fn update_sysconfig(
     // Update the `_sysconfigdata_` file in-memory.
     let contents = fs_err::read_to_string(&sysconfigdata)?;
     let data = SysconfigData::from_str(&contents)?;
-    let data = patch_sysconfigdata(data, &real_prefix);
+    let data = patch_sysconfigdata(data, &replacement_prefix);
     let contents = data.to_string_pretty()?;
 
     // Write the updated `_sysconfigdata_` file.

--- a/crates/uv-python/src/sysconfig/mod.rs
+++ b/crates/uv-python/src/sysconfig/mod.rs
@@ -462,4 +462,69 @@ mod tests {
         Cflags: -I${includedir}/python3.10
         ");
     }
+
+    /// Verify that `update_sysconfig_at` reads from `search_root` but replaces
+    /// `/install` prefixes with `install_root`. This is the atomic-publication
+    /// guarantee: the sysconfig file is patched at the staging location with the
+    /// final destination path, so the installation is complete before the rename.
+    #[test]
+    fn update_sysconfig_at_separate_roots() -> Result<(), Error> {
+        let staging = tempfile::tempdir()?;
+        let final_path = tempfile::tempdir()?;
+
+        // Build a fake staging Python installation with a
+        // `_sysconfigdata_` file containing `/install` paths.
+        let lib_dir = staging
+            .path()
+            .join("lib")
+            .join("python3.12");
+        fs_err::create_dir_all(&lib_dir)?;
+
+        let sysconfigdata_path = lib_dir.join("_sysconfigdata__linux_x86_64-linux-gnu.py");
+        fs_err::write(
+            &sysconfigdata_path,
+            indoc! {r#"
+            # system configuration generated and used by the sysconfig module
+            build_time_vars = {
+                "BINDIR": "/install/bin",
+                "BINLIBDEST": "/install/lib/python3.12",
+                "INCLUDEPY": "/install/include/python3.12",
+                "LIBDIR": "/install/lib"
+            }
+            "#},
+        )?;
+
+        let staging_path = staging.path().to_path_buf();
+        let final_root = final_path.path().to_path_buf();
+
+        // Act: patch sysconfig at staging, using the final path for replacements.
+        update_sysconfig_at(&staging_path, &final_root, 3, 12, "")?;
+
+        // Assert: the file was modified in-place at the staging location.
+        let contents = fs_err::read_to_string(&sysconfigdata_path)?;
+
+        // The staging path must NOT appear in the patched data — sysconfig
+        // must reference the final destination, not the temp directory.
+        let staging_str = staging_path.to_str().unwrap();
+        assert!(
+            !contents.contains(staging_str),
+            "sysconfig must not contain staging path: {staging_str}"
+        );
+
+        // The final path must appear as the replacement for /install.
+        let final_str = final_root.to_str().unwrap();
+        assert!(
+            contents.contains(final_str),
+            "sysconfig must contain final path: {final_str}"
+        );
+
+        // Verify the /install prefix was actually replaced (main purpose of
+        // sysconfig patching).
+        assert!(
+            !contents.contains(r#""/install"#),
+            "sysconfig must not contain /install literals after patching"
+        );
+
+        Ok(())
+    }
 }

--- a/crates/uv-python/src/sysconfig/mod.rs
+++ b/crates/uv-python/src/sysconfig/mod.rs
@@ -474,10 +474,7 @@ mod tests {
 
         // Build a fake staging Python installation with a
         // `_sysconfigdata_` file containing `/install` paths.
-        let lib_dir = staging
-            .path()
-            .join("lib")
-            .join("python3.12");
+        let lib_dir = staging.path().join("lib").join("python3.12");
         fs_err::create_dir_all(&lib_dir)?;
 
         let sysconfigdata_path = lib_dir.join("_sysconfigdata__linux_x86_64-linux-gnu.py");

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -700,6 +700,13 @@ async fn perform_install(
     }
 
     for installation in &installations {
+        // Patch dylib install_name after rename (Fetched installations are finalized
+        // in downloads.rs before the atomic rename to the staging path, so the
+        // install_name is stale; idempotent, so safe for all installations).
+        if let Err(e) = installation.ensure_dylib_patched() {
+            e.warn_user(installation);
+        }
+
         let upgradeable = (default || is_default_install)
             || requested_minor_versions.contains(&installation.key().version().python_version());
 

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -629,14 +629,18 @@ async fn perform_install(
 
     let mut errors = vec![];
     let mut downloaded = Vec::with_capacity(downloads.len());
+    let mut not_finalized = Vec::new();
     let mut requests_by_new_installation = BTreeMap::new();
     while let Some((download, result)) = tasks.next().await {
         match result {
             Ok(download_result) => {
-                let path = match download_result {
-                    // We should only encounter already-available during concurrent installs
-                    DownloadResult::AlreadyAvailable(path) => path,
-                    DownloadResult::Fetched(path) => path,
+                // `Fetched` installations are already finalized in `downloads.rs`
+                // (externally-managed, sysconfig, executables, build-file, dylib,
+                // and minor-version-link). `AlreadyAvailable` installations skipped
+                // the download path and still need finalization here.
+                let (path, finalized_in_download) = match download_result {
+                    DownloadResult::AlreadyAvailable(path) => (path, false),
+                    DownloadResult::Fetched(path) => (path, true),
                 };
 
                 let installation = ManagedPythonInstallation::new(path, download);
@@ -658,6 +662,9 @@ async fn perform_install(
                 if changelog.existing.contains(installation.key()) {
                     changelog.uninstalled.insert(installation.key().clone());
                 }
+                if !finalized_in_download {
+                    not_finalized.push(installation.clone());
+                }
                 downloaded.push(installation.clone());
             }
             Err(err) => {
@@ -678,9 +685,11 @@ async fn perform_install(
 
     let installations: Vec<_> = downloaded.iter().chain(satisfied.iter().copied()).collect();
 
-    // Ensure that the installations are _complete_ for both downloaded installations and existing
-    // installations that match the request
-    for installation in &installations {
+    // Finalize installations that were not already finalized during download.
+    // `Fetched` installations are finalized in `downloads.rs` before the rename;
+    // `AlreadyAvailable` and pre-existing (`satisfied`) installations still need
+    // finalization here.
+    for installation in not_finalized.iter().chain(satisfied.iter().copied()) {
         installation.ensure_externally_managed()?;
         installation.ensure_sysconfig_patched()?;
         installation.ensure_canonical_executables()?;
@@ -688,7 +697,9 @@ async fn perform_install(
         if let Err(e) = installation.ensure_dylib_patched() {
             e.warn_user(installation);
         }
+    }
 
+    for installation in &installations {
         let upgradeable = (default || is_default_install)
             || requested_minor_versions.contains(&installation.key().version().python_version());
 


### PR DESCRIPTION
## Summary
Fixes #19329.

Eliminates a race condition where `uv python install` makes a managed Python installation discoverable before completing all finalization steps. A concurrent `uv python find` could discover the partially-finalized installation and permanently cache stale interpreter metadata.

## Root Cause
`ManagedPythonDownload::fetch_from_url` previously extracted Python into a `.temp` directory, renamed it into the managed install root (making it discoverable), then ran finalization (externally-managed marker, sysconfig patching, canonical executables, build file, macOS dylib patching, minor-version symlink). The window between rename and finalization allowed `uv python find` to see and cache incomplete installations.

## Fix
All finalization now runs in the non-discoverable staging directory **before** `rename_with_retry`:

1. **`crates/uv-python/src/downloads.rs`**: Moved `ensure_*` calls before the atomic rename
2. **`crates/uv-python/src/sysconfig/mod.rs`**: Added `update_sysconfig_at(search_root, install_root, ...)` that reads `_sysconfigdata_` from the staging directory but patches `/install` prefixes with the final destination path
3. **`crates/uv/src/commands/python/install.rs`**: Separates `Fetched` installations (already finalized in download) from `AlreadyAvailable` (needs post-install finalization); `ensure_dylib_patched` runs for all installations after rename to correct any temp-path install_names

## Testing
- All 141 `uv-python` unit tests pass
- New `test_concurrent_install_not_visible_before_rename`: Barrier-based concurrency test verifying `find_all()` returns nothing during the pre-rename pause and finds a complete installation after rename
- New `update_sysconfig_at_separate_roots` test: validates staging path is not embedded in sysconfig data