### PR TITLE
Add suffix support to tool installs

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6020,6 +6020,19 @@ pub struct ToolInstallArgs {
     #[arg(long)]
     pub force: bool,
 
+    /// The suffix to append to the tool's executable names.
+    ///
+    /// The tool will be installed under a name formed by appending the suffix to the package name,
+    /// and can be referenced by that name in later commands. The unsuffixed executables will not
+    /// be installed.
+    #[arg(
+        long,
+        allow_hyphen_values = true,
+        value_hint = ValueHint::Other,
+        help_heading = "Installer options"
+    )]
+    pub suffix: Option<String>,
+
     /// Whether to use Git LFS when adding a dependency from Git.
     #[arg(long)]
     pub lfs: bool,
@@ -6154,7 +6167,7 @@ pub struct ToolDirArgs {
 pub struct ToolUninstallArgs {
     /// The name of the tool to uninstall.
     #[arg(required = true, value_hint = ValueHint::Other)]
-    pub name: Vec<PackageName>,
+    pub name: Vec<String>,
 
     /// Uninstall all tools.
     #[arg(long, conflicts_with("name"))]

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -63,7 +63,6 @@ impl ToolName {
         if name.is_empty()
             || matches!(name.as_str(), "." | "..")
             || name.ends_with(['.', ' '])
-            || is_windows_reserved_device_name(&name)
             || name.bytes().any(|character| {
                 character.is_ascii_control()
                     || matches!(
@@ -77,27 +76,6 @@ impl ToolName {
 
         Ok(Self(name))
     }
-}
-
-fn is_windows_reserved_device_name(name: &str) -> bool {
-    let basename = name
-        .split_once('.')
-        .map_or(name, |(basename, _)| basename)
-        .to_ascii_uppercase();
-
-    if matches!(basename.as_str(), "CON" | "PRN" | "AUX" | "NUL") {
-        return true;
-    }
-
-    basename
-        .strip_prefix("COM")
-        .or_else(|| basename.strip_prefix("LPT"))
-        .is_some_and(|port| {
-            matches!(
-                port,
-                "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
-            )
-        })
 }
 
 impl From<&PackageName> for ToolName {
@@ -600,37 +578,4 @@ pub fn entrypoint_paths(
     }
 
     Ok(entrypoints)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use super::ToolName;
-
-    #[test]
-    fn windows_reserved_device_names() {
-        for name in [
-            "con",
-            "CON.txt",
-            "prn.log",
-            "aux",
-            "nul.json",
-            "com1",
-            "COM9.exe",
-            "com¹.log",
-            "lpt1",
-            "LPT9.txt",
-            "lpt³.log",
-        ] {
-            assert!(
-                ToolName::from_str(name).is_err(),
-                "`{name}` should be rejected"
-            );
-        }
-
-        for name in ["console", "com0", "com10", "lpt0", "lpt10", "com1port"] {
-            assert!(ToolName::from_str(name).is_ok(), "`{name}` should be valid");
-        }
-    }
 }

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Display, Formatter};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -13,7 +14,7 @@ use uv_dirs::user_executable_directory;
 use uv_fs::{LockedFile, LockedFileError, LockedFileMode, Simplified};
 use uv_install_wheel::read_record;
 use uv_installer::SitePackages;
-use uv_normalize::{InvalidNameError, PackageName};
+use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_python::{BrokenLink, Interpreter, PythonEnvironment};
 use uv_state::{StateBucket, StateStore};
@@ -24,6 +25,112 @@ pub use tool::{Tool, ToolEntrypoint};
 
 mod receipt;
 mod tool;
+
+/// The name of an installed tool.
+///
+/// Unlike a [`PackageName`], a tool name includes any user-provided suffix and is not normalized.
+/// It is used as the name of the tool's environment directory and as the identifier accepted by
+/// commands such as `uv tool upgrade` and `uv tool uninstall`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ToolName(String);
+
+impl ToolName {
+    /// Create a tool name for a package and optional suffix.
+    pub fn from_package_name(
+        package: &PackageName,
+        suffix: Option<&str>,
+    ) -> Result<Self, InvalidToolNameError> {
+        if suffix.is_some_and(str::is_empty) {
+            return Err(InvalidToolNameError::empty_suffix());
+        }
+
+        let mut name = package.to_string();
+        if let Some(suffix) = suffix {
+            name.push_str(suffix);
+        }
+        Self::from_string(name)
+    }
+
+    /// Return the tool name as a string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn from_string(name: String) -> Result<Self, InvalidToolNameError> {
+        // Tool names are used as directory and executable names. Validate against the portable
+        // subset of filenames so a receipt created on one platform can be managed on another.
+        if name.is_empty()
+            || matches!(name.as_str(), "." | "..")
+            || name.ends_with(['.', ' '])
+            || name.bytes().any(|character| {
+                character.is_ascii_control()
+                    || matches!(
+                        character,
+                        b'/' | b'\\' | b'<' | b'>' | b':' | b'"' | b'|' | b'?' | b'*'
+                    )
+            })
+        {
+            return Err(InvalidToolNameError::invalid(&name));
+        }
+
+        Ok(Self(name))
+    }
+}
+
+impl From<&PackageName> for ToolName {
+    fn from(package: &PackageName) -> Self {
+        Self(package.to_string())
+    }
+}
+
+impl From<PackageName> for ToolName {
+    fn from(package: PackageName) -> Self {
+        Self(package.to_string())
+    }
+}
+
+impl FromStr for ToolName {
+    type Err = InvalidToolNameError;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        Self::from_string(name.to_string())
+    }
+}
+
+impl AsRef<str> for ToolName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Display for ToolName {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// An invalid [`ToolName`].
+#[derive(Debug, Clone, Error)]
+#[error("{message}")]
+pub struct InvalidToolNameError {
+    message: String,
+}
+
+impl InvalidToolNameError {
+    fn invalid(name: &str) -> Self {
+        Self {
+            message: format!(
+                "Invalid tool name `{name}`; tool names must be valid cross-platform filenames"
+            ),
+        }
+    }
+
+    fn empty_suffix() -> Self {
+        Self {
+            message: "Tool suffix cannot be empty".to_string(),
+        }
+    }
+}
 
 /// A wrapper around [`PythonEnvironment`] for tools that provides additional functionality.
 #[derive(Debug, Clone)]
@@ -77,7 +184,7 @@ pub enum Error {
     #[error("Failed to find a directory to install executables into")]
     NoExecutableDirectory,
     #[error(transparent)]
-    ToolName(#[from] InvalidNameError),
+    ToolName(#[from] InvalidToolNameError),
     #[error(transparent)]
     EnvironmentError(#[from] uv_python::Error),
     #[error("Failed to find a receipt for tool `{0}` at {1}")]
@@ -141,9 +248,9 @@ impl InstalledTools {
         }
     }
 
-    /// Return the expected directory for a tool with the given [`PackageName`].
-    pub fn tool_dir(&self, name: &PackageName) -> PathBuf {
-        self.root.join(name.to_string())
+    /// Return the expected directory for a tool with the given [`ToolName`].
+    pub fn tool_dir(&self, name: &ToolName) -> PathBuf {
+        self.root.join(name.as_str())
     }
 
     /// Return the metadata for all installed tools.
@@ -153,7 +260,7 @@ impl InstalledTools {
     ///
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
     #[expect(clippy::type_complexity)]
-    pub fn tools(&self) -> Result<Vec<(PackageName, Result<Tool, Error>)>, Error> {
+    pub fn tools(&self) -> Result<Vec<(ToolName, Result<Tool, Error>)>, Error> {
         let mut tools = Vec::new();
         for directory in uv_fs::directories(self.root())? {
             let Some(name) = directory
@@ -162,7 +269,7 @@ impl InstalledTools {
             else {
                 continue;
             };
-            let name = PackageName::from_str(name)?;
+            let name = ToolName::from_str(name)?;
             let path = directory.join("uv-receipt.toml");
             let contents = match fs_err::read_to_string(&path) {
                 Ok(contents) => contents,
@@ -190,7 +297,7 @@ impl InstalledTools {
     /// error.
     ///
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
-    pub fn get_tool_receipt(&self, name: &PackageName) -> Result<Option<Tool>, Error> {
+    pub fn get_tool_receipt(&self, name: &ToolName) -> Result<Option<Tool>, Error> {
         let path = self.tool_dir(name).join("uv-receipt.toml");
         match ToolReceipt::from_path(&path) {
             Ok(tool_receipt) => Ok(Some(tool_receipt.tool)),
@@ -214,7 +321,7 @@ impl InstalledTools {
     /// Any existing receipt will be replaced.
     ///
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
-    pub fn add_tool_receipt(&self, name: &PackageName, tool: Tool) -> Result<(), Error> {
+    pub fn add_tool_receipt(&self, name: &ToolName, tool: Tool) -> Result<(), Error> {
         let tool_receipt = ToolReceipt::from(tool);
         let path = self.tool_dir(name).join("uv-receipt.toml");
 
@@ -242,7 +349,7 @@ impl InstalledTools {
     /// # Errors
     ///
     /// If no such environment exists for the tool.
-    pub fn remove_environment(&self, name: &PackageName) -> Result<(), Error> {
+    pub fn remove_environment(&self, name: &ToolName) -> Result<(), Error> {
         let environment_path = self.tool_dir(name);
 
         debug!(
@@ -263,7 +370,8 @@ impl InstalledTools {
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
     pub fn get_environment(
         &self,
-        name: &PackageName,
+        name: &ToolName,
+        package: &PackageName,
         cache: &Cache,
     ) -> Result<Option<ToolEnvironment>, Error> {
         let environment_path = self.tool_dir(name);
@@ -274,7 +382,7 @@ impl InstalledTools {
                     "Found existing environment for tool `{name}`: {}",
                     environment_path.user_display()
                 );
-                Ok(Some(ToolEnvironment::new(venv, name.clone())))
+                Ok(Some(ToolEnvironment::new(venv, package.clone())))
             }
             Err(uv_python::Error::MissingEnvironment(_)) => Ok(None),
             Err(uv_python::Error::Query(uv_python::InterpreterError::NotFound(
@@ -317,7 +425,7 @@ impl InstalledTools {
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
     pub fn create_environment(
         &self,
-        name: &PackageName,
+        name: &ToolName,
         interpreter: Interpreter,
     ) -> Result<PythonEnvironment, Error> {
         let environment_path = self.tool_dir(name);

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -63,6 +63,7 @@ impl ToolName {
         if name.is_empty()
             || matches!(name.as_str(), "." | "..")
             || name.ends_with(['.', ' '])
+            || is_windows_reserved_device_name(&name)
             || name.bytes().any(|character| {
                 character.is_ascii_control()
                     || matches!(
@@ -76,6 +77,27 @@ impl ToolName {
 
         Ok(Self(name))
     }
+}
+
+fn is_windows_reserved_device_name(name: &str) -> bool {
+    let basename = name
+        .split_once('.')
+        .map_or(name, |(basename, _)| basename)
+        .to_ascii_uppercase();
+
+    if matches!(basename.as_str(), "CON" | "PRN" | "AUX" | "NUL") {
+        return true;
+    }
+
+    basename
+        .strip_prefix("COM")
+        .or_else(|| basename.strip_prefix("LPT"))
+        .is_some_and(|port| {
+            matches!(
+                port,
+                "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
+            )
+        })
 }
 
 impl From<&PackageName> for ToolName {
@@ -578,4 +600,37 @@ pub fn entrypoint_paths(
     }
 
     Ok(entrypoints)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::ToolName;
+
+    #[test]
+    fn windows_reserved_device_names() {
+        for name in [
+            "con",
+            "CON.txt",
+            "prn.log",
+            "aux",
+            "nul.json",
+            "com1",
+            "COM9.exe",
+            "com¹.log",
+            "lpt1",
+            "LPT9.txt",
+            "lpt³.log",
+        ] {
+            assert!(
+                ToolName::from_str(name).is_err(),
+                "`{name}` should be rejected"
+            );
+        }
+
+        for name in ["console", "com0", "com10", "lpt0", "lpt10", "com1port"] {
+            assert!(ToolName::from_str(name).is_ok(), "`{name}` should be valid");
+        }
+    }
 }

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fmt::{self, Display, Formatter};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -289,6 +290,24 @@ impl InstalledTools {
             }
         }
         Ok(tools)
+    }
+
+    /// Return an installed tool with a name that differs only by ASCII case.
+    pub fn find_case_insensitive_name(&self, name: &ToolName) -> Result<Option<ToolName>, Error> {
+        for directory in uv_fs::directories(self.root())? {
+            let Some(existing_name) = directory
+                .file_name()
+                .and_then(OsStr::to_str)
+                .and_then(|name| ToolName::from_str(name).ok())
+            else {
+                continue;
+            };
+            if existing_name != *name && existing_name.as_str().eq_ignore_ascii_case(name.as_str())
+            {
+                return Ok(Some(existing_name));
+            }
+        }
+        Ok(None)
     }
 
     /// Get the receipt for the given tool.

--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -7,6 +7,7 @@ use toml_edit::{Array, Item, Table, Value, value};
 use uv_configuration::ExcludeDependency;
 use uv_distribution_types::Requirement;
 use uv_fs::{PortablePath, Simplified};
+use uv_normalize::PackageName;
 use uv_pypi_types::VerbatimParsedUrl;
 use uv_python::PythonRequest;
 use uv_settings::{ToolOptions, ToolOptionsWire};
@@ -15,6 +16,10 @@ use uv_settings::{ToolOptions, ToolOptionsWire};
 #[derive(Debug, Clone, Deserialize)]
 #[serde(try_from = "ToolWire", into = "ToolWire")]
 pub struct Tool {
+    /// The package that provides the tool.
+    package: PackageName,
+    /// The suffix appended to the tool's environment and entry point names.
+    suffix: Option<String>,
     /// The requirements requested by the user during installation.
     ///
     /// The first requirement is the tool target itself; any remaining requirements come from
@@ -39,6 +44,8 @@ pub struct Tool {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct ToolWire {
+    package: Option<PackageName>,
+    suffix: Option<String>,
     #[serde(default)]
     requirements: Vec<RequirementWire>,
     #[serde(default)]
@@ -68,6 +75,8 @@ enum RequirementWire {
 impl From<Tool> for ToolWire {
     fn from(tool: Tool) -> Self {
         Self {
+            package: Some(tool.package),
+            suffix: tool.suffix,
             requirements: tool
                 .requirements
                 .into_iter()
@@ -88,15 +97,27 @@ impl TryFrom<ToolWire> for Tool {
     type Error = serde::de::value::Error;
 
     fn try_from(tool: ToolWire) -> Result<Self, Self::Error> {
+        let requirements = tool
+            .requirements
+            .into_iter()
+            .map(|req| match req {
+                RequirementWire::Requirement(requirements) => requirements,
+                RequirementWire::Deprecated(requirement) => Requirement::from(requirement),
+            })
+            .collect::<Vec<_>>();
+        let package = tool
+            .package
+            .or_else(|| {
+                requirements
+                    .first()
+                    .map(|requirement| requirement.name.clone())
+            })
+            .ok_or_else(|| serde::de::Error::custom("tool receipt is missing a package"))?;
+
         Ok(Self {
-            requirements: tool
-                .requirements
-                .into_iter()
-                .map(|req| match req {
-                    RequirementWire::Requirement(requirements) => requirements,
-                    RequirementWire::Deprecated(requirement) => Requirement::from(requirement),
-                })
-                .collect(),
+            package,
+            suffix: tool.suffix,
+            requirements,
             constraints: tool.constraints,
             overrides: tool.overrides,
             excludes: tool.excludes,
@@ -172,6 +193,8 @@ fn each_element_on_its_line_array(elements: impl Iterator<Item = impl Into<Value
 impl Tool {
     /// Create a new `Tool`.
     pub fn new(
+        package: PackageName,
+        suffix: Option<String>,
         requirements: Vec<Requirement>,
         constraints: Vec<Requirement>,
         overrides: Vec<Requirement>,
@@ -184,6 +207,8 @@ impl Tool {
         let mut entrypoints: Vec<_> = entrypoints.into_iter().collect();
         entrypoints.sort();
         Self {
+            package,
+            suffix,
             requirements,
             constraints,
             overrides,
@@ -204,6 +229,11 @@ impl Tool {
     /// Returns the TOML table for this tool.
     pub(crate) fn to_toml(&self) -> Result<Table, toml_edit::ser::Error> {
         let mut table = Table::new();
+
+        if let Some(suffix) = &self.suffix {
+            table.insert("package", value(self.package.to_string()));
+            table.insert("suffix", value(suffix));
+        }
 
         if !self.requirements.is_empty() {
             table.insert("requirements", {
@@ -353,6 +383,14 @@ impl Tool {
 
     pub fn entrypoints(&self) -> &[ToolEntrypoint] {
         &self.entrypoints
+    }
+
+    pub fn package(&self) -> &PackageName {
+        &self.package
+    }
+
+    pub fn suffix(&self) -> Option<&str> {
+        self.suffix.as_deref()
     }
 
     pub fn requirements(&self) -> &[Requirement] {

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -45,7 +45,7 @@ use uv_resolver::{
     FlatIndex, Installable, Lock, OptionsBuilder, Preference, ResolverManifest, ResolverOutput,
 };
 use uv_settings::{PythonInstallMirrors, ToolOptions};
-use uv_shell::Shell;
+use uv_shell::{Shell, shlex_posix};
 use uv_tool::{InstalledTools, Tool, ToolEntrypoint, ToolName, entrypoint_paths};
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::warn_user_once;
@@ -719,6 +719,11 @@ pub(crate) async fn refine_interpreter(
     }
 
     Ok(Some(interpreter))
+}
+
+/// Format a suffix as a safely quoted command-line argument.
+pub(crate) fn format_tool_suffix_arg(suffix: &str) -> String {
+    format!("--suffix={}", shlex_posix(suffix))
 }
 
 /// Finalizes a tool installation, after creation of an environment.

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -723,7 +723,21 @@ pub(crate) async fn refine_interpreter(
 
 /// Format a suffix as a safely quoted command-line argument.
 pub(crate) fn format_tool_suffix_arg(suffix: &str) -> String {
-    format!("--suffix={}", shlex_posix(suffix))
+    format_tool_suffix_arg_for_shell(suffix, Shell::from_env())
+}
+
+fn format_tool_suffix_arg_for_shell(suffix: &str, shell: Option<Shell>) -> String {
+    let argument = format!("--suffix={suffix}");
+    let posix = shlex_posix(&argument);
+    if posix == argument {
+        return argument;
+    }
+
+    match shell {
+        Some(Shell::Cmd) => format!(r#""{argument}""#),
+        Some(Shell::Powershell) => format!("'{}'", argument.replace('\'', "''")),
+        _ => posix,
+    }
 }
 
 /// Finalizes a tool installation, after creation of an environment.
@@ -1009,5 +1023,30 @@ fn warn_out_of_path(executable_directory: &Path) {
                 executable_directory.simplified_display().cyan(),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Shell, format_tool_suffix_arg_for_shell};
+
+    #[test]
+    fn format_tool_suffix_arg() {
+        assert_eq!(
+            format_tool_suffix_arg_for_shell("-0.11", Some(Shell::Cmd)),
+            "--suffix=-0.11"
+        );
+        assert_eq!(
+            format_tool_suffix_arg_for_shell(" old;echo unsafe", Some(Shell::Bash)),
+            "'--suffix= old;echo unsafe'"
+        );
+        assert_eq!(
+            format_tool_suffix_arg_for_shell(" old'unsafe", Some(Shell::Powershell)),
+            "'--suffix= old''unsafe'"
+        );
+        assert_eq!(
+            format_tool_suffix_arg_for_shell(" old&echo unsafe", Some(Shell::Cmd)),
+            r#""--suffix= old&echo unsafe""#
+        );
     }
 }

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -739,8 +739,17 @@ fn format_tool_suffix_arg_for_shell(suffix: &str, shell: Option<Shell>) -> Strin
 
     match shell {
         Some(Shell::Powershell) => format!("'{}'", argument.replace('\'', "''")),
+        Some(Shell::Nushell) => quote_nushell_raw_string(&argument),
         _ => posix,
     }
+}
+
+fn quote_nushell_raw_string(argument: &str) -> String {
+    let mut hashes = "#".to_string();
+    while argument.contains(&format!("'{hashes}")) {
+        hashes.push('#');
+    }
+    format!("r{hashes}'{argument}'{hashes}")
 }
 
 fn escape_cmd_argument(argument: &str) -> String {
@@ -1077,6 +1086,14 @@ mod tests {
         assert_eq!(
             format_tool_suffix_arg_for_shell(" old'unsafe", Some(Shell::Powershell)),
             "'--suffix= old''unsafe'"
+        );
+        assert_eq!(
+            format_tool_suffix_arg_for_shell("x'y", Some(Shell::Nushell)),
+            "r#'--suffix=x'y'#"
+        );
+        assert_eq!(
+            format_tool_suffix_arg_for_shell("x'#y", Some(Shell::Nushell)),
+            "r##'--suffix=x'#y'##"
         );
         assert_eq!(
             format_tool_suffix_arg_for_shell(" old&echo unsafe", Some(Shell::Cmd)),

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -728,16 +728,50 @@ pub(crate) fn format_tool_suffix_arg(suffix: &str) -> String {
 
 fn format_tool_suffix_arg_for_shell(suffix: &str, shell: Option<Shell>) -> String {
     let argument = format!("--suffix={suffix}");
+    if shell == Some(Shell::Cmd) {
+        return escape_cmd_argument(&argument);
+    }
+
     let posix = shlex_posix(&argument);
     if posix == argument {
         return argument;
     }
 
     match shell {
-        Some(Shell::Cmd) => format!(r#""{argument}""#),
         Some(Shell::Powershell) => format!("'{}'", argument.replace('\'', "''")),
         _ => posix,
     }
+}
+
+fn escape_cmd_argument(argument: &str) -> String {
+    let mut escaped = String::with_capacity(argument.len());
+    let mut in_variable = false;
+    for (index, character) in argument.char_indices() {
+        if character == '%' {
+            if in_variable {
+                escaped.push('%');
+                in_variable = false;
+            } else if argument[index + character.len_utf8()..].contains('%') {
+                // Command Prompt does not provide a direct escape for percent expansion in
+                // interactive commands. Include a caret in the variable name to prevent a match;
+                // the caret is removed by later command-line processing.
+                escaped.push_str("%^");
+                in_variable = true;
+            } else {
+                escaped.push('%');
+            }
+            continue;
+        }
+
+        if matches!(
+            character,
+            ' ' | '\t' | '&' | '|' | '<' | '>' | '(' | ')' | '^'
+        ) {
+            escaped.push('^');
+        }
+        escaped.push(character);
+    }
+    escaped
 }
 
 /// Finalizes a tool installation, after creation of an environment.
@@ -1046,7 +1080,15 @@ mod tests {
         );
         assert_eq!(
             format_tool_suffix_arg_for_shell(" old&echo unsafe", Some(Shell::Cmd)),
-            r#""--suffix= old&echo unsafe""#
+            "--suffix=^ old^&echo^ unsafe"
+        );
+        assert_eq!(
+            format_tool_suffix_arg_for_shell("%TEMP%", Some(Shell::Cmd)),
+            "--suffix=%^TEMP%"
+        );
+        assert_eq!(
+            format_tool_suffix_arg_for_shell("%TEMP%%USERNAME%", Some(Shell::Cmd)),
+            "--suffix=%^TEMP%%^USERNAME%"
         );
     }
 }

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -814,10 +814,10 @@ pub(crate) fn finalize_tool_install(
                                 .unwrap_or_else(|| filename.clone());
                             stem.push(suffix);
                             if let Some(extension) = path.extension() {
-                                PathBuf::from(stem).with_extension(extension).into_os_string()
-                            } else {
-                                stem
+                                stem.push(".");
+                                stem.push(extension);
                             }
+                            stem
                         },
                         unix => {
                             let mut filename = filename;

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -46,7 +46,7 @@ use uv_resolver::{
 };
 use uv_settings::{PythonInstallMirrors, ToolOptions};
 use uv_shell::Shell;
-use uv_tool::{InstalledTools, Tool, ToolEntrypoint, entrypoint_paths};
+use uv_tool::{InstalledTools, Tool, ToolEntrypoint, ToolName, entrypoint_paths};
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::warn_user_once;
 use uv_workspace::WorkspaceCache;
@@ -729,6 +729,8 @@ pub(crate) async fn refine_interpreter(
 pub(crate) fn finalize_tool_install(
     environment: &PythonEnvironment,
     name: &PackageName,
+    tool_name: &ToolName,
+    suffix: Option<&str>,
     entrypoints: &[PackageName],
     installed_tools: &InstalledTools,
     options: &ToolOptions,
@@ -763,9 +765,9 @@ pub(crate) fn finalize_tool_install(
 
     for package in ordered_packages {
         if package == name {
-            debug!("Installing entrypoints for tool `{package}`");
+            debug!("Installing entrypoints for tool `{tool_name}` from package `{package}`");
         } else {
-            debug!("Installing entrypoints for `{package}` as part of tool `{name}`");
+            debug!("Installing entrypoints for `{package}` as part of tool `{tool_name}`");
         }
 
         let installed = site_packages.get_packages(package);
@@ -784,7 +786,7 @@ pub(crate) fn finalize_tool_install(
                     .iter()
                     .map(|entrypoint| entrypoint.install_path.as_path()),
             );
-            installed_tools.remove_environment(name)?;
+            installed_tools.remove_environment(tool_name)?;
 
             return Err(NoExecutablesError::Root {
                 package: package.clone(),
@@ -798,12 +800,36 @@ pub(crate) fn finalize_tool_install(
         let target_entrypoints = dist_entrypoints
             .into_iter()
             .map(|(name, source_path)| {
-                let target_path = executable_directory.join(
-                    source_path
-                        .file_name()
-                        .map(std::borrow::ToOwned::to_owned)
-                        .unwrap_or_else(|| OsString::from(name.clone())),
-                );
+                let filename = source_path
+                    .file_name()
+                    .map(std::borrow::ToOwned::to_owned)
+                    .unwrap_or_else(|| OsString::from(name));
+                let filename = if let Some(suffix) = suffix {
+                    cfg_select! {
+                        windows => {
+                            let path = Path::new(&filename);
+                            let mut stem = path
+                                .file_stem()
+                                .map(std::borrow::ToOwned::to_owned)
+                                .unwrap_or_else(|| filename.clone());
+                            stem.push(suffix);
+                            if let Some(extension) = path.extension() {
+                                PathBuf::from(stem).with_extension(extension).into_os_string()
+                            } else {
+                                stem
+                            }
+                        },
+                        unix => {
+                            let mut filename = filename;
+                            filename.push(suffix);
+                            filename
+                        }
+                    }
+                } else {
+                    filename
+                };
+                let name = filename.to_string_lossy().into_owned();
+                let target_path = executable_directory.join(filename);
                 (name, source_path, target_path)
             })
             .collect::<BTreeSet<_>>();
@@ -849,7 +875,7 @@ pub(crate) fn finalize_tool_install(
                     .iter()
                     .map(|entrypoint| entrypoint.install_path.as_path()),
             );
-            installed_tools.remove_environment(name)?;
+            installed_tools.remove_environment(tool_name)?;
 
             return Err(err.into());
         }
@@ -867,7 +893,7 @@ pub(crate) fn finalize_tool_install(
                         .iter()
                         .map(|entrypoint| entrypoint.install_path.as_path()),
                 );
-                installed_tools.remove_environment(name)?;
+                installed_tools.remove_environment(tool_name)?;
 
                 let existing_entrypoints = existing_entrypoints
                     // SAFETY: We know the target has a filename because we just constructed it above
@@ -926,8 +952,10 @@ pub(crate) fn finalize_tool_install(
         )?;
     }
 
-    debug!("Adding receipt for tool `{name}`");
+    debug!("Adding receipt for tool `{tool_name}` from package `{name}`");
     let tool = Tool::new(
+        name.clone(),
+        suffix.map(ToOwned::to_owned),
         requirements,
         constraints,
         overrides,
@@ -937,8 +965,8 @@ pub(crate) fn finalize_tool_install(
         installed_entrypoints,
         options.clone(),
     );
-    ToolLock::write(&installed_tools.tool_dir(name), lock)?;
-    installed_tools.add_tool_receipt(name, tool)?;
+    ToolLock::write(&installed_tools.tool_dir(tool_name), lock)?;
+    installed_tools.add_tool_receipt(tool_name, tool)?;
 
     warn_out_of_path(&executable_directory);
 

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -470,6 +470,9 @@ pub(crate) async fn install(
 
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = installed_tools.lock().await?;
+    if let Some(existing_name) = installed_tools.find_case_insensitive_name(&tool_name)? {
+        bail!("Tool name `{tool_name}` conflicts with existing tool `{existing_name}`");
+    }
     let tool_dir = installed_tools.tool_dir(&tool_name);
 
     // Find the existing receipt, if it exists. If the receipt is present but malformed, we'll
@@ -512,6 +515,15 @@ pub(crate) async fn install(
             "Tool name `{tool_name}` is already used by package `{}`",
             existing_tool_receipt.package().cyan()
         );
+    }
+    if let Some(existing_tool_receipt) = &existing_tool_receipt
+        && existing_tool_receipt.suffix() != suffix.as_deref()
+    {
+        let existing_name = ToolName::from_package_name(
+            existing_tool_receipt.package(),
+            existing_tool_receipt.suffix(),
+        )?;
+        bail!("Tool name `{tool_name}` conflicts with existing tool `{existing_name}`");
     }
 
     let existing_environment = if force {

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -28,7 +28,7 @@ use uv_python::{
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
-use uv_tool::{InstalledTools, Tool};
+use uv_tool::{InstalledTools, Tool, ToolName};
 use uv_types::{HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::WorkspaceCache;
@@ -70,6 +70,7 @@ pub(crate) async fn install(
     python_platform: Option<TargetTriple>,
     install_mirrors: PythonInstallMirrors,
     force: bool,
+    suffix: Option<String>,
     options: ResolverInstallerOptions,
     settings: ResolverInstallerSettings,
     client_builder: BaseClientBuilder<'_>,
@@ -333,6 +334,7 @@ pub(crate) async fn install(
     };
 
     let package_name = &requirement.name;
+    let tool_name = ToolName::from_package_name(package_name, suffix.as_deref())?;
 
     // If the user passed, e.g., `ruff@latest`, we need to mark it as upgradable.
     let settings = if request.is_latest() {
@@ -468,7 +470,7 @@ pub(crate) async fn install(
 
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = installed_tools.lock().await?;
-    let tool_dir = installed_tools.tool_dir(package_name);
+    let tool_dir = installed_tools.tool_dir(&tool_name);
 
     // Find the existing receipt, if it exists. If the receipt is present but malformed, we'll
     // remove the environment and continue with the install.
@@ -479,16 +481,16 @@ pub(crate) async fn install(
     // (If we find existing entrypoints later on, and the tool _doesn't_ exist, we'll avoid removing
     // the external tool's entrypoints (without `--force`).)
     let (existing_tool_receipt, invalid_tool_receipt) =
-        match installed_tools.get_tool_receipt(package_name) {
+        match installed_tools.get_tool_receipt(&tool_name) {
             Ok(None) => (None, false),
             Ok(Some(receipt)) => (Some(receipt), false),
             Err(_) => {
                 // If the tool is not installed properly, remove the environment and continue.
-                match installed_tools.remove_environment(package_name) {
+                match installed_tools.remove_environment(&tool_name) {
                     Ok(()) => {
                         warn_user!(
                             "Removed existing `{}` with invalid receipt",
-                            package_name.cyan()
+                            tool_name.cyan()
                         );
                     }
                     Err(err)
@@ -503,11 +505,20 @@ pub(crate) async fn install(
             }
         };
 
+    if let Some(existing_tool_receipt) = &existing_tool_receipt
+        && existing_tool_receipt.package() != package_name
+    {
+        bail!(
+            "Tool name `{tool_name}` is already used by package `{}`",
+            existing_tool_receipt.package().cyan()
+        );
+    }
+
     let existing_environment = if force {
         None
     } else {
         installed_tools
-            .get_environment(package_name, &cache)?
+            .get_environment(&tool_name, package_name, &cache)?
             .filter(|environment| {
                 existing_environment_usable(
                     environment.environment(),
@@ -632,15 +643,20 @@ pub(crate) async fn install(
                     // Then we're done! Though we might need to update the receipt.
                     if *tool_receipt.options() != options {
                         installed_tools.add_tool_receipt(
-                            package_name,
+                            &tool_name,
                             tool_receipt.clone().with_options(options),
                         )?;
                     }
 
+                    let installed = if suffix.is_some() {
+                        tool_name.to_string()
+                    } else {
+                        requirement.to_string()
+                    };
                     writeln!(
                         printer.stderr(),
                         "`{}` is already installed",
-                        requirement.cyan()
+                        installed.cyan()
                     )?;
 
                     return Ok(ExitStatus::Success);
@@ -792,8 +808,10 @@ pub(crate) async fn install(
                 };
                 ToolLock::write(&tool_dir, Some(&tool_lock))?;
                 installed_tools.add_tool_receipt(
-                    package_name,
+                    &tool_name,
                     Tool::new(
+                        package_name.clone(),
+                        suffix.clone(),
                         requirements.clone(),
                         receipt_constraints.clone(),
                         receipt_overrides.clone(),
@@ -804,10 +822,15 @@ pub(crate) async fn install(
                         options.clone(),
                     ),
                 )?;
+                let installed = if suffix.is_some() {
+                    tool_name.to_string()
+                } else {
+                    requirement.to_string()
+                };
                 writeln!(
                     printer.stderr(),
                     "`{}` is already installed",
-                    requirement.cyan()
+                    installed.cyan()
                 )?;
                 return Ok(ExitStatus::Success);
             }
@@ -1013,7 +1036,7 @@ pub(crate) async fn install(
         } else {
             HashStrategy::default()
         };
-        let environment = installed_tools.create_environment(package_name, interpreter)?;
+        let environment = installed_tools.create_environment(&tool_name, interpreter)?;
 
         // At this point, we removed any existing environment, so we should remove any of its
         // executables.
@@ -1042,7 +1065,7 @@ pub(crate) async fn install(
         .inspect_err(|_| {
             // If we failed to sync, remove the newly created environment.
             debug!("Failed to sync environment; removing `{}`", package_name);
-            let _ = installed_tools.remove_environment(package_name);
+            let _ = installed_tools.remove_environment(&tool_name);
         }) {
             Ok(environment) => (environment, tool_lock),
             Err(ProjectError::Operation(err)) => {
@@ -1057,6 +1080,8 @@ pub(crate) async fn install(
     finalize_tool_install(
         &environment,
         package_name,
+        &tool_name,
+        suffix.as_deref(),
         entrypoints,
         &installed_tools,
         &options,

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -16,7 +16,7 @@ use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_python::LenientImplementationName;
 use uv_settings::{Combine, ResolverInstallerOptions};
-use uv_tool::InstalledTools;
+use uv_tool::{InstalledTools, Tool, ToolName};
 use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
@@ -76,19 +76,19 @@ pub(crate) async fn list(
         };
 
         // Get the tool environment
-        let tool_env = match installed_tools.get_environment(&name, cache) {
+        let tool_env = match installed_tools.get_environment(&name, tool.package(), cache) {
             Ok(Some(env)) => env,
             Ok(None) => {
                 warn_user!(
                     "Tool `{name}` environment not found (run `{}` to reinstall)",
-                    format!("uv tool install {name} --reinstall").green()
+                    reinstall_command(&tool).green()
                 );
                 continue;
             }
             Err(e) => {
                 warn_user!(
                     "{e} (run `{}` to reinstall)",
-                    format!("uv tool install {name} --reinstall").green()
+                    reinstall_command(&tool).green()
                 );
                 continue;
             }
@@ -101,7 +101,7 @@ pub(crate) async fn list(
                 if let uv_tool::Error::EnvironmentError(e) = e {
                     warn_user!(
                         "{e} (run `{}` to reinstall)",
-                        format!("uv tool install {name} --reinstall").green()
+                        reinstall_command(&tool).green()
                     );
                 } else {
                     writeln!(printer.stderr(), "{e}")?;
@@ -114,9 +114,7 @@ pub(crate) async fn list(
     }
 
     // Determine the latest version for each tool when `--outdated` is requested.
-    let latest: FxHashMap<PackageName, Option<DistFilename>> = if outdated
-        && !valid_tools.is_empty()
-    {
+    let latest: FxHashMap<ToolName, Option<DistFilename>> = if outdated && !valid_tools.is_empty() {
         let download_concurrency = concurrency.downloads_semaphore.clone();
 
         let reporter = LatestVersionReporter::from(printer).with_length(valid_tools.len() as u64);
@@ -161,17 +159,21 @@ pub(crate) async fn list(
                     };
 
                     let latest = latest_client
-                        .find_latest(name, None, &download_concurrency)
+                        .find_latest(tool.package(), None, &download_concurrency)
                         .await?;
-                    Ok::<(&PackageName, Option<DistFilename>), anyhow::Error>((name, latest))
+                    Ok::<(&ToolName, &PackageName, Option<DistFilename>), anyhow::Error>((
+                        name,
+                        tool.package(),
+                        latest,
+                    ))
                 }
             })
             .buffer_unordered(concurrency.downloads);
 
         let mut map = FxHashMap::default();
-        while let Some((name, version)) = fetches.next().await.transpose()? {
+        while let Some((name, package, version)) = fetches.next().await.transpose()? {
             if let Some(version) = version.as_ref() {
-                reporter.on_fetch_version(name, version.version());
+                reporter.on_fetch_version(package, version.version());
             } else {
                 reporter.on_fetch_progress();
             }
@@ -199,7 +201,7 @@ pub(crate) async fn list(
             .then(|| {
                 tool.requirements()
                     .iter()
-                    .filter(|req| req.name == name)
+                    .filter(|req| &req.name == tool.package())
                     .map(|req| req.source.to_string())
                     .filter(|s| !s.is_empty())
                     .peekable()
@@ -215,7 +217,7 @@ pub(crate) async fn list(
             .then(|| {
                 tool.requirements()
                     .iter()
-                    .filter(|req| req.name == name)
+                    .filter(|req| &req.name == tool.package())
                     .flat_map(|req| req.extras.iter()) // Flatten the extras from all matching requirements
                     .peekable()
             })
@@ -242,7 +244,7 @@ pub(crate) async fn list(
             .then(|| {
                 tool.requirements()
                     .iter()
-                    .filter(|req| req.name != name)
+                    .filter(|req| &req.name != tool.package())
                     .peekable()
             })
             .take_if(|requirements| requirements.peek().is_some())
@@ -296,4 +298,15 @@ pub(crate) async fn list(
     }
 
     Ok(ExitStatus::Success)
+}
+
+fn reinstall_command(tool: &Tool) -> String {
+    if let Some(suffix) = tool.suffix() {
+        format!(
+            "uv tool install {} --suffix={suffix} --reinstall",
+            tool.package()
+        )
+    } else {
+        format!("uv tool install {} --reinstall", tool.package())
+    }
 }

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -22,6 +22,7 @@ use uv_warnings::warn_user;
 use crate::commands::ExitStatus;
 use crate::commands::pip::latest::LatestClient;
 use crate::commands::reporters::LatestVersionReporter;
+use crate::commands::tool::common::format_tool_suffix_arg;
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 
@@ -303,8 +304,9 @@ pub(crate) async fn list(
 fn reinstall_command(tool: &Tool) -> String {
     if let Some(suffix) = tool.suffix() {
         format!(
-            "uv tool install {} --suffix={suffix} --reinstall",
-            tool.package()
+            "uv tool install {} {} --reinstall",
+            tool.package(),
+            format_tool_suffix_arg(suffix)
         )
     } else {
         format!("uv tool install {} --reinstall", tool.package())

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -35,7 +35,7 @@ use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_shell::WindowsRunnable;
 use uv_static::EnvVars;
-use uv_tool::{InstalledTools, entrypoint_paths};
+use uv_tool::{InstalledTools, ToolName, entrypoint_paths};
 use uv_warnings::warn_user_once;
 use uv_workspace::WorkspaceCache;
 
@@ -450,9 +450,9 @@ async fn show_help(
         .into_iter()
         // Skip invalid tools
         .filter_map(|(name, tool)| {
-            tool.ok().and_then(|_| {
+            tool.ok().and_then(|tool| {
                 installed_tools
-                    .get_environment(&name, cache)
+                    .get_environment(&name, tool.package(), cache)
                     .ok()
                     .flatten()
                     .and_then(|tool_env| tool_env.version().ok())
@@ -1005,8 +1005,9 @@ async fn get_or_create_environment(
         let _lock = installed_tools.lock().await?;
 
         if let ToolRequirement::Package { requirement, .. } = &from {
+            let tool_name = ToolName::from(&requirement.name);
             let existing_environment = installed_tools
-                .get_environment(&requirement.name, cache)?
+                .get_environment(&tool_name, &requirement.name, cache)?
                 .filter(|environment| {
                     python_request.as_ref().is_none_or(|python_request| {
                         python_request.satisfied(environment.environment().interpreter(), cache)
@@ -1016,7 +1017,7 @@ async fn get_or_create_environment(
             // Check if the installed packages meet the requirements.
             if let Some(environment) = existing_environment {
                 if installed_tools
-                    .get_tool_receipt(&requirement.name)
+                    .get_tool_receipt(&tool_name)
                     .ok()
                     .flatten()
                     .is_some_and(|receipt| ToolOptions::from(options) == *receipt.options())

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::str::FromStr;
 
 use anyhow::{Result, bail};
 use itertools::Itertools;
@@ -7,13 +8,13 @@ use tracing::debug;
 
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
-use uv_tool::{InstalledTools, Tool, ToolEntrypoint};
+use uv_tool::{InstalledTools, Tool, ToolEntrypoint, ToolName};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Uninstall a tool.
-pub(crate) async fn uninstall(name: Vec<PackageName>, printer: Printer) -> Result<ExitStatus> {
+pub(crate) async fn uninstall(name: Vec<String>, printer: Printer) -> Result<ExitStatus> {
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = match installed_tools.lock().await {
         Ok(lock) => lock,
@@ -96,7 +97,7 @@ impl IgnoreCurrentlyBeingDeleted for Result<(), std::io::Error> {
 /// Perform the uninstallation.
 async fn do_uninstall(
     installed_tools: &InstalledTools,
-    names: Vec<PackageName>,
+    names: Vec<String>,
     printer: Printer,
 ) -> Result<()> {
     let mut dangling = false;
@@ -133,6 +134,7 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
+            let name = resolve_tool_name(&name, installed_tools)?;
             let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
                 // If the tool is not installed properly, attempt to remove the environment anyway.
                 match installed_tools.remove_environment(&name) {
@@ -185,7 +187,7 @@ async fn do_uninstall(
 
 /// Uninstall a tool.
 async fn uninstall_tool(
-    name: &PackageName,
+    name: &ToolName,
     receipt: &Tool,
     tools: &InstalledTools,
 ) -> Result<Vec<ToolEntrypoint>> {
@@ -226,4 +228,19 @@ async fn uninstall_tool(
     }
 
     Ok(entrypoints.to_vec())
+}
+
+/// Resolve a user-provided tool name while preserving exact suffixed names.
+fn resolve_tool_name(name: &str, tools: &InstalledTools) -> Result<ToolName> {
+    let exact = ToolName::from_str(name)?;
+    if tools.tool_dir(&exact).exists() {
+        return Ok(exact);
+    }
+
+    // Preserve the historical normalization of unsuffixed package names.
+    if let Ok(package) = PackageName::from_str(name) {
+        return Ok(ToolName::from(package));
+    }
+
+    Ok(exact)
 }

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -23,7 +23,7 @@ use uv_python::{
 };
 use uv_requirements::RequirementsSpecification;
 use uv_settings::{Combine, PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
-use uv_tool::{InstalledTools, Tool};
+use uv_tool::{InstalledTools, Tool, ToolName};
 use uv_types::{HashStrategy, SourceTreeEditablePolicy};
 use uv_workspace::WorkspaceCache;
 
@@ -63,7 +63,7 @@ pub(crate) async fn upgrade(
     let _lock = installed_tools.lock().await?;
 
     // Collect the tools to upgrade, along with any constraints.
-    let names: BTreeMap<PackageName, Vec<Requirement>> = {
+    let names: BTreeMap<ToolName, Vec<Requirement>> = {
         if names.is_empty() {
             installed_tools
                 .tools()
@@ -72,12 +72,32 @@ pub(crate) async fn upgrade(
                 .map(|(name, _)| (name, Vec::new()))
                 .collect()
         } else {
+            let installed_names = installed_tools
+                .tools()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect::<Vec<_>>();
             let mut map = BTreeMap::new();
-            for name in names {
-                let requirement = Requirement::from(uv_pep508::Requirement::parse(&name, &*CWD)?);
-                map.entry(requirement.name.clone())
-                    .or_insert_with(Vec::new)
-                    .push(requirement);
+            for request in names {
+                if let Some((name, specifier)) = split_upgrade_request(&request, &installed_names) {
+                    let constraints = map.entry(name.clone()).or_insert_with(Vec::new);
+                    if !specifier.is_empty()
+                        && let Ok(Some(tool)) = installed_tools.get_tool_receipt(name)
+                    {
+                        let requirement = format!("{}{specifier}", tool.package());
+                        constraints.push(Requirement::from(uv_pep508::Requirement::parse(
+                            &requirement,
+                            &*CWD,
+                        )?));
+                    }
+                } else {
+                    let requirement =
+                        Requirement::from(uv_pep508::Requirement::parse(&request, &*CWD)?);
+                    map.entry(ToolName::from(requirement.name.clone()))
+                        .or_insert_with(Vec::new)
+                        .push(requirement);
+                }
             }
             map
         }
@@ -120,7 +140,7 @@ pub(crate) async fn upgrade(
     let mut did_upgrade_environment = vec![];
 
     // Constraints that caused upgrades to be skipped or altered.
-    let mut collected_constraints: Vec<(PackageName, UpgradeConstraint)> = Vec::new();
+    let mut collected_constraints: Vec<(ToolName, UpgradeConstraint)> = Vec::new();
 
     let mut errors = Vec::new();
     for (name, constraints) in &names {
@@ -214,6 +234,25 @@ pub(crate) async fn upgrade(
     Ok(ExitStatus::Success)
 }
 
+/// Split a request into an exact installed tool name and an optional requirement suffix.
+fn split_upgrade_request<'a>(
+    request: &'a str,
+    installed_names: &'a [ToolName],
+) -> Option<(&'a ToolName, &'a str)> {
+    installed_names
+        .iter()
+        .filter_map(|name| {
+            let specifier = request.strip_prefix(name.as_str())?;
+            (specifier.is_empty()
+                || specifier.as_bytes().first().is_some_and(|character| {
+                    character.is_ascii_whitespace()
+                        || matches!(character, b'<' | b'>' | b'=' | b'!' | b'~' | b'@')
+                }))
+            .then_some((name, specifier))
+        })
+        .max_by_key(|(name, _)| name.as_str().len())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UpgradeOutcome {
     /// The tool itself was upgraded.
@@ -229,20 +268,30 @@ enum UpgradeOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum UpgradeConstraint {
     /// The tool remains pinned to an exact version, so an upgrade was skipped.
-    PinnedVersion { version: Version },
+    PinnedVersion {
+        version: Version,
+        package: PackageName,
+        suffix: Option<String>,
+    },
 }
 
 impl UpgradeConstraint {
-    fn print(&self, name: &PackageName, printer: Printer) -> Result<()> {
+    fn print(&self, name: &ToolName, printer: Printer) -> Result<()> {
         match self {
-            Self::PinnedVersion { version } => {
-                let name = name.to_string();
-                let reinstall_command = format!("uv tool install {name}@latest");
+            Self::PinnedVersion {
+                version,
+                package,
+                suffix,
+            } => {
+                let reinstall_command = suffix.as_ref().map_or_else(
+                    || format!("uv tool install {package}@latest"),
+                    |suffix| format!("uv tool install {package}@latest --suffix={suffix}"),
+                );
 
                 writeln!(
                     printer.stderr(),
                     "hint: `{}` is pinned to `{}` (installed with an exact version pin); reinstall with `{}` to upgrade to a new version.",
-                    name.cyan(),
+                    name.to_string().cyan(),
                     version.to_string().magenta(),
                     reinstall_command.green(),
                 )?;
@@ -261,7 +310,7 @@ struct UpgradeReport {
 
 /// Upgrade a specific tool.
 async fn upgrade_tool(
-    name: &PackageName,
+    name: &ToolName,
     constraints: &[Requirement],
     interpreter: Option<&Interpreter>,
     python_platform: Option<&TargetTriple>,
@@ -297,11 +346,12 @@ async fn upgrade_tool(
             ));
         }
     };
+    let package = existing_tool_receipt.package();
 
-    let environment = match installed_tools.get_environment(name, cache) {
+    let environment = match installed_tools.get_environment(name, package, cache) {
         Ok(Some(environment)) => environment,
         Ok(None) => {
-            let install_command = format!("uv tool install {name}");
+            let install_command = install_command(&existing_tool_receipt, false);
             return Err(anyhow::anyhow!(
                 "`{}` is not installed; run `{}` to install",
                 name.cyan(),
@@ -309,7 +359,7 @@ async fn upgrade_tool(
             ));
         }
         Err(_) => {
-            let install_command = format!("uv tool install --force {name}");
+            let install_command = install_command(&existing_tool_receipt, true);
             return Err(anyhow::anyhow!(
                 "`{}` is missing a valid environment; run `{}` to reinstall",
                 name.cyan(),
@@ -386,7 +436,7 @@ async fn upgrade_tool(
         let tool_lock =
             ToolLock::from_resolution(&tool_dir, &universal_resolution, &lock_manifest)?;
         let resolution = tool_lock.to_resolution(
-            Some(name),
+            Some(package),
             target_interpreter,
             python_platform,
             &settings.resolver.build_options,
@@ -455,10 +505,10 @@ async fn upgrade_tool(
                 &tags,
             )?;
             let plan_is_empty = plan.is_empty();
-            let changes_tool = plan.cached.iter().any(|dist| dist.name() == name)
-                || plan.remote.iter().any(|dist| dist.name() == name)
-                || plan.reinstalls.iter().any(|dist| dist.name() == name)
-                || plan.extraneous.iter().any(|dist| dist.name() == name);
+            let changes_tool = plan.cached.iter().any(|dist| dist.name() == package)
+                || plan.remote.iter().any(|dist| dist.name() == package)
+                || plan.reinstalls.iter().any(|dist| dist.name() == package)
+                || plan.extraneous.iter().any(|dist| dist.name() == package);
             let outcome = if plan_is_empty {
                 UpgradeOutcome::NoOp
             } else if changes_tool {
@@ -478,7 +528,7 @@ async fn upgrade_tool(
                     (&settings).into(),
                     client_builder,
                     &state,
-                    Box::new(UpgradeInstallLogger::new(name.clone())),
+                    Box::new(UpgradeInstallLogger::new(package.clone())),
                     installer_metadata,
                     concurrency,
                     cache,
@@ -544,7 +594,7 @@ async fn upgrade_tool(
             client_builder,
             &state,
             Box::new(SummaryResolveLogger),
-            Box::new(UpgradeInstallLogger::new(name.clone())),
+            Box::new(UpgradeInstallLogger::new(package.clone())),
             installer_metadata,
             concurrency,
             cache,
@@ -555,7 +605,7 @@ async fn upgrade_tool(
         )
         .await?;
 
-        let outcome = if changelog.includes(name) {
+        let outcome = if changelog.includes(package) {
             UpgradeOutcome::UpgradeTool
         } else if changelog.is_empty() {
             UpgradeOutcome::NoOp
@@ -583,7 +633,9 @@ async fn upgrade_tool(
         // If we modified the target tool, reinstall the entrypoints.
         finalize_tool_install(
             &environment,
+            package,
             name,
+            existing_tool_receipt.suffix(),
             &entrypoints,
             installed_tools,
             &ToolOptions::from(options),
@@ -609,8 +661,13 @@ async fn upgrade_tool(
 
     let constraint = match &outcome {
         UpgradeOutcome::UpgradeDependencies | UpgradeOutcome::NoOp => {
-            pinned_requirement_version(&existing_tool_receipt, name)
-                .map(|version| UpgradeConstraint::PinnedVersion { version })
+            pinned_requirement_version(&existing_tool_receipt, package).map(|version| {
+                UpgradeConstraint::PinnedVersion {
+                    version,
+                    package: package.clone(),
+                    suffix: existing_tool_receipt.suffix().map(ToOwned::to_owned),
+                }
+            })
         }
         UpgradeOutcome::UpgradeTool | UpgradeOutcome::UpgradeEnvironment => None,
     };
@@ -619,6 +676,17 @@ async fn upgrade_tool(
         outcome,
         constraint,
     })
+}
+
+fn install_command(tool: &Tool, force: bool) -> String {
+    let mut command = format!("uv tool install {}", tool.package());
+    if let Some(suffix) = tool.suffix() {
+        let _ = write!(command, " --suffix={suffix}");
+    }
+    if force {
+        command.push_str(" --force");
+    }
+    command
 }
 
 fn pinned_requirement_version(tool: &Tool, name: &PackageName) -> Option<Version> {

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -36,7 +36,9 @@ use crate::commands::project::{
     update_environment,
 };
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::tool::common::{ToolLock, remove_entrypoints, tool_environment_spec};
+use crate::commands::tool::common::{
+    ToolLock, format_tool_suffix_arg, remove_entrypoints, tool_environment_spec,
+};
 use crate::commands::{ExitStatus, conjunction, tool::common::finalize_tool_install};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
@@ -285,7 +287,12 @@ impl UpgradeConstraint {
             } => {
                 let reinstall_command = suffix.as_ref().map_or_else(
                     || format!("uv tool install {package}@latest"),
-                    |suffix| format!("uv tool install {package}@latest --suffix={suffix}"),
+                    |suffix| {
+                        format!(
+                            "uv tool install {package}@latest {}",
+                            format_tool_suffix_arg(suffix)
+                        )
+                    },
                 );
 
                 writeln!(
@@ -679,10 +686,16 @@ async fn upgrade_tool(
 }
 
 fn install_command(tool: &Tool, force: bool) -> String {
-    let mut command = format!("uv tool install {}", tool.package());
-    if let Some(suffix) = tool.suffix() {
-        let _ = write!(command, " --suffix={suffix}");
-    }
+    let mut command = tool.suffix().map_or_else(
+        || format!("uv tool install {}", tool.package()),
+        |suffix| {
+            format!(
+                "uv tool install {} {}",
+                tool.package(),
+                format_tool_suffix_arg(suffix)
+            )
+        },
+    );
     if force {
         command.push_str(" --force");
     }

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -337,6 +337,12 @@ async fn upgrade_tool(
     let existing_tool_receipt = match installed_tools.get_tool_receipt(name) {
         Ok(Some(receipt)) => receipt,
         Ok(None) => {
+            if installed_tools.tool_dir(name).exists() {
+                return Err(anyhow::anyhow!(
+                    "`{}` is missing a receipt and cannot be upgraded",
+                    name.cyan()
+                ));
+            }
             let install_command = format!("uv tool install {name}");
             return Err(anyhow::anyhow!(
                 "`{}` is not installed; run `{}` to install",
@@ -345,11 +351,9 @@ async fn upgrade_tool(
             ));
         }
         Err(_) => {
-            let install_command = format!("uv tool install --force {name}");
             return Err(anyhow::anyhow!(
-                "`{}` is missing a valid receipt; run `{}` to reinstall",
-                name.cyan(),
-                install_command.green()
+                "`{}` is missing a valid receipt and cannot be upgraded",
+                name.cyan()
             ));
         }
     };

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1692,6 +1692,7 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
                 args.python_platform,
                 args.install_mirrors,
                 args.force,
+                args.suffix,
                 args.options,
                 args.settings,
                 client_builder.subcommand(vec!["tool".to_owned(), "install".to_owned()]),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1035,6 +1035,7 @@ pub(crate) struct ToolInstallSettings {
     pub(crate) options: ResolverInstallerOptions,
     pub(crate) settings: ResolverInstallerSettings,
     pub(crate) force: bool,
+    pub(crate) suffix: Option<String>,
     pub(crate) editable: bool,
     pub(crate) install_mirrors: PythonInstallMirrors,
 }
@@ -1061,6 +1062,7 @@ impl ToolInstallSettings {
             lfs,
             installer,
             force,
+            suffix,
             build,
             refresh,
             python,
@@ -1130,6 +1132,7 @@ impl ToolInstallSettings {
             python: python.and_then(Maybe::into_option),
             python_platform,
             force,
+            suffix,
             editable,
             refresh: Refresh::from(refresh),
             options,
@@ -1311,7 +1314,7 @@ impl ToolListSettings {
 /// The resolved settings to use for a `tool uninstall` invocation.
 #[derive(Debug, Clone)]
 pub(crate) struct ToolUninstallSettings {
-    pub(crate) name: Vec<PackageName>,
+    pub(crate) name: Vec<String>,
 }
 
 impl ToolUninstallSettings {

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -812,6 +812,7 @@ fn tool_install_baseline() {
             reinstall: None,
         },
         force: false,
+        suffix: None,
         editable: false,
         install_mirrors: PythonInstallMirrors {
             python_install_mirror: None,

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -334,6 +334,58 @@ fn tool_install_suffix() {
         .assert(predicate::path::exists());
 }
 
+/// Reject suffixes that alias an existing tool on case-insensitive filesystems.
+#[test]
+fn tool_install_case_insensitive_suffix_collision() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .arg("--suffix")
+        .arg("_PREVIEW")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black==24.2.0")
+        .arg("--suffix")
+        .arg("_preview")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Tool name `black_preview` conflicts with existing tool `black_PREVIEW`
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("black_PREVIEW").join("uv-receipt.toml")).unwrap(), @r#"
+        [tool]
+        package = "black"
+        suffix = "_PREVIEW"
+        requirements = [{ name = "black", specifier = "==24.2.0" }]
+        entrypoints = [
+            { name = "black_PREVIEW", install-path = "[TEMP_DIR]/bin/black_PREVIEW", from = "black" },
+            { name = "blackd_PREVIEW", install-path = "[TEMP_DIR]/bin/blackd_PREVIEW", from = "black" },
+        ]
+
+        [tool.options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+        "#);
+    });
+}
+
 #[test]
 fn tool_install_relative_exclude_newer_receipt_preserves_span() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -386,24 +386,6 @@ fn tool_install_case_insensitive_suffix_collision() {
     });
 }
 
-/// Reject tool names that are reserved device names on Windows, even when they have extensions.
-#[test]
-fn tool_install_windows_reserved_name() {
-    let context = uv_test::test_context!("3.12");
-
-    uv_snapshot!(context.filters(), context.tool_install()
-        .arg("c")
-        .arg("--suffix")
-        .arg("on.txt"), @"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Invalid tool name `con.txt`; tool names must be valid cross-platform filenames
-    ");
-}
-
 #[test]
 fn tool_install_relative_exclude_newer_receipt_preserves_span() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -212,6 +212,128 @@ fn tool_install() {
     });
 }
 
+/// Install multiple versions of a tool under distinct suffixes.
+#[test]
+fn tool_install_suffix() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black==24.2.0")
+        .arg("--suffix")
+        .arg("-old")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + black==24.2.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    Installed 2 executables: black-old, blackd-old
+    ");
+
+    context
+        .tool_install()
+        .arg("black==24.3.0")
+        .arg("--suffix")
+        .arg("-new")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    tool_dir
+        .child("black-old")
+        .assert(predicate::path::is_dir());
+    tool_dir
+        .child("black-new")
+        .assert(predicate::path::is_dir());
+    bin_dir
+        .child(format!("black-old{}", std::env::consts::EXE_SUFFIX))
+        .assert(predicate::path::exists());
+    bin_dir
+        .child(format!("black-new{}", std::env::consts::EXE_SUFFIX))
+        .assert(predicate::path::exists());
+    bin_dir
+        .child(format!("black{}", std::env::consts::EXE_SUFFIX))
+        .assert(predicate::path::missing());
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("black-old").join("uv-receipt.toml")).unwrap(), @r#"
+        [tool]
+        package = "black"
+        suffix = "-old"
+        requirements = [{ name = "black", specifier = "==24.2.0" }]
+        entrypoints = [
+            { name = "black-old", install-path = "[TEMP_DIR]/bin/black-old", from = "black" },
+            { name = "blackd-old", install-path = "[TEMP_DIR]/bin/blackd-old", from = "black" },
+        ]
+
+        [tool.options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+        "#);
+    });
+
+    uv_snapshot!(context.filters(), context.tool_list()
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    black-new v24.3.0
+    - black-new
+    - blackd-new
+    black-old v24.2.0
+    - black-old
+    - blackd-old
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), context.tool_uninstall()
+        .arg("black-old")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Uninstalled 2 executables: black-old, blackd-old
+    ");
+
+    tool_dir
+        .child("black-old")
+        .assert(predicate::path::missing());
+    tool_dir
+        .child("black-new")
+        .assert(predicate::path::is_dir());
+    bin_dir
+        .child(format!("black-old{}", std::env::consts::EXE_SUFFIX))
+        .assert(predicate::path::missing());
+    bin_dir
+        .child(format!("black-new{}", std::env::consts::EXE_SUFFIX))
+        .assert(predicate::path::exists());
+}
+
 #[test]
 fn tool_install_relative_exclude_newer_receipt_preserves_span() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -224,7 +224,7 @@ fn tool_install_suffix() {
     uv_snapshot!(context.filters(), context.tool_install()
         .arg("black==24.2.0")
         .arg("--suffix")
-        .arg("-old")
+        .arg("-0.11")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::PATH, bin_dir.as_os_str()), @"
@@ -242,14 +242,14 @@ fn tool_install_suffix() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
-    Installed 2 executables: black-old, blackd-old
+    Installed 2 executables: black-0.11, blackd-0.11
     ");
 
     context
         .tool_install()
         .arg("black==24.3.0")
         .arg("--suffix")
-        .arg("-new")
+        .arg("-0.12")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::PATH, bin_dir.as_os_str())
@@ -257,16 +257,16 @@ fn tool_install_suffix() {
         .success();
 
     tool_dir
-        .child("black-old")
+        .child("black-0.11")
         .assert(predicate::path::is_dir());
     tool_dir
-        .child("black-new")
+        .child("black-0.12")
         .assert(predicate::path::is_dir());
     bin_dir
-        .child(format!("black-old{}", std::env::consts::EXE_SUFFIX))
+        .child(format!("black-0.11{}", std::env::consts::EXE_SUFFIX))
         .assert(predicate::path::exists());
     bin_dir
-        .child(format!("black-new{}", std::env::consts::EXE_SUFFIX))
+        .child(format!("black-0.12{}", std::env::consts::EXE_SUFFIX))
         .assert(predicate::path::exists());
     bin_dir
         .child(format!("black{}", std::env::consts::EXE_SUFFIX))
@@ -275,14 +275,14 @@ fn tool_install_suffix() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(fs_err::read_to_string(tool_dir.join("black-old").join("uv-receipt.toml")).unwrap(), @r#"
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("black-0.11").join("uv-receipt.toml")).unwrap(), @r#"
         [tool]
         package = "black"
-        suffix = "-old"
+        suffix = "-0.11"
         requirements = [{ name = "black", specifier = "==24.2.0" }]
         entrypoints = [
-            { name = "black-old", install-path = "[TEMP_DIR]/bin/black-old", from = "black" },
-            { name = "blackd-old", install-path = "[TEMP_DIR]/bin/blackd-old", from = "black" },
+            { name = "black-0.11", install-path = "[TEMP_DIR]/bin/black-0.11", from = "black" },
+            { name = "blackd-0.11", install-path = "[TEMP_DIR]/bin/blackd-0.11", from = "black" },
         ]
 
         [tool.options]
@@ -297,18 +297,18 @@ fn tool_install_suffix() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black-new v24.3.0
-    - black-new
-    - blackd-new
-    black-old v24.2.0
-    - black-old
-    - blackd-old
+    black-0.11 v24.2.0
+    - black-0.11
+    - blackd-0.11
+    black-0.12 v24.3.0
+    - black-0.12
+    - blackd-0.12
 
     ----- stderr -----
     ");
 
     uv_snapshot!(context.filters(), context.tool_uninstall()
-        .arg("black-old")
+        .arg("black-0.11")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::PATH, bin_dir.as_os_str()), @"
@@ -317,20 +317,20 @@ fn tool_install_suffix() {
     ----- stdout -----
 
     ----- stderr -----
-    Uninstalled 2 executables: black-old, blackd-old
+    Uninstalled 2 executables: black-0.11, blackd-0.11
     ");
 
     tool_dir
-        .child("black-old")
+        .child("black-0.11")
         .assert(predicate::path::missing());
     tool_dir
-        .child("black-new")
+        .child("black-0.12")
         .assert(predicate::path::is_dir());
     bin_dir
-        .child(format!("black-old{}", std::env::consts::EXE_SUFFIX))
+        .child(format!("black-0.11{}", std::env::consts::EXE_SUFFIX))
         .assert(predicate::path::missing());
     bin_dir
-        .child(format!("black-new{}", std::env::consts::EXE_SUFFIX))
+        .child(format!("black-0.12{}", std::env::consts::EXE_SUFFIX))
         .assert(predicate::path::exists());
 }
 

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -386,6 +386,24 @@ fn tool_install_case_insensitive_suffix_collision() {
     });
 }
 
+/// Reject tool names that are reserved device names on Windows, even when they have extensions.
+#[test]
+fn tool_install_windows_reserved_name() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("c")
+        .arg("--suffix")
+        .arg("on.txt"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Invalid tool name `con.txt`; tool names must be valid cross-platform filenames
+    ");
+}
+
 #[test]
 fn tool_install_relative_exclude_newer_receipt_preserves_span() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();

--- a/crates/uv/tests/tool/tool_list.rs
+++ b/crates/uv/tests/tool/tool_list.rs
@@ -330,6 +330,7 @@ fn tool_list_bad_environment() -> Result<()> {
         context.filters(),
         context
             .tool_list()
+            .env(EnvVars::BASH_VERSION, "5")
             .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
             .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()),
         @"
@@ -340,7 +341,7 @@ fn tool_list_bad_environment() -> Result<()> {
     - ruff
 
     ----- stderr -----
-    warning: Invalid environment at `tools/black old;echo unsafe`: missing Python executable at `tools/black old;echo unsafe/[BIN]/[PYTHON]` (run `uv tool install black --suffix=' old;echo unsafe' --reinstall` to reinstall)
+    warning: Invalid environment at `tools/black old;echo unsafe`: missing Python executable at `tools/black old;echo unsafe/[BIN]/[PYTHON]` (run `uv tool install black '--suffix= old;echo unsafe' --reinstall` to reinstall)
     "
     );
 

--- a/crates/uv/tests/tool/tool_list.rs
+++ b/crates/uv/tests/tool/tool_list.rs
@@ -306,6 +306,8 @@ fn tool_list_bad_environment() -> Result<()> {
     context
         .tool_install()
         .arg("black==24.2.0")
+        .arg("--suffix")
+        .arg(" old;echo unsafe")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .assert()
@@ -320,7 +322,7 @@ fn tool_list_bad_environment() -> Result<()> {
         .assert()
         .success();
 
-    let venv_path = uv_test::venv_bin_path(tool_dir.path().join("black"));
+    let venv_path = uv_test::venv_bin_path(tool_dir.path().join("black old;echo unsafe"));
     // Remove the python interpreter for black
     fs::remove_dir_all(venv_path.clone())?;
 
@@ -338,7 +340,7 @@ fn tool_list_bad_environment() -> Result<()> {
     - ruff
 
     ----- stderr -----
-    warning: Invalid environment at `tools/black`: missing Python executable at `tools/black/[BIN]/[PYTHON]` (run `uv tool install black --reinstall` to reinstall)
+    warning: Invalid environment at `tools/black old;echo unsafe`: missing Python executable at `tools/black old;echo unsafe/[BIN]/[PYTHON]` (run `uv tool install black --suffix=' old;echo unsafe' --reinstall` to reinstall)
     "
     );
 

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -1019,6 +1019,8 @@ fn tool_upgrade_not_stop_if_upgrade_fails() -> anyhow::Result<()> {
     // Install `python-dotenv` from Test PyPI, to get an outdated version.
     uv_snapshot!(context.filters(), context.tool_install()
         .arg("python-dotenv")
+        .arg("--suffix")
+        .arg("_preview")
         .arg("--index-url")
         .arg("https://test.pypi.org/simple/")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
@@ -1033,8 +1035,21 @@ fn tool_upgrade_not_stop_if_upgrade_fails() -> anyhow::Result<()> {
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
      + python-dotenv==0.10.2.post2
-    Installed 1 executable: dotenv
+    Installed 1 executable: dotenv_preview
     ");
+
+    context
+        .tool_install()
+        .arg("python-dotenv")
+        .arg("--suffix")
+        .arg("_missing")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
 
     // Install `babel` from Test PyPI, to get an outdated version.
     uv_snapshot!(context.filters(), context.tool_install()
@@ -1057,9 +1072,14 @@ fn tool_upgrade_not_stop_if_upgrade_fails() -> anyhow::Result<()> {
     Installed 1 executable: pybabel
     ");
 
-    // Break the receipt for python-dotenv
+    // Remove one receipt and break the other.
+    fs_err::remove_file(
+        tool_dir
+            .child("python-dotenv_missing")
+            .child("uv-receipt.toml"),
+    )?;
     tool_dir
-        .child("python-dotenv")
+        .child("python-dotenv_preview")
         .child("uv-receipt.toml")
         .write_str("Invalid receipt")?;
 
@@ -1081,8 +1101,10 @@ fn tool_upgrade_not_stop_if_upgrade_fails() -> anyhow::Result<()> {
      + babel==2.14.0
      - pytz==2018.5
     Installed 1 executable: pybabel
-    error: Failed to upgrade python-dotenv
-      Caused by: `python-dotenv` is missing a valid receipt; run `uv tool install --force python-dotenv` to reinstall
+    error: Failed to upgrade python-dotenv_missing
+      Caused by: `python-dotenv_missing` is missing a receipt and cannot be upgraded
+    error: Failed to upgrade python-dotenv_preview
+      Caused by: `python-dotenv_preview` is missing a valid receipt and cannot be upgraded
     ");
 
     Ok(())

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -771,7 +771,7 @@ fn tool_upgrade_multiple_names() {
 }
 
 #[test]
-fn tool_upgrade_pinned_hint() {
+fn tool_upgrade_pinned_hint() -> Result<()> {
     let context = uv_test::test_context!("3.12")
         .with_filtered_counts()
         .with_filtered_exe_suffix();
@@ -782,6 +782,8 @@ fn tool_upgrade_pinned_hint() {
     // Install a specific version of `babel` so the receipt records an exact pin.
     uv_snapshot!(context.filters(), context.tool_install()
         .arg("babel==2.6.0")
+        .arg("--suffix")
+        .arg(" old;echo unsafe")
         .arg("--index-url")
         .arg("https://test.pypi.org/simple/")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
@@ -797,12 +799,12 @@ fn tool_upgrade_pinned_hint() {
     Installed [N] packages in [TIME]
      + babel==2.6.0
      + pytz==2018.5
-    Installed 1 executable: pybabel
+    Installed 1 executable: pybabel old;echo unsafe
     ");
 
     // Attempt to upgrade `babel`; it should remain pinned and emit a hint explaining why.
     uv_snapshot!(context.filters(), context.tool_upgrade()
-        .arg("babel")
+        .arg("babel old;echo unsafe")
         .arg("--index-url")
         .arg("https://pypi.org/simple/")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
@@ -817,8 +819,27 @@ fn tool_upgrade_pinned_hint() {
      - pytz==2018.5
      + pytz==2024.1
 
-    hint: `babel` is pinned to `2.6.0` (installed with an exact version pin); reinstall with `uv tool install babel@latest` to upgrade to a new version.
+    hint: `babel old;echo unsafe` is pinned to `2.6.0` (installed with an exact version pin); reinstall with `uv tool install babel@latest --suffix=' old;echo unsafe'` to upgrade to a new version.
     ");
+
+    let venv_path = uv_test::venv_bin_path(tool_dir.path().join("babel old;echo unsafe"));
+    fs_err::remove_dir_all(venv_path)?;
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("babel old;echo unsafe")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to upgrade babel old;echo unsafe
+      Caused by: `babel old;echo unsafe` is missing a valid environment; run `uv tool install babel --suffix=' old;echo unsafe' --force` to reinstall
+    ");
+
+    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -628,6 +628,74 @@ fn tool_upgrade_recomputes_relative_exclude_newer() {
 }
 
 #[test]
+fn tool_upgrade_suffix() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("black")
+        .arg("--suffix")
+        .arg("_preview")
+        .arg("--exclude-newer")
+        .arg("3 weeks")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, "2024-03-22T00:00:00Z")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("black_preview<=24.3.0")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, "2024-04-15T00:00:00Z")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Updated black v24.2.0 -> v24.3.0
+     - black==24.2.0
+     + black==24.3.0
+     - packaging==23.2
+     + packaging==24.0
+    Installed 2 executables: black_preview, blackd_preview
+    ");
+
+    bin_dir
+        .child(format!("black_preview{}", std::env::consts::EXE_SUFFIX))
+        .assert(predicate::path::exists());
+    bin_dir
+        .child(format!("black{}", std::env::consts::EXE_SUFFIX))
+        .assert(predicate::path::missing());
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("black_preview").join("uv-receipt.toml")).unwrap(), @r#"
+        [tool]
+        package = "black"
+        suffix = "_preview"
+        requirements = [{ name = "black" }]
+        entrypoints = [
+            { name = "black_preview", install-path = "[TEMP_DIR]/bin/black_preview", from = "black" },
+            { name = "blackd_preview", install-path = "[TEMP_DIR]/bin/blackd_preview", from = "black" },
+        ]
+
+        [tool.options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+        exclude-newer-span = "P3W"
+        "#);
+    });
+}
+
+#[test]
 fn tool_upgrade_multiple_names() {
     let context = uv_test::test_context!("3.12")
         .with_filtered_counts()

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -807,6 +807,7 @@ fn tool_upgrade_pinned_hint() -> Result<()> {
         .arg("babel old;echo unsafe")
         .arg("--index-url")
         .arg("https://pypi.org/simple/")
+        .env(EnvVars::BASH_VERSION, "5")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::PATH, bin_dir.as_os_str()), @"
@@ -819,7 +820,7 @@ fn tool_upgrade_pinned_hint() -> Result<()> {
      - pytz==2018.5
      + pytz==2024.1
 
-    hint: `babel old;echo unsafe` is pinned to `2.6.0` (installed with an exact version pin); reinstall with `uv tool install babel@latest --suffix=' old;echo unsafe'` to upgrade to a new version.
+    hint: `babel old;echo unsafe` is pinned to `2.6.0` (installed with an exact version pin); reinstall with `uv tool install babel@latest '--suffix= old;echo unsafe'` to upgrade to a new version.
     ");
 
     let venv_path = uv_test::venv_bin_path(tool_dir.path().join("babel old;echo unsafe"));
@@ -827,6 +828,7 @@ fn tool_upgrade_pinned_hint() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.tool_upgrade()
         .arg("babel old;echo unsafe")
+        .env(EnvVars::BASH_VERSION, "5")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::PATH, bin_dir.as_os_str()), @"
@@ -836,7 +838,7 @@ fn tool_upgrade_pinned_hint() -> Result<()> {
 
     ----- stderr -----
     error: Failed to upgrade babel old;echo unsafe
-      Caused by: `babel old;echo unsafe` is missing a valid environment; run `uv tool install babel --suffix=' old;echo unsafe' --force` to reinstall
+      Caused by: `babel old;echo unsafe` is missing a valid environment; run `uv tool install babel '--suffix= old;echo unsafe' --force` to reinstall
     ");
 
     Ok(())

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -219,6 +219,20 @@ Or package sources with [Git LFS](https://git-lfs.com):
 $ uv tool install --lfs git+https://github.com/astral-sh/lfs-cowsay
 ```
 
+### Installing multiple versions
+
+Use `--suffix` to install multiple versions of the same tool. The suffix is appended to every
+executable provided by the package:
+
+```console
+$ uv tool install 'ruff==0.11.0' --suffix '-0.11'
+$ uv tool install 'ruff==0.12.0' --suffix '-0.12'
+```
+
+These installations provide `ruff-0.11` and `ruff-0.12` without installing an unsuffixed `ruff`
+executable. The combined package name and suffix identifies the installation in later commands, for
+example, `uv tool upgrade ruff-0.11` or `uv tool uninstall ruff-0.11`.
+
 As with `uvx`, installations can include additional packages:
 
 ```console


### PR DESCRIPTION
## Summary

Add a `--suffix` option to `uv tool install`, allowing multiple versions of the same tool to be installed side by side. A custom suffix is appended literally to every entry point and becomes part of the installed tool identity, without installing the plain-name executable.

Preserve the underlying package and suffix in the tool receipt so suffixed installations continue to work with `uv tool list`, `uv tool upgrade`, and `uv tool uninstall`, including actionable recovery commands for malformed environments. Document the workflow with versioned Ruff installations.

Closes https://github.com/astral-sh/uv/issues/6365.
