### PR TITLE
Decode cached payloads on the cache-read pool

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -236,7 +236,7 @@ impl CachedClient {
     /// allowed to make subsequent requests, e.g. through the uncached client.
     #[instrument(skip_all)]
     async fn get_cacheable<
-        Payload: Cacheable,
+        Payload: Cacheable + 'static,
         CallBackError: std::error::Error + 'static,
         Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
     >(
@@ -264,7 +264,13 @@ impl CachedClient {
             }
         };
         match cached_response {
-            CachedResponse::FreshCache(cached) => match Payload::from_aligned_bytes(cached.data) {
+            CachedResponse::FreshCache(cached) => match self
+                .0
+                .cache_read_runtime()
+                .spawn_blocking(move || Payload::from_aligned_bytes(cached.data))
+                .await
+                .expect("cache payload decoding task panicked")
+            {
                 Ok(payload) => Ok(payload),
                 Err(err) => {
                     warn!(
@@ -289,7 +295,13 @@ impl CachedClient {
                     write_atomic(cache_entry.path(), data_with_cache_policy_bytes)
                         .await
                         .map_err(ErrorKind::CacheWrite)?;
-                    match Payload::from_aligned_bytes(cached.data) {
+                    match self
+                        .0
+                        .cache_read_runtime()
+                        .spawn_blocking(move || Payload::from_aligned_bytes(cached.data))
+                        .await
+                        .expect("cache payload decoding task panicked")
+                    {
                         Ok(payload) => Ok(payload),
                         Err(err) => {
                             warn!(
@@ -653,7 +665,7 @@ impl CachedClient {
     /// See: <https://github.com/TrueLayer/reqwest-middleware/blob/8a494c165734e24c62823714843e1c9347027e8a/reqwest-retry/src/middleware.rs#L137>
     #[instrument(skip_all)]
     pub(crate) async fn get_cacheable_with_retry<
-        Payload: Cacheable,
+        Payload: Cacheable + 'static,
         CallBackError: std::error::Error + 'static,
         Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
     >(


### PR DESCRIPTION
## Summary

Large cached Simple API responses spend significant time validating/decoding their archived payload on the async runtime. This moves both fresh-cache and revalidated-cache payload decoding onto the existing bounded cache-read runtime, keeping that CPU-heavy work off resolver workers.

This is intentionally a wall-time/CPU tradeoff: task handoff and overlap increase aggregate CPU, while larger lock workloads complete sooner.

## Performance

Measured with profiling binaries, a warm local cache, `--offline`, pinned CPUs (8-15), fixed `UV_EXCLUDE_NEWER`, alternating base/head order, 10 warmups, and 60 paired runs. This is incremental on current `main` (including #20461) plus #20450 and the marker fastpaths. Every pair produced identical lockfile hashes.

| Workload | Wall before → after | Wall Δ | CPU before → after | CPU Δ |
|---|---:|---:|---:|---:|
| Transformers | 309.1 → 300.8 ms | -2.7% | 335.9 → 353.8 ms | +5.4% |
| Home Assistant | 121.2 → 116.5 ms | -3.8% | 81.6 → 84.9 ms | +4.2% |
| Warehouse | 167.3 → 155.3 ms | -7.2% | 174.2 → 183.7 ms | +5.5% |
| JupyterLab | 111.1 → 112.0 ms | +0.8% | 57.2 → 60.0 ms | +5.0% |
| Semantic Kernel | 118.9 → 117.7 ms | -1.0% | 69.2 → 72.1 ms | +4.3% |

Across workloads, block-aware paired analysis shows **-3.92% wall** (95% CI -5.67 to -2.15) and **+4.97% CPU** (95% CI +4.49 to +5.45). Warehouse benefits most; small workloads are effectively neutral in wall time.

All 83 `uv-client` unit tests pass, and formatting, diff, and all-target compile checks are clean.