### PR TITLE
Decode stale cache entries in one blocking task

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -246,8 +246,43 @@ impl CachedClient {
         cache_control: CacheControl,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
-        let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
         let start = Instant::now();
+
+        if matches!(cache_control, CacheControl::AllowStale) {
+            let (req, cached) = self
+                .read_and_decode_stale_cache::<Payload>(req, cache_entry)
+                .await;
+            match cached {
+                Ok(Some(payload)) => return Ok(payload),
+                Ok(None) => warn!(
+                    "Cached response doesn't match current request for: {}",
+                    DisplaySafeUrl::from_url(req.url().clone())
+                ),
+                Err(err) if err.is_file_not_exists() => {
+                    trace!("No cache entry exists for {}", cache_entry.path().display());
+                }
+                Err(err) => {
+                    warn!(
+                        "Broken cache entry at {}, removing: {err}",
+                        cache_entry.path().display()
+                    );
+                    let _ = fs_err::tokio::remove_file(&cache_entry.path()).await;
+                }
+            }
+
+            let (response, cache_policy) = self.fresh_request(req, cache_control).await?;
+            return self
+                .run_response_callback(
+                    cache_entry,
+                    cache_policy,
+                    start,
+                    response,
+                    response_callback,
+                )
+                .await;
+        }
+
+        let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
         let cached_response = if let Some(cached) = self.read_cache(cache_entry).await {
             self.send_cached(req, cache_control.clone(), cached)
                 .boxed_local()
@@ -470,6 +505,30 @@ impl CachedClient {
                 None
             }
         }
+    }
+
+    /// Read, validate, and decode an entry that may be stale in one blocking task.
+    #[instrument(name = "read_and_decode_stale_cache", skip_all, fields(file = %cache_entry.path().display()))]
+    async fn read_and_decode_stale_cache<Payload: Cacheable + 'static>(
+        &self,
+        req: Request,
+        cache_entry: &CacheEntry,
+    ) -> (Request, Result<Option<Payload::Target>, Error>) {
+        let path = cache_entry.path().to_path_buf();
+        self.0
+            .cache_read_runtime()
+            .spawn_blocking(move || {
+                let cached = match DataWithCachePolicy::from_path_sync(&path) {
+                    Ok(cached) => cached,
+                    Err(err) => return (req, Err(err)),
+                };
+                if !cached.cache_policy.matches_stale_request(&req) {
+                    return (req, Ok(None));
+                }
+                (req, Payload::from_aligned_bytes(cached.data).map(Some))
+            })
+            .await
+            .expect("cache read and payload decoding task panicked")
     }
 
     /// Send a request given that we have a (possibly) stale cached response.

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -507,7 +507,10 @@ impl CachedClient {
         }
     }
 
-    /// Read, validate, and decode an entry that may be stale in one blocking task.
+    /// Reads and decodes an allowed-stale cache entry in one blocking task.
+    ///
+    /// The task returns the request it owns while checking the policy. `Ok(None)` means the entry
+    /// belongs to a different request; errors indicate a broken entry for the caller to remove.
     #[instrument(name = "read_and_decode_stale_cache", skip_all, fields(file = %cache_entry.path().display()))]
     async fn read_and_decode_stale_cache<Payload: Cacheable + 'static>(
         &self,
@@ -518,14 +521,14 @@ impl CachedClient {
         self.0
             .cache_read_runtime()
             .spawn_blocking(move || {
-                let cached = match DataWithCachePolicy::from_path_sync(&path) {
-                    Ok(cached) => cached,
-                    Err(err) => return (req, Err(err)),
-                };
-                if !cached.cache_policy.matches_stale_request(&req) {
-                    return (req, Ok(None));
-                }
-                (req, Payload::from_aligned_bytes(cached.data).map(Some))
+                let cached = DataWithCachePolicy::from_path_sync(&path).and_then(|cached| {
+                    if cached.cache_policy.matches_stale_request(&req) {
+                        Payload::from_aligned_bytes(cached.data).map(Some)
+                    } else {
+                        Ok(None)
+                    }
+                });
+                (req, cached)
             })
             .await
             .expect("cache read and payload decoding task panicked")

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -276,11 +276,11 @@ impl CachePolicy {
 }
 
 impl ArchivedCachePolicy {
-    /// Returns whether this cached response can be used for a request that permits stale data.
+    /// Returns whether this cached response matches a request that permits stale data.
     ///
-    /// Unlike [`Self::before_request`], this does not determine freshness or prepare a
-    /// revalidation request. A stale response can be reused as long as it is storable and the
-    /// request URI and method are supported.
+    /// This applies only the conditions from [`Self::before_request`] that produce
+    /// [`BeforeRequest::NoMatch`]. It intentionally skips freshness, `Vary`, and `no-cache`
+    /// checks because those produce [`BeforeRequest::Stale`], which an allow-stale caller accepts.
     pub(crate) fn matches_stale_request(&self, request: &reqwest::Request) -> bool {
         self.is_storable()
             && self.request.uri == request.url().as_str()
@@ -1420,6 +1420,20 @@ mod tests {
 
     use super::*;
 
+    fn http_request(method: http::Method, uri: &str) -> reqwest::Request {
+        reqwest::Request::new(method, uri.parse().unwrap())
+    }
+
+    fn archived_cache_policy(
+        request: &reqwest::Request,
+        response: http::response::Builder,
+    ) -> OwnedArchive<CachePolicy> {
+        let response = reqwest::Response::from(response.body(Vec::new()).unwrap());
+        CachePolicyBuilder::new(request)
+            .build(&response)
+            .to_archived()
+    }
+
     /// A server or proxy is free to send an arbitrarily large `Age` header, up
     /// to `u64::MAX`. Combined with the resident age of a cached response, the
     /// RFC 9111 S4.2.3 age computation must not overflow. Every term uses
@@ -1453,24 +1467,19 @@ mod tests {
 
     #[test]
     fn stale_request_ignores_freshness_and_vary() {
-        let mut original =
-            reqwest::Request::new(http::Method::GET, "https://example.com/".parse().unwrap());
+        let mut original = http_request(http::Method::GET, "https://example.com/");
         original
             .headers_mut()
             .insert(http::header::ACCEPT, "application/json".parse().unwrap());
-        let http_response = http::Response::builder()
-            .status(http::StatusCode::OK)
-            .header(http::header::CACHE_CONTROL, "no-cache")
-            .header(http::header::VARY, "accept")
-            .body(Vec::new())
-            .unwrap();
-        let response = reqwest::Response::from(http_response);
-        let archived = CachePolicyBuilder::new(&original)
-            .build(&response)
-            .to_archived();
+        let archived = archived_cache_policy(
+            &original,
+            http::Response::builder()
+                .status(http::StatusCode::OK)
+                .header(http::header::CACHE_CONTROL, "no-cache")
+                .header(http::header::VARY, "accept"),
+        );
 
-        let mut request =
-            reqwest::Request::new(http::Method::GET, "https://example.com/".parse().unwrap());
+        let mut request = http_request(http::Method::GET, "https://example.com/");
         request
             .headers_mut()
             .insert(http::header::ACCEPT, "text/html".parse().unwrap());
@@ -1481,43 +1490,30 @@ mod tests {
             BeforeRequest::Stale(_)
         ));
 
-        let request =
-            reqwest::Request::new(http::Method::HEAD, "https://example.com/".parse().unwrap());
+        let request = http_request(http::Method::HEAD, "https://example.com/");
         assert!(archived.matches_stale_request(&request));
     }
 
     #[test]
     fn stale_request_rejects_non_matching_cache_entries() {
-        let original =
-            reqwest::Request::new(http::Method::GET, "https://example.com/".parse().unwrap());
-        let http_response = http::Response::builder()
-            .status(http::StatusCode::OK)
-            .body(Vec::new())
-            .unwrap();
-        let response = reqwest::Response::from(http_response);
-        let archived = CachePolicyBuilder::new(&original)
-            .build(&response)
-            .to_archived();
-
-        let different_uri = reqwest::Request::new(
-            http::Method::GET,
-            "https://example.com/other".parse().unwrap(),
+        let original = http_request(http::Method::GET, "https://example.com/");
+        let archived = archived_cache_policy(
+            &original,
+            http::Response::builder().status(http::StatusCode::OK),
         );
+
+        let different_uri = http_request(http::Method::GET, "https://example.com/other");
         assert!(!archived.matches_stale_request(&different_uri));
 
-        let unsupported_method =
-            reqwest::Request::new(http::Method::POST, "https://example.com/".parse().unwrap());
+        let unsupported_method = http_request(http::Method::POST, "https://example.com/");
         assert!(!archived.matches_stale_request(&unsupported_method));
 
-        let http_response = http::Response::builder()
-            .status(http::StatusCode::OK)
-            .header(http::header::CACHE_CONTROL, "no-store")
-            .body(Vec::new())
-            .unwrap();
-        let response = reqwest::Response::from(http_response);
-        let unstorable = CachePolicyBuilder::new(&original)
-            .build(&response)
-            .to_archived();
+        let unstorable = archived_cache_policy(
+            &original,
+            http::Response::builder()
+                .status(http::StatusCode::OK)
+                .header(http::header::CACHE_CONTROL, "no-store"),
+        );
         assert!(!unstorable.matches_stale_request(&original));
     }
 }

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -276,6 +276,17 @@ impl CachePolicy {
 }
 
 impl ArchivedCachePolicy {
+    /// Returns whether this cached response can be used for a request that permits stale data.
+    ///
+    /// Unlike [`Self::before_request`], this does not determine freshness or prepare a
+    /// revalidation request. A stale response can be reused as long as it is storable and the
+    /// request URI and method are supported.
+    pub(crate) fn matches_stale_request(&self, request: &reqwest::Request) -> bool {
+        self.is_storable()
+            && self.request.uri == request.url().as_str()
+            && (request.method() == http::Method::GET || request.method() == http::Method::HEAD)
+    }
+
     /// Determines what caching behavior is correct given an existing
     /// `CachePolicy` and a new HTTP request for the resource managed by this
     /// cache policy. This is done as per [RFC 9111 S4].
@@ -1438,5 +1449,75 @@ mod tests {
         let now = SystemTime::now() + Duration::from_secs(5);
         assert_eq!(archived.age(now), Duration::from_secs(u64::MAX));
         assert!(!archived.is_fresh(now, &request));
+    }
+
+    #[test]
+    fn stale_request_ignores_freshness_and_vary() {
+        let mut original =
+            reqwest::Request::new(http::Method::GET, "https://example.com/".parse().unwrap());
+        original
+            .headers_mut()
+            .insert(http::header::ACCEPT, "application/json".parse().unwrap());
+        let http_response = http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header(http::header::CACHE_CONTROL, "no-cache")
+            .header(http::header::VARY, "accept")
+            .body(Vec::new())
+            .unwrap();
+        let response = reqwest::Response::from(http_response);
+        let archived = CachePolicyBuilder::new(&original)
+            .build(&response)
+            .to_archived();
+
+        let mut request =
+            reqwest::Request::new(http::Method::GET, "https://example.com/".parse().unwrap());
+        request
+            .headers_mut()
+            .insert(http::header::ACCEPT, "text/html".parse().unwrap());
+
+        assert!(archived.matches_stale_request(&request));
+        assert!(matches!(
+            archived.before_request(&mut request),
+            BeforeRequest::Stale(_)
+        ));
+
+        let request =
+            reqwest::Request::new(http::Method::HEAD, "https://example.com/".parse().unwrap());
+        assert!(archived.matches_stale_request(&request));
+    }
+
+    #[test]
+    fn stale_request_rejects_non_matching_cache_entries() {
+        let original =
+            reqwest::Request::new(http::Method::GET, "https://example.com/".parse().unwrap());
+        let http_response = http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body(Vec::new())
+            .unwrap();
+        let response = reqwest::Response::from(http_response);
+        let archived = CachePolicyBuilder::new(&original)
+            .build(&response)
+            .to_archived();
+
+        let different_uri = reqwest::Request::new(
+            http::Method::GET,
+            "https://example.com/other".parse().unwrap(),
+        );
+        assert!(!archived.matches_stale_request(&different_uri));
+
+        let unsupported_method =
+            reqwest::Request::new(http::Method::POST, "https://example.com/".parse().unwrap());
+        assert!(!archived.matches_stale_request(&unsupported_method));
+
+        let http_response = http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header(http::header::CACHE_CONTROL, "no-store")
+            .body(Vec::new())
+            .unwrap();
+        let response = reqwest::Response::from(http_response);
+        let unstorable = CachePolicyBuilder::new(&original)
+            .build(&response)
+            .to_archived();
+        assert!(!unstorable.matches_stale_request(&original));
     }
 }


### PR DESCRIPTION
Warm offline resolutions currently load and validate each cached response in one blocking task, then decode its payload in a second task, while the allowed-stale path also computes freshness and revalidation state it will never use.

Read, validate, check the request identity, and decode allowed-stale entries in a single blocking task. This preserves the existing miss, corrupt-entry, mismatched-request, `Vary`, and `no-cache` behavior while avoiding the extra request clone. In benchmarks, the largest workload (Airflow, 559 packages) improved wall time by 4.7% and CPU time by 4.2%; smaller workloads showed modest CPU gains with wall time within noise.
