### PR TITLE
Stop escaping `extends-environment` in pyvenv.cfg

### DIFF
--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -411,7 +411,6 @@ impl TestContext {
     /// depending on the specific machine used:
     /// - `home = foo/bar/baz/python3.X.X/bin`
     /// - `uv = X.Y.Z`
-    /// - `extends-environment = <path/to/parent/venv>`
     #[must_use]
     pub fn with_pyvenv_cfg_filters(mut self) -> Self {
         let added_filters = [
@@ -419,10 +418,6 @@ impl TestContext {
             (
                 r"uv = \d+\.\d+\.\d+(-(alpha|beta|rc)\.\d+)?(\+\d+)?".to_string(),
                 "uv = [UV_VERSION]".to_string(),
-            ),
-            (
-                r"extends-environment = .+".to_string(),
-                "extends-environment = [PARENT_VENV]".to_string(),
             ),
         ];
         for filter in added_filters {

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -19,7 +19,6 @@ use uv_configuration::{Concurrency, Constraints, HashCheckingMode, TargetTriple}
 use uv_distribution_types::{
     BuiltDist, Dist, Identifier, Node, Resolution, ResolvedDist, SourceDist,
 };
-use uv_fs::PythonExt;
 use uv_preview::Preview;
 use uv_python::{Interpreter, PythonEnvironment, canonicalize_executable};
 use uv_types::{HashStrategy, SourceTreeEditablePolicy};
@@ -77,10 +76,11 @@ impl EphemeralEnvironment {
         &self,
         parent_environment_sys_prefix: &Path,
     ) -> Result<(), ProjectError> {
-        self.0.set_pyvenv_cfg(
-            "extends-environment",
-            &parent_environment_sys_prefix.escape_for_python(),
-        )?;
+        let parent_environment_sys_prefix = parent_environment_sys_prefix
+            .to_str()
+            .ok_or(ProjectError::InvalidParentEnvironmentPath)?;
+        self.0
+            .set_pyvenv_cfg("extends-environment", parent_environment_sys_prefix)?;
         Ok(())
     }
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -285,6 +285,9 @@ pub(crate) enum ProjectError {
     #[error("Failed to find `site-packages` directory for environment")]
     NoSitePackages,
 
+    #[error("Cannot write parent environment path to `pyvenv.cfg` because it is not valid UTF-8")]
+    InvalidParentEnvironmentPath,
+
     #[error("Attempted to drop a temporary virtual environment while still in-use")]
     DroppedEnvironment,
 

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -1662,6 +1662,8 @@ fn run_with_local_wheel_refreshes_rebuilt_wheel() -> Result<()> {
 #[test]
 fn run_with_pyvenv_cfg_file() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_pyvenv_cfg_filters();
+    let parent_environment_path = context.venv.path().to_path_buf();
+    let context = context.with_filtered_path(&parent_environment_path, "PARENT_VENV");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -1700,7 +1702,7 @@ fn run_with_pyvenv_cfg_file() -> Result<()> {
     uv = [UV_VERSION]
     version_info = 3.12.[X]
     include-system-site-packages = false
-    extends-environment = [PARENT_VENV]
+    extends-environment = [PARENT_VENV]/
 
 
     ----- stderr -----

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -1661,19 +1661,22 @@ fn run_with_local_wheel_refreshes_rebuilt_wheel() -> Result<()> {
 /// search paths are available in these ephemeral environments.
 #[test]
 fn run_with_pyvenv_cfg_file() -> Result<()> {
-    let mut context = uv_test::test_context!("3.12").with_pyvenv_cfg_filters();
+    let context = uv_test::test_context_with_versions!(&["3.12"]).with_pyvenv_cfg_filters();
 
-    // This is kind of a pseudo regression-test to ensure we don't escape/mangle the path. Windows
-    // gives us free backslashes but on *nix we need to add something silly like a double quote.
+    // This sets up to test for a regression where we escaped double quotes and backslashes.
+    // Windows paths don't allow double quotes and use backslash as a path separator so the path has
+    // to differ.
     let parent_environment = context.temp_dir.child(if cfg!(windows) {
-        "parent-environment"
+        ".\\parent-environment"
     } else {
-        "parent\"environment"
+        "parent\"\\environment"
     });
-    let parent_environment_path = parent_environment.path().to_path_buf();
-    fs_err::rename(context.venv.path(), &parent_environment_path)?;
-    context.venv = parent_environment;
-    let context = context.with_filtered_path(&parent_environment_path, "PARENT_VENV");
+    context
+        .venv()
+        .arg(parent_environment.path())
+        .assert()
+        .success();
+    let context = context.with_filtered_path(&parent_environment, "PARENT_VENV");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -1704,7 +1707,8 @@ fn run_with_pyvenv_cfg_file() -> Result<()> {
     })?;
 
     uv_snapshot!(context.filters(), context.run()
-        .env(EnvVars::UV_PROJECT_ENVIRONMENT, &parent_environment_path)
+        .env(EnvVars::UV_PROJECT_ENVIRONMENT, parent_environment.path())
+        .env(EnvVars::VIRTUAL_ENV, parent_environment.path())
         .arg("--with")
         .arg("iniconfig")
         .arg("main.py"), @"

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -1661,8 +1661,18 @@ fn run_with_local_wheel_refreshes_rebuilt_wheel() -> Result<()> {
 /// search paths are available in these ephemeral environments.
 #[test]
 fn run_with_pyvenv_cfg_file() -> Result<()> {
-    let context = uv_test::test_context!("3.12").with_pyvenv_cfg_filters();
-    let parent_environment_path = context.venv.path().to_path_buf();
+    let mut context = uv_test::test_context!("3.12").with_pyvenv_cfg_filters();
+
+    // This is kind of a pseudo regression-test to ensure we don't escape/mangle the path. Windows
+    // gives us free backslashes but on *nix we need to add something silly like a double quote.
+    let parent_environment = context.temp_dir.child(if cfg!(windows) {
+        "parent-environment"
+    } else {
+        "parent\"environment"
+    });
+    let parent_environment_path = parent_environment.path().to_path_buf();
+    fs_err::rename(context.venv.path(), &parent_environment_path)?;
+    context.venv = parent_environment;
     let context = context.with_filtered_path(&parent_environment_path, "PARENT_VENV");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -1693,7 +1703,11 @@ fn run_with_pyvenv_cfg_file() -> Result<()> {
        "#
     })?;
 
-    uv_snapshot!(context.filters(), context.run().arg("--with").arg("iniconfig").arg("main.py"), @"
+    uv_snapshot!(context.filters(), context.run()
+        .env(EnvVars::UV_PROJECT_ENVIRONMENT, &parent_environment_path)
+        .arg("--with")
+        .arg("iniconfig")
+        .arg("main.py"), @"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
## Summary

This would produce broken results on *nix.

I also made it error on UTF-8 encoding but maybe a warning (and not writing the result) is more appropriate?

## Test Plan

I adjusted the test, I moved the filter inline so it could be tailored to specifically look for the path. The original one was not doing that.