### PR TITLE
Reuse temporary cache during settings resolution

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -292,8 +292,9 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
     //    starting from the current directory.
 
     // Pass the (possibly non-existent) cache dir path to the initial workspace discovery.
+    let discovery_no_cache = cli.top_level.cache_args.no_cache;
     let discovery_cache = Cache::from_settings(
-        cli.top_level.cache_args.no_cache,
+        discovery_no_cache,
         cli.top_level.cache_args.cache_dir.clone(),
     )?;
     let workspace_cache = WorkspaceCache::default();
@@ -578,7 +579,16 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
     if cache_settings.no_cache {
         debug!("Disabling the uv cache due to `--no-cache`");
     }
-    let cache = Cache::from_settings(cache_settings.no_cache, cache_settings.cache_dir)?;
+    // If `--no-cache` was set on the command line or in the environment, configuration cannot
+    // disable it. Reuse the temporary cache for the duration of the invocation instead of creating
+    // a second temporary directory after settings resolution.
+    let (cache, reuse_workspace_cache) = if discovery_no_cache && cache_settings.no_cache {
+        (discovery_cache, true)
+    } else {
+        let cache = Cache::from_settings(cache_settings.no_cache, cache_settings.cache_dir)?;
+        let reuse_workspace_cache = cache.root() == discovery_cache.root();
+        (cache, reuse_workspace_cache)
+    };
     // This check happens after the first (fallible) workspace discovery, which we need to resolve
     // the settings that go into the cache constructor, but the check happens before the first
     // workspace discovery that's used beyond settings discovery.
@@ -617,7 +627,7 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
 
     // Workspace discovery excludes the cache root, so only reuse the earlier discovery when the
     // resolved cache has the same root.
-    let workspace_cache = if cache.root() == discovery_cache.root() {
+    let workspace_cache = if reuse_workspace_cache {
         workspace_cache
     } else {
         WorkspaceCache::default()

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -1,12 +1,14 @@
+use std::process::Command;
+
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 
 use uv_static::EnvVars;
-use uv_test::{copy_dir_ignore, uv_snapshot};
+use uv_test::{copy_dir_ignore, get_bin, uv_snapshot};
 
 /// The workspace discovered while resolving settings is reused when the resolved cache root is
-/// unchanged, but not when constructing the resolved cache creates a new root.
+/// unchanged, but not when configuration changes the effective cache root.
 #[test]
 fn workspace_list_reuses_settings_discovery() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -37,6 +39,68 @@ fn workspace_list_reuses_settings_discovery() -> Result<()> {
     uv_snapshot!(context.filters(), context.workspace_list()
         .arg("--no-cache")
         .env(EnvVars::RUST_LOG, "uv_workspace=trace"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    member
+
+    ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `packages/member`
+    DEBUG Adding discovered workspace member: `[TEMP_DIR]/packages/member`
+    ");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+[tool.uv]
+no-cache = true
+
+[tool.uv.workspace]
+members = ["packages/*"]
+"#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .env(EnvVars::RUST_LOG, "uv_workspace=trace"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    member
+
+    ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `packages/member`
+    DEBUG Adding discovered workspace member: `[TEMP_DIR]/packages/member`
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `packages/member`
+    DEBUG Adding discovered workspace member: `[TEMP_DIR]/packages/member`
+    ");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+[tool.uv]
+cache-dir = "configured-cache"
+
+[tool.uv.workspace]
+members = ["packages/*"]
+"#,
+    )?;
+
+    // Build the command manually so that the configured cache directory isn't overridden by the
+    // test context's `--cache-dir` argument.
+    let mut command = Command::new(get_bin!());
+    command
+        .arg("workspace")
+        .arg("list")
+        .current_dir(context.temp_dir.path())
+        .env(EnvVars::RUST_LOG, "uv_workspace=trace");
+    context.add_shared_env(&mut command, false);
+    command.env_remove(EnvVars::UV_CACHE_DIR);
+
+    uv_snapshot!(context.filters(), command, @"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
## Summary

When `--no-cache` is set on the command line or in the environment, initial settings discovery already creates a temporary cache. We previously created a second temporary cache after resolving settings, which changed the cache root and forced us to discard the workspace discovery cache from the first pass.

Reuse the original temporary cache when no-cache mode was known before configuration loading. Continue creating a fresh cache when configuration introduces `no-cache` or changes the cache directory, since those cases can change workspace discovery semantics.