### PR TITLE
Error on unsupported `--cert` in pip compat layer

### DIFF
--- a/crates/uv-cli/src/compat.rs
+++ b/crates/uv-cli/src/compat.rs
@@ -110,6 +110,12 @@ impl CompatArgs for PipCompileCompatArgs {
             ));
         }
 
+        if self.cert.is_some() {
+            return Err(anyhow!(
+                "pip-compile's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)"
+            ));
+        }
+
         if self.client_cert.is_some() {
             return Err(anyhow!(
                 "pip-compile's `--client-cert` is unsupported (uv doesn't support dedicated client certificates)"
@@ -230,6 +236,12 @@ impl CompatArgs for PipSyncCompatArgs {
         if self.user {
             return Err(anyhow!(
                 "pip-sync's `--user` is unsupported (use a virtual environment instead)"
+            ));
+        }
+
+        if self.cert.is_some() {
+            return Err(anyhow!(
+                "pip-sync's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)"
             ));
         }
 

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -37,6 +37,30 @@ fn missing_requirements_txt() {
     requirements_txt.assert(predicates::path::missing());
 }
 
+/// `pip-sync`'s `--cert` is unsupported and must error, rather than being silently ignored,
+/// so users don't believe a custom CA bundle is in effect when it isn't.
+/// See <https://github.com/astral-sh/uv/issues/20350>.
+#[test]
+fn cert_unsupported() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("iniconfig==2.0.0")?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--cert")
+        .arg("ca-bundle.pem"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: pip-sync's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn missing_venv() -> Result<()> {
     let context = uv_test::test_context!("3.12")

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -6640,6 +6640,31 @@ fn resolver_legacy() -> Result<()> {
     Ok(())
 }
 
+/// `pip-compile`'s `--cert` is unsupported and must error, rather than being silently ignored,
+/// so users don't believe a custom CA bundle is in effect when it isn't.
+/// See <https://github.com/astral-sh/uv/issues/20350>.
+#[test]
+fn cert_unsupported() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let requirements_in = context.temp_dir.child("requirements.in");
+    requirements_in.write_str("werkzeug==3.0.1")?;
+
+    uv_snapshot!(context.filters(), context.pip_compile()
+            .arg("requirements.in")
+            .arg("--cert")
+            .arg("ca-bundle.pem"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: pip-compile's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)
+    "
+    );
+
+    Ok(())
+}
+
 /// Avoid including the `--index` and `-i` flags in the header.
 #[test]
 fn hide_index_urls() -> Result<()> {


### PR DESCRIPTION
## Summary

`uv pip compile` and `uv pip sync` accept pip's `--cert` flag but silently ignore it — no warning, no error, no effect. The `cert` field is parsed into `PipCompileCompatArgs` / `PipSyncCompatArgs` in `crates/uv-cli/src/compat.rs`, but neither struct's `validate()` ever inspects it, unlike every sibling flag (including the adjacent `--client-cert`, which errors).

This is a silent footgun: a user migrating a `pip-compile --cert /corp/ca.pem` command reasonably believes their custom CA bundle is in effect when it is not. Even a nonexistent `--cert` path was accepted without complaint.

This PR makes `--cert` error consistently with `--client-cert` and the module's documented contract ("return an error [when an argument] does not match uv's behavior"), and points users at the supported mechanism — the `SSL_CERT_FILE` / `SSL_CERT_DIR` environment variables ([docs](https://docs.astral.sh/uv/concepts/authentication/certificates/)).

Scoped narrowly to the compat-layer no-op — this does not add a first-class `--cert` flag or config key (that's #6715) and does not touch uv's global TLS behavior.

## Before / after

```console
# before
$ uv pip compile --cert /path/does-not-exist.pem requirements.in
# (proceeds normally; the cert is never validated or used)

# after
$ uv pip compile --cert /path/does-not-exist.pem requirements.in
error: pip-compile's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)
```

## Test plan

- Added `cert_unsupported` integration tests for both `uv pip compile` and `uv pip sync`, mirroring the existing `resolver_legacy` compat test.
- `cargo test -p uv --test pip_compile --test pip cert_unsupported` — both pass.
- `cargo clippy -p uv-cli` — no warnings.
- Verified `--client-cert` still errors unchanged (no regression).

Fixes #20350
