### PR TITLE
Only rebase pull requests targeting main

### DIFF
--- a/scripts/find-conflicted-pull-requests.sh
+++ b/scripts/find-conflicted-pull-requests.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # GitHub may initially return UNKNOWN while it recalculates mergeability after the base moves.
 for attempt in {1..5}; do
-    pull_requests=$(gh pr list --state open --limit 1000 --json number,mergeable,url,baseRefName,headRefName,headRefOid,isCrossRepository)
+    pull_requests=$(gh pr list --base main --state open --limit 1000 --json number,mergeable,url,baseRefName,headRefName,headRefOid,isCrossRepository)
     unknown=$(jq '[.[] | select(.mergeable == "UNKNOWN")] | length' <<< "$pull_requests")
 
     if (( unknown == 0 || attempt == 5 )); then


### PR DESCRIPTION
The conflicted-pull-request workflow runs when `main` moves, but discovery currently scans pull requests targeting every branch. Restrict `gh pr list` to `--base main` so the automation only rebases and updates pull request heads against the branch that triggered it, avoiding unintended privileged updates for unrelated base branches.