### PR TITLE
Revert "Error on unsupported `--cert` in pip compat layer"

### DIFF
--- a/crates/uv-cli/src/compat.rs
+++ b/crates/uv-cli/src/compat.rs
@@ -110,12 +110,6 @@ impl CompatArgs for PipCompileCompatArgs {
             ));
         }
 
-        if self.cert.is_some() {
-            return Err(anyhow!(
-                "pip-compile's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)"
-            ));
-        }
-
         if self.client_cert.is_some() {
             return Err(anyhow!(
                 "pip-compile's `--client-cert` is unsupported (uv doesn't support dedicated client certificates)"
@@ -236,12 +230,6 @@ impl CompatArgs for PipSyncCompatArgs {
         if self.user {
             return Err(anyhow!(
                 "pip-sync's `--user` is unsupported (use a virtual environment instead)"
-            ));
-        }
-
-        if self.cert.is_some() {
-            return Err(anyhow!(
-                "pip-sync's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)"
             ));
         }
 

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -37,30 +37,6 @@ fn missing_requirements_txt() {
     requirements_txt.assert(predicates::path::missing());
 }
 
-/// `pip-sync`'s `--cert` is unsupported and must error, rather than being silently ignored,
-/// so users don't believe a custom CA bundle is in effect when it isn't.
-/// See <https://github.com/astral-sh/uv/issues/20350>.
-#[test]
-fn cert_unsupported() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let requirements_txt = context.temp_dir.child("requirements.txt");
-    requirements_txt.write_str("iniconfig==2.0.0")?;
-
-    uv_snapshot!(context.filters(), context.pip_sync()
-        .arg("requirements.txt")
-        .arg("--cert")
-        .arg("ca-bundle.pem"), @"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: pip-sync's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)
-    ");
-
-    Ok(())
-}
-
 #[test]
 fn missing_venv() -> Result<()> {
     let context = uv_test::test_context!("3.12")

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -6640,31 +6640,6 @@ fn resolver_legacy() -> Result<()> {
     Ok(())
 }
 
-/// `pip-compile`'s `--cert` is unsupported and must error, rather than being silently ignored,
-/// so users don't believe a custom CA bundle is in effect when it isn't.
-/// See <https://github.com/astral-sh/uv/issues/20350>.
-#[test]
-fn cert_unsupported() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let requirements_in = context.temp_dir.child("requirements.in");
-    requirements_in.write_str("werkzeug==3.0.1")?;
-
-    uv_snapshot!(context.filters(), context.pip_compile()
-            .arg("requirements.in")
-            .arg("--cert")
-            .arg("ca-bundle.pem"), @"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: pip-compile's `--cert` is unsupported (set the `SSL_CERT_FILE` environment variable to use a custom CA certificate bundle)
-    "
-    );
-
-    Ok(())
-}
-
 /// Avoid including the `--index` and `-i` flags in the header.
 #[test]
 fn hide_index_urls() -> Result<()> {


### PR DESCRIPTION
## Summary

Revert #20351 (`c96eb710b6d22d7a992dbfe65a523f662983d1d9`), restoring the previous behavior for `--cert` in `uv pip compile` and `uv pip sync`. This is breaking, so at minimum needs to go in v0.12; we may also just want to support it.