### PR TITLE
Reject broken `.venv` symlinks and surface metadata errors

### DIFF
--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -206,6 +206,9 @@ mod tests {
     use std::{
         env,
         ffi::{OsStr, OsString},
+        fs::Permissions,
+        io,
+        os::unix::fs::PermissionsExt,
         path::{Path, PathBuf},
         str::FromStr,
     };
@@ -2252,6 +2255,65 @@ mod tests {
             matches!(result, Err(PythonNotFound { .. })),
             "We should not find an python; got {result:?}"
         );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_python_does_not_traverse_broken_child_virtualenv() -> Result<()> {
+        let context = TestContext::new()?;
+
+        let parent_venv = context.tempdir.child(".venv");
+        TestContext::mock_venv(&parent_venv, "3.12.0")?;
+        let child_venv = context.workdir.child(".venv");
+        fs_err::os::unix::fs::symlink(context.workdir.child("missing"), &child_venv)?;
+
+        let result = context.run(|| {
+            find_python_installation(
+                &PythonRequest::Default,
+                EnvironmentPreference::OnlyVirtual,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        });
+        assert!(
+            matches!(
+                &result,
+                Err(discovery::Error::VirtualEnv(
+                    crate::virtualenv::Error::MissingPyVenvCfg(path)
+                )) if path == child_venv.path()
+            ),
+            "A broken symlink at `.venv` should be eagerly rejected; got {result:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn find_python_propagates_virtualenv_metadata_errors() -> Result<()> {
+        let context = TestContext::new()?;
+
+        let permissions = fs_err::metadata(&context.workdir)?.permissions();
+        fs_err::set_permissions(&context.workdir, Permissions::from_mode(0o000))?;
+        let result = context.run(|| {
+            find_python_installation(
+                &PythonRequest::Default,
+                EnvironmentPreference::OnlyVirtual,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        });
+        fs_err::set_permissions(&context.workdir, permissions)?;
+
+        assert!(
+            matches!(
+                &result,
+                Err(discovery::Error::VirtualEnv(crate::virtualenv::Error::Io(error)))
+                    if error.kind() == io::ErrorKind::PermissionDenied
+            ),
+            "A virtual environment metadata error should not be ignored; got {result:?}"
+        );
+
         Ok(())
     }
 

--- a/crates/uv-python/src/virtualenv.rs
+++ b/crates/uv-python/src/virtualenv.rs
@@ -149,9 +149,9 @@ pub(crate) fn conda_environment_from_env(kind: CondaEnvironmentKind) -> Option<P
 
 /// Locate a virtual environment by searching the file system.
 ///
-/// Searches for a `.venv` directory in the current or any parent directory. If the current
-/// directory is itself a virtual environment (or a subdirectory of a virtual environment), the
-/// containing virtual environment is returned.
+/// Searches for a `.venv` directory or symlink in the current or any parent directory. If the
+/// current directory is itself a virtual environment (or a subdirectory of a virtual environment),
+/// the containing virtual environment is returned.
 pub(crate) fn virtualenv_from_working_dir() -> Result<Option<PathBuf>, Error> {
     let current_dir = crate::current_dir()?;
 
@@ -163,7 +163,12 @@ pub(crate) fn virtualenv_from_working_dir() -> Result<Option<PathBuf>, Error> {
 
         // Otherwise, search for a `.venv` directory.
         let dot_venv = dir.join(".venv");
-        if dot_venv.is_dir() {
+        let metadata = match fs::symlink_metadata(&dot_venv) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(err.into()),
+        };
+        if metadata.is_dir() || metadata.file_type().is_symlink() {
             if !uv_fs::is_virtualenv_base(&dot_venv) {
                 return Err(Error::MissingPyVenvCfg(dot_venv));
             }


### PR DESCRIPTION
Running a pip command beneath a broken child `.venv` symlink can skip that environment and modify an unrelated ancestor environment. Stop discovery at the broken link and report its exact path, preserving the actionable broken-link diagnostic introduced in [#12168](https://github.com/astral-sh/uv/pull/12168).

[#20333](https://github.com/astral-sh/uv/pull/20333) separately allows interpreter-only commands to fall back when `.venv` is a non-venv directory; this keeps pip from taking that fallback across a broken child link.
