### PR TITLE
Isolate cache reads on a blocking pool

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fmt::{Debug, Write};
 use std::num::ParseIntError;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, SystemTimeError};
 
 use anyhow::anyhow;
@@ -25,7 +25,7 @@ use uv_auth::{
     AuthMiddleware, Credentials, CredentialsCache, CredentialsFromUrlError, Indexes, PyxTokenStore,
 };
 use uv_configuration::ProxyUrlKind;
-use uv_configuration::{KeyringProviderType, ProxyUrl, TrustedHost};
+use uv_configuration::{Concurrency, KeyringProviderType, ProxyUrl, TrustedHost};
 use uv_distribution_types::IndexCredentialsError;
 use uv_git::GitHttpSettings;
 use uv_pep508::MarkerEnvironment;
@@ -121,6 +121,44 @@ pub struct BaseClientBuilder<'a> {
     client_name: Option<&'static str>,
     /// Whether to disable retry delays (for testing).
     no_retry_delay: bool,
+    /// A shared, dedicated blocking pool for short-lived cache reads.
+    cache_read_runtime: Arc<CacheReadRuntime>,
+}
+
+#[derive(Debug)]
+struct CacheReadRuntime {
+    workers: usize,
+    runtime: OnceLock<tokio::runtime::Runtime>,
+}
+
+impl CacheReadRuntime {
+    fn new(workers: usize) -> Self {
+        Self {
+            workers,
+            runtime: OnceLock::new(),
+        }
+    }
+
+    fn get(&self) -> &tokio::runtime::Runtime {
+        self.runtime.get_or_init(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .thread_name("uv-cache-read")
+                .thread_stack_size(uv_configuration::min_stack_size())
+                .max_blocking_threads(self.workers)
+                .build()
+                .expect("Failed building the cache-read Runtime")
+        })
+    }
+}
+
+impl Drop for CacheReadRuntime {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            // This pool can be released from within uv's main runtime, where waiting for another
+            // runtime to shut down is not permitted.
+            runtime.shutdown_background();
+        }
+    }
 }
 
 /// The policy for handling HTTP redirects.
@@ -185,6 +223,7 @@ impl Default for BaseClientBuilder<'_> {
             subcommand: None,
             client_name: None,
             no_retry_delay: env::var_os(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY).is_some(),
+            cache_read_runtime: Arc::new(CacheReadRuntime::new(Concurrency::DEFAULT_CACHE_READS)),
         }
     }
 }
@@ -249,6 +288,13 @@ impl<'a> BaseClientBuilder<'a> {
     #[must_use]
     pub fn no_retry_delay(mut self, no_retry_delay: bool) -> Self {
         self.no_retry_delay = no_retry_delay;
+        self
+    }
+
+    /// Set the number of workers available for reading cached HTTP responses.
+    #[must_use]
+    pub fn cache_read_concurrency(mut self, workers: usize) -> Self {
+        self.cache_read_runtime = Arc::new(CacheReadRuntime::new(workers));
         self
     }
 
@@ -429,6 +475,7 @@ impl<'a> BaseClientBuilder<'a> {
             connect_timeout: self.connect_timeout,
             credentials_cache: self.credentials_cache.clone(),
             certificate_source,
+            cache_read_runtime: self.cache_read_runtime.clone(),
         })
     }
 
@@ -459,6 +506,7 @@ impl<'a> BaseClientBuilder<'a> {
             connect_timeout: existing.connect_timeout,
             credentials_cache: existing.credentials_cache.clone(),
             certificate_source: existing.certificate_source,
+            cache_read_runtime: self.cache_read_runtime.clone(),
         }
     }
 
@@ -700,6 +748,8 @@ pub struct BaseClient {
     credentials_cache: Arc<CredentialsCache>,
     /// The certificate roots used by the underlying HTTP client.
     certificate_source: CertificateSource,
+    /// A shared, dedicated blocking pool for short-lived cache reads.
+    cache_read_runtime: Arc<CacheReadRuntime>,
 }
 
 /// The certificate roots used by a [`BaseClient`].
@@ -724,6 +774,10 @@ enum Security {
 }
 
 impl BaseClient {
+    pub(crate) fn cache_read_runtime(&self) -> &tokio::runtime::Runtime {
+        self.cache_read_runtime.get()
+    }
+
     /// Selects the appropriate client based on the host's trustworthiness.
     pub fn for_host(&self, url: &DisplaySafeUrl) -> &RedirectClientWithMiddleware {
         if self.disable_ssl(url) {
@@ -1175,6 +1229,13 @@ mod tests {
     use reqwest::{Client, Method};
     use wiremock::matchers::method;
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn cache_read_runtime_can_be_dropped_from_an_async_context() {
+        let runtime = CacheReadRuntime::new(1);
+        runtime.get().spawn_blocking(|| {}).await.unwrap();
+        drop(runtime);
+    }
 
     #[tokio::test]
     async fn test_redirect_preserves_authorization_header_on_same_origin() -> Result<()> {

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -810,7 +810,7 @@ static CACHE_READ_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| 
     tokio::runtime::Builder::new_current_thread()
         .thread_name("uv-cache-read")
         .thread_stack_size(min_stack_size())
-        .max_blocking_threads(2)
+        .max_blocking_threads(4)
         .build()
         .expect("Failed building the cache-read Runtime")
 });

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -1,4 +1,5 @@
-use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use std::{borrow::Cow, io::Read, path::Path};
 
@@ -7,6 +8,7 @@ use reqwest::{Request, Response};
 use rkyv::util::AlignedVec;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use tokio::sync::{Semaphore, SemaphorePermit};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 
 use uv_cache::{CacheEntry, Freshness};
@@ -810,10 +812,102 @@ static CACHE_READ_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| 
     tokio::runtime::Builder::new_current_thread()
         .thread_name("uv-cache-read")
         .thread_stack_size(min_stack_size())
-        .max_blocking_threads(2)
+        .max_blocking_threads(8)
         .build()
         .expect("Failed building the cache-read Runtime")
 });
+
+static CACHE_READ_CONCURRENCY: LazyLock<AdaptiveCacheReadConcurrency> = LazyLock::new(|| {
+    AdaptiveCacheReadConcurrency::new(2, 8, Duration::from_millis(10), Duration::from_secs(1))
+});
+
+struct AdaptiveCacheReadConcurrency {
+    semaphore: Semaphore,
+    state: Mutex<CacheReadConcurrencyState>,
+    expanded: AtomicBool,
+    minimum: usize,
+    maximum: usize,
+    growth_delay: Duration,
+    decay_delay: Duration,
+}
+
+struct CacheReadConcurrencyState {
+    current: usize,
+    last_pressure: Option<Instant>,
+}
+
+impl AdaptiveCacheReadConcurrency {
+    fn new(minimum: usize, maximum: usize, growth_delay: Duration, decay_delay: Duration) -> Self {
+        Self {
+            semaphore: Semaphore::new(minimum),
+            state: Mutex::new(CacheReadConcurrencyState {
+                current: minimum,
+                last_pressure: None,
+            }),
+            expanded: AtomicBool::new(false),
+            minimum,
+            maximum,
+            growth_delay,
+            decay_delay,
+        }
+    }
+
+    async fn acquire(&self) -> SemaphorePermit<'_> {
+        if let Ok(permit) = self.semaphore.try_acquire() {
+            return permit;
+        }
+
+        let acquire = self.semaphore.acquire();
+        tokio::pin!(acquire);
+
+        tokio::select! {
+            biased;
+            permit = &mut acquire => permit.expect("Cache-read semaphore should not be closed"),
+            () = tokio::time::sleep(self.growth_delay) => {
+                self.grow();
+                acquire.await.expect("Cache-read semaphore should not be closed")
+            }
+        }
+    }
+
+    fn grow(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("Cache-read concurrency state should not be poisoned");
+        state.last_pressure = Some(Instant::now());
+
+        if state.current < self.maximum {
+            state.current += 1;
+            self.semaphore.add_permits(1);
+            self.expanded.store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn shrink(&self) {
+        if !self.expanded.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let mut state = self
+            .state
+            .lock()
+            .expect("Cache-read concurrency state should not be poisoned");
+        if state
+            .last_pressure
+            .is_some_and(|last_pressure| last_pressure.elapsed() < self.decay_delay)
+        {
+            return;
+        }
+
+        let removed = self
+            .semaphore
+            .forget_permits(state.current.saturating_sub(self.minimum));
+        state.current -= removed;
+        self.expanded
+            .store(state.current > self.minimum, Ordering::Relaxed);
+    }
+}
 
 impl DataWithCachePolicy {
     /// Loads cached data and its associated HTTP cache policy from the given
@@ -825,8 +919,14 @@ impl DataWithCachePolicy {
     /// file given fails, then this returns an error.
     async fn from_path_async(path: &Path) -> Result<Self, Error> {
         let path = path.to_path_buf();
+        let permit = CACHE_READ_CONCURRENCY.acquire().await;
         CACHE_READ_RUNTIME
-            .spawn_blocking(move || Self::from_path_sync(&path))
+            .spawn_blocking(move || {
+                let result = Self::from_path_sync(&path);
+                drop(permit);
+                CACHE_READ_CONCURRENCY.shrink();
+                result
+            })
             .await
             // This just forwards panics from the closure.
             .unwrap()
@@ -1004,5 +1104,55 @@ impl DataWithCachePolicy {
             return Err(ErrorKind::ArchiveRead(msg).into());
         }
         Ok(len_usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::FutureExt;
+
+    use super::AdaptiveCacheReadConcurrency;
+
+    #[tokio::test]
+    async fn cache_read_concurrency_grows_under_pressure() {
+        let concurrency = AdaptiveCacheReadConcurrency::new(
+            2,
+            4,
+            Duration::from_millis(10),
+            Duration::from_millis(20),
+        );
+        let first = concurrency.acquire().await;
+        let second = concurrency.acquire().await;
+
+        let third = concurrency.acquire();
+        tokio::pin!(third);
+        assert!(third.as_mut().now_or_never().is_none());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let third = third.await;
+        assert_eq!(concurrency.semaphore.available_permits(), 0);
+
+        let fourth = concurrency.acquire();
+        tokio::pin!(fourth);
+        assert!(fourth.as_mut().now_or_never().is_none());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let fourth = fourth.await;
+
+        let fifth = concurrency.acquire();
+        tokio::pin!(fifth);
+        assert!(fifth.as_mut().now_or_never().is_none());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(fifth.as_mut().now_or_never().is_none());
+
+        drop(fourth);
+        let fifth = fifth.await;
+        drop(fifth);
+        drop(third);
+        drop(second);
+        drop(first);
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        concurrency.shrink();
+        assert_eq!(concurrency.semaphore.available_permits(), 2);
     }
 }

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -1,4 +1,3 @@
-use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use std::{borrow::Cow, io::Read, path::Path};
 
@@ -10,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 
 use uv_cache::{CacheEntry, Freshness};
-use uv_configuration::min_stack_size;
 use uv_fs::write_atomic;
 use uv_redacted::DisplaySafeUrl;
 
@@ -250,7 +248,7 @@ impl CachedClient {
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
         let start = Instant::now();
-        let cached_response = if let Some(cached) = Self::read_cache(cache_entry).await {
+        let cached_response = if let Some(cached) = self.read_cache(cache_entry).await {
             self.send_cached(req, cache_control.clone(), cached)
                 .boxed_local()
                 .await?
@@ -440,8 +438,10 @@ impl CachedClient {
 
     #[instrument(name = "read_and_parse_cache", skip_all, fields(file = %cache_entry.path().display()
     ))]
-    async fn read_cache(cache_entry: &CacheEntry) -> Option<DataWithCachePolicy> {
-        match DataWithCachePolicy::from_path_async(cache_entry.path()).await {
+    async fn read_cache(&self, cache_entry: &CacheEntry) -> Option<DataWithCachePolicy> {
+        match DataWithCachePolicy::from_path_async(cache_entry.path(), self.0.cache_read_runtime())
+            .await
+        {
             Ok(data) => Some(data),
             Err(err) => {
                 // When we know the cache entry doesn't exist, then things are
@@ -805,16 +805,6 @@ pub struct DataWithCachePolicy {
     cache_policy: OwnedArchive<CachePolicy>,
 }
 
-/// A small, dedicated blocking pool for short-lived cache reads.
-static CACHE_READ_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
-    tokio::runtime::Builder::new_current_thread()
-        .thread_name("uv-cache-read")
-        .thread_stack_size(min_stack_size())
-        .max_blocking_threads(4)
-        .build()
-        .expect("Failed building the cache-read Runtime")
-});
-
 impl DataWithCachePolicy {
     /// Loads cached data and its associated HTTP cache policy from the given
     /// file path in an asynchronous fashion (via `spawn_blocking`).
@@ -823,9 +813,12 @@ impl DataWithCachePolicy {
     ///
     /// If the given byte buffer is not in a valid format or if reading the
     /// file given fails, then this returns an error.
-    async fn from_path_async(path: &Path) -> Result<Self, Error> {
+    async fn from_path_async(
+        path: &Path,
+        runtime: &tokio::runtime::Runtime,
+    ) -> Result<Self, Error> {
         let path = path.to_path_buf();
-        CACHE_READ_RUNTIME
+        runtime
             .spawn_blocking(move || Self::from_path_sync(&path))
             .await
             // This just forwards panics from the closure.

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -1,5 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{LazyLock, Mutex};
+use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use std::{borrow::Cow, io::Read, path::Path};
 
@@ -8,7 +7,6 @@ use reqwest::{Request, Response};
 use rkyv::util::AlignedVec;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Semaphore, SemaphorePermit};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 
 use uv_cache::{CacheEntry, Freshness};
@@ -812,102 +810,10 @@ static CACHE_READ_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| 
     tokio::runtime::Builder::new_current_thread()
         .thread_name("uv-cache-read")
         .thread_stack_size(min_stack_size())
-        .max_blocking_threads(8)
+        .max_blocking_threads(2)
         .build()
         .expect("Failed building the cache-read Runtime")
 });
-
-static CACHE_READ_CONCURRENCY: LazyLock<AdaptiveCacheReadConcurrency> = LazyLock::new(|| {
-    AdaptiveCacheReadConcurrency::new(2, 8, Duration::from_millis(10), Duration::from_secs(1))
-});
-
-struct AdaptiveCacheReadConcurrency {
-    semaphore: Semaphore,
-    state: Mutex<CacheReadConcurrencyState>,
-    expanded: AtomicBool,
-    minimum: usize,
-    maximum: usize,
-    growth_delay: Duration,
-    decay_delay: Duration,
-}
-
-struct CacheReadConcurrencyState {
-    current: usize,
-    last_pressure: Option<Instant>,
-}
-
-impl AdaptiveCacheReadConcurrency {
-    fn new(minimum: usize, maximum: usize, growth_delay: Duration, decay_delay: Duration) -> Self {
-        Self {
-            semaphore: Semaphore::new(minimum),
-            state: Mutex::new(CacheReadConcurrencyState {
-                current: minimum,
-                last_pressure: None,
-            }),
-            expanded: AtomicBool::new(false),
-            minimum,
-            maximum,
-            growth_delay,
-            decay_delay,
-        }
-    }
-
-    async fn acquire(&self) -> SemaphorePermit<'_> {
-        if let Ok(permit) = self.semaphore.try_acquire() {
-            return permit;
-        }
-
-        let acquire = self.semaphore.acquire();
-        tokio::pin!(acquire);
-
-        tokio::select! {
-            biased;
-            permit = &mut acquire => permit.expect("Cache-read semaphore should not be closed"),
-            () = tokio::time::sleep(self.growth_delay) => {
-                self.grow();
-                acquire.await.expect("Cache-read semaphore should not be closed")
-            }
-        }
-    }
-
-    fn grow(&self) {
-        let mut state = self
-            .state
-            .lock()
-            .expect("Cache-read concurrency state should not be poisoned");
-        state.last_pressure = Some(Instant::now());
-
-        if state.current < self.maximum {
-            state.current += 1;
-            self.semaphore.add_permits(1);
-            self.expanded.store(true, Ordering::Relaxed);
-        }
-    }
-
-    fn shrink(&self) {
-        if !self.expanded.load(Ordering::Relaxed) {
-            return;
-        }
-
-        let mut state = self
-            .state
-            .lock()
-            .expect("Cache-read concurrency state should not be poisoned");
-        if state
-            .last_pressure
-            .is_some_and(|last_pressure| last_pressure.elapsed() < self.decay_delay)
-        {
-            return;
-        }
-
-        let removed = self
-            .semaphore
-            .forget_permits(state.current.saturating_sub(self.minimum));
-        state.current -= removed;
-        self.expanded
-            .store(state.current > self.minimum, Ordering::Relaxed);
-    }
-}
 
 impl DataWithCachePolicy {
     /// Loads cached data and its associated HTTP cache policy from the given
@@ -919,14 +825,8 @@ impl DataWithCachePolicy {
     /// file given fails, then this returns an error.
     async fn from_path_async(path: &Path) -> Result<Self, Error> {
         let path = path.to_path_buf();
-        let permit = CACHE_READ_CONCURRENCY.acquire().await;
         CACHE_READ_RUNTIME
-            .spawn_blocking(move || {
-                let result = Self::from_path_sync(&path);
-                drop(permit);
-                CACHE_READ_CONCURRENCY.shrink();
-                result
-            })
+            .spawn_blocking(move || Self::from_path_sync(&path))
             .await
             // This just forwards panics from the closure.
             .unwrap()
@@ -1104,55 +1004,5 @@ impl DataWithCachePolicy {
             return Err(ErrorKind::ArchiveRead(msg).into());
         }
         Ok(len_usize)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use futures::FutureExt;
-
-    use super::AdaptiveCacheReadConcurrency;
-
-    #[tokio::test]
-    async fn cache_read_concurrency_grows_under_pressure() {
-        let concurrency = AdaptiveCacheReadConcurrency::new(
-            2,
-            4,
-            Duration::from_millis(10),
-            Duration::from_millis(20),
-        );
-        let first = concurrency.acquire().await;
-        let second = concurrency.acquire().await;
-
-        let third = concurrency.acquire();
-        tokio::pin!(third);
-        assert!(third.as_mut().now_or_never().is_none());
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        let third = third.await;
-        assert_eq!(concurrency.semaphore.available_permits(), 0);
-
-        let fourth = concurrency.acquire();
-        tokio::pin!(fourth);
-        assert!(fourth.as_mut().now_or_never().is_none());
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        let fourth = fourth.await;
-
-        let fifth = concurrency.acquire();
-        tokio::pin!(fifth);
-        assert!(fifth.as_mut().now_or_never().is_none());
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        assert!(fifth.as_mut().now_or_never().is_none());
-
-        drop(fourth);
-        let fifth = fifth.await;
-        drop(fifth);
-        drop(third);
-        drop(second);
-        drop(first);
-        tokio::time::sleep(Duration::from_millis(30)).await;
-        concurrency.shrink();
-        assert_eq!(concurrency.semaphore.available_permits(), 2);
     }
 }

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -1,3 +1,4 @@
+use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use std::{borrow::Cow, io::Read, path::Path};
 
@@ -9,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 
 use uv_cache::{CacheEntry, Freshness};
+use uv_configuration::min_stack_size;
 use uv_fs::write_atomic;
 use uv_redacted::DisplaySafeUrl;
 
@@ -803,6 +805,16 @@ pub struct DataWithCachePolicy {
     cache_policy: OwnedArchive<CachePolicy>,
 }
 
+/// A small, dedicated blocking pool for short-lived cache reads.
+static CACHE_READ_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .thread_name("uv-cache-read")
+        .thread_stack_size(min_stack_size())
+        .max_blocking_threads(2)
+        .build()
+        .expect("Failed building the cache-read Runtime")
+});
+
 impl DataWithCachePolicy {
     /// Loads cached data and its associated HTTP cache policy from the given
     /// file path in an asynchronous fashion (via `spawn_blocking`).
@@ -813,7 +825,8 @@ impl DataWithCachePolicy {
     /// file given fails, then this returns an error.
     async fn from_path_async(path: &Path) -> Result<Self, Error> {
         let path = path.to_path_buf();
-        tokio::task::spawn_blocking(move || Self::from_path_sync(&path))
+        CACHE_READ_RUNTIME
+            .spawn_blocking(move || Self::from_path_sync(&path))
             .await
             // This just forwards panics from the closure.
             .unwrap()

--- a/crates/uv-configuration/src/concurrency.rs
+++ b/crates/uv-configuration/src/concurrency.rs
@@ -20,6 +20,10 @@ pub struct Concurrency {
     ///
     /// Note this value must be non-zero.
     pub installs: usize,
+    /// The maximum number of concurrent cache reads.
+    ///
+    /// Note this value must be non-zero.
+    pub cache_reads: usize,
     /// A global semaphore to limit the number of concurrent downloads.
     pub downloads_semaphore: Arc<Semaphore>,
     /// A global semaphore to limit the number of concurrent builds.
@@ -34,13 +38,19 @@ impl fmt::Debug for Concurrency {
             .field("downloads", &self.downloads)
             .field("builds", &self.builds)
             .field("installs", &self.installs)
+            .field("cache_reads", &self.cache_reads)
             .finish()
     }
 }
 
 impl Default for Concurrency {
     fn default() -> Self {
-        Self::new(Self::DEFAULT_DOWNLOADS, Self::threads(), Self::threads())
+        Self::new(
+            Self::DEFAULT_DOWNLOADS,
+            Self::threads(),
+            Self::threads(),
+            Self::DEFAULT_CACHE_READS,
+        )
     }
 }
 
@@ -48,12 +58,16 @@ impl Concurrency {
     // The default concurrent downloads limit.
     pub const DEFAULT_DOWNLOADS: usize = 50;
 
+    // The default concurrent cache reads limit.
+    pub const DEFAULT_CACHE_READS: usize = 4;
+
     /// Create a new [`Concurrency`] with the given limits.
-    pub fn new(downloads: usize, builds: usize, installs: usize) -> Self {
+    pub fn new(downloads: usize, builds: usize, installs: usize, cache_reads: usize) -> Self {
         Self {
             downloads,
             builds,
             installs,
+            cache_reads,
             downloads_semaphore: Arc::new(Semaphore::new(downloads)),
             builds_semaphore: Arc::new(Semaphore::new(builds)),
         }

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -689,6 +689,7 @@ pub struct Concurrency {
     pub downloads: Option<NonZeroUsize>,
     pub builds: Option<NonZeroUsize>,
     pub installs: Option<NonZeroUsize>,
+    pub cache_reads: Option<NonZeroUsize>,
 }
 
 /// A boolean flag parsed from an environment variable.
@@ -811,6 +812,10 @@ impl EnvironmentOptions {
                 builds: parse_integer_environment_variable(EnvVars::UV_CONCURRENT_BUILDS, None)?,
                 installs: parse_integer_environment_variable(
                     EnvVars::UV_CONCURRENT_INSTALLS,
+                    None,
+                )?,
+                cache_reads: parse_integer_environment_variable(
+                    EnvVars::UV_CONCURRENT_CACHE_READS,
                     None,
                 )?,
             },

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -422,6 +422,10 @@ impl EnvVars {
     #[attr_added_in("0.1.45")]
     pub const UV_CONCURRENT_INSTALLS: &'static str = "UV_CONCURRENT_INSTALLS";
 
+    /// Controls the number of threads used to read cached HTTP responses.
+    #[attr_added_in("0.11.29")]
+    pub const UV_CONCURRENT_CACHE_READS: &'static str = "UV_CONCURRENT_CACHE_READS";
+
     /// Equivalent to the `--no-progress` command-line argument. Disables all progress output. For
     /// example, spinners and progress bars.
     #[attr_added_in("0.2.28")]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -3046,6 +3046,7 @@ where
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .thread_stack_size(min_stack_size)
+            .max_blocking_threads(2)
             .build()
             .expect("Failed building the Runtime");
         // Box the large main future to avoid stack overflows.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -633,6 +633,7 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
         globals.network_settings.connect_timeout,
         globals.network_settings.retries,
     )
+    .cache_read_concurrency(globals.concurrency.cache_reads)
     .http_proxy(globals.network_settings.http_proxy.clone())
     .https_proxy(globals.network_settings.https_proxy.clone())
     .no_proxy(globals.network_settings.no_proxy.clone());

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -3046,7 +3046,6 @@ where
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .thread_stack_size(min_stack_size)
-            .max_blocking_threads(2)
             .build()
             .expect("Failed building the Runtime");
         // Box the large main future to avoid stack overflows.

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -128,6 +128,11 @@ impl GlobalSettings {
                     .combine(workspace.and_then(|workspace| workspace.globals.concurrent_installs))
                     .map(NonZeroUsize::get)
                     .unwrap_or_else(Concurrency::threads),
+                environment
+                    .concurrency
+                    .cache_reads
+                    .map(NonZeroUsize::get)
+                    .unwrap_or(Concurrency::DEFAULT_CACHE_READS),
             ),
             show_settings: args.show_settings,
             preview: resolve_preview(args, workspace, environment),

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -262,6 +262,7 @@ fn publish_resolved_settings() -> anyhow::Result<()> {
             downloads: 50,
             builds: 16,
             installs: 8,
+            cache_reads: 2,
         },
         show_settings: true,
         preview: Preview {

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -15,6 +15,7 @@ fn add_shared_args(mut command: Command) -> Command {
         .env(EnvVars::UV_CONCURRENT_DOWNLOADS, "50")
         .env(EnvVars::UV_CONCURRENT_BUILDS, "16")
         .env(EnvVars::UV_CONCURRENT_INSTALLS, "8")
+        .env(EnvVars::UV_CONCURRENT_CACHE_READS, "2")
         .env_remove(EnvVars::UV_EXCLUDE_NEWER)
         .env_remove(EnvVars::UV_PYTHON_DOWNLOADS);
 
@@ -60,6 +61,7 @@ fn pip_compile_baseline() {
             downloads: 50,
             builds: 16,
             installs: 8,
+            cache_reads: 2,
         },
         show_settings: true,
         preview: Preview {
@@ -427,6 +429,7 @@ fn pip_install_baseline() {
             downloads: 50,
             builds: 16,
             installs: 8,
+            cache_reads: 2,
         },
         show_settings: true,
         preview: Preview {
@@ -610,6 +613,7 @@ fn lock_baseline() {
             downloads: 50,
             builds: 16,
             installs: 8,
+            cache_reads: 2,
         },
         show_settings: true,
         preview: Preview {
@@ -732,6 +736,7 @@ fn version_baseline() {
             downloads: 50,
             builds: 16,
             installs: 8,
+            cache_reads: 2,
         },
         show_settings: true,
         preview: Preview {
@@ -869,6 +874,7 @@ fn tool_install_baseline() {
             downloads: 50,
             builds: 16,
             installs: 8,
+            cache_reads: 2,
         },
         show_settings: true,
         preview: Preview {


### PR DESCRIPTION
## Summary

We run uv's async entry point on Tokio's current-thread runtime, whose blocking pool can grow to 512 workers. Warm resolves issue many short-lived HTTP cache reads through `spawn_blocking`; the resulting thread fan-out adds allocator and scheduling overhead even though the actual work is small.

This moves those cache reads onto a lazily initialized, four-worker Tokio blocking pool. (The pool size is configurable via `UV_CONCURRENT_CACHE_READS`.)

(I ran an interleaved 2/4/8-worker sweep, and four was wall-time neutral against two on a warm cache while substantially improving slower reads; eight measurably regresses the target warm benchmark and consumes more CPU.)

## Performance

I measured fresh `uv lock` executions against the latest-main base (`38c326f2a`) with a warm shared cache. All timed runs were offline with a fixed `--exclude-newer`, CPU affinity, six warmups, and 40 randomized/alternating-order blocks per workload. Every generated lockfile was byte-identical.

| Workload | Wall time | Wall change (95% CI) | CPU time | CPU change (95% CI) |
| --- | ---: | ---: | ---: | ---: |
| Transformers | 378.8 -> 361.3 ms | -4.6% [-6.1, -2.9] | 436.6 -> 389.7 ms | -10.7% [-11.7, -9.5] |
| Home Assistant | 153.6 -> 139.2 ms | -9.4% [-13.3, -6.4] | 135.4 -> 96.2 ms | -28.9% [-29.7, -27.2] |
| Warehouse | 211.4 -> 200.6 ms | -5.1% [-7.8, -1.4] | 243.0 -> 203.5 ms | -16.2% [-18.0, -15.1] |
| JupyterLab | 128.1 -> 118.9 ms | -7.3% [-9.5, -4.1] | 79.1 -> 64.1 ms | -18.9% [-22.8, -17.0] |
| Semantic Kernel | 142.5 -> 136.7 ms | -4.1% [-7.0, -0.3] | 104.1 -> 87.6 ms | -15.9% [-17.4, -14.6] |
| **Geometric mean** | | **-6.1% [-7.2, -4.6]** | | **-18.4% [-19.3, -17.7]** |
