### PR TITLE
Make `uv_fs::PythonExt::escape_for_python` completely robust

### DIFF
--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -818,16 +818,16 @@ impl SourceBuild {
 
             prepare_metadata_for_build = getattr(backend, "prepare_metadata_for_build_{}", None)
             if prepare_metadata_for_build:
-                dirname = prepare_metadata_for_build("{}", {})
+                dirname = prepare_metadata_for_build({}, {})
             else:
                 dirname = None
 
-            with open("{}", "w") as fp:
+            with open({}, "w") as fp:
                 fp.write(dirname or "")
             "#,
             self.pep517_backend.backend_import(),
             self.build_kind,
-            escape_path_for_python(&metadata_directory),
+            metadata_directory.escape_for_python(),
             self.config_settings.escape_for_python(),
             outfile.escape_for_python(),
         };
@@ -899,7 +899,7 @@ impl SourceBuild {
         let script = match self.build_kind {
             BuildKind::Sdist => {
                 debug!(
-                    r#"Calling `{}.build_{}("{}", {})`"#,
+                    r"Calling `{}.build_{}({}, {})`",
                     self.pep517_backend.backend,
                     self.build_kind,
                     output_dir.escape_for_python(),
@@ -909,8 +909,8 @@ impl SourceBuild {
                     r#"
                     {}
 
-                    sdist_filename = backend.build_{}("{}", {})
-                    with open("{}", "w") as fp:
+                    sdist_filename = backend.build_{}({}, {})
+                    with open({}, "w") as fp:
                         fp.write(sdist_filename)
                     "#,
                     self.pep517_backend.backend_import(),
@@ -924,11 +924,9 @@ impl SourceBuild {
                 let metadata_directory = self
                     .metadata_directory
                     .as_deref()
-                    .map_or("None".to_string(), |path| {
-                        format!(r#""{}""#, path.escape_for_python())
-                    });
+                    .map_or("None".to_string(), |path| path.escape_for_python());
                 debug!(
-                    r#"Calling `{}.build_{}("{}", {}, {})`"#,
+                    r"Calling `{}.build_{}({}, {}, {})`",
                     self.pep517_backend.backend,
                     self.build_kind,
                     output_dir.escape_for_python(),
@@ -939,8 +937,8 @@ impl SourceBuild {
                     r#"
                     {}
 
-                    wheel_filename = backend.build_{}("{}", {}, {})
-                    with open("{}", "w") as fp:
+                    wheel_filename = backend.build_{}({}, {}, {})
+                    with open({}, "w") as fp:
                         fp.write(wheel_filename)
                     "#,
                     self.pep517_backend.backend_import(),
@@ -1011,12 +1009,6 @@ impl SourceBuildTrait for SourceBuild {
     }
 }
 
-fn escape_path_for_python(path: &Path) -> String {
-    path.to_string_lossy()
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-}
-
 /// Not a method because we call it before the builder is completely initialized
 async fn create_pep517_build_environment(
     runner: &PythonRunner,
@@ -1062,7 +1054,7 @@ async fn create_pep517_build_environment(
             else:
                 requires = []
 
-            with open("{}", "w") as fp:
+            with open({}, "w") as fp:
                 json.dump(requires, fp)
         "#,
         pep517_backend.backend_import(),

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -119,17 +119,61 @@ impl<T: AsRef<Path>> Simplified for T {
 }
 
 pub trait PythonExt {
-    /// Escape a [`Path`] for use in Python code.
+    /// Render a [`Path`] as a Python expression that evaluates to a [`str`].
+    ///
+    /// On Unix, paths are arbitrary byte strings, so this uses [`os.fsdecode()`] to produce a
+    /// surrogate-escaped `str`. On Windows, paths are encoded as UTF-16, so this returns a `str`
+    /// literal that preserves the original UTF-16 code units.
+    ///
+    /// [`str`]: https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str
+    /// [`os.fsdecode()`]: https://docs.python.org/3/library/os.html#os.fsdecode
     fn escape_for_python(&self) -> String;
 }
 
 impl<T: AsRef<Path>> PythonExt for T {
     fn escape_for_python(&self) -> String {
-        self.as_ref()
-            .to_string_lossy()
-            .replace('\\', "\\\\")
-            .replace('"', "\\\"")
+        escape_path_for_python(self)
     }
+}
+
+/// Serialize a path as a Python expression that evaluates to a `str`.
+///
+/// Note: Due to the fun quirks *nix paths, how python handles them, and expectations of things that
+/// might consume those paths, this produces an expression wrapped in `__import__("os").fsdecode()`.
+#[cfg(unix)]
+fn escape_path_for_python<P: AsRef<Path>>(path: P) -> String {
+    use std::os::unix::ffi::OsStrExt;
+    format!(
+        r#"__import__("os").fsdecode(b"{}")"#,
+        path.as_ref().as_os_str().as_bytes().escape_ascii()
+    )
+}
+
+/// Serialize a path as a Python expression that evaluates to a `str`.
+#[cfg(windows)]
+fn escape_path_for_python<P: AsRef<Path>>(path: P) -> String {
+    use std::fmt::Write;
+    use std::os::windows::ffi::OsStrExt;
+
+    let mut literal = String::new();
+    literal.push('"');
+    for character in char::decode_utf16(path.as_ref().as_os_str().encode_wide()) {
+        match character {
+            Ok(character) if character.is_ascii() => {
+                literal.extend((character as u8).escape_ascii().map(char::from));
+            }
+            // `is_control` also covers the non-ASCII C1 range (`U+0080..=U+009F`).
+            Ok(character) if character.is_control() => {
+                let _ = write!(literal, r"\u{:04x}", u32::from(character));
+            }
+            Ok(character) => literal.push(character),
+            Err(error) => {
+                let _ = write!(literal, r"\u{:04x}", error.unpaired_surrogate());
+            }
+        }
+    }
+    literal.push('"');
+    literal
 }
 
 /// Normalize the `path` component of a URL for use as a file path.
@@ -896,5 +940,45 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(verbatim_path(Path::new(input)), Path::new(expected));
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_path_escape_for_python() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        // A *nix filename can contain any byte except NUL and the path separator.
+        let bytes = b"/foo/"
+            .iter()
+            .copied()
+            .chain((1..=u8::MAX).filter(|byte| *byte != b'/'))
+            .chain(b"/bar".iter().copied())
+            .collect::<Box<[_]>>();
+        let path = Path::new(OsStr::from_bytes(&bytes));
+        // This should be copy-pastable into a python interpreter and reproduce the path.
+        assert_eq!(
+            path.escape_for_python(),
+            r##"__import__("os").fsdecode(b"/foo/\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&\'()*+,-.0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff/bar")"##
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_path_escape_for_python() {
+        use std::os::windows::ffi::OsStringExt;
+
+        // Exhaustive testing for windows is impractical, this has ASCII range (including NUL and
+        // control chars), surrogate pairs, and unpaired surrogates.
+        let path_osstr = OsString::from_wide(&[
+            0x5c, 0x5c, 0x3f, 0x5c, 0x43, 0x3a, 0x5c, 0x63, 0x61, 0x66, 0x00e9, 0x5c, 0xd83d,
+            0xde00, 0x5c, 0xd800, 0x78, 0xdc00, 0x22, 0x09, 0x0a, 0x0d,
+        ]);
+        let path = Path::new(&path_osstr);
+        // This should be copy-pastable into a python interpreter and reproduce the path.
+        assert_eq!(
+            path.escape_for_python(),
+            r#""\\\\?\\C:\\café\\😀\\\ud800x\udc00\"\t\n\r""#
+        );
     }
 }

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -948,19 +948,35 @@ mod tests {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 
-        // A *nix filename can contain any byte except NUL and the path separator.
-        let bytes = b"/foo/"
-            .iter()
-            .copied()
-            .chain((1..=u8::MAX).filter(|byte| *byte != b'/'))
-            .chain(b"/bar".iter().copied())
-            .collect::<Box<[_]>>();
-        let path = Path::new(OsStr::from_bytes(&bytes));
-        // This should be copy-pastable into a python interpreter and reproduce the path.
-        assert_eq!(
-            path.escape_for_python(),
-            r##"__import__("os").fsdecode(b"/foo/\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&\'()*+,-.0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff/bar")"##
-        );
+        // A *nix path can contain any byte except NUL.
+        // Each expected value is intentionally Python pastable for verification.
+        for (range, expected) in [
+            (
+                1..=0x5e,
+                r##"__import__("os").fsdecode(b"/foo/\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^/bar")"##,
+            ),
+            (
+                0x5f..=0xa3,
+                r#"__import__("os").fsdecode(b"/foo/_`abcdefghijklmnopqrstuvwxyz{|}~\x7f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3/bar")"#,
+            ),
+            (
+                0xa4..=0xd1,
+                r#"__import__("os").fsdecode(b"/foo/\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1/bar")"#,
+            ),
+            (
+                0xd2..=u8::MAX,
+                r#"__import__("os").fsdecode(b"/foo/\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff/bar")"#,
+            ),
+        ] {
+            let bytes = b"/foo/"
+                .iter()
+                .copied()
+                .chain(range)
+                .chain(b"/bar".iter().copied())
+                .collect::<Box<[_]>>();
+            let path = Path::new(OsStr::from_bytes(&bytes));
+            assert_eq!(path.escape_for_python(), expected);
+        }
     }
 
     #[cfg(windows)]

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -970,7 +970,7 @@ impl InterpreterInfo {
         // `sys.path`. We may want to fix this in the future if there are more reports. See:
         // https://github.com/astral-sh/uv/issues/11508.
         let script = format!(
-            r#"import sys; sys.path = ["{}"] + sys.path; from python.get_interpreter_info import main; main()"#,
+            r"import sys; sys.path = [{}] + sys.path; from python.get_interpreter_info import main; main()",
             tempdir.path().escape_for_python()
         );
         let mut command = Command::new(interpreter);

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -411,7 +411,6 @@ impl TestContext {
     /// depending on the specific machine used:
     /// - `home = foo/bar/baz/python3.X.X/bin`
     /// - `uv = X.Y.Z`
-    /// - `extends-environment = <path/to/parent/venv>`
     #[must_use]
     pub fn with_pyvenv_cfg_filters(mut self) -> Self {
         let added_filters = [
@@ -419,10 +418,6 @@ impl TestContext {
             (
                 r"uv = \d+\.\d+\.\d+(-(alpha|beta|rc)\.\d+)?(\+\d+)?".to_string(),
                 "uv = [UV_VERSION]".to_string(),
-            ),
-            (
-                r"extends-environment = .+".to_string(),
-                "extends-environment = [PARENT_VENV]".to_string(),
             ),
         ];
         for filter in added_filters {

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -19,7 +19,6 @@ use uv_configuration::{Concurrency, Constraints, HashCheckingMode, TargetTriple}
 use uv_distribution_types::{
     BuiltDist, Dist, Identifier, Node, Resolution, ResolvedDist, SourceDist,
 };
-use uv_fs::PythonExt;
 use uv_preview::Preview;
 use uv_python::{Interpreter, PythonEnvironment, canonicalize_executable};
 use uv_types::{HashStrategy, SourceTreeEditablePolicy};
@@ -77,10 +76,11 @@ impl EphemeralEnvironment {
         &self,
         parent_environment_sys_prefix: &Path,
     ) -> Result<(), ProjectError> {
-        self.0.set_pyvenv_cfg(
-            "extends-environment",
-            &parent_environment_sys_prefix.escape_for_python(),
-        )?;
+        let parent_environment_sys_prefix = parent_environment_sys_prefix
+            .to_str()
+            .ok_or(ProjectError::InvalidParentEnvironmentPath)?;
+        self.0
+            .set_pyvenv_cfg("extends-environment", parent_environment_sys_prefix)?;
         Ok(())
     }
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -285,6 +285,9 @@ pub(crate) enum ProjectError {
     #[error("Failed to find `site-packages` directory for environment")]
     NoSitePackages,
 
+    #[error("Cannot write parent environment path to `pyvenv.cfg` because it is not valid UTF-8")]
+    InvalidParentEnvironmentPath,
+
     #[error("Attempted to drop a temporary virtual environment while still in-use")]
     DroppedEnvironment,
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1083,7 +1083,7 @@ pub(crate) async fn run(
                     .chain(base_site_packages)
                     .dedup()
                     .inspect(|path| debug!("Adding `{}` to site packages", path.display()))
-                    .map(|path| format!("site.addsitedir(\"{}\")", path.escape_for_python()))
+                    .map(|path| format!("site.addsitedir({})", path.escape_for_python()))
                     .collect::<Vec<_>>()
                     .join("; ")
             );

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -1662,6 +1662,8 @@ fn run_with_local_wheel_refreshes_rebuilt_wheel() -> Result<()> {
 #[test]
 fn run_with_pyvenv_cfg_file() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_pyvenv_cfg_filters();
+    let parent_environment_path = context.venv.path().to_path_buf();
+    let context = context.with_filtered_path(&parent_environment_path, "PARENT_VENV");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -1700,7 +1702,7 @@ fn run_with_pyvenv_cfg_file() -> Result<()> {
     uv = [UV_VERSION]
     version_info = 3.12.[X]
     include-system-site-packages = false
-    extends-environment = [PARENT_VENV]
+    extends-environment = [PARENT_VENV]/
 
 
     ----- stderr -----

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -1661,19 +1661,22 @@ fn run_with_local_wheel_refreshes_rebuilt_wheel() -> Result<()> {
 /// search paths are available in these ephemeral environments.
 #[test]
 fn run_with_pyvenv_cfg_file() -> Result<()> {
-    let mut context = uv_test::test_context!("3.12").with_pyvenv_cfg_filters();
+    let context = uv_test::test_context_with_versions!(&["3.12"]).with_pyvenv_cfg_filters();
 
-    // This is kind of a pseudo regression-test to ensure we don't escape/mangle the path. Windows
-    // gives us free backslashes but on *nix we need to add something silly like a double quote.
+    // This sets up to test for a regression where we escaped double quotes and backslashes.
+    // Windows paths don't allow double quotes and use backslash as a path separator so the path has
+    // to differ.
     let parent_environment = context.temp_dir.child(if cfg!(windows) {
-        "parent-environment"
+        ".\\parent-environment"
     } else {
-        "parent\"environment"
+        "parent\"\\environment"
     });
-    let parent_environment_path = parent_environment.path().to_path_buf();
-    fs_err::rename(context.venv.path(), &parent_environment_path)?;
-    context.venv = parent_environment;
-    let context = context.with_filtered_path(&parent_environment_path, "PARENT_VENV");
+    context
+        .venv()
+        .arg(parent_environment.path())
+        .assert()
+        .success();
+    let context = context.with_filtered_path(&parent_environment, "PARENT_VENV");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -1704,7 +1707,8 @@ fn run_with_pyvenv_cfg_file() -> Result<()> {
     })?;
 
     uv_snapshot!(context.filters(), context.run()
-        .env(EnvVars::UV_PROJECT_ENVIRONMENT, &parent_environment_path)
+        .env(EnvVars::UV_PROJECT_ENVIRONMENT, parent_environment.path())
+        .env(EnvVars::VIRTUAL_ENV, parent_environment.path())
         .arg("--with")
         .arg("iniconfig")
         .arg("main.py"), @"

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -1661,8 +1661,18 @@ fn run_with_local_wheel_refreshes_rebuilt_wheel() -> Result<()> {
 /// search paths are available in these ephemeral environments.
 #[test]
 fn run_with_pyvenv_cfg_file() -> Result<()> {
-    let context = uv_test::test_context!("3.12").with_pyvenv_cfg_filters();
-    let parent_environment_path = context.venv.path().to_path_buf();
+    let mut context = uv_test::test_context!("3.12").with_pyvenv_cfg_filters();
+
+    // This is kind of a pseudo regression-test to ensure we don't escape/mangle the path. Windows
+    // gives us free backslashes but on *nix we need to add something silly like a double quote.
+    let parent_environment = context.temp_dir.child(if cfg!(windows) {
+        "parent-environment"
+    } else {
+        "parent\"environment"
+    });
+    let parent_environment_path = parent_environment.path().to_path_buf();
+    fs_err::rename(context.venv.path(), &parent_environment_path)?;
+    context.venv = parent_environment;
     let context = context.with_filtered_path(&parent_environment_path, "PARENT_VENV");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -1693,7 +1703,11 @@ fn run_with_pyvenv_cfg_file() -> Result<()> {
        "#
     })?;
 
-    uv_snapshot!(context.filters(), context.run().arg("--with").arg("iniconfig").arg("main.py"), @"
+    uv_snapshot!(context.filters(), context.run()
+        .env(EnvVars::UV_PROJECT_ENVIRONMENT, &parent_environment_path)
+        .arg("--with")
+        .arg("iniconfig")
+        .arg("main.py"), @"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
## Summary

Previously we only handled a subset of paths and silently broke them if they contained invalid unicode.

This now handles all possible paths in a way that python would accept losslessly.

In a lot of cases we assume paths are valid unicode elsewhere, but making this work properly is a one-off exercise, and now we no longer need to worry about it.

This also cleans up uv-build-frontend using its own custom implementation, it now pulls from uv_fs.

## Test Plan

Some testing was manual to ensure we correctly handle the result in Python.

There's an exhaustive test for *nix, and a selective test for Windows.