### PR TITLE
Skip fully cutoff-excluded resolver candidates

### DIFF
--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -439,7 +439,7 @@ impl CandidateSelector {
                         .enumerate()
                         .map(|(map_index, version_map)| {
                             version_map
-                                .iter(range)
+                                .iter_included(range)
                                 .rev()
                                 .map(move |item| (map_index, item))
                         })
@@ -464,7 +464,9 @@ impl CandidateSelector {
                         .iter()
                         .enumerate()
                         .map(|(map_index, version_map)| {
-                            version_map.iter(range).map(move |item| (map_index, item))
+                            version_map
+                                .iter_included(range)
+                                .map(move |item| (map_index, item))
                         })
                         .kmerge_by(
                             |(index1, (version1, _)), (index2, (version2, _))| match version1
@@ -486,7 +488,7 @@ impl CandidateSelector {
             if highest {
                 version_maps.iter().find_map(|version_map| {
                     Self::select_candidate(
-                        version_map.iter(range).rev(),
+                        version_map.iter_included(range).rev(),
                         package_name,
                         range,
                         allow_prerelease,
@@ -496,7 +498,7 @@ impl CandidateSelector {
             } else {
                 version_maps.iter().find_map(|version_map| {
                     Self::select_candidate(
-                        version_map.iter(range),
+                        version_map.iter_included(range),
                         package_name,
                         range,
                         allow_prerelease,

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -253,6 +253,18 @@ impl VersionMap {
         }
     }
 
+    /// Return an iterator over the versions that can be considered for selection.
+    ///
+    /// Unlike [`Self::iter`], this skips lazy registry versions whose files are all excluded by
+    /// an upload-time cutoff without materializing their distributions. Files without an upload
+    /// time remain included so that materialization can emit the appropriate warning.
+    pub(crate) fn iter_included(
+        &self,
+        range: &Ranges<Version>,
+    ) -> impl DoubleEndedIterator<Item = (&Version, VersionMapDistHandle<'_>)> {
+        self.iter(range).filter(|(_, dist)| dist.is_included())
+    }
+
     /// Return the [`Hashes`] for the given version, if any.
     pub(crate) fn hashes(&self, version: &Version) -> Option<&[HashDigest]> {
         match self.inner {
@@ -327,6 +339,18 @@ enum VersionMapDistHandleInner<'a> {
 }
 
 impl<'a> VersionMapDistHandle<'a> {
+    /// Returns whether this distribution can be considered for selection.
+    fn is_included(&self) -> bool {
+        match self.inner {
+            VersionMapDistHandleInner::Eager(_) => true,
+            VersionMapDistHandleInner::Lazy { lazy, dist } => match (&dist.flat, &dist.simple) {
+                (Some(_), _) => true,
+                (None, Some(simple)) => lazy.any_file_materializable(simple),
+                (None, None) => false,
+            },
+        }
+    }
+
     /// Returns a prioritized distribution from this handle.
     pub(crate) fn prioritized_dist(&self) -> Option<&'a PrioritizedDist> {
         match self.inner {
@@ -558,6 +582,34 @@ impl VersionMapLazy {
                     false
                 };
                 !excluded
+            })
+    }
+
+    /// Returns whether a version should be materialized during candidate selection.
+    ///
+    /// Missing upload times are retained here, even for `included_version_cutoff`, since
+    /// materializing them is what emits the corresponding `exclude-newer` warning.
+    fn any_file_materializable(&self, simple: &SimplePrioritizedDist) -> bool {
+        let Some(cutoff) = self
+            .included_version_cutoff
+            .as_ref()
+            .or(self.available_version_cutoff.as_ref())
+        else {
+            return true;
+        };
+        let Some(datum) = self.simple_metadata.datum(simple.datum_index) else {
+            return false;
+        };
+        datum
+            .files
+            .wheels
+            .iter()
+            .map(|wheel| &wheel.file)
+            .chain(datum.files.source_dists.iter().map(|sdist| &sdist.file))
+            .any(|file| {
+                file.upload_time_utc_ms
+                    .as_ref()
+                    .is_none_or(|upload_time| upload_time.to_native() < cutoff.as_millisecond())
             })
     }
 


### PR DESCRIPTION
## Summary

Warm locking with `exclude-newer` can encounter tens of thousands of registry versions whose files are all beyond the cutoff. Resolution intentionally treats those versions as nonexistent, but candidate selection previously materialized each lazy `PrioritizedDist` first, deserializing files and performing compatibility work only to discard the candidate.

This PR adds a cutoff-aware candidate iterator that checks archived upload times before materialization.

## Performance

| Workload | Wall time | Wall change (95% CI) | CPU time | CPU change (95% CI) |
| --- | ---: | ---: | ---: | ---: |
| Transformers | 343.0 → 315.1 ms | −8.1% [−9.2, −5.7] | 378.8 → 352.8 ms | −6.9% [−7.4, −6.0] |
| Home Assistant | 132.1 → 119.9 ms | −9.2% [−10.3, −6.8] | 95.2 → 81.9 ms | −13.9% [−15.2, −12.4] |
| Warehouse | 187.4 → 170.1 ms | −9.2% [−11.6, −7.1] | 197.9 → 178.2 ms | −10.0% [−11.6, −9.0] |
| JupyterLab | 117.4 → 110.4 ms | −6.0% [−8.1, −3.7] | 62.9 → 57.4 ms | −8.7% [−9.6, −7.8] |
| Semantic Kernel | 132.7 → 119.9 ms | −9.7% [−12.2, −6.8] | 86.0 → 69.4 ms | −19.2% [−20.2, −18.7] |
| **Geometric mean** | | **−8.5% [−9.3, −7.4]** | | **−11.9% [−12.4, −11.4]** |
