### PR TITLE
Render Packse scenario graphs as Markdown

### DIFF
--- a/crates/uv-dev/src/generate_scenarios.rs
+++ b/crates/uv-dev/src/generate_scenarios.rs
@@ -162,22 +162,26 @@ fn scenarios_for_template(
 ) -> Vec<&ScenarioCase> {
     scenarios
         .iter()
-        .filter(|case| match case.scenario.resolver_options.test {
-            Some(ScenarioTest::None) => false,
-            Some(ScenarioTest::Install) => template == TemplateKind::Install,
-            Some(ScenarioTest::Compile) => template == TemplateKind::Compile,
-            Some(ScenarioTest::Lock) => template == TemplateKind::Lock,
-            None => match template {
-                TemplateKind::Install => {
-                    !case.scenario.resolver_options.universal
-                        && case.scenario.resolver_options.python.is_none()
-                }
-                TemplateKind::Compile => {
-                    !case.scenario.resolver_options.universal
-                        && case.scenario.resolver_options.python.is_some()
-                }
-                TemplateKind::Lock => case.scenario.resolver_options.universal,
-            },
+        .filter(|case| {
+            if case.scenario.testgen.disable {
+                return false;
+            }
+            match case.scenario.testgen.kind {
+                Some(ScenarioTest::Install) => template == TemplateKind::Install,
+                Some(ScenarioTest::Compile) => template == TemplateKind::Compile,
+                Some(ScenarioTest::Lock) => template == TemplateKind::Lock,
+                None => match template {
+                    TemplateKind::Install => {
+                        !case.scenario.resolver_options.universal
+                            && case.scenario.resolver_options.python.is_none()
+                    }
+                    TemplateKind::Compile => {
+                        !case.scenario.resolver_options.universal
+                            && case.scenario.resolver_options.python.is_some()
+                    }
+                    TemplateKind::Lock => case.scenario.resolver_options.universal,
+                },
+            }
         })
         .collect()
 }
@@ -1015,8 +1019,9 @@ requires = []
 [expected]
 satisfiable = true
 
-[resolver_options]
-test = "none"
+[testgen]
+disable = true
+kind = "compile"
 "#,
         )
         .expect("scenario should be written");

--- a/crates/uv-dev/src/generate_scenarios.rs
+++ b/crates/uv-dev/src/generate_scenarios.rs
@@ -163,6 +163,7 @@ fn scenarios_for_template(
     scenarios
         .iter()
         .filter(|case| match case.scenario.resolver_options.test {
+            Some(ScenarioTest::None) => false,
             Some(ScenarioTest::Install) => template == TemplateKind::Install,
             Some(ScenarioTest::Compile) => template == TemplateKind::Compile,
             Some(ScenarioTest::Lock) => template == TemplateKind::Lock,
@@ -997,6 +998,39 @@ mod tests {
         let scenarios = load_scenarios().expect("vendored scenarios should parse");
 
         assert!(!scenarios.is_empty());
+    }
+
+    #[test]
+    fn scenario_can_skip_generated_tests() {
+        let temporary_directory =
+            tempfile::tempdir().expect("temporary directory should be created");
+        fs_err::write(
+            temporary_directory.path().join("skip.toml"),
+            r#"
+name = "skip"
+
+[root]
+requires = []
+
+[expected]
+satisfiable = true
+
+[resolver_options]
+test = "none"
+"#,
+        )
+        .expect("scenario should be written");
+
+        let scenarios =
+            load_scenarios_from(temporary_directory.path()).expect("scenario should parse");
+        assert_eq!(scenarios.len(), 1);
+        for template in [
+            TemplateKind::Install,
+            TemplateKind::Compile,
+            TemplateKind::Lock,
+        ] {
+            assert!(scenarios_for_template(template, &scenarios).is_empty());
+        }
     }
 
     #[test]

--- a/crates/uv-dev/src/generate_scenarios.rs
+++ b/crates/uv-dev/src/generate_scenarios.rs
@@ -1,10 +1,10 @@
 //! Generate the Packse scenario integration tests.
 
 use std::fmt::Write as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use anstream::println;
+use anstream::{print, println};
 use anyhow::{Context, Result, bail};
 use clap::ValueEnum;
 use itertools::Itertools;
@@ -34,6 +34,12 @@ pub(crate) struct Args {
     /// Skip `cargo insta test --accept` after refreshing generated Rust files.
     #[arg(long)]
     no_snapshot_update: bool,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct RenderScenarioArgs {
+    /// Path to a Packse scenario, relative to `test/scenarios` or absolute.
+    path: PathBuf,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
@@ -107,6 +113,17 @@ pub(crate) fn main(args: &Args) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+pub(crate) fn render_scenario(args: &RenderScenarioArgs) -> Result<()> {
+    let path = if args.path.is_absolute() {
+        args.path.clone()
+    } else {
+        Path::new(ROOT_DIR).join(GENERATED_FROM).join(&args.path)
+    };
+    let scenario = Scenario::from_path(&path)?;
+    print!("{}", render_scenario_markdown(&scenario)?);
     Ok(())
 }
 
@@ -692,6 +709,27 @@ fn render_case_docs(output: &mut String, scenario: &Scenario) -> Result<()> {
     Ok(())
 }
 
+fn render_scenario_markdown(scenario: &Scenario) -> Result<String> {
+    let mut output = String::new();
+    output.push_str("<!-- Generated with `cargo dev render-scenario` -->\n\n");
+    output.push_str("# ");
+    output.push_str(&scenario.name);
+    output.push_str("\n\n");
+    if let Some(description) = &scenario.description {
+        output.push_str(description);
+        output.push_str("\n\n");
+    }
+    output.push_str("```text\n");
+    output.push_str(&scenario.name);
+    output.push('\n');
+    for line in pretty_tree(scenario)? {
+        output.push_str(&line);
+        output.push('\n');
+    }
+    output.push_str("```\n");
+    Ok(output)
+}
+
 fn pretty_tree(scenario: &Scenario) -> Result<Vec<String>> {
     const SPACE: &str = "    ";
     const BRANCH: &str = "│   ";
@@ -930,8 +968,8 @@ fn requirement_specifiers(requirement: &Requirement) -> Option<&uv_pep440::Versi
 #[cfg(test)]
 mod tests {
     use super::{
-        TemplateKind, check_generated_file, compile_requirements, load_scenarios,
-        load_scenarios_from, module_name, render, scenarios_for_template,
+        Scenario, TemplateKind, check_generated_file, compile_requirements, load_scenarios,
+        load_scenarios_from, module_name, render, render_scenario_markdown, scenarios_for_template,
     };
 
     #[test]
@@ -1036,6 +1074,70 @@ kind = "compile"
         ] {
             assert!(scenarios_for_template(template, &scenarios).is_empty());
         }
+    }
+
+    #[test]
+    fn scenario_can_render_as_markdown() {
+        let temporary_directory =
+            tempfile::tempdir().expect("temporary directory should be created");
+        let path = temporary_directory.path().join("scenario.toml");
+        fs_err::write(
+            &path,
+            r#"
+name = "rendered-scenario"
+description = "A scenario with base and optional dependencies."
+
+[root]
+requires = ["a[extra]"]
+
+[expected]
+satisfiable = true
+
+[packages.a.versions."1.0.0"]
+requires = ["b>=2"]
+
+[packages.a.versions."1.0.0".extras]
+extra = ["c"]
+
+[packages.b.versions."2.0.0"]
+
+[packages.c.versions."1.0.0"]
+"#,
+        )
+        .expect("scenario should be written");
+        let scenario = Scenario::from_path(&path).expect("scenario should parse");
+
+        insta::assert_snapshot!(
+            render_scenario_markdown(&scenario).expect("scenario should render"),
+            @r"
+        <!-- Generated with `cargo dev render-scenario` -->
+
+        # rendered-scenario
+
+        A scenario with base and optional dependencies.
+
+        ```text
+        rendered-scenario
+        ├── environment
+        │   └── python3.12
+        ├── root
+        │   └── requires a[extra]
+        │       ├── satisfied by a-1.0.0
+        │       └── satisfied by a-1.0.0[extra]
+        ├── a
+        │   ├── a-1.0.0
+        │   │   └── requires b>=2
+        │   │       └── satisfied by b-2.0.0
+        │   └── a-1.0.0[extra]
+        │       └── requires c
+        │           └── satisfied by c-1.0.0
+        ├── b
+        │   └── b-2.0.0
+        └── c
+            └── c-1.0.0
+        ```
+        "
+        );
     }
 
     #[test]

--- a/crates/uv-dev/src/lib.rs
+++ b/crates/uv-dev/src/lib.rs
@@ -13,7 +13,7 @@ use crate::generate_cli_reference::Args as GenerateCliReferenceArgs;
 use crate::generate_env_vars_reference::Args as GenerateEnvVarsReferenceArgs;
 use crate::generate_json_schema::Args as GenerateJsonSchemaArgs;
 use crate::generate_options_reference::Args as GenerateOptionsReferenceArgs;
-use crate::generate_scenarios::Args as GenerateScenarioTestsArgs;
+use crate::generate_scenarios::{Args as GenerateScenarioTestsArgs, RenderScenarioArgs};
 use crate::generate_sysconfig_mappings::Args as GenerateSysconfigMetadataArgs;
 use crate::list_packages::ListPackagesArgs;
 #[cfg(feature = "render")]
@@ -61,6 +61,8 @@ enum Cli {
     GenerateEnvVarsReference(GenerateEnvVarsReferenceArgs),
     /// Generate the Packse scenario integration tests.
     GenerateScenarioTests(GenerateScenarioTestsArgs),
+    /// Render a Packse scenario dependency tree as Markdown.
+    RenderScenario(RenderScenarioArgs),
     /// Generate the sysconfig metadata from derived targets.
     GenerateSysconfigMetadata(GenerateSysconfigMetadataArgs),
     #[cfg(feature = "render")]
@@ -87,6 +89,7 @@ pub async fn run() -> Result<()> {
         Cli::GenerateCliReference(args) => generate_cli_reference::main(&args)?,
         Cli::GenerateEnvVarsReference(args) => generate_env_vars_reference::main(&args)?,
         Cli::GenerateScenarioTests(args) => generate_scenarios::main(&args)?,
+        Cli::RenderScenario(args) => generate_scenarios::render_scenario(&args)?,
         Cli::GenerateSysconfigMetadata(args) => generate_sysconfig_mappings::main(&args).await?,
         #[cfg(feature = "render")]
         Cli::RenderBenchmarks(args) => render_benchmarks::render_benchmarks(&args)?,
@@ -106,5 +109,6 @@ mod tests {
 
         assert!(command.find_subcommand("generate-scenario-tests").is_some());
         assert!(command.find_subcommand("generate-scenarios").is_none());
+        assert!(command.find_subcommand("render-scenario").is_some());
     }
 }

--- a/crates/uv-test/src/packse/scenario.rs
+++ b/crates/uv-test/src/packse/scenario.rs
@@ -46,6 +46,10 @@ pub struct Scenario {
     /// Additional resolver options.
     #[serde(default)]
     pub resolver_options: ResolverOptions,
+
+    /// Options for generating tests from this scenario.
+    #[serde(default)]
+    pub testgen: TestGeneration,
 }
 
 impl Scenario {
@@ -74,6 +78,7 @@ impl Scenario {
             },
             environment: Environment::default(),
             resolver_options: ResolverOptions::default(),
+            testgen: TestGeneration::default(),
         }
     }
 }
@@ -210,10 +215,6 @@ impl Default for Environment {
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResolverOptions {
-    /// Select the generated test command for this scenario.
-    #[serde(default)]
-    pub test: Option<ScenarioTest>,
-
     /// Version selection strategy.
     #[serde(default)]
     pub resolution: Option<Resolution>,
@@ -247,12 +248,23 @@ pub struct ResolverOptions {
     pub required_environments: Vec<MarkerTree>,
 }
 
+/// Options for generating tests from a scenario.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TestGeneration {
+    /// Disable test generation for this scenario.
+    #[serde(default)]
+    pub disable: bool,
+
+    /// Select the generated test command for this scenario.
+    #[serde(default)]
+    pub kind: Option<ScenarioTest>,
+}
+
 /// The command template used to generate a scenario test.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ScenarioTest {
-    /// Do not generate a test for this scenario.
-    None,
     Install,
     Compile,
     Lock,
@@ -369,12 +381,14 @@ requires = ["a"]
 [expected]
 satisfiable = true
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest-direct"
 "#;
         let scenario: Scenario = toml::from_str(toml).expect("scenario should parse");
-        assert_eq!(scenario.resolver_options.test, Some(ScenarioTest::Compile));
+        assert_eq!(scenario.testgen.kind, Some(ScenarioTest::Compile));
         assert_eq!(
             scenario.resolver_options.resolution,
             Some(Resolution::LowestDirect)

--- a/crates/uv-test/src/packse/scenario.rs
+++ b/crates/uv-test/src/packse/scenario.rs
@@ -251,6 +251,8 @@ pub struct ResolverOptions {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ScenarioTest {
+    /// Do not generate a test for this scenario.
+    None,
     Install,
     Compile,
     Lock,

--- a/crates/uv-test/src/packse/server.rs
+++ b/crates/uv-test/src/packse/server.rs
@@ -215,8 +215,7 @@ fn handle_request(req: &Request, server_uri: &str, index: &ServerIndex) -> Respo
     if let Some(filename) = path.strip_prefix("/files/") {
         if let Some(file) = index.files.get(filename) {
             return match file.bytes() {
-                Ok(bytes) => ResponseTemplate::new(200)
-                    .set_body_raw(bytes.to_vec(), content_type_for_filename(filename)),
+                Ok(bytes) => build_file_response(req, filename, &bytes),
                 Err(error) => ResponseTemplate::new(500).set_body_string(format!("{error:#}")),
             };
         }
@@ -224,6 +223,62 @@ fn handle_request(req: &Request, server_uri: &str, index: &ServerIndex) -> Respo
     }
 
     ResponseTemplate::new(404)
+}
+
+/// Build a response for a distribution file, including support for single byte ranges.
+fn build_file_response(req: &Request, filename: &str, bytes: &[u8]) -> ResponseTemplate {
+    let content_type = content_type_for_filename(filename);
+    let Some(range) = req.headers.get("range") else {
+        return ResponseTemplate::new(200)
+            .insert_header("Accept-Ranges", "bytes")
+            .set_body_raw(bytes.to_vec(), content_type);
+    };
+
+    let Some((start, end)) = range
+        .to_str()
+        .ok()
+        .and_then(|range| parse_byte_range(range, bytes.len()))
+    else {
+        return ResponseTemplate::new(416)
+            .insert_header("Accept-Ranges", "bytes")
+            .insert_header("Content-Range", format!("bytes */{}", bytes.len()));
+    };
+
+    ResponseTemplate::new(206)
+        .insert_header("Accept-Ranges", "bytes")
+        .insert_header(
+            "Content-Range",
+            format!("bytes {start}-{end}/{}", bytes.len()),
+        )
+        .set_body_raw(bytes[start..=end].to_vec(), content_type)
+}
+
+/// Parse a single HTTP byte range and return its inclusive bounds.
+fn parse_byte_range(range: &str, length: usize) -> Option<(usize, usize)> {
+    let range = range.strip_prefix("bytes=")?;
+    let (start, end) = range.split_once('-')?;
+
+    if start.is_empty() {
+        let suffix = end.parse::<usize>().ok()?;
+        if suffix == 0 || length == 0 {
+            return None;
+        }
+        return Some((length.saturating_sub(suffix), length - 1));
+    }
+
+    let start = start.parse::<usize>().ok()?;
+    if start >= length {
+        return None;
+    }
+    let end = if end.is_empty() {
+        length - 1
+    } else {
+        end.parse::<usize>().ok()?.min(length - 1)
+    };
+    if start > end {
+        return None;
+    }
+    Some((start, end))
 }
 
 /// Build PEP 691 JSON response for a package.
@@ -279,9 +334,13 @@ fn extract_package_name(path: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+    use reqwest::StatusCode;
+    use reqwest::header::{ACCEPT_RANGES, CONTENT_RANGE, RANGE};
+
     use crate::vendor::vendor_artifacts;
 
-    use super::{Scenario, build_server_index, extract_package_name};
+    use super::{PackseServer, Scenario, build_server_index, extract_package_name};
 
     #[test]
     fn extract_package_name_accepts_with_or_without_trailing_slash() {
@@ -305,5 +364,84 @@ mod tests {
                 .iter()
                 .all(|artifact| !artifact.is_loaded())
         );
+    }
+
+    #[tokio::test]
+    async fn file_requests_support_byte_ranges() -> Result<()> {
+        let scenario = toml::from_str::<Scenario>(
+            r#"
+name = "range-requests"
+
+[root]
+requires = ["a"]
+
+[expected]
+satisfiable = true
+
+[packages.a.versions."1.0.0"]
+sdist = false
+"#,
+        )?;
+        let server = PackseServer::from_scenario(&scenario);
+        let url = server.file_url("a-1.0.0-py3-none-any.whl");
+        let client = reqwest::Client::new();
+
+        let response = client.get(&url).send().await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(ACCEPT_RANGES),
+            Some(&"bytes".parse()?)
+        );
+        let bytes = response.bytes().await?;
+        let length = bytes.len();
+
+        let response = client.get(&url).header(RANGE, "bytes=-8").send().await?;
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            response.headers().get(CONTENT_RANGE),
+            Some(&format!("bytes {}-{}/{}", length - 8, length - 1, length).parse()?)
+        );
+        assert_eq!(response.bytes().await?, bytes[length - 8..]);
+
+        let response = client
+            .get(&url)
+            .header(RANGE, "bytes=-999999")
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            response.headers().get(CONTENT_RANGE),
+            Some(&format!("bytes 0-{}/{}", length - 1, length).parse()?)
+        );
+        assert_eq!(response.bytes().await?, bytes);
+
+        let response = client.get(&url).header(RANGE, "bytes=3-9").send().await?;
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            response.headers().get(CONTENT_RANGE),
+            Some(&format!("bytes 3-9/{length}").parse()?)
+        );
+        assert_eq!(response.bytes().await?, bytes[3..=9]);
+
+        let response = client.get(&url).header(RANGE, "bytes=10-").send().await?;
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            response.headers().get(CONTENT_RANGE),
+            Some(&format!("bytes 10-{}/{}", length - 1, length).parse()?)
+        );
+        assert_eq!(response.bytes().await?, bytes[10..]);
+
+        let response = client
+            .get(&url)
+            .header(RANGE, format!("bytes={length}-"))
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+        assert_eq!(
+            response.headers().get(CONTENT_RANGE),
+            Some(&format!("bytes */{length}").parse()?)
+        );
+
+        Ok(())
     }
 }

--- a/test/scenarios/fork/lowest-direct-fork-max-python.toml
+++ b/test/scenarios/fork/lowest-direct-fork-max-python.toml
@@ -35,7 +35,9 @@ requires_python = ">=0"
 [packages.forkleaf.versions."1.1.0"]
 requires_python = ">=3.11"
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest-direct"
 universal = true

--- a/test/scenarios/fork/lowest-direct-fork-min-python.toml
+++ b/test/scenarios/fork/lowest-direct-fork-min-python.toml
@@ -35,7 +35,9 @@ requires_python = ">=0"
 [packages.forkleaf.versions."1.1.0"]
 requires_python = ">=3.11"
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest-direct"
 universal = true

--- a/test/scenarios/fork/lowest-fork-max-python.toml
+++ b/test/scenarios/fork/lowest-fork-max-python.toml
@@ -35,7 +35,9 @@ requires_python = ">=0"
 [packages.forkleaf.versions."1.1.0"]
 requires_python = ">=3.11"
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest"
 universal = true

--- a/test/scenarios/fork/lowest-fork-min-python.toml
+++ b/test/scenarios/fork/lowest-fork-min-python.toml
@@ -35,7 +35,9 @@ requires_python = ">=0"
 [packages.forkleaf.versions."1.1.0"]
 requires_python = ">=3.11"
 
+[testgen]
+kind = "compile"
+
 [resolver_options]
-test = "compile"
 resolution = "lowest"
 universal = true


### PR DESCRIPTION
Packse scenarios that intentionally skip generated tests lose the rendered dependency tree that normally makes their fixtures easy to understand. Add `cargo dev render-scenario <scenario>` to render the same tree as Markdown, allowing complex fixtures to keep an inspectable graph alongside the scenario without introducing generated tests.