### PR TITLE
Allow `uv upgrade` to update multiple declarations of the same package

### DIFF
--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -12,7 +12,7 @@ pub use lock::{
     DependencySelection, Installable, Lock, LockError, LockVersion, Metadata, Package, PackageMap,
     PylockToml, PylockTomlError, PylockTomlErrorKind, PythonReport, RequirementsTxtExport,
     ResolverManifest, SatisfiesResult, SelectedDependency, TreeDisplay, TreeJsonTarget, VERSION,
-    cyclonedx_json,
+    cyclonedx_json, implicit_constraints_marker,
 };
 pub use manifest::Manifest;
 pub use options::{Flexibility, Options, OptionsBuilder};

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -302,6 +302,24 @@ pub struct Lock {
     manifest: ResolverManifest,
 }
 
+/// Return the marker domain covered by the supported environments and `requires-python`.
+pub fn implicit_constraints_marker(
+    requires_python: MarkerTree,
+    supported_environments: &[MarkerTree],
+) -> MarkerTree {
+    let mut environments_union = if supported_environments.is_empty() {
+        MarkerTree::TRUE
+    } else {
+        let mut environments_union = MarkerTree::FALSE;
+        for environment in supported_environments {
+            environments_union.or(*environment);
+        }
+        environments_union
+    };
+    environments_union.and(requires_python);
+    environments_union
+}
+
 /// A direct dependency selected from a [`Lock`].
 #[derive(Clone, Debug)]
 pub struct SelectedDependency<'lock> {
@@ -1348,17 +1366,10 @@ impl Lock {
     /// Returns the actually covered and the expected marker space on validation error.
     pub fn check_marker_coverage(&self) -> Result<(), (MarkerTree, MarkerTree)> {
         let fork_markers_union = self.fork_markers_union();
-        let mut environments_union = if !self.supported_environments.is_empty() {
-            let mut environments_union = MarkerTree::FALSE;
-            for fork_marker in &self.supported_environments {
-                environments_union.or(*fork_marker);
-            }
-            environments_union
-        } else {
-            MarkerTree::TRUE
-        };
-        // When a user defines environments, they are implicitly constrained by requires-python.
-        environments_union.and(self.requires_python.to_marker_tree());
+        let environments_union = implicit_constraints_marker(
+            self.requires_python.to_marker_tree(),
+            &self.supported_environments,
+        );
         if fork_markers_union.negate().is_disjoint(environments_union) {
             Ok(())
         } else {

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -363,14 +363,16 @@ impl PyProjectTomlMut {
         Ok(edit)
     }
 
-    /// Replaces a dependency in `project.dependencies` without modifying its source.
+    /// Replaces every exact match for a dependency in `project.dependencies` without modifying
+    /// its source.
     ///
-    /// Returns `Some` if the dependency was replaced, or `None` if it was not found.
+    /// Returns the position of every dependency that was replaced.
     pub fn replace_dependency(
         &mut self,
-        req: &Requirement,
+        existing: &Requirement,
+        replacement: &Requirement,
         raw: bool,
-    ) -> Result<Option<ArrayEdit>, Error> {
+    ) -> Result<Vec<ArrayEdit>, Error> {
         let Some(dependencies) = self
             .project_mut()?
             .and_then(|project| project.get_mut("dependencies"))
@@ -381,30 +383,24 @@ impl PyProjectTomlMut {
             })
             .transpose()?
         else {
-            return Ok(None);
+            return Ok(Vec::new());
         };
-        let mut to_replace = find_dependencies(&req.name, Some(&req.marker), dependencies);
 
-        match to_replace.as_slice() {
-            [] => Ok(None),
-            [_] => {
-                let (index, _) = to_replace.remove(0);
-                let req_string = if raw {
-                    req.displayable_with_credentials().to_string()
-                } else {
-                    req.to_string()
-                };
-                dependencies.replace(index, req_string);
-                Ok(Some(ArrayEdit::Update(index)))
+        let replacement = if raw {
+            replacement.displayable_with_credentials().to_string()
+        } else {
+            replacement.to_string()
+        };
+        let mut edits = Vec::new();
+        for (index, requirement) in
+            find_dependencies(&existing.name, Some(&existing.marker), dependencies)
+        {
+            if same_requirement_declaration(&requirement, existing) {
+                dependencies.replace(index, replacement.clone());
+                edits.push(ArrayEdit::Update(index));
             }
-            _ => Err(Error::Ambiguous {
-                package_name: req.name.clone(),
-                requirements: to_replace
-                    .into_iter()
-                    .map(|(_, requirement)| requirement)
-                    .collect(),
-            }),
         }
+        Ok(edits)
     }
 
     /// Adds a development dependency to `tool.uv.dev-dependencies`.
@@ -1696,6 +1692,14 @@ fn find_dependencies(
     to_replace
 }
 
+/// Return whether two requirements represent the same serialized dependency declaration.
+fn same_requirement_declaration(left: &Requirement, right: &Requirement) -> bool {
+    left.name == right.name
+        && left.extras == right.extras
+        && left.version_or_url == right.version_or_url
+        && left.marker == right.marker
+}
+
 /// Returns the key in `tool.uv.sources` that matches the given package name.
 fn find_source(name: &PackageName, sources: &Table) -> Option<String> {
     for (key, _) in sources {
@@ -1866,7 +1870,7 @@ fn split_specifiers(req: &str) -> (&str, &str) {
 #[cfg(test)]
 mod test {
     use super::{
-        AddBoundsKind, DependencyTarget, PyProjectTomlMut, reformat_array_multiline,
+        AddBoundsKind, ArrayEdit, DependencyTarget, PyProjectTomlMut, reformat_array_multiline,
         remove_dependency, split_specifiers,
     };
     use anyhow::Result;
@@ -1877,7 +1881,7 @@ mod test {
     use uv_distribution_types::Index;
     use uv_normalize::PackageName;
     use uv_pep440::Version;
-    use uv_pep508::Requirement;
+    use uv_pep508::{Requirement, RequirementOrigin};
 
     #[test]
     fn split() {
@@ -2053,26 +2057,27 @@ dependencies = [
     }
 
     #[test]
-    fn replace_dependency_preserves_source() -> Result<()> {
+    fn replace_dependency_updates_every_exact_match() -> Result<()> {
         let mut pyproject = PyProjectTomlMut::from_toml(
             r#"[project]
-dependencies = ["anyio<=2"]
+dependencies = ["anyio<=2", "anyio>=1", "anyio<=2"]
 
 [tool.uv.sources]
 anyio = { index = "internal" }
             "#,
             DependencyTarget::PyProjectToml,
         )?;
-        let requirement = Requirement::from_str("anyio")?;
+        let existing = Requirement::from_str("anyio<=2")?.with_origin(RequirementOrigin::Workspace);
+        let replacement = Requirement::from_str("anyio<3")?;
 
-        let replaced = pyproject.replace_dependency(&requirement, false)?;
-        assert!(replaced.is_some());
+        let replaced = pyproject.replace_dependency(&existing, &replacement, false)?;
+        assert_eq!(replaced, vec![ArrayEdit::Update(0), ArrayEdit::Update(2)]);
 
         assert_snapshot!(
             pyproject.to_string(),
             @r#"
 [project]
-dependencies = ["anyio"]
+dependencies = ["anyio<3", "anyio>=1", "anyio<3"]
 
 [tool.uv.sources]
 anyio = { index = "internal" }

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -371,17 +371,12 @@ impl PyProjectTomlMut {
         dependency_type: &DependencyType,
         existing: &Requirement,
         replacement: &Requirement,
-        raw: bool,
     ) -> Result<Vec<ArrayEdit>, Error> {
         let Some(dependencies) = self.dependency_type_array_mut(dependency_type)? else {
             return Ok(Vec::new());
         };
 
-        let replacement = if raw {
-            replacement.displayable_with_credentials().to_string()
-        } else {
-            replacement.to_string()
-        };
+        let replacement = replacement.to_string();
         let mut edits = Vec::new();
         for (index, requirement) in
             find_dependencies(&existing.name, Some(&existing.marker), dependencies)
@@ -391,6 +386,39 @@ impl PyProjectTomlMut {
                 edits.push(ArrayEdit::Update(index));
             }
         }
+        Ok(edits)
+    }
+
+    /// Removes every exact string match for a dependency declaration without modifying its source.
+    ///
+    /// Returns the position of every dependency that was removed.
+    pub fn remove_dependency_declaration_text(
+        &mut self,
+        dependency_type: &DependencyType,
+        existing: &str,
+    ) -> Result<Vec<ArrayEdit>, Error> {
+        let Some(dependencies) = self.dependency_type_array_mut(dependency_type)? else {
+            return Ok(Vec::new());
+        };
+
+        let mut edits = Vec::new();
+        for index in dependencies
+            .iter()
+            .enumerate()
+            .filter_map(|(index, dependency)| {
+                (dependency.as_str() == Some(existing)).then_some(index)
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+        {
+            remove_dependency_at(index, dependencies);
+            edits.push(ArrayEdit::Update(index));
+        }
+        if !edits.is_empty() {
+            reformat_array_multiline(dependencies);
+        }
+        edits.reverse();
         Ok(edits)
     }
 
@@ -1767,7 +1795,7 @@ fn find_dependencies(
     to_replace
 }
 
-/// Return whether two requirements represent the same serialized dependency declaration.
+/// Return whether two requirements have the same serialized fields, ignoring their parsed origin.
 fn same_requirement_declaration(left: &Requirement, right: &Requirement) -> bool {
     left.name == right.name
         && left.extras == right.extras
@@ -2151,7 +2179,6 @@ anyio = { index = "internal" }
             &DependencyType::Production,
             &existing,
             &replacement,
-            false,
         )?;
         assert_eq!(replaced, vec![ArrayEdit::Update(0), ArrayEdit::Update(2)]);
 
@@ -2190,7 +2217,6 @@ dev = ["anyio<=2"]
             &DependencyType::Optional(ExtraName::from_str("test")?),
             &existing,
             &optional_replacement,
-            false,
         )?;
         assert_eq!(replaced, vec![ArrayEdit::Update(0)]);
 
@@ -2198,7 +2224,6 @@ dev = ["anyio<=2"]
             &DependencyType::Group(GroupName::from_str("dev")?),
             &existing,
             &group_replacement,
-            false,
         )?;
         assert_eq!(replaced, vec![ArrayEdit::Update(0)]);
 

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -363,26 +363,17 @@ impl PyProjectTomlMut {
         Ok(edit)
     }
 
-    /// Replaces every exact match for a dependency in `project.dependencies` without modifying
-    /// its source.
+    /// Replaces every exact match for a dependency declaration without modifying its source.
     ///
     /// Returns the position of every dependency that was replaced.
-    pub fn replace_dependency(
+    pub fn replace_dependency_declaration(
         &mut self,
+        dependency_type: &DependencyType,
         existing: &Requirement,
         replacement: &Requirement,
         raw: bool,
     ) -> Result<Vec<ArrayEdit>, Error> {
-        let Some(dependencies) = self
-            .project_mut()?
-            .and_then(|project| project.get_mut("dependencies"))
-            .map(|dependencies| {
-                dependencies
-                    .as_array_mut()
-                    .ok_or(Error::MalformedDependencies)
-            })
-            .transpose()?
-        else {
+        let Some(dependencies) = self.dependency_type_array_mut(dependency_type)? else {
             return Ok(Vec::new());
         };
 
@@ -968,6 +959,89 @@ impl PyProjectTomlMut {
             .ok_or(Error::MalformedDependencies)?;
 
         Ok(group)
+    }
+
+    /// Get an existing TOML array for a dependency type.
+    fn dependency_type_array_mut(
+        &mut self,
+        dependency_type: &DependencyType,
+    ) -> Result<Option<&mut Array>, Error> {
+        let dependencies = match dependency_type {
+            DependencyType::Production => self
+                .project_mut()?
+                .and_then(|project| project.get_mut("dependencies"))
+                .map(|dependencies| {
+                    dependencies
+                        .as_array_mut()
+                        .ok_or(Error::MalformedDependencies)
+                })
+                .transpose()?,
+            DependencyType::Dev => self
+                .doc
+                .get_mut("tool")
+                .map(|tool| tool.as_table_mut().ok_or(Error::MalformedDependencies))
+                .transpose()?
+                .and_then(|tool| tool.get_mut("uv"))
+                .map(|tool_uv| tool_uv.as_table_mut().ok_or(Error::MalformedDependencies))
+                .transpose()?
+                .and_then(|tool_uv| tool_uv.get_mut("dev-dependencies"))
+                .map(|dependencies| {
+                    dependencies
+                        .as_array_mut()
+                        .ok_or(Error::MalformedDependencies)
+                })
+                .transpose()?,
+            DependencyType::Optional(extra) => self
+                .project_mut()?
+                .and_then(|project| project.get_mut("optional-dependencies"))
+                .map(|extras| {
+                    extras
+                        .as_table_like_mut()
+                        .ok_or(Error::MalformedDependencies)
+                })
+                .transpose()?
+                .and_then(|extras| {
+                    extras.iter_mut().find_map(|(key, value)| {
+                        if ExtraName::from_str(key.get()).is_ok_and(|name| name == *extra) {
+                            Some(value)
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .map(|dependencies| {
+                    dependencies
+                        .as_array_mut()
+                        .ok_or(Error::MalformedDependencies)
+                })
+                .transpose()?,
+            DependencyType::Group(group) => self
+                .doc
+                .get_mut("dependency-groups")
+                .map(|groups| {
+                    groups
+                        .as_table_like_mut()
+                        .ok_or(Error::MalformedDependencies)
+                })
+                .transpose()?
+                .and_then(|groups| {
+                    groups.iter_mut().find_map(|(key, value)| {
+                        if GroupName::from_str(key.get()).is_ok_and(|name| name == *group) {
+                            Some(value)
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .map(|dependencies| {
+                    dependencies
+                        .as_array_mut()
+                        .ok_or(Error::MalformedDependencies)
+                })
+                .transpose()?,
+        };
+
+        Ok(dependencies)
     }
 
     /// Adds a source to `tool.uv.sources`.
@@ -1870,6 +1944,8 @@ fn split_specifiers(req: &str) -> (&str, &str) {
 
 #[cfg(test)]
 mod test {
+    use crate::pyproject::DependencyType;
+
     use super::{
         AddBoundsKind, ArrayEdit, DependencyTarget, PyProjectTomlMut, reformat_array_multiline,
         remove_dependency, split_specifiers,
@@ -1880,7 +1956,7 @@ mod test {
     use std::str::FromStr;
     use toml_edit::DocumentMut;
     use uv_distribution_types::Index;
-    use uv_normalize::PackageName;
+    use uv_normalize::{ExtraName, GroupName, PackageName};
     use uv_pep440::Version;
     use uv_pep508::{Requirement, RequirementOrigin};
 
@@ -2071,7 +2147,12 @@ anyio = { index = "internal" }
         let existing = Requirement::from_str("anyio<=2")?.with_origin(RequirementOrigin::Workspace);
         let replacement = Requirement::from_str("anyio<3")?;
 
-        let replaced = pyproject.replace_dependency(&existing, &replacement, false)?;
+        let replaced = pyproject.replace_dependency_declaration(
+            &DependencyType::Production,
+            &existing,
+            &replacement,
+            false,
+        )?;
         assert_eq!(replaced, vec![ArrayEdit::Update(0), ArrayEdit::Update(2)]);
 
         assert_snapshot!(
@@ -2082,6 +2163,56 @@ dependencies = ["anyio<3", "anyio>=1", "anyio<3"]
 
 [tool.uv.sources]
 anyio = { index = "internal" }
+"#
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn replace_dependency_declaration_updates_selected_type() -> Result<()> {
+        let mut pyproject = PyProjectTomlMut::from_toml(
+            r#"[project]
+dependencies = ["anyio<=2"]
+
+[project.optional-dependencies]
+test = ["anyio<=2"]
+
+[dependency-groups]
+dev = ["anyio<=2"]
+            "#,
+            DependencyTarget::PyProjectToml,
+        )?;
+        let existing = Requirement::from_str("anyio<=2")?;
+        let optional_replacement = Requirement::from_str("anyio<3")?;
+        let group_replacement = Requirement::from_str("anyio<4")?;
+
+        let replaced = pyproject.replace_dependency_declaration(
+            &DependencyType::Optional(ExtraName::from_str("test")?),
+            &existing,
+            &optional_replacement,
+            false,
+        )?;
+        assert_eq!(replaced, vec![ArrayEdit::Update(0)]);
+
+        let replaced = pyproject.replace_dependency_declaration(
+            &DependencyType::Group(GroupName::from_str("dev")?),
+            &existing,
+            &group_replacement,
+            false,
+        )?;
+        assert_eq!(replaced, vec![ArrayEdit::Update(0)]);
+
+        assert_snapshot!(
+            pyproject.to_string(),
+            @r#"
+[project]
+dependencies = ["anyio<=2"]
+
+[project.optional-dependencies]
+test = ["anyio<3"]
+
+[dependency-groups]
+dev = ["anyio<4"]
 "#
         );
         Ok(())

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1633,37 +1633,7 @@ fn remove_dependency(name: &PackageName, deps: &mut Array) -> Vec<Requirement> {
     let removed = find_dependencies(name, None, deps)
         .into_iter()
         .rev()
-        .filter_map(|(i, _)| {
-            if let Some(prefix) = deps
-                .get(i)
-                .and_then(|item| item.decor().prefix().and_then(|s| s.as_str()))
-                .filter(|s| !s.is_empty())
-            {
-                let prefix = prefix.to_string();
-                if let Some(next) = deps.get(i + 1)
-                    && let Some(existing) = next.decor().prefix().and_then(|s| s.as_str())
-                {
-                    // Transfer removed item's prefix to the next item's prefix.
-                    let existing = existing.to_string();
-                    deps.get_mut(i + 1)
-                        .unwrap()
-                        .decor_mut()
-                        .set_prefix(format!("{prefix}{existing}"));
-                } else if let Some(next) = deps.get_mut(i + 1) {
-                    // Next item exists but has no prefix; use ours directly.
-                    next.decor_mut().set_prefix(&prefix);
-                } else if let Some(existing) = deps.trailing().as_str() {
-                    // No next item; move comments to the array trailing.
-                    deps.set_trailing(format!("{prefix}{existing}"));
-                } else {
-                    deps.set_trailing(&prefix);
-                }
-            }
-
-            deps.remove(i)
-                .as_str()
-                .and_then(|req| Requirement::from_str(req).ok())
-        })
+        .filter_map(|(i, _)| remove_dependency_at(i, deps))
         .collect::<Vec<_>>();
 
     if !removed.is_empty() {
@@ -1671,6 +1641,37 @@ fn remove_dependency(name: &PackageName, deps: &mut Array) -> Vec<Requirement> {
     }
 
     removed
+}
+
+fn remove_dependency_at(index: usize, deps: &mut Array) -> Option<Requirement> {
+    if let Some(prefix) = deps
+        .get(index)
+        .and_then(|item| item.decor().prefix().and_then(|s| s.as_str()))
+        .filter(|s| !s.is_empty())
+    {
+        let prefix = prefix.to_string();
+        if let Some(next) = deps.get(index + 1)
+            && let Some(existing) = next.decor().prefix().and_then(|s| s.as_str())
+        {
+            // Transfer removed item's prefix to the next item's prefix.
+            let existing = existing.to_string();
+            if let Some(next) = deps.get_mut(index + 1) {
+                next.decor_mut().set_prefix(format!("{prefix}{existing}"));
+            }
+        } else if let Some(next) = deps.get_mut(index + 1) {
+            // Next item exists but has no prefix; use ours directly.
+            next.decor_mut().set_prefix(&prefix);
+        } else if let Some(existing) = deps.trailing().as_str() {
+            // No next item; move comments to the array trailing.
+            deps.set_trailing(format!("{prefix}{existing}"));
+        } else {
+            deps.set_trailing(&prefix);
+        }
+    }
+
+    deps.remove(index)
+        .as_str()
+        .and_then(|req| Requirement::from_str(req).ok())
 }
 
 /// Returns a `Vec` containing the all dependencies with the given name, along with their positions

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -19,7 +19,7 @@ use uv_python::{ConfigDiscovery, PythonDownloads, PythonPreference};
 use uv_redacted::DisplaySafeUrl;
 use uv_resolver::{MetadataResponse, implicit_constraints_marker};
 use uv_settings::PythonInstallMirrors;
-use uv_workspace::pyproject::Source;
+use uv_workspace::pyproject::{DependencyType, Source};
 use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
 use uv_workspace::{
     DiscoveryOptions, ProjectWorkspace, VirtualProject, WorkspaceCache, WorkspaceErrorKind,
@@ -33,11 +33,23 @@ use crate::commands::{ExitStatus, diagnostics};
 use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 
-struct SelectedRequirement {
+/// A dependency declaration selected for upgrading.
+struct UpgradableDeclaration {
+    package: PackageName,
+    dependency_type: DependencyType,
     text: String,
     requirement: Requirement<VerbatimParsedUrl>,
-    applicability: MarkerTree,
+    effective_marker: MarkerTree,
     resolved_versions: BTreeSet<Version>,
+}
+
+/// An existing requirement and its proposed replacement.
+struct RequirementUpdate {
+    package: PackageName,
+    dependency_type: DependencyType,
+    text: String,
+    existing: Requirement<VerbatimUrl>,
+    replacement: Requirement<VerbatimUrl>,
 }
 
 pub(crate) async fn upgrade(
@@ -82,10 +94,12 @@ pub(crate) async fn upgrade(
         .iter()
         .map(|selected| {
             Ok((
-                into_verbatim_requirement(selected.requirement.clone(), &package)?,
+                selected.package.clone(),
+                selected.dependency_type.clone(),
+                into_verbatim_requirement(selected.requirement.clone(), &selected.package)?,
                 into_verbatim_requirement(
                     relax_requirement(selected.requirement.clone()),
-                    &package,
+                    &selected.package,
                 )?,
             ))
         })
@@ -99,8 +113,9 @@ pub(crate) async fn upgrade(
         &mut pyproject,
         relaxed_requirements
             .iter()
-            .map(|(existing, replacement)| (existing, replacement)),
-        &package,
+            .map(|(package, dependency_type, existing, replacement)| {
+                (package, dependency_type, existing, replacement)
+            }),
     )?;
     let pyproject = pyproject.to_string();
     let pyproject = PyProjectToml::from_toml(
@@ -198,6 +213,7 @@ pub(crate) async fn upgrade(
                 .conflicts()
                 .contains(project.project_name(), extra.as_ref())
         {
+            let package = &selected.package;
             bail!(
                 "Dependency `{package}` is declared under conflicting extra `{extra}` and cannot be upgraded yet"
             );
@@ -205,16 +221,24 @@ pub(crate) async fn upgrade(
     }
 
     for resolved_package in lock.packages() {
-        if resolved_package.name() == &package
-            && resolved_package
-                .index(project.workspace().install_path())?
-                .is_some()
+        if !requirements
+            .iter()
+            .any(|selected| resolved_package.name() == &selected.package)
+        {
+            continue;
+        }
+        if resolved_package
+            .index(project.workspace().install_path())?
+            .is_some()
             && let Some(version) = resolved_package.version()
         {
             // A universal lock can contain versions from disjoint forks, so collect each version
             // only for the declarations that apply to its fork.
             for selected in &mut requirements {
-                if resolved_package.is_included_by_marker(selected.applicability) {
+                if resolved_package.name() != &selected.package {
+                    continue;
+                }
+                if resolved_package.is_included_by_marker(selected.effective_marker) {
                     selected.resolved_versions.insert(version.clone());
                 }
             }
@@ -226,15 +250,24 @@ pub(crate) async fn upgrade(
         let proposed_requirement =
             propose_requirement(&selected.requirement, &selected.resolved_versions)?;
         if proposed_requirement != selected.requirement {
-            let existing = into_verbatim_requirement(selected.requirement.clone(), &package)?;
-            let replacement = into_verbatim_requirement(proposed_requirement, &package)?;
+            let existing =
+                into_verbatim_requirement(selected.requirement.clone(), &selected.package)?;
+            let replacement = into_verbatim_requirement(proposed_requirement, &selected.package)?;
             if !updated_requirements
                 .iter()
-                .any(|(_, updated_existing, updated_replacement)| {
-                    updated_existing == &existing && updated_replacement == &replacement
+                .any(|update: &RequirementUpdate| {
+                    update.dependency_type == selected.dependency_type
+                        && update.existing == existing
+                        && update.replacement == replacement
                 })
             {
-                updated_requirements.push((selected.text.clone(), existing, replacement));
+                updated_requirements.push(RequirementUpdate {
+                    package: selected.package.clone(),
+                    dependency_type: selected.dependency_type.clone(),
+                    text: selected.text.clone(),
+                    existing,
+                    replacement,
+                });
             }
         }
     }
@@ -246,10 +279,14 @@ pub(crate) async fn upgrade(
         )?;
         apply_requirement_replacements(
             &mut pyproject,
-            updated_requirements
-                .iter()
-                .map(|(_, existing, replacement)| (existing, replacement)),
-            &package,
+            updated_requirements.iter().map(|update| {
+                (
+                    &update.package,
+                    &update.dependency_type,
+                    &update.existing,
+                    &update.replacement,
+                )
+            }),
         )?;
         let pyproject_path = project.project_root().join("pyproject.toml");
         fs_err::write(pyproject_path, pyproject.to_string())?;
@@ -267,21 +304,23 @@ pub(crate) async fn upgrade(
     } else {
         writeln!(printer.stderr(), "No version change for {package}")?;
     }
-    for (requirement_text, _, proposed_requirement) in updated_requirements {
+    for update in updated_requirements {
         writeln!(
             printer.stderr(),
-            "Updated requirement: `{requirement_text}` -> `{proposed_requirement}`"
+            "Updated requirement: `{}` -> `{}`",
+            update.text,
+            update.replacement
         )?;
     }
 
     Ok(ExitStatus::Success)
 }
 
-/// Select the production dependency declarations targeted by `uv upgrade`.
+/// Select the dependency declarations targeted by `uv upgrade`.
 fn select_requirements(
     project: &ProjectWorkspace,
     package: &PackageName,
-) -> Result<Vec<SelectedRequirement>> {
+) -> Result<Vec<UpgradableDeclaration>> {
     if project.workspace().packages().len() != 1 {
         bail!("`uv upgrade` does not support workspaces with multiple members yet");
     }
@@ -294,7 +333,7 @@ fn select_requirements(
         .as_deref()
         .unwrap_or_default();
     let pyproject_path = project.project_root().join("pyproject.toml");
-    let mut matching = Vec::new();
+    let mut to_upgrade = Vec::new();
     for dependency in dependencies {
         let requirement =
             Requirement::<VerbatimParsedUrl>::from_str(dependency).with_context(|| {
@@ -304,27 +343,29 @@ fn select_requirements(
                 )
             })?;
         if requirement.name == *package {
-            let mut applicability = requirement.marker;
-            applicability.and(resolution_marker);
-            if applicability.is_false() {
+            let mut effective_marker = requirement.marker;
+            effective_marker.and(resolution_marker);
+            if effective_marker.is_false() {
                 bail!(
                     "Dependency `{package}` has declarations excluded by the project's Python or environment constraints and cannot be upgraded"
                 );
             }
-            matching.push(SelectedRequirement {
+            to_upgrade.push(UpgradableDeclaration {
+                package: package.clone(),
+                dependency_type: DependencyType::Production,
                 text: dependency.clone(),
                 requirement,
-                applicability,
+                effective_marker,
                 resolved_versions: BTreeSet::new(),
             });
         }
     }
 
-    if matching.is_empty() {
+    if to_upgrade.is_empty() {
         bail!("Dependency `{package}` was not found in `project.dependencies`");
     }
 
-    if matching.iter().any(|selected| {
+    if to_upgrade.iter().any(|selected| {
         matches!(
             selected.requirement.version_or_url,
             Some(VersionOrUrl::Url(_))
@@ -347,9 +388,9 @@ fn select_requirements(
         .and_then(|sources| sources.inner().get(package))
         .or_else(|| project.workspace().sources().get(package));
     let applies_to_selected_requirement = |source| {
-        matching
-            .iter()
-            .any(|selected| source_is_applicable(source, selected.applicability))
+        to_upgrade.iter().any(|selected| {
+            source_is_applicable(source, &selected.dependency_type, selected.effective_marker)
+        })
     };
     if sources.is_some_and(|sources| {
         sources.iter().any(|source| {
@@ -371,7 +412,7 @@ fn select_requirements(
         );
     }
 
-    Ok(matching)
+    Ok(to_upgrade)
 }
 
 /// Return the marker domain that the project will resolve for dependency declarations.
@@ -392,14 +433,23 @@ fn project_resolution_marker(project: &ProjectWorkspace) -> Result<MarkerTree> {
 /// Apply exact requirement replacements, coalescing repeated identical declarations.
 fn apply_requirement_replacements<'a>(
     pyproject: &mut PyProjectTomlMut,
-    replacements: impl IntoIterator<Item = (&'a Requirement<VerbatimUrl>, &'a Requirement<VerbatimUrl>)>,
-    package: &PackageName,
+    replacements: impl IntoIterator<
+        Item = (
+            &'a PackageName,
+            &'a DependencyType,
+            &'a Requirement<VerbatimUrl>,
+            &'a Requirement<VerbatimUrl>,
+        ),
+    >,
 ) -> Result<()> {
     let mut applied = Vec::new();
-    for (existing, replacement) in replacements {
-        if let Some((_, applied_replacement)) = applied
-            .iter()
-            .find(|(applied_existing, _)| *applied_existing == existing)
+    for (package, dependency_type, existing, replacement) in replacements {
+        if let Some((_, _, applied_replacement)) =
+            applied
+                .iter()
+                .find(|(applied_dependency_type, applied_existing, _)| {
+                    *applied_dependency_type == dependency_type && *applied_existing == existing
+                })
         {
             if *applied_replacement != replacement {
                 bail!("Dependency `{package}` has conflicting requirement updates");
@@ -408,24 +458,40 @@ fn apply_requirement_replacements<'a>(
         }
 
         if pyproject
-            .replace_dependency(existing, replacement, false)?
+            .replace_dependency_declaration(dependency_type, existing, replacement, false)?
             .is_empty()
         {
-            bail!("Dependency `{package}` was not found in `project.dependencies`");
+            bail!(
+                "Dependency `{package}` was not found in {}",
+                dependency_type.toml_table_name()
+            );
         }
-        applied.push((existing, replacement));
+        applied.push((dependency_type, existing, replacement));
     }
     Ok(())
 }
 
 /// Return whether a source applies to the selected requirement declaration.
-fn source_is_applicable(source: &Source, requirement_marker: MarkerTree) -> bool {
-    let extra = requirement_marker.top_level_extra_name();
-    source
-        .extra()
-        .is_none_or(|target| extra.as_deref() == Some(target))
-        && source.group().is_none()
-        && !source.marker().is_disjoint(requirement_marker)
+fn source_is_applicable(
+    source: &Source,
+    dependency_type: &DependencyType,
+    requirement_marker: MarkerTree,
+) -> bool {
+    let source_origin_applies = match dependency_type {
+        DependencyType::Production => {
+            let extra = requirement_marker.top_level_extra_name();
+            source
+                .extra()
+                .is_none_or(|target| extra.as_deref() == Some(target))
+                && source.group().is_none()
+        }
+        DependencyType::Dev => source.extra().is_none() && source.group().is_none(),
+        DependencyType::Optional(extra) => {
+            source.extra() == Some(extra) && source.group().is_none()
+        }
+        DependencyType::Group(group) => source.extra().is_none() && source.group() == Some(group),
+    };
+    source_origin_applies && !source.marker().is_disjoint(requirement_marker)
 }
 
 /// Convert a parsed requirement into the representation used by the mutable manifest.

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -298,28 +298,31 @@ pub(crate) async fn upgrade(
 
     let mut updated_requirements = Vec::new();
     for selected in &requirements {
-        let proposed_requirement =
-            propose_requirement(&selected.requirement, &selected.resolved_versions)?;
-        if proposed_requirement != selected.requirement {
-            let existing =
-                into_verbatim_requirement(selected.requirement.clone(), &selected.package)?;
-            let replacement = into_verbatim_requirement(proposed_requirement, &selected.package)?;
-            if !updated_requirements
-                .iter()
-                .any(|update: &RequirementUpdate| {
-                    update.dependency_type == selected.dependency_type
-                        && update.existing == existing
-                        && update.replacement == replacement
-                })
-            {
-                updated_requirements.push(RequirementUpdate {
-                    package: selected.package.clone(),
-                    dependency_type: selected.dependency_type.clone(),
-                    original_text: selected.original_text.clone(),
-                    existing,
-                    replacement,
-                });
-            }
+        let Some(specifiers) =
+            propose_specifiers(&selected.requirement, &selected.resolved_versions)?
+        else {
+            continue;
+        };
+
+        let existing = into_verbatim_requirement(selected.requirement.clone(), &selected.package)?;
+        let mut proposed_requirement = selected.requirement.clone();
+        proposed_requirement.version_or_url = Some(VersionOrUrl::VersionSpecifier(specifiers));
+        let replacement = into_verbatim_requirement(proposed_requirement, &selected.package)?;
+        if !updated_requirements
+            .iter()
+            .any(|update: &RequirementUpdate| {
+                update.dependency_type == selected.dependency_type
+                    && update.existing == existing
+                    && update.replacement == replacement
+            })
+        {
+            updated_requirements.push(RequirementUpdate {
+                package: selected.package.clone(),
+                dependency_type: selected.dependency_type.clone(),
+                original_text: selected.original_text.clone(),
+                existing,
+                replacement,
+            });
         }
     }
 
@@ -637,32 +640,32 @@ fn into_verbatim_requirement(
     })
 }
 
-/// Return a requirement that admits every applicable resolved version.
+/// Propose version specifiers that admit every resolved version.
 ///
-/// For example, `foo>=1,<2` resolving to `2.4` becomes `foo>=1,<3`. Preserve
-/// [`VersionSpecifier`]s that already admit the resolution, and rewrite only the specifiers that
-/// exclude it. If a requirement resolves to multiple versions, rewrite each specifier using the
-/// appropriate version boundary for its operator, then verify that the result admits every
-/// resolved version.
-fn propose_requirement(
+/// Return `None` if no update is needed. Otherwise, rewrite only blocking specifiers and return
+/// them in `Some`. When multiple versions are resolved, choose bounds that admit all of them, or
+/// return an error if that is impossible.
+///
+/// For example, resolving `foo>=1,<2` to `2.4` produces `>=1, <3`.
+fn propose_specifiers(
     requirement: &Requirement<VerbatimParsedUrl>,
     resolved_versions: &BTreeSet<Version>,
-) -> Result<Requirement<VerbatimParsedUrl>> {
+) -> Result<Option<VersionSpecifiers>> {
     if resolved_versions.is_empty() {
-        return Ok(requirement.clone());
+        return Ok(None);
     }
 
     let Some(VersionOrUrl::VersionSpecifier(specifiers)) = &requirement.version_or_url else {
-        return Ok(requirement.clone());
+        return Ok(None);
     };
     if resolved_versions
         .iter()
         .all(|version| specifiers.contains(version))
     {
-        return Ok(requirement.clone());
+        return Ok(None);
     }
     let Some(highest_resolved_version) = resolved_versions.last() else {
-        return Ok(requirement.clone());
+        return Ok(None);
     };
 
     let specifiers = specifiers
@@ -696,9 +699,7 @@ fn propose_requirement(
             requirement.name
         );
     }
-    let mut proposed = requirement.clone();
-    proposed.version_or_url = Some(VersionOrUrl::VersionSpecifier(specifiers));
-    Ok(proposed)
+    Ok(Some(specifiers))
 }
 
 /// Attempt to rewrite a [`VersionSpecifier`] to admit all resolved versions while preserving its
@@ -828,7 +829,7 @@ mod tests {
     use uv_pep508::Requirement;
     use uv_pypi_types::VerbatimParsedUrl;
 
-    use super::{increment_version_at_precision, propose_requirement, relax_requirement};
+    use super::{increment_version_at_precision, propose_specifiers, relax_requirement};
 
     fn resolved_versions(versions: &[&str]) -> BTreeSet<Version> {
         versions
@@ -838,96 +839,112 @@ mod tests {
     }
 
     #[test]
-    fn propose_requirement_preserves_satisfied_constraints() {
+    fn propose_specifiers_preserves_satisfied_constraints() {
         for requirement in ["requests", "requests>=1.2", "requests!=2.3"] {
             let requirement =
                 Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
 
-            let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.0"]))
-                .expect("requirement can be proposed");
+            let proposed = propose_specifiers(&requirement, &resolved_versions(&["2.4.0"]))
+                .expect("specifiers can be proposed");
 
-            assert_eq!(proposed, requirement);
+            assert!(proposed.is_none());
         }
     }
 
     #[test]
-    fn propose_requirement_expands_exclusive_upper_bounds_at_existing_precision() {
+    fn propose_specifiers_returns_none_without_resolved_versions() {
+        let requirement =
+            Requirement::<VerbatimParsedUrl>::from_str("requests<2").expect("valid requirement");
+
+        let proposed =
+            propose_specifiers(&requirement, &BTreeSet::new()).expect("specifiers can be proposed");
+
+        assert!(proposed.is_none());
+    }
+
+    #[test]
+    fn propose_specifiers_expands_exclusive_upper_bounds_at_existing_precision() {
         for (requirement, version, expected) in [
-            ("requests>=1.2,<2", "2.4.0", "requests>=1.2,<3"),
-            ("requests>=1.2,<1.3", "1.4.2", "requests>=1.2,<1.5"),
+            ("requests>=1.2,<2", "2.4.0", ">=1.2, <3"),
+            ("requests>=1.2,<1.3", "1.4.2", ">=1.2, <1.5"),
         ] {
             let requirement =
                 Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
 
-            let proposed = propose_requirement(&requirement, &resolved_versions(&[version]))
-                .expect("requirement can be proposed");
+            let proposed = propose_specifiers(&requirement, &resolved_versions(&[version]))
+                .expect("specifiers can be proposed")
+                .expect("specifiers need an update");
 
             assert_eq!(proposed.to_string(), expected);
         }
     }
 
     #[test]
-    fn propose_requirement_only_rewrites_blocking_specifiers() {
+    fn propose_specifiers_only_rewrites_blocking_specifiers() {
         let requirement = Requirement::<VerbatimParsedUrl>::from_str("requests>=1,<2,<4")
             .expect("valid requirement");
 
-        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.0"]))
-            .expect("requirement can be proposed");
+        let proposed = propose_specifiers(&requirement, &resolved_versions(&["2.4.0"]))
+            .expect("specifiers can be proposed")
+            .expect("specifiers need an update");
 
-        assert_eq!(proposed.to_string(), "requests>=1,<3,<4");
+        assert_eq!(proposed.to_string(), ">=1, <3, <4");
     }
 
     #[test]
-    fn propose_requirement_preserves_operator_style() {
+    fn propose_specifiers_preserves_operator_style() {
         for (requirement, version, expected) in [
-            ("requests==1.2.3", "2.4.5", "requests==2.4.5"),
-            ("requests===1.2.3", "2.4.5", "requests===2.4.5"),
-            ("requests==1.2.*", "2.4.5", "requests==2.4.*"),
-            ("requests~=1.2", "2.4.5", "requests~=2.4"),
-            ("requests~=1.2.3", "2.4.5", "requests~=2.4.5"),
-            ("requests<=1.2.3", "2.4.5", "requests<=2.4.5"),
+            ("requests==1.2.3", "2.4.5", "==2.4.5"),
+            ("requests===1.2.3", "2.4.5", "===2.4.5"),
+            ("requests==1.2.*", "2.4.5", "==2.4.*"),
+            ("requests~=1.2", "2.4.5", "~=2.4"),
+            ("requests~=1.2.3", "2.4.5", "~=2.4.5"),
+            ("requests<=1.2.3", "2.4.5", "<=2.4.5"),
         ] {
             let requirement =
                 Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
 
-            let proposed = propose_requirement(&requirement, &resolved_versions(&[version]))
-                .expect("requirement can be proposed");
+            let proposed = propose_specifiers(&requirement, &resolved_versions(&[version]))
+                .expect("specifiers can be proposed")
+                .expect("specifiers need an update");
 
             assert_eq!(proposed.to_string(), expected);
         }
     }
 
     #[test]
-    fn propose_requirement_preserves_compatible_release_suffixes() {
+    fn propose_specifiers_preserves_compatible_release_suffixes() {
         let requirement =
             Requirement::<VerbatimParsedUrl>::from_str("requests~=1.2").expect("valid requirement");
 
-        let proposed = propose_requirement(
+        let proposed = propose_specifiers(
             &requirement,
             &resolved_versions(&["1!2.4rc1.post2.dev3+local"]),
         )
-        .expect("requirement can be proposed");
+        .expect("specifiers can be proposed")
+        .expect("specifiers need an update");
 
-        assert_eq!(proposed.to_string(), "requests~=1!2.4rc1.post2.dev3");
+        assert_eq!(proposed.to_string(), "~=1!2.4rc1.post2.dev3");
     }
 
     #[test]
-    fn propose_requirement_strips_local_version_from_inclusive_upper_bound() {
+    fn propose_specifiers_strips_local_version_from_inclusive_upper_bound() {
         let requirement = Requirement::<VerbatimParsedUrl>::from_str("requests<=1.2.3")
             .expect("valid requirement");
 
-        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.5+local"]))
-            .expect("requirement can be proposed");
+        let proposed = propose_specifiers(&requirement, &resolved_versions(&["2.4.5+local"]))
+            .expect("specifiers can be proposed")
+            .expect("specifiers need an update");
 
-        assert_eq!(proposed.to_string(), "requests<=2.4.5");
+        assert_eq!(proposed.to_string(), "<=2.4.5");
     }
 
     #[test]
-    fn propose_requirement_rejects_constraint_that_still_excludes_resolved_version() {
+    fn propose_specifiers_rejects_constraint_that_still_excludes_resolved_version() {
         let requirement = Requirement::<VerbatimParsedUrl>::from_str("requests!=2.4,<2")
             .expect("valid requirement");
 
-        let error = propose_requirement(&requirement, &resolved_versions(&["2.4"]))
+        let error = propose_specifiers(&requirement, &resolved_versions(&["2.4"]))
             .expect_err("rewritten requirement must admit the resolved version");
 
         assert_eq!(
@@ -937,49 +954,49 @@ mod tests {
     }
 
     #[test]
-    fn propose_requirement_preserves_metadata_lower_bounds_and_exclusions() {
+    fn propose_specifiers_preserves_lower_bounds_and_exclusions() {
         let requirement = Requirement::<VerbatimParsedUrl>::from_str(
             "Requests_Plus[security,tests]>=1.2,!=2.3,<2 ; python_version >= '3.12'",
         )
         .expect("valid requirement");
 
-        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.0"]))
-            .expect("requirement can be proposed");
+        let proposed = propose_specifiers(&requirement, &resolved_versions(&["2.4.0"]))
+            .expect("specifiers can be proposed")
+            .expect("specifiers need an update");
 
-        assert_eq!(
-            proposed.to_string(),
-            "requests-plus[security,tests]>=1.2,!=2.3,<3 ; python_full_version >= '3.12'"
-        );
+        assert_eq!(proposed.to_string(), ">=1.2, !=2.3, <3");
     }
 
     #[test]
-    fn propose_requirement_expands_upper_bound_for_multiple_versions() {
+    fn propose_specifiers_expands_upper_bound_for_multiple_versions() {
         let requirement =
             Requirement::<VerbatimParsedUrl>::from_str("requests<2").expect("valid requirement");
 
-        let proposed = propose_requirement(&requirement, &resolved_versions(&["1.5.0", "2.4.0"]))
-            .expect("upper bound can admit both versions");
+        let proposed = propose_specifiers(&requirement, &resolved_versions(&["1.5.0", "2.4.0"]))
+            .expect("upper bound can admit both versions")
+            .expect("specifiers need an update");
 
-        assert_eq!(proposed.to_string(), "requests<3");
+        assert_eq!(proposed.to_string(), "<3");
     }
 
     #[test]
-    fn propose_requirement_uses_lowest_compatible_version_for_multiple_versions() {
+    fn propose_specifiers_uses_lowest_compatible_version_for_multiple_versions() {
         let requirement =
             Requirement::<VerbatimParsedUrl>::from_str("requests~=1.2").expect("valid requirement");
 
-        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4", "2.5"]))
-            .expect("compatible release can admit both versions");
+        let proposed = propose_specifiers(&requirement, &resolved_versions(&["2.4", "2.5"]))
+            .expect("compatible release can admit both versions")
+            .expect("specifiers need an update");
 
-        assert_eq!(proposed.to_string(), "requests~=2.4");
+        assert_eq!(proposed.to_string(), "~=2.4");
     }
 
     #[test]
-    fn propose_requirement_rejects_unrepresentable_multiple_versions() {
+    fn propose_specifiers_rejects_unrepresentable_multiple_versions() {
         let requirement =
             Requirement::<VerbatimParsedUrl>::from_str("requests==1.*").expect("valid requirement");
 
-        let error = propose_requirement(&requirement, &resolved_versions(&["1.5.0", "2.4.0"]))
+        let error = propose_specifiers(&requirement, &resolved_versions(&["1.5.0", "2.4.0"]))
             .expect_err("wildcard cannot admit versions from different major lines");
 
         assert_eq!(

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -33,21 +33,41 @@ use crate::commands::{ExitStatus, diagnostics};
 use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 
-/// A dependency declaration selected for upgrading.
-struct UpgradableDeclaration {
+/// A dependency requirement selected for upgrading.
+struct UpgradableRequirement {
     package: PackageName,
     dependency_type: DependencyType,
-    text: String,
+    original_text: String,
     requirement: Requirement<VerbatimParsedUrl>,
     effective_marker: MarkerTree,
     resolved_versions: BTreeSet<Version>,
+}
+
+/// A selected requirement that cannot apply to the project.
+struct SkippedRequirement {
+    package: PackageName,
+    dependency_type: DependencyType,
+    original_text: String,
+    display_text: String,
+    reason: SkippedReason,
+}
+
+enum SkippedReason {
+    EnvironmentOrPythonRequirement,
+    UndefinedExtra,
+}
+
+/// The requirements selected for upgrade and those that cannot apply.
+struct RequirementSelection {
+    to_upgrade: Vec<UpgradableRequirement>,
+    skipped: Vec<SkippedRequirement>,
 }
 
 /// An existing requirement and its proposed replacement.
 struct RequirementUpdate {
     package: PackageName,
     dependency_type: DependencyType,
-    text: String,
+    original_text: String,
     existing: Requirement<VerbatimUrl>,
     replacement: Requirement<VerbatimUrl>,
 }
@@ -89,19 +109,34 @@ pub(crate) async fn upgrade(
         }
         Err(err) => return Err(err.into()),
     };
-    let mut requirements = select_requirements(&project, &package)?;
+    let RequirementSelection {
+        to_upgrade: mut requirements,
+        skipped,
+    } = select_requirements(&project, &package)?;
+    render_skipped_requirements(&skipped, printer)?;
+    if requirements.is_empty() {
+        return Ok(ExitStatus::Success);
+    }
+    validate_requirements(&project, &package, &requirements)?;
+
+    // Relax the selected requirements in a temporary manifest so the resolver can select newer
+    // versions without changing the user's manifest.
     let relaxed_requirements = requirements
         .iter()
         .map(|selected| {
-            Ok((
-                selected.package.clone(),
-                selected.dependency_type.clone(),
-                into_verbatim_requirement(selected.requirement.clone(), &selected.package)?,
-                into_verbatim_requirement(
+            Ok(RequirementUpdate {
+                package: selected.package.clone(),
+                dependency_type: selected.dependency_type.clone(),
+                original_text: selected.original_text.clone(),
+                existing: into_verbatim_requirement(
+                    selected.requirement.clone(),
+                    &selected.package,
+                )?,
+                replacement: into_verbatim_requirement(
                     relax_requirement(selected.requirement.clone()),
                     &selected.package,
                 )?,
-            ))
+            })
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -109,14 +144,30 @@ pub(crate) async fn upgrade(
         &project.current_project().pyproject_toml().raw,
         DependencyTarget::PyProjectToml,
     )?;
-    apply_requirement_replacements(
-        &mut pyproject,
-        relaxed_requirements
-            .iter()
-            .map(|(package, dependency_type, existing, replacement)| {
-                (package, dependency_type, existing, replacement)
-            }),
-    )?;
+    // Remove unreachable requirements from the temporary manifest, since URL requirements can be
+    // fetched during metadata preparation even when their markers cannot apply.
+    for (index, requirement) in skipped.iter().enumerate() {
+        if skipped[..index].iter().any(|removed| {
+            removed.dependency_type == requirement.dependency_type
+                && removed.original_text == requirement.original_text
+        }) {
+            continue;
+        }
+        if pyproject
+            .remove_dependency_declaration_text(
+                &requirement.dependency_type,
+                &requirement.original_text,
+            )?
+            .is_empty()
+        {
+            bail!(
+                "Dependency `{}` was not found in {}",
+                requirement.package,
+                requirement.dependency_type.toml_table_name()
+            );
+        }
+    }
+    apply_requirement_replacements(&mut pyproject, relaxed_requirements.iter())?;
     let pyproject = pyproject.to_string();
     let pyproject = PyProjectToml::from_toml(
         &pyproject,
@@ -264,7 +315,7 @@ pub(crate) async fn upgrade(
                 updated_requirements.push(RequirementUpdate {
                     package: selected.package.clone(),
                     dependency_type: selected.dependency_type.clone(),
-                    text: selected.text.clone(),
+                    original_text: selected.original_text.clone(),
                     existing,
                     replacement,
                 });
@@ -277,17 +328,7 @@ pub(crate) async fn upgrade(
             &project.current_project().pyproject_toml().raw,
             DependencyTarget::PyProjectToml,
         )?;
-        apply_requirement_replacements(
-            &mut pyproject,
-            updated_requirements.iter().map(|update| {
-                (
-                    &update.package,
-                    &update.dependency_type,
-                    &update.existing,
-                    &update.replacement,
-                )
-            }),
-        )?;
+        apply_requirement_replacements(&mut pyproject, updated_requirements.iter())?;
         let pyproject_path = project.project_root().join("pyproject.toml");
         fs_err::write(pyproject_path, pyproject.to_string())?;
     }
@@ -308,7 +349,7 @@ pub(crate) async fn upgrade(
         writeln!(
             printer.stderr(),
             "Updated requirement: `{}` -> `{}`",
-            update.text,
+            update.original_text,
             update.replacement
         )?;
     }
@@ -316,11 +357,11 @@ pub(crate) async fn upgrade(
     Ok(ExitStatus::Success)
 }
 
-/// Select the dependency declarations targeted by `uv upgrade`.
+/// Select the dependency requirements targeted by `uv upgrade`.
 fn select_requirements(
     project: &ProjectWorkspace,
     package: &PackageName,
-) -> Result<Vec<UpgradableDeclaration>> {
+) -> Result<RequirementSelection> {
     if project.workspace().packages().len() != 1 {
         bail!("`uv upgrade` does not support workspaces with multiple members yet");
     }
@@ -333,7 +374,14 @@ fn select_requirements(
         .as_deref()
         .unwrap_or_default();
     let pyproject_path = project.project_root().join("pyproject.toml");
+    let optional_dependencies = project
+        .current_project()
+        .project()
+        .optional_dependencies
+        .as_ref();
     let mut to_upgrade = Vec::new();
+    let mut skipped = Vec::new();
+    let mut found_matching_name = false;
     for dependency in dependencies {
         let requirement =
             Requirement::<VerbatimParsedUrl>::from_str(dependency).with_context(|| {
@@ -343,17 +391,39 @@ fn select_requirements(
                 )
             })?;
         if requirement.name == *package {
+            found_matching_name = true;
             let mut effective_marker = requirement.marker;
             effective_marker.and(resolution_marker);
             if effective_marker.is_false() {
-                bail!(
-                    "Dependency `{package}` has declarations excluded by the project's Python or environment constraints and cannot be upgraded"
-                );
+                skipped.push(SkippedRequirement {
+                    package: package.clone(),
+                    dependency_type: DependencyType::Production,
+                    original_text: dependency.clone(),
+                    display_text: display_requirement(&requirement),
+                    reason: SkippedReason::EnvironmentOrPythonRequirement,
+                });
+                continue;
             }
-            to_upgrade.push(UpgradableDeclaration {
+
+            effective_marker = effective_marker.simplify_not_extras_with(|extra| {
+                optional_dependencies
+                    .is_none_or(|optional_dependencies| !optional_dependencies.contains_key(extra))
+            });
+            if effective_marker.is_false() {
+                skipped.push(SkippedRequirement {
+                    package: package.clone(),
+                    dependency_type: DependencyType::Production,
+                    original_text: dependency.clone(),
+                    display_text: display_requirement(&requirement),
+                    reason: SkippedReason::UndefinedExtra,
+                });
+                continue;
+            }
+
+            to_upgrade.push(UpgradableRequirement {
                 package: package.clone(),
                 dependency_type: DependencyType::Production,
-                text: dependency.clone(),
+                original_text: dependency.clone(),
                 requirement,
                 effective_marker,
                 resolved_versions: BTreeSet::new(),
@@ -361,11 +431,22 @@ fn select_requirements(
         }
     }
 
-    if to_upgrade.is_empty() {
+    if !found_matching_name {
         bail!("Dependency `{package}` was not found in `project.dependencies`");
     }
 
-    if to_upgrade.iter().any(|selected| {
+    Ok(RequirementSelection {
+        to_upgrade,
+        skipped,
+    })
+}
+
+fn validate_requirements(
+    project: &ProjectWorkspace,
+    package: &PackageName,
+    requirements: &[UpgradableRequirement],
+) -> Result<()> {
+    if requirements.iter().any(|selected| {
         matches!(
             selected.requirement.version_or_url,
             Some(VersionOrUrl::Url(_))
@@ -388,7 +469,7 @@ fn select_requirements(
         .and_then(|sources| sources.inner().get(package))
         .or_else(|| project.workspace().sources().get(package));
     let applies_to_selected_requirement = |source| {
-        to_upgrade.iter().any(|selected| {
+        requirements.iter().any(|selected| {
             source_is_applicable(source, &selected.dependency_type, selected.effective_marker)
         })
     };
@@ -412,7 +493,39 @@ fn select_requirements(
         );
     }
 
-    Ok(to_upgrade)
+    Ok(())
+}
+
+/// Return a requirement suitable for diagnostics without exposing URL query parameters.
+fn display_requirement(requirement: &Requirement<VerbatimParsedUrl>) -> String {
+    let mut requirement = requirement.clone();
+    if let Some(VersionOrUrl::Url(url)) = &mut requirement.version_or_url {
+        let mut display_url = url.verbatim.to_url();
+        display_url.set_query(None);
+        url.verbatim = VerbatimUrl::from_url(display_url);
+    }
+    requirement.to_string()
+}
+
+fn render_skipped_requirements(skipped: &[SkippedRequirement], printer: Printer) -> Result<()> {
+    for requirement in skipped {
+        let reason = match requirement.reason {
+            SkippedReason::EnvironmentOrPythonRequirement => {
+                "excluded by the project's environments or Python requirement"
+            }
+            SkippedReason::UndefinedExtra => {
+                "references an extra that the project does not provide"
+            }
+        };
+        writeln!(
+            printer.stderr(),
+            "warning: Skipping dependency `{}` in {}: `{}` ({reason})",
+            requirement.package,
+            requirement.dependency_type.toml_table_name(),
+            requirement.display_text
+        )?;
+    }
+    Ok(())
 }
 
 /// Return the marker domain that the project will resolve for dependency declarations.
@@ -433,17 +546,17 @@ fn project_resolution_marker(project: &ProjectWorkspace) -> Result<MarkerTree> {
 /// Apply exact requirement replacements, coalescing repeated identical declarations.
 fn apply_requirement_replacements<'a>(
     pyproject: &mut PyProjectTomlMut,
-    replacements: impl IntoIterator<
-        Item = (
-            &'a PackageName,
-            &'a DependencyType,
-            &'a Requirement<VerbatimUrl>,
-            &'a Requirement<VerbatimUrl>,
-        ),
-    >,
+    replacements: impl IntoIterator<Item = &'a RequirementUpdate>,
 ) -> Result<()> {
     let mut applied = Vec::new();
-    for (package, dependency_type, existing, replacement) in replacements {
+    for RequirementUpdate {
+        package,
+        dependency_type,
+        existing,
+        replacement,
+        ..
+    } in replacements
+    {
         if let Some((_, _, applied_replacement)) =
             applied
                 .iter()
@@ -458,7 +571,7 @@ fn apply_requirement_replacements<'a>(
         }
 
         if pyproject
-            .replace_dependency_declaration(dependency_type, existing, replacement, false)?
+            .replace_dependency_declaration(dependency_type, existing, replacement)?
             .is_empty()
         {
             bail!(

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -14,10 +14,10 @@ use uv_normalize::PackageName;
 use uv_pep440::{Operator, Version, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{MarkerTree, Requirement, VerbatimUrl, VersionOrUrl};
 use uv_preview::Preview;
-use uv_pypi_types::{PyProjectToml, ResolutionMetadata, VerbatimParsedUrl};
+use uv_pypi_types::{PyProjectToml, ResolutionMetadata, SupportedEnvironments, VerbatimParsedUrl};
 use uv_python::{ConfigDiscovery, PythonDownloads, PythonPreference};
 use uv_redacted::DisplaySafeUrl;
-use uv_resolver::MetadataResponse;
+use uv_resolver::{MetadataResponse, implicit_constraints_marker};
 use uv_settings::PythonInstallMirrors;
 use uv_workspace::pyproject::Source;
 use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
@@ -36,6 +36,7 @@ use crate::settings::ResolverSettings;
 struct SelectedRequirement {
     text: String,
     requirement: Requirement<VerbatimParsedUrl>,
+    applicability: MarkerTree,
     resolved_versions: BTreeSet<Version>,
 }
 
@@ -191,15 +192,17 @@ pub(crate) async fn upgrade(
     };
 
     let lock = result.lock();
-    let mut resolution_marker = lock.requires_python().to_marker_tree();
-    if !lock.supported_environments().is_empty() {
-        let mut supported_environments = MarkerTree::FALSE;
-        for environment in lock.supported_environments() {
-            supported_environments.or(*environment);
+    for selected in &requirements {
+        if let Some(extra) = selected.requirement.marker.top_level_extra_name()
+            && lock
+                .conflicts()
+                .contains(project.project_name(), extra.as_ref())
+        {
+            bail!(
+                "Dependency `{package}` is declared under conflicting extra `{extra}` and cannot be upgraded yet"
+            );
         }
-        resolution_marker.and(supported_environments);
     }
-    requirements.retain(|selected| !selected.requirement.marker.is_disjoint(resolution_marker));
 
     for resolved_package in lock.packages() {
         if resolved_package.name() == &package
@@ -211,7 +214,7 @@ pub(crate) async fn upgrade(
             // A universal lock can contain versions from disjoint forks, so collect each version
             // only for the declarations that apply to its fork.
             for selected in &mut requirements {
-                if resolved_package.is_included_by_marker(selected.requirement.marker) {
+                if resolved_package.is_included_by_marker(selected.applicability) {
                     selected.resolved_versions.insert(version.clone());
                 }
             }
@@ -283,6 +286,7 @@ fn select_requirements(
         bail!("`uv upgrade` does not support workspaces with multiple members yet");
     }
 
+    let resolution_marker = project_resolution_marker(project)?;
     let dependencies = project
         .current_project()
         .project()
@@ -300,9 +304,17 @@ fn select_requirements(
                 )
             })?;
         if requirement.name == *package {
+            let mut applicability = requirement.marker;
+            applicability.and(resolution_marker);
+            if applicability.is_false() {
+                bail!(
+                    "Dependency `{package}` has declarations excluded by the project's Python or environment constraints and cannot be upgraded"
+                );
+            }
             matching.push(SelectedRequirement {
                 text: dependency.clone(),
                 requirement,
+                applicability,
                 resolved_versions: BTreeSet::new(),
             });
         }
@@ -337,7 +349,7 @@ fn select_requirements(
     let applies_to_selected_requirement = |source| {
         matching
             .iter()
-            .any(|selected| source_is_applicable(source, selected.requirement.marker))
+            .any(|selected| source_is_applicable(source, selected.applicability))
     };
     if sources.is_some_and(|sources| {
         sources.iter().any(|source| {
@@ -360,6 +372,21 @@ fn select_requirements(
     }
 
     Ok(matching)
+}
+
+/// Return the marker domain that the project will resolve for dependency declarations.
+fn project_resolution_marker(project: &ProjectWorkspace) -> Result<MarkerTree> {
+    let target = LockTarget::from(project.workspace());
+    let requires_python = target
+        .requires_python()?
+        .map_or(MarkerTree::TRUE, |requires_python| {
+            requires_python.to_marker_tree()
+        });
+    let environments = target
+        .environments()
+        .map(SupportedEnvironments::as_markers)
+        .unwrap_or_default();
+    Ok(implicit_constraints_marker(requires_python, environments))
 }
 
 /// Apply exact requirement replacements, coalescing repeated identical declarations.

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -33,6 +33,12 @@ use crate::commands::{ExitStatus, diagnostics};
 use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 
+struct SelectedRequirement {
+    text: String,
+    requirement: Requirement<VerbatimParsedUrl>,
+    resolved_versions: BTreeSet<Version>,
+}
+
 pub(crate) async fn upgrade(
     project_dir: &Path,
     package: PackageName,
@@ -70,21 +76,31 @@ pub(crate) async fn upgrade(
         }
         Err(err) => return Err(err.into()),
     };
-    let (requirement_text, requirement) = select_requirement(&project, &package)?;
-
-    let relaxed_requirement =
-        into_verbatim_requirement(relax_requirement(requirement.clone()), &package)?;
+    let mut requirements = select_requirements(&project, &package)?;
+    let relaxed_requirements = requirements
+        .iter()
+        .map(|selected| {
+            Ok((
+                into_verbatim_requirement(selected.requirement.clone(), &package)?,
+                into_verbatim_requirement(
+                    relax_requirement(selected.requirement.clone()),
+                    &package,
+                )?,
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     let mut pyproject = PyProjectTomlMut::from_toml(
         &project.current_project().pyproject_toml().raw,
         DependencyTarget::PyProjectToml,
     )?;
-    if pyproject
-        .replace_dependency(&relaxed_requirement, false)?
-        .is_none()
-    {
-        bail!("Dependency `{package}` was not found in `project.dependencies`");
-    }
+    apply_requirement_replacements(
+        &mut pyproject,
+        relaxed_requirements
+            .iter()
+            .map(|(existing, replacement)| (existing, replacement)),
+        &package,
+    )?;
     let pyproject = pyproject.to_string();
     let pyproject = PyProjectToml::from_toml(
         &pyproject,
@@ -174,40 +190,67 @@ pub(crate) async fn upgrade(
         Err(err) => return Err(err.into()),
     };
 
-    let mut resolved_versions = BTreeSet::new();
-    for resolved_package in result.lock().packages() {
-        // A universal lock can contain versions from disjoint forks, so only collect versions
-        // from forks where the selected requirement applies.
+    let lock = result.lock();
+    let mut resolution_marker = lock.requires_python().to_marker_tree();
+    if !lock.supported_environments().is_empty() {
+        let mut supported_environments = MarkerTree::FALSE;
+        for environment in lock.supported_environments() {
+            supported_environments.or(*environment);
+        }
+        resolution_marker.and(supported_environments);
+    }
+    requirements.retain(|selected| !selected.requirement.marker.is_disjoint(resolution_marker));
+
+    for resolved_package in lock.packages() {
         if resolved_package.name() == &package
             && resolved_package
                 .index(project.workspace().install_path())?
                 .is_some()
-            && resolved_package.is_included_by_marker(requirement.marker)
             && let Some(version) = resolved_package.version()
         {
-            resolved_versions.insert(version.clone());
+            // A universal lock can contain versions from disjoint forks, so collect each version
+            // only for the declarations that apply to its fork.
+            for selected in &mut requirements {
+                if resolved_package.is_included_by_marker(selected.requirement.marker) {
+                    selected.resolved_versions.insert(version.clone());
+                }
+            }
         }
     }
-    let proposed_requirement = propose_requirement(&requirement, &resolved_versions)?;
-    let updated_requirement = if proposed_requirement == requirement {
-        None
-    } else {
-        let proposed_requirement = into_verbatim_requirement(proposed_requirement, &package)?;
-        let proposed_text = proposed_requirement.to_string();
+
+    let mut updated_requirements = Vec::new();
+    for selected in &requirements {
+        let proposed_requirement =
+            propose_requirement(&selected.requirement, &selected.resolved_versions)?;
+        if proposed_requirement != selected.requirement {
+            let existing = into_verbatim_requirement(selected.requirement.clone(), &package)?;
+            let replacement = into_verbatim_requirement(proposed_requirement, &package)?;
+            if !updated_requirements
+                .iter()
+                .any(|(_, updated_existing, updated_replacement)| {
+                    updated_existing == &existing && updated_replacement == &replacement
+                })
+            {
+                updated_requirements.push((selected.text.clone(), existing, replacement));
+            }
+        }
+    }
+
+    if !updated_requirements.is_empty() {
         let mut pyproject = PyProjectTomlMut::from_toml(
             &project.current_project().pyproject_toml().raw,
             DependencyTarget::PyProjectToml,
         )?;
-        if pyproject
-            .replace_dependency(&proposed_requirement, false)?
-            .is_none()
-        {
-            bail!("Dependency `{package}` was not found in `project.dependencies`");
-        }
+        apply_requirement_replacements(
+            &mut pyproject,
+            updated_requirements
+                .iter()
+                .map(|(_, existing, replacement)| (existing, replacement)),
+            &package,
+        )?;
         let pyproject_path = project.project_root().join("pyproject.toml");
         fs_err::write(pyproject_path, pyproject.to_string())?;
-        Some(proposed_text)
-    };
+    }
 
     let event = match &result {
         LockResult::Changed(previous, lock) => {
@@ -221,21 +264,21 @@ pub(crate) async fn upgrade(
     } else {
         writeln!(printer.stderr(), "No version change for {package}")?;
     }
-    if let Some(proposed_text) = updated_requirement {
+    for (requirement_text, _, proposed_requirement) in updated_requirements {
         writeln!(
             printer.stderr(),
-            "Updated requirement: `{requirement_text}` -> `{proposed_text}`"
+            "Updated requirement: `{requirement_text}` -> `{proposed_requirement}`"
         )?;
     }
 
     Ok(ExitStatus::Success)
 }
 
-/// Select the single production dependency declaration targeted by `uv upgrade`.
-fn select_requirement(
+/// Select the production dependency declarations targeted by `uv upgrade`.
+fn select_requirements(
     project: &ProjectWorkspace,
     package: &PackageName,
-) -> Result<(String, Requirement<VerbatimParsedUrl>)> {
+) -> Result<Vec<SelectedRequirement>> {
     if project.workspace().packages().len() != 1 {
         bail!("`uv upgrade` does not support workspaces with multiple members yet");
     }
@@ -257,21 +300,28 @@ fn select_requirement(
                 )
             })?;
         if requirement.name == *package {
-            matching.push((dependency.clone(), requirement));
+            matching.push(SelectedRequirement {
+                text: dependency.clone(),
+                requirement,
+                resolved_versions: BTreeSet::new(),
+            });
         }
     }
 
-    let (requirement_text, requirement) = match matching.as_slice() {
-        [] => bail!("Dependency `{package}` was not found in `project.dependencies`"),
-        [(requirement_text, requirement)] => (requirement_text.clone(), requirement.clone()),
-        _ => bail!("Dependency `{package}` is declared multiple times in `project.dependencies`"),
-    };
+    if matching.is_empty() {
+        bail!("Dependency `{package}` was not found in `project.dependencies`");
+    }
 
-    if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
+    if matching.iter().any(|selected| {
+        matches!(
+            selected.requirement.version_or_url,
+            Some(VersionOrUrl::Url(_))
+        )
+    }) {
         bail!("Dependency `{package}` is a direct URL requirement and cannot be upgraded");
     }
 
-    if requirement.name == *project.project_name() {
+    if package == project.project_name() {
         bail!("Dependency `{package}` refers to the current project and cannot be upgraded");
     }
 
@@ -284,9 +334,14 @@ fn select_requirement(
         .and_then(|uv| uv.sources.as_ref())
         .and_then(|sources| sources.inner().get(package))
         .or_else(|| project.workspace().sources().get(package));
+    let applies_to_selected_requirement = |source| {
+        matching
+            .iter()
+            .any(|selected| source_is_applicable(source, selected.requirement.marker))
+    };
     if sources.is_some_and(|sources| {
         sources.iter().any(|source| {
-            source_is_applicable(source, requirement.marker)
+            applies_to_selected_requirement(source)
                 && matches!(source, Source::Git { rev: Some(_), .. })
         })
     }) {
@@ -296,8 +351,7 @@ fn select_requirement(
     }
     if sources.is_some_and(|sources| {
         sources.iter().any(|source| {
-            source_is_applicable(source, requirement.marker)
-                && !matches!(source, Source::Registry { .. })
+            applies_to_selected_requirement(source) && !matches!(source, Source::Registry { .. })
         })
     }) {
         bail!(
@@ -305,7 +359,36 @@ fn select_requirement(
         );
     }
 
-    Ok((requirement_text, requirement))
+    Ok(matching)
+}
+
+/// Apply exact requirement replacements, coalescing repeated identical declarations.
+fn apply_requirement_replacements<'a>(
+    pyproject: &mut PyProjectTomlMut,
+    replacements: impl IntoIterator<Item = (&'a Requirement<VerbatimUrl>, &'a Requirement<VerbatimUrl>)>,
+    package: &PackageName,
+) -> Result<()> {
+    let mut applied = Vec::new();
+    for (existing, replacement) in replacements {
+        if let Some((_, applied_replacement)) = applied
+            .iter()
+            .find(|(applied_existing, _)| *applied_existing == existing)
+        {
+            if *applied_replacement != replacement {
+                bail!("Dependency `{package}` has conflicting requirement updates");
+            }
+            continue;
+        }
+
+        if pyproject
+            .replace_dependency(existing, replacement, false)?
+            .is_empty()
+        {
+            bail!("Dependency `{package}` was not found in `project.dependencies`");
+        }
+        applied.push((existing, replacement));
+    }
+    Ok(())
 }
 
 /// Return whether a source applies to the selected requirement declaration.

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::path::Path;
 use std::str::FromStr;
@@ -296,7 +296,7 @@ pub(crate) async fn upgrade(
         }
     }
 
-    let mut updated_requirements = Vec::new();
+    let mut updated_requirements = BTreeMap::new();
     for selected in &requirements {
         let Some(specifiers) =
             propose_specifiers(&selected.requirement, &selected.resolved_versions)?
@@ -308,22 +308,19 @@ pub(crate) async fn upgrade(
         let mut proposed_requirement = selected.requirement.clone();
         proposed_requirement.version_or_url = Some(VersionOrUrl::VersionSpecifier(specifiers));
         let replacement = into_verbatim_requirement(proposed_requirement, &selected.package)?;
-        if !updated_requirements
-            .iter()
-            .any(|update: &RequirementUpdate| {
-                update.dependency_type == selected.dependency_type
-                    && update.existing == existing
-                    && update.replacement == replacement
-            })
-        {
-            updated_requirements.push(RequirementUpdate {
+        updated_requirements
+            .entry((
+                selected.dependency_type.toml_table_name().into_owned(),
+                existing.clone(),
+                replacement.clone(),
+            ))
+            .or_insert_with(|| RequirementUpdate {
                 package: selected.package.clone(),
                 dependency_type: selected.dependency_type.clone(),
                 original_text: selected.original_text.clone(),
                 existing,
                 replacement,
             });
-        }
     }
 
     if !updated_requirements.is_empty() {
@@ -331,7 +328,7 @@ pub(crate) async fn upgrade(
             &project.current_project().pyproject_toml().raw,
             DependencyTarget::PyProjectToml,
         )?;
-        apply_requirement_replacements(&mut pyproject, updated_requirements.iter())?;
+        apply_requirement_replacements(&mut pyproject, updated_requirements.values())?;
         let pyproject_path = project.project_root().join("pyproject.toml");
         fs_err::write(pyproject_path, pyproject.to_string())?;
     }
@@ -348,7 +345,7 @@ pub(crate) async fn upgrade(
     } else {
         writeln!(printer.stderr(), "No version change for {package}")?;
     }
-    for update in updated_requirements {
+    for update in updated_requirements.into_values() {
         writeln!(
             printer.stderr(),
             "Updated requirement: `{}` -> `{}`",

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -223,7 +223,7 @@ fn upgrade_preserves_constraint_that_admits_multiple_fork_versions() -> Result<(
 }
 
 #[test]
-fn upgrade_rejects_inapplicable_marked_dependency() -> Result<()> {
+fn upgrade_skips_inapplicable_marked_dependency() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let pyproject_toml = r#"
         [project]
@@ -237,12 +237,71 @@ fn upgrade_rejects_inapplicable_marked_dependency() -> Result<()> {
         .child("pyproject.toml")
         .write_str(pyproject_toml)?;
     uv_snapshot!(context.filters(), context.upgrade().arg("anyio"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Skipping dependency `anyio` in `project.dependencies`: `anyio<3 ; python_full_version < '3.12'` (excluded by the project's environments or Python requirement)
+    ");
+
+    assert_project_unchanged(&context, pyproject_toml)
+}
+
+#[test]
+fn upgrade_skips_undefined_extra() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]);
+    let pyproject_toml = r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio<3 ; extra == 'does-not-exist'"]
+
+        [project.optional-dependencies]
+        test = []
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+    uv_snapshot!(context.filters(), context.upgrade().arg("anyio"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Skipping dependency `anyio` in `project.dependencies`: `anyio<3 ; extra == 'does-not-exist'` (references an extra that the project does not provide)
+    ");
+
+    assert_project_unchanged(&context, pyproject_toml)
+}
+
+#[test]
+fn upgrade_warns_for_skipped_requirement_before_validation_error() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]);
+    let pyproject_toml = r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "bar @ https://example.com/bar-1.0.0-py3-none-any.whl",
+            "bar<2 ; python_version < '3.12'",
+        ]
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+    uv_snapshot!(context.filters(), context.upgrade().arg("bar"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    error: Dependency `anyio` has declarations excluded by the project's Python or environment constraints and cannot be upgraded
+    warning: Skipping dependency `bar` in `project.dependencies`: `bar<2 ; python_full_version < '3.12'` (excluded by the project's environments or Python requirement)
+    error: Dependency `bar` is a direct URL requirement and cannot be upgraded
     ");
 
     assert_project_unchanged(&context, pyproject_toml)
@@ -698,26 +757,26 @@ fn upgrade_updates_multiple_marked_production_dependencies() -> Result<()> {
             updated_pyproject_toml,
             @r#"
 
-[project]
-name = "example"
-version = "0.1.0"
-requires-python = ">=3.12"
-dependencies = [
-    # No upper bound to upgrade.
-    "bar>=1",
-    "bar<2 ; sys_platform == 'linux'",
-    "bar<3 ; sys_platform != 'linux'",
-    "bar<3 ; sys_platform != 'linux'",
-    "foo==1",
-]
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            # No upper bound to upgrade.
+            "bar>=1",
+            "bar<2 ; sys_platform == 'linux'",
+            "bar<3 ; sys_platform != 'linux'",
+            "bar<3 ; sys_platform != 'linux'",
+            "foo==1",
+        ]
 
-[tool.uv]
-environments = ["sys_platform != 'win32'"]
+        [tool.uv]
+        environments = ["sys_platform != 'win32'"]
 
-[[tool.uv.index]]
-url = "http://[LOCALHOST]/simple/"
-default = true
-"#
+        [[tool.uv.index]]
+        url = "http://[LOCALHOST]/simple/"
+        default = true
+        "#
         );
     });
     assert!(!context.temp_dir.child("uv.lock").exists());
@@ -956,7 +1015,7 @@ fn upgrade_rejects_non_registry_sources() -> Result<()> {
 }
 
 #[test]
-fn upgrade_rejects_non_registry_source_for_top_level_extra() -> Result<()> {
+fn upgrade_skips_non_registry_source_for_undefined_extra() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let pyproject_toml = r#"
         [project]
@@ -976,12 +1035,12 @@ fn upgrade_rejects_non_registry_source_for_top_level_extra() -> Result<()> {
         context.filters(),
         context.upgrade().arg("requests"),
         @"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Dependency `requests` uses a non-registry source in `tool.uv.sources` and cannot be upgraded
+    warning: Skipping dependency `requests` in `project.dependencies`: `requests>=2 ; extra == 'gpu'` (references an extra that the project does not provide)
     "
     );
 
@@ -1104,40 +1163,66 @@ fn upgrade_ignores_inapplicable_non_registry_source() -> Result<()> {
 }
 
 #[test]
-fn upgrade_rejects_excluded_declaration() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&[]);
-    let pyproject_toml = r#"
+fn upgrade_skips_excluded_declarations_and_updates_applicable_requirement() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
         [project]
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
             "bar<2",
-            "bar @ https://example.com/bar-1.0.0-py3-none-any.whl ; python_version < '3.12' or sys_platform == 'win32'",
+            "bar>=1 ; extra == 'does-not-exist' or sys_platform != 'win32'",
+            "bar @ https://user:secret@example.com/bar-1.0.0-py3-none-any.whl?token=secret ; python_version < '3.12' or sys_platform == 'win32'",
+            "bar<2 ; extra == 'does-not-exist'",
+            "foo==2",
         ]
 
         [tool.uv]
         environments = ["sys_platform != 'win32'"]
-    "#;
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
     context
         .temp_dir
         .child("pyproject.toml")
-        .write_str(pyproject_toml)?;
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
 
     uv_snapshot!(
-        context.filters(),
-        context.upgrade().arg("bar"),
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
         @"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Dependency `bar` has declarations excluded by the project's Python or environment constraints and cannot be upgraded
+    warning: Skipping dependency `bar` in `project.dependencies`: `bar @ https://user:****@example.com/bar-1.0.0-py3-none-any.whl ; python_full_version < '3.12' or sys_platform == 'win32'` (excluded by the project's environments or Python requirement)
+    warning: Skipping dependency `bar` in `project.dependencies`: `bar<2 ; extra == 'does-not-exist'` (references an extra that the project does not provide)
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 3 packages in [TIME]
+    Add bar v2.0.0
+    Updated requirement: `bar<2` -> `bar<3`
     "
     );
 
-    assert_project_unchanged(&context, pyproject_toml)
+    assert_eq!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        pyproject_toml.replacen("bar<2\",", "bar<3\",", 1)
+    );
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -712,7 +712,7 @@ fn upgrade_updates_multiple_marked_production_dependencies() -> Result<()> {
             "bar>=1",
             "bar<1 ; sys_platform == 'linux'",
             "bar<2 ; sys_platform != 'linux'",
-            "bar<2 ; sys_platform != 'linux'",
+            "BAR<2; sys_platform != 'linux'",
             "foo==1",
         ]
 

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -726,6 +726,96 @@ default = true
 }
 
 #[test]
+fn upgrade_ignores_unrelated_path_package_when_attributing_versions() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "bar<2",
+            "localpkg",
+        ]
+
+        [tool.uv.sources]
+        localpkg = {{ path = "localpkg" }}
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    context
+        .temp_dir
+        .child("localpkg")
+        .child("pyproject.toml")
+        .write_str(
+            r#"
+        [project]
+        name = "localpkg"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+    "#,
+        )?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 3 packages in [TIME]
+    Add bar v2.0.0
+    Updated requirement: `bar<2` -> `bar<3`
+    "
+    );
+
+    let updated_pyproject_toml = fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?;
+    insta::with_settings!({ filters => packse_filters(&context) }, {
+        insta::assert_snapshot!(
+            updated_pyproject_toml,
+            @r#"
+
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "bar<3",
+    "localpkg",
+]
+
+[tool.uv.sources]
+localpkg = { path = "localpkg" }
+
+[[tool.uv.index]]
+url = "http://[LOCALHOST]/simple/"
+default = true
+"#
+        );
+    });
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
 fn upgrade_rejects_direct_url_requirement() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let pyproject_toml = r#"

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -223,8 +223,8 @@ fn upgrade_preserves_constraint_that_admits_multiple_fork_versions() -> Result<(
 }
 
 #[test]
-fn upgrade_preserves_inapplicable_marked_dependency() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
+fn upgrade_rejects_inapplicable_marked_dependency() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]);
     let pyproject_toml = r#"
         [project]
         name = "project"
@@ -236,20 +236,77 @@ fn upgrade_preserves_inapplicable_marked_dependency() -> Result<()> {
         .temp_dir
         .child("pyproject.toml")
         .write_str(pyproject_toml)?;
+    uv_snapshot!(context.filters(), context.upgrade().arg("anyio"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Dependency `anyio` has declarations excluded by the project's Python or environment constraints and cannot be upgraded
+    ");
+
+    assert_project_unchanged(&context, pyproject_toml)
+}
+
+#[test]
+fn upgrade_rejects_conflicting_extra_declarations() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "bar<1 ; extra == 'cpu'",
+            "bar<2 ; extra == 'gpu'",
+            "foo==1",
+        ]
+
+        [project.optional-dependencies]
+        cpu = []
+        gpu = []
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ extra = "cpu" }},
+                {{ extra = "gpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
     fs_err::remove_dir_all(&context.venv)?;
 
-    uv_snapshot!(context.filters(), context.upgrade().arg("anyio"), @"
-    success: true
-    exit_code: 0
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    success: false
+    exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    Resolved 1 package in [TIME]
-    No version change for anyio
-    ");
+    Resolved 4 packages in [TIME]
+    error: Dependency `bar` is declared under conflicting extra `cpu` and cannot be upgraded yet
+    "
+    );
 
-    assert_project_unchanged(&context, pyproject_toml)
+    assert_project_unchanged(&context, &pyproject_toml)
 }
 
 #[test]
@@ -669,90 +726,6 @@ default = true
 }
 
 #[test]
-fn upgrade_updates_duplicate_production_dependencies_in_resolution_domain() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let server = PackseServer::new("fork/fork-upgrade.toml");
-    let pyproject_toml = format!(
-        r#"
-        [project]
-        name = "example"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = [
-            "bar<1 ; python_version < '3.12' or sys_platform == 'win32'",
-            "bar>=1",
-            "bar<2",
-            "bar<2",
-            "foo==2",
-        ]
-
-        [tool.uv]
-        environments = ["sys_platform != 'win32'"]
-
-        [[tool.uv.index]]
-        url = "{}"
-        default = true
-    "#,
-        server.index_url()
-    );
-    context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(&pyproject_toml)?;
-    fs_err::remove_dir_all(&context.venv)?;
-
-    uv_snapshot!(
-        packse_filters(&context),
-        context
-            .upgrade()
-            .arg("bar")
-            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
-        @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    Resolved 3 packages in [TIME]
-    Add bar v2.0.0
-    Updated requirement: `bar<2` -> `bar<3`
-    "
-    );
-
-    let updated_pyproject_toml = fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?;
-    insta::with_settings!({ filters => packse_filters(&context) }, {
-        insta::assert_snapshot!(
-            updated_pyproject_toml,
-            @r#"
-
-[project]
-name = "example"
-version = "0.1.0"
-requires-python = ">=3.12"
-dependencies = [
-    "bar<1 ; python_version < '3.12' or sys_platform == 'win32'",
-    "bar>=1",
-    "bar<3",
-    "bar<3",
-    "foo==2",
-]
-
-[tool.uv]
-environments = ["sys_platform != 'win32'"]
-
-[[tool.uv.index]]
-url = "http://[LOCALHOST]/simple/"
-default = true
-"#
-        );
-    });
-    assert!(!context.temp_dir.child("uv.lock").exists());
-    assert!(!context.temp_dir.child(".venv").exists());
-    Ok(())
-}
-
-#[test]
 fn upgrade_rejects_direct_url_requirement() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let pyproject_toml = r#"
@@ -1038,6 +1011,43 @@ fn upgrade_ignores_inapplicable_non_registry_source() -> Result<()> {
     assert!(!context.temp_dir.child("uv.lock").exists());
     assert!(!context.temp_dir.child(".venv").exists());
     Ok(())
+}
+
+#[test]
+fn upgrade_rejects_excluded_declaration() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]);
+    let pyproject_toml = r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "bar<2",
+            "bar @ https://example.com/bar-1.0.0-py3-none-any.whl ; python_version < '3.12' or sys_platform == 'win32'",
+        ]
+
+        [tool.uv]
+        environments = ["sys_platform != 'win32'"]
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.upgrade().arg("bar"),
+        @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Dependency `bar` has declarations excluded by the project's Python or environment constraints and cannot be upgraded
+    "
+    );
+
+    assert_project_unchanged(&context, pyproject_toml)
 }
 
 #[test]

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -582,36 +582,174 @@ fn upgrade_requires_production_dependency() -> Result<()> {
 }
 
 #[test]
-fn upgrade_rejects_duplicate_marked_production_dependencies() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&[]);
-    let pyproject_toml = r#"
+fn upgrade_updates_multiple_marked_production_dependencies() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
         [project]
         name = "example"
         version = "0.1.0"
+        requires-python = ">=3.12"
         dependencies = [
-            "Requests>=2 ; sys_platform == 'darwin'",
-            "requests<3 ; sys_platform != 'darwin'",
+            # No upper bound to upgrade.
+            "bar>=1",
+            "bar<1 ; sys_platform == 'linux'",
+            "bar<2 ; sys_platform != 'linux'",
+            "bar<2 ; sys_platform != 'linux'",
+            "foo==1",
         ]
-    "#;
+
+        [tool.uv]
+        environments = ["sys_platform != 'win32'"]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
     context
         .temp_dir
         .child("pyproject.toml")
-        .write_str(pyproject_toml)?;
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
 
     uv_snapshot!(
-        context.filters(),
-        context.upgrade().arg("requests"),
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
         @"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Dependency `requests` is declared multiple times in `project.dependencies`
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    Add bar v1.0.0, v2.0.0
+    Updated requirement: `bar<1 ; sys_platform == 'linux'` -> `bar<2 ; sys_platform == 'linux'`
+    Updated requirement: `bar<2 ; sys_platform != 'linux'` -> `bar<3 ; sys_platform != 'linux'`
     "
     );
 
-    assert_project_unchanged(&context, pyproject_toml)
+    let updated_pyproject_toml = fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?;
+    insta::with_settings!({ filters => packse_filters(&context) }, {
+        insta::assert_snapshot!(
+            updated_pyproject_toml,
+            @r#"
+
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    # No upper bound to upgrade.
+    "bar>=1",
+    "bar<2 ; sys_platform == 'linux'",
+    "bar<3 ; sys_platform != 'linux'",
+    "bar<3 ; sys_platform != 'linux'",
+    "foo==1",
+]
+
+[tool.uv]
+environments = ["sys_platform != 'win32'"]
+
+[[tool.uv.index]]
+url = "http://[LOCALHOST]/simple/"
+default = true
+"#
+        );
+    });
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
+fn upgrade_updates_duplicate_production_dependencies_in_resolution_domain() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "bar<1 ; python_version < '3.12' or sys_platform == 'win32'",
+            "bar>=1",
+            "bar<2",
+            "bar<2",
+            "foo==2",
+        ]
+
+        [tool.uv]
+        environments = ["sys_platform != 'win32'"]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 3 packages in [TIME]
+    Add bar v2.0.0
+    Updated requirement: `bar<2` -> `bar<3`
+    "
+    );
+
+    let updated_pyproject_toml = fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?;
+    insta::with_settings!({ filters => packse_filters(&context) }, {
+        insta::assert_snapshot!(
+            updated_pyproject_toml,
+            @r#"
+
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "bar<1 ; python_version < '3.12' or sys_platform == 'win32'",
+    "bar>=1",
+    "bar<3",
+    "bar<3",
+    "foo==2",
+]
+
+[tool.uv]
+environments = ["sys_platform != 'win32'"]
+
+[[tool.uv.index]]
+url = "http://[LOCALHOST]/simple/"
+default = true
+"#
+        );
+    });
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
`uv upgrade` currently rejects multiple declarations for the same dependency. For example:

```toml
dependencies = [
    "bar<1 ; sys_platform == 'linux'",
    "bar<2 ; sys_platform != 'linux'",
]
```

This updates every matching declaration using the versions resolved for its marker, including exact duplicates, instead of rejecting the upgrade.

Declarations excluded by `requires-python` or configured environments now fail before resolution, avoiding partial upgrades. Requirement replacement and source validation retain the declaration type so subsequent workspace, optional-dependency, and dependency-group support can reuse the same path.