### PR TITLE
docs: link dynamic metadata cache settings from project config

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -544,9 +544,11 @@ requires-dist = ["torch", "einops"]
 
 ## Dynamic metadata
 
-If your project uses dynamic metadata (e.g., to determine the version or dependencies dynamically), uv may need additional configuration to invalidate its cache when the metadata changes.
+If your project uses dynamic metadata (e.g., to determine the version or dependencies dynamically),
+uv may need additional configuration to invalidate its cache when the metadata changes.
 
-See the [caching documentation](../cache.md#dynamic-metadata) for details on configuring cache invalidation for dynamic metadata.
+See the [caching documentation](../cache.md#dynamic-metadata) for details on configuring cache
+invalidation for dynamic metadata.
 
 ## Editable mode
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -542,6 +542,12 @@ version = "2.6.3"
 requires-dist = ["torch", "einops"]
 ```
 
+## Dynamic metadata
+
+If your project uses dynamic metadata (e.g., to determine the version or dependencies dynamically), uv may need additional configuration to invalidate its cache when the metadata changes.
+
+See the [caching documentation](../cache.md#dynamic-metadata) for details on configuring cache invalidation for dynamic metadata.
+
 ## Editable mode
 
 By default, the project will be installed in editable mode, such that changes to the source code are


### PR DESCRIPTION
Closes #15413.

Adds a short section under `Configuring projects` to link to the dynamic metadata cache settings, making it easier to discover from the project documentation section.