### PR TITLE
Remove the stdin metadata from `uv check`

### DIFF
--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -231,7 +231,6 @@ pub(crate) async fn check(
     };
 
     // Select an environment and, if we found a project, sync it before running checks.
-    let mut workspace_metadata = None;
     let mut locked_ty_path = None;
     let venv_path = if let Some(script) = &script {
         let extras = extras.with_defaults(DefaultExtras::default());
@@ -364,21 +363,6 @@ pub(crate) async fn check(
                 "`--no-sync` is a no-op for Python scripts with inline metadata, which always run in isolation"
             );
         }
-
-        let lock = result.into_lock();
-        let metadata = crate::commands::workspace::metadata::metadata_from_target(
-            Some(&venv),
-            InstallTarget::Script {
-                script,
-                lock: &lock,
-            },
-            &extras,
-            &groups,
-            &settings.resolver,
-        )?;
-        let mut metadata = metadata.to_json()?;
-        metadata.push('\n');
-        workspace_metadata = Some(metadata);
 
         Some(venv.root().to_owned())
     } else if let Some(project) = &project {
@@ -606,30 +590,6 @@ pub(crate) async fn check(
             }
         }
 
-        let lock = result.into_lock();
-
-        let target = match project {
-            VirtualProject::Project(project) => InstallTarget::Project {
-                workspace: project.workspace(),
-                name: project.project_name(),
-                lock: &lock,
-            },
-            VirtualProject::NonProject(workspace) => InstallTarget::NonProjectWorkspace {
-                workspace,
-                lock: &lock,
-            },
-        };
-        let metadata = crate::commands::workspace::metadata::metadata_from_target(
-            (!no_sync).then_some(&venv),
-            target,
-            &extras,
-            &groups,
-            &settings.resolver,
-        )?;
-        let mut metadata = metadata.to_json()?;
-        metadata.push('\n');
-        workspace_metadata = Some(metadata);
-
         Some(venv.root().to_owned())
     } else {
         isolated_venv.map(|venv| venv.root().to_owned())
@@ -647,7 +607,6 @@ pub(crate) async fn check(
         &target_dir,
         script.as_ref().map(|script| script.path.as_path()),
         venv_path.as_deref(),
-        workspace_metadata,
         exclude_newer,
         show_version,
         &client_builder,

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -1,12 +1,9 @@
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::str::FromStr;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
-use tokio::io::AsyncWriteExt;
-use tokio::process::{ChildStdin, Command};
+use tokio::process::Command;
 use tracing::debug;
 
 use uv_bin_install::{BinVersion, Binary, ResolvedVersion, bin_install, find_matching_version};
@@ -18,23 +15,6 @@ use crate::commands::ExitStatus;
 use crate::commands::reporters::BinaryDownloadReporter;
 use crate::printer::Printer;
 
-/// Limit how long uv can block if a version of ty does not consume metadata from stdin.
-const WORKSPACE_METADATA_WRITE_TIMEOUT: Duration = Duration::from_mins(1);
-
-async fn write_workspace_metadata(mut stdin: ChildStdin, workspace_metadata: String) -> Result<()> {
-    match tokio::time::timeout(
-        WORKSPACE_METADATA_WRITE_TIMEOUT,
-        stdin.write_all(workspace_metadata.as_bytes()),
-    )
-    .await
-    {
-        Err(err) => Err(err).context("Timed out while writing workspace metadata to `ty check`"),
-        Ok(Err(err)) if err.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
-        Ok(Err(err)) => Err(err).context("Failed to write workspace metadata to `ty check`"),
-        Ok(Ok(())) => Ok(()),
-    }
-}
-
 /// Run a type check powered by ty.
 pub(super) async fn run(
     version: Option<String>,
@@ -42,7 +22,6 @@ pub(super) async fn run(
     target_dir: &Path,
     check_target: Option<&Path>,
     venv_path: Option<&Path>,
-    workspace_metadata: Option<String>,
     exclude_newer: Option<jiff::Timestamp>,
     show_version: bool,
     client_builder: &BaseClientBuilder<'_>,
@@ -163,33 +142,6 @@ pub(super) async fn run(
         command.env("VIRTUAL_ENV", venv_path);
     }
 
-    if workspace_metadata.is_some() {
-        // Tell `ty` to expect uv metadata on stdin.
-        // This is an environment variable so older ty's don't complain about an unknown CLI flag.
-        command.env("TY_UV_METADATA", "1");
-        command.stdin(Stdio::piped());
-        command.kill_on_drop(true);
-    } else {
-        // Do not let the calling environment opt ty into a protocol uv cannot supply.
-        command.env_remove("TY_UV_METADATA");
-    }
-
-    let mut handle = command.spawn().context("Failed to spawn `ty check`")?;
-    let writer = if let Some(workspace_metadata) = workspace_metadata {
-        debug!("Passing workspace metadata to `ty check` via stdin");
-        let stdin = handle
-            .stdin
-            .take()
-            .context("Failed to open stdin for `ty check`")?;
-        Some(write_workspace_metadata(stdin, workspace_metadata))
-    } else {
-        None
-    };
-
-    if let Some(writer) = writer {
-        let (status, ()) = tokio::try_join!(run_to_completion(handle), writer)?;
-        Ok(status)
-    } else {
-        run_to_completion(handle).await
-    }
+    let handle = command.spawn().context("Failed to spawn `ty check`")?;
+    run_to_completion(handle).await
 }

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -4,13 +4,9 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use uv_cache::{Cache, Refresh};
 use uv_client::BaseClientBuilder;
-use uv_configuration::{
-    Concurrency, DependencyGroupsWithDefaults, DryRun, ExtrasSpecificationWithDefaults,
-};
+use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun};
 use uv_preview::{Preview, PreviewFeature};
-use uv_python::{
-    ConfigDiscovery, PythonDownloads, PythonEnvironment, PythonPreference, PythonRequest,
-};
+use uv_python::{ConfigDiscovery, PythonDownloads, PythonPreference, PythonRequest};
 use uv_resolver::Metadata;
 use uv_scripts::Pep723Script;
 use uv_settings::{MalwareCheckSettings, PythonInstallMirrors};
@@ -29,7 +25,7 @@ use crate::commands::{ExitStatus, UvError, diagnostics};
 use crate::printer::Printer;
 use crate::settings::{FrozenSource, LockCheck, ResolverSettings};
 
-use super::module_owners::{collect_module_owners, find_module_owners};
+use super::module_owners::collect_module_owners;
 
 /// Display metadata about the workspace.
 pub(crate) async fn metadata(
@@ -244,26 +240,6 @@ pub(crate) async fn metadata(
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into())),
         Err(err) => Err(err.into()),
     }
-}
-
-/// Build metadata from an existing lock and environment without synchronizing it.
-pub(crate) fn metadata_from_target(
-    environment: Option<&PythonEnvironment>,
-    target: InstallTarget<'_>,
-    extras: &ExtrasSpecificationWithDefaults,
-    groups: &DependencyGroupsWithDefaults,
-    settings: &ResolverSettings,
-) -> Result<Metadata> {
-    let mut export = metadata_for_target(target)?;
-    if let Some(environment) = environment {
-        let module_owners = find_module_owners(target, environment, extras, groups, settings)
-            .context("Failed to collect module owners")?;
-        export = export
-            .with_environment(environment)
-            .with_module_owners(module_owners);
-    }
-
-    Ok(export)
 }
 
 fn metadata_for_target(target: InstallTarget<'_>) -> Result<Metadata> {

--- a/crates/uv/src/commands/workspace/module_owners.rs
+++ b/crates/uv/src/commands/workspace/module_owners.rs
@@ -95,21 +95,6 @@ pub(crate) async fn collect_module_owners(
     find_module_owners_in_environment(venv, &package_ids)
 }
 
-/// Map the modules in an existing environment to package IDs from the lockfile.
-pub(crate) fn find_module_owners(
-    target: InstallTarget<'_>,
-    venv: &PythonEnvironment,
-    extras: &ExtrasSpecificationWithDefaults,
-    groups: &DependencyGroupsWithDefaults,
-    settings: &ResolverSettings,
-) -> Result<BTreeMap<ModuleName, Vec<String>>> {
-    let Some(package_ids) = selected_package_ids(target, venv, extras, groups, settings)? else {
-        return Ok(BTreeMap::new());
-    };
-
-    find_module_owners_in_environment(venv, &package_ids)
-}
-
 /// Select the package IDs that can own modules in the target resolution.
 fn selected_package_ids(
     target: InstallTarget<'_>,

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -1231,49 +1231,6 @@ fn check_script_ignores_transitive_ty_for_tool_selection() -> Result<()> {
 }
 
 #[test]
-fn check_passes_workspace_metadata_to_ty() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(indoc! {r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = []
-    "#})?;
-    context.temp_dir.child("main.py").write_str(indoc! {r"
-        x: int = 1
-    "})?;
-
-    uv_snapshot!(
-        context.filters(),
-        context
-            .check()
-            .arg("--ty-version")
-            .arg("0.0.17")
-            .arg("--verbose")
-            .env(EnvVars::RUST_LOG, "uv::commands::project::check::ty=debug"),
-        @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
-
-    ----- stderr -----
-    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    DEBUG `--exclude-newer` is ignored for pinned version `0.0.17`
-    DEBUG Using `ty==0.0.17`
-    DEBUG Passing workspace metadata to `ty check` via stdin
-    "
-    );
-
-    Ok(())
-}
-
-#[test]
 fn check_no_sync_errors_on_invalid_lockfile() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
Although it was a nice idea that it would simplify config contracts for an mvp, Micha and I agreed it Simply Doesn't Work because in scanning a workspace's files, ty is liable to find PEP-723 scripts, and then it *definitely* needs to call back into uv anyway.

So, rather than include two modes, where one maybe works better in simple workspaces with weird flags, we're going to just have the one mode where ty calls back into uv.

This does mean we're preserving a bit of unfortunate redundancy, in that we still need to do a sync to get the ty binary to invoke, and then ty will turn around and ask for the sync again... but it's fine, if they were going to be able to reuse the sync then it's gonna be a super cheap resync.

The more notable "hole" this opens up is this command now takes various cli flags that ty will not respect when it reinvokes uv. For the MVP we are mostly just going with "that's fine, let's ship and iterate, it's all in preview".

The most important settings to forward along should really be persistently saved in config or env-vars, so common things will "just work". The most important contradiction to this is IMO `--isolated`, especially because we published some docs that suggested it with the precommit hook, that's what https://github.com/astral-sh/uv/pull/20500 is for.