### PR TITLE
Reject duplicate active pylock packages

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -44,6 +45,8 @@ use crate::{Installable, LockError, ResolverOutput};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PylockTomlErrorKind {
+    #[error("Multiple active package entries found for `{0}`")]
+    DuplicateActivePackage(PackageName),
     #[error("Package `{0}` requires Python {2}, but the target Python version is {1}")]
     IncompatibleRequiresPython(PackageName, Version, RequiresPython),
     #[error(
@@ -1051,11 +1054,17 @@ impl<'lock> PylockToml {
 
         // Add the root node.
         let root = graph.add_node(Node::Root);
+        let mut active_packages = HashSet::new();
 
         for package in self.packages {
             // Omit packages that aren't relevant to the current environment.
             if !package.marker.evaluate_pep751(markers, extras, groups) {
                 continue;
+            }
+            if !active_packages.insert(package.name.clone()) {
+                return Err(
+                    PylockTomlErrorKind::DuplicateActivePackage(package.name.clone()).into(),
+                );
             }
 
             if let Some(requires_python) = package.requires_python.as_ref()

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -6069,6 +6069,41 @@ fn pep_751() -> Result<()> {
 }
 
 #[test]
+fn pep_751_rejects_duplicate_active_packages() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pylock.toml").write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "iniconfig"
+        version = "2.0.0"
+        wheels = [{ url = "https://example.com/iniconfig-2.0.0-py3-none-any.whl", hashes = { sha256 = "0000000000000000000000000000000000000000000000000000000000000000" } }]
+
+        [[packages]]
+        name = "iniconfig"
+        version = "2.1.0"
+        wheels = [{ url = "https://example.com/iniconfig-2.1.0-py3-none-any.whl", hashes = { sha256 = "1111111111111111111111111111111111111111111111111111111111111111" } }]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Multiple active package entries found for `iniconfig`
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_require_hashes_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
Two matching `[[packages]]` entries for the same package can produce duplicate or conflicting installation plans. Reject a `pylock.toml` when more than one active entry remains for a package.

See [the `pylock.toml` packages specification](https://packaging.python.org/en/latest/specifications/pylock-toml/#packages).

Legitimate multiple entries with mutually exclusive markers, such as Torch in [uv#13127](https://github.com/astral-sh/uv/issues/13127), remain valid; only duplicate active identities are rejected.
