### PR TITLE
Show resolved publish settings

### DIFF
--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -21,7 +21,7 @@ use crate::Pep508Url;
 /// A wrapper around [`Url`] that preserves the original string.
 ///
 /// The original string is not preserved after serialization/deserialization.
-#[derive(Debug, Clone, Eq)]
+#[derive(Clone, Eq)]
 pub struct VerbatimUrl {
     /// The parsed URL.
     url: DisplaySafeUrl,
@@ -33,6 +33,30 @@ pub struct VerbatimUrl {
     /// Given value is a [`Pep508Url`] which contained variable references which were successfully
     /// expanded.
     expanded: bool,
+}
+
+impl Debug for VerbatimUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let given = self.given.as_deref().map(|given| {
+            DisplaySafeUrl::parse(given).map_or_else(
+                |_| Cow::Borrowed(given),
+                |url| {
+                    let redacted = url.to_string();
+                    if redacted == url.displayable_with_credentials().to_string() {
+                        Cow::Borrowed(given)
+                    } else {
+                        Cow::Owned(redacted)
+                    }
+                },
+            )
+        });
+
+        f.debug_struct("VerbatimUrl")
+            .field("url", &self.url)
+            .field("given", &given)
+            .field("expanded", &self.expanded)
+            .finish()
+    }
 }
 
 impl Hash for VerbatimUrl {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1983,8 +1983,6 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
             Ok(ExitStatus::Success)
         }
         Commands::Publish(args) => {
-            show_settings!(args);
-
             if args.skip_existing {
                 bail!(
                     "`uv publish` does not support `--skip-existing` because there is not a \
@@ -1996,6 +1994,9 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
             }
 
             // Resolve the settings from the command-line arguments and workspace configuration.
+            let args = PublishSettings::resolve(args, filesystem);
+            show_settings!(args);
+
             let PublishSettings {
                 files,
                 username,
@@ -2009,7 +2010,7 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
                 check_url,
                 index,
                 index_locations,
-            } = PublishSettings::resolve(args, filesystem);
+            } = args;
 
             commands::publish(
                 files,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1,4 +1,5 @@
 use std::env::VarError;
+use std::fmt;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::process;
@@ -4984,7 +4985,7 @@ impl<'a> From<&'a ResolverInstallerSettings> for InstallerSettingsRef<'a> {
 }
 
 /// The resolved settings to use for an invocation of the `uv publish` CLI.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct PublishSettings {
     // CLI only, see [`PublishArgs`] for docs.
     pub(crate) files: Vec<String>,
@@ -5003,6 +5004,25 @@ pub(crate) struct PublishSettings {
 
     // Configuration only
     pub(crate) index_locations: IndexLocations,
+}
+
+impl fmt::Debug for PublishSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublishSettings")
+            .field("files", &self.files)
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| "****"))
+            .field("index", &self.index)
+            .field("dry_run", &self.dry_run)
+            .field("no_attestations", &self.no_attestations)
+            .field("direct", &self.direct)
+            .field("publish_url", &self.publish_url)
+            .field("trusted_publishing", &self.trusted_publishing)
+            .field("keyring_provider", &self.keyring_provider)
+            .field("check_url", &self.check_url)
+            .field("index_locations", &self.index_locations)
+            .finish()
+    }
 }
 
 impl PublishSettings {

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -216,6 +216,186 @@ fn pip_compile_baseline() {
     windows,
     ignore = "Configuration tests are not yet supported on Windows"
 )]
+fn publish_resolved_settings() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("uv.toml")
+        .write_str(indoc::indoc! {r#"
+        publish-url = "https://test.pypi.org/legacy/"
+        trusted-publishing = "never"
+        check-url = "https://check-user:check-secret@test.pypi.org/simple/"
+        keyring-provider = "subprocess"
+
+        [[index]]
+        name = "private"
+        url = "https://index-user:index-secret@test.pypi.org/simple/"
+    "#})?;
+
+    uv_snapshot!(context.filters(), add_shared_args(context.publish())
+        .arg("--show-settings")
+        .env(EnvVars::UV_PUBLISH_TOKEN, "publish-secret-token"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    GlobalSettings {
+        required_version: None,
+        quiet: 0,
+        verbose: 0,
+        color: Auto,
+        network_settings: NetworkSettings {
+            connectivity: Online,
+            offline: Disabled,
+            system_certs: false,
+            http_proxy: None,
+            https_proxy: None,
+            no_proxy: None,
+            allow_insecure_host: [],
+            read_timeout: [TIME],
+            connect_timeout: [TIME],
+            retries: 3,
+        },
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
+        show_settings: true,
+        preview: Preview {
+            flags: [],
+        },
+        python_preference: Managed,
+        python_downloads: Automatic,
+        no_progress: false,
+        installer_metadata: true,
+    }
+    CacheSettings {
+        no_cache: false,
+        cache_dir: Some(
+            "[CACHE_DIR]/",
+        ),
+    }
+    PublishSettings {
+        files: [
+            "dist/*",
+        ],
+        username: Some(
+            "__token__",
+        ),
+        password: Some(
+            "****",
+        ),
+        index: None,
+        dry_run: false,
+        no_attestations: false,
+        direct: false,
+        publish_url: DisplaySafeUrl {
+            scheme: "https",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: Some(
+                Domain(
+                    "test.pypi.org",
+                ),
+            ),
+            port: None,
+            path: "/legacy/",
+            query: None,
+            fragment: None,
+        },
+        trusted_publishing: Never,
+        keyring_provider: Subprocess,
+        check_url: Some(
+            Url(
+                VerbatimUrl {
+                    url: DisplaySafeUrl {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "check-user",
+                        password: Some(
+                            "****",
+                        ),
+                        host: Some(
+                            Domain(
+                                "test.pypi.org",
+                            ),
+                        ),
+                        port: None,
+                        path: "/simple/",
+                        query: None,
+                        fragment: None,
+                    },
+                    given: Some(
+                        "https://check-user:****@test.pypi.org/simple/",
+                    ),
+                    expanded: false,
+                },
+            ),
+        ),
+        index_locations: IndexLocations {
+            indexes: [
+                Index {
+                    name: Some(
+                        IndexName(
+                            "private",
+                        ),
+                    ),
+                    url: Url(
+                        VerbatimUrl {
+                            url: DisplaySafeUrl {
+                                scheme: "https",
+                                cannot_be_a_base: false,
+                                username: "index-user",
+                                password: Some(
+                                    "****",
+                                ),
+                                host: Some(
+                                    Domain(
+                                        "test.pypi.org",
+                                    ),
+                                ),
+                                port: None,
+                                path: "/simple/",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "https://index-user:****@test.pypi.org/simple/",
+                            ),
+                            expanded: false,
+                        },
+                    ),
+                    explicit: false,
+                    default: false,
+                    origin: Some(
+                        Project,
+                    ),
+                    format: Simple,
+                    publish_url: None,
+                    authenticate: Auto,
+                    ignore_error_codes: None,
+                    cache_control: None,
+                    exclude_newer: None,
+                },
+            ],
+            flat_index: [],
+            no_index: false,
+        },
+    }
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
 fn pip_install_baseline() {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
`uv publish --show-settings` omits configured publish settings and can expose credentials embedded in URLs because it renders raw arguments. Render the resolved settings and redact publish tokens and URL credentials while retaining useful diagnostics.

[#8840](https://github.com/astral-sh/uv/issues/8840) shows how `--show-settings` can place a PAT in pipeline logs. [#20218](https://github.com/astral-sh/uv/pull/20218) also extends the publish and show-settings path for proxy indexes, which will need the same resolved and redacted output.
