### PR TITLE
Reuse resolver fork markers while recording preferences

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -443,14 +443,15 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 self.options.resolution_mode,
                                 ResolutionMode::Lowest | ResolutionMode::Highest
                             ) {
+                                let marker = resolution
+                                    .env
+                                    .try_universal_markers()
+                                    .unwrap_or(UniversalMarker::TRUE);
                                 for (package, version) in &resolution.nodes {
                                     preferences.insert(
                                         package.name.clone(),
                                         package.index.clone(),
-                                        resolution
-                                            .env
-                                            .try_universal_markers()
-                                            .unwrap_or(UniversalMarker::TRUE),
+                                        marker,
                                         version.clone(),
                                         PreferenceSource::Resolver,
                                     );

--- a/crates/uv-resolver/src/universal_marker.rs
+++ b/crates/uv-resolver/src/universal_marker.rs
@@ -132,6 +132,9 @@ impl UniversalMarker {
     /// two items from the same set in the given conflicts can be active at a
     /// given time.
     pub(crate) fn imbibe(&mut self, conflicts: ConflictMarker) {
+        if conflicts.marker.is_true() {
+            return;
+        }
         let self_marker = self.marker;
         self.marker = conflicts.marker;
         self.marker.implies(self_marker);
@@ -178,7 +181,6 @@ impl UniversalMarker {
             ConflictKind::Group(ref group) => self.assume_group(item.package(), group),
             ConflictKind::Project => self.assume_project(item.package()),
         }
-        self.pep508 = self.marker.without_extras();
     }
 
     /// Assumes that a given extra/group for the given package is not
@@ -192,7 +194,6 @@ impl UniversalMarker {
             ConflictKind::Group(ref group) => self.assume_not_group(item.package(), group),
             ConflictKind::Project => self.assume_not_project(item.package()),
         }
-        self.pep508 = self.marker.without_extras();
     }
 
     /// Assumes that the "production" dependencies for the given project are
@@ -1055,6 +1056,18 @@ mod tests {
         );
         dep_conflict_marker.imbibe(conflicts_marker);
         assert_eq!(format!("{dep_conflict_marker:?}"), "true");
+    }
+
+    #[test]
+    fn imbibe_true() {
+        let pep508 =
+            MarkerTree::from_str("sys_platform == 'darwin'").expect("valid marker expression");
+        let mut marker = UniversalMarker::new(pep508, create_extra_marker("foo"));
+        let expected = marker;
+
+        marker.imbibe(ConflictMarker::TRUE);
+
+        assert_eq!(marker, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This avoids recomputing the same fork marker for every resolved node while recording preferences, skips the identity case in `UniversalMarker::imbibe`, and removes two redundant PEP 508 projections that are already performed by the underlying conflict helpers.

## Performance

Measured with profiling binaries, a warm local cache, `--offline`, pinned CPUs (8-15), fixed `UV_EXCLUDE_NEWER`, alternating base/head order, 10 warmups, and 60 paired runs. The baseline is current `main` (including the just-merged Python-requirement marker cache, #20461) plus the in-review TOML writer (#20450). Every pair produced identical lockfile hashes.

| Workload | Wall before → after | Wall Δ | CPU before → after | CPU Δ |
|---|---:|---:|---:|---:|
| Transformers | 308.5 → 301.1 ms | -2.4% | 343.3 → 336.0 ms | -2.1% |
| Home Assistant | 121.5 → 120.9 ms | -0.5% | 82.2 → 81.4 ms | -1.0% |
| Warehouse | 167.4 → 168.2 ms | +0.5% | 176.5 → 175.7 ms | -0.5% |
| JupyterLab | 112.5 → 112.3 ms | -0.1% | 57.3 → 56.9 ms | -0.6% |
| Semantic Kernel | 120.8 → 119.4 ms | -1.1% | 70.0 → 70.2 ms | +0.2% |

Transformers is the clear win: block-aware paired analysis was **-2.23% wall** (95% CI -4.17 to -0.26) and **-2.37% CPU** (95% CI -3.46 to -1.22).

The focused resolver suite passes (63 tests), including the added `imbibe(TRUE)` regression test; formatting and diff checks are clean.