### PR TITLE
Rebase conflicted pull requests in uv-dev

### DIFF
--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -135,6 +135,7 @@ jobs:
           repository: astral-sh/uv-dev
           permissions: |
             contents: write
+            workflows: write
 
       - name: Push rebased pull request
         env:

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -1,0 +1,148 @@
+name: Rebase conflicted pull requests
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pull-request-conflicts-main
+  cancel-in-progress: true
+
+jobs:
+  identify:
+    name: Identify conflicted pull requests
+    if: github.repository == 'astral-sh/uv-dev'
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.identify.outputs.matrix }}
+      rebasable: ${{ steps.identify.outputs.rebasable }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Identify conflicted pull requests
+        id: identify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: ./scripts/find-conflicted-pull-requests.sh
+
+  rebase:
+    name: Rebase pull request #${{ matrix.number }}
+    needs: identify
+    if: needs.identify.outputs.rebasable != '0'
+    runs-on: ubuntu-latest
+    environment: automations
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.identify.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prepare pull request branch
+        env:
+          BASE_REF: ${{ matrix.base_ref }}
+          HEAD_REF: ${{ matrix.head_ref }}
+          HEAD_SHA: ${{ matrix.head_sha }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/codex-home"
+          cp agents/codex/config.toml "$RUNNER_TEMP/codex-home/config.toml"
+          cp agents/prompts/rebase-pull-request.md "$RUNNER_TEMP/rebase-pull-request.md"
+
+          git fetch --no-tags origin "refs/heads/$HEAD_REF"
+          current_head=$(git rev-parse 'FETCH_HEAD^{commit}')
+          if [ "$current_head" != "$HEAD_SHA" ]; then
+            echo "The pull request head changed; refusing to rebase a stale revision." >&2
+            exit 1
+          fi
+
+          git checkout --detach "$HEAD_SHA"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git rev-parse --verify "refs/remotes/origin/$BASE_REF^{commit}" > /dev/null
+
+      - name: Start rebase
+        id: start-rebase
+        env:
+          BASE_REF: ${{ matrix.base_ref }}
+        run: |
+          if git rebase "refs/remotes/origin/$BASE_REF"; then
+            echo "conflicts=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "$(git diff --name-only --diff-filter=U)" ]; then
+            echo "Rebase failed without producing any conflicted files." >&2
+            exit 1
+          fi
+
+          echo "conflicts=true" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve rebase conflicts
+        if: steps.start-rebase.outputs.conflicts == 'true'
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        env:
+          TMPDIR: ${{ runner.temp }}
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-5.6-sol
+          codex-home: "${{ runner.temp }}/codex-home"
+          permission-profile: "rebase-pull-request"
+          safety-strategy: drop-sudo
+          allow-bot-users: "astral-automations-bot[bot]"
+          prompt-file: "${{ runner.temp }}/rebase-pull-request.md"
+
+      - name: Verify rebased pull request
+        env:
+          BASE_REF: ${{ matrix.base_ref }}
+        run: |
+          if [ -d "$(git rev-parse --git-path rebase-merge)" ] || [ -d "$(git rev-parse --git-path rebase-apply)" ]; then
+            echo "The rebase is still in progress; refusing to push." >&2
+            exit 1
+          fi
+
+          git diff --check "refs/remotes/origin/$BASE_REF...HEAD"
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "The worktree is not clean after the rebase; refusing to push." >&2
+            exit 1
+          fi
+
+          git_dir=$(git rev-parse --absolute-git-dir)
+          mv "$git_dir/config" "$RUNNER_TEMP/untrusted-git-config"
+
+      - name: Get uv-dev token
+        id: token
+        uses: open-security-tools/ost-simple-sts@9e012247e07c39080fb6a832dbfbcfeacebc19c4
+        with:
+          exchange-url: ${{ secrets.STS_API_URL }}/exchange
+          audience: ${{ secrets.STS_API_URL }}
+          repository: astral-sh/uv-dev
+          permissions: |
+            contents: write
+
+      - name: Push rebased pull request
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          HEAD_REF: ${{ matrix.head_ref }}
+          HEAD_SHA: ${{ matrix.head_sha }}
+        run: |
+          GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git -c core.hooksPath=/dev/null push \
+            --force-with-lease="refs/heads/$HEAD_REF:$HEAD_SHA" \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            HEAD:"refs/heads/$HEAD_REF"

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 concurrency:
   group: pull-request-conflicts-main
+  # Let an in-progress rebase finish; newer pushes replace the single pending run.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 concurrency:
   group: pull-request-conflicts-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   identify:

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -75,7 +75,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -137,8 +136,61 @@ jobs:
             exit 1
           fi
 
-          git_dir=$(git rev-parse --absolute-git-dir)
-          mv "$git_dir/config" "$RUNNER_TEMP/untrusted-git-config"
+          git bundle create "$RUNNER_TEMP/rebased.bundle" "refs/remotes/origin/$BASE_REF..HEAD"
+
+      - name: Upload rebased pull request
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rebased-pull-request-${{ matrix.number }}-${{ matrix.head_sha }}
+          path: ${{ runner.temp }}/rebased.bundle
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  push:
+    name: Push rebased pull request #${{ matrix.number }}
+    needs: [identify, rebase]
+    if: needs.identify.outputs.rebasable != '0'
+    runs-on: ubuntu-slim
+    environment: automations
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.identify.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download rebased pull request
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rebased-pull-request-${{ matrix.number }}-${{ matrix.head_sha }}
+          path: ${{ runner.temp }}/rebased-pull-request
+
+      - name: Import rebased pull request
+        id: import
+        env:
+          BASE_REF: ${{ matrix.base_ref }}
+          GIT_CONFIG_GLOBAL: /dev/null
+          GIT_CONFIG_NOSYSTEM: "1"
+        run: |
+          bundle="$RUNNER_TEMP/rebased-pull-request/rebased.bundle"
+          git bundle verify "$bundle"
+          git -c core.hooksPath=/dev/null fetch --no-tags "$bundle" HEAD
+          rebased_head=$(git rev-parse 'FETCH_HEAD^{commit}')
+
+          if ! git merge-base --is-ancestor "refs/remotes/origin/$BASE_REF" "$rebased_head"; then
+            echo "The rebased pull request does not contain its base; refusing to push." >&2
+            exit 1
+          fi
+
+          echo "head_sha=$rebased_head" >> "$GITHUB_OUTPUT"
 
       - name: Get uv-dev token
         id: token
@@ -159,8 +211,9 @@ jobs:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           HEAD_REF: ${{ matrix.head_ref }}
           HEAD_SHA: ${{ matrix.head_sha }}
+          REBASED_HEAD: ${{ steps.import.outputs.head_sha }}
         run: |
           git -c core.hooksPath=/dev/null push \
             --force-with-lease="refs/heads/$HEAD_REF:$HEAD_SHA" \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            HEAD:"refs/heads/$HEAD_REF"
+            "${REBASED_HEAD}:refs/heads/$HEAD_REF"

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -33,7 +33,38 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: ./scripts/find-conflicted-pull-requests.sh
+        run: |
+          pull_requests=$(./scripts/find-conflicted-pull-requests.sh)
+          conflicted=$(jq 'length' <<< "$pull_requests")
+          rebasable=$(jq '[.[] | select(.is_cross_repository | not)] | length' <<< "$pull_requests")
+          cross_repository=$(( conflicted - rebasable ))
+
+          if (( rebasable > 256 )); then
+            echo "Found $rebasable rebasable pull requests, which exceeds the GitHub Actions matrix limit of 256." >&2
+            exit 1
+          fi
+
+          matrix=$(jq --compact-output '{include: [.[] | select(.is_cross_repository | not) | {number, base_ref, head_ref, head_sha}]}' <<< "$pull_requests")
+          {
+            echo "matrix=$matrix"
+            echo "rebasable=$rebasable"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Conflicted pull requests"
+            echo
+            echo "Found $conflicted conflicted pull requests."
+
+            if (( cross_repository > 0 )); then
+              echo
+              echo "Skipping $cross_repository cross-repository pull requests that cannot be updated by the uv-dev app token."
+            fi
+
+            if (( conflicted > 0 )); then
+              echo
+              jq --raw-output '.[] | "- \(.url)"' <<< "$pull_requests"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   rebase:
     name: Rebase pull request #${{ matrix.number }}
@@ -73,37 +104,20 @@ jobs:
           fi
 
           git checkout --detach "$HEAD_SHA"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "astral-automations-bot[bot]"
+          git config user.email "305554984+astral-automations-bot[bot]@users.noreply.github.com"
           git rev-parse --verify "refs/remotes/origin/$BASE_REF^{commit}" > /dev/null
 
-      - name: Start rebase
-        id: start-rebase
-        env:
-          BASE_REF: ${{ matrix.base_ref }}
-        run: |
-          if git rebase "refs/remotes/origin/$BASE_REF"; then
-            echo "conflicts=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -z "$(git diff --name-only --diff-filter=U)" ]; then
-            echo "Rebase failed without producing any conflicted files." >&2
-            exit 1
-          fi
-
-          echo "conflicts=true" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve rebase conflicts
-        if: steps.start-rebase.outputs.conflicts == 'true'
+      - name: Rebase pull request
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
         env:
+          BASE_REF: ${{ matrix.base_ref }}
           TMPDIR: ${{ runner.temp }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.6-sol
           codex-home: "${{ runner.temp }}/codex-home"
-          permission-profile: "rebase-pull-request"
+          permission-profile: "pull-request-rebase"
           safety-strategy: drop-sudo
           allow-bot-users: "astral-automations-bot[bot]"
           prompt-file: "${{ runner.temp }}/rebase-pull-request.md"
@@ -133,17 +147,20 @@ jobs:
           exchange-url: ${{ secrets.STS_API_URL }}/exchange
           audience: ${{ secrets.STS_API_URL }}
           repository: astral-sh/uv-dev
+          # `workflows: write` is required when a rebased pull request modifies workflow files.
           permissions: |
             contents: write
             workflows: write
 
       - name: Push rebased pull request
         env:
+          GIT_CONFIG_GLOBAL: /dev/null
+          GIT_CONFIG_NOSYSTEM: "1"
           GH_TOKEN: ${{ steps.token.outputs.token }}
           HEAD_REF: ${{ matrix.head_ref }}
           HEAD_SHA: ${{ matrix.head_sha }}
         run: |
-          GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git -c core.hooksPath=/dev/null push \
+          git -c core.hooksPath=/dev/null push \
             --force-with-lease="refs/heads/$HEAD_REF:$HEAD_SHA" \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             HEAD:"refs/heads/$HEAD_REF"

--- a/agents/codex/config.toml
+++ b/agents/codex/config.toml
@@ -39,9 +39,9 @@ enabled = true
 "api.github.com" = "allow"
 "github.com" = "allow"
 
-[permissions.rebase-pull-request]
+[permissions.pull-request-rebase]
 description = "Pull request rebase with workspace and Git metadata access."
 extends = ":workspace"
 
-[permissions.rebase-pull-request.filesystem.":workspace_roots"]
+[permissions.pull-request-rebase.filesystem.":workspace_roots"]
 ".git" = "write"

--- a/agents/codex/config.toml
+++ b/agents/codex/config.toml
@@ -38,3 +38,10 @@ enabled = true
 [permissions.pull-request-review.network.domains]
 "api.github.com" = "allow"
 "github.com" = "allow"
+
+[permissions.rebase-pull-request]
+description = "Pull request rebase with workspace and Git metadata access."
+extends = ":workspace"
+
+[permissions.rebase-pull-request.filesystem.":workspace_roots"]
+".git" = "write"

--- a/agents/prompts/rebase-pull-request.md
+++ b/agents/prompts/rebase-pull-request.md
@@ -1,9 +1,11 @@
-Resolve the conflicts in the pull request rebase that is already in progress.
+Rebase the checked-out pull request onto `refs/remotes/origin/$BASE_REF` and resolve its conflicts.
 
 - Inspect the conflicted files and preserve the intent of both the pull request and its updated
   base.
 - Resolve every conflict, stage the resolved files, and run `GIT_EDITOR=true git rebase --continue`.
   Repeat until the rebase completes; later commits may introduce additional conflicts.
+- Run the relevant formatting and lint checks, fix any failures introduced by the rebase, and prefer
+  focused checks over the full suite.
 - Keep the changes narrowly scoped to the pull request. Do not add dependencies, run release builds,
   or make unrelated cleanups.
 - Do not abort the rebase or push the branch. The workflow will verify and push the completed

--- a/agents/prompts/rebase-pull-request.md
+++ b/agents/prompts/rebase-pull-request.md
@@ -1,0 +1,10 @@
+Resolve the conflicts in the pull request rebase that is already in progress.
+
+- Inspect the conflicted files and preserve the intent of both the pull request and its updated
+  base.
+- Resolve every conflict, stage the resolved files, and run `GIT_EDITOR=true git rebase --continue`.
+  Repeat until the rebase completes; later commits may introduce additional conflicts.
+- Keep the changes narrowly scoped to the pull request. Do not add dependencies, run release builds,
+  or make unrelated cleanups.
+- Do not abort the rebase or push the branch. The workflow will verify and push the completed
+  rebase.

--- a/scripts/find-conflicted-pull-requests.sh
+++ b/scripts/find-conflicted-pull-requests.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+# GitHub may initially return UNKNOWN while it recalculates mergeability after the base moves.
 for attempt in {1..5}; do
     pull_requests=$(gh pr list --state open --limit 1000 --json number,mergeable,url,baseRefName,headRefName,headRefOid,isCrossRepository)
     unknown=$(jq '[.[] | select(.mergeable == "UNKNOWN")] | length' <<< "$pull_requests")
@@ -10,43 +11,12 @@ for attempt in {1..5}; do
         break
     fi
 
-    echo "Waiting for GitHub to calculate mergeability for $unknown pull requests (attempt $attempt/5)..."
+    echo "Waiting for GitHub to calculate mergeability for $unknown pull requests (attempt $attempt/5)..." >&2
     sleep 5
 done
 
-conflicted=$(jq '[.[] | select(.mergeable == "CONFLICTING")] | length' <<< "$pull_requests")
-rebasable=$(jq '[.[] | select(.mergeable == "CONFLICTING" and (.isCrossRepository | not))] | length' <<< "$pull_requests")
-cross_repository=$(( conflicted - rebasable ))
-
-if (( rebasable > 256 )); then
-    echo "Found $rebasable rebasable pull requests, which exceeds the GitHub Actions matrix limit of 256." >&2
-    exit 1
+if (( unknown > 0 )); then
+    echo "GitHub could not determine mergeability for $unknown pull requests." >&2
 fi
 
-matrix=$(jq --compact-output '{include: [.[] | select(.mergeable == "CONFLICTING" and (.isCrossRepository | not)) | {number, base_ref: .baseRefName, head_ref: .headRefName, head_sha: .headRefOid}]}' <<< "$pull_requests")
-
-{
-    echo "matrix=$matrix"
-    echo "rebasable=$rebasable"
-} >> "$GITHUB_OUTPUT"
-
-{
-    echo "## Conflicted pull requests"
-    echo
-    echo "Found $conflicted conflicted pull requests."
-
-    if (( cross_repository > 0 )); then
-        echo
-        echo "Skipping $cross_repository cross-repository pull requests that cannot be updated by the uv-dev app token."
-    fi
-
-    if (( unknown > 0 )); then
-        echo
-        echo "GitHub could not determine mergeability for $unknown pull requests."
-    fi
-
-    if (( conflicted > 0 )); then
-        echo
-        jq --raw-output '.[] | select(.mergeable == "CONFLICTING") | "- \(.url)"' <<< "$pull_requests"
-    fi
-} >> "$GITHUB_STEP_SUMMARY"
+jq --compact-output '[.[] | select(.mergeable == "CONFLICTING") | {number, url, base_ref: .baseRefName, head_ref: .headRefName, head_sha: .headRefOid, is_cross_repository: .isCrossRepository}]' <<< "$pull_requests"

--- a/scripts/find-conflicted-pull-requests.sh
+++ b/scripts/find-conflicted-pull-requests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+for attempt in {1..5}; do
+    pull_requests=$(gh pr list --state open --limit 1000 --json number,mergeable,url,baseRefName,headRefName,headRefOid,isCrossRepository)
+    unknown=$(jq '[.[] | select(.mergeable == "UNKNOWN")] | length' <<< "$pull_requests")
+
+    if (( unknown == 0 || attempt == 5 )); then
+        break
+    fi
+
+    echo "Waiting for GitHub to calculate mergeability for $unknown pull requests (attempt $attempt/5)..."
+    sleep 5
+done
+
+conflicted=$(jq '[.[] | select(.mergeable == "CONFLICTING")] | length' <<< "$pull_requests")
+rebasable=$(jq '[.[] | select(.mergeable == "CONFLICTING" and (.isCrossRepository | not))] | length' <<< "$pull_requests")
+cross_repository=$(( conflicted - rebasable ))
+
+if (( rebasable > 256 )); then
+    echo "Found $rebasable rebasable pull requests, which exceeds the GitHub Actions matrix limit of 256." >&2
+    exit 1
+fi
+
+matrix=$(jq --compact-output '{include: [.[] | select(.mergeable == "CONFLICTING" and (.isCrossRepository | not)) | {number, base_ref: .baseRefName, head_ref: .headRefName, head_sha: .headRefOid}]}' <<< "$pull_requests")
+
+{
+    echo "matrix=$matrix"
+    echo "rebasable=$rebasable"
+} >> "$GITHUB_OUTPUT"
+
+{
+    echo "## Conflicted pull requests"
+    echo
+    echo "Found $conflicted conflicted pull requests."
+
+    if (( cross_repository > 0 )); then
+        echo
+        echo "Skipping $cross_repository cross-repository pull requests that cannot be updated by the uv-dev app token."
+    fi
+
+    if (( unknown > 0 )); then
+        echo
+        echo "GitHub could not determine mergeability for $unknown pull requests."
+    fi
+
+    if (( conflicted > 0 )); then
+        echo
+        jq --raw-output '.[] | select(.mergeable == "CONFLICTING") | "- \(.url)"' <<< "$pull_requests"
+    fi
+} >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Syncing `uv-dev` with upstream can leave its open pull requests conflicted against their updated base.

Add a `uv-dev`-only workflow that identifies conflicted same-repository pull requests and uses `codex-action` in a bounded matrix to rebase them. Preserve the expected head revision, resolve multi-commit conflicts with a narrowly scoped permission profile, and update each branch with a lease-protected, repository-scoped app token so pull request CI runs normally. Cross-repository pull requests remain visible in the workflow summary but are skipped because the token cannot update their heads.
