### PR TITLE
Preserve direct archive hashes in pip freeze

### DIFF
--- a/crates/uv-distribution-types/src/requirement.rs
+++ b/crates/uv-distribution-types/src/requirement.rs
@@ -92,11 +92,15 @@ impl Requirement {
 
     /// Return the hashes of the requirement, as specified in the URL fragment.
     pub fn hashes(&self) -> Option<Hashes> {
-        let RequirementSource::Url { ref url, .. } = self.source else {
+        let (RequirementSource::Url { ref url, .. } | RequirementSource::Path { ref url, .. }) =
+            self.source
+        else {
             return None;
         };
         let fragment = url.fragment()?;
-        Hashes::parse_fragment(fragment).ok()
+        fragment
+            .split('&')
+            .find_map(|fragment| Hashes::parse_fragment(fragment).ok())
     }
 
     /// Set the source file containing the requirement.

--- a/crates/uv-distribution-types/src/specified_requirement.rs
+++ b/crates/uv-distribution-types/src/specified_requirement.rs
@@ -202,7 +202,9 @@ impl UnresolvedRequirement {
             Self::Named(requirement) => requirement.hashes(),
             Self::Unnamed(requirement) => {
                 let fragment = requirement.url.verbatim.fragment()?;
-                Hashes::parse_fragment(fragment).ok()
+                fragment
+                    .split('&')
+                    .find_map(|fragment| Hashes::parse_fragment(fragment).ok())
             }
         }
     }

--- a/crates/uv-pypi-types/src/direct_url.rs
+++ b/crates/uv-pypi-types/src/direct_url.rs
@@ -115,11 +115,39 @@ impl TryFrom<&DirectUrl> for DisplaySafeUrl {
             DirectUrl::ArchiveUrl {
                 url,
                 subdirectory,
-                archive_info: _,
+                archive_info,
             } => {
                 let mut url = Self::parse(url)?;
+                let mut fragments = Vec::new();
                 if let Some(subdirectory) = subdirectory {
-                    url.set_fragment(Some(&format!("subdirectory={}", subdirectory.display())));
+                    fragments.push(format!("subdirectory={}", subdirectory.display()));
+                }
+                if let Some(hash) = archive_info
+                    .hashes
+                    .as_ref()
+                    .and_then(|hashes| {
+                        ["sha512", "sha384", "sha256", "blake2b", "md5"]
+                            .into_iter()
+                            .find_map(|algorithm| {
+                                hashes
+                                    .get(algorithm)
+                                    .map(|digest| format!("{algorithm}={digest}"))
+                            })
+                    })
+                    .or_else(|| {
+                        let hash = archive_info.hash.as_ref()?;
+                        let (algorithm, _) = hash.split_once('=')?;
+                        matches!(
+                            algorithm,
+                            "sha512" | "sha384" | "sha256" | "blake2b" | "md5"
+                        )
+                        .then(|| hash.clone())
+                    })
+                {
+                    fragments.push(hash);
+                }
+                if !fragments.is_empty() {
+                    url.set_fragment(Some(&fragments.join("&")));
                 }
                 Ok(url)
             }

--- a/crates/uv-pypi-types/src/direct_url.rs
+++ b/crates/uv-pypi-types/src/direct_url.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 
+use crate::{HashAlgorithm, Hashes};
+
 /// Metadata for a distribution that was installed via a direct URL.
 ///
 /// See: <https://packaging.python.org/en/latest/specifications/direct-url-data-structure/>
@@ -126,22 +128,15 @@ impl TryFrom<&DirectUrl> for DisplaySafeUrl {
                     .hashes
                     .as_ref()
                     .and_then(|hashes| {
-                        ["sha512", "sha384", "sha256", "blake2b", "md5"]
-                            .into_iter()
-                            .find_map(|algorithm| {
-                                hashes
-                                    .get(algorithm)
-                                    .map(|digest| format!("{algorithm}={digest}"))
-                            })
+                        HashAlgorithm::preferred().find_map(|algorithm| {
+                            hashes
+                                .get(algorithm.as_str())
+                                .map(|digest| format!("{algorithm}={digest}"))
+                        })
                     })
                     .or_else(|| {
                         let hash = archive_info.hash.as_ref()?;
-                        let (algorithm, _) = hash.split_once('=')?;
-                        matches!(
-                            algorithm,
-                            "sha512" | "sha384" | "sha256" | "blake2b" | "md5"
-                        )
-                        .then(|| hash.clone())
+                        Hashes::parse_fragment(hash).is_ok().then(|| hash.clone())
                     })
                 {
                     fragments.push(hash);

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -616,6 +616,31 @@ pub enum HashAlgorithm {
     Blake2b,
 }
 
+impl HashAlgorithm {
+    /// Return the supported [`HashAlgorithm`] variants in order of preference.
+    pub fn preferred() -> impl Iterator<Item = Self> {
+        [
+            Self::Sha512,
+            Self::Sha384,
+            Self::Sha256,
+            Self::Blake2b,
+            Self::Md5,
+        ]
+        .into_iter()
+    }
+
+    /// Return the string representation of the [`HashAlgorithm`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Md5 => "md5",
+            Self::Sha256 => "sha256",
+            Self::Sha384 => "sha384",
+            Self::Sha512 => "sha512",
+            Self::Blake2b => "blake2b",
+        }
+    }
+}
+
 impl FromStr for HashAlgorithm {
     type Err = HashError;
 
@@ -633,13 +658,7 @@ impl FromStr for HashAlgorithm {
 
 impl std::fmt::Display for HashAlgorithm {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Md5 => write!(f, "md5"),
-            Self::Sha256 => write!(f, "sha256"),
-            Self::Sha384 => write!(f, "sha384"),
-            Self::Sha512 => write!(f, "sha512"),
-            Self::Blake2b => write!(f, "blake2b"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -618,7 +618,7 @@ pub enum HashAlgorithm {
 
 impl HashAlgorithm {
     /// Return the supported [`HashAlgorithm`] variants in order of preference.
-    pub fn preferred() -> impl Iterator<Item = Self> {
+    pub(crate) fn preferred() -> impl Iterator<Item = Self> {
         [
             Self::Sha512,
             Self::Sha384,
@@ -630,7 +630,7 @@ impl HashAlgorithm {
     }
 
     /// Return the string representation of the [`HashAlgorithm`].
-    pub fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Md5 => "md5",
             Self::Sha256 => "sha256",

--- a/crates/uv/tests/pip/pip_freeze.rs
+++ b/crates/uv/tests/pip/pip_freeze.rs
@@ -1,7 +1,8 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
+use url::Url;
 
 use uv_test::uv_snapshot;
 
@@ -118,6 +119,117 @@ fn freeze_url() -> Result<()> {
     warning: The package `anyio` requires `sniffio>=1.1`, but it's not installed
     "
     );
+
+    Ok(())
+}
+
+/// Preserve archive hashes recorded by another installer in `direct_url.json` so that frozen
+/// requirements keep their artifact verification.
+#[test]
+fn freeze_direct_archive_hashes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let site_packages = ChildPath::new(context.site_packages());
+
+    let project = site_packages.child("project-1.0.0.dist-info");
+    project.create_dir_all()?;
+    project
+        .child("METADATA")
+        .write_str("Metadata-Version: 2.1\nName: project\nVersion: 1.0.0\n")?;
+    project.child("direct_url.json").write_str(
+        r#"{"url":"https://example.com/project-1.0.0.tar.gz","subdirectory":"src","archive_info":{"hashes":{"sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}}"#,
+    )?;
+
+    let legacy = site_packages.child("legacy-1.0.0.dist-info");
+    legacy.create_dir_all()?;
+    legacy
+        .child("METADATA")
+        .write_str("Metadata-Version: 2.1\nName: legacy\nVersion: 1.0.0\n")?;
+    legacy.child("direct_url.json").write_str(
+        r#"{"url":"https://example.com/legacy-1.0.0.tar.gz","archive_info":{"hash":"sha256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}"#,
+    )?;
+
+    uv_snapshot!(context.pip_freeze(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    legacy @ https://example.com/legacy-1.0.0.tar.gz#sha256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    project @ https://example.com/project-1.0.0.tar.gz#subdirectory=src&sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// A frozen direct URL with both a subdirectory and archive hash must keep enforcing that hash
+/// when it is consumed as a requirement again.
+#[test]
+fn freeze_direct_archive_hash_roundtrip() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let site_packages = ChildPath::new(context.site_packages());
+    let wheel_url = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+    )
+    .map_err(|()| anyhow!("Failed to create wheel URL"))?;
+
+    let ok = site_packages.child("ok-1.0.0.dist-info");
+    ok.create_dir_all()?;
+    ok.child("METADATA")
+        .write_str("Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\n")?;
+    ok.child("direct_url.json").write_str(&format!(
+        r#"{{"url":"{wheel_url}","subdirectory":"src","archive_info":{{"hashes":{{"sha256":"79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f"}}}}}}"#,
+    ))?;
+
+    let frozen = uv_snapshot!(context.filters(), context.pip_freeze(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ok @ file://[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl#subdirectory=src&sha256=79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
+
+    ----- stderr -----
+    ");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_binary(&frozen.stdout)?;
+    fs_err::remove_dir_all(ok.path())?;
+
+    context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements_txt.path())
+        .arg("--no-deps")
+        .arg("--require-hashes")
+        .assert()
+        .success();
+
+    requirements_txt.write_str(&String::from_utf8(frozen.stdout)?.replace(
+        "79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ))?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("-r")
+        .arg(requirements_txt.path())
+        .arg("--no-deps")
+        .arg("--require-hashes")
+        .arg("--reinstall"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+      × Failed to read `ok @ file://[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl#subdirectory=src&sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+      ╰─▶ Hash mismatch for `ok @ file://[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl#subdirectory=src&sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+
+          Expected:
+            sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+          Computed:
+            sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
`uv pip freeze` discards recorded `archive_info.hashes` from `direct_url.json`, so frozen direct-archive requirements lose their expected artifact hash. Preserve a supported hash fragment when reconstructing the direct reference.

See [the Direct URL archive specification](https://packaging.python.org/en/latest/specifications/direct-url-data-structure/#archive-urls) and [PEP 610's freezing motivation](https://peps.python.org/pep-0610/#freezing-an-environment).
