### PR TITLE
Contain nested wheel-data symlinks

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -80,6 +80,8 @@ pub enum Error {
     /// Either an absolute path or a parent path through `..`.
     #[error("The path for the data directory {} must be inside the project: {}", name, path.user_display())]
     InvalidDataRoot { name: String, path: PathBuf },
+    #[error("The path for the data file must be inside the project: {}", _0.user_display())]
+    InvalidDataFile(PathBuf),
     #[error("Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: {}", _0.user_display())]
     VenvInSourceTree(PathBuf),
     #[error("Inconsistent metadata between prepare and build step: {0}")]

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -633,6 +633,27 @@ fn wheel_subdir_from_globs(
             continue;
         }
 
+        if entry.file_type().is_symlink()
+            && let Some((exclude_matcher, source_tree)) = exclude_matcher
+        {
+            let canonical_source_tree = source_tree.simple_canonicalize()?;
+            let canonical_path = entry.path().simple_canonicalize()?;
+            let Ok(canonical_relative) = canonical_path.strip_prefix(&canonical_source_tree) else {
+                return Err(Error::InvalidDataFile(
+                    entry
+                        .path()
+                        .strip_prefix(source_tree)
+                        .unwrap_or(entry.path())
+                        .to_path_buf(),
+                ));
+            };
+
+            if exclude_matcher.is_match(canonical_relative) {
+                trace!("Excluding {}: {}", globs_field, relative.user_display());
+                continue;
+            }
+        }
+
         debug!("Adding for {}: {}", globs_field, relative.user_display());
         write_directory_once(wheel_writer, &mut written_directories, target)?;
         write_file_with_directories(

--- a/crates/uv/tests/build/build_backend.rs
+++ b/crates/uv/tests/build/build_backend.rs
@@ -1251,6 +1251,75 @@ fn wheel_data_symlink_containment() -> Result<()> {
     Ok(())
 }
 
+/// A symlink below a contained wheel data root must not package an external file or bypass an
+/// exclude that applies to its internal target.
+#[test]
+#[cfg(unix)]
+fn wheel_data_nested_symlink_containment() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let project = context.temp_dir.child("project");
+    project.child("src/project/__init__.py").touch()?;
+    project.child("assets/public.txt").touch()?;
+    project.child("assets/private.secret").touch()?;
+    context
+        .temp_dir
+        .child("outside/secret.txt")
+        .write_str("not for distribution")?;
+    fs_err::os::unix::fs::symlink(
+        context.temp_dir.child("outside/secret.txt").path(),
+        project.child("assets/external.txt").path(),
+    )?;
+
+    let pyproject_toml = project.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [tool.uv.build-backend]
+        wheel-exclude = ["assets/private.secret"]
+
+        [tool.uv.build-backend.data]
+        data = "assets"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.build().arg("project").arg("--wheel").arg("--list"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: The path for the data file must be inside the project: assets/external.txt
+    ");
+
+    fs_err::remove_file(project.child("assets/external.txt"))?;
+    fs_err::os::unix::fs::symlink(
+        project.child("assets/private.secret").path(),
+        project.child("assets/aliased.txt").path(),
+    )?;
+
+    uv_snapshot!(context.build().arg("project").arg("--wheel").arg("--list"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Building project-0.1.0-py3-none-any.whl will include the following files:
+    project/__init__.py (src/project/__init__.py)
+    project-0.1.0.data/data/public.txt (assets/public.txt)
+    project-0.1.0.dist-info/WHEEL (generated)
+    project-0.1.0.dist-info/METADATA (generated)
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 /// Show an explicit error when there is a venv in source tree.
 #[test]
 fn venv_in_source_tree() {


### PR DESCRIPTION
A nested symlink beneath `tool.uv.build-backend.data` can package files outside the source tree or files excluded from the source and wheel, even after the data root is contained. Resolve each data file against the source tree, reject escaped targets, and apply both exclusion sets before adding it to the wheel.

[#20397](https://github.com/astral-sh/uv/pull/20397) contained data roots but left this nested-symlink path open. [#15243](https://github.com/astral-sh/uv/issues/15243) documents that the backend already follows external file symlinks, so this closes that path into an artifact.
