### PR TITLE
Allow issue triage automation to run manually

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,6 +4,12 @@ name: "issue-triage"
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "The issue URL or number to triage"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -25,13 +31,13 @@ jobs:
 
       - name: "Collect issue context"
         run: |
-          gh issue view "$ISSUE_NUMBER" \
+          gh issue view "$ISSUE" \
             --repo "$GITHUB_REPOSITORY" \
             --json number,title,body,author \
             > .issue-triage-event.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE: ${{ inputs.issue || github.event.issue.number }}
 
       - name: "Triage issue"
         id: triage

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       issue:
-        description: "The issue URL or number to triage"
+        description: "An issue URL or number"
         required: true
         type: string
 


### PR DESCRIPTION
Allow maintainers to run the issue triage workflow against an existing issue by providing its URL or number. Opened issues continue to use the event issue automatically, while manual runs resolve the supplied reference with the same read-only collection step.