### PR TITLE
Allow Packse scenarios without generated tests

### DIFF
--- a/crates/uv-dev/src/generate_scenarios.rs
+++ b/crates/uv-dev/src/generate_scenarios.rs
@@ -162,22 +162,26 @@ fn scenarios_for_template(
 ) -> Vec<&ScenarioCase> {
     scenarios
         .iter()
-        .filter(|case| match case.scenario.resolver_options.test {
-            Some(ScenarioTest::None) => false,
-            Some(ScenarioTest::Install) => template == TemplateKind::Install,
-            Some(ScenarioTest::Compile) => template == TemplateKind::Compile,
-            Some(ScenarioTest::Lock) => template == TemplateKind::Lock,
-            None => match template {
-                TemplateKind::Install => {
-                    !case.scenario.resolver_options.universal
-                        && case.scenario.resolver_options.python.is_none()
-                }
-                TemplateKind::Compile => {
-                    !case.scenario.resolver_options.universal
-                        && case.scenario.resolver_options.python.is_some()
-                }
-                TemplateKind::Lock => case.scenario.resolver_options.universal,
-            },
+        .filter(|case| {
+            if case.scenario.testgen.disable {
+                return false;
+            }
+            match case.scenario.testgen.kind {
+                Some(ScenarioTest::Install) => template == TemplateKind::Install,
+                Some(ScenarioTest::Compile) => template == TemplateKind::Compile,
+                Some(ScenarioTest::Lock) => template == TemplateKind::Lock,
+                None => match template {
+                    TemplateKind::Install => {
+                        !case.scenario.resolver_options.universal
+                            && case.scenario.resolver_options.python.is_none()
+                    }
+                    TemplateKind::Compile => {
+                        !case.scenario.resolver_options.universal
+                            && case.scenario.resolver_options.python.is_some()
+                    }
+                    TemplateKind::Lock => case.scenario.resolver_options.universal,
+                },
+            }
         })
         .collect()
 }
@@ -1015,8 +1019,9 @@ requires = []
 [expected]
 satisfiable = true
 
-[resolver_options]
-test = "none"
+[testgen]
+disable = true
+kind = "compile"
 "#,
         )
         .expect("scenario should be written");

--- a/crates/uv-dev/src/generate_scenarios.rs
+++ b/crates/uv-dev/src/generate_scenarios.rs
@@ -163,6 +163,7 @@ fn scenarios_for_template(
     scenarios
         .iter()
         .filter(|case| match case.scenario.resolver_options.test {
+            Some(ScenarioTest::None) => false,
             Some(ScenarioTest::Install) => template == TemplateKind::Install,
             Some(ScenarioTest::Compile) => template == TemplateKind::Compile,
             Some(ScenarioTest::Lock) => template == TemplateKind::Lock,
@@ -997,6 +998,39 @@ mod tests {
         let scenarios = load_scenarios().expect("vendored scenarios should parse");
 
         assert!(!scenarios.is_empty());
+    }
+
+    #[test]
+    fn scenario_can_skip_generated_tests() {
+        let temporary_directory =
+            tempfile::tempdir().expect("temporary directory should be created");
+        fs_err::write(
+            temporary_directory.path().join("skip.toml"),
+            r#"
+name = "skip"
+
+[root]
+requires = []
+
+[expected]
+satisfiable = true
+
+[resolver_options]
+test = "none"
+"#,
+        )
+        .expect("scenario should be written");
+
+        let scenarios =
+            load_scenarios_from(temporary_directory.path()).expect("scenario should parse");
+        assert_eq!(scenarios.len(), 1);
+        for template in [
+            TemplateKind::Install,
+            TemplateKind::Compile,
+            TemplateKind::Lock,
+        ] {
+            assert!(scenarios_for_template(template, &scenarios).is_empty());
+        }
     }
 
     #[test]

--- a/crates/uv-test/src/packse/scenario.rs
+++ b/crates/uv-test/src/packse/scenario.rs
@@ -46,6 +46,10 @@ pub struct Scenario {
     /// Additional resolver options.
     #[serde(default)]
     pub resolver_options: ResolverOptions,
+
+    /// Options for generating tests from this scenario.
+    #[serde(default)]
+    pub testgen: TestGeneration,
 }
 
 impl Scenario {
@@ -74,6 +78,7 @@ impl Scenario {
             },
             environment: Environment::default(),
             resolver_options: ResolverOptions::default(),
+            testgen: TestGeneration::default(),
         }
     }
 }
@@ -210,10 +215,6 @@ impl Default for Environment {
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResolverOptions {
-    /// Select the generated test command for this scenario.
-    #[serde(default)]
-    pub test: Option<ScenarioTest>,
-
     /// Version selection strategy.
     #[serde(default)]
     pub resolution: Option<Resolution>,
@@ -247,12 +248,23 @@ pub struct ResolverOptions {
     pub required_environments: Vec<MarkerTree>,
 }
 
+/// Options for generating tests from a scenario.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TestGeneration {
+    /// Disable test generation for this scenario.
+    #[serde(default)]
+    pub disable: bool,
+
+    /// Select the generated test command for this scenario.
+    #[serde(default)]
+    pub kind: Option<ScenarioTest>,
+}
+
 /// The command template used to generate a scenario test.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ScenarioTest {
-    /// Do not generate a test for this scenario.
-    None,
     Install,
     Compile,
     Lock,
@@ -369,12 +381,14 @@ requires = ["a"]
 [expected]
 satisfiable = true
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest-direct"
 "#;
         let scenario: Scenario = toml::from_str(toml).expect("scenario should parse");
-        assert_eq!(scenario.resolver_options.test, Some(ScenarioTest::Compile));
+        assert_eq!(scenario.testgen.kind, Some(ScenarioTest::Compile));
         assert_eq!(
             scenario.resolver_options.resolution,
             Some(Resolution::LowestDirect)

--- a/crates/uv-test/src/packse/scenario.rs
+++ b/crates/uv-test/src/packse/scenario.rs
@@ -251,6 +251,8 @@ pub struct ResolverOptions {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ScenarioTest {
+    /// Do not generate a test for this scenario.
+    None,
     Install,
     Compile,
     Lock,

--- a/test/scenarios/fork/lowest-direct-fork-max-python.toml
+++ b/test/scenarios/fork/lowest-direct-fork-max-python.toml
@@ -35,7 +35,9 @@ requires_python = ">=0"
 [packages.forkleaf.versions."1.1.0"]
 requires_python = ">=3.11"
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest-direct"
 universal = true

--- a/test/scenarios/fork/lowest-direct-fork-min-python.toml
+++ b/test/scenarios/fork/lowest-direct-fork-min-python.toml
@@ -35,7 +35,9 @@ requires_python = ">=0"
 [packages.forkleaf.versions."1.1.0"]
 requires_python = ">=3.11"
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest-direct"
 universal = true

--- a/test/scenarios/fork/lowest-fork-max-python.toml
+++ b/test/scenarios/fork/lowest-fork-max-python.toml
@@ -35,7 +35,9 @@ requires_python = ">=0"
 [packages.forkleaf.versions."1.1.0"]
 requires_python = ">=3.11"
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest"
 universal = true

--- a/test/scenarios/fork/lowest-fork-min-python.toml
+++ b/test/scenarios/fork/lowest-fork-min-python.toml
@@ -35,7 +35,9 @@ requires_python = ">=0"
 [packages.forkleaf.versions."1.1.0"]
 requires_python = ">=3.11"
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest"
 universal = true


### PR DESCRIPTION
Packse scenarios used solely as fixtures for higher-level integration tests can have an empty root requirement set, which otherwise produces an invalid generated `uv pip install` test. Allow scenarios to set `test = "none"` to opt out of all generated suites while remaining available to integration tests.
