### PR TITLE
Reject pylock artifacts with mismatched declared sizes

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1089,6 +1089,7 @@ impl RegistryClient {
             filename,
             file,
             index,
+            ..
         } = wheel;
 
         // If the metadata file is available at its own url (PEP 658), download it from there.

--- a/crates/uv-client/tests/it/remote_metadata.rs
+++ b/crates/uv-client/tests/it/remote_metadata.rs
@@ -1,6 +1,9 @@
+use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::Result;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, RegistryClientBuilder};
@@ -12,25 +15,36 @@ use uv_redacted::DisplaySafeUrl;
 
 #[tokio::test]
 async fn remote_metadata_with_and_without_cache() -> Result<()> {
+    let server = MockServer::start().await;
+    let wheel = fs_err::read(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test/links/ok-1.0.0-py3-none-any.whl"),
+    )?;
+    Mock::given(method("GET"))
+        .and(path("/ok-1.0.0-py3-none-any.whl"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(wheel, "application/octet-stream"))
+        .mount(&server)
+        .await;
+
     let cache = Cache::temp()?.init().await?;
     let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache).build()?;
 
     // The first run is without cache (the tempdir is empty), the second has the cache from the
     // first run.
     for _ in 0..2 {
-        let url = "https://files.pythonhosted.org/packages/00/e5/f12a80907d0884e6dff9c16d0c0114d81b8cd07dc3ae54c5e962cc83037e/tqdm-4.66.1-py3-none-any.whl";
-        let filename = WheelFilename::from_str(url.rsplit_once('/').unwrap().1)?;
+        let url = format!("{}/ok-1.0.0-py3-none-any.whl", server.uri());
+        let filename = WheelFilename::from_str("ok-1.0.0-py3-none-any.whl")?;
         let dist = BuiltDist::DirectUrl(DirectUrlBuiltDist {
             filename,
-            location: Box::new(DisplaySafeUrl::parse(url)?),
-            url: VerbatimUrl::from_str(url)?,
+            location: Box::new(DisplaySafeUrl::parse(&url)?),
+            url: VerbatimUrl::from_str(&url)?,
+            size: None,
         });
         let resolver = GitResolver::default();
         let capabilities = IndexCapabilities::default();
         let metadata = client
             .wheel_metadata(&dist, &resolver, &capabilities, None)
             .await?;
-        assert_eq!(metadata.version.to_string(), "4.66.1");
+        assert_eq!(metadata.version.to_string(), "1.0.0");
     }
 
     Ok(())

--- a/crates/uv-dev/src/wheel_metadata.rs
+++ b/crates/uv-dev/src/wheel_metadata.rs
@@ -47,6 +47,7 @@ pub(crate) async fn wheel_metadata(
                 filename,
                 location: Box::new(archive.url),
                 url: args.url,
+                size: None,
             }),
             &resolver,
             &capabilities,

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -233,6 +233,8 @@ pub struct RegistryBuiltWheel {
     pub filename: WheelFilename,
     pub file: Box<File>,
     pub index: IndexUrl,
+    /// Whether the recorded size must be validated when the wheel is downloaded.
+    pub size_is_authoritative: bool,
 }
 
 /// A built distribution (wheel) that exists in a registry, like `PyPI`.
@@ -275,6 +277,8 @@ pub struct DirectUrlBuiltDist {
     pub location: Box<DisplaySafeUrl>,
     /// The URL as it was provided by the user.
     pub url: VerbatimUrl,
+    /// The expected size of the archive, if provided by a lockfile.
+    pub size: Option<u64>,
 }
 
 /// A built distribution (wheel) that exists in a local directory.
@@ -316,6 +320,8 @@ pub struct RegistrySourceDist {
     /// skip emitting wheels to the lockfile just because the host generating
     /// the lockfile didn't have any compatible wheels available.
     pub wheels: Vec<RegistryBuiltWheel>,
+    /// Whether the recorded size must be validated when the source distribution is downloaded.
+    pub size_is_authoritative: bool,
 }
 
 /// A source distribution that exists at an arbitrary URL.
@@ -332,6 +338,8 @@ pub struct DirectUrlSourceDist {
     pub ext: SourceDistExtension,
     /// The URL as it was provided by the user, including the subdirectory fragment.
     pub url: VerbatimUrl,
+    /// The expected size of the archive, if provided by a lockfile.
+    pub size: Option<u64>,
 }
 
 /// A source distribution that exists at the root or in a subdirectory of a Git repository.
@@ -414,6 +422,7 @@ impl Dist {
                     filename,
                     location: Box::new(location),
                     url,
+                    size: None,
                 })))
             }
             DistExtension::Source(ext) => {
@@ -426,6 +435,7 @@ impl Dist {
                     subdirectory,
                     ext,
                     url,
+                    size: None,
                 })))
             }
         }
@@ -1256,7 +1266,7 @@ impl RemoteSource for DirectUrlBuiltDist {
     }
 
     fn size(&self) -> Option<u64> {
-        self.url.size()
+        self.size
     }
 }
 
@@ -1266,7 +1276,7 @@ impl RemoteSource for DirectUrlSourceDist {
     }
 
     fn size(&self) -> Option<u64> {
-        self.url.size()
+        self.size
     }
 }
 

--- a/crates/uv-distribution/src/archive.rs
+++ b/crates/uv-distribution/src/archive.rs
@@ -14,16 +14,25 @@ pub struct Archive {
     pub filename: WheelFilename,
     /// The version of the archive bucket.
     pub version: u8,
+    /// The size of the downloaded archive.
+    #[serde(default)]
+    pub size: Option<u64>,
 }
 
 impl Archive {
     /// Create a new [`Archive`] with the given ID and hashes.
-    pub(crate) fn new(id: ArchiveId, hashes: HashDigests, filename: WheelFilename) -> Self {
+    pub(crate) fn new(
+        id: ArchiveId,
+        hashes: HashDigests,
+        filename: WheelFilename,
+        size: Option<u64>,
+    ) -> Self {
         Self {
             id,
             hashes,
             filename,
             version: ARCHIVE_VERSION,
+            size,
         }
     }
 
@@ -36,5 +45,35 @@ impl Archive {
 impl Hashed for Archive {
     fn hashes(&self) -> &[HashDigest] {
         self.hashes.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn deserialize_legacy_archive() {
+        #[derive(serde::Serialize)]
+        struct LegacyArchive {
+            id: ArchiveId,
+            hashes: HashDigests,
+            filename: WheelFilename,
+            version: u8,
+        }
+
+        let legacy = LegacyArchive {
+            id: ArchiveId::default(),
+            hashes: HashDigests::empty(),
+            filename: WheelFilename::from_str("iniconfig-2.0.0-py3-none-any.whl")
+                .expect("valid wheel filename"),
+            version: ARCHIVE_VERSION,
+        };
+        let bytes = rmp_serde::to_vec(&legacy).expect("serialize legacy archive");
+        let archive: Archive = rmp_serde::from_slice(&bytes).expect("deserialize legacy archive");
+
+        assert_eq!(archive.size, None);
     }
 }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -298,7 +298,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         None,
                         &wheel.filename,
                         WheelExtension::Whl,
-                        None,
+                        wheel.size,
                         &wheel_entry,
                         dist,
                         hashes,
@@ -336,7 +336,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                                 None,
                                 &wheel.filename,
                                 WheelExtension::Whl,
-                                None,
+                                wheel.size,
                                 &wheel_entry,
                                 dist,
                                 hashes,
@@ -675,6 +675,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         dist: &BuiltDist,
         hashes: HashPolicy<'_>,
     ) -> Result<Archive, Error> {
+        let expected_size = match dist {
+            BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
+            BuiltDist::DirectUrl(_) => size,
+            _ => None,
+        };
+
         // Acquire an advisory lock, to guard against concurrent writes.
         #[cfg(windows)]
         let _lock = {
@@ -687,12 +693,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let download = |response: reqwest::Response| {
             async {
-                let size = size.or_else(|| content_length(&response));
+                let progress_size = size.or_else(|| content_length(&response));
 
-                let progress = self
-                    .reporter
-                    .as_ref()
-                    .map(|reporter| (reporter, reporter.on_download_start(dist.name(), size)));
+                let progress = self.reporter.as_ref().map(|reporter| {
+                    (
+                        reporter,
+                        reporter.on_download_start(dist.name(), progress_size),
+                    )
+                });
 
                 let reader = response
                     .bytes_stream()
@@ -739,6 +747,16 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 };
                 // Exhaust the reader to compute the hashes.
                 hasher.finish().await.map_err(Error::HashExhaustion)?;
+                let actual_size = hasher.bytes_read();
+                if let Some(expected) = expected_size
+                    && actual_size != expected
+                {
+                    return Err(Error::MismatchedSize {
+                        distribution: dist.to_string(),
+                        expected,
+                        actual: actual_size,
+                    });
+                }
 
                 // Before we make the wheel accessible by persisting it, ensure that the RECORD is
                 // valid.
@@ -761,6 +779,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     id,
                     hashers.into_iter().map(HashDigest::from).collect(),
                     filename.clone(),
+                    Some(actual_size),
                 ))
             }
             .instrument(info_span!("wheel", wheel = %dist))
@@ -805,10 +824,21 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
-        // If the archive is missing the required hashes, or has since been removed, force a refresh.
+        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
+            && expected != actual
+        {
+            return Err(Error::MismatchedSize {
+                distribution: dist.to_string(),
+                expected,
+                actual,
+            });
+        }
+
+        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
         let archive = Some(archive)
             .filter(|archive| archive.has_digests(hashes))
-            .filter(|archive| archive.exists(self.build_context.cache()));
+            .filter(|archive| archive.exists(self.build_context.cache()))
+            .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
         let archive = if let Some(archive) = archive {
             archive
@@ -847,6 +877,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         dist: &BuiltDist,
         hashes: HashPolicy<'_>,
     ) -> Result<Archive, Error> {
+        let expected_size = match dist {
+            BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
+            BuiltDist::DirectUrl(_) => size,
+            _ => None,
+        };
+
         // Acquire an advisory lock, to guard against concurrent writes.
         #[cfg(windows)]
         let _lock = {
@@ -859,12 +895,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let download = |response: reqwest::Response| {
             async {
-                let size = size.or_else(|| content_length(&response));
+                let progress_size = size.or_else(|| content_length(&response));
 
-                let progress = self
-                    .reporter
-                    .as_ref()
-                    .map(|reporter| (reporter, reporter.on_download_start(dist.name(), size)));
+                let progress = self.reporter.as_ref().map(|reporter| {
+                    (
+                        reporter,
+                        reporter.on_download_start(dist.name(), progress_size),
+                    )
+                });
 
                 let reader = response
                     .bytes_stream()
@@ -898,6 +936,18 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                             .map_err(Error::CacheWrite)?;
                     }
                 }
+
+                if let Some(expected) = expected_size
+                    && hasher.bytes_read() != expected
+                {
+                    return Err(Error::MismatchedSize {
+                        distribution: dist.to_string(),
+                        expected,
+                        actual: hasher.bytes_read(),
+                    });
+                }
+
+                let actual_size = hasher.bytes_read();
 
                 // Unzip the wheel to a temporary directory.
                 let temp_dir = tempfile::tempdir_in(self.build_context.cache().root())
@@ -936,7 +986,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
-                Ok(Archive::new(id, hashes, filename.clone()))
+                Ok(Archive::new(
+                    id,
+                    hashes,
+                    filename.clone(),
+                    Some(actual_size),
+                ))
             }
             .instrument(info_span!("wheel", wheel = %dist))
         };
@@ -980,10 +1035,21 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
-        // If the archive is missing the required hashes, or has since been removed, force a refresh.
+        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
+            && expected != actual
+        {
+            return Err(Error::MismatchedSize {
+                distribution: dist.to_string(),
+                expected,
+                actual,
+            });
+        }
+
+        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
         let archive = Some(archive)
             .filter(|archive| archive.has_digests(hashes))
-            .filter(|archive| archive.exists(self.build_context.cache()));
+            .filter(|archive| archive.exists(self.build_context.cache()))
+            .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
         let archive = if let Some(archive) = archive {
             archive
@@ -1060,6 +1126,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .await?,
                 HashDigests::empty(),
                 filename.clone(),
+                None,
             );
 
             // Write the archive pointer to the cache.
@@ -1125,7 +1192,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 .map_err(Error::CacheWrite)?;
 
             // Create an archive.
-            let archive = Archive::new(id, hashes, filename.clone());
+            let archive = Archive::new(id, hashes, filename.clone(), None);
 
             // Write the archive pointer to the cache.
             let pointer = PathArchivePointer {

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -174,6 +174,15 @@ pub enum Error {
     },
 
     #[error(
+        "Size mismatch for `{distribution}`: expected {expected} bytes, but downloaded {actual} bytes"
+    )]
+    MismatchedSize {
+        distribution: String,
+        expected: u64,
+        actual: u64,
+    },
+
+    #[error(
         "Hash-checking is enabled, but no hashes were provided or computed for: `{distribution}`"
     )]
     MissingHashes { distribution: String },

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -33,7 +33,7 @@ use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::{
     BuildInfo, BuildVariables, BuildableSource, ConfigSettings, DirectorySourceUrl,
     ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, HashPolicy, Hashed, IndexUrl,
-    PathSourceUrl, RequirementSource, RequiresPython, SourceDist, SourceUrl,
+    PathSourceUrl, RemoteSource, RequirementSource, RequiresPython, SourceDist, SourceUrl,
 };
 use uv_extract::hash::Hasher;
 use uv_fs::{Simplified, rename_with_retry, write_atomic};
@@ -983,11 +983,13 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 debug!("Downloading source distribution: {source}");
                 let entry = cache_shard.shard(revision.id()).entry(SOURCE);
                 let algorithms = http_hash_algorithms(hashes);
-                let hashes = self
+                let (hashes, size) = self
                     .download_archive(response, source, ext, entry.path(), &algorithms)
                     .await?;
 
-                Ok(revision.with_hashes(HashDigests::from(hashes)))
+                Ok(revision
+                    .with_hashes(HashDigests::from(hashes))
+                    .with_size(size))
             }
             .boxed_local()
             .instrument(info_span!("download", source_dist = %source))
@@ -1008,8 +1010,25 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
-        // If the archive is missing the required hashes, force a refresh.
-        if revision.has_digests(hashes) {
+        let expected_size = match source {
+            BuildableSource::Dist(SourceDist::Registry(dist)) if dist.size_is_authoritative => {
+                dist.size()
+            }
+            BuildableSource::Dist(SourceDist::DirectUrl(dist)) => dist.size(),
+            _ => None,
+        };
+        if let (Some(expected), Some(actual)) = (expected_size, revision.size())
+            && expected != actual
+        {
+            return Err(Error::MismatchedSize {
+                distribution: source.to_string(),
+                expected,
+                actual,
+            });
+        }
+
+        // If the archive is missing the required hashes or size, force a refresh.
+        if revision.has_digests(hashes) && (expected_size.is_none() || revision.size().is_some()) {
             Ok(revision)
         } else {
             client
@@ -2759,7 +2778,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     algorithms
                 };
 
-                let hashes = self
+                let (hashes, size) = self
                     .download_archive(response, source, ext, entry.path(), &algorithms)
                     .await?;
                 for existing in revision.hashes() {
@@ -2767,7 +2786,10 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         return Err(Error::CacheHeal(source.to_string(), existing.algorithm()));
                     }
                 }
-                Ok(revision.clone().with_hashes(HashDigests::from(hashes)))
+                Ok(revision
+                    .clone()
+                    .with_hashes(HashDigests::from(hashes))
+                    .with_size(size))
             }
             .boxed_local()
             .instrument(info_span!("download", source_dist = %source))
@@ -2799,7 +2821,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         ext: SourceDistExtension,
         target: &Path,
         algorithms: &[HashAlgorithm],
-    ) -> Result<Vec<HashDigest>, Error> {
+    ) -> Result<(Vec<HashDigest>, u64), Error> {
         let temp_dir = tempfile::tempdir_in(
             self.build_context
                 .cache()
@@ -2827,11 +2849,29 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .map_err(|err| Error::Extract(source.to_string(), err))?;
         drop(span);
 
-        // If necessary, exhaust the reader to compute the hash.
-        if !algorithms.is_empty() {
+        let expected_size = match source {
+            BuildableSource::Dist(SourceDist::Registry(dist)) if dist.size_is_authoritative => {
+                dist.size()
+            }
+            BuildableSource::Dist(SourceDist::DirectUrl(dist)) => dist.size(),
+            _ => None,
+        };
+
+        // If necessary, exhaust the reader to compute the hash or validate the archive size.
+        if !algorithms.is_empty() || expected_size.is_some() {
             hasher.finish().await.map_err(Error::HashExhaustion)?;
         }
+        if let Some(expected) = expected_size
+            && hasher.bytes_read() != expected
+        {
+            return Err(Error::MismatchedSize {
+                distribution: source.to_string(),
+                expected,
+                actual: hasher.bytes_read(),
+            });
+        }
 
+        let size = hasher.bytes_read();
         let hashes = hashers.into_iter().map(HashDigest::from).collect();
 
         // Extract the top-level directory.
@@ -2859,7 +2899,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             }
         }
 
-        Ok(hashes)
+        Ok((hashes, size))
     }
 
     /// Extract a local archive, and store it at the given [`CacheEntry`].

--- a/crates/uv-distribution/src/source/revision.rs
+++ b/crates/uv-distribution/src/source/revision.rs
@@ -14,6 +14,8 @@ use uv_pypi_types::{HashDigest, HashDigests};
 pub(crate) struct Revision {
     id: RevisionId,
     hashes: HashDigests,
+    #[serde(default)]
+    size: Option<u64>,
 }
 
 impl Revision {
@@ -22,6 +24,7 @@ impl Revision {
         Self {
             id: RevisionId::new(),
             hashes: HashDigests::empty(),
+            size: None,
         }
     }
 
@@ -40,10 +43,22 @@ impl Revision {
         self.hashes
     }
 
+    /// Return the size of the downloaded archive.
+    pub(crate) fn size(&self) -> Option<u64> {
+        self.size
+    }
+
     /// Set the computed hashes of the archive.
     #[must_use]
     pub(crate) fn with_hashes(mut self, hashes: HashDigests) -> Self {
         self.hashes = hashes;
+        self
+    }
+
+    /// Set the size of the downloaded archive.
+    #[must_use]
+    pub(crate) fn with_size(mut self, size: u64) -> Self {
+        self.size = Some(size);
         self
     }
 }
@@ -92,9 +107,15 @@ mod tests {
     /// Regression test for <https://github.com/astral-sh/uv/issues/19298>.
     #[test]
     fn deserialize_legacy_nanoid_revision() {
+        #[derive(Serialize)]
+        struct LegacyRevision {
+            id: RevisionId,
+            hashes: HashDigests,
+        }
+
         // A representative 21-character nanoid ID, drawn from the same alphabet
         // used by both the old `nanoid` crate and `uv_fastid`.
-        let legacy = Revision {
+        let legacy = LegacyRevision {
             id: RevisionId("HM0NxJml5hc7UjbfTWT1r".to_string()),
             hashes: HashDigests::empty(),
         };

--- a/crates/uv-extract/src/hash.rs
+++ b/crates/uv-extract/src/hash.rs
@@ -69,6 +69,7 @@ impl From<Hasher> for HashDigest {
 pub struct HashReader<'a, R> {
     reader: R,
     hashers: &'a mut [Hasher],
+    bytes_read: u64,
 }
 
 impl<'a, R> HashReader<'a, R>
@@ -76,7 +77,16 @@ where
     R: tokio::io::AsyncRead + Unpin,
 {
     pub fn new(reader: R, hashers: &'a mut [Hasher]) -> Self {
-        HashReader { reader, hashers }
+        HashReader {
+            reader,
+            hashers,
+            bytes_read: 0,
+        }
+    }
+
+    /// Return the number of bytes read from the underlying reader.
+    pub fn bytes_read(&self) -> u64 {
+        self.bytes_read
     }
 
     /// Exhaust the underlying reader.
@@ -97,10 +107,13 @@ where
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
         let reader = Pin::new(&mut self.reader);
+        let filled = buf.filled().len();
         match reader.poll_read(cx, buf) {
             Poll::Ready(Ok(())) => {
+                let bytes = &buf.filled()[filled..];
+                self.bytes_read += bytes.len() as u64;
                 for hasher in self.hashers.iter_mut() {
-                    hasher.update(buf.filled());
+                    hasher.update(bytes);
                 }
                 Poll::Ready(Ok(()))
             }

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -116,6 +116,7 @@ impl FlatDistributions {
                     filename,
                     file: Box::new(file),
                     index,
+                    size_is_authoritative: false,
                 };
                 match self.0.entry(version) {
                     Entry::Occupied(mut entry) => {
@@ -140,6 +141,7 @@ impl FlatDistributions {
                     file: Box::new(file),
                     index,
                     wheels: vec![],
+                    size_is_authoritative: false,
                 };
                 match self.0.entry(filename.version) {
                     Entry::Occupied(mut entry) => {

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -61,6 +61,15 @@ fn each_element_on_its_line_array(elements: impl Iterator<Item = impl Into<Value
 pub enum PylockTomlErrorKind {
     #[error("Multiple active package entries found for `{0}`")]
     DuplicateActivePackage(PackageName),
+    #[error(
+        "Archive `{}` has size {actual}, but the lockfile records {expected}",
+        path.display()
+    )]
+    ArchiveSizeMismatch {
+        path: PathBuf,
+        expected: u64,
+        actual: u64,
+    },
     #[error("Package `{0}` requires Python {2}, but the target Python version is {1}")]
     IncompatibleRequiresPython(PackageName, Version, RequiresPython),
     #[error(
@@ -195,6 +204,21 @@ impl uv_errors::Hint for PylockTomlError {
             uv_errors::Hints::none()
         }
     }
+}
+
+fn validate_path_size(path: &Path, expected: Option<u64>) -> Result<(), PylockTomlErrorKind> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let actual = fs_err::metadata(path)?.len();
+    if actual != expected {
+        return Err(PylockTomlErrorKind::ArchiveSizeMismatch {
+            path: path.to_path_buf(),
+            expected,
+            actual,
+        });
+    }
+    Ok(())
 }
 
 impl<E> From<E> for PylockTomlError
@@ -1451,6 +1475,7 @@ impl PylockTomlWheel {
 
         let file_url = if let Some(path) = self.path.as_ref() {
             let path = install_path.join(path);
+            validate_path_size(&path, self.size)?;
             let url = DisplaySafeUrl::from_file_path(path)
                 .map_err(|()| PylockTomlErrorKind::PathToUrl)?;
             UrlString::from(url)
@@ -1491,6 +1516,7 @@ impl PylockTomlWheel {
             filename,
             file,
             index,
+            size_is_authoritative: true,
         })
     }
 }
@@ -1612,6 +1638,7 @@ impl PylockTomlSdist {
 
         let file_url = if let Some(path) = self.path.as_ref() {
             let path = install_path.join(path);
+            validate_path_size(&path, self.size)?;
             let url = DisplaySafeUrl::from_file_path(path)
                 .map_err(|()| PylockTomlErrorKind::PathToUrl)?;
             UrlString::from(url)
@@ -1655,6 +1682,7 @@ impl PylockTomlSdist {
             ext,
             index,
             wheels: vec![],
+            size_is_authoritative: true,
         })
     }
 }
@@ -1680,6 +1708,7 @@ impl PylockTomlArchive {
                 DistExtension::Wheel => {
                     let filename = WheelFilename::from_str(filename)?;
                     let install_path = install_path.join(path);
+                    validate_path_size(&install_path, self.size)?;
                     let url = VerbatimUrl::from_absolute_path(&install_path)
                         .map_err(|_| PylockTomlErrorKind::PathToUrl)?;
                     Ok(Dist::Built(BuiltDist::Path(PathBuiltDist {
@@ -1690,6 +1719,7 @@ impl PylockTomlArchive {
                 }
                 DistExtension::Source(ext) => {
                     let install_path = install_path.join(path);
+                    validate_path_size(&install_path, self.size)?;
                     let url = VerbatimUrl::from_absolute_path(&install_path)
                         .map_err(|_| PylockTomlErrorKind::PathToUrl)?;
                     Ok(Dist::Source(SourceDist::Path(PathSourceDist {
@@ -1714,6 +1744,7 @@ impl PylockTomlArchive {
                         filename,
                         location: Box::new(url.clone()),
                         url: VerbatimUrl::from_url(url.clone()),
+                        size: self.size,
                     })))
                 }
                 DistExtension::Source(ext) => {
@@ -1723,6 +1754,7 @@ impl PylockTomlArchive {
                         subdirectory: self.subdirectory.clone().map(Box::<Path>::from),
                         ext,
                         url: VerbatimUrl::from_url(url.clone()),
+                        size: self.size,
                     })))
                 }
             }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2996,6 +2996,7 @@ impl Package {
                             filename,
                             location: Box::new(url.clone()),
                             url: VerbatimUrl::from_url(url),
+                            size: None,
                         };
                         let built_dist = BuiltDist::DirectUrl(direct_dist);
                         Dist::Built(built_dist)
@@ -3298,6 +3299,7 @@ impl Package {
                     subdirectory: direct.subdirectory.clone(),
                     ext,
                     url: VerbatimUrl::from_url(url),
+                    size: None,
                 };
                 uv_distribution_types::SourceDist::DirectUrl(direct_dist)
             }
@@ -3353,6 +3355,7 @@ impl Package {
                     ext,
                     index,
                     wheels: vec![],
+                    size_is_authoritative: false,
                 };
                 uv_distribution_types::SourceDist::Registry(reg_dist)
             }
@@ -3429,6 +3432,7 @@ impl Package {
                     ext,
                     index,
                     wheels: vec![],
+                    size_is_authoritative: false,
                 };
                 uv_distribution_types::SourceDist::Registry(reg_dist)
             }
@@ -5082,6 +5086,7 @@ impl Wheel {
                     filename,
                     file,
                     index,
+                    size_is_authoritative: false,
                 })
             }
             RegistrySource::Path(index_path) => {
@@ -5133,6 +5138,7 @@ impl Wheel {
                     filename,
                     file,
                     index,
+                    size_is_authoritative: false,
                 })
             }
         }

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -687,6 +687,7 @@ impl VersionMapLazy {
                             filename,
                             file: Box::new(file),
                             index: self.index.clone(),
+                            size_is_authoritative: false,
                         };
                         priority_dist.insert_built(dist, hashes, compatibility);
                     }
@@ -705,6 +706,7 @@ impl VersionMapLazy {
                             file: Box::new(file),
                             index: self.index.clone(),
                             wheels: vec![],
+                            size_is_authoritative: false,
                         };
                         priority_dist.insert_source(dist, hashes, compatibility);
                     }

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -5,7 +5,7 @@ use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use fs_err as fs;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use predicates::Predicate;
 use url::Url;
 use wiremock::matchers::{method, path};
@@ -5514,6 +5514,148 @@ fn pep_751_requires_packages() -> Result<()> {
         1 |
           | ^
         missing field `packages`
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn pep_751_validates_archive_size() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("iniconfig-2.0.0-py3-none-any.whl")
+        .touch()?;
+
+    context.temp_dir.child("pylock.toml").write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "iniconfig"
+        version = "2.0.0"
+        archive = { path = "iniconfig-2.0.0-py3-none-any.whl", size = 1, hashes = { sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" } }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml"), @r#"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Archive `[TEMP_DIR]/iniconfig-2.0.0-py3-none-any.whl` has size 0, but the lockfile records 1
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn pep_751_validates_remote_archive_size() -> Result<()> {
+    let server = PackseServer::new("simple/single-package.toml");
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("pylock.toml").write_str(&formatdoc! {
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "a"
+        version = "1.0.0"
+        archive = {{ url = "{wheel_url}", size = 1, hashes = {{ sha256 = "f936eedc194aa91ca01a4c6c9981136ca6c75ce6df47e3951b12522881dce809" }} }}
+        "#,
+        wheel_url = server.file_url("a-1.0.0-py3-none-any.whl"),
+    })?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml"), @r#"
+    exit_code: 1 (failure)
+    ----- stderr -----
+      × Failed to download `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`
+      ╰─▶ Size mismatch for `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`: expected 1 bytes, but downloaded 921 bytes
+    "#);
+
+    context.temp_dir.child("pylock.toml").write_str(&formatdoc! {
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "a"
+        version = "1.0.0"
+        wheels = [{{ url = "{wheel_url}", size = 1, hashes = {{ sha256 = "f936eedc194aa91ca01a4c6c9981136ca6c75ce6df47e3951b12522881dce809" }} }}]
+        "#,
+        wheel_url = server.file_url("a-1.0.0-py3-none-any.whl"),
+    })?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml"), @r#"
+    exit_code: 1 (failure)
+    ----- stderr -----
+      × Failed to download `a==1.0.0`
+      ╰─▶ Size mismatch for `a==1.0.0`: expected 1 bytes, but downloaded 921 bytes
+    "#);
+
+    context.temp_dir.child("pylock.toml").write_str(&formatdoc! {
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "a"
+        version = "1.0.0"
+        sdist = {{ url = "{sdist_url}", size = 1, hashes = {{ sha256 = "3d2b4c28a4e112f3a1cef1db4dc5efa33fcbbcc38bc11ccc80321097db86c097" }} }}
+        "#,
+        sdist_url = server.file_url("a-1.0.0.tar.gz"),
+    })?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml"), @r#"
+    exit_code: 1 (failure)
+    ----- stderr -----
+      × Failed to download and build `a==1.0.0`
+      ╰─▶ Size mismatch for `a==1.0.0`: expected 1 bytes, but downloaded 453 bytes
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn pep_751_validates_cached_remote_archive_size() -> Result<()> {
+    let server = PackseServer::new("simple/single-package.toml");
+    let context = uv_test::test_context!("3.12");
+    let wheel_url = server.file_url("a-1.0.0-py3-none-any.whl");
+
+    context
+        .pip_install()
+        .arg(format!("a @ {wheel_url}"))
+        .assert()
+        .success();
+
+    context.temp_dir.child("pylock.toml").write_str(&formatdoc! {
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "a"
+        version = "1.0.0"
+        archive = {{ url = "{wheel_url}", size = 1, hashes = {{ sha256 = "f936eedc194aa91ca01a4c6c9981136ca6c75ce6df47e3951b12522881dce809" }} }}
+        "#,
+    })?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("--reinstall")
+        .arg("pylock.toml"), @r#"
+    exit_code: 1 (failure)
+    ----- stderr -----
+      × Failed to download `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`
+      ╰─▶ Size mismatch for `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`: expected 1 bytes, but downloaded 921 bytes
     "#);
 
     Ok(())

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -7506,6 +7506,69 @@ async fn find_links_uppercase_html() -> Result<()> {
     Ok(())
 }
 
+/// Treat an incorrect wheel size from the Simple API as advisory.
+#[tokio::test]
+async fn registry_wheel_size_is_advisory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = MockServer::start().await;
+    let wheel_filename = "tqdm-1000.0.0-py3-none-any.whl";
+    let wheel_path = context
+        .workspace_root
+        .join("test/links")
+        .join(wheel_filename);
+
+    Mock::given(method("GET"))
+        .and(path("/tqdm/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            formatdoc! {r#"
+                {{
+                    "name": "tqdm",
+                    "files": [{{
+                        "filename": "{wheel_filename}",
+                        "url": "/{wheel_filename}",
+                        "hashes": {{}},
+                        "size": 1,
+                        "core-metadata": true,
+                        "upload-time": "2024-03-24T00:00:00Z"
+                    }}]
+                }}
+            "#},
+            "application/vnd.pypi.simple.v1+json",
+        ))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{wheel_filename}.metadata")))
+        .respond_with(ResponseTemplate::new(200).set_body_string(indoc! {"
+            Metadata-Version: 2.1
+            Name: tqdm
+            Version: 1000.0.0
+        "}))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{wheel_filename}")))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(fs::read(wheel_path)?))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("tqdm==1000.0.0")
+        .arg("--index-url")
+        .arg(server.uri()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + tqdm==1000.0.0
+    "
+    );
+
+    Ok(())
+}
+
 /// Reject a wheel with multiple `.dist-info` directories when PEP 658 metadata bypasses
 /// reading metadata from the wheel archive.
 #[tokio::test]


### PR DESCRIPTION
A `pylock.toml` artifact can declare an incorrect `size` and still install when its hash is correct, despite the [`pylock.toml` installation specification](https://packaging.python.org/en/latest/specifications/pylock-toml/#installation) requiring size checks when present. Validate declared sizes for local, remote, and cached wheels, source distributions, and archives before installation, while continuing to treat registry-reported sizes as advisory.

This is breaking for locks with stale sizes that were accepted by installers such as [pip, which currently leaves file-size validation unimplemented](https://github.com/pypa/pip/blob/main/src/pip/_internal/req/constructors.py#L590-L605). Regenerate the lock or remove the stale optional `size`; pre-existing cache entries without recorded sizes will refresh.
