### PR TITLE
Return an error from unsupported build-backend requires hooks

### DIFF
--- a/crates/uv/src/commands/build_backend.rs
+++ b/crates/uv/src/commands/build_backend.rs
@@ -1,5 +1,5 @@
 use crate::commands::ExitStatus;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use std::env;
 use std::io::Write;
 use std::path::Path;
@@ -53,12 +53,12 @@ pub(crate) fn build_editable(
 
 /// Not used from Python code, exists for symmetry with PEP 517.
 pub(crate) fn get_requires_for_build_sdist() -> Result<ExitStatus> {
-    unimplemented!("uv does not support extra requires")
+    bail!("uv does not support extra requires")
 }
 
 /// Not used from Python code, exists for symmetry with PEP 517.
 pub(crate) fn get_requires_for_build_wheel() -> Result<ExitStatus> {
-    unimplemented!("uv does not support extra requires")
+    bail!("uv does not support extra requires")
 }
 
 /// PEP 517 hook to just emit metadata through `.dist-info`.
@@ -75,7 +75,7 @@ pub(crate) fn prepare_metadata_for_build_wheel(metadata_directory: &Path) -> Res
 
 /// Not used from Python code, exists for symmetry with PEP 660.
 pub(crate) fn get_requires_for_build_editable() -> Result<ExitStatus> {
-    unimplemented!("uv does not support extra requires")
+    bail!("uv does not support extra requires")
 }
 
 /// PEP 660 hook to just emit metadata through `.dist-info`.

--- a/crates/uv/tests/build/build_backend.rs
+++ b/crates/uv/tests/build/build_backend.rs
@@ -5,7 +5,7 @@ use flate2::bufread::GzDecoder;
 use fs_err::File;
 use futures::io::AllowStdIo;
 use indoc::{formatdoc, indoc};
-use insta::{assert_json_snapshot, assert_snapshot};
+use insta::{allow_duplicates, assert_json_snapshot, assert_snapshot};
 use std::io::BufReader;
 use std::path::Path;
 use std::process::Command;
@@ -13,6 +13,28 @@ use tempfile::TempDir;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use uv_static::EnvVars;
 use uv_test::{uv_snapshot, venv_bin_path};
+
+#[test]
+fn get_requires_for_build_returns_error() {
+    let context = uv_test::test_context!("3.12");
+
+    allow_duplicates! {
+        for command in [
+            "get-requires-for-build-sdist",
+            "get-requires-for-build-wheel",
+            "get-requires-for-build-editable",
+        ] {
+            uv_snapshot!(context.build_backend().arg(command), @"
+            success: false
+            exit_code: 2
+            ----- stdout -----
+
+            ----- stderr -----
+            error: uv does not support extra requires
+            ");
+        }
+    }
+}
 
 const BUILT_BY_UV_TEST_SCRIPT: &str = indoc! {r#"
     from built_by_uv import greet


### PR DESCRIPTION
The three unsupported `uv build-backend get-requires-*` hooks currently panic when invoked. Exit with a clear unsupported-operation error instead.