### PR TITLE
Add uv-dev promotion dispatch policy

### DIFF
--- a/.github/automations-dispatch.json
+++ b/.github/automations-dispatch.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "delivery_ttl_seconds": 1209600,
+  "rules": [
+    {
+      "event": "pull_request",
+      "action": "ready_for_review",
+      "repository": "astral-sh/uv-dev",
+      "repository_id": 1302176231,
+      "conditions": {
+        "/pull_request/draft": false,
+        "/pull_request/state": "open",
+        "/pull_request/base/repo/id": 1302176231,
+        "/pull_request/head/repo/id": 1302176231
+      },
+      "verify_pull_request": true,
+      "workflow": {
+        "repository": "astral-sh/uv-dev",
+        "repository_id": 1302176231,
+        "path": ".github/workflows/promote-pull-request.yml",
+        "ref": "main",
+        "inputs": {
+          "pull_request": "/pull_request/number",
+          "head_sha": "/pull_request/head/sha"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add the trusted `uv-dev` promotion route for the automation dispatcher. The policy handles `pull_request.ready_for_review`, verifies the source repository and open, non-draft, same-repository pull request state, and dispatches `promote-pull-request.yml` at `main` with the pull request number and exact head SHA; comment routes remain disabled until their workflow lands.