### PR TITLE
Make locking idempotent for impossible platform markers

### DIFF
--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -925,17 +925,27 @@ impl InternerGuard<'_> {
         ///
         /// This is equivalent to [`InternerGuard::or`], with the exception that it does not
         /// incorporate knowledge from outside the marker algebra.
-        fn disjunction(guard: &mut InternerGuard<'_>, xi: NodeId, yi: NodeId) -> NodeId {
+        fn disjunction(
+            guard: &mut InternerGuard<'_>,
+            cache: &mut FxHashMap<(NodeId, NodeId), NodeId>,
+            xi: NodeId,
+            yi: NodeId,
+        ) -> NodeId {
             // We take advantage of cheap negation here and implement OR in terms
             // of it's De Morgan complement.
-            conjunction(guard, xi.not(), yi.not()).not()
+            conjunction(guard, cache, xi.not(), yi.not()).not()
         }
 
         /// Perform a conjunction operation between two nodes.
         ///
         /// This is equivalent to [`InternerGuard::and`], with the exception that it does not
         /// incorporate knowledge from outside the marker algebra.
-        fn conjunction(guard: &mut InternerGuard<'_>, xi: NodeId, yi: NodeId) -> NodeId {
+        fn conjunction(
+            guard: &mut InternerGuard<'_>,
+            cache: &mut FxHashMap<(NodeId, NodeId), NodeId>,
+            xi: NodeId,
+            yi: NodeId,
+        ) -> NodeId {
             if xi.is_true() {
                 return yi;
             }
@@ -954,7 +964,7 @@ impl InternerGuard<'_> {
             }
 
             // The operation was memoized.
-            if let Some(result) = guard.state.cache.get(&(xi, yi)) {
+            if let Some(result) = cache.get(&(xi, yi)) {
                 return *result;
             }
 
@@ -964,19 +974,23 @@ impl InternerGuard<'_> {
             let (func, children) = match x.var.cmp(&y.var) {
                 // X is higher order than Y, apply Y to every child of X.
                 Ordering::Less => {
-                    let children = x.children.map(xi, |node| conjunction(guard, node, yi));
+                    let children = x
+                        .children
+                        .map(xi, |node| conjunction(guard, cache, node, yi));
                     (x.var.clone(), children)
                 }
                 // Y is higher order than X, apply X to every child of Y.
                 Ordering::Greater => {
-                    let children = y.children.map(yi, |node| conjunction(guard, node, xi));
+                    let children = y
+                        .children
+                        .map(yi, |node| conjunction(guard, cache, node, xi));
                     (y.var.clone(), children)
                 }
                 // X and Y represent the same variable, merge their children.
                 Ordering::Equal => {
                     let children = x
                         .children
-                        .apply(xi, &y.children, yi, |x, y| conjunction(guard, x, y));
+                        .apply(xi, &y.children, yi, |x, y| conjunction(guard, cache, x, y));
                     (x.var.clone(), children)
                 }
             };
@@ -985,7 +999,7 @@ impl InternerGuard<'_> {
             let node = guard.create_node(func, children);
 
             // Memoize the result of this operation.
-            guard.state.cache.insert((xi, yi), node);
+            cache.insert((xi, yi), node);
 
             node
         }
@@ -994,6 +1008,9 @@ impl InternerGuard<'_> {
             return exclusions;
         }
         let mut tree = NodeId::FALSE;
+        // These operations omit known-incompatibility checks, so their results must not be reused
+        // by regular marker operations.
+        let mut cache = FxHashMap::default();
 
         // Create all nodes upfront.
         let os_name_nt = self.expression(MarkerExpression::String {
@@ -1126,8 +1143,8 @@ impl InternerGuard<'_> {
         }
 
         for (a, b) in pairs {
-            let a_and_b = conjunction(self, a, b);
-            tree = disjunction(self, tree, a_and_b);
+            let a_and_b = conjunction(self, &mut cache, a, b);
+            tree = disjunction(self, &mut cache, tree, a_and_b);
         }
 
         self.state.exclusions = Some(tree);

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -16329,6 +16329,72 @@ fn normalize_false_marker_requires_dist() -> Result<()> {
     Ok(())
 }
 
+/// Check that multiple markers with known-incompatible platform values are all normalized to
+/// `false`, independent of the order in which they are processed.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_impossible_platform_markers() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.9"
+        dependencies = [
+            "certifi ; os_name == 'nt' and sys_platform == 'linux'",
+            "idna ; os_name == 'posix' and sys_platform == 'win32'",
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--check"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.9"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+
+        [package.metadata]
+        requires-dist = [
+            { name = "certifi", marker = "python_version < '0'" },
+            { name = "idna", marker = "python_version < '0'" },
+        ]
+        "#);
+    });
+
+    Ok(())
+}
+
 /// Change indexes between locking operations.
 #[cfg(feature = "test-universal")]
 #[tokio::test]


### PR DESCRIPTION
## Summary

Marker exclusion construction intentionally bypasses known-incompatibility checks, but it previously memoized those internal conjunctions in the global cache used by ordinary marker operations. Once the exclusion tree was initialized, a later impossible cross-variable marker could reuse an unchecked cached result, so only the first impossible dependency normalized to false.

Closes https://github.com/astral-sh/uv/issues/20368.