### PR TITLE
Scope OSV fixes to matching packages

### DIFF
--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use uv_cache::{Cache, CacheBucket, CacheEntry};
 use uv_client::{CacheControl, CachedClient, CachedClientError};
 use uv_configuration::Concurrency;
+use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 
@@ -49,7 +50,7 @@ pub enum Error {
 }
 
 /// Package specification for OSV queries.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct Package {
     /// The package's name.
     name: String,
@@ -113,6 +114,7 @@ struct Range {
 /// Package affected by a vulnerability.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Affected {
+    package: Option<Package>,
     ranges: Option<Vec<Range>>,
     // TODO: Enable these fields if/when they contain information that's
     // useful to us, e.g. metadata that constrains a vulnerability to specific
@@ -452,6 +454,13 @@ impl Osv {
             .affected
             .iter()
             .flatten()
+            .filter(|affected| {
+                affected.package.as_ref().is_some_and(|package| {
+                    package.ecosystem == "PyPI"
+                        && PackageName::from_str(&package.name)
+                            .is_ok_and(|name| &name == dependency.name())
+                })
+            })
             .flat_map(|affected| affected.ranges.iter().flatten())
             .filter(|range| matches!(range.range_type, RangeType::Ecosystem))
             .flat_map(|range| &range.events)

--- a/crates/uv/tests/build/audit.rs
+++ b/crates/uv/tests/build/audit.rs
@@ -7,6 +7,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use uv_static::EnvVars;
+use uv_test::packse::PackseServer;
 use uv_test::uv_snapshot;
 
 /// The workspace discovered while resolving settings is reused by `uv audit`.
@@ -277,6 +278,10 @@ async fn audit_vulnerability_found() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "A test vulnerability in iniconfig",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -596,6 +601,10 @@ async fn audit_multiple_vulnerabilities_same_package() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "First vulnerability",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -619,6 +628,10 @@ async fn audit_multiple_vulnerabilities_same_package() {
             "modified": "2026-01-02T00:00:00Z",
             "summary": "Second vulnerability",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -937,6 +950,10 @@ async fn audit_ignore_by_id() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "A test vulnerability in iniconfig",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -1147,6 +1164,10 @@ async fn audit_ignore_until_fixed_with_fix() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "A test vulnerability in iniconfig",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -1189,6 +1210,104 @@ async fn audit_ignore_until_fixed_with_fix() {
     ");
 }
 
+/// `--ignore-until-fixed` ignores fixes for other or missing packages in the same OSV record.
+#[tokio::test]
+async fn audit_ignore_until_fixed_with_fix_for_other_package() {
+    let index = PackseServer::new("simple/single-package.toml");
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["a==1.0.0"]
+    "#})
+        .unwrap();
+
+    context
+        .lock()
+        .arg("--index")
+        .arg(index.index_url())
+        .assert()
+        .success();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "PYSEC-2023-0001"}]}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/PYSEC-2023-0001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "PYSEC-2023-0001",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A test vulnerability in multiple packages",
+            "affected": [
+                {
+                    "package": {
+                        "ecosystem": "PyPI",
+                        "name": "a"
+                    },
+                    "ranges": [{
+                        "type": "ECOSYSTEM",
+                        "events": [{"introduced": "0"}]
+                    }]
+                },
+                {
+                    "package": {
+                        "ecosystem": "PyPI",
+                        "name": "other-package"
+                    },
+                    "ranges": [{
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "0"},
+                            {"fixed": "2.1.0"}
+                        ]
+                    }]
+                },
+                {
+                    "ranges": [{
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "0"},
+                            {"fixed": "9.9.9"}
+                        ]
+                    }]
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--preview-features")
+        .arg("audit")
+        .arg("--index")
+        .arg(index.index_url())
+        .arg("--ignore-until-fixed")
+        .arg("PYSEC-2023-0001")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Found no known vulnerabilities and no adverse project statuses in 1 package
+    ");
+}
+
 /// `[tool.uv.audit]` config supports `ignore`.
 #[tokio::test]
 async fn audit_ignore_config() {
@@ -1227,6 +1346,10 @@ async fn audit_ignore_config() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "A test vulnerability in iniconfig",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -1349,6 +1472,10 @@ async fn audit_ignore_partial() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "First vulnerability",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -1368,6 +1495,10 @@ async fn audit_ignore_partial() {
             "modified": "2026-01-02T00:00:00Z",
             "summary": "Second vulnerability",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -1541,6 +1672,10 @@ async fn audit_ignore_mixed_matched_unmatched() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "A test vulnerability in iniconfig",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -1705,6 +1840,10 @@ async fn audit_script_vulnerability_found() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "A test vulnerability in iniconfig",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -2258,6 +2397,10 @@ async fn audit_vulnerability_and_project_status() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "A test vulnerability in iniconfig",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -2325,6 +2468,10 @@ async fn audit_json_vulnerability_and_project_status() {
             "modified": "2026-01-01T00:00:00Z",
             "summary": "A test vulnerability in iniconfig",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -2422,6 +2569,10 @@ async fn audit_sarif_vulnerability_and_project_status() -> Result<()> {
             "summary": "A test vulnerability in iniconfig",
             "details": "A longer description of the test vulnerability.",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [
@@ -2615,6 +2766,10 @@ async fn audit_sarif_project_artifact_uri() -> Result<()> {
             "id": "PYSEC-2023-0001",
             "modified": "2026-01-01T00:00:00Z",
             "affected": [{
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "iniconfig"
+                },
                 "ranges": [{
                     "type": "ECOSYSTEM",
                     "events": [{"introduced": "0"}]


### PR DESCRIPTION
`uv audit --ignore-until-fixed` can hide or misclassify a vulnerability when an OSV record contains fixes for multiple packages: fixed versions are combined without preserving their `affected[].package` identity. Apply fixed-version events only to the matching package and ecosystem.

See [the OSV affected-package schema](https://ossf.github.io/osv-schema/#affectedpackage-field).

This refines the `--ignore-until-fixed` semantics introduced in [uv#18737](https://github.com/astral-sh/uv/pull/18737).
