### PR TITLE
Request JSON metadata for exclude-newer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6247,6 +6247,7 @@ dependencies = [
  "astral_async_http_range_reader",
  "astral_async_zip",
  "async-trait",
+ "bitflags 2.13.0",
  "bytecheck",
  "fs-err",
  "futures",

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -47,6 +47,7 @@ astral-tl = { workspace = true }
 async-trait = { workspace = true }
 async_http_range_reader = { workspace = true }
 async_zip = { workspace = true }
+bitflags = { workspace = true }
 bytecheck = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -9,7 +9,7 @@ pub use error::{Error, ErrorKind, ProblemDetails, WrappedReqwestError};
 pub use flat_index::{FlatIndexClient, FlatIndexEntries, FlatIndexEntry, FlatIndexError};
 pub use registry_client::{
     Connectivity, MetadataFormat, RegistryClient, RegistryClientBuilder, SimpleDetailMetadata,
-    SimpleDetailMetadatum, SimpleIndexMetadata, VersionFiles,
+    SimpleDetailMetadatum, SimpleDetailRequirements, SimpleIndexMetadata, VersionFiles,
 };
 pub(crate) use retry::UvRetryableStrategy;
 pub use retry::{RetriableError, RetryState, retryable_on_request_failure};

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -309,12 +309,31 @@ impl RegistryClient {
     /// "Simple" here refers to [PEP 503 – Simple Repository API](https://peps.python.org/pep-0503/)
     /// and [PEP 691 – JSON-based Simple API for Python Package Indexes](https://peps.python.org/pep-0691/),
     /// which the PyPI JSON API implements.
-    #[instrument(skip_all, fields(package = % package_name))]
     pub async fn simple_detail<'index>(
         &'index self,
         package_name: &PackageName,
         index: Option<IndexMetadataRef<'index>>,
         capabilities: &IndexCapabilities,
+        download_concurrency: &Semaphore,
+    ) -> Result<Vec<(&'index IndexUrl, MetadataFormat)>, Error> {
+        self.simple_detail_with_requirements(
+            package_name,
+            index,
+            capabilities,
+            |_| SimpleDetailRequirements::default(),
+            download_concurrency,
+        )
+        .await
+    }
+
+    /// Fetch package metadata from an index with per-index metadata requirements.
+    #[instrument(skip_all, fields(package = % package_name))]
+    pub async fn simple_detail_with_requirements<'index>(
+        &'index self,
+        package_name: &PackageName,
+        index: Option<IndexMetadataRef<'index>>,
+        capabilities: &IndexCapabilities,
+        requirements: impl Fn(&IndexUrl) -> SimpleDetailRequirements + Sync,
         download_concurrency: &Semaphore,
     ) -> Result<Vec<(&'index IndexUrl, MetadataFormat)>, Error> {
         // If `--no-index` is specified, avoid fetching regardless of whether the index is implicit,
@@ -346,6 +365,7 @@ impl RegistryClient {
                                     index.url,
                                     capabilities,
                                     &status_code_strategy,
+                                    requirements(index.url),
                                 )
                                 .await?
                             {
@@ -392,6 +412,7 @@ impl RegistryClient {
                                         index.url,
                                         capabilities,
                                         &status_code_strategy,
+                                        requirements(index.url),
                                     )
                                     .await?
                                 {
@@ -507,6 +528,7 @@ impl RegistryClient {
         index: &IndexUrl,
         capabilities: &IndexCapabilities,
         status_code_strategy: &IndexStatusCodeStrategy,
+        requirements: SimpleDetailRequirements,
     ) -> Result<SimpleMetadataSearchOutcome, Error> {
         // Format the URL for PyPI.
         let mut url = index.url().clone();
@@ -549,8 +571,15 @@ impl RegistryClient {
         let result = if matches!(index, IndexUrl::Path(_)) {
             self.fetch_local_simple_detail(package_name, &url).await
         } else {
-            self.fetch_remote_simple_detail(package_name, &url, index, &cache_entry, cache_control)
-                .await
+            self.fetch_remote_simple_detail(
+                package_name,
+                &url,
+                index,
+                &cache_entry,
+                cache_control,
+                requirements,
+            )
+            .await
         };
 
         match result {
@@ -593,19 +622,16 @@ impl RegistryClient {
         index: &IndexUrl,
         cache_entry: &CacheEntry,
         cache_control: CacheControl,
+        requirements: SimpleDetailRequirements,
     ) -> Result<OwnedArchive<SimpleDetailMetadata>, Error> {
         // In theory, we should be able to pass `MediaType::all()` to all registries, and as
         // unsupported media types should be ignored by the server. For now, we implement this
         // defensively to avoid issues with misconfigured servers.
-        let accept = if self
+        let is_pyx = self
             .pyx_token_store
             .as_ref()
-            .is_some_and(|token_store| token_store.is_known_url(index.url()))
-        {
-            MediaType::all()
-        } else {
-            MediaType::pypi()
-        };
+            .is_some_and(|token_store| token_store.is_known_url(index.url()));
+        let accept = simple_detail_accept(index, is_pyx, requirements);
         let simple_request = self
             .uncached_client(url)
             .get(Url::from(url.clone()))
@@ -1655,6 +1681,15 @@ impl IntoIterator for SimpleDetailMetadata {
     }
 }
 
+bitflags::bitflags! {
+    /// Metadata required from a Simple API project detail response.
+    #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+    pub struct SimpleDetailRequirements: u8 {
+        /// Request a representation that can include file upload times.
+        const UPLOAD_TIME = 1;
+    }
+}
+
 impl ArchivedSimpleDetailMetadata {
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = &rkyv::Archived<SimpleDetailMetadatum>> {
         self.versions.iter()
@@ -1669,6 +1704,31 @@ impl ArchivedSimpleDetailMetadata {
     /// [PEP 792]: https://peps.python.org/pep-0792/
     pub fn project_status(&self) -> &rkyv::Archived<ProjectStatus> {
         &self.project_status
+    }
+}
+
+/// Return whether an index supports uv's non-standard `data-upload-time` HTML extension.
+fn supports_html_upload_time(index: &IndexUrl) -> bool {
+    let url = index.url();
+    url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("download.pytorch.org")
+            || (host.eq_ignore_ascii_case("astral-sh.github.io")
+                && url.path().starts_with("/pytorch-mirror/"))
+    })
+}
+
+fn simple_detail_accept(
+    index: &IndexUrl,
+    is_pyx: bool,
+    requirements: SimpleDetailRequirements,
+) -> &'static str {
+    let requires_upload_time = requirements.contains(SimpleDetailRequirements::UPLOAD_TIME);
+    match (is_pyx, requires_upload_time) {
+        (true, true) => MediaType::all_with_upload_time(),
+        (true, false) => MediaType::all(),
+        (false, true) if supports_html_upload_time(index) => MediaType::pypi(),
+        (false, true) => MediaType::pypi_with_upload_time(),
+        (false, false) => MediaType::pypi(),
     }
 }
 
@@ -1701,11 +1761,24 @@ impl MediaType {
         "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html;q=0.2, text/html;q=0.01"
     }
 
+    /// Return the `Accept` header value for PyPI media types that support upload times.
+    #[inline]
+    const fn pypi_with_upload_time() -> &'static str {
+        // PEP 700 only defines upload times for the JSON representation.
+        "application/vnd.pypi.simple.v1+json"
+    }
+
     /// Return the `Accept` header value for all supported media types.
     #[inline]
     const fn all() -> &'static str {
         // See: https://peps.python.org/pep-0691/#version-format-selection
         "application/vnd.pyx.simple.v1+msgpack, application/vnd.pyx.simple.v1+json;q=0.9, application/vnd.pypi.simple.v1+json;q=0.8, application/vnd.pypi.simple.v1+html;q=0.2, text/html;q=0.01"
+    }
+
+    /// Return the `Accept` header value for all media types that support upload times.
+    #[inline]
+    const fn all_with_upload_time() -> &'static str {
+        "application/vnd.pyx.simple.v1+msgpack, application/vnd.pyx.simple.v1+json;q=0.9, application/vnd.pypi.simple.v1+json;q=0.8"
     }
 }
 
@@ -1766,6 +1839,32 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     type Error = Box<dyn std::error::Error>;
+
+    #[test]
+    fn upload_time_accept_headers() {
+        let requirements = super::SimpleDetailRequirements::UPLOAD_TIME;
+        for index in [
+            "https://download.pytorch.org/whl/cu130",
+            "https://astral-sh.github.io/pytorch-mirror/whl/cu130",
+        ] {
+            let index = IndexUrl::from_str(index).unwrap();
+            assert_eq!(
+                super::simple_detail_accept(&index, false, requirements),
+                super::MediaType::pypi()
+            );
+        }
+
+        for index in [
+            "https://pypi.org/simple",
+            "https://astral-sh.github.io/another-index/simple",
+        ] {
+            let index = IndexUrl::from_str(index).unwrap();
+            assert_eq!(
+                super::simple_detail_accept(&index, false, requirements),
+                super::MediaType::pypi_with_upload_time()
+            );
+        }
+    }
 
     async fn start_test_server(username: &'static str, password: &'static str) -> MockServer {
         let server = MockServer::start().await;

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use reqwest::StatusCode;
 
-use uv_client::MetadataFormat;
+use uv_client::{MetadataFormat, SimpleDetailRequirements};
 use uv_configuration::BuildOptions;
 use uv_distribution::{ArchiveMetadata, DistributionDatabase, Reporter};
 use uv_distribution_types::{
@@ -179,14 +179,29 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
         package_name: &'io PackageName,
         index: Option<&'io IndexMetadata>,
     ) -> PackageVersionsResult {
+        let exclude_newer = &self.exclude_newer;
+        let index_locations = self.index_locations;
         let result = self
             .fetcher
             .client()
             .manual(|client, semaphore| {
-                client.simple_detail(
+                client.simple_detail_with_requirements(
                     package_name,
                     index.map(IndexMetadataRef::from),
                     self.capabilities,
+                    |index| {
+                        if exclude_newer
+                            .exclude_newer_package_for_index(
+                                package_name,
+                                index_locations.exclude_newer_for(index),
+                            )
+                            .is_some()
+                        {
+                            SimpleDetailRequirements::UPLOAD_TIME
+                        } else {
+                            SimpleDetailRequirements::empty()
+                        }
+                    },
                     semaphore,
                 )
             })

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -1,7 +1,7 @@
 use tokio::sync::Semaphore;
 use tracing::debug;
 
-use uv_client::{MetadataFormat, RegistryClient, VersionFiles};
+use uv_client::{MetadataFormat, RegistryClient, SimpleDetailRequirements, VersionFiles};
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{
     File, IndexCapabilities, IndexLocations, IndexMetadataRef, IndexUrl, RequiresPython,
@@ -122,10 +122,17 @@ impl LatestClient<'_> {
 
         let archives = match self
             .client
-            .simple_detail(
+            .simple_detail_with_requirements(
                 package,
                 index.map(IndexMetadataRef::from),
                 self.capabilities,
+                |index| {
+                    if self.effective_exclude_newer(package, index).is_some() {
+                        SimpleDetailRequirements::UPLOAD_TIME
+                    } else {
+                        SimpleDetailRequirements::empty()
+                    }
+                },
                 download_concurrency,
             )
             .await

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -21,7 +21,7 @@ use url::Url;
 use walkdir::WalkDir;
 use wiremock::{
     Mock, MockServer, ResponseTemplate,
-    matchers::{basic_auth, method, path},
+    matchers::{basic_auth, header, method, path},
 };
 
 use uv_fs::{PortablePath, Simplified};
@@ -3979,6 +3979,112 @@ fn no_prerelease_hint_source_builds() -> Result<()> {
 
     hint: `setuptools` was filtered by `exclude-newer` to only include packages uploaded before 2018-10-09T00:00:00Z. The latest version satisfying the requirement is v69.2.0, published at 2024-03-13T11:20:54.103Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     "
+    );
+
+    Ok(())
+}
+
+/// Request the JSON Simple API when `exclude-newer` requires upload times.
+#[tokio::test]
+async fn exclude_newer_requests_json_simple_api() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-01T00:00:00Z");
+    let server = MockServer::start().await;
+    let wheel_filename = "tqdm-1000.0.0-py3-none-any.whl";
+    let wheel_url = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links")
+            .join(wheel_filename),
+    )
+    .map_err(|()| anyhow!("Failed to convert wheel path to URL"))?;
+
+    Mock::given(method("GET"))
+        .and(path("/tqdm/"))
+        .and(header("Accept", "application/vnd.pypi.simple.v1+json"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(
+                serde_json::json!({
+                    "name": "tqdm",
+                    "files": [{
+                        "filename": wheel_filename,
+                        "url": wheel_url,
+                        "hashes": {},
+                        "requires-python": ">=3.8",
+                        "upload-time": "2024-01-01T00:00:00Z"
+                    }]
+                })
+                .to_string(),
+                "application/vnd.pypi.simple.v1+json",
+            ),
+        )
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("tqdm")
+        .arg("--index-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + tqdm==1000.0.0
+    "
+    );
+
+    Ok(())
+}
+
+/// Preserve HTML Simple API compatibility when `exclude-newer` is disabled for a package.
+#[tokio::test]
+async fn exclude_newer_package_disabled_accepts_html_simple_api() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-01T00:00:00Z");
+    let server = MockServer::start().await;
+    let wheel_filename = "tqdm-1000.0.0-py3-none-any.whl";
+    let wheel_url = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links")
+            .join(wheel_filename),
+    )
+    .map_err(|()| anyhow!("Failed to convert wheel path to URL"))?;
+
+    Mock::given(method("GET"))
+        .and(path("/tqdm/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            format!(r#"<a href="{wheel_url}">{wheel_filename}</a>"#),
+            "text/html",
+        ))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("tqdm")
+        .arg("--exclude-newer-package")
+        .arg("tqdm=false")
+        .arg("--index-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + tqdm==1000.0.0
+    "
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].headers.get("Accept").unwrap(),
+        "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html;q=0.2, text/html;q=0.01"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

When an effective `exclude-newer` cutoff applies, we can limit the set of supported index formats (in the `Accept` header) to those that can actually provide an `upload-time` value -- namely, JSON.

We retain the existing HTML-capable header for `download.pytorch.org` and the Astral PyTorch mirror, which support our non-standard `data-upload-time` extension.
