### PR TITLE
Reuse workspace discovery after settings resolution

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -615,7 +615,13 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
         }
     }
 
-    let workspace_cache = WorkspaceCache::default();
+    // Workspace discovery excludes the cache root, so only reuse the earlier discovery when the
+    // resolved cache has the same root.
+    let workspace_cache = if cache.root() == discovery_cache.root() {
+        workspace_cache
+    } else {
+        WorkspaceCache::default()
+    };
 
     // Configure the global network settings.
     let client_builder = BaseClientBuilder::new(

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -21129,7 +21129,6 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Found project root: `[TEMP_DIR]/`
-    DEBUG No workspace root found, using project root
     DEBUG No Python version file found in workspace: [TEMP_DIR]/
     DEBUG Using Python request `>=3.12` from `requires-python` metadata
     DEBUG Checking for Python environment at: `.venv`

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -1,8 +1,60 @@
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
-use assert_fs::fixture::{FileWriteStr, PathChild};
+use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 
+use uv_static::EnvVars;
 use uv_test::{copy_dir_ignore, uv_snapshot};
+
+/// The workspace discovered while resolving settings is reused when the resolved cache root is
+/// unchanged, but not when constructing the resolved cache creates a new root.
+#[test]
+fn workspace_list_reuses_settings_discovery() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str("[tool.uv.workspace]\nmembers = [\"packages/*\"]\n")?;
+    let member = context.temp_dir.child("packages/member");
+    member.create_dir_all()?;
+    member
+        .child("pyproject.toml")
+        .write_str("[project]\nname = \"member\"\nversion = \"0.1.0\"\n")?;
+
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .env(EnvVars::RUST_LOG, "uv_workspace=trace"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    member
+
+    ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `packages/member`
+    DEBUG Adding discovered workspace member: `[TEMP_DIR]/packages/member`
+    ");
+
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--no-cache")
+        .env(EnvVars::RUST_LOG, "uv_workspace=trace"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    member
+
+    ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `packages/member`
+    DEBUG Adding discovered workspace member: `[TEMP_DIR]/packages/member`
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `packages/member`
+    DEBUG Adding discovered workspace member: `[TEMP_DIR]/packages/member`
+    ");
+
+    Ok(())
+}
 
 /// Test basic list output for a simple workspace with one member.
 #[test]


### PR DESCRIPTION
## Summary

When settings resolution discovers a workspace, carry its `WorkspaceCache` into command dispatch when the resolved cache root matches the provisional root. This avoids rebuilding the same workspace discovery cache twice during a single command.

Workspace discovery excludes the cache root, so continue creating a fresh `WorkspaceCache` when settings resolution changes that root, including under `--no-cache`. Add an integration snapshot covering both the one-build reuse path and the two-build changed-root path.

Closes https://github.com/astral-sh/uv/issues/20308.