### PR TITLE
Require package entries in pylock files

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -204,7 +204,6 @@ pub struct PylockToml {
     pub dependency_groups: Vec<GroupName>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub default_groups: Vec<GroupName>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub packages: Vec<PylockTomlPackage>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     attestation_identities: Vec<PylockTomlAttestationIdentity>,

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -6069,6 +6069,36 @@ fn pep_751() -> Result<()> {
 }
 
 #[test]
+fn pep_751_requires_packages() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pylock.toml").write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Not a valid `pylock.toml` file: pylock.toml
+      Caused by: TOML parse error at line 1, column 1
+          |
+        1 |
+          | ^
+        missing field `packages`
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_require_hashes_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
A `pylock.toml` missing the required `packages` array is treated as an empty lock, so sync can uninstall an environment instead of rejecting malformed input. Require the array during deserialization while continuing to accept an explicitly empty array.

See [the `pylock.toml` packages specification](https://packaging.python.org/en/latest/specifications/pylock-toml/#packages).
