### PR TITLE
Support UV_ONLY_BINARY for pip commands

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1667,7 +1667,12 @@ pub struct PipCompileArgs {
     ///
     /// Multiple packages may be provided. Disable binaries for all packages with `:all:`.
     /// Clear previously specified packages with `:none:`.
-    #[arg(long, value_delimiter = ',', conflicts_with = "no_build")]
+    #[arg(
+        long,
+        env = EnvVars::UV_ONLY_BINARY,
+        value_delimiter = ',',
+        conflicts_with = "no_build"
+    )]
     pub only_binary: Option<Vec<PackageNameSpecifier>>,
 
     /// The Python version to use for resolution.
@@ -2029,7 +2034,12 @@ pub struct PipSyncArgs {
     ///
     /// Multiple packages may be provided. Disable binaries for all packages with `:all:`. Clear
     /// previously specified packages with `:none:`.
-    #[arg(long, value_delimiter = ',', conflicts_with = "no_build")]
+    #[arg(
+        long,
+        env = EnvVars::UV_ONLY_BINARY,
+        value_delimiter = ',',
+        conflicts_with = "no_build"
+    )]
     pub only_binary: Option<Vec<PackageNameSpecifier>>,
 
     /// Allow sync of empty requirements, which will clear the environment of all packages.
@@ -2415,7 +2425,12 @@ pub struct PipInstallArgs {
     ///
     /// Multiple packages may be provided. Disable binaries for all packages with `:all:`. Clear
     /// previously specified packages with `:none:`.
-    #[arg(long, value_delimiter = ',', conflicts_with = "no_build")]
+    #[arg(
+        long,
+        env = EnvVars::UV_ONLY_BINARY,
+        value_delimiter = ',',
+        conflicts_with = "no_build"
+    )]
     pub only_binary: Option<Vec<PackageNameSpecifier>>,
 
     /// The minimum Python version that should be supported by the requirements (e.g., `3.7` or

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -312,6 +312,11 @@ impl EnvVars {
     #[attr_added_in("0.5.30")]
     pub const UV_NO_BINARY_PACKAGE: &'static str = "UV_NO_BINARY_PACKAGE";
 
+    /// Equivalent to the `--only-binary` command-line argument. If set, uv will only
+    /// use pre-built wheels for the given comma-delimited list of packages.
+    #[attr_added_in("0.11.0")]
+    pub const UV_ONLY_BINARY: &'static str = "UV_ONLY_BINARY";
+
     /// Equivalent to the `--no-build` command-line argument. If set, uv will not build
     /// source distributions.
     #[attr_added_in("0.1.40")]

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -3795,6 +3795,34 @@ fn require_hashes_wheel_only_binary() -> Result<()> {
     Ok(())
 }
 
+/// Include the hash for _just_ the wheel with `UV_ONLY_BINARY`.
+#[test]
+fn require_hashes_wheel_only_binary_env() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt
+        .write_str("anyio==4.0.0 --hash=sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f")?;
+
+    uv_snapshot!(context.pip_sync()
+        .arg("requirements.txt")
+        .env(EnvVars::UV_ONLY_BINARY, ":all:")
+        .arg("--require-hashes"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + anyio==4.0.0
+    "
+    );
+
+    Ok(())
+}
+
 /// Include the hash for _just_ the source distribution with `--no-binary`.
 #[test]
 fn require_hashes_source_no_binary() -> Result<()> {

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -14474,6 +14474,33 @@ fn file_url() -> Result<()> {
     Ok(())
 }
 
+/// Disable source distributions with an environment variable.
+#[test]
+fn only_binary_env() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-29T00:00:00Z");
+    let requirements_in = context.temp_dir.child("requirements.in");
+    requirements_in.write_str("source-distribution<=0.0.1")?;
+
+    uv_snapshot!(context
+        .pip_compile()
+        .arg("requirements.in")
+        .env(EnvVars::UV_ONLY_BINARY, ":all:"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only source-distribution>=0.0.1 is available and source-distribution==0.0.1 has no usable wheels, we can conclude that source-distribution<=0.0.1 cannot be used.
+          And because you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
+
+    hint: Wheels are required for `source-distribution` because building from source is disabled for all packages (i.e., with `--no-build`)
+    "
+    );
+
+    Ok(())
+}
+
 /// Allow `--no-binary` to override `--only-binary`, to allow select source distributions.
 #[test]
 fn no_binary_only_binary() -> Result<()> {

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -3696,7 +3696,7 @@ fn install_only_binary_env() {
     let mut command = context.pip_install();
     command
         .arg("django-allauth==0.51.0")
-        .env(EnvVars::UV_ONLY_BINARY, "django_allauth")
+        .env(EnvVars::UV_ONLY_BINARY, "django-allauth")
         .arg("--strict");
     uv_snapshot!(
         command,
@@ -3706,8 +3706,8 @@ fn install_only_binary_env() {
     ----- stdout -----
 
     ----- stderr -----
-      Ã— No solution found when resolving dependencies:
-      â•°â”€â–¶ Because django-allauth==0.51.0 has no usable wheels and you require django-allauth==0.51.0, we can conclude that your requirements are unsatisfiable.
+      × No solution found when resolving dependencies:
+      ╰─▶ Because django-allauth==0.51.0 has no usable wheels and you require django-allauth==0.51.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are required for `django-allauth` because building from source is disabled for `django-allauth` (i.e., with `--no-build-package django-allauth`)
     "

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -3688,6 +3688,32 @@ fn install_only_binary_comma_separated() {
     context.assert_command("import anyio").success();
 }
 
+/// Disable source distributions with an environment variable.
+#[test]
+fn install_only_binary_env() {
+    let context = uv_test::test_context!("3.12");
+
+    let mut command = context.pip_install();
+    command
+        .arg("django-allauth==0.51.0")
+        .env(EnvVars::UV_ONLY_BINARY, "django_allauth")
+        .arg("--strict");
+    uv_snapshot!(
+        command,
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      Ã— No solution found when resolving dependencies:
+      â•°â”€â–¶ Because django-allauth==0.51.0 has no usable wheels and you require django-allauth==0.51.0, we can conclude that your requirements are unsatisfiable.
+
+    hint: Wheels are required for `django-allauth` because building from source is disabled for `django-allauth` (i.e., with `--no-build-package django-allauth`)
+    "
+    );
+}
+
 /// Overlapping usage of `--no-binary` and `--only-binary`
 // TODO(zanieb): We should have a better error message here
 #[test]


### PR DESCRIPTION
## Summary

- add `UV_ONLY_BINARY` to the public uv environment variable list
- wire `UV_ONLY_BINARY` into `uv pip compile`, `uv pip sync`, and `uv pip install` as the env-var equivalent of `--only-binary`
- add a `uv pip install` regression test for disabling source distributions through the env var

Closes #4291

## Validation

- `cargo fmt --check`
- `git diff --check`

Attempted `cargo test -p uv --test pip_install install_only_binary_env`; local validation is blocked because this checkout pins Rust 1.97.0 and rustup could not download that toolchain here due repeated `static.rust-lang.org` connection resets. I also tried Rust 1.95.0, but the build stops before this patch at `cfg_select!`, which requires the pinned newer toolchain.