### PR TITLE
Respect package-scoped source filtering for scripts

### DIFF
--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -98,29 +99,38 @@ impl Pep723ItemRef<'_> {
     /// Collect any `tool.uv.index` from the script.
     pub fn indexes(&self, source_strategy: &NoSources) -> &[uv_distribution_types::Index] {
         match source_strategy {
-            NoSources::None => self
+            NoSources::None | NoSources::Packages(_) => self
                 .metadata()
                 .tool
                 .as_ref()
                 .and_then(|tool| tool.uv.as_ref())
                 .and_then(|uv| uv.top_level.index.as_deref())
                 .unwrap_or(&[]),
-            NoSources::All | NoSources::Packages(_) => &[],
+            NoSources::All => &[],
         }
     }
 
     /// Collect any `tool.uv.sources` from the script.
-    pub fn sources(&self, source_strategy: &NoSources) -> &BTreeMap<PackageName, Sources> {
+    pub fn sources(&self, source_strategy: &NoSources) -> Cow<'_, BTreeMap<PackageName, Sources>> {
         static EMPTY: BTreeMap<PackageName, Sources> = BTreeMap::new();
+        let sources = self
+            .metadata()
+            .tool
+            .as_ref()
+            .and_then(|tool| tool.uv.as_ref())
+            .and_then(|uv| uv.sources.as_ref())
+            .unwrap_or(&EMPTY);
+
         match source_strategy {
-            NoSources::None => self
-                .metadata()
-                .tool
-                .as_ref()
-                .and_then(|tool| tool.uv.as_ref())
-                .and_then(|uv| uv.sources.as_ref())
-                .unwrap_or(&EMPTY),
-            NoSources::All | NoSources::Packages(_) => &EMPTY,
+            NoSources::None => Cow::Borrowed(sources),
+            NoSources::All => Cow::Borrowed(&EMPTY),
+            NoSources::Packages(packages) => Cow::Owned(
+                sources
+                    .iter()
+                    .filter(|(name, _)| !packages.contains(name))
+                    .map(|(name, sources)| (name.clone(), sources.clone()))
+                    .collect(),
+            ),
         }
     }
 }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -3158,7 +3158,7 @@ pub(crate) fn script_specification(
             LoweredRequirement::from_non_workspace_requirement(
                 requirement,
                 script_dir.as_ref(),
-                script_sources,
+                script_sources.as_ref(),
                 script_indexes,
                 &settings.index_locations,
                 credentials_cache,
@@ -3179,7 +3179,7 @@ pub(crate) fn script_specification(
             LoweredRequirement::from_non_workspace_requirement(
                 requirement,
                 script_dir.as_ref(),
-                script_sources,
+                script_sources.as_ref(),
                 script_indexes,
                 &settings.index_locations,
                 credentials_cache,
@@ -3205,7 +3205,7 @@ pub(crate) fn script_specification(
                         LoweredRequirement::from_non_workspace_requirement(
                             requirement,
                             script_dir.as_ref(),
-                            script_sources,
+                            script_sources.as_ref(),
                             script_indexes,
                             &settings.index_locations,
                             credentials_cache,
@@ -3224,7 +3224,7 @@ pub(crate) fn script_specification(
                             LoweredRequirement::from_non_workspace_requirement(
                                 requirement,
                                 script_dir.as_ref(),
-                                script_sources,
+                                script_sources.as_ref(),
                                 script_indexes,
                                 &settings.index_locations,
                                 credentials_cache,
@@ -3293,7 +3293,7 @@ pub(crate) fn script_extra_build_requires(
                     LoweredRequirement::from_non_workspace_requirement(
                         requirement,
                         script_dir.as_ref(),
-                        script_sources,
+                        script_sources.as_ref(),
                         script_indexes,
                         &settings.index_locations,
                         credentials_cache,

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::{fixture::ChildPath, prelude::*};
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
 use predicates::{prelude::predicate, str::contains};
 use serde_json::json;
@@ -14,7 +14,7 @@ use uv_static::EnvVars;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use uv_test::{TestContext, uv_snapshot};
+use uv_test::{TestContext, packse::PackseServer, uv_snapshot};
 
 #[test]
 fn run_with_python_version() -> Result<()> {
@@ -838,6 +838,64 @@ fn run_pep723_script_index() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + idna==2.7
+    ");
+
+    Ok(())
+}
+
+/// Package-scoped source disabling must not discard unrelated script sources or indexes.
+#[test]
+fn run_pep723_script_no_sources_package() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let explicit = PackseServer::new("simple/single-package.toml");
+    let default = PackseServer::new("extras/missing-extra.toml");
+
+    let test_script = context.temp_dir.child("main.py");
+    test_script.write_str(&formatdoc! { r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "a",
+        # ]
+        #
+        # [[tool.uv.index]]
+        # name = "test"
+        # url = "{index}"
+        # explicit = true
+        #
+        # [tool.uv.sources]
+        # a = {{ index = "test" }}
+        # ///
+
+        import a
+       "#,
+        index = explicit.index_url(),
+    })?;
+
+    uv_snapshot!(context.filters(), context.run().arg("--default-index").arg(default.index_url()).arg("--no-sources-package").arg("unrelated").arg("main.py"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + a==2.0.0
+    ");
+
+    fs_err::remove_dir_all(&context.cache_dir)?;
+
+    uv_snapshot!(context.filters(), context.run().arg("--default-index").arg(default.index_url()).arg("--no-sources-package").arg("a").arg("main.py"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + a==1.0.0
     ");
 
     Ok(())


### PR DESCRIPTION
`uv run --no-sources-package unrelated` drops every PEP 723 `tool.uv.sources` and `[[tool.uv.index]]` entry, so an unrelated package filter can make a valid local-wheel dependency unavailable even though `uv lock --script` retains it. Filter script sources by the specified package.

See [the original package-scoped-sources request](https://github.com/astral-sh/uv/issues/14694).
