### PR TITLE
Fix pull request security review setup

### DIFF
--- a/.github/workflows/pull-request-security-review.yml
+++ b/.github/workflows/pull-request-security-review.yml
@@ -27,7 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -90,7 +89,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/agents/codex/config.toml
+++ b/agents/codex/config.toml
@@ -1,3 +1,5 @@
+default_permissions = ":read-only"
+
 [permissions.issue-triage]
 description = "Read-only issue triage with GitHub API access."
 extends = ":read-only"


### PR DESCRIPTION
Pull requests whose branches predate the security-review workflow [fail before review](https://github.com/astral-sh/uv/actions/runs/29371521285/job/87215677482?pr=20410) because the workflow checks out the head SHA, which does not contain the newly introduced `agents/` helpers. Plugin installation also loads the shared Codex configuration before the action selects its permission profile, so defining profiles without `default_permissions` prevents setup from completing. Use the default pull-request merge commit for review and preparation, and set a conservative `:read-only` default so the base-side helpers and configuration can load while findings remain anchored to the head commit.
