### PR TITLE
docs: document platform limitation for required-environments

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -624,6 +624,8 @@ pub struct ToolUv {
     /// macOS (and ignoring Linux and Windows). On the other hand, `required-environments = ["sys_platform == 'darwin'"]`
     /// would _require_ that any package without a source distribution include a wheel for macOS in
     /// order to be installable.
+    ///
+    /// Note that `required-environments` is limited to platforms for which uv can map markers to compatibility tags (currently macOS, Linux, and Windows). Other platforms (like FreeBSD) are not currently supported.
     #[cfg_attr(
         feature = "schemars",
         schemars(


### PR DESCRIPTION
## Summary

Adds a note to the `required-environments` docstring explaining that environment marker resolution is limited to platforms that `uv` can manually map compatibility tags for (currently macOS, Linux, and Windows). Other platforms like FreeBSD are not currently supported.

Closes #17382.

## Test Plan

- Ran `cargo dev generate-all` to rebuild options reference.
- Verified that the generated `docs/reference/settings.md` now includes the note.