### PR TITLE
Compact cached distribution metadata

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -1203,7 +1203,7 @@ impl CacheBucket {
             Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_clean.rs`.
-            Self::Simple => "simple-v22",
+            Self::Simple => "simple-v23",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_prune.rs`.
             Self::Wheels => "wheels-v6",

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1398,9 +1398,7 @@ impl VersionFiles {
             .into_iter()
             .chain(self.wheels)
             .filter_map(|file| {
-                let filename =
-                    DistFilename::try_from_filename_with_reason(&file.filename, package_name)
-                        .ok()?;
+                let filename = DistFilename::try_from_filename(&file.filename, package_name)?;
                 Some((filename, file))
             })
     }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -18,7 +18,7 @@ use uv_auth::{CredentialsCache, Indexes, PyxTokenStore};
 use uv_cache::{Cache, CacheBucket, CacheEntry, WheelCache};
 use uv_configuration::IndexStrategy;
 use uv_configuration::KeyringProviderType;
-use uv_distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
+use uv_distribution_filename::{DistFilename, WheelFilename};
 use uv_distribution_types::{
     BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
     IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name, RegistryBuiltWheel,
@@ -1382,37 +1382,28 @@ type FlatIndexSlot = Arc<Mutex<Option<FlatIndexEntriesByPackage>>>;
 #[rkyv(derive(Debug))]
 pub struct VersionFiles {
     pub wheels: Vec<File>,
-    pub source_dists: Vec<VersionSourceDist>,
+    pub source_dists: Vec<File>,
 }
 
 impl VersionFiles {
     fn push(&mut self, filename: DistFilename, file: File) {
         match filename {
             DistFilename::WheelFilename(_) => self.wheels.push(file),
-            DistFilename::SourceDistFilename(name) => {
-                self.source_dists.push(VersionSourceDist { name, file });
-            }
+            DistFilename::SourceDistFilename(_) => self.source_dists.push(file),
         }
     }
 
     pub fn all(self, package_name: &PackageName) -> impl Iterator<Item = (DistFilename, File)> {
         self.source_dists
             .into_iter()
-            .map(|VersionSourceDist { name, file }| (DistFilename::SourceDistFilename(name), file))
-            .chain(self.wheels.into_iter().filter_map(|file| {
+            .chain(self.wheels)
+            .filter_map(|file| {
                 let filename =
                     DistFilename::try_from_filename_with_reason(&file.filename, package_name)
                         .ok()?;
                 Some((filename, file))
-            }))
+            })
     }
-}
-
-#[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[rkyv(derive(Debug))]
-pub struct VersionSourceDist {
-    pub name: SourceDistFilename,
-    pub file: File,
 }
 
 /// The list of projects available in a Simple API index.
@@ -1531,7 +1522,7 @@ impl SimpleDetailMetadata {
                 .sort_unstable_by(|left, right| left.filename.cmp(&right.filename));
             files
                 .source_dists
-                .sort_unstable_by(|left, right| left.file.filename.cmp(&right.file.filename));
+                .sort_unstable_by(|left, right| left.filename.cmp(&right.filename));
         }
 
         Self {
@@ -2097,26 +2088,26 @@ mod tests {
     }
 
     #[test]
-    fn wheel_files_round_trip() -> Result<(), Error> {
+    fn distribution_files_round_trip() -> Result<(), Error> {
         let response = r#"
         {
             "files": [
                 {
-                    "filename": "example-1.0.0-py3-none-any.whl",
+                    "filename": "example_1-1.0.0-py3-none-any.whl",
                     "hashes": {},
-                    "url": "https://files.pythonhosted.org/example-1.0.0-py3-none-any.whl"
+                    "url": "https://files.pythonhosted.org/example_1-1.0.0-py3-none-any.whl"
                 },
                 {
-                    "filename": "example-1.0.0.tar.gz",
+                    "filename": "example-1-1.0.0.tar.gz",
                     "hashes": {},
-                    "url": "https://files.pythonhosted.org/example-1.0.0.tar.gz"
+                    "url": "https://files.pythonhosted.org/example-1-1.0.0.tar.gz"
                 }
             ]
         }
         "#;
-        let package_name = PackageName::from_str("example")?;
+        let package_name = PackageName::from_str("example-1")?;
         let data: PypiSimpleDetail = serde_json::from_str(response)?;
-        let base = DisplaySafeUrl::parse("https://pypi.org/simple/example/")?;
+        let base = DisplaySafeUrl::parse("https://pypi.org/simple/example-1/")?;
         let simple_metadata = SimpleDetailMetadata::from_pypi_files(
             data.files,
             &package_name,
@@ -2134,7 +2125,7 @@ mod tests {
             .collect();
         assert_eq!(
             filenames,
-            ["example-1.0.0.tar.gz", "example-1.0.0-py3-none-any.whl"]
+            ["example_1-1.0.0.tar.gz", "example_1-1.0.0-py3-none-any.whl"]
         );
 
         Ok(())
@@ -2198,53 +2189,44 @@ mod tests {
                     files: VersionFiles {
                         wheels: [],
                         source_dists: [
-                            VersionSourceDist {
-                                name: SourceDistFilename {
-                                    name: PackageName(
-                                        "pepy",
-                                    ),
-                                    version: "2.1.1",
-                                    extension: TarGz,
-                                },
-                                file: File {
-                                    dist_info_metadata: false,
-                                    filename: "pepy-2.1.1.tar.gz",
-                                    hashes: HashDigests(
+                            File {
+                                dist_info_metadata: false,
+                                filename: "pepy-2.1.1.tar.gz",
+                                hashes: HashDigests(
+                                    [
+                                        HashDigest {
+                                            algorithm: Sha256,
+                                            digest: "cec463c444b71d1664229121897b22df753dc91fabb2113d1c89992638c90829",
+                                        },
+                                    ],
+                                ),
+                                requires_python: Some(
+                                    VersionSpecifiers(
                                         [
-                                            HashDigest {
-                                                algorithm: Sha256,
-                                                digest: "cec463c444b71d1664229121897b22df753dc91fabb2113d1c89992638c90829",
+                                            VersionSpecifier {
+                                                operator: GreaterThanEqual,
+                                                version: "3.7",
                                             },
                                         ],
                                     ),
-                                    requires_python: Some(
-                                        VersionSpecifiers(
-                                            [
-                                                VersionSpecifier {
-                                                    operator: GreaterThanEqual,
-                                                    version: "3.7",
-                                                },
-                                            ],
-                                        ),
+                                ),
+                                size: Some(
+                                    15399,
+                                ),
+                                upload_time_utc_ms: Some(
+                                    1668446093935,
+                                ),
+                                url: AbsoluteUrl(
+                                    UrlString(
+                                        "https://files.pythonhosted.org/packages/78/7e/123d89ce0e999e957e53f0b985f734565c93b9a698af53586fc2a1be0dbf/pepy-2.1.1.tar.gz",
                                     ),
-                                    size: Some(
-                                        15399,
+                                ),
+                                yanked: Some(
+                                    Bool(
+                                        false,
                                     ),
-                                    upload_time_utc_ms: Some(
-                                        1668446093935,
-                                    ),
-                                    url: AbsoluteUrl(
-                                        UrlString(
-                                            "https://files.pythonhosted.org/packages/78/7e/123d89ce0e999e957e53f0b985f734565c93b9a698af53586fc2a1be0dbf/pepy-2.1.1.tar.gz",
-                                        ),
-                                    ),
-                                    yanked: Some(
-                                        Bool(
-                                            false,
-                                        ),
-                                    ),
-                                    zstd: None,
-                                },
+                                ),
+                                zstd: None,
                             },
                         ],
                     },
@@ -2290,45 +2272,36 @@ mod tests {
                     files: VersionFiles {
                         wheels: [],
                         source_dists: [
-                            VersionSourceDist {
-                                name: SourceDistFilename {
-                                    name: PackageName(
-                                        "pepy",
-                                    ),
-                                    version: "2.1.1",
-                                    extension: TarGz,
-                                },
-                                file: File {
-                                    dist_info_metadata: false,
-                                    filename: "pepy-2.1.1.tar.gz",
-                                    hashes: HashDigests(
+                            File {
+                                dist_info_metadata: false,
+                                filename: "pepy-2.1.1.tar.gz",
+                                hashes: HashDigests(
+                                    [
+                                        HashDigest {
+                                            algorithm: Sha256,
+                                            digest: "cec463c444b71d1664229121897b22df753dc91fabb2113d1c89992638c90829",
+                                        },
+                                    ],
+                                ),
+                                requires_python: Some(
+                                    VersionSpecifiers(
                                         [
-                                            HashDigest {
-                                                algorithm: Sha256,
-                                                digest: "cec463c444b71d1664229121897b22df753dc91fabb2113d1c89992638c90829",
+                                            VersionSpecifier {
+                                                operator: GreaterThanEqual,
+                                                version: "3.7",
                                             },
                                         ],
                                     ),
-                                    requires_python: Some(
-                                        VersionSpecifiers(
-                                            [
-                                                VersionSpecifier {
-                                                    operator: GreaterThanEqual,
-                                                    version: "3.7",
-                                                },
-                                            ],
-                                        ),
+                                ),
+                                size: None,
+                                upload_time_utc_ms: None,
+                                url: AbsoluteUrl(
+                                    UrlString(
+                                        "https://files.pythonhosted.org/packages/78/7e/123d89ce0e999e957e53f0b985f734565c93b9a698af53586fc2a1be0dbf/pepy-2.1.1.tar.gz",
                                     ),
-                                    size: None,
-                                    upload_time_utc_ms: None,
-                                    url: AbsoluteUrl(
-                                        UrlString(
-                                            "https://files.pythonhosted.org/packages/78/7e/123d89ce0e999e957e53f0b985f734565c93b9a698af53586fc2a1be0dbf/pepy-2.1.1.tar.gz",
-                                        ),
-                                    ),
-                                    yanked: None,
-                                    zstd: None,
-                                },
+                                ),
+                                yanked: None,
+                                zstd: None,
                             },
                         ],
                     },

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1381,37 +1381,31 @@ type FlatIndexSlot = Arc<Mutex<Option<FlatIndexEntriesByPackage>>>;
 #[derive(Default, Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 pub struct VersionFiles {
-    pub wheels: Vec<VersionWheel>,
+    pub wheels: Vec<File>,
     pub source_dists: Vec<VersionSourceDist>,
 }
 
 impl VersionFiles {
     fn push(&mut self, filename: DistFilename, file: File) {
         match filename {
-            DistFilename::WheelFilename(name) => self.wheels.push(VersionWheel { name, file }),
+            DistFilename::WheelFilename(_) => self.wheels.push(file),
             DistFilename::SourceDistFilename(name) => {
                 self.source_dists.push(VersionSourceDist { name, file });
             }
         }
     }
 
-    pub fn all(self) -> impl Iterator<Item = (DistFilename, File)> {
+    pub fn all(self, package_name: &PackageName) -> impl Iterator<Item = (DistFilename, File)> {
         self.source_dists
             .into_iter()
             .map(|VersionSourceDist { name, file }| (DistFilename::SourceDistFilename(name), file))
-            .chain(
-                self.wheels
-                    .into_iter()
-                    .map(|VersionWheel { name, file }| (DistFilename::WheelFilename(name), file)),
-            )
+            .chain(self.wheels.into_iter().filter_map(|file| {
+                let filename =
+                    DistFilename::try_from_filename_with_reason(&file.filename, package_name)
+                        .ok()?;
+                Some((filename, file))
+            }))
     }
-}
-
-#[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[rkyv(derive(Debug))]
-pub struct VersionWheel {
-    pub name: WheelFilename,
-    pub file: File,
 }
 
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
@@ -1534,7 +1528,7 @@ impl SimpleDetailMetadata {
         for files in version_map.values_mut() {
             files
                 .wheels
-                .sort_unstable_by(|left, right| left.file.filename.cmp(&right.file.filename));
+                .sort_unstable_by(|left, right| left.filename.cmp(&right.filename));
             files
                 .source_dists
                 .sort_unstable_by(|left, right| left.file.filename.cmp(&right.file.filename));
@@ -2100,6 +2094,50 @@ mod tests {
             .map(|SimpleDetailMetadatum { version, .. }| version.to_string())
             .collect();
         assert_eq!(versions, ["1.7.8".to_string()]);
+    }
+
+    #[test]
+    fn wheel_files_round_trip() -> Result<(), Error> {
+        let response = r#"
+        {
+            "files": [
+                {
+                    "filename": "example-1.0.0-py3-none-any.whl",
+                    "hashes": {},
+                    "url": "https://files.pythonhosted.org/example-1.0.0-py3-none-any.whl"
+                },
+                {
+                    "filename": "example-1.0.0.tar.gz",
+                    "hashes": {},
+                    "url": "https://files.pythonhosted.org/example-1.0.0.tar.gz"
+                }
+            ]
+        }
+        "#;
+        let package_name = PackageName::from_str("example")?;
+        let data: PypiSimpleDetail = serde_json::from_str(response)?;
+        let base = DisplaySafeUrl::parse("https://pypi.org/simple/example/")?;
+        let simple_metadata = SimpleDetailMetadata::from_pypi_files(
+            data.files,
+            &package_name,
+            data.project_status,
+            &base,
+        );
+        let archived = super::OwnedArchive::from_unarchived(&simple_metadata)?;
+        let simple_metadata = super::OwnedArchive::deserialize(&archived);
+
+        let filenames: Vec<_> = simple_metadata
+            .versions
+            .into_iter()
+            .flat_map(|datum| datum.files.all(&package_name))
+            .map(|(filename, _)| filename.to_string())
+            .collect();
+        assert_eq!(
+            filenames,
+            ["example-1.0.0.tar.gz", "example-1.0.0-py3-none-any.whl"]
+        );
+
+        Ok(())
     }
 
     /// Test for project statuses from PyPI's JSON detail response.

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1386,7 +1386,7 @@ pub struct VersionFiles {
 }
 
 impl VersionFiles {
-    fn push(&mut self, filename: DistFilename, file: File) {
+    fn push(&mut self, filename: &DistFilename, file: File) {
         match filename {
             DistFilename::WheelFilename(_) => self.wheels.push(file),
             DistFilename::SourceDistFilename(_) => self.source_dists.push(file),
@@ -1503,11 +1503,11 @@ impl SimpleDetailMetadata {
             };
             match version_map.entry(filename.version().clone()) {
                 std::collections::btree_map::Entry::Occupied(mut entry) => {
-                    entry.get_mut().push(filename, file);
+                    entry.get_mut().push(&filename, file);
                 }
                 std::collections::btree_map::Entry::Vacant(entry) => {
                     let mut files = VersionFiles::default();
-                    files.push(filename, file);
+                    files.push(&filename, file);
                     entry.insert(files);
                 }
             }
@@ -1571,11 +1571,11 @@ impl SimpleDetailMetadata {
                 };
             match version_map.entry(filename.version().clone()) {
                 std::collections::btree_map::Entry::Occupied(mut entry) => {
-                    entry.get_mut().push(filename, file);
+                    entry.get_mut().push(&filename, file);
                 }
                 std::collections::btree_map::Entry::Vacant(entry) => {
                     let mut files = VersionFiles::default();
-                    files.push(filename, file);
+                    files.push(&filename, file);
                     entry.insert(files);
                 }
             }

--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -40,8 +40,7 @@ pub enum DistFilename {
 
 impl DistFilename {
     /// Parse a filename as wheel or source dist name.
-    #[cfg(test)]
-    fn try_from_filename(filename: &str, package_name: &PackageName) -> Option<Self> {
+    pub fn try_from_filename(filename: &str, package_name: &PackageName) -> Option<Self> {
         Self::try_from_filename_with_reason(filename, package_name).ok()
     }
 

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -2,7 +2,6 @@ mod trusted_publishing;
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -31,9 +30,7 @@ use uv_client::{
     RegistryClientBuilder, RequestBuilder, RetryParsingError, RetryState,
 };
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
-use uv_distribution_filename::{
-    DistFilename, SourceDistExtension, SourceDistFilename, WheelFilename,
-};
+use uv_distribution_filename::{DistFilename, SourceDistExtension, SourceDistFilename};
 use uv_distribution_types::{IndexCapabilities, IndexUrl};
 use uv_extract::hash::{HashReader, Hasher};
 use uv_fs::{ProgressReader, Simplified};
@@ -1004,18 +1001,14 @@ pub async fn check_url(
         return Ok(false);
     };
 
-    let archived_file =
-        match filename {
-            DistFilename::SourceDistFilename(source_dist) => metadatum
-                .files
-                .source_dists
-                .iter()
-                .find(|entry| &entry.name == source_dist)
-                .map(|entry| &entry.file),
-            DistFilename::WheelFilename(wheel) => metadatum.files.wheels.iter().find(|file| {
-                WheelFilename::from_str(&file.filename).is_ok_and(|name| &name == wheel)
-            }),
-        };
+    let archived_files = match filename {
+        DistFilename::SourceDistFilename(_) => &metadatum.files.source_dists,
+        DistFilename::WheelFilename(_) => &metadatum.files.wheels,
+    };
+    let archived_file = archived_files.iter().find(|file| {
+        DistFilename::try_from_filename_with_reason(&file.filename, filename.name())
+            .is_ok_and(|candidate| &candidate == filename)
+    });
     let Some(archived_file) = archived_file else {
         return Ok(false);
     };

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1006,8 +1006,8 @@ pub async fn check_url(
         DistFilename::WheelFilename(_) => &metadatum.files.wheels,
     };
     let archived_file = archived_files.iter().find(|file| {
-        DistFilename::try_from_filename_with_reason(&file.filename, filename.name())
-            .is_ok_and(|candidate| &candidate == filename)
+        DistFilename::try_from_filename(&file.filename, filename.name())
+            .is_some_and(|candidate| &candidate == filename)
     });
     let Some(archived_file) = archived_file else {
         return Ok(false);

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -2,6 +2,7 @@ mod trusted_publishing;
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -30,7 +31,9 @@ use uv_client::{
     RegistryClientBuilder, RequestBuilder, RetryParsingError, RetryState,
 };
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
-use uv_distribution_filename::{DistFilename, SourceDistExtension, SourceDistFilename};
+use uv_distribution_filename::{
+    DistFilename, SourceDistExtension, SourceDistFilename, WheelFilename,
+};
 use uv_distribution_types::{IndexCapabilities, IndexUrl};
 use uv_extract::hash::{HashReader, Hasher};
 use uv_fs::{ProgressReader, Simplified};
@@ -1001,20 +1004,18 @@ pub async fn check_url(
         return Ok(false);
     };
 
-    let archived_file = match filename {
-        DistFilename::SourceDistFilename(source_dist) => metadatum
-            .files
-            .source_dists
-            .iter()
-            .find(|entry| &entry.name == source_dist)
-            .map(|entry| &entry.file),
-        DistFilename::WheelFilename(wheel) => metadatum
-            .files
-            .wheels
-            .iter()
-            .find(|entry| &entry.name == wheel)
-            .map(|entry| &entry.file),
-    };
+    let archived_file =
+        match filename {
+            DistFilename::SourceDistFilename(source_dist) => metadatum
+                .files
+                .source_dists
+                .iter()
+                .find(|entry| &entry.name == source_dist)
+                .map(|entry| &entry.file),
+            DistFilename::WheelFilename(wheel) => metadatum.files.wheels.iter().find(|file| {
+                WheelFilename::from_str(&file.filename).is_ok_and(|name| &name == wheel)
+            }),
+        };
     let Some(archived_file) = archived_file else {
         return Ok(false);
     };

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -94,6 +94,7 @@ impl VersionMap {
         }
         Self {
             inner: VersionMapInner::Lazy(VersionMapLazy {
+                package_name: package_name.clone(),
                 map,
                 stable,
                 local,
@@ -490,6 +491,8 @@ impl VersionMapLazyIndex {
 /// provide substantial savings in some cases.
 #[derive(Debug)]
 struct VersionMapLazy {
+    /// The normalized package name used to reconstruct cached wheel filenames.
+    package_name: PackageName,
     /// An immutable archive-order index from version to possibly-initialized distribution.
     map: VersionMapLazyIndex,
     /// Whether the version map contains at least one stable (non-pre-release) version.
@@ -570,7 +573,6 @@ impl VersionMapLazy {
         files
             .wheels
             .iter()
-            .map(|wheel| &wheel.file)
             .chain(files.source_dists.iter().map(|sdist| &sdist.file))
             .any(|file| {
                 let upload_time = file.upload_time_utc_ms.as_ref().map(|t| t.to_native());
@@ -604,7 +606,6 @@ impl VersionMapLazy {
             .files
             .wheels
             .iter()
-            .map(|wheel| &wheel.file)
             .chain(datum.files.source_dists.iter().map(|sdist| &sdist.file))
             .any(|file| {
                 file.upload_time_utc_ms
@@ -646,7 +647,7 @@ impl VersionMapLazy {
             )
             .expect("archived version files always deserializes");
             let mut priority_dist = init.cloned().unwrap_or_default();
-            for (filename, file) in files.all() {
+            for (filename, file) in files.all(&self.package_name) {
                 // Support resolving as if it were an earlier timestamp, at least as long files have
                 // upload time information.
                 let (excluded, upload_time) = if let Some(included_version_cutoff) =

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -573,7 +573,7 @@ impl VersionMapLazy {
         files
             .wheels
             .iter()
-            .chain(files.source_dists.iter().map(|sdist| &sdist.file))
+            .chain(files.source_dists.iter())
             .any(|file| {
                 let upload_time = file.upload_time_utc_ms.as_ref().map(|t| t.to_native());
                 let excluded = if let Some(cutoff) = &self.included_version_cutoff {
@@ -606,7 +606,7 @@ impl VersionMapLazy {
             .files
             .wheels
             .iter()
-            .chain(datum.files.source_dists.iter().map(|sdist| &sdist.file))
+            .chain(datum.files.source_dists.iter())
             .any(|file| {
                 file.upload_time_utc_ms
                     .as_ref()

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -154,7 +154,7 @@ impl LatestClient<'_> {
                             rkyv::deserialize::<VersionFiles, rkyv::rancor::Error>(&datum.files)
                                 .expect("archived version files always deserializes");
 
-                        for (filename, file) in files.all() {
+                        for (filename, file) in files.all(package) {
                             if self.consider_candidate(&filename, &file, exclude_newer.as_ref()) {
                                 update_latest(filename);
                             }

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -143,7 +143,7 @@ fn clean_package_pypi() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v22")
+        .child("simple-v23")
         .child("pypi")
         .child("iniconfig.rkyv");
     assert!(
@@ -219,7 +219,7 @@ fn clean_package_index() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v22")
+        .child("simple-v23")
         .child("index")
         .child("e8208120cae3ba69")
         .child("iniconfig.rkyv");


### PR DESCRIPTION
## Summary

The Simple API cache currently archives both each distribution's parsed filename and its original filename string. This stores both wheels and source distributions as `File`, reconstructs their parsed filenames only for versions that are actually initialized, updates the resolver/publish/outdated consumers, and bumps the incompatible cache bucket to `simple-v23`.

This substantially reduces archive size and the cost of validation/deserialization while preserving resolution output.

## Performance

| Workload | Wall before → after | Wall Δ | CPU before → after | CPU Δ |
|---|---:|---:|---:|---:|
| Transformers | 297.9 → 296.3 ms | -0.5% | 345.2 → 333.5 ms | -3.4% |
| Home Assistant | 117.4 → 115.8 ms | -1.4% | 84.5 → 78.7 ms | -6.9% |
| Warehouse | 157.9 → 152.5 ms | -3.4% | 181.3 → 172.1 ms | -5.1% |
| JupyterLab | 111.8 → 111.9 ms | +0.1% | 60.3 → 58.2 ms | -3.4% |
| Semantic Kernel | 116.1 → 115.0 ms | -1.0% | 71.8 → 66.9 ms | -6.7% |

Across workloads, block-aware paired analysis shows **-4.93% CPU** (95% CI -5.26 to -4.59); overall wall is directionally lower but noisy. The 632-entry Simple API cache shrank from **188.1 MB to 154.6 MB (-17.8%)**, with the largest entry falling from 24.9 MB to 20.2 MB.
