### PR TITLE
Reject wheels with mismatched internal tags

### DIFF
--- a/crates/uv-install-wheel/src/install.rs
+++ b/crates/uv-install-wheel/src/install.rs
@@ -1,13 +1,15 @@
 //! Like `wheel.rs`, but for installing wheels that have already been unzipped, rather than
 //! reading from a zip file.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use fs_err::File;
+use itertools::{Itertools, iproduct};
 use tracing::{instrument, trace};
 
-use uv_distribution_filename::WheelFilename;
+use uv_distribution_filename::{ExpandedTags, WheelFilename};
 use uv_pep440::Version;
 use uv_pypi_types::{DirectUrl, Metadata10};
 
@@ -23,23 +25,24 @@ pub fn installed_dist_info_path(
     layout: &Layout,
     wheel: impl AsRef<Path>,
 ) -> Result<PathBuf, Error> {
-    let (dist_info_prefix, site_packages) = wheel_destination(layout, wheel.as_ref())?;
+    let (dist_info_prefix, site_packages, _) = wheel_destination(layout, wheel.as_ref())?;
     Ok(site_packages.join(format!("{dist_info_prefix}.dist-info")))
 }
 
-/// Return the wheel's `.dist-info` prefix and target `site-packages` directory.
+/// Return the wheel's `.dist-info` prefix, target `site-packages` directory, and parsed `WHEEL`.
 fn wheel_destination<'layout>(
     layout: &'layout Layout,
     wheel: &Path,
-) -> Result<(String, &'layout Path), Error> {
+) -> Result<(String, &'layout Path, WheelFile), Error> {
     let dist_info_prefix = find_dist_info(wheel)?;
     let wheel_file_path = wheel.join(format!("{dist_info_prefix}.dist-info/WHEEL"));
     let wheel_text = fs_err::read_to_string(wheel_file_path)?;
-    let site_packages = match WheelFile::parse(&wheel_text)?.lib_kind() {
+    let wheel_file = WheelFile::parse(&wheel_text)?;
+    let site_packages = match wheel_file.lib_kind() {
         LibKind::Pure => &layout.scheme.purelib,
         LibKind::Plat => &layout.scheme.platlib,
     };
-    Ok((dist_info_prefix, site_packages))
+    Ok((dist_info_prefix, site_packages, wheel_file))
 }
 
 /// Install the given wheel to the given venv
@@ -64,7 +67,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
     state: &InstallState,
 ) -> Result<(), Error> {
     let wheel = wheel.as_ref();
-    let (dist_info_prefix, site_packages) = wheel_destination(layout, wheel)?;
+    let (dist_info_prefix, site_packages, wheel_file) = wheel_destination(layout, wheel)?;
     let metadata = dist_info_metadata(&dist_info_prefix, wheel)?;
     let Metadata10 { name, version } = Metadata10::parse_pkg_info(&metadata)
         .map_err(|err| Error::InvalidWheel(err.to_string()))?;
@@ -79,6 +82,34 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
 
         if version != filename.version && version != filename.version.clone().without_local() {
             return Err(Error::MismatchedVersion(version, filename.version.clone()));
+        }
+
+        let mut wheel_tags = BTreeSet::new();
+        for tag in wheel_file.tags().unwrap_or_default() {
+            let expanded = ExpandedTags::parse([tag.as_str()])
+                .map_err(|err| Error::InvalidWheel(err.to_string()))?;
+            wheel_tags.extend(
+                iproduct!(
+                    expanded.python_tags(),
+                    expanded.abi_tags(),
+                    expanded.platform_tags()
+                )
+                .map(|(python, abi, platform)| format!("{python}-{abi}-{platform}")),
+            );
+        }
+        let filename_tags = iproduct!(
+            filename.python_tags(),
+            filename.abi_tags(),
+            filename.platform_tags()
+        )
+        .map(|(python, abi, platform)| format!("{python}-{abi}-{platform}"))
+        .collect::<BTreeSet<_>>();
+        if wheel_tags != filename_tags {
+            return Err(Error::InvalidWheel(format!(
+                "Wheel tags do not match filename ({} != {})",
+                wheel_tags.iter().join(", "),
+                filename_tags.iter().join(", ")
+            )));
         }
     }
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -14153,6 +14153,52 @@ fn reserved_script_name() -> Result<()> {
     Ok(())
 }
 
+/// Reject a wheel whose filename advertises a compatible tag while its internal WHEEL metadata
+/// declares a different, incompatible platform.
+#[test]
+fn reject_mismatched_wheel_tags() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel = context.temp_dir.child("foo-0.1.0-py3-none-any.whl");
+
+    let mut writer = ZipFileWriter::new(Vec::new());
+    for (path, contents) in [
+        ("foo/__init__.py", "VALUE = 1\n"),
+        (
+            "foo-0.1.0.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: foo\nVersion: 0.1.0\n",
+        ),
+        (
+            "foo-0.1.0.dist-info/WHEEL",
+            "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-win_amd64\n",
+        ),
+        (
+            "foo-0.1.0.dist-info/RECORD",
+            "foo/__init__.py,,\nfoo-0.1.0.dist-info/METADATA,,\nfoo-0.1.0.dist-info/WHEEL,,\nfoo-0.1.0.dist-info/RECORD,,\n",
+        ),
+    ] {
+        let entry = ZipEntryBuilder::new(path.into(), Compression::Stored);
+        block_on(writer.write_entry_whole(entry, contents.as_bytes()))?;
+    }
+    fs_err::write(wheel.path(), block_on(writer.close())?)?;
+
+    uv_snapshot!(context.filters(), context.pip_install().arg(wheel.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: The wheel is invalid: Wheel tags do not match filename (py3-none-win_amd64 != py3-none-any)
+    ");
+
+    assert!(!context.site_packages().join("foo").exists());
+    assert!(!context.site_packages().join("foo-0.1.0.dist-info").exists());
+
+    Ok(())
+}
+
 fn repacked_wheel_with_entrypoint(
     context: &TestContext,
     section: &str,
@@ -16053,32 +16099,19 @@ fn build_backend_wrong_wheel_platform() -> Result<()> {
 
         [build-system]
         requires = ["hatchling"]
-        backend-path = ["."]
-        build-backend = "build_backend"
+        build-backend = "hatchling.build"
+
+        [tool.hatch.build.targets.wheel.hooks.custom]
     "#})?;
 
-    let build_backend = py313.child("build_backend.py");
-    build_backend.write_str(indoc! {r#"
-        import os
-
-        from hatchling.build import *
-        from hatchling.build import build_wheel as build_wheel_original
+    let hatch_build = py313.child("hatch_build.py");
+    hatch_build.write_str(indoc! {r#"
+        from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
-        def build_wheel(
-            wheel_directory: str,
-            config_settings: "Mapping[Any, Any] | None" = None,
-            metadata_directory: "str | None" = None,
-        ) -> str:
-            filename = build_wheel_original(
-                wheel_directory, config_settings, metadata_directory
-            )
-            py313_wheel = "py313-0.1.0-py313-none-any.whl"
-            os.rename(
-                os.path.join(wheel_directory, filename),
-                os.path.join(wheel_directory, py313_wheel),
-            )
-            return py313_wheel
+        class CustomBuildHook(BuildHookInterface):
+            def initialize(self, version, build_data):
+                build_data["tag"] = "py313-none-any"
     "#})?;
     py313.child("src/py313/__init__.py").touch()?;
 


### PR DESCRIPTION
A wheel whose filename advertises `py3-none-any` while its internal `WHEEL` advertises an incompatible `Tag` can be selected and installed, then remains permanently out of date. Reject disagreement between filename and internal compatibility tags.

See [the wheel-format specification](https://packaging.python.org/en/latest/specifications/binary-distribution-format/).

This fixes the repeated-reinstall behavior reported in [uv#17711](https://github.com/astral-sh/uv/issues/17711) for published wheels with inconsistent tags. Such wheels are now rejected during installation.
