### PR TITLE
Prefer local artifacts when installing pylock files

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1425,12 +1425,12 @@ impl PylockTomlWheel {
     ) -> Result<RegistryBuiltWheel, PylockTomlErrorKind> {
         let filename = self.filename(name)?.into_owned();
 
-        let file_url = if let Some(url) = self.url.as_ref() {
-            UrlString::from(url)
-        } else if let Some(path) = self.path.as_ref() {
+        let file_url = if let Some(path) = self.path.as_ref() {
             let path = install_path.join(path);
             let url = DisplaySafeUrl::from_file_path(path)
                 .map_err(|()| PylockTomlErrorKind::PathToUrl)?;
+            UrlString::from(url)
+        } else if let Some(url) = self.url.as_ref() {
             UrlString::from(url)
         } else {
             return Err(PylockTomlErrorKind::WheelMissingPathUrl(name.clone()));
@@ -1583,12 +1583,12 @@ impl PylockTomlSdist {
             Cow::Owned(filename.version)
         };
 
-        let file_url = if let Some(url) = self.url.as_ref() {
-            UrlString::from(url)
-        } else if let Some(path) = self.path.as_ref() {
+        let file_url = if let Some(path) = self.path.as_ref() {
             let path = install_path.join(path);
             let url = DisplaySafeUrl::from_file_path(path)
                 .map_err(|()| PylockTomlErrorKind::PathToUrl)?;
+            UrlString::from(url)
+        } else if let Some(url) = self.url.as_ref() {
             UrlString::from(url)
         } else {
             return Err(PylockTomlErrorKind::SdistMissingPathUrl(name.clone()));
@@ -1636,32 +1636,7 @@ impl PylockTomlArchive {
         name: &PackageName,
         version: Option<&Version>,
     ) -> Result<Dist, PylockTomlErrorKind> {
-        if let Some(url) = self.url.as_ref() {
-            let filename = url
-                .filename()
-                .map_err(|_| PylockTomlErrorKind::UrlMissingFilename(url.clone()))?;
-
-            let ext = DistExtension::from_path(filename.as_ref())?;
-            match ext {
-                DistExtension::Wheel => {
-                    let filename = WheelFilename::from_str(&filename)?;
-                    Ok(Dist::Built(BuiltDist::DirectUrl(DirectUrlBuiltDist {
-                        filename,
-                        location: Box::new(url.clone()),
-                        url: VerbatimUrl::from_url(url.clone()),
-                    })))
-                }
-                DistExtension::Source(ext) => {
-                    Ok(Dist::Source(SourceDist::DirectUrl(DirectUrlSourceDist {
-                        name: name.clone(),
-                        location: Box::new(url.clone()),
-                        subdirectory: self.subdirectory.clone().map(Box::<Path>::from),
-                        ext,
-                        url: VerbatimUrl::from_url(url.clone()),
-                    })))
-                }
-            }
-        } else if let Some(path) = self.path.as_ref() {
+        if let Some(path) = self.path.as_ref() {
             let filename = path
                 .as_ref()
                 .file_name()
@@ -1696,6 +1671,31 @@ impl PylockTomlArchive {
                     })))
                 }
             }
+        } else if let Some(url) = self.url.as_ref() {
+            let filename = url
+                .filename()
+                .map_err(|_| PylockTomlErrorKind::UrlMissingFilename(url.clone()))?;
+
+            let ext = DistExtension::from_path(filename.as_ref())?;
+            match ext {
+                DistExtension::Wheel => {
+                    let filename = WheelFilename::from_str(&filename)?;
+                    Ok(Dist::Built(BuiltDist::DirectUrl(DirectUrlBuiltDist {
+                        filename,
+                        location: Box::new(url.clone()),
+                        url: VerbatimUrl::from_url(url.clone()),
+                    })))
+                }
+                DistExtension::Source(ext) => {
+                    Ok(Dist::Source(SourceDist::DirectUrl(DirectUrlSourceDist {
+                        name: name.clone(),
+                        location: Box::new(url.clone()),
+                        subdirectory: self.subdirectory.clone().map(Box::<Path>::from),
+                        ext,
+                        url: VerbatimUrl::from_url(url.clone()),
+                    })))
+                }
+            }
         } else {
             Err(PylockTomlErrorKind::ArchiveMissingPathUrl(name.clone()))
         }
@@ -1703,14 +1703,7 @@ impl PylockTomlArchive {
 
     /// Returns `true` if the [`PylockTomlArchive`] is a wheel.
     fn is_wheel(&self, name: &PackageName) -> Result<bool, PylockTomlErrorKind> {
-        if let Some(url) = self.url.as_ref() {
-            let filename = url
-                .filename()
-                .map_err(|_| PylockTomlErrorKind::UrlMissingFilename(url.clone()))?;
-
-            let ext = DistExtension::from_path(filename.as_ref())?;
-            Ok(matches!(ext, DistExtension::Wheel))
-        } else if let Some(path) = self.path.as_ref() {
+        if let Some(path) = self.path.as_ref() {
             let filename = path
                 .as_ref()
                 .file_name()
@@ -1720,6 +1713,13 @@ impl PylockTomlArchive {
                 })?;
 
             let ext = DistExtension::from_path(filename)?;
+            Ok(matches!(ext, DistExtension::Wheel))
+        } else if let Some(url) = self.url.as_ref() {
+            let filename = url
+                .filename()
+                .map_err(|_| PylockTomlErrorKind::UrlMissingFilename(url.clone()))?;
+
+            let ext = DistExtension::from_path(filename.as_ref())?;
             Ok(matches!(ext, DistExtension::Wheel))
         } else {
             Err(PylockTomlErrorKind::ArchiveMissingPathUrl(name.clone()))

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13457,6 +13457,57 @@ fn pep_751_install_path_wheel() -> Result<()> {
 }
 
 #[test]
+fn pep_751_prefers_path_over_url() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+
+    for wheel in [
+        "ok-1.0.0-py3-none-any.whl",
+        "basic_package-0.1.0-py3-none-any.whl",
+    ] {
+        fs::copy(
+            context.workspace_root.join("test/links").join(wheel),
+            context.temp_dir.child(wheel),
+        )?;
+    }
+
+    context.temp_dir.child("pylock.toml").write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "ok"
+        version = "1.0.0"
+        archive = { path = "ok-1.0.0-py3-none-any.whl", url = "https://example.invalid/ok-1.0.0.tar.gz", hashes = { sha256 = "79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f" } }
+
+        [[packages]]
+        name = "basic-package"
+        version = "0.1.0"
+        wheels = [{ path = "basic_package-0.1.0-py3-none-any.whl", url = "https://example.invalid/basic_package-0.1.0-py3-none-any.whl", hashes = { sha256 = "7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" } }]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("--no-build")
+        .arg("-r")
+        .arg("pylock.toml"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + basic-package==0.1.0
+     + ok==1.0.0 (from file://[TEMP_DIR]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_install_path_sdist() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
When a `pylock.toml` wheel or sdist has both `path` and `url`, uv selects the URL first, so offline installation can fail or fetch an unintended artifact. Prefer `path`, matching the installation algorithm, and apply the same precedence when converting or classifying `[packages.archive]`.

See [the `pylock.toml` installation specification](https://packaging.python.org/en/latest/specifications/pylock-toml/#installation).
