### PR TITLE
Add URL redaction for embedded messages

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -932,13 +932,8 @@ fn fetch_lfs(
 
 /// Redact a credentialed remote URL from a Git process error.
 fn redact_git_error(mut error: anyhow::Error, url: &DisplaySafeUrl) -> anyhow::Error {
-    let credentialed_root = remote_url_root((**url).clone());
-    let redacted_root = DisplaySafeUrl::from_url(credentialed_root.clone()).to_string();
-    let redact = |message: &str| {
-        message
-            .replace(url.as_str(), &url.to_string())
-            .replace(credentialed_root.as_str(), &redacted_root)
-    };
+    let credentialed_root = DisplaySafeUrl::from_url(remote_url_root((**url).clone()));
+    let redact = |message: &str| credentialed_root.redact_in(&url.redact_in(message));
 
     if let Some(process_error) = error.downcast_mut::<ProcessError>() {
         process_error.desc = redact(&process_error.desc);

--- a/crates/uv-redacted/src/lib.rs
+++ b/crates/uv-redacted/src/lib.rs
@@ -228,6 +228,14 @@ impl DisplaySafeUrl {
     pub fn displayable_with_credentials(&self) -> impl Display {
         &self.0
     }
+
+    /// Redact all occurrences of this URL in a message.
+    ///
+    /// This is useful for errors from external tools, which may include the credentialed URL in
+    /// their command or output instead of using the URL's [`Display`] implementation.
+    pub fn redact_in(&self, message: &str) -> String {
+        message.replace(self.0.as_str(), &self.to_string())
+    }
 }
 
 impl Deref for DisplaySafeUrl {
@@ -492,6 +500,35 @@ mod tests {
         assert_eq!(
             log_safe_url.displayable_with_credentials().to_string(),
             url_str
+        );
+    }
+
+    #[test]
+    fn redact_url_in_message() {
+        let url = DisplaySafeUrl::parse("https://user:pass@example.com/org/repo.git").unwrap();
+        let message = format!(
+            "process didn't exit successfully: `git fetch '{}'`\n--- stderr\nfatal: Authentication failed for '{}'",
+            url.as_str(),
+            url.as_str()
+        );
+
+        assert_eq!(
+            url.redact_in(&message),
+            "process didn't exit successfully: `git fetch 'https://user:****@example.com/org/repo.git'`\n--- stderr\nfatal: Authentication failed for 'https://user:****@example.com/org/repo.git'"
+        );
+    }
+
+    #[test]
+    fn redact_presigned_url_in_message() {
+        let url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz%2DSignature=signature&X-Amz-Credential=credential&X-Amz-Security-Token=token&safe=value",
+        )
+        .unwrap();
+        let message = format!("failed to fetch '{}'", url.as_str());
+
+        assert_eq!(
+            url.redact_in(&message),
+            "failed to fetch 'https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Signature=****&X-Amz-Credential=****&X-Amz-Security-Token=****&safe=value'"
         );
     }
 


### PR DESCRIPTION
External tools can embed credential-bearing URLs in command or error text, bypassing `DisplaySafeUrl`'s normal display redaction. Add `DisplaySafeUrl::redact_in` to consistently replace embedded URLs using the existing credential and sensitive-query-parameter rules, and use it for failed Git fetch, LFS, and submodule commands while preserving the original process error.