### PR TITLE
Avoid panic for non-UTF-8 virtualenv paths

### DIFF
--- a/crates/uv-virtualenv/src/lib.rs
+++ b/crates/uv-virtualenv/src/lib.rs
@@ -32,6 +32,11 @@ pub enum Error {
         /// The non-virtual environment directory that would have been cleared.
         path: PathBuf,
     },
+    #[error("Virtual environment path is not valid UTF-8: {}", path.user_display())]
+    NonUtf8Path {
+        /// The non-UTF-8 virtual environment path.
+        path: PathBuf,
+    },
 }
 
 impl uv_errors::Hint for Error {

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -101,6 +101,12 @@ pub(crate) fn create(
     };
     let absolute = std::path::absolute(location)?;
 
+    if absolute.to_str().is_none() {
+        return Err(Error::NonUtf8Path {
+            path: location.to_path_buf(),
+        });
+    }
+
     // Validate the existing location.
     match location.metadata() {
         Ok(metadata) if metadata.is_file() => {

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -101,12 +101,6 @@ pub(crate) fn create(
     };
     let absolute = std::path::absolute(location)?;
 
-    if absolute.to_str().is_none() {
-        return Err(Error::NonUtf8Path {
-            path: location.to_path_buf(),
-        });
-    }
-
     // Validate the existing location.
     match location.metadata() {
         Ok(metadata) if metadata.is_file() => {
@@ -486,6 +480,12 @@ pub(crate) fn create(
         .map(|path| path.simplified().to_str().unwrap().replace('\\', "\\\\"))
         .join(path_sep);
 
+        let location_string = location
+            .simplified()
+            .to_str()
+            .ok_or_else(|| Error::NonUtf8Path {
+                path: location.clone(),
+            })?;
         let virtual_env_dir = match (relocatable, name.to_owned()) {
             (true, "activate") => Cow::Borrowed(
                 r#"'"$(dirname -- "$(dirname -- "$(realpath -- "$SCRIPT_PATH")")")"'"#,
@@ -497,10 +497,10 @@ pub(crate) fn create(
             (true, "activate.nu") => Cow::Borrowed(r"(path self | path dirname | path dirname)"),
             (false, "activate.nu") => Cow::Owned(format!(
                 "'{}'",
-                escape_posix_for_single_quotes(location.simplified().to_str().unwrap())
+                escape_posix_for_single_quotes(location_string)
             )),
             // Note: `activate.ps1` is already relocatable by default.
-            _ => escape_posix_for_single_quotes(location.simplified().to_str().unwrap()),
+            _ => escape_posix_for_single_quotes(location_string),
         };
 
         let activator = template

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -10,6 +10,8 @@ use uv_static::EnvVars;
 
 #[cfg(unix)]
 use fs_err::os::unix::fs::symlink;
+#[cfg(unix)]
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 use uv_test::{site_packages_path, uv_snapshot};
 
@@ -1487,6 +1489,31 @@ fn file_exists() -> Result<()> {
     );
 
     Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn non_utf8_path() {
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+    let path = OsStr::from_bytes(b".venv-\xff");
+
+    uv_snapshot!(context.filters(), context.venv()
+        .arg(path)
+        .arg("--python")
+        .arg("3.12"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv-�
+    error: Failed to create virtual environment
+      Caused by: Virtual environment path is not valid UTF-8: .venv-�
+    "
+    );
+
+    assert!(!context.temp_dir.path().join(path).exists());
 }
 
 #[test]

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1496,10 +1496,10 @@ fn file_exists() -> Result<()> {
 #[test]
 fn non_utf8_path() {
     let context = uv_test::test_context_with_versions!(&["3.12"]);
-    #[cfg(unix)]
-    let path = OsStr::from_bytes(b".venv-\xff");
-    #[cfg(windows)]
-    let path = OsString::from_wide(&[0x002e, 0x0076, 0x0065, 0x006e, 0x0076, 0x002d, 0xd800]);
+    let path = cfg_select! {
+        unix => OsStr::from_bytes(b".venv-\xff"),
+        windows => OsString::from_wide(&[0x002e, 0x0076, 0x0065, 0x006e, 0x0076, 0x002d, 0xd800]),
+    };
 
     uv_snapshot!(context.filters(), context.venv()
         .arg(path)

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1512,8 +1512,6 @@ fn non_utf8_path() {
       Caused by: Virtual environment path is not valid UTF-8: .venv-�
     "
     );
-
-    assert!(!context.temp_dir.path().join(path).exists());
 }
 
 #[test]

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -12,6 +12,8 @@ use uv_static::EnvVars;
 use fs_err::os::unix::fs::symlink;
 #[cfg(unix)]
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+#[cfg(windows)]
+use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
 use uv_test::{site_packages_path, uv_snapshot};
 
@@ -1491,11 +1493,13 @@ fn file_exists() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 #[test]
 fn non_utf8_path() {
     let context = uv_test::test_context_with_versions!(&["3.12"]);
+    #[cfg(unix)]
     let path = OsStr::from_bytes(b".venv-\xff");
+    #[cfg(windows)]
+    let path = OsString::from_wide(&[0x002e, 0x0076, 0x0065, 0x006e, 0x0076, 0x002d, 0xd800]);
 
     uv_snapshot!(context.filters(), context.venv()
         .arg(path)


### PR DESCRIPTION
A non-UTF-8 `uv venv` destination currently panics while generating activation scripts. Return a clear error at the activation-script conversion site instead.