### PR TITLE
Avoid panics for invalid cloud endpoint URLs

### DIFF
--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -15,6 +15,7 @@ use uv_warnings::owo_colors::OwoColorize;
 
 use crate::providers::{
     AzureEndpointProvider, GcsEndpointProvider, HuggingFaceProvider, S3EndpointProvider,
+    validate_endpoint_urls,
 };
 use crate::pyx::{DEFAULT_TOLERANCE_SECS, PyxTokenStore};
 use crate::{
@@ -371,6 +372,8 @@ impl Middleware for AuthMiddleware {
         extensions: &mut Extensions,
         next: Next<'_>,
     ) -> reqwest_middleware::Result<Response> {
+        validate_endpoint_urls().map_err(Error::Middleware)?;
+
         // Check for credentials attached to the request already
         let request_credentials = Credentials::from_request(&request)?.map(Authentication::from);
 

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -15,7 +15,6 @@ use uv_warnings::owo_colors::OwoColorize;
 
 use crate::providers::{
     AzureEndpointProvider, GcsEndpointProvider, HuggingFaceProvider, S3EndpointProvider,
-    validate_endpoint_urls,
 };
 use crate::pyx::{DEFAULT_TOLERANCE_SECS, PyxTokenStore};
 use crate::{
@@ -372,8 +371,6 @@ impl Middleware for AuthMiddleware {
         extensions: &mut Extensions,
         next: Next<'_>,
     ) -> reqwest_middleware::Result<Response> {
-        validate_endpoint_urls().map_err(Error::Middleware)?;
-
         // Check for credentials attached to the request already
         let request_credentials = Credentials::from_request(&request)?.map(Authentication::from);
 
@@ -527,7 +524,7 @@ impl Middleware for AuthMiddleware {
                 index,
                 auth_policy,
             )
-            .await
+            .await?
         {
             retry_request = credentials.authenticate(retry_request).await?;
             trace!("Retrying request for {url} with {credentials:?}");
@@ -672,7 +669,7 @@ impl AuthMiddleware {
                 index,
                 auth_policy,
             )
-            .await
+            .await?
         {
             request = credentials.authenticate(request).await?;
             Some(credentials)
@@ -705,7 +702,13 @@ impl AuthMiddleware {
         url: &DisplaySafeUrl,
         index: Option<&Index>,
         auth_policy: AuthPolicy,
-    ) -> Option<Arc<Authentication>> {
+    ) -> reqwest_middleware::Result<Option<Arc<Authentication>>> {
+        let is_s3_endpoint =
+            S3EndpointProvider::is_s3_endpoint(url, self.preview).map_err(Error::Middleware)?;
+        let is_gcs_endpoint =
+            GcsEndpointProvider::is_gcs_endpoint(url, self.preview).map_err(Error::Middleware)?;
+        let is_azure_endpoint = AzureEndpointProvider::is_azure_endpoint(url, self.preview)
+            .map_err(Error::Middleware)?;
         let username = Username::from(
             credentials.map(|credentials| credentials.username().unwrap_or_default().to_string()),
         );
@@ -727,7 +730,7 @@ impl AuthMiddleware {
                 );
             }
 
-            return credentials;
+            return Ok(credentials);
         }
 
         // Support for known providers, like Hugging Face and S3.
@@ -737,10 +740,10 @@ impl AuthMiddleware {
         {
             debug!("Found Hugging Face credentials for {url}");
             self.cache().fetches.done(key, Some(credentials.clone()));
-            return Some(credentials);
+            return Ok(Some(credentials));
         }
 
-        if S3EndpointProvider::is_s3_endpoint(url, self.preview) {
+        if is_s3_endpoint {
             let mut s3_state = self.s3_credential_state.lock().await;
 
             // If the S3 credential state is uninitialized, initialize it.
@@ -758,11 +761,11 @@ impl AuthMiddleware {
             if let Some(credentials) = credentials {
                 debug!("Found S3 credentials for {url}");
                 self.cache().fetches.done(key, Some(credentials.clone()));
-                return Some(credentials);
+                return Ok(Some(credentials));
             }
         }
 
-        if GcsEndpointProvider::is_gcs_endpoint(url, self.preview) {
+        if is_gcs_endpoint {
             let mut gcs_state = self.gcs_credential_state.lock().await;
 
             // If the GCS credential state is uninitialized, initialize it.
@@ -780,11 +783,11 @@ impl AuthMiddleware {
             if let Some(credentials) = credentials {
                 debug!("Found GCS credentials for {url}");
                 self.cache().fetches.done(key, Some(credentials.clone()));
-                return Some(credentials);
+                return Ok(Some(credentials));
             }
         }
 
-        if AzureEndpointProvider::is_azure_endpoint(url, self.preview) {
+        if is_azure_endpoint {
             let mut azure_state = self.azure_credential_state.lock().await;
 
             // If the Azure credential state is uninitialized, initialize it.
@@ -802,7 +805,7 @@ impl AuthMiddleware {
             if let Some(credentials) = credentials {
                 debug!("Found Azure credentials for {url}");
                 self.cache().fetches.done(key, Some(credentials.clone()));
-                return Some(credentials);
+                return Ok(Some(credentials));
             }
         }
 
@@ -963,7 +966,7 @@ impl AuthMiddleware {
         // Register the fetch for this key
         self.cache().fetches.done(key, credentials.clone());
 
-        credentials
+        Ok(credentials)
     }
 }
 

--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -58,11 +58,8 @@ impl HuggingFaceProvider {
 }
 
 /// The [`Url`] for the S3 endpoint, if set.
-static S3_ENDPOINT_URL: LazyLock<Option<Url>> = LazyLock::new(|| {
-    let s3_endpoint_url = std::env::var(EnvVars::UV_S3_ENDPOINT_URL).ok()?;
-    let url = Url::parse(&s3_endpoint_url).expect("Failed to parse S3 endpoint URL");
-    Some(url)
-});
+static S3_ENDPOINT_URL: LazyLock<Option<Url>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_S3_ENDPOINT_URL));
 
 /// A provider for authentication credentials for S3 endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,11 +104,8 @@ impl S3EndpointProvider {
 }
 
 /// The [`Url`] for the GCS endpoint, if set.
-static GCS_ENDPOINT_URL: LazyLock<Option<Url>> = LazyLock::new(|| {
-    let gcs_endpoint_url = std::env::var(EnvVars::UV_GCS_ENDPOINT_URL).ok()?;
-    let url = Url::parse(&gcs_endpoint_url).expect("Failed to parse GCS endpoint URL");
-    Some(url)
-});
+static GCS_ENDPOINT_URL: LazyLock<Option<Url>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_GCS_ENDPOINT_URL));
 
 /// A provider for authentication credentials for GCS endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,11 +141,20 @@ impl GcsEndpointProvider {
 }
 
 /// The [`Url`] for the Azure endpoint, if set.
-static AZURE_ENDPOINT_URL: LazyLock<Option<Url>> = LazyLock::new(|| {
-    let azure_endpoint_url = std::env::var(EnvVars::UV_AZURE_ENDPOINT_URL).ok()?;
-    let url = Url::parse(&azure_endpoint_url).expect("Failed to parse Azure endpoint URL");
-    Some(url)
-});
+static AZURE_ENDPOINT_URL: LazyLock<Option<Url>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_AZURE_ENDPOINT_URL));
+
+/// Returns the configured endpoint [`Url`], if set and valid.
+fn endpoint_url(env_var: &str) -> Option<Url> {
+    let endpoint_url = std::env::var(env_var).ok()?;
+    match Url::parse(&endpoint_url) {
+        Ok(url) => Some(url),
+        Err(err) => {
+            warn_user_once!("Ignoring invalid `{env_var}`: {err}");
+            None
+        }
+    }
+}
 
 /// A provider for authentication credentials for Azure endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -58,13 +58,13 @@ impl HuggingFaceProvider {
     }
 }
 
+/// The [`Url`] for the S3 endpoint, if set.
+static S3_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_S3_ENDPOINT_URL));
+
 /// A provider for authentication credentials for S3 endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct S3EndpointProvider;
-
-/// The parsed S3 endpoint, if configured.
-static S3_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
-    LazyLock::new(|| endpoint_url(EnvVars::UV_S3_ENDPOINT_URL));
 
 impl S3EndpointProvider {
     /// Returns `true` if the URL matches the configured S3 endpoint.
@@ -108,13 +108,13 @@ impl S3EndpointProvider {
     }
 }
 
+/// The [`Url`] for the GCS endpoint, if set.
+static GCS_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_GCS_ENDPOINT_URL));
+
 /// A provider for authentication credentials for GCS endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GcsEndpointProvider;
-
-/// The parsed GCS endpoint, if configured.
-static GCS_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
-    LazyLock::new(|| endpoint_url(EnvVars::UV_GCS_ENDPOINT_URL));
 
 impl GcsEndpointProvider {
     /// Returns `true` if the URL matches the configured GCS endpoint.
@@ -149,21 +149,13 @@ impl GcsEndpointProvider {
     }
 }
 
-/// Returns the configured endpoint [`Url`], if set and valid.
-fn endpoint_url(env_var: &str) -> Result<Option<Url>, ParseError> {
-    let Some(endpoint_url) = std::env::var(env_var).ok() else {
-        return Ok(None);
-    };
-    Url::parse(&endpoint_url).map(Some)
-}
+/// The [`Url`] for the Azure endpoint, if set.
+static AZURE_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_AZURE_ENDPOINT_URL));
 
 /// A provider for authentication credentials for Azure endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AzureEndpointProvider;
-
-/// The parsed Azure endpoint, if configured.
-static AZURE_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
-    LazyLock::new(|| endpoint_url(EnvVars::UV_AZURE_ENDPOINT_URL));
 
 impl AzureEndpointProvider {
     /// Returns `true` if the URL matches the configured Azure endpoint.
@@ -196,6 +188,14 @@ impl AzureEndpointProvider {
     pub(crate) fn create_signer() -> AzureDefaultSigner {
         reqsign::azure::default_signer()
     }
+}
+
+/// Returns the configured endpoint [`Url`], if set and valid.
+fn endpoint_url(env_var: &str) -> Result<Option<Url>, ParseError> {
+    let Some(endpoint_url) = std::env::var(env_var).ok() else {
+        return Ok(None);
+    };
+    Url::parse(&endpoint_url).map(Some)
 }
 
 /// Returns `true` if `url` is within the configured S3, GCS, or Azure-compatible endpoint URL.

--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 use std::sync::LazyLock;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result};
 use reqsign::aws::DefaultSigner as AwsDefaultSigner;
 use reqsign::azure::DefaultSigner as AzureDefaultSigner;
 use reqsign::google::DefaultSigner as GcsDefaultSigner;
 use tracing::debug;
-use url::{ParseError, Url};
+use url::Url;
 
 use uv_preview::{Preview, PreviewFeature};
 use uv_static::EnvVars;
@@ -58,18 +58,14 @@ impl HuggingFaceProvider {
     }
 }
 
-/// The [`Url`] for the S3 endpoint, if set.
-static S3_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
-    LazyLock::new(|| endpoint_url(EnvVars::UV_S3_ENDPOINT_URL));
-
 /// A provider for authentication credentials for S3 endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct S3EndpointProvider;
 
 impl S3EndpointProvider {
     /// Returns `true` if the URL matches the configured S3 endpoint.
-    pub(crate) fn is_s3_endpoint(url: &Url, preview: Preview) -> bool {
-        if let Ok(Some(s3_endpoint_url)) = S3_ENDPOINT_URL.as_ref() {
+    pub(crate) fn is_s3_endpoint(url: &Url, preview: Preview) -> Result<bool> {
+        if let Some(s3_endpoint_url) = endpoint_url(EnvVars::UV_S3_ENDPOINT_URL)? {
             if !preview.is_enabled(PreviewFeature::S3Endpoint) {
                 warn_user_once!(
                     "The `s3-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -79,11 +75,11 @@ impl S3EndpointProvider {
 
             // Treat any URL under the endpoint path on the same domain or subdomain as available
             // for S3 signing.
-            if is_endpoint_url(url, s3_endpoint_url) {
-                return true;
+            if is_endpoint_url(url, &s3_endpoint_url) {
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 
     /// Creates a new S3 signer with the configured region.
@@ -104,18 +100,14 @@ impl S3EndpointProvider {
     }
 }
 
-/// The [`Url`] for the GCS endpoint, if set.
-static GCS_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
-    LazyLock::new(|| endpoint_url(EnvVars::UV_GCS_ENDPOINT_URL));
-
 /// A provider for authentication credentials for GCS endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GcsEndpointProvider;
 
 impl GcsEndpointProvider {
     /// Returns `true` if the URL matches the configured GCS endpoint.
-    pub(crate) fn is_gcs_endpoint(url: &Url, preview: Preview) -> bool {
-        if let Ok(Some(gcs_endpoint_url)) = GCS_ENDPOINT_URL.as_ref() {
+    pub(crate) fn is_gcs_endpoint(url: &Url, preview: Preview) -> Result<bool> {
+        if let Some(gcs_endpoint_url) = endpoint_url(EnvVars::UV_GCS_ENDPOINT_URL)? {
             if !preview.is_enabled(PreviewFeature::GcsEndpoint) {
                 warn_user_once!(
                     "The `gcs-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -125,11 +117,11 @@ impl GcsEndpointProvider {
 
             // Treat any URL under the endpoint path on the same domain or subdomain as available
             // for GCS signing.
-            if is_endpoint_url(url, gcs_endpoint_url) {
-                return true;
+            if is_endpoint_url(url, &gcs_endpoint_url) {
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 
     /// Creates a new GCS signer.
@@ -141,30 +133,14 @@ impl GcsEndpointProvider {
     }
 }
 
-/// The [`Url`] for the Azure endpoint, if set.
-static AZURE_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
-    LazyLock::new(|| endpoint_url(EnvVars::UV_AZURE_ENDPOINT_URL));
-
 /// Returns the configured endpoint [`Url`], if set and valid.
-fn endpoint_url(env_var: &str) -> Result<Option<Url>, ParseError> {
+fn endpoint_url(env_var: &str) -> Result<Option<Url>> {
     let Some(endpoint_url) = std::env::var(env_var).ok() else {
         return Ok(None);
     };
-    Url::parse(&endpoint_url).map(Some)
-}
-
-/// Returns an error if a configured endpoint URL is invalid.
-pub(crate) fn validate_endpoint_urls() -> Result<()> {
-    for (env_var, endpoint_url) in [
-        (EnvVars::UV_S3_ENDPOINT_URL, &*S3_ENDPOINT_URL),
-        (EnvVars::UV_GCS_ENDPOINT_URL, &*GCS_ENDPOINT_URL),
-        (EnvVars::UV_AZURE_ENDPOINT_URL, &*AZURE_ENDPOINT_URL),
-    ] {
-        if let Err(err) = endpoint_url {
-            bail!("Invalid `{env_var}`: {err}");
-        }
-    }
-    Ok(())
+    Url::parse(&endpoint_url)
+        .map(Some)
+        .with_context(|| format!("Invalid `{env_var}`"))
 }
 
 /// A provider for authentication credentials for Azure endpoints.
@@ -173,8 +149,8 @@ pub(crate) struct AzureEndpointProvider;
 
 impl AzureEndpointProvider {
     /// Returns `true` if the URL matches the configured Azure endpoint.
-    pub(crate) fn is_azure_endpoint(url: &Url, preview: Preview) -> bool {
-        if let Ok(Some(azure_endpoint_url)) = AZURE_ENDPOINT_URL.as_ref() {
+    pub(crate) fn is_azure_endpoint(url: &Url, preview: Preview) -> Result<bool> {
+        if let Some(azure_endpoint_url) = endpoint_url(EnvVars::UV_AZURE_ENDPOINT_URL)? {
             if !preview.is_enabled(PreviewFeature::AzureEndpoint) {
                 warn_user_once!(
                     "The `azure-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -184,11 +160,11 @@ impl AzureEndpointProvider {
 
             // Treat any URL under the endpoint path on the same domain or subdomain as available
             // for Azure signing.
-            if is_endpoint_url(url, azure_endpoint_url) {
-                return true;
+            if is_endpoint_url(url, &azure_endpoint_url) {
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 
     /// Creates a new Azure signer using the default Azure credential chain.

--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -6,7 +6,7 @@ use reqsign::aws::DefaultSigner as AwsDefaultSigner;
 use reqsign::azure::DefaultSigner as AzureDefaultSigner;
 use reqsign::google::DefaultSigner as GcsDefaultSigner;
 use tracing::debug;
-use url::Url;
+use url::{ParseError, Url};
 
 use uv_preview::{Preview, PreviewFeature};
 use uv_static::EnvVars;
@@ -62,10 +62,18 @@ impl HuggingFaceProvider {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct S3EndpointProvider;
 
+/// The parsed S3 endpoint, if configured.
+static S3_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_S3_ENDPOINT_URL));
+
 impl S3EndpointProvider {
     /// Returns `true` if the URL matches the configured S3 endpoint.
     pub(crate) fn is_s3_endpoint(url: &Url, preview: Preview) -> Result<bool> {
-        if let Some(s3_endpoint_url) = endpoint_url(EnvVars::UV_S3_ENDPOINT_URL)? {
+        if let Some(s3_endpoint_url) = S3_ENDPOINT_URL
+            .as_ref()
+            .map_err(|error| *error)
+            .with_context(|| format!("Invalid `{}`", EnvVars::UV_S3_ENDPOINT_URL))?
+        {
             if !preview.is_enabled(PreviewFeature::S3Endpoint) {
                 warn_user_once!(
                     "The `s3-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -75,7 +83,7 @@ impl S3EndpointProvider {
 
             // Treat any URL under the endpoint path on the same domain or subdomain as available
             // for S3 signing.
-            if is_endpoint_url(url, &s3_endpoint_url) {
+            if is_endpoint_url(url, s3_endpoint_url) {
                 return Ok(true);
             }
         }
@@ -104,10 +112,18 @@ impl S3EndpointProvider {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GcsEndpointProvider;
 
+/// The parsed GCS endpoint, if configured.
+static GCS_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_GCS_ENDPOINT_URL));
+
 impl GcsEndpointProvider {
     /// Returns `true` if the URL matches the configured GCS endpoint.
     pub(crate) fn is_gcs_endpoint(url: &Url, preview: Preview) -> Result<bool> {
-        if let Some(gcs_endpoint_url) = endpoint_url(EnvVars::UV_GCS_ENDPOINT_URL)? {
+        if let Some(gcs_endpoint_url) = GCS_ENDPOINT_URL
+            .as_ref()
+            .map_err(|error| *error)
+            .with_context(|| format!("Invalid `{}`", EnvVars::UV_GCS_ENDPOINT_URL))?
+        {
             if !preview.is_enabled(PreviewFeature::GcsEndpoint) {
                 warn_user_once!(
                     "The `gcs-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -117,7 +133,7 @@ impl GcsEndpointProvider {
 
             // Treat any URL under the endpoint path on the same domain or subdomain as available
             // for GCS signing.
-            if is_endpoint_url(url, &gcs_endpoint_url) {
+            if is_endpoint_url(url, gcs_endpoint_url) {
                 return Ok(true);
             }
         }
@@ -134,23 +150,29 @@ impl GcsEndpointProvider {
 }
 
 /// Returns the configured endpoint [`Url`], if set and valid.
-fn endpoint_url(env_var: &str) -> Result<Option<Url>> {
+fn endpoint_url(env_var: &str) -> Result<Option<Url>, ParseError> {
     let Some(endpoint_url) = std::env::var(env_var).ok() else {
         return Ok(None);
     };
-    Url::parse(&endpoint_url)
-        .map(Some)
-        .with_context(|| format!("Invalid `{env_var}`"))
+    Url::parse(&endpoint_url).map(Some)
 }
 
 /// A provider for authentication credentials for Azure endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AzureEndpointProvider;
 
+/// The parsed Azure endpoint, if configured.
+static AZURE_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
+    LazyLock::new(|| endpoint_url(EnvVars::UV_AZURE_ENDPOINT_URL));
+
 impl AzureEndpointProvider {
     /// Returns `true` if the URL matches the configured Azure endpoint.
     pub(crate) fn is_azure_endpoint(url: &Url, preview: Preview) -> Result<bool> {
-        if let Some(azure_endpoint_url) = endpoint_url(EnvVars::UV_AZURE_ENDPOINT_URL)? {
+        if let Some(azure_endpoint_url) = AZURE_ENDPOINT_URL
+            .as_ref()
+            .map_err(|error| *error)
+            .with_context(|| format!("Invalid `{}`", EnvVars::UV_AZURE_ENDPOINT_URL))?
+        {
             if !preview.is_enabled(PreviewFeature::AzureEndpoint) {
                 warn_user_once!(
                     "The `azure-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -160,7 +182,7 @@ impl AzureEndpointProvider {
 
             // Treat any URL under the endpoint path on the same domain or subdomain as available
             // for Azure signing.
-            if is_endpoint_url(url, &azure_endpoint_url) {
+            if is_endpoint_url(url, azure_endpoint_url) {
                 return Ok(true);
             }
         }

--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -1,11 +1,12 @@
 use std::borrow::Cow;
 use std::sync::LazyLock;
 
+use anyhow::{Result, bail};
 use reqsign::aws::DefaultSigner as AwsDefaultSigner;
 use reqsign::azure::DefaultSigner as AzureDefaultSigner;
 use reqsign::google::DefaultSigner as GcsDefaultSigner;
 use tracing::debug;
-use url::Url;
+use url::{ParseError, Url};
 
 use uv_preview::{Preview, PreviewFeature};
 use uv_static::EnvVars;
@@ -58,7 +59,7 @@ impl HuggingFaceProvider {
 }
 
 /// The [`Url`] for the S3 endpoint, if set.
-static S3_ENDPOINT_URL: LazyLock<Option<Url>> =
+static S3_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
     LazyLock::new(|| endpoint_url(EnvVars::UV_S3_ENDPOINT_URL));
 
 /// A provider for authentication credentials for S3 endpoints.
@@ -68,7 +69,7 @@ pub(crate) struct S3EndpointProvider;
 impl S3EndpointProvider {
     /// Returns `true` if the URL matches the configured S3 endpoint.
     pub(crate) fn is_s3_endpoint(url: &Url, preview: Preview) -> bool {
-        if let Some(s3_endpoint_url) = S3_ENDPOINT_URL.as_ref() {
+        if let Ok(Some(s3_endpoint_url)) = S3_ENDPOINT_URL.as_ref() {
             if !preview.is_enabled(PreviewFeature::S3Endpoint) {
                 warn_user_once!(
                     "The `s3-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -104,7 +105,7 @@ impl S3EndpointProvider {
 }
 
 /// The [`Url`] for the GCS endpoint, if set.
-static GCS_ENDPOINT_URL: LazyLock<Option<Url>> =
+static GCS_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
     LazyLock::new(|| endpoint_url(EnvVars::UV_GCS_ENDPOINT_URL));
 
 /// A provider for authentication credentials for GCS endpoints.
@@ -114,7 +115,7 @@ pub(crate) struct GcsEndpointProvider;
 impl GcsEndpointProvider {
     /// Returns `true` if the URL matches the configured GCS endpoint.
     pub(crate) fn is_gcs_endpoint(url: &Url, preview: Preview) -> bool {
-        if let Some(gcs_endpoint_url) = GCS_ENDPOINT_URL.as_ref() {
+        if let Ok(Some(gcs_endpoint_url)) = GCS_ENDPOINT_URL.as_ref() {
             if !preview.is_enabled(PreviewFeature::GcsEndpoint) {
                 warn_user_once!(
                     "The `gcs-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -141,19 +142,29 @@ impl GcsEndpointProvider {
 }
 
 /// The [`Url`] for the Azure endpoint, if set.
-static AZURE_ENDPOINT_URL: LazyLock<Option<Url>> =
+static AZURE_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
     LazyLock::new(|| endpoint_url(EnvVars::UV_AZURE_ENDPOINT_URL));
 
 /// Returns the configured endpoint [`Url`], if set and valid.
-fn endpoint_url(env_var: &str) -> Option<Url> {
-    let endpoint_url = std::env::var(env_var).ok()?;
-    match Url::parse(&endpoint_url) {
-        Ok(url) => Some(url),
-        Err(err) => {
-            warn_user_once!("Ignoring invalid `{env_var}`: {err}");
-            None
+fn endpoint_url(env_var: &str) -> Result<Option<Url>, ParseError> {
+    let Some(endpoint_url) = std::env::var(env_var).ok() else {
+        return Ok(None);
+    };
+    Url::parse(&endpoint_url).map(Some)
+}
+
+/// Returns an error if a configured endpoint URL is invalid.
+pub(crate) fn validate_endpoint_urls() -> Result<()> {
+    for (env_var, endpoint_url) in [
+        (EnvVars::UV_S3_ENDPOINT_URL, &*S3_ENDPOINT_URL),
+        (EnvVars::UV_GCS_ENDPOINT_URL, &*GCS_ENDPOINT_URL),
+        (EnvVars::UV_AZURE_ENDPOINT_URL, &*AZURE_ENDPOINT_URL),
+    ] {
+        if let Err(err) = endpoint_url {
+            bail!("Invalid `{env_var}`: {err}");
         }
     }
+    Ok(())
 }
 
 /// A provider for authentication credentials for Azure endpoints.
@@ -163,7 +174,7 @@ pub(crate) struct AzureEndpointProvider;
 impl AzureEndpointProvider {
     /// Returns `true` if the URL matches the configured Azure endpoint.
     pub(crate) fn is_azure_endpoint(url: &Url, preview: Preview) -> bool {
-        if let Some(azure_endpoint_url) = AZURE_ENDPOINT_URL.as_ref() {
+        if let Ok(Some(azure_endpoint_url)) = AZURE_ENDPOINT_URL.as_ref() {
             if !preview.is_enabled(PreviewFeature::AzureEndpoint) {
                 warn_user_once!(
                     "The `azure-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",

--- a/crates/uv/tests/it/auth.rs
+++ b/crates/uv/tests/it/auth.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::{fixture::PathChild, prelude::FileWriteStr};
+use insta::allow_duplicates;
 use uv_static::EnvVars;
 
 use uv_test::uv_snapshot;
@@ -9,28 +10,31 @@ use uv_test::uv_snapshot;
 async fn invalid_cloud_endpoint_urls() {
     let context = uv_test::test_context!("3.12");
     let proxy = crate::pypi_proxy::start().await;
+    let mut filters = context.filters();
+    filters.push((r"UV_(S3|GCS|AZURE)_ENDPOINT_URL", "UV_[CLOUD]_ENDPOINT_URL"));
 
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg("--dry-run")
-        .arg("--default-index")
-        .arg(proxy.url("/basic-auth/simple"))
-        .arg("iniconfig")
-        .env(EnvVars::UV_S3_ENDPOINT_URL, "not-a-url")
-        .env(EnvVars::UV_GCS_ENDPOINT_URL, "not-a-url")
-        .env(EnvVars::UV_AZURE_ENDPOINT_URL, "not-a-url"), @"
-    success: false
-    exit_code: 1
-    ----- stdout -----
+    allow_duplicates! {
+        for env_var in [
+            EnvVars::UV_S3_ENDPOINT_URL,
+            EnvVars::UV_GCS_ENDPOINT_URL,
+            EnvVars::UV_AZURE_ENDPOINT_URL,
+        ] {
+            uv_snapshot!(filters, context.pip_install()
+                .arg("--dry-run")
+                .arg("--default-index")
+                .arg(proxy.url("/basic-auth/simple"))
+                .arg("iniconfig")
+                .env(env_var, "not-a-url"), @"
+            success: false
+            exit_code: 2
+            ----- stdout -----
 
-    ----- stderr -----
-    warning: Ignoring invalid `UV_S3_ENDPOINT_URL`: relative URL without a base
-    warning: Ignoring invalid `UV_GCS_ENDPOINT_URL`: relative URL without a base
-    warning: Ignoring invalid `UV_AZURE_ENDPOINT_URL`: relative URL without a base
-      × No solution found when resolving dependencies:
-      ╰─▶ Because iniconfig was not found in the package registry and you require iniconfig, we can conclude that your requirements are unsatisfiable.
-
-    hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
-    ");
+            ----- stderr -----
+            error: Failed to fetch: `http://[LOCALHOST]/basic-auth/simple/iniconfig/`
+              Caused by: Invalid `UV_[CLOUD]_ENDPOINT_URL`: relative URL without a base
+            ");
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/uv/tests/it/auth.rs
+++ b/crates/uv/tests/it/auth.rs
@@ -6,6 +6,34 @@ use uv_static::EnvVars;
 use uv_test::uv_snapshot;
 
 #[tokio::test]
+async fn invalid_cloud_endpoint_urls() {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--dry-run")
+        .arg("--default-index")
+        .arg(proxy.url("/basic-auth/simple"))
+        .arg("iniconfig")
+        .env(EnvVars::UV_S3_ENDPOINT_URL, "not-a-url")
+        .env(EnvVars::UV_GCS_ENDPOINT_URL, "not-a-url")
+        .env(EnvVars::UV_AZURE_ENDPOINT_URL, "not-a-url"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Ignoring invalid `UV_S3_ENDPOINT_URL`: relative URL without a base
+    warning: Ignoring invalid `UV_GCS_ENDPOINT_URL`: relative URL without a base
+    warning: Ignoring invalid `UV_AZURE_ENDPOINT_URL`: relative URL without a base
+      × No solution found when resolving dependencies:
+      ╰─▶ Because iniconfig was not found in the package registry and you require iniconfig, we can conclude that your requirements are unsatisfiable.
+
+    hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
+    ");
+}
+
+#[tokio::test]
 #[cfg(feature = "native-auth")]
 async fn add_package_native_auth_realm() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_real_home();

--- a/crates/uv/tests/it/auth.rs
+++ b/crates/uv/tests/it/auth.rs
@@ -31,7 +31,8 @@ async fn invalid_cloud_endpoint_urls() {
 
             ----- stderr -----
             error: Failed to fetch: `http://[LOCALHOST]/basic-auth/simple/iniconfig/`
-              Caused by: Invalid `UV_[CLOUD]_ENDPOINT_URL`: relative URL without a base
+              Caused by: Invalid `UV_[CLOUD]_ENDPOINT_URL`
+              Caused by: relative URL without a base
             ");
         }
     }


### PR DESCRIPTION
Invalid public S3, GCS, or Azure endpoint URL settings currently panic during credential-provider initialization. Parse the configured endpoint and return a clear error instead.