### PR TITLE
Fix security review secret inheritance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
     needs: plan
     if: ${{ github.event_name == 'pull_request' && github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.full_name == github.repository && needs.plan.outputs.review-security == 'true' }}
     uses: ./.github/workflows/pull-request-security-review.yml
+    secrets: inherit # zizmor: ignore[secrets-inherit] required for the automations environment, as in release.yml
     permissions:
       contents: read
       issues: read


### PR DESCRIPTION
The security-review job fails before Codex starts because moving it under CI made it a reusable workflow and the automations environment's OpenAI API key is not inherited. Inherit the caller's secrets so the Responses API proxy can start and same-repository code changes receive a security review again.