### PR TITLE
Handle corrupt tool receipts gracefully during uninstall

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,30 +133,29 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let receipt = match installed_tools.get_tool_receipt(&name) {
-                Ok(Some(receipt)) => receipt,
-                _ => {
-                    // If the tool is not installed properly (missing or corrupt receipt),
-                    // attempt to remove the environment anyway.
-                    match installed_tools.remove_environment(&name) {
-                        Ok(()) => {
-                            dangling = true;
-                            writeln!(
-                                printer.stderr(),
-                                "Removed dangling environment for `{name}`"
-                            )?;
-                        }
-                        Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
-                            if err.kind() == std::io::ErrorKind::NotFound =>
-                        {
-                            bail!("`{name}` is not installed");
-                        }
-                        Err(err) => {
-                            return Err(err.into());
-                        }
+            let receipt = if let Ok(Some(receipt)) = installed_tools.get_tool_receipt(&name) {
+                receipt
+            } else {
+                // If the tool is not installed properly (missing or corrupt receipt),
+                // attempt to remove the environment anyway.
+                match installed_tools.remove_environment(&name) {
+                    Ok(()) => {
+                        dangling = true;
+                        writeln!(
+                            printer.stderr(),
+                            "Removed dangling environment for `{name}`"
+                        )?;
                     }
-                    continue;
+                    Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
+                        if err.kind() == std::io::ErrorKind::NotFound =>
+                    {
+                        bail!("`{name}` is not installed");
+                    }
+                    Err(err) => {
+                        return Err(err.into());
+                    }
                 }
+                continue;
             };
 
             entrypoints.extend(uninstall_tool(&name, &receipt, installed_tools).await?);

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,25 +133,29 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
-                // If the tool is not installed properly, attempt to remove the environment anyway.
-                match installed_tools.remove_environment(&name) {
-                    Ok(()) => {
-                        dangling = true;
-                        writeln!(
-                            printer.stderr(),
-                            "Removed dangling environment for `{name}`"
-                        )?;
-                        continue;
+            let receipt = match installed_tools.get_tool_receipt(&name) {
+                Ok(Some(receipt)) => receipt,
+                _ => {
+                    // If the tool is not installed properly (missing or corrupt receipt),
+                    // attempt to remove the environment anyway.
+                    match installed_tools.remove_environment(&name) {
+                        Ok(()) => {
+                            dangling = true;
+                            writeln!(
+                                printer.stderr(),
+                                "Removed dangling environment for `{name}`"
+                            )?;
+                        }
+                        Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
+                            if err.kind() == std::io::ErrorKind::NotFound =>
+                        {
+                            bail!("`{name}` is not installed");
+                        }
+                        Err(err) => {
+                            return Err(err.into());
+                        }
                     }
-                    Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
-                        if err.kind() == std::io::ErrorKind::NotFound =>
-                    {
-                        bail!("`{name}` is not installed");
-                    }
-                    Err(err) => {
-                        return Err(err.into());
-                    }
+                    continue;
                 }
             };
 

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,9 +133,7 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let receipt = if let Ok(Some(receipt)) = installed_tools.get_tool_receipt(&name) {
-                receipt
-            } else {
+            let Ok(Some(receipt)) = installed_tools.get_tool_receipt(&name) else {
                 // If the tool is not installed properly (missing or corrupt receipt),
                 // attempt to remove the environment anyway.
                 match installed_tools.remove_environment(&name) {

--- a/crates/uv/tests/tool/tool_uninstall.rs
+++ b/crates/uv/tests/tool/tool_uninstall.rs
@@ -161,6 +161,40 @@ fn tool_uninstall_missing_receipt() {
 }
 
 #[test]
+fn tool_uninstall_corrupt_receipt() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black`
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    // Corrupt the receipt
+    fs_err::write(
+        tool_dir.join("black").join("uv-receipt.toml"),
+        "garbage",
+    )
+    .unwrap();
+
+    uv_snapshot!(context.filters(), context.tool_uninstall().arg("black")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed dangling environment for `black`
+    ");
+}
+
+#[test]
 fn tool_uninstall_multiple_names_with_missing_receipt() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");

--- a/crates/uv/tests/tool/tool_uninstall.rs
+++ b/crates/uv/tests/tool/tool_uninstall.rs
@@ -176,11 +176,7 @@ fn tool_uninstall_corrupt_receipt() {
         .success();
 
     // Corrupt the receipt
-    fs_err::write(
-        tool_dir.join("black").join("uv-receipt.toml"),
-        "garbage",
-    )
-    .unwrap();
+    fs_err::write(tool_dir.join("black").join("uv-receipt.toml"), "garbage").unwrap();
 
     uv_snapshot!(context.filters(), context.tool_uninstall().arg("black")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())


### PR DESCRIPTION
When a tool's `uv-receipt.toml` contains invalid TOML, `uv tool list` correctly suggests `uv tool uninstall <name>`:

```
warning: Ignoring malformed tool `ruff` (run `uv tool uninstall ruff` to remove)
```

But `uv tool uninstall <name>` failed:

```
error: Failed to read `uv-receipt.toml` at ...
  Caused by: TOML parse error at line 1, column 8
key with no value, expected `=`
```

## What changed

The named-tool branch of `do_uninstall` now handles both `Ok(None)` (missing receipt) and `Err(_)` (corrupt receipt) from `get_tool_receipt()` by calling `remove_environment()`. This matches what the `--all` branch already did — the pattern was there, just not applied to the single-tool path.

## Test

Added `tool_uninstall_corrupt_receipt` — installs a tool, writes garbage to the receipt, verifies clean uninstall with "Removed dangling environment".

Fixes #19630.