### PR TITLE
docs: clarify that `system` and `UV_SYSTEM_PYTHON` apply only to `uv pip`

### DIFF
--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -1297,6 +1297,9 @@ pub struct PipOptions {
     /// any parent directory. The `--system` option instructs uv to instead use the first Python
     /// found in the system `PATH`.
     ///
+    /// This option only applies to the `uv pip` interface. For other commands (like `uv sync`
+    /// or `uv run`), see the `UV_PROJECT_ENVIRONMENT` environment variable.
+    ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
     #[option(

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -95,6 +95,9 @@ impl EnvVars {
     /// Equivalent to the `--system` command-line argument. If set to `true`, uv will
     /// use the first Python interpreter found in the system `PATH`.
     ///
+    /// This option only applies to the `uv pip` interface. For other commands (like `uv sync`
+    /// or `uv run`), see the `UV_PROJECT_ENVIRONMENT` environment variable.
+    ///
     /// WARNING: `UV_SYSTEM_PYTHON=true` is intended for use in continuous integration (CI)
     /// or containerized environments and should be used with caution, as modifying the system
     /// Python can lead to unexpected behavior.

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1652,7 +1652,7 @@
           "type": ["boolean", "null"]
         },
         "system": {
-          "description": "Install packages into the system Python environment.\n\nBy default, uv installs into the virtual environment in the current working directory or\nany parent directory. The `--system` option instructs uv to instead use the first Python\nfound in the system `PATH`.\n\nWARNING: `--system` is intended for use in continuous integration (CI) environments and\nshould be used with caution, as it can modify the system Python installation.",
+          "description": "Install packages into the system Python environment.\n\nBy default, uv installs into the virtual environment in the current working directory or\nany parent directory. The `--system` option instructs uv to instead use the first Python\nfound in the system `PATH`.\n\nThis option only applies to the `uv pip` interface. For other commands (like `uv sync`\nor `uv run`), see the `UV_PROJECT_ENVIRONMENT` environment variable.\n\nWARNING: `--system` is intended for use in continuous integration (CI) environments and\nshould be used with caution, as it can modify the system Python installation.",
           "type": ["boolean", "null"]
         },
         "target": {


### PR DESCRIPTION
Closes #12987.

The `--system` option, the `system` config setting, and the `UV_SYSTEM_PYTHON` environment variable only apply to the `uv pip` interface. Other commands (like `uv sync`) use `UV_PROJECT_ENVIRONMENT` instead. This PR updates the doc comments for these settings to explicitly mention this limitation and point users to `UV_PROJECT_ENVIRONMENT` for non-pip commands.