### PR TITLE
Further compact cached distribution metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6251,6 +6251,7 @@ dependencies = [
  "fs-err",
  "futures",
  "h2",
+ "hex",
  "html-escape",
  "http",
  "http-body-util",

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -1203,7 +1203,7 @@ impl CacheBucket {
             Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_clean.rs`.
-            Self::Simple => "simple-v23",
+            Self::Simple => "simple-v24",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_prune.rs`.
             Self::Wheels => "wheels-v6",

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -1198,7 +1198,7 @@ impl CacheBucket {
             Self::SourceDistributions => "sdists-v9",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/lock/lock.rs`.
-            Self::FlatIndex => "flat-index-v3",
+            Self::FlatIndex => "flat-index-v4",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -50,6 +50,7 @@ async_zip = { workspace = true }
 bytecheck = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
+hex = { workspace = true }
 h2 = { workspace = true }
 html-escape = { workspace = true }
 http = { workspace = true }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1407,7 +1407,11 @@ impl VersionFiles {
     }
 }
 
-/// A compact representation of a registry file in the Simple API cache.
+/// A compact, cache-local representation of a registry file from the Simple API.
+///
+/// Filenames recoverable from the URL and false `yanked` markers are omitted, while optional
+/// scalar values use presence bits. Converting back to [`File`] restores equivalent Simple API
+/// metadata.
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 pub struct CachedFile {
@@ -1428,16 +1432,14 @@ pub struct CachedFile {
 }
 
 impl CachedFile {
-    /// Return the filename, reconstructing it from the URL when it was elided.
+    /// Returns the stored filename or reconstructs it from the file URL.
     pub fn filename(&self) -> &str {
         self.filename
             .as_deref()
-            .map(SmallString::as_ref)
-            .or_else(|| filename_from_location(&self.url))
-            .unwrap_or_default()
+            .map_or_else(|| filename_from_location(&self.url), SmallString::as_ref)
     }
 
-    /// Return the hashes associated with this file.
+    /// Reconstructs the file's hash digests from their compact cache representation.
     pub fn hashes(&self) -> HashDigests {
         HashDigests::from(&self.hashes)
     }
@@ -1445,8 +1447,7 @@ impl CachedFile {
 
 impl From<File> for CachedFile {
     fn from(file: File) -> Self {
-        let filename = filename_from_location(&file.url)
-            .is_none_or(|filename| filename != file.filename.as_ref())
+        let filename = (filename_from_location(&file.url) != file.filename.as_ref())
             .then(|| Box::new(file.filename));
         let has_size = file.size.is_some();
         let has_upload_time = file.upload_time_utc_ms.is_some();
@@ -1483,15 +1484,22 @@ impl From<CachedFile> for File {
     }
 }
 
-fn filename_from_location(location: &FileLocation) -> Option<&str> {
+/// Returns the final URL path component after removing any query or fragment.
+fn filename_from_location(location: &FileLocation) -> &str {
     let path = match location {
         FileLocation::RelativeUrl(_, path) => path.as_ref(),
         FileLocation::AbsoluteUrl(url) => url.as_ref(),
     };
-    path.split(['?', '#']).next()?.rsplit('/').next()
+    let path = path.split_once(['?', '#']).map_or(path, |(path, _)| path);
+    path.rsplit_once('/').map_or(path, |(_, filename)| filename)
 }
 
 /// A compact representation of a single, canonical hash digest.
+///
+/// Only lowercase hexadecimal digests of the expected length use the packed variants. Multiple
+/// hashes and non-canonical spellings remain in [`Self::Other`] so conversion back to
+/// [`HashDigests`] is lossless. The larger digests are boxed to keep the common archived layout
+/// small.
 #[derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 enum CachedHashDigests {
@@ -1570,6 +1578,10 @@ impl From<&CachedHashDigests> for HashDigests {
     }
 }
 
+/// Decodes a lowercase hexadecimal digest of exactly `N` bytes.
+///
+/// Rejecting non-canonical spellings lets [`CachedHashDigests::Other`] preserve their original
+/// text.
 fn decode_digest<const N: usize>(hash: &HashDigest) -> Option<[u8; N]> {
     if hash.digest.len() != N * 2
         || !hash
@@ -1585,6 +1597,7 @@ fn decode_digest<const N: usize>(hash: &HashDigest) -> Option<[u8; N]> {
     Some(digest)
 }
 
+/// Reconstructs the canonical lowercase spelling of a packed digest.
 fn hash_digest(algorithm: HashAlgorithm, digest: &[u8]) -> HashDigest {
     let mut encoded = [0; 128];
     let length = digest.len() * 2;

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1491,20 +1491,29 @@ fn filename_from_location(location: &FileLocation) -> Option<&str> {
     path.split(['?', '#']).next()?.rsplit('/').next()
 }
 
-/// A compact representation of the overwhelmingly common single SHA-256 hash.
+/// A compact representation of a single, canonical hash digest.
 #[derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 enum CachedHashDigests {
     Sha256([u8; 32]),
     Other(HashDigests),
+    Md5([u8; 16]),
+    Blake2b([u8; 32]),
+    Sha384(Box<[u8; 48]>),
+    Sha512(Box<[u8; 64]>),
 }
 
 impl Debug for CachedHashDigests {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Sha256(digest) => f.debug_tuple("Sha256").field(&hex::encode(digest)).finish(),
-            Self::Other(hashes) => f.debug_tuple("Other").field(hashes).finish(),
-        }
+        let (name, digest) = match self {
+            Self::Md5(digest) => ("Md5", digest.as_slice()),
+            Self::Sha256(digest) => ("Sha256", digest.as_slice()),
+            Self::Blake2b(digest) => ("Blake2b", digest.as_slice()),
+            Self::Sha384(digest) => ("Sha384", digest.as_slice()),
+            Self::Sha512(digest) => ("Sha512", digest.as_slice()),
+            Self::Other(hashes) => return f.debug_tuple("Other").field(hashes).finish(),
+        };
+        f.debug_tuple(name).field(&hex::encode(digest)).finish()
     }
 }
 
@@ -1513,31 +1522,29 @@ impl From<HashDigests> for CachedHashDigests {
         let [hash] = hashes.as_slice() else {
             return Self::Other(hashes);
         };
-        if hash.algorithm != HashAlgorithm::Sha256 {
+        let cached = match hash.algorithm {
+            HashAlgorithm::Md5 => decode_digest(hash).map(Self::Md5),
+            HashAlgorithm::Sha256 => decode_digest(hash).map(Self::Sha256),
+            HashAlgorithm::Blake2b => decode_digest(hash).map(Self::Blake2b),
+            HashAlgorithm::Sha384 => {
+                decode_digest(hash).map(|digest| Self::Sha384(Box::new(digest)))
+            }
+            HashAlgorithm::Sha512 => {
+                decode_digest(hash).map(|digest| Self::Sha512(Box::new(digest)))
+            }
+        };
+        let Some(cached) = cached else {
             return Self::Other(hashes);
-        }
-        if hash.digest.len() != 64
-            || !hash
-                .digest
-                .as_bytes()
-                .iter()
-                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
-        {
-            return Self::Other(hashes);
-        }
-        let mut digest = [0; 32];
-        if hex::decode_to_slice(hash.digest.as_bytes(), &mut digest).is_err() {
-            return Self::Other(hashes);
-        }
-        Self::Sha256(digest)
+        };
+        cached
     }
 }
 
 impl From<CachedHashDigests> for HashDigests {
     fn from(hashes: CachedHashDigests) -> Self {
         match hashes {
-            CachedHashDigests::Sha256(digest) => Self::from(sha256_digest(&digest)),
             CachedHashDigests::Other(hashes) => hashes,
+            hashes => Self::from(&hashes),
         }
     }
 }
@@ -1545,23 +1552,50 @@ impl From<CachedHashDigests> for HashDigests {
 impl From<&CachedHashDigests> for HashDigests {
     fn from(hashes: &CachedHashDigests) -> Self {
         match hashes {
-            CachedHashDigests::Sha256(digest) => Self::from(sha256_digest(digest)),
+            CachedHashDigests::Md5(digest) => Self::from(hash_digest(HashAlgorithm::Md5, digest)),
+            CachedHashDigests::Sha256(digest) => {
+                Self::from(hash_digest(HashAlgorithm::Sha256, digest))
+            }
+            CachedHashDigests::Blake2b(digest) => {
+                Self::from(hash_digest(HashAlgorithm::Blake2b, digest))
+            }
+            CachedHashDigests::Sha384(digest) => {
+                Self::from(hash_digest(HashAlgorithm::Sha384, digest.as_slice()))
+            }
+            CachedHashDigests::Sha512(digest) => {
+                Self::from(hash_digest(HashAlgorithm::Sha512, digest.as_slice()))
+            }
             CachedHashDigests::Other(hashes) => hashes.clone(),
         }
     }
 }
 
-fn sha256_digest(digest: &[u8; 32]) -> HashDigest {
-    let mut encoded = [0; 64];
-    let digest = if hex::encode_to_slice(digest, &mut encoded).is_ok() {
-        SmallString::from(String::from_utf8_lossy(&encoded))
+fn decode_digest<const N: usize>(hash: &HashDigest) -> Option<[u8; N]> {
+    if hash.digest.len() != N * 2
+        || !hash
+            .digest
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return None;
+    }
+    let mut digest = [0; N];
+    hex::decode_to_slice(hash.digest.as_bytes(), &mut digest).ok()?;
+    Some(digest)
+}
+
+fn hash_digest(algorithm: HashAlgorithm, digest: &[u8]) -> HashDigest {
+    let mut encoded = [0; 128];
+    let length = digest.len() * 2;
+    let digest = if let Some(encoded) = encoded.get_mut(..length)
+        && hex::encode_to_slice(digest, &mut *encoded).is_ok()
+    {
+        SmallString::from(String::from_utf8_lossy(encoded))
     } else {
         SmallString::from(hex::encode(digest))
     };
-    HashDigest {
-        algorithm: HashAlgorithm::Sha256,
-        digest,
-    }
+    HashDigest { algorithm, digest }
 }
 
 /// The list of projects available in a Simple API index.
@@ -1678,10 +1712,10 @@ impl SimpleDetailMetadata {
         for files in version_map.values_mut() {
             files
                 .wheels
-                .sort_unstable_by(|left, right| left.filename.cmp(&right.filename));
+                .sort_unstable_by(|left, right| left.filename().cmp(right.filename()));
             files
                 .source_dists
-                .sort_unstable_by(|left, right| left.filename.cmp(&right.filename));
+                .sort_unstable_by(|left, right| left.filename().cmp(right.filename()));
         }
 
         Self {
@@ -2332,17 +2366,71 @@ mod tests {
         };
         assert_eq!(File::from(file), expected);
 
-        for digest in [
-            "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
-            "not-a-valid-sha256",
+        for (algorithm, bytes) in [
+            (HashAlgorithm::Md5, 16),
+            (HashAlgorithm::Sha256, 32),
+            (HashAlgorithm::Blake2b, 32),
+            (HashAlgorithm::Sha384, 48),
+            (HashAlgorithm::Sha512, 64),
         ] {
             let file = File {
                 dist_info_metadata: false,
                 filename: SmallString::from("example-1.0.0.tar.gz"),
                 hashes: HashDigests::from(HashDigest {
-                    algorithm: HashAlgorithm::Sha256,
-                    digest: SmallString::from(digest),
+                    algorithm,
+                    digest: SmallString::from("01".repeat(bytes)),
                 }),
+                requires_python: None,
+                size: None,
+                upload_time_utc_ms: None,
+                url: FileLocation::new(
+                    SmallString::from("https://files.pythonhosted.org/example-1.0.0.tar.gz"),
+                    &base,
+                ),
+                yanked: None,
+                zstd: None,
+            };
+            let expected = file.clone();
+            let cached = super::CachedFile::from(file);
+            assert!(matches!(
+                (&cached.hashes, algorithm),
+                (super::CachedHashDigests::Md5(_), HashAlgorithm::Md5)
+                    | (super::CachedHashDigests::Sha256(_), HashAlgorithm::Sha256)
+                    | (super::CachedHashDigests::Blake2b(_), HashAlgorithm::Blake2b)
+                    | (super::CachedHashDigests::Sha384(_), HashAlgorithm::Sha384)
+                    | (super::CachedHashDigests::Sha512(_), HashAlgorithm::Sha512)
+            ));
+            assert_eq!(cached.hashes(), expected.hashes);
+
+            let files = super::VersionFiles {
+                wheels: Vec::new(),
+                source_dists: vec![cached],
+            };
+            let archive = super::OwnedArchive::from_unarchived(&files)?;
+            let mut files = super::OwnedArchive::deserialize(&archive);
+            let Some(file) = files.source_dists.pop() else {
+                return Err("missing cached source distribution".into());
+            };
+            assert_eq!(File::from(file), expected);
+        }
+
+        for (algorithm, digest) in [
+            (
+                HashAlgorithm::Sha256,
+                SmallString::from(
+                    "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+                ),
+            ),
+            (
+                HashAlgorithm::Sha256,
+                SmallString::from("not-a-valid-sha256"),
+            ),
+            (HashAlgorithm::Blake2b, SmallString::from("01".repeat(64))),
+        ] {
+            let file = File {
+                dist_info_metadata: false,
+                filename: SmallString::from("example-1.0.0.tar.gz"),
+                hashes: HashDigests::from(HashDigest { algorithm, digest }),
                 requires_python: None,
                 size: None,
                 upload_time_utc_ms: None,
@@ -2359,6 +2447,21 @@ mod tests {
             assert!(matches!(cached.hashes, super::CachedHashDigests::Other(_)));
             assert_eq!(File::from(cached), expected);
         }
+
+        let hashes = HashDigests::from(vec![
+            HashDigest {
+                algorithm: HashAlgorithm::Sha256,
+                digest: SmallString::from("01".repeat(32)),
+            },
+            HashDigest {
+                algorithm: HashAlgorithm::Blake2b,
+                digest: SmallString::from("23".repeat(32)),
+            },
+        ]);
+        let expected = hashes.clone();
+        let cached = super::CachedHashDigests::from(hashes);
+        assert!(matches!(cached, super::CachedHashDigests::Other(_)));
+        assert_eq!(HashDigests::from(cached), expected);
 
         assert_eq!(std::mem::size_of::<rkyv::Archived<super::CachedFile>>(), 96);
         assert_eq!(

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1416,7 +1416,7 @@ impl VersionFiles {
 #[rkyv(derive(Debug))]
 pub struct CachedFile {
     size: u64,
-    pub upload_time_utc_ms: i64,
+    upload_time_utc_ms: i64,
     hashes: CachedHashDigests,
     url: FileLocation,
     requires_python: Option<Arc<VersionSpecifiers>>,
@@ -1426,9 +1426,17 @@ pub struct CachedFile {
     yanked: Option<Box<Yanked>>,
     #[rkyv(with = rkyv::with::Niche)]
     zstd: Option<Box<Zstd>>,
-    pub dist_info_metadata: bool,
+    dist_info_metadata: bool,
     has_size: bool,
-    pub has_upload_time: bool,
+    has_upload_time: bool,
+}
+
+impl ArchivedCachedFile {
+    /// Returns the upload time in UTC milliseconds, if it was present in the index metadata.
+    pub fn upload_time_utc_ms(&self) -> Option<i64> {
+        self.has_upload_time
+            .then_some(self.upload_time_utc_ms.to_native())
+    }
 }
 
 impl CachedFile {
@@ -1436,7 +1444,7 @@ impl CachedFile {
     pub fn filename(&self) -> &str {
         self.filename
             .as_deref()
-            .map_or_else(|| filename_from_location(&self.url), SmallString::as_ref)
+            .map_or_else(|| self.url.raw_filename(), SmallString::as_ref)
     }
 
     /// Reconstructs the file's hash digests from their compact cache representation.
@@ -1447,8 +1455,8 @@ impl CachedFile {
 
 impl From<File> for CachedFile {
     fn from(file: File) -> Self {
-        let filename = (filename_from_location(&file.url) != file.filename.as_ref())
-            .then(|| Box::new(file.filename));
+        let filename =
+            (file.url.raw_filename() != file.filename.as_ref()).then(|| Box::new(file.filename));
         let has_size = file.size.is_some();
         let has_upload_time = file.upload_time_utc_ms.is_some();
         Self {
@@ -1484,16 +1492,6 @@ impl From<CachedFile> for File {
     }
 }
 
-/// Returns the final URL path component after removing any query or fragment.
-fn filename_from_location(location: &FileLocation) -> &str {
-    let path = match location {
-        FileLocation::RelativeUrl(_, path) => path.as_ref(),
-        FileLocation::AbsoluteUrl(url) => url.as_ref(),
-    };
-    let path = path.split_once(['?', '#']).map_or(path, |(path, _)| path);
-    path.rsplit_once('/').map_or(path, |(_, filename)| filename)
-}
-
 /// A compact representation of a single, canonical hash digest.
 ///
 /// Only lowercase hexadecimal digests of the expected length use the packed variants. Multiple
@@ -1504,11 +1502,11 @@ fn filename_from_location(location: &FileLocation) -> &str {
 #[rkyv(derive(Debug))]
 enum CachedHashDigests {
     Sha256([u8; 32]),
-    Other(HashDigests),
     Md5([u8; 16]),
     Blake2b([u8; 32]),
     Sha384(Box<[u8; 48]>),
     Sha512(Box<[u8; 64]>),
+    Other(HashDigests),
 }
 
 impl Debug for CachedHashDigests {
@@ -1948,10 +1946,9 @@ mod tests {
     };
     use uv_cache::Cache;
     use uv_distribution_types::{
-        File, FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations,
-        IndexMetadataRef, IndexUrl, ToUrlError,
+        FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
+        IndexUrl, ToUrlError,
     };
-    use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, Yanked};
     use uv_small_str::SmallString;
     use wiremock::matchers::{basic_auth, method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -2332,154 +2329,6 @@ mod tests {
         assert_eq!(
             filenames,
             ["example_1-1.0.0.tar.gz", "example_1-1.0.0-py3-none-any.whl"]
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn cached_file_round_trip() -> Result<(), Error> {
-        let base = SmallString::from("https://pypi.org/simple/example/");
-        let file = File {
-            dist_info_metadata: true,
-            filename: SmallString::from("example-1.0.0-py3-none-any.whl"),
-            hashes: HashDigests::from(HashDigest {
-                algorithm: HashAlgorithm::Sha256,
-                digest: SmallString::from(
-                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-                ),
-            }),
-            requires_python: None,
-            size: Some(0),
-            upload_time_utc_ms: Some(0),
-            url: FileLocation::new(
-                SmallString::from(
-                    "https://files.pythonhosted.org/example-1.0.0-py3-none-any.whl?download=1",
-                ),
-                &base,
-            ),
-            yanked: Some(Box::new(Yanked::Bool(false))),
-            zstd: None,
-        };
-        let mut expected = file.clone();
-        expected.yanked = None;
-        let cached = super::CachedFile::from(file);
-        assert!(cached.filename.is_none());
-        assert!(matches!(cached.hashes, super::CachedHashDigests::Sha256(_)));
-        assert!(cached.yanked.is_none());
-
-        let files = super::VersionFiles {
-            wheels: vec![cached],
-            source_dists: Vec::new(),
-        };
-        let archive = super::OwnedArchive::from_unarchived(&files)?;
-        let mut files = super::OwnedArchive::deserialize(&archive);
-        let Some(file) = files.wheels.pop() else {
-            return Err("missing cached wheel".into());
-        };
-        assert_eq!(File::from(file), expected);
-
-        for (algorithm, bytes) in [
-            (HashAlgorithm::Md5, 16),
-            (HashAlgorithm::Sha256, 32),
-            (HashAlgorithm::Blake2b, 32),
-            (HashAlgorithm::Sha384, 48),
-            (HashAlgorithm::Sha512, 64),
-        ] {
-            let file = File {
-                dist_info_metadata: false,
-                filename: SmallString::from("example-1.0.0.tar.gz"),
-                hashes: HashDigests::from(HashDigest {
-                    algorithm,
-                    digest: SmallString::from("01".repeat(bytes)),
-                }),
-                requires_python: None,
-                size: None,
-                upload_time_utc_ms: None,
-                url: FileLocation::new(
-                    SmallString::from("https://files.pythonhosted.org/example-1.0.0.tar.gz"),
-                    &base,
-                ),
-                yanked: None,
-                zstd: None,
-            };
-            let expected = file.clone();
-            let cached = super::CachedFile::from(file);
-            assert!(matches!(
-                (&cached.hashes, algorithm),
-                (super::CachedHashDigests::Md5(_), HashAlgorithm::Md5)
-                    | (super::CachedHashDigests::Sha256(_), HashAlgorithm::Sha256)
-                    | (super::CachedHashDigests::Blake2b(_), HashAlgorithm::Blake2b)
-                    | (super::CachedHashDigests::Sha384(_), HashAlgorithm::Sha384)
-                    | (super::CachedHashDigests::Sha512(_), HashAlgorithm::Sha512)
-            ));
-            assert_eq!(cached.hashes(), expected.hashes);
-
-            let files = super::VersionFiles {
-                wheels: Vec::new(),
-                source_dists: vec![cached],
-            };
-            let archive = super::OwnedArchive::from_unarchived(&files)?;
-            let mut files = super::OwnedArchive::deserialize(&archive);
-            let Some(file) = files.source_dists.pop() else {
-                return Err("missing cached source distribution".into());
-            };
-            assert_eq!(File::from(file), expected);
-        }
-
-        for (algorithm, digest) in [
-            (
-                HashAlgorithm::Sha256,
-                SmallString::from(
-                    "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
-                ),
-            ),
-            (
-                HashAlgorithm::Sha256,
-                SmallString::from("not-a-valid-sha256"),
-            ),
-            (HashAlgorithm::Blake2b, SmallString::from("01".repeat(64))),
-        ] {
-            let file = File {
-                dist_info_metadata: false,
-                filename: SmallString::from("example-1.0.0.tar.gz"),
-                hashes: HashDigests::from(HashDigest { algorithm, digest }),
-                requires_python: None,
-                size: None,
-                upload_time_utc_ms: None,
-                url: FileLocation::new(
-                    SmallString::from("https://files.pythonhosted.org/renamed.tar.gz#download"),
-                    &base,
-                ),
-                yanked: Some(Box::new(Yanked::Reason(SmallString::from("broken")))),
-                zstd: None,
-            };
-            let expected = file.clone();
-            let cached = super::CachedFile::from(file);
-            assert!(cached.filename.is_some());
-            assert!(matches!(cached.hashes, super::CachedHashDigests::Other(_)));
-            assert_eq!(File::from(cached), expected);
-        }
-
-        let hashes = HashDigests::from(vec![
-            HashDigest {
-                algorithm: HashAlgorithm::Sha256,
-                digest: SmallString::from("01".repeat(32)),
-            },
-            HashDigest {
-                algorithm: HashAlgorithm::Blake2b,
-                digest: SmallString::from("23".repeat(32)),
-            },
-        ]);
-        let expected = hashes.clone();
-        let cached = super::CachedHashDigests::from(hashes);
-        assert!(matches!(cached, super::CachedHashDigests::Other(_)));
-        assert_eq!(HashDigests::from(cached), expected);
-
-        assert_eq!(std::mem::size_of::<rkyv::Archived<super::CachedFile>>(), 96);
-        assert_eq!(
-            std::mem::size_of::<rkyv::Archived<SimpleDetailMetadatum>>(),
-            48
         );
 
         Ok(())

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,16 +20,17 @@ use uv_configuration::IndexStrategy;
 use uv_configuration::KeyringProviderType;
 use uv_distribution_filename::{DistFilename, WheelFilename};
 use uv_distribution_types::{
-    BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-    IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name, RegistryBuiltWheel,
+    BuiltDist, File, FileLocation, IndexCapabilities, IndexFormat, IndexLocations,
+    IndexMetadataRef, IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
+    RegistryBuiltWheel, Zstd,
 };
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
 use uv_normalize::PackageName;
-use uv_pep440::Version;
+use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::MarkerEnvironment;
 use uv_platform_tags::Platform;
-use uv_pypi_types::ProjectStatus;
+use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, ProjectStatus, Yanked};
 use uv_pypi_types::{
     PypiSimpleDetail, PypiSimpleIndex, PyxSimpleDetail, PyxSimpleIndex, ResolutionMetadata,
 };
@@ -1381,12 +1382,13 @@ type FlatIndexSlot = Arc<Mutex<Option<FlatIndexEntriesByPackage>>>;
 #[derive(Default, Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 pub struct VersionFiles {
-    pub wheels: Vec<File>,
-    pub source_dists: Vec<File>,
+    pub wheels: Vec<CachedFile>,
+    pub source_dists: Vec<CachedFile>,
 }
 
 impl VersionFiles {
     fn push(&mut self, filename: &DistFilename, file: File) {
+        let file = CachedFile::from(file);
         match filename {
             DistFilename::WheelFilename(_) => self.wheels.push(file),
             DistFilename::SourceDistFilename(_) => self.source_dists.push(file),
@@ -1398,9 +1400,167 @@ impl VersionFiles {
             .into_iter()
             .chain(self.wheels)
             .filter_map(|file| {
+                let file = File::from(file);
                 let filename = DistFilename::try_from_filename(&file.filename, package_name)?;
                 Some((filename, file))
             })
+    }
+}
+
+/// A compact representation of a registry file in the Simple API cache.
+#[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[rkyv(derive(Debug))]
+pub struct CachedFile {
+    size: u64,
+    pub upload_time_utc_ms: i64,
+    hashes: CachedHashDigests,
+    url: FileLocation,
+    requires_python: Option<Arc<VersionSpecifiers>>,
+    #[rkyv(with = rkyv::with::Niche)]
+    filename: Option<Box<SmallString>>,
+    #[rkyv(with = rkyv::with::Niche)]
+    yanked: Option<Box<Yanked>>,
+    #[rkyv(with = rkyv::with::Niche)]
+    zstd: Option<Box<Zstd>>,
+    pub dist_info_metadata: bool,
+    has_size: bool,
+    pub has_upload_time: bool,
+}
+
+impl CachedFile {
+    /// Return the filename, reconstructing it from the URL when it was elided.
+    pub fn filename(&self) -> &str {
+        self.filename
+            .as_deref()
+            .map(SmallString::as_ref)
+            .or_else(|| filename_from_location(&self.url))
+            .unwrap_or_default()
+    }
+
+    /// Return the hashes associated with this file.
+    pub fn hashes(&self) -> HashDigests {
+        HashDigests::from(&self.hashes)
+    }
+}
+
+impl From<File> for CachedFile {
+    fn from(file: File) -> Self {
+        let filename = filename_from_location(&file.url)
+            .is_none_or(|filename| filename != file.filename.as_ref())
+            .then(|| Box::new(file.filename));
+        let has_size = file.size.is_some();
+        let has_upload_time = file.upload_time_utc_ms.is_some();
+        Self {
+            dist_info_metadata: file.dist_info_metadata,
+            filename,
+            hashes: CachedHashDigests::from(file.hashes),
+            requires_python: file.requires_python,
+            size: file.size.unwrap_or_default(),
+            upload_time_utc_ms: file.upload_time_utc_ms.unwrap_or_default(),
+            has_size,
+            has_upload_time,
+            url: file.url,
+            yanked: file.yanked.filter(|yanked| yanked.is_yanked()),
+            zstd: file.zstd,
+        }
+    }
+}
+
+impl From<CachedFile> for File {
+    fn from(file: CachedFile) -> Self {
+        let filename = SmallString::from(file.filename());
+        Self {
+            dist_info_metadata: file.dist_info_metadata,
+            filename,
+            hashes: HashDigests::from(file.hashes),
+            requires_python: file.requires_python,
+            size: file.has_size.then_some(file.size),
+            upload_time_utc_ms: file.has_upload_time.then_some(file.upload_time_utc_ms),
+            url: file.url,
+            yanked: file.yanked,
+            zstd: file.zstd,
+        }
+    }
+}
+
+fn filename_from_location(location: &FileLocation) -> Option<&str> {
+    let path = match location {
+        FileLocation::RelativeUrl(_, path) => path.as_ref(),
+        FileLocation::AbsoluteUrl(url) => url.as_ref(),
+    };
+    path.split(['?', '#']).next()?.rsplit('/').next()
+}
+
+/// A compact representation of the overwhelmingly common single SHA-256 hash.
+#[derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[rkyv(derive(Debug))]
+enum CachedHashDigests {
+    Sha256([u8; 32]),
+    Other(HashDigests),
+}
+
+impl Debug for CachedHashDigests {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sha256(digest) => f.debug_tuple("Sha256").field(&hex::encode(digest)).finish(),
+            Self::Other(hashes) => f.debug_tuple("Other").field(hashes).finish(),
+        }
+    }
+}
+
+impl From<HashDigests> for CachedHashDigests {
+    fn from(hashes: HashDigests) -> Self {
+        let [hash] = hashes.as_slice() else {
+            return Self::Other(hashes);
+        };
+        if hash.algorithm != HashAlgorithm::Sha256 {
+            return Self::Other(hashes);
+        }
+        if hash.digest.len() != 64
+            || !hash
+                .digest
+                .as_bytes()
+                .iter()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Self::Other(hashes);
+        }
+        let mut digest = [0; 32];
+        if hex::decode_to_slice(hash.digest.as_bytes(), &mut digest).is_err() {
+            return Self::Other(hashes);
+        }
+        Self::Sha256(digest)
+    }
+}
+
+impl From<CachedHashDigests> for HashDigests {
+    fn from(hashes: CachedHashDigests) -> Self {
+        match hashes {
+            CachedHashDigests::Sha256(digest) => Self::from(sha256_digest(&digest)),
+            CachedHashDigests::Other(hashes) => hashes,
+        }
+    }
+}
+
+impl From<&CachedHashDigests> for HashDigests {
+    fn from(hashes: &CachedHashDigests) -> Self {
+        match hashes {
+            CachedHashDigests::Sha256(digest) => Self::from(sha256_digest(digest)),
+            CachedHashDigests::Other(hashes) => hashes.clone(),
+        }
+    }
+}
+
+fn sha256_digest(digest: &[u8; 32]) -> HashDigest {
+    let mut encoded = [0; 64];
+    let digest = if hex::encode_to_slice(digest, &mut encoded).is_ok() {
+        SmallString::from(String::from_utf8_lossy(&encoded))
+    } else {
+        SmallString::from(hex::encode(digest))
+    };
+    HashDigest {
+        algorithm: HashAlgorithm::Sha256,
+        digest,
     }
 }
 
@@ -1461,7 +1621,8 @@ pub struct SimpleDetailMetadata {
 pub struct SimpleDetailMetadatum {
     pub version: Version,
     pub files: VersionFiles,
-    pub metadata: Option<ResolutionMetadata>,
+    #[rkyv(with = rkyv::with::Niche)]
+    pub metadata: Option<Box<ResolutionMetadata>>,
 }
 
 impl SimpleDetailMetadata {
@@ -1585,17 +1746,16 @@ impl SimpleDetailMetadata {
             versions: version_map
                 .into_iter()
                 .map(|(version, files)| {
-                    let metadata =
-                        core_metadata
-                            .remove(&version)
-                            .map(|metadata| ResolutionMetadata {
-                                name: package_name.clone(),
-                                version: version.clone(),
-                                requires_dist: metadata.requires_dist,
-                                requires_python: metadata.requires_python,
-                                provides_extra: metadata.provides_extra,
-                                dynamic: false,
-                            });
+                    let metadata = core_metadata.remove(&version).map(|metadata| {
+                        Box::new(ResolutionMetadata {
+                            name: package_name.clone(),
+                            version: version.clone(),
+                            requires_dist: metadata.requires_dist,
+                            requires_python: metadata.requires_python,
+                            provides_extra: metadata.provides_extra,
+                            dynamic: false,
+                        })
+                    });
                     SimpleDetailMetadatum {
                         version,
                         files,
@@ -1741,9 +1901,10 @@ mod tests {
     };
     use uv_cache::Cache;
     use uv_distribution_types::{
-        FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
-        IndexUrl, ToUrlError,
+        File, FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations,
+        IndexMetadataRef, IndexUrl, ToUrlError,
     };
+    use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, Yanked};
     use uv_small_str::SmallString;
     use wiremock::matchers::{basic_auth, method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -2129,6 +2290,85 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn cached_file_round_trip() -> Result<(), Error> {
+        let base = SmallString::from("https://pypi.org/simple/example/");
+        let file = File {
+            dist_info_metadata: true,
+            filename: SmallString::from("example-1.0.0-py3-none-any.whl"),
+            hashes: HashDigests::from(HashDigest {
+                algorithm: HashAlgorithm::Sha256,
+                digest: SmallString::from(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                ),
+            }),
+            requires_python: None,
+            size: Some(0),
+            upload_time_utc_ms: Some(0),
+            url: FileLocation::new(
+                SmallString::from(
+                    "https://files.pythonhosted.org/example-1.0.0-py3-none-any.whl?download=1",
+                ),
+                &base,
+            ),
+            yanked: Some(Box::new(Yanked::Bool(false))),
+            zstd: None,
+        };
+        let mut expected = file.clone();
+        expected.yanked = None;
+        let cached = super::CachedFile::from(file);
+        assert!(cached.filename.is_none());
+        assert!(matches!(cached.hashes, super::CachedHashDigests::Sha256(_)));
+        assert!(cached.yanked.is_none());
+
+        let files = super::VersionFiles {
+            wheels: vec![cached],
+            source_dists: Vec::new(),
+        };
+        let archive = super::OwnedArchive::from_unarchived(&files)?;
+        let mut files = super::OwnedArchive::deserialize(&archive);
+        let Some(file) = files.wheels.pop() else {
+            return Err("missing cached wheel".into());
+        };
+        assert_eq!(File::from(file), expected);
+
+        for digest in [
+            "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+            "not-a-valid-sha256",
+        ] {
+            let file = File {
+                dist_info_metadata: false,
+                filename: SmallString::from("example-1.0.0.tar.gz"),
+                hashes: HashDigests::from(HashDigest {
+                    algorithm: HashAlgorithm::Sha256,
+                    digest: SmallString::from(digest),
+                }),
+                requires_python: None,
+                size: None,
+                upload_time_utc_ms: None,
+                url: FileLocation::new(
+                    SmallString::from("https://files.pythonhosted.org/renamed.tar.gz#download"),
+                    &base,
+                ),
+                yanked: Some(Box::new(Yanked::Reason(SmallString::from("broken")))),
+                zstd: None,
+            };
+            let expected = file.clone();
+            let cached = super::CachedFile::from(file);
+            assert!(cached.filename.is_some());
+            assert!(matches!(cached.hashes, super::CachedHashDigests::Other(_)));
+            assert_eq!(File::from(cached), expected);
+        }
+
+        assert_eq!(std::mem::size_of::<rkyv::Archived<super::CachedFile>>(), 96);
+        assert_eq!(
+            std::mem::size_of::<rkyv::Archived<SimpleDetailMetadatum>>(),
+            48
+        );
+
+        Ok(())
+    }
+
     /// Test for project statuses from PyPI's JSON detail response.
     #[test]
     fn project_status_pypi_json() {
@@ -2187,16 +2427,16 @@ mod tests {
                     files: VersionFiles {
                         wheels: [],
                         source_dists: [
-                            File {
-                                dist_info_metadata: false,
-                                filename: "pepy-2.1.1.tar.gz",
-                                hashes: HashDigests(
-                                    [
-                                        HashDigest {
-                                            algorithm: Sha256,
-                                            digest: "cec463c444b71d1664229121897b22df753dc91fabb2113d1c89992638c90829",
-                                        },
-                                    ],
+                            CachedFile {
+                                size: 15399,
+                                upload_time_utc_ms: 1668446093935,
+                                hashes: Sha256(
+                                    "cec463c444b71d1664229121897b22df753dc91fabb2113d1c89992638c90829",
+                                ),
+                                url: AbsoluteUrl(
+                                    UrlString(
+                                        "https://files.pythonhosted.org/packages/78/7e/123d89ce0e999e957e53f0b985f734565c93b9a698af53586fc2a1be0dbf/pepy-2.1.1.tar.gz",
+                                    ),
                                 ),
                                 requires_python: Some(
                                     VersionSpecifiers(
@@ -2208,23 +2448,12 @@ mod tests {
                                         ],
                                     ),
                                 ),
-                                size: Some(
-                                    15399,
-                                ),
-                                upload_time_utc_ms: Some(
-                                    1668446093935,
-                                ),
-                                url: AbsoluteUrl(
-                                    UrlString(
-                                        "https://files.pythonhosted.org/packages/78/7e/123d89ce0e999e957e53f0b985f734565c93b9a698af53586fc2a1be0dbf/pepy-2.1.1.tar.gz",
-                                    ),
-                                ),
-                                yanked: Some(
-                                    Bool(
-                                        false,
-                                    ),
-                                ),
+                                filename: None,
+                                yanked: None,
                                 zstd: None,
+                                dist_info_metadata: false,
+                                has_size: true,
+                                has_upload_time: true,
                             },
                         ],
                     },
@@ -2270,16 +2499,16 @@ mod tests {
                     files: VersionFiles {
                         wheels: [],
                         source_dists: [
-                            File {
-                                dist_info_metadata: false,
-                                filename: "pepy-2.1.1.tar.gz",
-                                hashes: HashDigests(
-                                    [
-                                        HashDigest {
-                                            algorithm: Sha256,
-                                            digest: "cec463c444b71d1664229121897b22df753dc91fabb2113d1c89992638c90829",
-                                        },
-                                    ],
+                            CachedFile {
+                                size: 0,
+                                upload_time_utc_ms: 0,
+                                hashes: Sha256(
+                                    "cec463c444b71d1664229121897b22df753dc91fabb2113d1c89992638c90829",
+                                ),
+                                url: AbsoluteUrl(
+                                    UrlString(
+                                        "https://files.pythonhosted.org/packages/78/7e/123d89ce0e999e957e53f0b985f734565c93b9a698af53586fc2a1be0dbf/pepy-2.1.1.tar.gz",
+                                    ),
                                 ),
                                 requires_python: Some(
                                     VersionSpecifiers(
@@ -2291,15 +2520,12 @@ mod tests {
                                         ],
                                     ),
                                 ),
-                                size: None,
-                                upload_time_utc_ms: None,
-                                url: AbsoluteUrl(
-                                    UrlString(
-                                        "https://files.pythonhosted.org/packages/78/7e/123d89ce0e999e957e53f0b985f734565c93b9a698af53586fc2a1be0dbf/pepy-2.1.1.tar.gz",
-                                    ),
-                                ),
+                                filename: None,
                                 yanked: None,
                                 zstd: None,
+                                dist_info_metadata: false,
+                                has_size: false,
+                                has_upload_time: false,
                             },
                         ],
                     },

--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -144,6 +144,18 @@ impl FileLocation {
         }
     }
 
+    /// Returns the final raw URL path component after removing any query or fragment.
+    ///
+    /// The filename is not percent-decoded.
+    pub fn raw_filename(&self) -> &str {
+        let path = match self {
+            Self::RelativeUrl(_, path) => path.as_ref(),
+            Self::AbsoluteUrl(url) => url.as_ref(),
+        };
+        let path = path.split_once(['?', '#']).map_or(path, |(path, _)| path);
+        path.rsplit_once('/').map_or(path, |(_, filename)| filename)
+    }
+
     /// Convert this location to a URL.
     ///
     /// A relative URL has its base joined to the path. An absolute URL is
@@ -308,6 +320,23 @@ pub struct Zstd {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn raw_filename() {
+        let base = SmallString::from("https://example.com/simple/");
+
+        let location = FileLocation::new(
+            SmallString::from("files/example%20pkg.whl?download=1#fragment"),
+            &base,
+        );
+        assert_eq!(location.raw_filename(), "example%20pkg.whl");
+
+        let location = FileLocation::new(
+            SmallString::from("https://files.example.com/example.whl#sha256=digest"),
+            &base,
+        );
+        assert_eq!(location.raw_filename(), "example.whl");
+    }
 
     #[test]
     fn base_str() {

--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -1167,13 +1167,13 @@ pub enum BumpCommand {
 )]
 #[cfg_attr(feature = "rkyv", rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord)))]
 struct VersionSmall {
+    /// The representation discussed above.
+    repr: u64,
     /// The number of segments in the release component.
     ///
     /// PEP 440 considers `1.2`  equivalent to `1.2.0.0`, but we want to preserve trailing zeroes
     /// in roundtrips, as the "full" version representation also does.
     len: u8,
-    /// The representation discussed above.
-    repr: u64,
     /// Force a niche into the aligned type so the [`Version`] enum is two words instead of three.
     _force_niche: NonZero<u8>,
 }
@@ -4373,6 +4373,11 @@ mod tests {
     fn type_size() {
         assert_eq!(size_of::<VersionSmall>(), size_of::<usize>() * 2);
         assert_eq!(size_of::<Version>(), size_of::<usize>() * 2);
+        #[cfg(feature = "rkyv")]
+        {
+            assert_eq!(size_of::<rkyv::Archived<VersionSmall>>(), 16);
+            assert_eq!(size_of::<rkyv::Archived<Version>>(), 24);
+        }
     }
 
     /// Test major bumping

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1006,7 +1006,7 @@ pub async fn check_url(
         DistFilename::WheelFilename(_) => &metadatum.files.wheels,
     };
     let archived_file = archived_files.iter().find(|file| {
-        DistFilename::try_from_filename(&file.filename, filename.name())
+        DistFilename::try_from_filename(file.filename(), filename.name())
             .is_some_and(|candidate| &candidate == filename)
     });
     let Some(archived_file) = archived_file else {
@@ -1014,7 +1014,7 @@ pub async fn check_url(
     };
 
     // TODO(konsti): Do we have a preference for a hash here?
-    if let Some(remote_hash) = archived_file.hashes.first() {
+    if let Some(remote_hash) = archived_file.hashes().first() {
         // We accept the risk for TOCTOU errors here, since we already read the file once before the
         // streaming upload to compute the hash for the form metadata.
         let local_hash = &hash_file(

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -532,7 +532,7 @@ impl VersionMapLazy {
             .get(version)
             .and_then(|entry| entry.dist.simple.as_ref())
             .and_then(|simple| self.simple_metadata.datum(simple.datum_index))
-            .and_then(|datum| datum.metadata.as_ref())?;
+            .and_then(|datum| datum.metadata.as_deref())?;
         Some(
             rkyv::deserialize::<ResolutionMetadata, rkyv::rancor::Error>(archived)
                 .expect("archived metadata always deserializes"),
@@ -575,7 +575,9 @@ impl VersionMapLazy {
             .iter()
             .chain(files.source_dists.iter())
             .any(|file| {
-                let upload_time = file.upload_time_utc_ms.as_ref().map(|t| t.to_native());
+                let upload_time = file
+                    .has_upload_time
+                    .then_some(file.upload_time_utc_ms.to_native());
                 let excluded = if let Some(cutoff) = &self.included_version_cutoff {
                     upload_time.is_none_or(|t| t >= cutoff.as_millisecond())
                 } else if let Some(cutoff) = &self.available_version_cutoff {
@@ -608,9 +610,8 @@ impl VersionMapLazy {
             .iter()
             .chain(datum.files.source_dists.iter())
             .any(|file| {
-                file.upload_time_utc_ms
-                    .as_ref()
-                    .is_none_or(|upload_time| upload_time.to_native() < cutoff.as_millisecond())
+                !file.has_upload_time
+                    || file.upload_time_utc_ms.to_native() < cutoff.as_millisecond()
             })
     }
 

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -575,9 +575,7 @@ impl VersionMapLazy {
             .iter()
             .chain(files.source_dists.iter())
             .any(|file| {
-                let upload_time = file
-                    .has_upload_time
-                    .then_some(file.upload_time_utc_ms.to_native());
+                let upload_time = file.upload_time_utc_ms();
                 let excluded = if let Some(cutoff) = &self.included_version_cutoff {
                     upload_time.is_none_or(|t| t >= cutoff.as_millisecond())
                 } else if let Some(cutoff) = &self.available_version_cutoff {
@@ -610,8 +608,8 @@ impl VersionMapLazy {
             .iter()
             .chain(datum.files.source_dists.iter())
             .any(|file| {
-                !file.has_upload_time
-                    || file.upload_time_utc_ms.to_native() < cutoff.as_millisecond()
+                file.upload_time_utc_ms()
+                    .is_none_or(|upload_time| upload_time < cutoff.as_millisecond())
             })
     }
 

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -143,7 +143,7 @@ fn clean_package_pypi() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v23")
+        .child("simple-v24")
         .child("pypi")
         .child("iniconfig.rkyv");
     assert!(
@@ -219,7 +219,7 @@ fn clean_package_index() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v23")
+        .child("simple-v24")
         .child("index")
         .child("e8208120cae3ba69")
         .child("iniconfig.rkyv");

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -13767,7 +13767,7 @@ fn lock_find_links_http_wheel() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
-    assert!(context.cache_dir.child("flat-index-v3").is_dir());
+    assert!(context.cache_dir.child("flat-index-v4").is_dir());
 
     let lock = context.read("uv.lock");
 


### PR DESCRIPTION
## Summary

Follow-up to #20463 that further compacts the cached Simple API representation:

- We now store registry files in a cache-local `CachedFile`, eliding filenames recoverable from their URLs, normalizing false-yanked entries, packing optional size/upload-time fields, and retaining fallbacks for renamed files and uncommon hashes;
- We now store a single canonical MD5, SHA-256, BLAKE2b-256, SHA-384, or SHA-512 digest in binary form; the two larger digests are boxed so the common SHA-256/BLAKE2b layout stays compact;
- We now niche-box optional resolution metadata and reorder `VersionSmall` to reduce the archived version/metadatum layouts;
- we now sort by reconstructed filenames to preserve deterministic wheel/sdist ordering, bump the Simple cache bucket to `simple-v24`, and update cutoff/publish consumers.

## Performance

For the exact 1,750 common entries, the Simple cache falls from 222,371,536 B to 146,852,744 B (-33.96%).

| workload | wall before | wall after | change | CPU before | CPU after | change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| jupyter (97 packages) | 99.8 ms | 97.6 ms | -2.28% | 53.8 ms | 51.2 ms | -4.99% |
| boto3 (7 packages, backtracking) | 162.0 ms | 162.1 ms | +0.05% | 222.8 ms | 247.1 ms | +10.90% |
| airflow (559 packages) | 239.8 ms | 234.8 ms | -2.07% | 368.4 ms | 348.0 ms | -5.55% |
| large-index (26 large Simple pages, no deps) | 100.6 ms | 97.3 ms | -3.36% | 57.8 ms | 50.9 ms | -11.90% |
