### PR TITLE
Reuse complete workspace discovery for frozen sync

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -72,7 +72,8 @@ type CachedWorkspaceResult = Result<Arc<Workspace>, WorkspaceError>;
 /// * `stop_discovery_at` is only used for isolation workspaces in the cache. Otherwise, we avoid
 ///   traversing into an external cache if `cache` is accidentally included in the workspace member
 ///   glob.
-/// * TODO(konsti): Support caching for [`MemberDiscovery`] modes that aren't `All`.
+/// * Only [`MemberDiscovery::All`] results are stored. Successful results can be reused for
+///   [`MemberDiscovery::Existing`], which discovers the same members when none are missing.
 #[derive(Debug, Default, Clone)]
 pub struct WorkspaceCache {
     workspaces: Arc<FxOnceMap<PathBuf, CachedWorkspaceResult>>,
@@ -115,8 +116,22 @@ impl WorkspaceCache {
     }
 
     /// Get the cached workspace, if any, from the path to the workspace root or to a member root.
-    fn get(&self, path: &Path) -> Option<CachedWorkspaceResult> {
-        self.workspaces.get(path)
+    ///
+    /// A successful complete discovery can satisfy [`MemberDiscovery::Existing`]. Cached errors
+    /// cannot, since `Existing` intentionally tolerates missing workspace members.
+    fn get(
+        &self,
+        path: &Path,
+        member_discovery: &MemberDiscovery,
+    ) -> Option<CachedWorkspaceResult> {
+        match member_discovery {
+            MemberDiscovery::All => self.workspaces.get(path),
+            MemberDiscovery::Existing => match self.workspaces.get(path) {
+                Some(Ok(workspace)) => Some(Ok(workspace)),
+                Some(Err(_)) | None => None,
+            },
+            MemberDiscovery::None | MemberDiscovery::Ignore(_) => None,
+        }
     }
 
     /// Remove all cached workspace entries for the given workspace root. Used before modifying the
@@ -327,9 +342,7 @@ impl Workspace {
         // at the same time from different roots, both failing this check. These cases are fine, we
         // synchronize them after finding the workspace root and allow only one of them to perform
         // the full discovery.
-        if options.members == MemberDiscovery::All
-            && let Some(workspace) = workspace_cache.get(&project_path)
-        {
+        if let Some(workspace) = workspace_cache.get(&project_path, &options.members) {
             return workspace;
         }
 
@@ -1476,10 +1489,7 @@ impl ProjectWorkspace {
         options: &DiscoveryOptions,
         cache: &WorkspaceCache,
     ) -> Result<Option<Self>, WorkspaceError> {
-        if options.members != MemberDiscovery::All {
-            return Ok(None);
-        }
-        let workspace = match cache.get(project_root) {
+        let workspace = match cache.get(project_root, &options.members) {
             Some(Ok(workspace)) => workspace,
             Some(Err(error)) => return Err(error),
             None => return Ok(None),
@@ -2025,9 +2035,7 @@ impl VirtualProject {
         );
 
         // Fast path: The workspace is already cached.
-        if options.members == MemberDiscovery::All
-            && let Some(workspace) = workspace_cache.get(project_root)
-        {
+        if let Some(workspace) = workspace_cache.get(project_root, &options.members) {
             let workspace = workspace?;
             let virtual_project = if let Some((project_name, _member)) = workspace
                 .packages

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -1511,12 +1511,23 @@ fn sync_non_project_frozen() -> Result<()> {
      + iniconfig==2.0.0
     ");
 
-    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @"
+    // Reuse the complete workspace discovered while resolving settings for the partial frozen
+    // discovery.
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--frozen")
+        .env(EnvVars::RUST_LOG, "uv_workspace=trace"), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `foo`
+    DEBUG Adding discovered workspace member: `[TEMP_DIR]/foo`
+    TRACE Processing workspace member: `bar`
+    DEBUG Adding discovered workspace member: `[TEMP_DIR]/bar`
+    DEBUG Found project root: `[TEMP_DIR]/`
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + typing-extensions==4.10.0
@@ -6067,15 +6078,30 @@ fn no_install_workspace() -> Result<()> {
 
     fs_err::remove_dir_all(&context.venv)?;
 
-    // We don't require the `pyproject.toml` for non-root members, if `--frozen` is provided.
+    // We don't require the `pyproject.toml` for non-root members, if `--frozen` is provided. The
+    // failed complete discovery while resolving settings must not prevent a fresh partial
+    // discovery from ignoring the missing member.
     fs_err::remove_file(child.join("pyproject.toml"))?;
 
-    uv_snapshot!(context.filters(), context.sync().arg("--no-install-workspace").arg("--frozen"), @"
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--no-install-workspace")
+        .arg("--frozen")
+        .env(EnvVars::RUST_LOG, "uv_workspace=trace"), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    DEBUG Adding root workspace member: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `child`
+    DEBUG Found project root: `[TEMP_DIR]/`
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    TRACE Discovering workspace members for: `[TEMP_DIR]/`
+    DEBUG Adding root workspace member: `[TEMP_DIR]/`
+    TRACE Processing workspace member: `child`
+    DEBUG Ignoring missing workspace member: `[TEMP_DIR]/child`
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     Installed 4 packages in [TIME]


### PR DESCRIPTION
## Summary

A successful complete workspace discovery contains every member needed by `MemberDiscovery::Existing`, but the workspace cache previously served only later `MemberDiscovery::All` requests. As a result, frozen sync repeated workspace discovery after settings resolution.

Allow successful complete discoveries to satisfy `Existing` requests. Cached discovery errors are still ignored for this mode because `Existing` intentionally tolerates missing members, and the other partial discovery modes continue to bypass the cache.