### PR TITLE
Reject multi-dot pylock filenames

### DIFF
--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -59,7 +59,7 @@ impl RequirementsSource {
             .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
         {
             Err(anyhow::anyhow!(
-                "`{}` is not a valid PEP 751 filename: expected TOML file to start with `pylock.` and end with `.toml` (e.g., `pylock.toml`, `pylock.dev.toml`)",
+                "`{}` is not a valid PEP 751 filename: expected `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots",
                 path.user_display(),
             ))
         } else if path
@@ -329,7 +329,13 @@ impl std::fmt::Display for RequirementsSource {
 }
 
 /// Returns `true` if a file name matches the `pylock.toml` pattern defined in PEP 751.
-#[expect(clippy::case_sensitive_file_extension_comparisons)]
 pub fn is_pylock_toml(file_name: &str) -> bool {
-    file_name.starts_with("pylock.") && file_name.ends_with(".toml")
+    if file_name == "pylock.toml" {
+        return true;
+    }
+
+    file_name
+        .strip_prefix("pylock.")
+        .and_then(|name| name.strip_suffix(".toml"))
+        .is_some_and(|name| !name.is_empty() && !name.contains('.'))
 }

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -159,7 +159,7 @@ pub(crate) async fn pip_compile(
         {
             if !is_pylock_toml(file_name) {
                 return Err(anyhow!(
-                    "Expected the output filename to start with `pylock.` and end with `.toml` (e.g., `pylock.toml`, `pylock.dev.toml`); `{file_name}` won't be recognized as a `pylock.toml` file in subsequent commands",
+                    "Expected the output filename to be `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots; found `{file_name}`",
                 ));
             }
         }

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -360,7 +360,7 @@ pub(crate) async fn export(
         {
             if !is_pylock_toml(file_name) {
                 return Err(anyhow!(
-                    "Expected the output filename to start with `pylock.` and end with `.toml` (e.g., `pylock.toml`, `pylock.dev.toml`); `{file_name}` won't be recognized as a `pylock.toml` file in subsequent commands",
+                    "Expected the output filename to be `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots; found `{file_name}`",
                 ));
             }
         }

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -13,6 +13,7 @@ use flate2::write::GzEncoder;
 use fs_err::File;
 use futures::executor::block_on;
 use futures::io::AllowStdIo;
+#[cfg(feature = "test-python-managed")]
 use http::StatusCode;
 #[cfg(feature = "test-universal")]
 use indoc::formatdoc;
@@ -16951,7 +16952,33 @@ fn pep_751_filename() -> Result<()> {
         .arg("test.toml"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    error: Expected the output filename to start with `pylock.` and end with `.toml` (e.g., `pylock.toml`, `pylock.dev.toml`); `test.toml` won't be recognized as a `pylock.toml` file in subsequent commands
+    error: Expected the output filename to be `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots; found `test.toml`
+    ");
+
+    uv_snapshot!(context.filters(), context
+        .pip_compile()
+        .arg("requirements.txt")
+        .arg("--universal")
+        .arg("--format")
+        .arg("pylock.toml")
+        .arg("-o")
+        .arg("pylock..toml"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Expected the output filename to be `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots; found `pylock..toml`
+    ");
+
+    uv_snapshot!(context.filters(), context
+        .pip_compile()
+        .arg("requirements.txt")
+        .arg("--universal")
+        .arg("--format")
+        .arg("pylock.toml")
+        .arg("-o")
+        .arg("pylock.foo.bar.toml"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Expected the output filename to be `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots; found `pylock.foo.bar.toml`
     ");
 
     Ok(())

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -589,7 +589,34 @@ fn invalid_toml_filename() -> Result<()> {
         .arg("test.toml"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    error: `test.toml` is not a valid PEP 751 filename: expected TOML file to start with `pylock.` and end with `.toml` (e.g., `pylock.toml`, `pylock.dev.toml`)
+    error: `test.toml` is not a valid PEP 751 filename: expected `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_pylock_toml_filename() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("pylock..toml").touch()?;
+    context.temp_dir.child("pylock.foo.bar.toml").touch()?;
+
+    uv_snapshot!(context.pip_install()
+        .arg("-r")
+        .arg("pylock..toml"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: `pylock..toml` is not a valid PEP 751 filename: expected `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots
+    "
+    );
+
+    uv_snapshot!(context.pip_install()
+        .arg("-r")
+        .arg("pylock.foo.bar.toml"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: `pylock.foo.bar.toml` is not a valid PEP 751 filename: expected `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots
     "
     );
 

--- a/crates/uv/tests/project/export.rs
+++ b/crates/uv/tests/project/export.rs
@@ -4982,6 +4982,12 @@ fn pep_751_infer_output_format() -> Result<()> {
 #[test]
 fn pep_751_filename() -> Result<()> {
     let context = uv_test::test_context!("3.12");
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+        context.temp_dir.child("ok-1.0.0-py3-none-any.whl"),
+    )?;
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(
@@ -4990,7 +4996,10 @@ fn pep_751_filename() -> Result<()> {
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = ["anyio==3.7.0"]
+        dependencies = ["ok"]
+
+        [tool.uv.sources]
+        ok = { path = "ok-1.0.0-py3-none-any.whl" }
 
         [build-system]
         requires = ["uv_build>=0.7,<10000"]
@@ -5003,8 +5012,22 @@ fn pep_751_filename() -> Result<()> {
     uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("-o").arg("test.toml"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    Resolved 4 packages in [TIME]
-    error: Expected the output filename to start with `pylock.` and end with `.toml` (e.g., `pylock.toml`, `pylock.dev.toml`); `test.toml` won't be recognized as a `pylock.toml` file in subsequent commands
+    Resolved 2 packages in [TIME]
+    error: Expected the output filename to be `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots; found `test.toml`
+    ");
+
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("-o").arg("pylock..toml"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: Expected the output filename to be `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots; found `pylock..toml`
+    ");
+
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("-o").arg("pylock.foo.bar.toml"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: Expected the output filename to be `pylock.toml` or `pylock.<name>.toml`, where `<name>` is non-empty and contains no dots; found `pylock.foo.bar.toml`
     ");
 
     Ok(())


### PR DESCRIPTION
Invalid names such as `pylock..toml` and `pylock.foo.bar.toml` are accepted even though the [`pylock.toml` filename specification](https://packaging.python.org/en/latest/specifications/pylock-toml/#file-name) permits only `pylock.toml` and single-name variants such as `pylock.dev.toml`. Validate the complete filename.

This is breaking for existing dotted lock names, including files discovered by [Pipenv's `pylock.*.toml` glob](https://github.com/pypa/pipenv/blob/main/pipenv/utils/pylock.py#L746-L768); those files must be renamed.
