### PR TITLE
Migrate lockfile serialization to `toml_writer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7230,6 +7230,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "toml_edit",
+ "toml_writer",
  "tracing",
  "url",
  "uv-cache-key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,6 +281,7 @@ toml = { version = "1.1.0", features = ["fast_hash"] }
 toml_datetime = { version = "1.1.0" }
 toml_edit = { version = "0.25.8", features = ["serde"] }
 toml_parser = { version = "1.1.0", features = ["simd"] }
+toml_writer = { version = "1.1.0" }
 tracing = { version = "0.1.40" }
 tracing-durations-export = { version = "0.3.0", features = ["plot"] }
 tracing-subscriber = { version = "0.3.18" } # Default feature set for uv_build, uv activates extra features

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -76,6 +76,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
+toml_writer = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -10,7 +10,7 @@ use jiff::civil::{Date, DateTime, Time};
 use jiff::tz::{Offset, TimeZone};
 use petgraph::graph::NodeIndex;
 use serde::Deserialize;
-use toml_edit::{Array, ArrayOfTables, Item, Table, value};
+use toml_edit::{Array, ArrayOfTables, Item, Table, Value, value};
 use url::Url;
 
 use uv_cache_key::RepositoryUrl;
@@ -40,8 +40,22 @@ use uv_redacted::DisplaySafeUrl;
 use uv_small_str::SmallString;
 
 use crate::lock::export::ExportableRequirements;
-use crate::lock::{Source, WheelTagHint, each_element_on_its_line_array, is_wheel_unreachable};
+use crate::lock::{Source, WheelTagHint, is_wheel_unreachable};
 use crate::{Installable, LockError, ResolverOutput};
+
+/// Format an array so that each element is on its own line and has a trailing comma.
+fn each_element_on_its_line_array(elements: impl Iterator<Item = impl Into<Value>>) -> Array {
+    let mut array = elements
+        .map(|item| {
+            let mut value = item.into();
+            value.decor_mut().set_prefix("\n    ");
+            value
+        })
+        .collect::<Array>();
+    array.set_trailing_comma(true);
+    array.set_trailing("\n");
+    array
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum PylockTomlErrorKind {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -13,8 +13,6 @@ use owo_colors::OwoColorize;
 use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
-use serde::Serializer;
-use toml_edit::{Array, ArrayOfTables, InlineTable, Item, Table, Value, value};
 use tracing::{debug, instrument, trace};
 use url::Url;
 
@@ -49,7 +47,7 @@ use uv_platform_tags::{
     AbiTag, IncompatibleTag, LanguageTag, PlatformTag, TagCompatibility, TagPriority, Tags,
 };
 use uv_pypi_types::{
-    ConflictKind, Conflicts, HashAlgorithm, HashDigest, HashDigests, Hashes, ParsedArchiveUrl,
+    Conflicts, HashAlgorithm, HashDigest, HashDigests, Hashes, ParsedArchiveUrl,
     ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml,
 };
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
@@ -76,6 +74,7 @@ use crate::{
 pub(crate) mod export;
 mod installable;
 mod map;
+mod serialize;
 mod tree;
 
 /// The current version of the lockfile format.
@@ -1391,356 +1390,7 @@ impl Lock {
 
     /// Returns the TOML representation of this lockfile.
     pub fn to_toml(&self) -> Result<String, toml_edit::ser::Error> {
-        // Catch a lockfile where the union of fork markers doesn't cover the supported
-        // environments.
-        debug_assert!(self.check_marker_coverage().is_ok());
-
-        // We construct a TOML document manually instead of going through Serde to enable
-        // the use of inline tables.
-        let mut doc = toml_edit::DocumentMut::new();
-        doc.insert("version", value(i64::from(self.version)));
-
-        if self.revision > 0 {
-            doc.insert("revision", value(i64::from(self.revision)));
-        }
-
-        doc.insert("requires-python", value(self.requires_python.to_string()));
-
-        if !self.fork_markers.is_empty() {
-            let fork_markers = each_element_on_its_line_array(
-                simplified_universal_markers(&self.fork_markers, &self.requires_python).into_iter(),
-            );
-            if !fork_markers.is_empty() {
-                doc.insert("resolution-markers", value(fork_markers));
-            }
-        }
-
-        // The simplified marker space covered by this resolution.
-        let simplified_environment =
-            SimplifiedMarkerTree::new(&self.requires_python, self.fork_markers_union())
-                .as_simplified_marker_tree();
-
-        if !self.supported_environments.is_empty() {
-            let supported_environments = each_element_on_its_line_array(
-                self.supported_environments
-                    .iter()
-                    .copied()
-                    .map(|marker| SimplifiedMarkerTree::new(&self.requires_python, marker))
-                    .filter_map(SimplifiedMarkerTree::try_to_string),
-            );
-            doc.insert("supported-markers", value(supported_environments));
-        }
-
-        if !self.required_environments.is_empty() {
-            let required_environments = each_element_on_its_line_array(
-                self.required_environments
-                    .iter()
-                    .copied()
-                    .map(|marker| SimplifiedMarkerTree::new(&self.requires_python, marker))
-                    .filter_map(SimplifiedMarkerTree::try_to_string),
-            );
-            doc.insert("required-markers", value(required_environments));
-        }
-
-        if !self.conflicts.is_empty() {
-            let mut list = Array::new();
-            for set in self.conflicts.iter() {
-                list.push(each_element_on_its_line_array(set.iter().map(|item| {
-                    let mut table = InlineTable::new();
-                    table.insert("package", Value::from(item.package().to_string()));
-                    match item.kind() {
-                        ConflictKind::Project => {}
-                        ConflictKind::Extra(extra) => {
-                            table.insert("extra", Value::from(extra.to_string()));
-                        }
-                        ConflictKind::Group(group) => {
-                            table.insert("group", Value::from(group.to_string()));
-                        }
-                    }
-                    table
-                })));
-            }
-            doc.insert("conflicts", value(list));
-        }
-
-        // Write the settings that were used to generate the resolution.
-        // This enables us to invalidate the lockfile if the user changes
-        // their settings.
-        {
-            let mut options_table = Table::new();
-
-            if self.options.resolution_mode != ResolutionMode::default() {
-                options_table.insert(
-                    "resolution-mode",
-                    value(self.options.resolution_mode.to_string()),
-                );
-            }
-            if self.options.prerelease_mode != PrereleaseMode::default() {
-                options_table.insert(
-                    "prerelease-mode",
-                    value(self.options.prerelease_mode.to_string()),
-                );
-            }
-            if self.options.fork_strategy != ForkStrategy::default() {
-                options_table.insert(
-                    "fork-strategy",
-                    value(self.options.fork_strategy.to_string()),
-                );
-            }
-            let exclude_newer = &self.options.exclude_newer;
-            if !exclude_newer.is_empty() {
-                // Always serialize global exclude-newer as a string
-                if let Some(global) = &exclude_newer.global {
-                    if let Some(span) = global.span() {
-                        // When a relative span is present, write a no-op timestamp to avoid
-                        // merge conflicts in the lockfile. In a future version of uv, we'll drop
-                        // this field entirely but it's retained for backwards compatibility for now.
-                        let mut noop = value(ExcludeNewerValue::PLACEHOLDER);
-                        if let Item::Value(ref mut v) = noop {
-                            v.decor_mut().set_suffix(" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.");
-                        }
-                        options_table.insert("exclude-newer", noop);
-                        options_table.insert("exclude-newer-span", value(span.to_string()));
-                    } else {
-                        options_table.insert("exclude-newer", value(global.to_string()));
-                    }
-                }
-
-                // Serialize package-specific exclusions as a separate field
-                if !exclude_newer.package.is_empty() {
-                    let mut package_table = toml_edit::Table::new();
-                    for (name, setting) in &exclude_newer.package {
-                        match setting {
-                            ExcludeNewerOverride::Enabled(exclude_newer_value) => {
-                                if let Some(span) = exclude_newer_value.span() {
-                                    // When a relative span is present, write a no-op timestamp
-                                    // for backwards compatibility. This matches treatment for
-                                    // the global `exclude-newer`.
-                                    let mut inline = toml_edit::InlineTable::new();
-                                    inline
-                                        .insert("timestamp", ExcludeNewerValue::PLACEHOLDER.into());
-                                    inline.insert("span", span.to_string().into());
-                                    package_table.insert(name.as_ref(), Item::Value(inline.into()));
-                                } else {
-                                    // Serialize as simple string
-                                    package_table.insert(
-                                        name.as_ref(),
-                                        value(exclude_newer_value.to_string()),
-                                    );
-                                }
-                            }
-                            ExcludeNewerOverride::Disabled => {
-                                package_table.insert(name.as_ref(), value(false));
-                            }
-                        }
-                    }
-                    options_table.insert("exclude-newer-package", Item::Table(package_table));
-                }
-            }
-
-            if !options_table.is_empty() {
-                doc.insert("options", Item::Table(options_table));
-            }
-        }
-
-        // Write the manifest that was used to generate the resolution.
-        {
-            let mut manifest_table = Table::new();
-
-            if !self.manifest.members.is_empty() {
-                manifest_table.insert(
-                    "members",
-                    value(each_element_on_its_line_array(
-                        self.manifest
-                            .members
-                            .iter()
-                            .map(std::string::ToString::to_string),
-                    )),
-                );
-            }
-
-            if !self.manifest.requirements.is_empty() {
-                let requirements = self
-                    .manifest
-                    .requirements
-                    .iter()
-                    .map(|requirement| {
-                        serde::Serialize::serialize(
-                            &requirement,
-                            toml_edit::ser::ValueSerializer::new(),
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                let requirements = match requirements.as_slice() {
-                    [] => Array::new(),
-                    [requirement] => Array::from_iter([requirement]),
-                    requirements => each_element_on_its_line_array(requirements.iter()),
-                };
-                manifest_table.insert("requirements", value(requirements));
-            }
-
-            if !self.manifest.constraints.is_empty() {
-                let constraints = self
-                    .manifest
-                    .constraints
-                    .iter()
-                    .map(|requirement| {
-                        serde::Serialize::serialize(
-                            &requirement,
-                            toml_edit::ser::ValueSerializer::new(),
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                let constraints = match constraints.as_slice() {
-                    [] => Array::new(),
-                    [requirement] => Array::from_iter([requirement]),
-                    constraints => each_element_on_its_line_array(constraints.iter()),
-                };
-                manifest_table.insert("constraints", value(constraints));
-            }
-
-            if !self.manifest.overrides.is_empty() {
-                let overrides = self
-                    .manifest
-                    .overrides
-                    .iter()
-                    .map(|requirement| {
-                        serde::Serialize::serialize(
-                            &requirement,
-                            toml_edit::ser::ValueSerializer::new(),
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                let overrides = match overrides.as_slice() {
-                    [] => Array::new(),
-                    [requirement] => Array::from_iter([requirement]),
-                    overrides => each_element_on_its_line_array(overrides.iter()),
-                };
-                manifest_table.insert("overrides", value(overrides));
-            }
-
-            if !self.manifest.excludes.is_empty() {
-                let excludes = self
-                    .manifest
-                    .excludes
-                    .iter()
-                    .map(|name| {
-                        serde::Serialize::serialize(&name, toml_edit::ser::ValueSerializer::new())
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                let excludes = match excludes.as_slice() {
-                    [] => Array::new(),
-                    [name] => Array::from_iter([name]),
-                    excludes => each_element_on_its_line_array(excludes.iter()),
-                };
-                manifest_table.insert("excludes", value(excludes));
-            }
-
-            if !self.manifest.build_constraints.is_empty() {
-                let build_constraints = self
-                    .manifest
-                    .build_constraints
-                    .iter()
-                    .map(|requirement| {
-                        serde::Serialize::serialize(
-                            &requirement,
-                            toml_edit::ser::ValueSerializer::new(),
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                let build_constraints = match build_constraints.as_slice() {
-                    [] => Array::new(),
-                    [requirement] => Array::from_iter([requirement]),
-                    build_constraints => each_element_on_its_line_array(build_constraints.iter()),
-                };
-                manifest_table.insert("build-constraints", value(build_constraints));
-            }
-
-            if !self.manifest.dependency_groups.is_empty() {
-                let mut dependency_groups = Table::new();
-                for (extra, requirements) in &self.manifest.dependency_groups {
-                    let requirements = requirements
-                        .iter()
-                        .map(|requirement| {
-                            serde::Serialize::serialize(
-                                &requirement,
-                                toml_edit::ser::ValueSerializer::new(),
-                            )
-                        })
-                        .collect::<Result<Vec<_>, _>>()?;
-                    let requirements = match requirements.as_slice() {
-                        [] => Array::new(),
-                        [requirement] => Array::from_iter([requirement]),
-                        requirements => each_element_on_its_line_array(requirements.iter()),
-                    };
-                    if !requirements.is_empty() {
-                        dependency_groups.insert(extra.as_ref(), value(requirements));
-                    }
-                }
-                if !dependency_groups.is_empty() {
-                    manifest_table.insert("dependency-groups", Item::Table(dependency_groups));
-                }
-            }
-
-            if !self.manifest.dependency_metadata.is_empty() {
-                let mut tables = ArrayOfTables::new();
-                for metadata in &self.manifest.dependency_metadata {
-                    let mut table = Table::new();
-                    table.insert("name", value(metadata.name.to_string()));
-                    if let Some(version) = metadata.version.as_ref() {
-                        table.insert("version", value(version.to_string()));
-                    }
-                    if !metadata.requires_dist.is_empty() {
-                        table.insert(
-                            "requires-dist",
-                            value(serde::Serialize::serialize(
-                                &metadata.requires_dist,
-                                toml_edit::ser::ValueSerializer::new(),
-                            )?),
-                        );
-                    }
-                    if let Some(requires_python) = metadata.requires_python.as_ref() {
-                        table.insert("requires-python", value(requires_python.to_string()));
-                    }
-                    if !metadata.provides_extra.is_empty() {
-                        table.insert(
-                            "provides-extras",
-                            value(serde::Serialize::serialize(
-                                &metadata.provides_extra,
-                                toml_edit::ser::ValueSerializer::new(),
-                            )?),
-                        );
-                    }
-                    tables.push(table);
-                }
-                manifest_table.insert("dependency-metadata", Item::ArrayOfTables(tables));
-            }
-
-            if !manifest_table.is_empty() {
-                doc.insert("manifest", Item::Table(manifest_table));
-            }
-        }
-
-        // Count the number of packages for each package name. When
-        // there's only one package for a particular package name (the
-        // overwhelmingly common case), we can omit some data (like source and
-        // version) on dependency edges since it is strictly redundant.
-        let mut dist_count_by_name: FxHashMap<PackageName, u64> = FxHashMap::default();
-        for dist in &self.packages {
-            *dist_count_by_name.entry(dist.id.name.clone()).or_default() += 1;
-        }
-
-        let mut packages = ArrayOfTables::new();
-        for dist in &self.packages {
-            packages.push(dist.to_toml(
-                &self.requires_python,
-                simplified_environment,
-                &dist_count_by_name,
-            )?);
-        }
-
-        doc.insert("package", Item::ArrayOfTables(packages));
-        Ok(doc.to_string())
+        serialize::to_toml(self)
     }
 
     /// Returns the package with the given name. If there are multiple
@@ -3815,150 +3465,6 @@ impl Package {
         Ok(Some(sdist))
     }
 
-    fn to_toml(
-        &self,
-        requires_python: &RequiresPython,
-        simplified_environment: MarkerTree,
-        dist_count_by_name: &FxHashMap<PackageName, u64>,
-    ) -> Result<Table, toml_edit::ser::Error> {
-        let mut table = Table::new();
-
-        self.id.to_toml(None, &mut table);
-
-        if !self.fork_markers.is_empty() {
-            let fork_markers = each_element_on_its_line_array(
-                simplified_universal_markers(&self.fork_markers, requires_python).into_iter(),
-            );
-            if !fork_markers.is_empty() {
-                table.insert("resolution-markers", value(fork_markers));
-            }
-        }
-
-        if !self.dependencies.is_empty() {
-            let deps = each_element_on_its_line_array(self.dependencies.iter().map(|dep| {
-                dep.to_toml(simplified_environment, dist_count_by_name)
-                    .into_inline_table()
-            }));
-            table.insert("dependencies", value(deps));
-        }
-
-        if !self.optional_dependencies.is_empty() {
-            let mut optional_deps = Table::new();
-            for (extra, deps) in &self.optional_dependencies {
-                let deps = each_element_on_its_line_array(deps.iter().map(|dep| {
-                    dep.to_toml(simplified_environment, dist_count_by_name)
-                        .into_inline_table()
-                }));
-                if !deps.is_empty() {
-                    optional_deps.insert(extra.as_ref(), value(deps));
-                }
-            }
-            if !optional_deps.is_empty() {
-                table.insert("optional-dependencies", Item::Table(optional_deps));
-            }
-        }
-
-        if !self.dependency_groups.is_empty() {
-            let mut dependency_groups = Table::new();
-            for (extra, deps) in &self.dependency_groups {
-                let deps = each_element_on_its_line_array(deps.iter().map(|dep| {
-                    dep.to_toml(simplified_environment, dist_count_by_name)
-                        .into_inline_table()
-                }));
-                if !deps.is_empty() {
-                    dependency_groups.insert(extra.as_ref(), value(deps));
-                }
-            }
-            if !dependency_groups.is_empty() {
-                table.insert("dev-dependencies", Item::Table(dependency_groups));
-            }
-        }
-
-        if let Some(ref sdist) = self.sdist {
-            table.insert("sdist", value(sdist.to_toml()?));
-        }
-
-        if !self.wheels.is_empty() {
-            let wheels = each_element_on_its_line_array(
-                self.wheels
-                    .iter()
-                    .map(Wheel::to_toml)
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_iter(),
-            );
-            table.insert("wheels", value(wheels));
-        }
-
-        // Write the package metadata, if non-empty.
-        {
-            let mut metadata_table = Table::new();
-
-            if !self.metadata.requires_dist.is_empty() {
-                let requires_dist = self
-                    .metadata
-                    .requires_dist
-                    .iter()
-                    .map(|requirement| {
-                        serde::Serialize::serialize(
-                            &requirement,
-                            toml_edit::ser::ValueSerializer::new(),
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                let requires_dist = match requires_dist.as_slice() {
-                    [] => Array::new(),
-                    [requirement] => Array::from_iter([requirement]),
-                    requires_dist => each_element_on_its_line_array(requires_dist.iter()),
-                };
-                metadata_table.insert("requires-dist", value(requires_dist));
-            }
-
-            if !self.metadata.dependency_groups.is_empty() {
-                let mut dependency_groups = Table::new();
-                for (extra, deps) in &self.metadata.dependency_groups {
-                    let deps = deps
-                        .iter()
-                        .map(|requirement| {
-                            serde::Serialize::serialize(
-                                &requirement,
-                                toml_edit::ser::ValueSerializer::new(),
-                            )
-                        })
-                        .collect::<Result<Vec<_>, _>>()?;
-                    let deps = match deps.as_slice() {
-                        [] => Array::new(),
-                        [requirement] => Array::from_iter([requirement]),
-                        deps => each_element_on_its_line_array(deps.iter()),
-                    };
-                    dependency_groups.insert(extra.as_ref(), value(deps));
-                }
-                if !dependency_groups.is_empty() {
-                    metadata_table.insert("requires-dev", Item::Table(dependency_groups));
-                }
-            }
-
-            if !self.metadata.provides_extra.is_empty() {
-                let provides_extras = self
-                    .metadata
-                    .provides_extra
-                    .iter()
-                    .map(|extra| {
-                        serde::Serialize::serialize(&extra, toml_edit::ser::ValueSerializer::new())
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                // This is just a list of names, so linebreaking it is excessive.
-                let provides_extras = Array::from_iter(provides_extras);
-                metadata_table.insert("provides-extras", value(provides_extras));
-            }
-
-            if !metadata_table.is_empty() {
-                table.insert("metadata", Item::Table(metadata_table));
-            }
-        }
-
-        Ok(table)
-    }
-
     fn find_best_wheel(&self, tag_policy: TagPolicy<'_>) -> Option<usize> {
         type WheelPriority<'lock> = (TagPriority, Option<&'lock BuildTag>);
 
@@ -4274,23 +3780,6 @@ impl PackageId {
             version,
             source,
         })
-    }
-
-    /// Writes this package ID inline into the table given.
-    ///
-    /// When a map is given, and if the package name in this ID is unambiguous
-    /// (i.e., it has a count of 1 in the map), then the `version` and `source`
-    /// fields are omitted. In all other cases, including when a map is not
-    /// given, the `version` and `source` fields are written.
-    fn to_toml(&self, dist_count_by_name: Option<&FxHashMap<PackageName, u64>>, table: &mut Table) {
-        let count = dist_count_by_name.and_then(|map| map.get(&self.name).copied());
-        table.insert("name", value(self.name.to_string()));
-        if count.is_none_or(|count| count > 1) {
-            if let Some(version) = &self.version {
-                table.insert("version", value(version.to_string()));
-            }
-            self.source.to_toml(table);
-        }
     }
 }
 
@@ -4653,54 +4142,6 @@ impl Source {
             Self::Directory(path) | Self::Editable(path) | Self::Virtual(path) => Some(path),
             Self::Path(..) | Self::Git(..) | Self::Registry(..) | Self::Direct(..) => None,
         }
-    }
-
-    fn to_toml(&self, table: &mut Table) {
-        let mut source_table = InlineTable::new();
-        match self {
-            Self::Registry(source) => match source {
-                RegistrySource::Url(url) => {
-                    source_table.insert("registry", Value::from(url.as_ref()));
-                }
-                RegistrySource::Path(path) => {
-                    source_table.insert(
-                        "registry",
-                        Value::from(PortablePath::from(path).to_string()),
-                    );
-                }
-            },
-            Self::Git(url, _) => {
-                source_table.insert("git", Value::from(url.as_ref()));
-            }
-            Self::Direct(url, DirectSource { subdirectory }) => {
-                source_table.insert("url", Value::from(url.as_ref()));
-                if let Some(ref subdirectory) = *subdirectory {
-                    source_table.insert(
-                        "subdirectory",
-                        Value::from(PortablePath::from(subdirectory).to_string()),
-                    );
-                }
-            }
-            Self::Path(path) => {
-                source_table.insert("path", Value::from(PortablePath::from(path).to_string()));
-            }
-            Self::Directory(path) => {
-                source_table.insert(
-                    "directory",
-                    Value::from(PortablePath::from(path).to_string()),
-                );
-            }
-            Self::Editable(path) => {
-                source_table.insert(
-                    "editable",
-                    Value::from(PortablePath::from(path).to_string()),
-                );
-            }
-            Self::Virtual(path) => {
-                source_table.insert("virtual", Value::from(PortablePath::from(path).to_string()));
-            }
-        }
-        table.insert("source", value(source_table));
     }
 
     /// Check if a package is local by examining its source.
@@ -5276,35 +4717,6 @@ enum SourceDistWire {
     },
 }
 
-impl SourceDist {
-    /// Returns the TOML representation of this source distribution.
-    fn to_toml(&self) -> Result<InlineTable, toml_edit::ser::Error> {
-        let mut table = InlineTable::new();
-        match self {
-            Self::Metadata { .. } => {}
-            Self::Url { url, .. } => {
-                table.insert("url", Value::from(url.as_ref()));
-            }
-            Self::Path { path, .. } => {
-                table.insert("path", Value::from(PortablePath::from(path).to_string()));
-            }
-        }
-        if let Some(hash) = self.hash() {
-            table.insert("hash", Value::from(hash.to_string()));
-        }
-        if let Some(size) = self.size() {
-            table.insert(
-                "size",
-                toml_edit::ser::ValueSerializer::new().serialize_u64(size)?,
-            );
-        }
-        if let Some(upload_time) = self.upload_time() {
-            table.insert("upload-time", Value::from(upload_time.to_string()));
-        }
-        Ok(table)
-    }
-}
-
 impl From<SourceDistWire> for SourceDist {
     fn from(wire: SourceDistWire) -> Self {
         match wire {
@@ -5759,50 +5171,6 @@ enum WheelWireSource {
     },
 }
 
-impl Wheel {
-    /// Returns the TOML representation of this wheel.
-    fn to_toml(&self) -> Result<InlineTable, toml_edit::ser::Error> {
-        let mut table = InlineTable::new();
-        match &self.url {
-            WheelWireSource::Url { url } => {
-                table.insert("url", Value::from(url.as_ref()));
-            }
-            WheelWireSource::Path { path } => {
-                table.insert("path", Value::from(PortablePath::from(path).to_string()));
-            }
-            WheelWireSource::Filename { filename } => {
-                table.insert("filename", Value::from(filename.to_string()));
-            }
-        }
-        if let Some(ref hash) = self.hash {
-            table.insert("hash", Value::from(hash.to_string()));
-        }
-        if let Some(size) = self.size {
-            table.insert(
-                "size",
-                toml_edit::ser::ValueSerializer::new().serialize_u64(size)?,
-            );
-        }
-        if let Some(upload_time) = self.upload_time {
-            table.insert("upload-time", Value::from(upload_time.to_string()));
-        }
-        if let Some(zstd) = &self.zstd {
-            let mut inner = InlineTable::new();
-            if let Some(ref hash) = zstd.hash {
-                inner.insert("hash", Value::from(hash.to_string()));
-            }
-            if let Some(size) = zstd.size {
-                inner.insert(
-                    "size",
-                    toml_edit::ser::ValueSerializer::new().serialize_u64(size)?,
-                );
-            }
-            table.insert("zstd", Value::from(inner));
-        }
-        Ok(table)
-    }
-}
-
 impl TryFrom<WheelWire> for Wheel {
     type Error = String;
 
@@ -5903,36 +5271,6 @@ impl Dependency {
             extra,
             complexified_marker,
         ))
-    }
-
-    /// Returns the TOML representation of this dependency.
-    fn to_toml(
-        &self,
-        simplified_environment: MarkerTree,
-        dist_count_by_name: &FxHashMap<PackageName, u64>,
-    ) -> Table {
-        let mut table = Table::new();
-        self.package_id
-            .to_toml(Some(dist_count_by_name), &mut table);
-        if !self.extra.is_empty() {
-            let extra_array = self
-                .extra
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Array>();
-            table.insert("extra", value(extra_array));
-        }
-        // Avoid restating the resolution's environment on every dependency edge.
-        if let Some(marker) = self
-            .simplified_marker
-            .as_simplified_marker_tree()
-            .restrict(simplified_environment)
-            .try_to_string()
-        {
-            table.insert("marker", value(marker));
-        }
-
-        table
     }
 
     /// Returns the package name of this dependency.
@@ -7128,33 +6466,6 @@ impl Display for HashParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         Display::fmt(self.0, f)
     }
-}
-
-/// Format an array so that each element is on its own line and has a trailing comma.
-///
-/// Example:
-///
-/// ```toml
-/// dependencies = [
-///     { name = "idna" },
-///     { name = "sniffio" },
-/// ]
-/// ```
-fn each_element_on_its_line_array(elements: impl Iterator<Item = impl Into<Value>>) -> Array {
-    let mut array = elements
-        .map(|item| {
-            let mut value = item.into();
-            // Each dependency is on its own line and indented.
-            value.decor_mut().set_prefix("\n    ");
-            value
-        })
-        .collect::<Array>();
-    // With a trailing comma, inserting another entry doesn't change the preceding line,
-    // reducing the diff noise.
-    array.set_trailing_comma(true);
-    // The line break between the last element's comma and the closing square bracket.
-    array.set_trailing("\n");
-    array
 }
 
 /// Return the PEP 508 marker space covered by the resolution.

--- a/crates/uv-resolver/src/lock/serialize.rs
+++ b/crates/uv-resolver/src/lock/serialize.rs
@@ -1,0 +1,814 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+use rustc_hash::FxHashMap;
+use serde::Serialize;
+use toml_edit::Value;
+use toml_writer::{TomlWrite, WriteTomlValue};
+use uv_distribution_types::{RequiresPython, SimplifiedMarkerTree};
+use uv_fs::PortablePath;
+use uv_normalize::PackageName;
+use uv_pep508::MarkerTree;
+use uv_pypi_types::ConflictKind;
+
+use super::{
+    Dependency, DirectSource, ExcludeNewerOverride, ExcludeNewerValue, ForkStrategy, Lock, Package,
+    PackageId, PrereleaseMode, RegistrySource, ResolutionMode, ResolverManifest, ResolverOptions,
+    Source, SourceDist, Wheel, WheelWireSource, simplified_universal_markers,
+};
+
+/// Serializes a lockfile directly while preserving the canonical `uv.lock` layout.
+pub(super) fn to_toml(lock: &Lock) -> Result<String, toml_edit::ser::Error> {
+    let mut writer = LockWriter::default();
+    write_lock(&mut writer, lock).map_err(|error| match error {
+        WriteError::Format => {
+            toml_edit::ser::Error::Custom("failed to write lockfile to a string".to_string())
+        }
+        WriteError::Serialize(error) => error,
+    })?;
+    Ok(writer.output)
+}
+
+fn write_lock(writer: &mut LockWriter, lock: &Lock) -> Result<(), WriteError> {
+    // Catch a lockfile where the union of fork markers doesn't cover the supported
+    // environments.
+    debug_assert!(lock.check_marker_coverage().is_ok());
+
+    writer.key_value("version", lock.version)?;
+    if lock.revision > 0 {
+        writer.key_value("revision", lock.revision)?;
+    }
+    writer.key_value_string("requires-python", &lock.requires_python.to_string())?;
+
+    if !lock.fork_markers.is_empty() {
+        let markers = simplified_universal_markers(&lock.fork_markers, &lock.requires_python);
+        if !markers.is_empty() {
+            writer.multiline_array("resolution-markers", markers, |writer, marker| {
+                writer.string(&marker)
+            })?;
+        }
+    }
+
+    // The simplified marker space covered by this resolution.
+    let simplified_environment =
+        SimplifiedMarkerTree::new(&lock.requires_python, lock.fork_markers_union())
+            .as_simplified_marker_tree();
+
+    if !lock.supported_environments.is_empty() {
+        let markers = lock
+            .supported_environments
+            .iter()
+            .copied()
+            .map(|marker| SimplifiedMarkerTree::new(&lock.requires_python, marker))
+            .filter_map(SimplifiedMarkerTree::try_to_string);
+        writer.multiline_array("supported-markers", markers, |writer, marker| {
+            writer.string(&marker)
+        })?;
+    }
+
+    if !lock.required_environments.is_empty() {
+        let markers = lock
+            .required_environments
+            .iter()
+            .copied()
+            .map(|marker| SimplifiedMarkerTree::new(&lock.requires_python, marker))
+            .filter_map(SimplifiedMarkerTree::try_to_string);
+        writer.multiline_array("required-markers", markers, |writer, marker| {
+            writer.string(&marker)
+        })?;
+    }
+
+    if !lock.conflicts.is_empty() {
+        writer.key_start("conflicts")?;
+        writer.raw("[");
+        for (index, set) in lock.conflicts.iter().enumerate() {
+            if index > 0 {
+                writer.raw(", ");
+            }
+            writer.raw("[\n");
+            for item in set.iter() {
+                writer.raw("    ");
+                let mut first = true;
+                writer.start_inline_table();
+                writer.inline_string(&mut first, "package", item.package().as_ref())?;
+                match item.kind() {
+                    ConflictKind::Project => {}
+                    ConflictKind::Extra(extra) => {
+                        writer.inline_string(&mut first, "extra", extra.as_ref())?;
+                    }
+                    ConflictKind::Group(group) => {
+                        writer.inline_string(&mut first, "group", group.as_ref())?;
+                    }
+                }
+                writer.finish_inline_table(first);
+                writer.raw(",\n");
+            }
+            writer.raw("]");
+        }
+        writer.raw("]\n");
+    }
+
+    write_options(writer, &lock.options)?;
+    write_manifest(writer, &lock.manifest)?;
+
+    // Count the number of packages for each package name. When there's only one package for a
+    // particular package name (the overwhelmingly common case), we can omit some data (like
+    // source and version) on dependency edges since it is strictly redundant.
+    let mut dist_count_by_name: FxHashMap<PackageName, u64> = FxHashMap::default();
+    for package in &lock.packages {
+        *dist_count_by_name
+            .entry(package.id.name.clone())
+            .or_default() += 1;
+    }
+
+    for package in &lock.packages {
+        write_package(
+            writer,
+            package,
+            &lock.requires_python,
+            simplified_environment,
+            &dist_count_by_name,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn write_options(writer: &mut LockWriter, options: &ResolverOptions) -> Result<(), WriteError> {
+    let has_options = options.resolution_mode != ResolutionMode::default()
+        || options.prerelease_mode != PrereleaseMode::default()
+        || options.fork_strategy != ForkStrategy::default()
+        || !options.exclude_newer.is_empty();
+    if !has_options {
+        return Ok(());
+    }
+
+    writer.table(&["options"])?;
+    if options.resolution_mode != ResolutionMode::default() {
+        writer.key_value_string("resolution-mode", &options.resolution_mode.to_string())?;
+    }
+    if options.prerelease_mode != PrereleaseMode::default() {
+        writer.key_value_string("prerelease-mode", &options.prerelease_mode.to_string())?;
+    }
+    if options.fork_strategy != ForkStrategy::default() {
+        writer.key_value_string("fork-strategy", &options.fork_strategy.to_string())?;
+    }
+
+    let exclude_newer = &options.exclude_newer;
+    if let Some(global) = &exclude_newer.global {
+        if let Some(span) = global.span() {
+            writer.key_start("exclude-newer")?;
+            writer.string(ExcludeNewerValue::PLACEHOLDER)?;
+            writer.raw(" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.\n");
+            writer.key_value_string("exclude-newer-span", &span.to_string())?;
+        } else {
+            writer.key_value_string("exclude-newer", &global.to_string())?;
+        }
+    }
+
+    if !exclude_newer.package.is_empty() {
+        writer.table(&["options", "exclude-newer-package"])?;
+        for (name, setting) in &exclude_newer.package {
+            match setting {
+                ExcludeNewerOverride::Enabled(value) => {
+                    if let Some(span) = value.span() {
+                        writer.key_start(name.as_ref())?;
+                        let mut first = true;
+                        writer.start_inline_table();
+                        writer.inline_string(
+                            &mut first,
+                            "timestamp",
+                            ExcludeNewerValue::PLACEHOLDER,
+                        )?;
+                        writer.inline_string(&mut first, "span", &span.to_string())?;
+                        writer.finish_inline_table(first);
+                        writer.raw("\n");
+                    } else {
+                        writer.key_value_string(name.as_ref(), &value.to_string())?;
+                    }
+                }
+                ExcludeNewerOverride::Disabled => {
+                    writer.key_value(name.as_ref(), false)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn write_manifest(writer: &mut LockWriter, manifest: &ResolverManifest) -> Result<(), WriteError> {
+    let has_dependency_groups = manifest
+        .dependency_groups
+        .values()
+        .any(|requirements| !requirements.is_empty());
+    let has_manifest = !manifest.members.is_empty()
+        || !manifest.requirements.is_empty()
+        || !manifest.constraints.is_empty()
+        || !manifest.overrides.is_empty()
+        || !manifest.excludes.is_empty()
+        || !manifest.build_constraints.is_empty()
+        || has_dependency_groups
+        || !manifest.dependency_metadata.is_empty();
+    if !has_manifest {
+        return Ok(());
+    }
+
+    writer.table(&["manifest"])?;
+    if !manifest.members.is_empty() {
+        writer.multiline_array("members", &manifest.members, |writer, member| {
+            writer.string(member.as_ref())
+        })?;
+    }
+    write_serialized_array(writer, "requirements", &manifest.requirements)?;
+    write_serialized_array(writer, "constraints", &manifest.constraints)?;
+    write_serialized_array(writer, "overrides", &manifest.overrides)?;
+    write_serialized_array(writer, "excludes", &manifest.excludes)?;
+    write_serialized_array(writer, "build-constraints", &manifest.build_constraints)?;
+
+    if has_dependency_groups {
+        writer.table(&["manifest", "dependency-groups"])?;
+        for (group, requirements) in &manifest.dependency_groups {
+            if requirements.is_empty() {
+                continue;
+            }
+            write_serialized_array(writer, group.as_ref(), requirements)?;
+        }
+    }
+
+    for metadata in &manifest.dependency_metadata {
+        writer.array_of_tables(&["manifest", "dependency-metadata"])?;
+        writer.key_value_string("name", metadata.name.as_ref())?;
+        if let Some(version) = metadata.version.as_ref() {
+            writer.key_value_string("version", &version.to_string())?;
+        }
+        if !metadata.requires_dist.is_empty() {
+            let value = serialize_value(&metadata.requires_dist)?;
+            writer.key_value_raw("requires-dist", &value)?;
+        }
+        if let Some(requires_python) = metadata.requires_python.as_ref() {
+            writer.key_value_string("requires-python", &requires_python.to_string())?;
+        }
+        if !metadata.provides_extra.is_empty() {
+            let value = serialize_value(&metadata.provides_extra)?;
+            writer.key_value_raw("provides-extras", &value)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_package(
+    writer: &mut LockWriter,
+    package: &Package,
+    requires_python: &RequiresPython,
+    simplified_environment: MarkerTree,
+    dist_count_by_name: &FxHashMap<PackageName, u64>,
+) -> Result<(), WriteError> {
+    writer.array_of_tables(&["package"])?;
+    write_package_id(writer, &package.id, None)?;
+
+    if !package.fork_markers.is_empty() {
+        let markers = simplified_universal_markers(&package.fork_markers, requires_python);
+        if !markers.is_empty() {
+            writer.multiline_array("resolution-markers", markers, |writer, marker| {
+                writer.string(&marker)
+            })?;
+        }
+    }
+
+    if !package.dependencies.is_empty() {
+        writer.multiline_array(
+            "dependencies",
+            &package.dependencies,
+            |writer, dependency| {
+                write_dependency_inline(
+                    writer,
+                    dependency,
+                    simplified_environment,
+                    dist_count_by_name,
+                )
+            },
+        )?;
+    }
+
+    if let Some(source_dist) = &package.sdist {
+        writer.key_start("sdist")?;
+        write_source_dist_inline(writer, source_dist)?;
+        writer.raw("\n");
+    }
+
+    if !package.wheels.is_empty() {
+        writer.multiline_array("wheels", &package.wheels, write_wheel_inline)?;
+    }
+
+    if package
+        .optional_dependencies
+        .values()
+        .any(|dependencies| !dependencies.is_empty())
+    {
+        writer.table(&["package", "optional-dependencies"])?;
+        for (extra, dependencies) in &package.optional_dependencies {
+            if dependencies.is_empty() {
+                continue;
+            }
+            writer.multiline_array(extra.as_ref(), dependencies, |writer, dependency| {
+                write_dependency_inline(
+                    writer,
+                    dependency,
+                    simplified_environment,
+                    dist_count_by_name,
+                )
+            })?;
+        }
+    }
+
+    if package
+        .dependency_groups
+        .values()
+        .any(|dependencies| !dependencies.is_empty())
+    {
+        writer.table(&["package", "dev-dependencies"])?;
+        for (group, dependencies) in &package.dependency_groups {
+            if dependencies.is_empty() {
+                continue;
+            }
+            writer.multiline_array(group.as_ref(), dependencies, |writer, dependency| {
+                write_dependency_inline(
+                    writer,
+                    dependency,
+                    simplified_environment,
+                    dist_count_by_name,
+                )
+            })?;
+        }
+    }
+
+    let metadata = &package.metadata;
+    let has_metadata = !metadata.requires_dist.is_empty()
+        || !metadata.dependency_groups.is_empty()
+        || !metadata.provides_extra.is_empty();
+    if has_metadata {
+        writer.table(&["package", "metadata"])?;
+        write_serialized_array(writer, "requires-dist", &metadata.requires_dist)?;
+        if !metadata.provides_extra.is_empty() {
+            writer.key_start("provides-extras")?;
+            writer.inline_array(&metadata.provides_extra, |writer, extra| {
+                writer.string(extra.as_ref())
+            })?;
+            writer.raw("\n");
+        }
+
+        if !metadata.dependency_groups.is_empty() {
+            writer.table(&["package", "metadata", "requires-dev"])?;
+            for (group, requirements) in &metadata.dependency_groups {
+                write_serialized_array_including_empty(writer, group.as_ref(), requirements)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Writes a package identity, omitting fields that a unique package name makes redundant.
+///
+/// Passing no distribution counts forces the full version and source identity to be written.
+fn write_package_id(
+    writer: &mut LockWriter,
+    package_id: &PackageId,
+    dist_count_by_name: Option<&FxHashMap<PackageName, u64>>,
+) -> Result<(), WriteError> {
+    let count = dist_count_by_name.and_then(|map| map.get(&package_id.name).copied());
+    writer.key_value_string("name", package_id.name.as_ref())?;
+    if count.is_none_or(|count| count > 1) {
+        if let Some(version) = &package_id.version {
+            writer.key_value_string("version", &version.to_string())?;
+        }
+        writer.key_start("source")?;
+        write_source_inline(writer, &package_id.source)?;
+        writer.raw("\n");
+    }
+    Ok(())
+}
+
+fn write_source_inline(writer: &mut LockWriter, source: &Source) -> Result<(), WriteError> {
+    let mut first = true;
+    writer.start_inline_table();
+    match source {
+        Source::Registry(source) => match source {
+            RegistrySource::Url(url) => {
+                writer.inline_string(&mut first, "registry", url.as_ref())?;
+            }
+            RegistrySource::Path(path) => {
+                writer.inline_string(
+                    &mut first,
+                    "registry",
+                    &PortablePath::from(path).to_string(),
+                )?;
+            }
+        },
+        Source::Git(url, _) => {
+            writer.inline_string(&mut first, "git", url.as_ref())?;
+        }
+        Source::Direct(url, DirectSource { subdirectory }) => {
+            writer.inline_string(&mut first, "url", url.as_ref())?;
+            if let Some(subdirectory) = subdirectory {
+                writer.inline_string(
+                    &mut first,
+                    "subdirectory",
+                    &PortablePath::from(subdirectory).to_string(),
+                )?;
+            }
+        }
+        Source::Path(path) => {
+            writer.inline_string(&mut first, "path", &PortablePath::from(path).to_string())?;
+        }
+        Source::Directory(path) => {
+            writer.inline_string(
+                &mut first,
+                "directory",
+                &PortablePath::from(path).to_string(),
+            )?;
+        }
+        Source::Editable(path) => {
+            writer.inline_string(
+                &mut first,
+                "editable",
+                &PortablePath::from(path).to_string(),
+            )?;
+        }
+        Source::Virtual(path) => {
+            writer.inline_string(&mut first, "virtual", &PortablePath::from(path).to_string())?;
+        }
+    }
+    writer.finish_inline_table(first);
+    Ok(())
+}
+
+fn write_source_dist_inline(
+    writer: &mut LockWriter,
+    source_dist: &SourceDist,
+) -> Result<(), WriteError> {
+    let mut first = true;
+    writer.start_inline_table();
+    match source_dist {
+        SourceDist::Metadata { .. } => {}
+        SourceDist::Url { url, .. } => {
+            writer.inline_string(&mut first, "url", url.as_ref())?;
+        }
+        SourceDist::Path { path, .. } => {
+            writer.inline_string(&mut first, "path", &PortablePath::from(path).to_string())?;
+        }
+    }
+    if let Some(hash) = source_dist.hash() {
+        writer.inline_string(&mut first, "hash", &hash.to_string())?;
+    }
+    if let Some(size) = source_dist.size() {
+        writer.inline_value(&mut first, "size", size)?;
+    }
+    if let Some(upload_time) = source_dist.upload_time() {
+        writer.inline_string(&mut first, "upload-time", &upload_time.to_string())?;
+    }
+    writer.finish_inline_table(first);
+    Ok(())
+}
+
+fn write_wheel_inline(writer: &mut LockWriter, wheel: &Wheel) -> Result<(), WriteError> {
+    let mut first = true;
+    writer.start_inline_table();
+    match &wheel.url {
+        WheelWireSource::Url { url } => {
+            writer.inline_string(&mut first, "url", url.as_ref())?;
+        }
+        WheelWireSource::Path { path } => {
+            writer.inline_string(&mut first, "path", &PortablePath::from(path).to_string())?;
+        }
+        WheelWireSource::Filename { filename } => {
+            writer.inline_string(&mut first, "filename", &filename.to_string())?;
+        }
+    }
+    if let Some(hash) = &wheel.hash {
+        writer.inline_string(&mut first, "hash", &hash.to_string())?;
+    }
+    if let Some(size) = wheel.size {
+        writer.inline_value(&mut first, "size", size)?;
+    }
+    if let Some(upload_time) = wheel.upload_time {
+        writer.inline_string(&mut first, "upload-time", &upload_time.to_string())?;
+    }
+    if let Some(zstd) = &wheel.zstd {
+        writer.inline_key(&mut first, "zstd")?;
+        let mut zstd_first = true;
+        writer.start_inline_table();
+        if let Some(hash) = &zstd.hash {
+            writer.inline_string(&mut zstd_first, "hash", &hash.to_string())?;
+        }
+        if let Some(size) = zstd.size {
+            writer.inline_value(&mut zstd_first, "size", size)?;
+        }
+        writer.finish_inline_table(zstd_first);
+    }
+    writer.finish_inline_table(first);
+    Ok(())
+}
+
+/// Writes a dependency edge without identity or marker data implied by the enclosing resolution.
+fn write_dependency_inline(
+    writer: &mut LockWriter,
+    dependency: &Dependency,
+    simplified_environment: MarkerTree,
+    dist_count_by_name: &FxHashMap<PackageName, u64>,
+) -> Result<(), WriteError> {
+    let mut first = true;
+    writer.start_inline_table();
+
+    let count = dist_count_by_name.get(&dependency.package_id.name).copied();
+    writer.inline_string(&mut first, "name", dependency.package_id.name.as_ref())?;
+    if count.is_none_or(|count| count > 1) {
+        if let Some(version) = &dependency.package_id.version {
+            writer.inline_string(&mut first, "version", &version.to_string())?;
+        }
+        writer.inline_key(&mut first, "source")?;
+        write_source_inline(writer, &dependency.package_id.source)?;
+    }
+
+    if !dependency.extra.is_empty() {
+        writer.inline_key(&mut first, "extra")?;
+        writer.inline_array(&dependency.extra, |writer, extra| {
+            writer.string(extra.as_ref())
+        })?;
+    }
+
+    // Avoid restating the resolution's environment on every dependency edge.
+    if let Some(marker) = dependency
+        .simplified_marker
+        .as_simplified_marker_tree()
+        .restrict(simplified_environment)
+        .try_to_string()
+    {
+        writer.inline_string(&mut first, "marker", &marker)?;
+    }
+
+    writer.finish_inline_table(first);
+    Ok(())
+}
+
+/// Writes a Serde-backed array, omitting the key when the array is empty.
+fn write_serialized_array<T: Serialize>(
+    writer: &mut LockWriter,
+    key: &str,
+    values: &BTreeSet<T>,
+) -> Result<(), WriteError> {
+    if values.is_empty() {
+        return Ok(());
+    }
+    write_serialized_array_including_empty(writer, key, values)
+}
+
+/// Writes a Serde-backed array using the canonical layout for its cardinality.
+///
+/// Empty and single-element arrays stay on one line, while larger arrays place each element on
+/// its own line. Unlike [`write_serialized_array`], this retains empty dependency groups.
+fn write_serialized_array_including_empty<T: Serialize>(
+    writer: &mut LockWriter,
+    key: &str,
+    values: &BTreeSet<T>,
+) -> Result<(), WriteError> {
+    writer.key_start(key)?;
+    let write_value = |writer: &mut LockWriter, value: &T| {
+        let value = serialize_value(value)?;
+        writer.raw_value(&value);
+        Ok(())
+    };
+    if values.len() <= 1 {
+        writer.inline_array(values, write_value)?;
+        writer.raw("\n");
+    } else {
+        writer.multiline_array_values(values, write_value)?;
+    }
+    Ok(())
+}
+
+/// Converts values without native `toml_writer` support through Serde's TOML value serializer.
+fn serialize_value<T: Serialize + ?Sized>(value: &T) -> Result<Value, WriteError> {
+    Ok(Serialize::serialize(
+        value,
+        toml_edit::ser::ValueSerializer::new(),
+    )?)
+}
+
+#[derive(Debug)]
+enum WriteError {
+    Format,
+    Serialize(toml_edit::ser::Error),
+}
+
+impl From<fmt::Error> for WriteError {
+    fn from(_: fmt::Error) -> Self {
+        Self::Format
+    }
+}
+
+impl From<toml_edit::ser::Error> for WriteError {
+    fn from(error: toml_edit::ser::Error) -> Self {
+        Self::Serialize(error)
+    }
+}
+
+/// Emits TOML while retaining the established whitespace and inline-table layout of `uv.lock`.
+#[derive(Default)]
+struct LockWriter {
+    output: String,
+}
+
+impl LockWriter {
+    fn raw(&mut self, value: &str) {
+        self.output.push_str(value);
+    }
+
+    fn raw_value(&mut self, value: &Value) {
+        self.output.push_str(&value.to_string());
+    }
+
+    fn key(&mut self, key: &str) -> fmt::Result {
+        self.output.key(key)
+    }
+
+    fn string(&mut self, value: &str) -> Result<(), WriteError> {
+        self.output.value(value)?;
+        Ok(())
+    }
+
+    fn key_start(&mut self, key: &str) -> Result<(), WriteError> {
+        self.key(key)?;
+        self.raw(" = ");
+        Ok(())
+    }
+
+    fn key_value(&mut self, key: &str, value: impl WriteTomlValue) -> Result<(), WriteError> {
+        self.key_start(key)?;
+        self.output.value(value)?;
+        self.raw("\n");
+        Ok(())
+    }
+
+    fn key_value_string(&mut self, key: &str, value: &str) -> Result<(), WriteError> {
+        self.key_start(key)?;
+        self.string(value)?;
+        self.raw("\n");
+        Ok(())
+    }
+
+    fn key_value_raw(&mut self, key: &str, value: &Value) -> Result<(), WriteError> {
+        self.key_start(key)?;
+        self.raw_value(value);
+        self.raw("\n");
+        Ok(())
+    }
+
+    fn table(&mut self, path: &[&str]) -> Result<(), WriteError> {
+        self.header(path, false)
+    }
+
+    fn array_of_tables(&mut self, path: &[&str]) -> Result<(), WriteError> {
+        self.header(path, true)
+    }
+
+    /// Starts a table header on a new line, separating it from the preceding table body.
+    fn header(&mut self, path: &[&str], array: bool) -> Result<(), WriteError> {
+        self.raw("\n");
+        if array {
+            self.raw("[[");
+        } else {
+            self.raw("[");
+        }
+        for (index, key) in path.iter().enumerate() {
+            if index > 0 {
+                self.raw(".");
+            }
+            self.key(key)?;
+        }
+        if array {
+            self.raw("]]\n");
+        } else {
+            self.raw("]\n");
+        }
+        Ok(())
+    }
+
+    fn multiline_array<I, T, F>(
+        &mut self,
+        key: &str,
+        values: I,
+        write_value: F,
+    ) -> Result<(), WriteError>
+    where
+        I: IntoIterator<Item = T>,
+        F: FnMut(&mut Self, T) -> Result<(), WriteError>,
+    {
+        self.key_start(key)?;
+        self.multiline_array_values(values, write_value)
+    }
+
+    fn multiline_array_values<I, T, F>(
+        &mut self,
+        values: I,
+        mut write_value: F,
+    ) -> Result<(), WriteError>
+    where
+        I: IntoIterator<Item = T>,
+        F: FnMut(&mut Self, T) -> Result<(), WriteError>,
+    {
+        self.raw("[\n");
+        for value in values {
+            self.raw("    ");
+            write_value(self, value)?;
+            self.raw(",\n");
+        }
+        self.raw("]\n");
+        Ok(())
+    }
+
+    fn inline_array<I, T, F>(&mut self, values: I, mut write_value: F) -> Result<(), WriteError>
+    where
+        I: IntoIterator<Item = T>,
+        F: FnMut(&mut Self, T) -> Result<(), WriteError>,
+    {
+        self.raw("[");
+        for (index, value) in values.into_iter().enumerate() {
+            if index > 0 {
+                self.raw(", ");
+            }
+            write_value(self, value)?;
+        }
+        self.raw("]");
+        Ok(())
+    }
+
+    fn start_inline_table(&mut self) {
+        self.raw("{");
+    }
+
+    fn finish_inline_table(&mut self, first: bool) {
+        if !first {
+            self.raw(" ");
+        }
+        self.raw("}");
+    }
+
+    /// Writes the separator and key for the next inline-table entry.
+    fn inline_key(&mut self, first: &mut bool, key: &str) -> Result<(), WriteError> {
+        if *first {
+            self.raw(" ");
+            *first = false;
+        } else {
+            self.raw(", ");
+        }
+        self.key_start(key)
+    }
+
+    fn inline_value(
+        &mut self,
+        first: &mut bool,
+        key: &str,
+        value: impl WriteTomlValue,
+    ) -> Result<(), WriteError> {
+        self.inline_key(first, key)?;
+        self.output.value(value)?;
+        Ok(())
+    }
+
+    fn inline_string(
+        &mut self,
+        first: &mut bool,
+        key: &str,
+        value: &str,
+    ) -> Result<(), WriteError> {
+        self.inline_key(first, key)?;
+        self.string(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LockWriter, Value};
+
+    #[test]
+    fn string_encoding_matches_toml_edit() {
+        for value in [
+            "",
+            "https://example.com/packages/example-1.0.0-py3-none-any.whl",
+            "it's valid",
+            "unicode-λ",
+            "contains\"quote",
+            r"contains\backslash",
+            "contains\ttab",
+            "contains\nnewline",
+            "contains\u{7f}delete",
+        ] {
+            let mut writer = LockWriter::default();
+            writer.string(value).expect("writing to a string succeeds");
+            assert_eq!(writer.output, Value::from(value).to_string());
+        }
+    }
+}

--- a/crates/uv-resolver/src/lock/serialize.rs
+++ b/crates/uv-resolver/src/lock/serialize.rs
@@ -38,13 +38,13 @@ fn write_lock(writer: &mut LockWriter, lock: &Lock) -> Result<(), WriteError> {
     if lock.revision > 0 {
         writer.key_value("revision", lock.revision)?;
     }
-    writer.key_value_string("requires-python", &lock.requires_python.to_string())?;
+    writer.key_value("requires-python", lock.requires_python.to_string())?;
 
     if !lock.fork_markers.is_empty() {
         let markers = simplified_universal_markers(&lock.fork_markers, &lock.requires_python);
         if !markers.is_empty() {
-            writer.multiline_array("resolution-markers", markers, |writer, marker| {
-                writer.string(&marker)
+            writer.key_multiline_array("resolution-markers", markers, |writer, marker| {
+                writer.value(&marker)
             })?;
         }
     }
@@ -61,8 +61,8 @@ fn write_lock(writer: &mut LockWriter, lock: &Lock) -> Result<(), WriteError> {
             .copied()
             .map(|marker| SimplifiedMarkerTree::new(&lock.requires_python, marker))
             .filter_map(SimplifiedMarkerTree::try_to_string);
-        writer.multiline_array("supported-markers", markers, |writer, marker| {
-            writer.string(&marker)
+        writer.key_multiline_array("supported-markers", markers, |writer, marker| {
+            writer.value(&marker)
         })?;
     }
 
@@ -73,8 +73,8 @@ fn write_lock(writer: &mut LockWriter, lock: &Lock) -> Result<(), WriteError> {
             .copied()
             .map(|marker| SimplifiedMarkerTree::new(&lock.requires_python, marker))
             .filter_map(SimplifiedMarkerTree::try_to_string);
-        writer.multiline_array("required-markers", markers, |writer, marker| {
-            writer.string(&marker)
+        writer.key_multiline_array("required-markers", markers, |writer, marker| {
+            writer.value(&marker)
         })?;
     }
 
@@ -90,14 +90,14 @@ fn write_lock(writer: &mut LockWriter, lock: &Lock) -> Result<(), WriteError> {
                 writer.raw("    ");
                 let mut first = true;
                 writer.start_inline_table();
-                writer.inline_string(&mut first, "package", item.package().as_ref())?;
+                writer.inline_value(&mut first, "package", item.package().as_ref())?;
                 match item.kind() {
                     ConflictKind::Project => {}
                     ConflictKind::Extra(extra) => {
-                        writer.inline_string(&mut first, "extra", extra.as_ref())?;
+                        writer.inline_value(&mut first, "extra", extra.as_ref())?;
                     }
                     ConflictKind::Group(group) => {
-                        writer.inline_string(&mut first, "group", group.as_ref())?;
+                        writer.inline_value(&mut first, "group", group.as_ref())?;
                     }
                 }
                 writer.finish_inline_table(first);
@@ -145,24 +145,24 @@ fn write_options(writer: &mut LockWriter, options: &ResolverOptions) -> Result<(
 
     writer.table(&["options"])?;
     if options.resolution_mode != ResolutionMode::default() {
-        writer.key_value_string("resolution-mode", &options.resolution_mode.to_string())?;
+        writer.key_value("resolution-mode", options.resolution_mode.to_string())?;
     }
     if options.prerelease_mode != PrereleaseMode::default() {
-        writer.key_value_string("prerelease-mode", &options.prerelease_mode.to_string())?;
+        writer.key_value("prerelease-mode", options.prerelease_mode.to_string())?;
     }
     if options.fork_strategy != ForkStrategy::default() {
-        writer.key_value_string("fork-strategy", &options.fork_strategy.to_string())?;
+        writer.key_value("fork-strategy", options.fork_strategy.to_string())?;
     }
 
     let exclude_newer = &options.exclude_newer;
     if let Some(global) = &exclude_newer.global {
         if let Some(span) = global.span() {
             writer.key_start("exclude-newer")?;
-            writer.string(ExcludeNewerValue::PLACEHOLDER)?;
+            writer.value(ExcludeNewerValue::PLACEHOLDER)?;
             writer.raw(" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.\n");
-            writer.key_value_string("exclude-newer-span", &span.to_string())?;
+            writer.key_value("exclude-newer-span", span.to_string())?;
         } else {
-            writer.key_value_string("exclude-newer", &global.to_string())?;
+            writer.key_value("exclude-newer", global.to_string())?;
         }
     }
 
@@ -175,16 +175,16 @@ fn write_options(writer: &mut LockWriter, options: &ResolverOptions) -> Result<(
                         writer.key_start(name.as_ref())?;
                         let mut first = true;
                         writer.start_inline_table();
-                        writer.inline_string(
+                        writer.inline_value(
                             &mut first,
                             "timestamp",
                             ExcludeNewerValue::PLACEHOLDER,
                         )?;
-                        writer.inline_string(&mut first, "span", &span.to_string())?;
+                        writer.inline_value(&mut first, "span", span.to_string())?;
                         writer.finish_inline_table(first);
                         writer.raw("\n");
                     } else {
-                        writer.key_value_string(name.as_ref(), &value.to_string())?;
+                        writer.key_value(name.as_ref(), value.to_string())?;
                     }
                 }
                 ExcludeNewerOverride::Disabled => {
@@ -216,15 +216,15 @@ fn write_manifest(writer: &mut LockWriter, manifest: &ResolverManifest) -> Resul
 
     writer.table(&["manifest"])?;
     if !manifest.members.is_empty() {
-        writer.multiline_array("members", &manifest.members, |writer, member| {
-            writer.string(member.as_ref())
+        writer.key_multiline_array("members", &manifest.members, |writer, member| {
+            writer.value(member.as_ref())
         })?;
     }
-    write_serialized_array(writer, "requirements", &manifest.requirements)?;
-    write_serialized_array(writer, "constraints", &manifest.constraints)?;
-    write_serialized_array(writer, "overrides", &manifest.overrides)?;
-    write_serialized_array(writer, "excludes", &manifest.excludes)?;
-    write_serialized_array(writer, "build-constraints", &manifest.build_constraints)?;
+    write_serialized_non_empty_array(writer, "requirements", &manifest.requirements)?;
+    write_serialized_non_empty_array(writer, "constraints", &manifest.constraints)?;
+    write_serialized_non_empty_array(writer, "overrides", &manifest.overrides)?;
+    write_serialized_non_empty_array(writer, "excludes", &manifest.excludes)?;
+    write_serialized_non_empty_array(writer, "build-constraints", &manifest.build_constraints)?;
 
     if has_dependency_groups {
         writer.table(&["manifest", "dependency-groups"])?;
@@ -232,26 +232,26 @@ fn write_manifest(writer: &mut LockWriter, manifest: &ResolverManifest) -> Resul
             if requirements.is_empty() {
                 continue;
             }
-            write_serialized_array(writer, group.as_ref(), requirements)?;
+            write_serialized_non_empty_array(writer, group.as_ref(), requirements)?;
         }
     }
 
     for metadata in &manifest.dependency_metadata {
         writer.array_of_tables(&["manifest", "dependency-metadata"])?;
-        writer.key_value_string("name", metadata.name.as_ref())?;
+        writer.key_value("name", metadata.name.as_ref())?;
         if let Some(version) = metadata.version.as_ref() {
-            writer.key_value_string("version", &version.to_string())?;
+            writer.key_value("version", version.to_string())?;
         }
         if !metadata.requires_dist.is_empty() {
             let value = serialize_value(&metadata.requires_dist)?;
-            writer.key_value_raw("requires-dist", &value)?;
+            writer.key_value("requires-dist", value)?;
         }
         if let Some(requires_python) = metadata.requires_python.as_ref() {
-            writer.key_value_string("requires-python", &requires_python.to_string())?;
+            writer.key_value("requires-python", requires_python.to_string())?;
         }
         if !metadata.provides_extra.is_empty() {
             let value = serialize_value(&metadata.provides_extra)?;
-            writer.key_value_raw("provides-extras", &value)?;
+            writer.key_value("provides-extras", value)?;
         }
     }
 
@@ -266,19 +266,19 @@ fn write_package(
     dist_count_by_name: &FxHashMap<PackageName, u64>,
 ) -> Result<(), WriteError> {
     writer.array_of_tables(&["package"])?;
-    write_package_id(writer, &package.id, None)?;
+    write_package_id(writer, &package.id, None, PackageIdLocation::Table)?;
 
     if !package.fork_markers.is_empty() {
         let markers = simplified_universal_markers(&package.fork_markers, requires_python);
         if !markers.is_empty() {
-            writer.multiline_array("resolution-markers", markers, |writer, marker| {
-                writer.string(&marker)
+            writer.key_multiline_array("resolution-markers", markers, |writer, marker| {
+                writer.value(&marker)
             })?;
         }
     }
 
     if !package.dependencies.is_empty() {
-        writer.multiline_array(
+        writer.key_multiline_array(
             "dependencies",
             &package.dependencies,
             |writer, dependency| {
@@ -299,7 +299,7 @@ fn write_package(
     }
 
     if !package.wheels.is_empty() {
-        writer.multiline_array("wheels", &package.wheels, write_wheel_inline)?;
+        writer.key_multiline_array("wheels", &package.wheels, write_wheel_inline)?;
     }
 
     if package
@@ -312,7 +312,7 @@ fn write_package(
             if dependencies.is_empty() {
                 continue;
             }
-            writer.multiline_array(extra.as_ref(), dependencies, |writer, dependency| {
+            writer.key_multiline_array(extra.as_ref(), dependencies, |writer, dependency| {
                 write_dependency_inline(
                     writer,
                     dependency,
@@ -333,7 +333,7 @@ fn write_package(
             if dependencies.is_empty() {
                 continue;
             }
-            writer.multiline_array(group.as_ref(), dependencies, |writer, dependency| {
+            writer.key_multiline_array(group.as_ref(), dependencies, |writer, dependency| {
                 write_dependency_inline(
                     writer,
                     dependency,
@@ -350,11 +350,11 @@ fn write_package(
         || !metadata.provides_extra.is_empty();
     if has_metadata {
         writer.table(&["package", "metadata"])?;
-        write_serialized_array(writer, "requires-dist", &metadata.requires_dist)?;
+        write_serialized_non_empty_array(writer, "requires-dist", &metadata.requires_dist)?;
         if !metadata.provides_extra.is_empty() {
             writer.key_start("provides-extras")?;
-            writer.inline_array(&metadata.provides_extra, |writer, extra| {
-                writer.string(extra.as_ref())
+            writer.array(&metadata.provides_extra, |writer, extra| {
+                writer.value(extra.as_ref())
             })?;
             writer.raw("\n");
         }
@@ -362,7 +362,7 @@ fn write_package(
         if !metadata.dependency_groups.is_empty() {
             writer.table(&["package", "metadata", "requires-dev"])?;
             for (group, requirements) in &metadata.dependency_groups {
-                write_serialized_array_including_empty(writer, group.as_ref(), requirements)?;
+                write_serialized_array(writer, group.as_ref(), requirements)?;
             }
         }
     }
@@ -377,18 +377,58 @@ fn write_package_id(
     writer: &mut LockWriter,
     package_id: &PackageId,
     dist_count_by_name: Option<&FxHashMap<PackageName, u64>>,
+    mut location: PackageIdLocation<'_>,
 ) -> Result<(), WriteError> {
     let count = dist_count_by_name.and_then(|map| map.get(&package_id.name).copied());
-    writer.key_value_string("name", package_id.name.as_ref())?;
+    location.value(writer, "name", package_id.name.as_ref())?;
     if count.is_none_or(|count| count > 1) {
         if let Some(version) = &package_id.version {
-            writer.key_value_string("version", &version.to_string())?;
+            location.value(writer, "version", version.to_string())?;
         }
-        writer.key_start("source")?;
-        write_source_inline(writer, &package_id.source)?;
-        writer.raw("\n");
+        location.nested_value(writer, "source", |writer| {
+            write_source_inline(writer, &package_id.source)
+        })?;
     }
     Ok(())
+}
+
+enum PackageIdLocation<'a> {
+    Table,
+    Inline(&'a mut bool),
+}
+
+impl PackageIdLocation<'_> {
+    fn value(
+        &mut self,
+        writer: &mut LockWriter,
+        key: &str,
+        value: impl WriteTomlValue,
+    ) -> Result<(), WriteError> {
+        match self {
+            Self::Table => writer.key_value(key, value),
+            Self::Inline(first) => writer.inline_value(first, key, value),
+        }
+    }
+
+    fn nested_value(
+        &mut self,
+        writer: &mut LockWriter,
+        key: &str,
+        write_value: impl FnOnce(&mut LockWriter) -> Result<(), WriteError>,
+    ) -> Result<(), WriteError> {
+        match self {
+            Self::Table => {
+                writer.key_start(key)?;
+                write_value(writer)?;
+                writer.raw("\n");
+            }
+            Self::Inline(first) => {
+                writer.inline_key_start(first, key)?;
+                write_value(writer)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 fn write_source_inline(writer: &mut LockWriter, source: &Source) -> Result<(), WriteError> {
@@ -397,48 +437,44 @@ fn write_source_inline(writer: &mut LockWriter, source: &Source) -> Result<(), W
     match source {
         Source::Registry(source) => match source {
             RegistrySource::Url(url) => {
-                writer.inline_string(&mut first, "registry", url.as_ref())?;
+                writer.inline_value(&mut first, "registry", url.as_ref())?;
             }
             RegistrySource::Path(path) => {
-                writer.inline_string(
+                writer.inline_value(
                     &mut first,
                     "registry",
-                    &PortablePath::from(path).to_string(),
+                    PortablePath::from(path).to_string(),
                 )?;
             }
         },
         Source::Git(url, _) => {
-            writer.inline_string(&mut first, "git", url.as_ref())?;
+            writer.inline_value(&mut first, "git", url.as_ref())?;
         }
         Source::Direct(url, DirectSource { subdirectory }) => {
-            writer.inline_string(&mut first, "url", url.as_ref())?;
+            writer.inline_value(&mut first, "url", url.as_ref())?;
             if let Some(subdirectory) = subdirectory {
-                writer.inline_string(
+                writer.inline_value(
                     &mut first,
                     "subdirectory",
-                    &PortablePath::from(subdirectory).to_string(),
+                    PortablePath::from(subdirectory).to_string(),
                 )?;
             }
         }
         Source::Path(path) => {
-            writer.inline_string(&mut first, "path", &PortablePath::from(path).to_string())?;
+            writer.inline_value(&mut first, "path", PortablePath::from(path).to_string())?;
         }
         Source::Directory(path) => {
-            writer.inline_string(
+            writer.inline_value(
                 &mut first,
                 "directory",
-                &PortablePath::from(path).to_string(),
+                PortablePath::from(path).to_string(),
             )?;
         }
         Source::Editable(path) => {
-            writer.inline_string(
-                &mut first,
-                "editable",
-                &PortablePath::from(path).to_string(),
-            )?;
+            writer.inline_value(&mut first, "editable", PortablePath::from(path).to_string())?;
         }
         Source::Virtual(path) => {
-            writer.inline_string(&mut first, "virtual", &PortablePath::from(path).to_string())?;
+            writer.inline_value(&mut first, "virtual", PortablePath::from(path).to_string())?;
         }
     }
     writer.finish_inline_table(first);
@@ -454,20 +490,20 @@ fn write_source_dist_inline(
     match source_dist {
         SourceDist::Metadata { .. } => {}
         SourceDist::Url { url, .. } => {
-            writer.inline_string(&mut first, "url", url.as_ref())?;
+            writer.inline_value(&mut first, "url", url.as_ref())?;
         }
         SourceDist::Path { path, .. } => {
-            writer.inline_string(&mut first, "path", &PortablePath::from(path).to_string())?;
+            writer.inline_value(&mut first, "path", PortablePath::from(path).to_string())?;
         }
     }
     if let Some(hash) = source_dist.hash() {
-        writer.inline_string(&mut first, "hash", &hash.to_string())?;
+        writer.inline_value(&mut first, "hash", hash.to_string())?;
     }
     if let Some(size) = source_dist.size() {
         writer.inline_value(&mut first, "size", size)?;
     }
     if let Some(upload_time) = source_dist.upload_time() {
-        writer.inline_string(&mut first, "upload-time", &upload_time.to_string())?;
+        writer.inline_value(&mut first, "upload-time", upload_time.to_string())?;
     }
     writer.finish_inline_table(first);
     Ok(())
@@ -478,30 +514,30 @@ fn write_wheel_inline(writer: &mut LockWriter, wheel: &Wheel) -> Result<(), Writ
     writer.start_inline_table();
     match &wheel.url {
         WheelWireSource::Url { url } => {
-            writer.inline_string(&mut first, "url", url.as_ref())?;
+            writer.inline_value(&mut first, "url", url.as_ref())?;
         }
         WheelWireSource::Path { path } => {
-            writer.inline_string(&mut first, "path", &PortablePath::from(path).to_string())?;
+            writer.inline_value(&mut first, "path", PortablePath::from(path).to_string())?;
         }
         WheelWireSource::Filename { filename } => {
-            writer.inline_string(&mut first, "filename", &filename.to_string())?;
+            writer.inline_value(&mut first, "filename", filename.to_string())?;
         }
     }
     if let Some(hash) = &wheel.hash {
-        writer.inline_string(&mut first, "hash", &hash.to_string())?;
+        writer.inline_value(&mut first, "hash", hash.to_string())?;
     }
     if let Some(size) = wheel.size {
         writer.inline_value(&mut first, "size", size)?;
     }
     if let Some(upload_time) = wheel.upload_time {
-        writer.inline_string(&mut first, "upload-time", &upload_time.to_string())?;
+        writer.inline_value(&mut first, "upload-time", upload_time.to_string())?;
     }
     if let Some(zstd) = &wheel.zstd {
-        writer.inline_key(&mut first, "zstd")?;
+        writer.inline_key_start(&mut first, "zstd")?;
         let mut zstd_first = true;
         writer.start_inline_table();
         if let Some(hash) = &zstd.hash {
-            writer.inline_string(&mut zstd_first, "hash", &hash.to_string())?;
+            writer.inline_value(&mut zstd_first, "hash", hash.to_string())?;
         }
         if let Some(size) = zstd.size {
             writer.inline_value(&mut zstd_first, "size", size)?;
@@ -522,20 +558,17 @@ fn write_dependency_inline(
     let mut first = true;
     writer.start_inline_table();
 
-    let count = dist_count_by_name.get(&dependency.package_id.name).copied();
-    writer.inline_string(&mut first, "name", dependency.package_id.name.as_ref())?;
-    if count.is_none_or(|count| count > 1) {
-        if let Some(version) = &dependency.package_id.version {
-            writer.inline_string(&mut first, "version", &version.to_string())?;
-        }
-        writer.inline_key(&mut first, "source")?;
-        write_source_inline(writer, &dependency.package_id.source)?;
-    }
+    write_package_id(
+        writer,
+        &dependency.package_id,
+        Some(dist_count_by_name),
+        PackageIdLocation::Inline(&mut first),
+    )?;
 
     if !dependency.extra.is_empty() {
-        writer.inline_key(&mut first, "extra")?;
-        writer.inline_array(&dependency.extra, |writer, extra| {
-            writer.string(extra.as_ref())
+        writer.inline_key_start(&mut first, "extra")?;
+        writer.array(&dependency.extra, |writer, extra| {
+            writer.value(extra.as_ref())
         })?;
     }
 
@@ -546,7 +579,7 @@ fn write_dependency_inline(
         .restrict(simplified_environment)
         .try_to_string()
     {
-        writer.inline_string(&mut first, "marker", &marker)?;
+        writer.inline_value(&mut first, "marker", &marker)?;
     }
 
     writer.finish_inline_table(first);
@@ -554,7 +587,7 @@ fn write_dependency_inline(
 }
 
 /// Writes a Serde-backed array, omitting the key when the array is empty.
-fn write_serialized_array<T: Serialize>(
+fn write_serialized_non_empty_array<T: Serialize>(
     writer: &mut LockWriter,
     key: &str,
     values: &BTreeSet<T>,
@@ -562,14 +595,14 @@ fn write_serialized_array<T: Serialize>(
     if values.is_empty() {
         return Ok(());
     }
-    write_serialized_array_including_empty(writer, key, values)
+    write_serialized_array(writer, key, values)
 }
 
 /// Writes a Serde-backed array using the canonical layout for its cardinality.
 ///
 /// Empty and single-element arrays stay on one line, while larger arrays place each element on
-/// its own line. Unlike [`write_serialized_array`], this retains empty dependency groups.
-fn write_serialized_array_including_empty<T: Serialize>(
+/// its own line. Unlike [`write_serialized_non_empty_array`], this retains empty dependency groups.
+fn write_serialized_array<T: Serialize>(
     writer: &mut LockWriter,
     key: &str,
     values: &BTreeSet<T>,
@@ -577,24 +610,31 @@ fn write_serialized_array_including_empty<T: Serialize>(
     writer.key_start(key)?;
     let write_value = |writer: &mut LockWriter, value: &T| {
         let value = serialize_value(value)?;
-        writer.raw_value(&value);
-        Ok(())
+        writer.value(value)
     };
     if values.len() <= 1 {
-        writer.inline_array(values, write_value)?;
+        writer.array(values, write_value)?;
         writer.raw("\n");
     } else {
-        writer.multiline_array_values(values, write_value)?;
+        writer.multiline_array(values, write_value)?;
     }
     Ok(())
 }
 
-/// Converts values without native `toml_writer` support through Serde's TOML value serializer.
-fn serialize_value<T: Serialize + ?Sized>(value: &T) -> Result<Value, WriteError> {
-    Ok(Serialize::serialize(
+/// Adapts values without native `toml_writer` support through Serde's TOML value serializer.
+struct SerializedValue(Value);
+
+impl WriteTomlValue for SerializedValue {
+    fn write_toml_value<W: TomlWrite + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        writer.write_str(&self.0.to_string())
+    }
+}
+
+fn serialize_value<T: Serialize + ?Sized>(value: &T) -> Result<SerializedValue, WriteError> {
+    Ok(SerializedValue(Serialize::serialize(
         value,
         toml_edit::ser::ValueSerializer::new(),
-    )?)
+    )?))
 }
 
 #[derive(Debug)]
@@ -626,15 +666,11 @@ impl LockWriter {
         self.output.push_str(value);
     }
 
-    fn raw_value(&mut self, value: &Value) {
-        self.output.push_str(&value.to_string());
-    }
-
     fn key(&mut self, key: &str) -> fmt::Result {
         self.output.key(key)
     }
 
-    fn string(&mut self, value: &str) -> Result<(), WriteError> {
+    fn value(&mut self, value: impl WriteTomlValue) -> Result<(), WriteError> {
         self.output.value(value)?;
         Ok(())
     }
@@ -647,21 +683,7 @@ impl LockWriter {
 
     fn key_value(&mut self, key: &str, value: impl WriteTomlValue) -> Result<(), WriteError> {
         self.key_start(key)?;
-        self.output.value(value)?;
-        self.raw("\n");
-        Ok(())
-    }
-
-    fn key_value_string(&mut self, key: &str, value: &str) -> Result<(), WriteError> {
-        self.key_start(key)?;
-        self.string(value)?;
-        self.raw("\n");
-        Ok(())
-    }
-
-    fn key_value_raw(&mut self, key: &str, value: &Value) -> Result<(), WriteError> {
-        self.key_start(key)?;
-        self.raw_value(value);
+        self.value(value)?;
         self.raw("\n");
         Ok(())
     }
@@ -696,7 +718,7 @@ impl LockWriter {
         Ok(())
     }
 
-    fn multiline_array<I, T, F>(
+    fn key_multiline_array<I, T, F>(
         &mut self,
         key: &str,
         values: I,
@@ -707,14 +729,10 @@ impl LockWriter {
         F: FnMut(&mut Self, T) -> Result<(), WriteError>,
     {
         self.key_start(key)?;
-        self.multiline_array_values(values, write_value)
+        self.multiline_array(values, write_value)
     }
 
-    fn multiline_array_values<I, T, F>(
-        &mut self,
-        values: I,
-        mut write_value: F,
-    ) -> Result<(), WriteError>
+    fn multiline_array<I, T, F>(&mut self, values: I, mut write_value: F) -> Result<(), WriteError>
     where
         I: IntoIterator<Item = T>,
         F: FnMut(&mut Self, T) -> Result<(), WriteError>,
@@ -729,7 +747,7 @@ impl LockWriter {
         Ok(())
     }
 
-    fn inline_array<I, T, F>(&mut self, values: I, mut write_value: F) -> Result<(), WriteError>
+    fn array<I, T, F>(&mut self, values: I, mut write_value: F) -> Result<(), WriteError>
     where
         I: IntoIterator<Item = T>,
         F: FnMut(&mut Self, T) -> Result<(), WriteError>,
@@ -757,7 +775,7 @@ impl LockWriter {
     }
 
     /// Writes the separator and key for the next inline-table entry.
-    fn inline_key(&mut self, first: &mut bool, key: &str) -> Result<(), WriteError> {
+    fn inline_key_start(&mut self, first: &mut bool, key: &str) -> Result<(), WriteError> {
         if *first {
             self.raw(" ");
             *first = false;
@@ -773,19 +791,8 @@ impl LockWriter {
         key: &str,
         value: impl WriteTomlValue,
     ) -> Result<(), WriteError> {
-        self.inline_key(first, key)?;
-        self.output.value(value)?;
-        Ok(())
-    }
-
-    fn inline_string(
-        &mut self,
-        first: &mut bool,
-        key: &str,
-        value: &str,
-    ) -> Result<(), WriteError> {
-        self.inline_key(first, key)?;
-        self.string(value)
+        self.inline_key_start(first, key)?;
+        self.value(value)
     }
 }
 
@@ -807,7 +814,7 @@ mod tests {
             "contains\u{7f}delete",
         ] {
             let mut writer = LockWriter::default();
-            writer.string(value).expect("writing to a string succeeds");
+            writer.value(value).expect("writing to a string succeeds");
             assert_eq!(writer.output, Value::from(value).to_string());
         }
     }


### PR DESCRIPTION
## Summary

Migrate native `uv.lock` serialization from building a `toml_edit` document to writing TOML directly with `toml_writer`.

The output format remains unchanged, including inline tables, multiline arrays, marker simplification, conflict metadata, relative `exclude-newer` compatibility fields, and package and dependency metadata. The separate `pylock.toml` export continues to use `toml_edit`.

This avoids constructing a full editable TOML AST when serializing lockfiles:

Workload | Serialization | uv lock wall | CPU
-- | -- | -- | --
transformers | 15.34 → 6.15 ms (−60%) | −2.4% | −1.5%
home-assistant | 2.59 → 0.80 ms (−69%) | −3.9% | −5.5%
warehouse | 6.49 → 1.98 ms (−70%) | −1.5% | −1.6%
jupyterlab | 1.97 → 0.56 ms (−72%) | −2.6% | −1.5%
semantic-kernel | 1.79 → 0.51 ms (−71%) | −1.2% | −1.4%

Note that the changes here are largely moving code out of `lock/mod.rs` and into `serialize.rs`, with alterations to leverage `toml_writer`.
