### PR TITLE
Fix versionless egg-info file handling

### DIFF
--- a/crates/uv-distribution-types/src/installed.rs
+++ b/crates/uv-distribution-types/src/installed.rs
@@ -281,8 +281,8 @@ impl InstalledDist {
                 let Some(egg_metadata) = read_metadata(path) else {
                     return Ok(None);
                 };
-                return Ok(Some(Self::from(InstalledDistKind::EggInfoDirectory(
-                    InstalledEggInfoDirectory {
+                return Ok(Some(Self::from(InstalledDistKind::EggInfoFile(
+                    InstalledEggInfoFile {
                         name: file_name.name,
                         version: Version::from_str(&egg_metadata.version)?,
                         path: path.to_path_buf().into_boxed_path(),

--- a/crates/uv/tests/pip/pip_check.rs
+++ b/crates/uv/tests/pip/pip_check.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use assert_fs::fixture::ChildPath;
 use assert_fs::fixture::FileWriteStr;
 use assert_fs::fixture::PathChild;
 
@@ -39,6 +40,29 @@ fn check_compatible_packages() -> Result<()> {
 
     ----- stderr -----
     Checked 5 packages in [TIME]
+    All installed packages are compatible
+    "
+    );
+
+    Ok(())
+}
+
+/// Check a versionless `.egg-info` file installed by distutils.
+#[test]
+fn check_versionless_egg_info_file() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    ChildPath::new(context.site_packages())
+        .child("demo.egg-info")
+        .write_str("Metadata-Version: 1.1\nName: demo\nVersion: 1.0\n")?;
+
+    uv_snapshot!(context.pip_check(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Checked 1 package in [TIME]
     All installed packages are compatible
     "
     );

--- a/crates/uv/tests/pip/pip_uninstall.rs
+++ b/crates/uv/tests/pip/pip_uninstall.rs
@@ -385,6 +385,29 @@ fn uninstall_egg_info() -> Result<()> {
     Ok(())
 }
 
+/// Refuse to uninstall a versionless `.egg-info` file without the metadata required to do so safely.
+#[test]
+fn uninstall_versionless_egg_info_file() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let egg_info = ChildPath::new(context.site_packages()).child("demo.egg-info");
+    egg_info.write_str("Metadata-Version: 1.1\nName: demo\nVersion: 1.0\n")?;
+
+    uv_snapshot!(context.pip_uninstall().arg("demo"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Unable to uninstall `demo==1.0`. distutils-installed distributions do not include the metadata required to uninstall safely.
+    "
+    );
+
+    assert!(egg_info.exists());
+
+    Ok(())
+}
+
 fn normcase(s: &str) -> String {
     if cfg!(windows) {
         s.replace('/', "\\").to_lowercase()


### PR DESCRIPTION
Versionless `name.egg-info` files are valid legacy metadata, but are classified as directories, causing false `uv pip check` diagnostics and `Not a directory` uninstall failures. Handle the `.egg-info` file variant correctly.

See [the setuptools egg-metadata documentation](https://setuptools.pypa.io/en/stable/deprecated/python_eggs.html#project-metadata).
