### PR TITLE
Avoid unnecessary setup for version reads

### DIFF
--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -12,8 +12,7 @@ use uv_cli::version::ProjectVersionInfo;
 use uv_cli::{VersionBump, VersionBumpSpec, VersionFormat};
 use uv_client::BaseClientBuilder;
 use uv_configuration::{
-    Concurrency, DependencyGroups, DependencyGroupsWithDefaults, DryRun, ExtrasSpecification,
-    InstallOptions,
+    Concurrency, DependencyGroups, DryRun, ExtrasSpecification, InstallOptions,
 };
 use uv_fs::Simplified;
 use uv_normalize::DefaultExtras;
@@ -35,6 +34,7 @@ use crate::commands::pip::operations::Modifications;
 use crate::commands::project::add::{AddTarget, PythonTarget};
 use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::lock::LockMode;
+use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
     LinkErrorReporting, ProjectEnvironment, ProjectError, ProjectInterpreter, UniversalState,
     WorkspacePython, default_dependency_groups,
@@ -122,17 +122,10 @@ pub(crate) async fn project_version(
             return Box::pin(print_frozen_version(
                 project,
                 &name,
-                project_dir,
                 frozen_source,
-                active,
-                python,
-                install_mirrors,
                 &settings,
                 client_builder,
-                python_preference,
-                python_downloads,
                 &concurrency,
-                no_config,
                 cache,
                 workspace_cache,
                 short,
@@ -474,17 +467,10 @@ fn update_project(
 async fn print_frozen_version(
     project: VirtualProject,
     name: &PackageName,
-    project_dir: &Path,
     frozen_source: FrozenSource,
-    active: Option<bool>,
-    python: Option<String>,
-    install_mirrors: PythonInstallMirrors,
     settings: &ResolverInstallerSettings,
     client_builder: BaseClientBuilder<'_>,
-    python_preference: PythonPreference,
-    python_downloads: PythonDownloads,
     concurrency: &Concurrency,
-    no_config: bool,
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     short: bool,
@@ -492,33 +478,7 @@ async fn print_frozen_version(
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
-    // Discover the interpreter (this is the same interpreter --no-sync uses).
-    let groups = DependencyGroupsWithDefaults::none();
-    let workspace_python = WorkspacePython::from_request(
-        python.as_deref().map(PythonRequest::parse),
-        Some(project.workspace()),
-        &groups,
-        project_dir,
-        no_config,
-    )
-    .await?;
-    let interpreter = ProjectInterpreter::discover(
-        project.workspace(),
-        &groups,
-        workspace_python,
-        &client_builder,
-        python_preference,
-        python_downloads,
-        &install_mirrors,
-        false,
-        active,
-        cache,
-        printer,
-    )
-    .await?
-    .into_interpreter();
-
-    let target = AddTarget::Project(project, Box::new(PythonTarget::Interpreter(interpreter)));
+    let target = LockTarget::Workspace(project.workspace());
 
     // Initialize any shared state.
     let state = UniversalState::default();
@@ -537,7 +497,7 @@ async fn print_frozen_version(
             printer,
             preview,
         )
-        .execute((&target).into()),
+        .execute(target),
     )
     .await
     {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2679,8 +2679,13 @@ async fn run_project(
                 .network_settings
                 .check_refresh_conflict(&args.refresh);
 
-            // Initialize the cache.
-            let cache = cache.init().await?.with_refresh(
+            // Reading a project version only accesses `pyproject.toml` or the lockfile.
+            let cache = if args.value.is_none() && args.bump.is_empty() {
+                cache
+            } else {
+                cache.init().await?
+            }
+            .with_refresh(
                 args.refresh
                     .combine(Refresh::from(args.settings.reinstall.clone()))
                     .combine(Refresh::from(args.settings.resolver.upgrade.clone())),

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -4,6 +4,7 @@ use assert_fs::prelude::*;
 use indoc::indoc;
 use insta::assert_snapshot;
 
+use uv_static::EnvVars;
 use uv_test::uv_snapshot;
 
 // Print the version
@@ -2566,6 +2567,76 @@ fn version_virtual_workspace_root_rejects_before_members() -> Result<()> {
 
     ----- stderr -----
     error: No `project` table found in: [TEMP_DIR]/pyproject.toml
+    ");
+
+    Ok(())
+}
+
+/// Read the frozen version of a workspace member without discovering an interpreter.
+#[test]
+fn version_get_frozen_workspace_without_python() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["child"]
+        "#})?;
+
+    context
+        .temp_dir
+        .child("child/pyproject.toml")
+        .write_str(indoc! {r#"
+            [project]
+            name = "child"
+            version = "2.0.0"
+            requires-python = ">=3.12"
+        "#})?;
+
+    context.temp_dir.child("uv.lock").write_str(indoc! {r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [manifest]
+        members = ["child"]
+
+        [[package]]
+        name = "child"
+        version = "1.0.0"
+        source = { editable = "child" }
+    "#})?;
+
+    // A file can't be initialized as a cache directory.
+    let cache_file = context.temp_dir.child("cache-file");
+    cache_file.touch()?;
+
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child")
+        .arg("--short")
+        .env(EnvVars::UV_CACHE_DIR, cache_file.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    2.0.0
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child")
+        .arg("--frozen")
+        .arg("--python").arg("9.9")
+        .arg("--no-python-downloads")
+        .env(EnvVars::UV_CACHE_DIR, cache_file.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child 1.0.0
+
+    ----- stderr -----
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

Reading a project version only requires `pyproject.toml`, or the lockfile under `--frozen`, but we previously initialized the cache for every `uv version` invocation. The frozen path also discovered a Python interpreter solely to construct an installation target.

Skip cache initialization for read-only version commands and construct the frozen lock target directly from the already-discovered workspace. Version updates retain the existing setup, while ordinary and frozen reads now work without a writable cache or available interpreter.