### PR TITLE
Mention project in missing extra errors

### DIFF
--- a/crates/uv/src/commands/project/install_target.rs
+++ b/crates/uv/src/commands/project/install_target.rs
@@ -356,9 +356,10 @@ impl<'lock> InstallTarget<'lock> {
                 for extra in extras.explicit_names() {
                     if !known_extras.contains(extra) {
                         return match self {
-                            Self::Project { .. } => {
-                                Err(ProjectError::MissingExtraProject(extra.clone()))
-                            }
+                            Self::Project { name, .. } => Err(ProjectError::MissingExtraProject(
+                                extra.clone(),
+                                name.clone(),
+                            )),
                             Self::Projects { .. } => {
                                 Err(ProjectError::MissingExtraProjects(extra.clone()))
                             }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -233,8 +233,8 @@ pub(crate) enum ProjectError {
     )]
     MissingDefaultGroup(GroupName),
 
-    #[error("Extra `{0}` is not defined in the project's `optional-dependencies` table")]
-    MissingExtraProject(ExtraName),
+    #[error("Extra `{0}` is not defined in the `optional-dependencies` table for `{1}`")]
+    MissingExtraProject(ExtraName, PackageName),
 
     #[error("Extra `{0}` is not defined in any project's `optional-dependencies` table")]
     MissingExtraProjects(ExtraName),

--- a/crates/uv/tests/lock_scenarios/lock_conflict.rs
+++ b/crates/uv/tests/lock_scenarios/lock_conflict.rs
@@ -5157,7 +5157,7 @@ conflicts = [
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    error: Extra `x2` is not defined in the project's `optional-dependencies` table
+    error: Extra `x2` is not defined in the `optional-dependencies` table for `project`
     ");
 
     uv_snapshot!(context.filters(), context.sync(), @"

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -5394,7 +5394,7 @@ fn sync_non_existent_extra() -> Result<()> {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    error: Extra `baz` is not defined in the project's `optional-dependencies` table
+    error: Extra `baz` is not defined in the `optional-dependencies` table for `project`
     ");
 
     // Excluding a non-existing extra when requesting all extras should fail.
@@ -5405,7 +5405,7 @@ fn sync_non_existent_extra() -> Result<()> {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    error: Extra `baz` is not defined in the project's `optional-dependencies` table
+    error: Extra `baz` is not defined in the `optional-dependencies` table for `project`
     ");
 
     Ok(())
@@ -5435,7 +5435,7 @@ fn sync_non_existent_extra_no_optional_dependencies() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    error: Extra `baz` is not defined in the project's `optional-dependencies` table
+    error: Extra `baz` is not defined in the `optional-dependencies` table for `project`
     ");
 
     // Excluding a non-existing extra when requesting all extras should fail.
@@ -5446,7 +5446,7 @@ fn sync_non_existent_extra_no_optional_dependencies() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    error: Extra `baz` is not defined in the project's `optional-dependencies` table
+    error: Extra `baz` is not defined in the `optional-dependencies` table for `project`
     ");
 
     Ok(())
@@ -5657,7 +5657,7 @@ fn sync_non_existent_extra_workspace_member() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    error: Extra `async` is not defined in the project's `optional-dependencies` table
+    error: Extra `async` is not defined in the `optional-dependencies` table for `project`
     ");
 
     // Unless we sync from the child directory.
@@ -5757,7 +5757,7 @@ fn sync_non_existent_extra_non_project_workspace() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    error: Extra `async` is not defined in the project's `optional-dependencies` table
+    error: Extra `async` is not defined in the `optional-dependencies` table for `other`
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

When validating an explicitly requested extra for a single project, include the selected project's package name in the missing-extra error. This disambiguates failures in workspaces by reporting the selected package:

```console
error: Extra `async` is not defined in the `optional-dependencies` table for `other`
```
