### PR TITLE
Avoid panic for invalid audit service URLs

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5573,7 +5573,7 @@ pub struct AuditArgs {
     /// The service needs to use the OSV protocol, unless a different
     /// format was requested by `--service-format`.
     #[arg(long, value_hint = ValueHint::Url)]
-    pub service_url: Option<String>,
+    pub service_url: Option<DisplaySafeUrl>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -17,7 +17,7 @@ use crate::commands::reporters::AuditReporter;
 use crate::printer::Printer;
 use crate::settings::{FrozenSource, LockCheck, ResolverSettings};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use rustc_hash::FxHashSet;
 use tracing::trace;
 use uv_audit::{
@@ -33,6 +33,7 @@ use uv_fs::{CWD, find_git_repository_root, relative_to};
 use uv_normalize::{DefaultExtras, DefaultGroups};
 use uv_preview::{Preview, PreviewFeature};
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
+use uv_redacted::DisplaySafeUrl;
 use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
 use uv_warnings::warn_user;
@@ -63,16 +64,10 @@ pub(crate) async fn audit(
     preview: Preview,
     output_format: AuditOutputFormat,
     service: VulnerabilityServiceFormat,
-    service_url: Option<String>,
+    service_url: Option<DisplaySafeUrl>,
     ignore: Vec<VulnerabilityID>,
     ignore_until_fixed: Vec<VulnerabilityID>,
 ) -> Result<ExitStatus> {
-    let service_url = service_url
-        .as_deref()
-        .map(str::parse)
-        .transpose()
-        .context("Invalid OSV service URL")?;
-
     // Check if the audit feature is in preview
     if !preview.is_enabled(PreviewFeature::Audit) {
         warn_user!(
@@ -254,9 +249,8 @@ pub(crate) async fn audit(
     let osv_future = async {
         match service {
             VulnerabilityServiceFormat::Osv => {
-                let osv_url = service_url.unwrap_or_else(|| osv::API_BASE.clone());
                 let client = CachedClient::new(base_client);
-                let service = osv::Osv::new(client, Some(osv_url), concurrency, cache.clone());
+                let service = osv::Osv::new(client, service_url, concurrency, cache.clone());
                 trace!("Auditing {n} dependencies against OSV", n = auditable.len());
                 service.query_batch(&dependencies, osv::Filter::All).await
             }

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -17,7 +17,7 @@ use crate::commands::reporters::AuditReporter;
 use crate::printer::Printer;
 use crate::settings::{FrozenSource, LockCheck, ResolverSettings};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rustc_hash::FxHashSet;
 use tracing::trace;
 use uv_audit::{
@@ -67,6 +67,12 @@ pub(crate) async fn audit(
     ignore: Vec<VulnerabilityID>,
     ignore_until_fixed: Vec<VulnerabilityID>,
 ) -> Result<ExitStatus> {
+    let service_url = service_url
+        .as_deref()
+        .map(str::parse)
+        .transpose()
+        .context("Invalid OSV service URL")?;
+
     // Check if the audit feature is in preview
     if !preview.is_enabled(PreviewFeature::Audit) {
         warn_user!(
@@ -248,10 +254,7 @@ pub(crate) async fn audit(
     let osv_future = async {
         match service {
             VulnerabilityServiceFormat::Osv => {
-                let osv_url = service_url
-                    .as_deref()
-                    .map(|url| url.parse().expect("invalid OSV service URL"))
-                    .unwrap_or_else(|| osv::API_BASE.clone());
+                let osv_url = service_url.unwrap_or_else(|| osv::API_BASE.clone());
                 let client = CachedClient::new(base_client);
                 let service = osv::Osv::new(client, Some(osv_url), concurrency, cache.clone());
                 trace!("Auditing {n} dependencies against OSV", n = auditable.len());

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -3114,7 +3114,7 @@ pub(crate) struct AuditSettings {
     pub(crate) settings: ResolverSettings,
     pub(crate) output_format: AuditOutputFormat,
     pub(crate) service_format: VulnerabilityServiceFormat,
-    pub(crate) service_url: Option<String>,
+    pub(crate) service_url: Option<DisplaySafeUrl>,
     pub(crate) ignore: Vec<VulnerabilityID>,
     pub(crate) ignore_until_fixed: Vec<VulnerabilityID>,
 }

--- a/crates/uv/tests/build/audit.rs
+++ b/crates/uv/tests/build/audit.rs
@@ -9,6 +9,25 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
 
+#[test]
+fn audit_invalid_service_url() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.audit()
+        .arg("--preview-features")
+        .arg("audit")
+        .arg("--service-url")
+        .arg("not-a-url"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Invalid OSV service URL
+      Caused by: relative URL without a base
+    ");
+}
+
 /// The workspace discovered while resolving settings is reused by `uv audit`.
 #[test]
 fn audit_reuses_settings_workspace_discovery() -> Result<()> {

--- a/crates/uv/tests/build/audit.rs
+++ b/crates/uv/tests/build/audit.rs
@@ -23,8 +23,9 @@ fn audit_invalid_service_url() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Invalid OSV service URL
-      Caused by: relative URL without a base
+    error: invalid value 'not-a-url' for '--service-url <SERVICE_URL>': relative URL without a base
+
+    For more information, try '--help'.
     ");
 }
 


### PR DESCRIPTION
An invalid `uv audit --service-url` value currently panics during URL parsing. Parse the service URL in the CLI layer and return the standard argument error instead.