### PR TITLE
Reject build backends outside the source tree

### DIFF
--- a/crates/uv-build-frontend/src/error.rs
+++ b/crates/uv-build-frontend/src/error.rs
@@ -71,6 +71,8 @@ pub enum Error {
     InvalidPyprojectTomlSchema(#[from] toml_edit::de::Error),
     #[error("`backend-path` entry `{0}` does not exist or is not a directory")]
     InvalidBackendPath(String),
+    #[error("`backend-path` entry `{0}` must be a relative path within the source tree")]
+    BackendPathOutsideSourceTree(String),
     #[error("Failed to resolve requirements from {0}")]
     RequirementsResolve(&'static str, #[source] AnyErrorBuild),
     #[error("Failed to install requirements from {0}")]
@@ -108,6 +110,7 @@ impl IsBuildBackendError for Error {
             | Self::InvalidPyprojectTomlSyntax(_)
             | Self::InvalidPyprojectTomlSchema(_)
             | Self::InvalidBackendPath(_)
+            | Self::BackendPathOutsideSourceTree(_)
             | Self::RequirementsResolve(_, _)
             | Self::RequirementsInstall(_, _)
             | Self::Virtualenv(_)

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -616,9 +616,24 @@ impl SourceBuild {
             .as_ref()
             .and_then(|build_system| build_system.backend_path.as_ref())
         {
+            let source_tree = fs_err::canonicalize(source_tree).map_err(Error::Io)?;
             for path in backend_path.iter() {
-                if !source_tree.join(path).is_dir() {
+                if Path::new(path).is_absolute() {
+                    return Err(Box::new(Error::BackendPathOutsideSourceTree(
+                        path.to_string(),
+                    )));
+                }
+                let backend_path = source_tree.join(path);
+                if !backend_path.is_dir() {
                     return Err(Box::new(Error::InvalidBackendPath(path.to_string())));
+                }
+                if !fs_err::canonicalize(backend_path)
+                    .map_err(Error::Io)?
+                    .starts_with(&source_tree)
+                {
+                    return Err(Box::new(Error::BackendPathOutsideSourceTree(
+                        path.to_string(),
+                    )));
                 }
             }
         }

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -247,6 +247,117 @@ fn build_sdist_missing_backend_path() -> Result<()> {
     Ok(())
 }
 
+/// An in-tree build backend must not be able to escape the source tree via `backend-path`.
+#[test]
+fn build_backend_path_outside_source_tree() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let project = context.temp_dir.child("project");
+
+    project.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = []
+        build-backend = "backend"
+        backend-path = ["../backend"]
+    "#})?;
+    context
+        .temp_dir
+        .child("backend/backend.py")
+        .write_str("raise RuntimeError('outside backend was executed')\n")?;
+
+    uv_snapshot!(context.filters(), context.build().arg("--wheel").arg(project.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel...
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: `backend-path` entry `../backend` must be a relative path within the source tree
+    ");
+
+    Ok(())
+}
+
+/// PEP 517 requires `backend-path` entries to be relative, even when they point inside the tree.
+#[cfg(unix)]
+#[test]
+fn build_backend_path_absolute_inside_source_tree() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let project = context.temp_dir.child("project");
+    let backend = project.child("backend");
+
+    project.child("pyproject.toml").write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = []
+        build-backend = "backend"
+        backend-path = ["{}"]
+    "#, backend.path().display()})?;
+    backend
+        .child("backend.py")
+        .write_str("raise RuntimeError('absolute backend was executed')\n")?;
+
+    uv_snapshot!(context.filters(), context.build().arg("--wheel").arg(project.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel...
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: `backend-path` entry `[TEMP_DIR]/project/backend` must be a relative path within the source tree
+    ");
+
+    Ok(())
+}
+
+/// Resolving an in-tree backend path must not follow a symlink outside the source tree.
+#[cfg(unix)]
+#[test]
+fn build_backend_path_symlink_outside_source_tree() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let project = context.temp_dir.child("project");
+
+    project.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = []
+        build-backend = "backend"
+        backend-path = ["backend"]
+    "#})?;
+    context
+        .temp_dir
+        .child("backend/backend.py")
+        .write_str("raise RuntimeError('outside backend was executed')\n")?;
+    fs_err::os::unix::fs::symlink(context.temp_dir.child("backend"), project.child("backend"))?;
+
+    uv_snapshot!(context.filters(), context.build().arg("--wheel").arg(project.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel...
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: `backend-path` entry `backend` must be a relative path within the source tree
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn build_sdist() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
A PEP 517 `backend-path` containing `../outside` can pass an `is_dir` check and be prepended to `sys.path`; uv then executes the external backend while pip rejects the project. Canonicalize `backend-path` entries and enforce source-tree containment, including symlinks.

See [PEP 517's in-tree-backend requirements](https://peps.python.org/pep-0517/#in-tree-build-backends).

This extends backend-path validation from [uv#19834](https://github.com/astral-sh/uv/pull/19834) but revisits the compatibility decision in [uv#3747](https://github.com/astral-sh/uv/issues/3747); out-of-tree backends that previously worked will be rejected.