### PR TITLE
Preserve Python variants in equality requests

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2716,9 +2716,29 @@ impl VersionRequest {
             && specifier.operator() == &uv_pep440::Operator::Equal
             && let Ok(request) = Self::from_str(&specifier.version().to_string())
         {
-            return request;
+            return request.with_variant(variant);
         }
         Self::Range(specifiers, variant)
+    }
+
+    /// Replace the variant on a concrete or ranged version request.
+    #[must_use]
+    fn with_variant(self, variant: PythonVariant) -> Self {
+        match self {
+            request @ (Self::Any | Self::Default) => request,
+            Self::Major(major, _) => Self::Major(major, variant),
+            Self::MajorMinor(major, minor, _) => Self::MajorMinor(major, minor, variant),
+            Self::MajorMinorPatch(major, minor, patch, _) => {
+                Self::MajorMinorPatch(major, minor, patch, variant)
+            }
+            Self::MajorMinorPrerelease(major, minor, prerelease, _) => {
+                Self::MajorMinorPrerelease(major, minor, prerelease, variant)
+            }
+            Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, _) => {
+                Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, variant)
+            }
+            Self::Range(specifiers, _) => Self::Range(specifiers, variant),
+        }
     }
 
     /// Drop any patch or prerelease information from the version request.
@@ -4344,6 +4364,19 @@ mod tests {
             VersionRequest::from_str("==3.12.1").unwrap(),
             VersionRequest::MajorMinorPatch(3, 12, 1, PythonVariant::Default)
         );
+
+        for (request, variant) in [
+            ("==3.14t", PythonVariant::Freethreaded),
+            ("==3.14d", PythonVariant::Debug),
+            ("==3.14td", PythonVariant::FreethreadedDebug),
+            ("==3.14+gil", PythonVariant::Gil),
+            ("==3.14+gil+debug", PythonVariant::GilDebug),
+        ] {
+            assert_eq!(
+                VersionRequest::from_str(request).unwrap(),
+                VersionRequest::MajorMinor(3, 14, variant)
+            );
+        }
     }
 
     #[test]

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2722,6 +2722,8 @@ impl VersionRequest {
     }
 
     /// Replace the variant on the version request.
+    ///
+    /// If `Any` or `Default`, the request is returned unchanged.
     #[must_use]
     fn with_variant(self, variant: PythonVariant) -> Self {
         match self {

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2721,7 +2721,7 @@ impl VersionRequest {
         Self::Range(specifiers, variant)
     }
 
-    /// Replace the variant on a concrete or ranged version request.
+    /// Replace the variant on the version request.
     #[must_use]
     fn with_variant(self, variant: PythonVariant) -> Self {
         match self {


### PR DESCRIPTION
Explicit equality requests such as `uv python find --managed-python '==3.14t'` can lose the requested Python variant and select the wrong interpreter. Preserve the variant when parsing equality requests.

This does not change free-threaded interpreter selection for `requires-python` ranges, which is tracked in [uv#16434](https://github.com/astral-sh/uv/issues/16434).