### PR TITLE
Finalize compressed tar streams during extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,20 +359,16 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.19"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
 dependencies = [
- "bzip2",
- "flate2",
+ "compression-codecs",
+ "compression-core",
  "futures-core",
  "futures-io",
- "memchr",
  "pin-project-lite",
  "tokio",
- "xz2",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -660,21 +656,11 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -966,6 +952,27 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+dependencies = [
+ "bzip2",
+ "compression-core",
+ "flate2",
+ "liblzma",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
 
 [[package]]
 name = "concurrent-queue"
@@ -2622,10 +2629,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "liblzma"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bf66f4598dc77ff96677c8e763655494f00ff9c1cf79e2eb5bb07bc31f807d"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5839bad90c3cc2e0b8c4ed8296b80e86040240f81d46b9c0e9bc8dd51ddd3af1"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -2689,17 +2722,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "mailparse"
@@ -6586,12 +6608,14 @@ dependencies = [
  "flate2",
  "fs-err",
  "futures",
+ "liblzma",
  "md-5",
  "rayon",
  "regex",
  "reqwest",
  "rustc-hash",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -6601,7 +6625,6 @@ dependencies = [
  "uv-pypi-types",
  "uv-static",
  "uv-warnings",
- "xz2",
 ]
 
 [[package]]
@@ -8127,15 +8150,6 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ arcstr = { version = "1.2.0" }
 arrayvec = { version = "0.7.6" }
 astral-tokio-tar = { version = "0.6.3" }
 async-channel = { version = "2.3.1" }
-async-compression = { version = "0.4.12", features = [
+async-compression = { version = "0.4.33", features = [
   "bzip2",
   "gzip",
   "xz",
@@ -176,6 +176,7 @@ indoc = { version = "2.0.5" }
 itertools = { version = "0.14.0" }
 jiff = { version = "0.2.0", features = ["serde"] }
 junction = { version = "2.0.0" }
+liblzma = { version = "0.4.4", default-features = false, features = ["static"] }
 mailparse = { version = "0.16.0" }
 md-5 = { version = "0.10.6" }
 memchr = { version = "2.7.4" }
@@ -316,7 +317,6 @@ windows = { version = "0.61.0", features = [
 windows-registry = { version = "0.5.0" }
 windows-version = { version = "0.1.6" }
 wiremock = { version = "0.6.4" }
-xz2 = { version = "0.1.7", features = ["static"] }
 zeroize = { version = "1.8.1" }
 
 # dev-dependencies

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -29,6 +29,7 @@ blake2 = { workspace = true }
 flate2 = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
+liblzma = { workspace = true }
 md-5 = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
@@ -39,15 +40,17 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
-xz2 = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [features]
 default = []
 # Avoid a liblzma.so dependency
-static = ["xz2/static"]
+static = ["liblzma/static"]
 
 [package.metadata.cargo-shear]
 # NOTE: `async-compression` owns the actual Deflate codec, but we need to
 # explicitly declare `flate2` here so the workspace's `zlib-rs` backend stays
 # selected after removing the synchronous `zip` dependency.
-ignored = ["flate2", "xz2"]
+ignored = ["liblzma"]

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -670,17 +670,8 @@ async fn untar_gz<R: tokio::io::AsyncRead + Unpin>(
 ) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let mut decompressed_bytes = async_compression::tokio::bufread::GzipDecoder::new(reader);
-
-    let archive = tokio_tar::ArchiveBuilder::new(
-        &mut decompressed_bytes as &mut (dyn tokio::io::AsyncRead + Unpin),
-    )
-    .set_preserve_mtime(false)
-    .set_preserve_permissions(false)
-    .set_allow_external_symlinks(false)
-    .build();
-    untar_in(archive, target.as_ref())
-        .await
-        .map_err(Error::io_or_compression)
+    decompressed_bytes.multiple_members(true);
+    untar_compressed(decompressed_bytes, target.as_ref()).await
 }
 
 /// Unpack a `.tar.bz2` archive into the target directory, without requiring `Seek`.
@@ -694,17 +685,8 @@ async fn untar_bz2<R: tokio::io::AsyncRead + Unpin>(
 ) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let mut decompressed_bytes = async_compression::tokio::bufread::BzDecoder::new(reader);
-
-    let archive = tokio_tar::ArchiveBuilder::new(
-        &mut decompressed_bytes as &mut (dyn tokio::io::AsyncRead + Unpin),
-    )
-    .set_preserve_mtime(false)
-    .set_preserve_permissions(false)
-    .set_allow_external_symlinks(false)
-    .build();
-    untar_in(archive, target.as_ref())
-        .await
-        .map_err(Error::io_or_compression)
+    decompressed_bytes.multiple_members(true);
+    untar_compressed(decompressed_bytes, target.as_ref()).await
 }
 
 /// Unpack a `.tar.zst` archive into the target directory, without requiring `Seek`.
@@ -718,17 +700,8 @@ pub async fn untar_zst<R: tokio::io::AsyncRead + Unpin>(
 ) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let mut decompressed_bytes = async_compression::tokio::bufread::ZstdDecoder::new(reader);
-
-    let archive = tokio_tar::ArchiveBuilder::new(
-        &mut decompressed_bytes as &mut (dyn tokio::io::AsyncRead + Unpin),
-    )
-    .set_preserve_mtime(false)
-    .set_preserve_permissions(false)
-    .set_allow_external_symlinks(false)
-    .build();
-    untar_in(archive, target.as_ref())
-        .await
-        .map_err(Error::io_or_compression)
+    decompressed_bytes.multiple_members(true);
+    untar_compressed(decompressed_bytes, target.as_ref()).await
 }
 
 /// Unpack a `.tar.xz` archive into the target directory, without requiring `Seek`.
@@ -742,7 +715,15 @@ async fn untar_xz<R: tokio::io::AsyncRead + Unpin>(
 ) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let mut decompressed_bytes = async_compression::tokio::bufread::XzDecoder::new(reader);
+    decompressed_bytes.multiple_members(true);
+    untar_compressed(decompressed_bytes, target.as_ref()).await
+}
 
+/// Unpack a compressed tar archive and drain the decoder to validate its trailer.
+async fn untar_compressed<R: tokio::io::AsyncRead + Unpin>(
+    mut decompressed_bytes: R,
+    target: &Path,
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     let archive = tokio_tar::ArchiveBuilder::new(
         &mut decompressed_bytes as &mut (dyn tokio::io::AsyncRead + Unpin),
     )
@@ -750,9 +731,16 @@ async fn untar_xz<R: tokio::io::AsyncRead + Unpin>(
     .set_preserve_permissions(false)
     .set_allow_external_symlinks(false)
     .build();
-    untar_in(archive, target.as_ref())
+    let files = untar_in(archive, target)
         .await
-        .map_err(Error::io_or_compression)
+        .map_err(Error::io_or_compression)?;
+
+    // TAR readers stop at the zero blocks, before the compression trailer is necessarily read.
+    tokio::io::copy(&mut decompressed_bytes, &mut tokio::io::sink())
+        .await
+        .map_err(Error::io_or_compression)?;
+
+    Ok(files)
 }
 
 /// Unpack a `.tar` archive into the target directory, without requiring `Seek`.
@@ -801,5 +789,98 @@ pub async fn archive<D: Display, R: tokio::io::AsyncRead + Unpin>(
         | SourceDistExtension::TarLz
         | SourceDistExtension::TarLzma => untar_xz(reader, target).await,
         SourceDistExtension::TarZst => untar_zst(reader, target).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use async_compression::tokio::write::{BzEncoder, GzipEncoder, XzEncoder, ZstdEncoder};
+    use tokio::io::AsyncWriteExt;
+    use uv_distribution_filename::SourceDistExtension;
+
+    #[tokio::test]
+    async fn compressed_tar_is_finalized() {
+        let mut tar = Vec::new();
+        flate2::read::GzDecoder::new(
+            &include_bytes!("../../../test/links/basic_package-0.1.0.tar.gz")[..],
+        )
+        .read_to_end(&mut tar)
+        .expect("source distribution should decompress");
+
+        macro_rules! compress {
+            ($encoder:ident, $tar:expr) => {{
+                let mut encoder = $encoder::new(Vec::new());
+                encoder.write_all($tar).await.expect("tar should compress");
+                encoder.shutdown().await.expect("encoder should finish");
+                encoder.into_inner()
+            }};
+        }
+
+        let mut padded_tar = tar.clone();
+        padded_tar.resize(tar.len() + 2 * 1024 * 1024, 0);
+
+        for (name, extension, mut compressed, padded) in [
+            (
+                "gzip",
+                SourceDistExtension::TarGz,
+                compress!(GzipEncoder, &tar),
+                compress!(GzipEncoder, &padded_tar),
+            ),
+            (
+                "bzip2",
+                SourceDistExtension::TarBz2,
+                compress!(BzEncoder, &tar),
+                compress!(BzEncoder, &padded_tar),
+            ),
+            (
+                "xz",
+                SourceDistExtension::TarXz,
+                compress!(XzEncoder, &tar),
+                compress!(XzEncoder, &padded_tar),
+            ),
+            (
+                "zstd",
+                SourceDistExtension::TarZst,
+                compress!(ZstdEncoder, &tar),
+                compress!(ZstdEncoder, &padded_tar),
+            ),
+        ] {
+            let target = tempfile::tempdir().expect("temporary directory should be created");
+            super::archive(name, compressed.as_slice(), extension, target.path())
+                .await
+                .expect("complete archive should extract");
+
+            let target = tempfile::tempdir().expect("temporary directory should be created");
+            super::archive(name, padded.as_slice(), extension, target.path())
+                .await
+                .expect("archive with valid tar padding should extract");
+
+            let mut concatenated = compressed.clone();
+            concatenated.extend_from_slice(&compressed);
+            let target = tempfile::tempdir().expect("temporary directory should be created");
+            super::archive(name, concatenated.as_slice(), extension, target.path())
+                .await
+                .expect("concatenated archive should extract");
+
+            concatenated.pop();
+            let target = tempfile::tempdir().expect("temporary directory should be created");
+            assert!(
+                super::archive(name, concatenated.as_slice(), extension, target.path())
+                    .await
+                    .is_err(),
+                "archive with a truncated second {name} member should be rejected"
+            );
+
+            compressed.pop();
+            let target = tempfile::tempdir().expect("temporary directory should be created");
+            assert!(
+                super::archive(name, compressed.as_slice(), extension, target.path())
+                    .await
+                    .is_err(),
+                "truncated {name} archive should be rejected"
+            );
+        }
     }
 }


### PR DESCRIPTION
Compressed-tar integrity is not finalized before executing a backend. Extraction stops at tar zero blocks without draining the `gzip`, `bzip2`, `xz`, or `zstd` decoders; corrupt or truncated archives can still extract and execute backend code. Drain and finalize every decoder.

See [Python's tar end-of-archive behavior](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile) and [Python's compressed-stream EOF semantics](https://docs.python.org/3/library/zlib.html#zlib.Decompress.eof).

The shared extraction path has previously needed compatibility relaxations for malformed ZIPs ([uv#15452](https://github.com/astral-sh/uv/pull/15452), [uv#17944](https://github.com/astral-sh/uv/pull/17944)); keep the existing retry behavior for transient tar EOFs introduced in [uv#9753](https://github.com/astral-sh/uv/pull/9753).
