### PR TITLE
Reject dev dependency removal from scripts

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4651,7 +4651,13 @@ pub struct RemoveArgs {
     /// Remove the packages from the development dependency group [env: UV_DEV=]
     ///
     /// This option is an alias for `--group dev`.
-    #[arg(long, conflicts_with("optional"), conflicts_with("group"), value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(
+        long,
+        conflicts_with("optional"),
+        conflicts_with("group"),
+        conflicts_with("script"),
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
     pub dev: bool,
 
     /// Remove the packages from the project's optional dependencies for the specified extra.

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -8538,6 +8538,34 @@ fn remove_script() -> Result<()> {
     Ok(())
 }
 
+/// `uv remove --dev` cannot be used with a PEP 723 script.
+#[test]
+fn remove_dev_script_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("script.py").write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = ["anyio"]
+        # ///
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.remove().arg("anyio").arg("--dev").arg("--script").arg("script.py"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--dev' cannot be used with '--script <SCRIPT>'
+
+    Usage: uv remove --cache-dir [CACHE_DIR] --dev --exclude-newer <EXCLUDE_NEWER> <PACKAGES>...
+
+    For more information, try '--help'.
+    ");
+
+    Ok(())
+}
+
 /// Remove last dependency PEP 723 script
 #[test]
 fn remove_last_dep_script() -> Result<()> {


### PR DESCRIPTION
`uv remove --dev --script` is accepted even though scripts do not support dependency groups, then reports a misleading dependency-not-found error. Reject `--dev` with `--script` during argument validation, matching the existing treatment of unsupported group-selection flags.
