### PR TITLE
Avoid panics for invalid pylock artifact URLs

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -100,6 +100,8 @@ pub enum PylockTomlErrorKind {
     VcsMissingPathUrl(PackageName),
     #[error("URL must end in a valid wheel filename: `{0}`")]
     UrlMissingFilename(DisplaySafeUrl),
+    #[error("Artifact URL cannot be used to infer an index: `{0}`")]
+    InvalidArtifactUrl(UrlString),
     #[error("Path must end in a valid wheel filename: `{0}`")]
     PathMissingFilename(Box<Path>),
     #[error("Failed to convert path to URL")]
@@ -1444,7 +1446,10 @@ impl PylockTomlWheel {
             // do. In practice, the only effect here should be that we cache the wheel under a hash
             // of this URL (since we cache under the hash of the index).
             let mut index = file_url.to_url().map_err(PylockTomlErrorKind::ToUrl)?;
-            index.path_segments_mut().unwrap().pop();
+            index
+                .path_segments_mut()
+                .map_err(|()| PylockTomlErrorKind::InvalidArtifactUrl(file_url.clone()))?
+                .pop();
             IndexUrl::from(VerbatimUrl::from_url(index))
         };
 
@@ -1602,7 +1607,10 @@ impl PylockTomlSdist {
             // do. In practice, the only effect here should be that we cache the sdist under a hash
             // of this URL (since we cache under the hash of the index).
             let mut index = file_url.to_url().map_err(PylockTomlErrorKind::ToUrl)?;
-            index.path_segments_mut().unwrap().pop();
+            index
+                .path_segments_mut()
+                .map_err(|()| PylockTomlErrorKind::InvalidArtifactUrl(file_url.clone()))?
+                .pop();
             IndexUrl::from(VerbatimUrl::from_url(index))
         };
 

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -100,7 +100,7 @@ pub enum PylockTomlErrorKind {
     VcsMissingPathUrl(PackageName),
     #[error("URL must end in a valid wheel filename: `{0}`")]
     UrlMissingFilename(DisplaySafeUrl),
-    #[error("Artifact URL cannot be used to infer an index: `{0}`")]
+    #[error("Invalid artifact URL: `{0}`")]
     InvalidArtifactUrl(UrlString),
     #[error("Path must end in a valid wheel filename: `{0}`")]
     PathMissingFilename(Box<Path>),

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13068,6 +13068,70 @@ fn pep_751_install_registry_sdist() -> Result<()> {
 }
 
 #[test]
+fn pep_751_install_invalid_artifact_urls() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+    pylock_toml.write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+        requires-python = ">=3.12"
+
+        [[packages]]
+        name = "foo"
+        version = "1.0.0"
+        wheels = [{ name = "foo-1.0.0-py3-none-any.whl", url = "data:application/octet-stream,ignored", hashes = { sha256 = "0000000000000000000000000000000000000000000000000000000000000000" } }]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("--dry-run")
+        .arg("-r")
+        .arg("pylock.toml"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Artifact URL cannot be used to infer an index: `data:application/octet-stream,ignored`
+    "
+    );
+
+    pylock_toml.write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+        requires-python = ">=3.12"
+
+        [[packages]]
+        name = "foo"
+        version = "1.0.0"
+        sdist = { name = "foo-1.0.0.tar.gz", url = "data:application/octet-stream,ignored", hashes = { sha256 = "0000000000000000000000000000000000000000000000000000000000000000" } }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("--dry-run")
+        .arg("-r")
+        .arg("pylock.toml"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Artifact URL cannot be used to infer an index: `data:application/octet-stream,ignored`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_install_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13096,7 +13096,7 @@ fn pep_751_install_invalid_artifact_urls() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Artifact URL cannot be used to infer an index: `data:application/octet-stream,ignored`
+    error: Invalid artifact URL: `data:application/octet-stream,ignored`
     "
     );
 
@@ -13124,7 +13124,7 @@ fn pep_751_install_invalid_artifact_urls() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Artifact URL cannot be used to infer an index: `data:application/octet-stream,ignored`
+    error: Invalid artifact URL: `data:application/octet-stream,ignored`
     "
     );
 


### PR DESCRIPTION
Wheel and sdist artifact URLs that cannot be used to infer an index currently panic while processing `pylock.toml`. Return a clear invalid-artifact-URL error instead.