### PR TITLE
docs: differentiate global index option anchors by type

### DIFF
--- a/crates/uv-dev/src/generate_options_reference.rs
+++ b/crates/uv-dev/src/generate_options_reference.rs
@@ -208,9 +208,8 @@ impl Set {
 
 #[expect(clippy::format_push_string)]
 fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[Set]) {
-    let option_type = match &parents[0] {
-        Set::Global { option_type, .. } => option_type,
-        _ => unreachable!(),
+    let Set::Global { option_type, .. } = &parents[0] else {
+        unreachable!()
     };
 
     let header_level = if parents.len() > 1 { "####" } else { "###" };

--- a/crates/uv-dev/src/generate_options_reference.rs
+++ b/crates/uv-dev/src/generate_options_reference.rs
@@ -208,13 +208,31 @@ impl Set {
 
 #[expect(clippy::format_push_string)]
 fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[Set]) {
+    let option_type = match &parents[0] {
+        Set::Global { option_type, .. } => option_type,
+        _ => unreachable!(),
+    };
+
     let header_level = if parents.len() > 1 { "####" } else { "###" };
     let parents_anchor = parents.iter().filter_map(|parent| parent.name()).join("_");
 
     if parents_anchor.is_empty() {
+        let anchor = if name == "index" {
+            match option_type {
+                OptionType::ProjectMetadata => "index",
+                OptionType::Configuration => "index-configuration",
+            }
+        } else {
+            name
+        };
+
         output.push_str(&format!(
-            "{header_level} [`{name}`](#{name}) {{: #{name} }}\n"
+            "{header_level} [`{name}`](#{anchor}) {{: #{anchor} }}\n"
         ));
+
+        if anchor != name {
+            output.push_str(&format!("<span id=\"{name}\"></span>\n"));
+        }
     } else {
         output.push_str(&format!(
             "{header_level} [`{name}`](#{parents_anchor}_{name}) {{: #{parents_anchor}_{name} }}\n"


### PR DESCRIPTION
## Summary

Differentiates the anchor names generated for the duplicate top-level `index` option settings. The Project Metadata `index` retains `#index` as its anchor, while the Configuration `index` gets `#index-configuration` to avoid overlapping headings and broken sidebar links.

Closes #18789.

## Test Plan

- Ran `cargo dev generate-all` to regenerate settings reference.
- Verified that the generated `docs/reference/settings.md` correctly has the unique anchor `#index-configuration` and retains a fallback `<span id="index"></span>` for backwards compatibility.