### PR TITLE
Allow fallback to interpreter discovery for non-venv .venv directory

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1023,19 +1023,7 @@ fn discover_project_environment(
                         inner.kind.to_string(),
                     ));
                 }
-                InvalidEnvironmentKind::MissingExecutable(_) => {
-                    if !centralized
-                        && fs_err::read_dir(root).is_ok_and(|mut dir| dir.next().is_some())
-                    {
-                        if !root.join("pyvenv.cfg").try_exists().unwrap_or_default() {
-                            return Err(ProjectError::InvalidProjectEnvironmentDir(
-                                root.to_path_buf(),
-                                "it is not a valid Python environment (no Python executable was found)"
-                                    .to_string(),
-                            ));
-                        }
-                    }
-                }
+                InvalidEnvironmentKind::MissingExecutable(_) => {}
                 InvalidEnvironmentKind::Empty => {}
             }
             return Ok(None);

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -7268,7 +7268,8 @@ fn sync_custom_environment_path() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Project virtual environment directory `[TEMP_DIR]/foo` cannot be used because it is not a valid Python environment (no Python executable was found)
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    error: Project virtual environment directory `[TEMP_DIR]/foo` cannot be used because it is not a compatible environment but cannot be recreated because it is not a virtual environment
     ");
 
     // But if it's just an incompatible virtual environment...
@@ -9522,7 +9523,8 @@ fn sync_invalid_environment() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Project virtual environment directory `[VENV]/` cannot be used because it is not a valid Python environment (no Python executable was found)
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    error: Project virtual environment directory `[VENV]/` cannot be used because it is not a compatible environment but cannot be recreated because it is not a virtual environment
     ");
 
     // But if it's just an incompatible virtual environment...
@@ -9636,7 +9638,8 @@ fn sync_invalid_environment() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Project virtual environment directory `[VENV]/` cannot be used because it is not a valid Python environment (no Python executable was found)
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    error: Project virtual environment directory `[VENV]/` cannot be used because it is not a compatible environment but cannot be recreated because it is not a virtual environment
     ");
 
     context


### PR DESCRIPTION
When `.venv` exists but is not a valid Python virtual environment (e.g., it contains other venvs or unrelated files), `uv lock` and other commands that only need an interpreter fail with:

```
error: Project virtual environment directory `./.venv` cannot be used because it is not a valid Python environment (no Python executable was found)
```

But `uv lock` doesn't even need a venv — it just needs a Python interpreter for resolution.

## What changed

Removed the hard error in `discover_project_environment` for the `MissingExecutable` case when the directory is non-empty and has no `pyvenv.cfg`. Now it returns `Ok(None)` instead, letting the existing fallback through `PythonInstallation::find_or_download` find a usable interpreter.

## Safety

For `uv sync` (which does create a venv), a second check in `get_or_init_environment` (line 1748) still prevents overwriting non-venv directories with user content — it errors with "cannot be recreated because it is not a virtual environment". This behavior is unchanged.

Fixes #19832.