### PR TITLE
Add python interpreter info to `uv workspace metadata`

### DIFF
--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -12,7 +12,8 @@ pub enum Error {
     UnknownImplementation(String),
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Default, PartialOrd, Ord, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Default, PartialOrd, Ord, Hash, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ImplementationName {
     Pyodide,
     GraalPy,
@@ -21,7 +22,8 @@ pub enum ImplementationName {
     CPython,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash, serde::Serialize)]
+#[serde(untagged)]
 pub enum LenientImplementationName {
     Unknown(String),
     Known(ImplementationName),

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -10,8 +10,9 @@ pub use flat_index::{FlatDistributions, FlatIndex};
 pub use fork_strategy::ForkStrategy;
 pub use lock::{
     DependencySelection, Installable, Lock, LockError, LockVersion, Metadata, Package, PackageMap,
-    PylockToml, PylockTomlError, PylockTomlErrorKind, RequirementsTxtExport, ResolverManifest,
-    SatisfiesResult, SelectedDependency, TreeDisplay, TreeJsonTarget, VERSION, cyclonedx_json,
+    PylockToml, PylockTomlError, PylockTomlErrorKind, PythonReport, RequirementsTxtExport,
+    ResolverManifest, SatisfiesResult, SelectedDependency, TreeDisplay, TreeJsonTarget, VERSION,
+    cyclonedx_json,
 };
 pub use manifest::Manifest;
 pub use options::{Flexibility, Options, OptionsBuilder};

--- a/crates/uv-resolver/src/lock/export/metadata.rs
+++ b/crates/uv-resolver/src/lock/export/metadata.rs
@@ -7,9 +7,9 @@ use uv_distribution_types::{Name, Requirement, RequiresPython, ResolvedDist, Url
 use uv_fs::PortablePathBuf;
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
-use uv_pep508::MarkerTree;
+use uv_pep508::{MarkerTree, StringVersion};
 use uv_pypi_types::{ConflictItem, ConflictKind, ConflictSet, Conflicts, ModuleName};
-use uv_python::PythonEnvironment;
+use uv_python::{Interpreter, LenientImplementationName, PythonEnvironment};
 use uv_workspace::Workspace;
 
 use crate::lock::{
@@ -115,18 +115,42 @@ struct MetadataEnvironment {
     /// Absolute path to the environment root.
     root: PortablePathBuf,
     /// Information about the Python interpreter in the environment.
-    python: MetadataPython,
+    python: PythonReport,
 }
 
 /// Information about the Python interpreter in a synchronized environment.
 #[derive(Debug, serde::Serialize)]
-struct MetadataPython {
+pub struct PythonReport {
     /// Absolute path to the Python executable.
     path: PortablePathBuf,
     /// Full Python version.
-    version: Version,
+    version: StringVersion,
     /// Python implementation name.
-    implementation: String,
+    implementation: LenientImplementationName,
+}
+
+impl From<&Interpreter> for PythonReport {
+    fn from(interpreter: &Interpreter) -> Self {
+        Self {
+            path: PortablePathBuf::from(interpreter.sys_executable()),
+            version: interpreter.python_full_version().clone(),
+            implementation: LenientImplementationName::from(interpreter.implementation_name()),
+        }
+    }
+}
+
+impl PythonReport {
+    /// Return the path to the Python executable.
+    pub fn path(&self) -> &Path {
+        self.path.as_ref()
+    }
+
+    /// Set the path to the Python executable.
+    #[must_use]
+    pub fn with_path(mut self, path: PortablePathBuf) -> Self {
+        self.path = path;
+        self
+    }
 }
 
 /// The script entry-point.
@@ -1445,14 +1469,9 @@ impl Metadata {
 
     #[must_use]
     pub fn with_environment(mut self, environment: &PythonEnvironment) -> Self {
-        let interpreter = environment.interpreter();
         self.environment = Some(MetadataEnvironment {
             root: PortablePathBuf::from(environment.root()),
-            python: MetadataPython {
-                path: PortablePathBuf::from(interpreter.sys_executable()),
-                version: interpreter.python_version().clone(),
-                implementation: interpreter.implementation_name().to_string(),
-            },
+            python: PythonReport::from(environment.interpreter()),
         });
         self
     }

--- a/crates/uv-resolver/src/lock/export/metadata.rs
+++ b/crates/uv-resolver/src/lock/export/metadata.rs
@@ -9,6 +9,7 @@ use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
 use uv_pypi_types::{ConflictItem, ConflictKind, ConflictSet, Conflicts, ModuleName};
+use uv_python::PythonEnvironment;
 use uv_workspace::Workspace;
 
 use crate::lock::{
@@ -113,6 +114,19 @@ struct SchemaReport {
 struct MetadataEnvironment {
     /// Absolute path to the environment root.
     root: PortablePathBuf,
+    /// Information about the Python interpreter in the environment.
+    python: MetadataPython,
+}
+
+/// Information about the Python interpreter in a synchronized environment.
+#[derive(Debug, serde::Serialize)]
+struct MetadataPython {
+    /// Absolute path to the Python executable.
+    path: PortablePathBuf,
+    /// Full Python version.
+    version: Version,
+    /// Python implementation name.
+    implementation: String,
 }
 
 /// The script entry-point.
@@ -1430,9 +1444,15 @@ impl Metadata {
     }
 
     #[must_use]
-    pub fn with_environment_root(mut self, environment_root: &Path) -> Self {
+    pub fn with_environment(mut self, environment: &PythonEnvironment) -> Self {
+        let interpreter = environment.interpreter();
         self.environment = Some(MetadataEnvironment {
-            root: PortablePathBuf::from(environment_root),
+            root: PortablePathBuf::from(environment.root()),
+            python: MetadataPython {
+                path: PortablePathBuf::from(interpreter.sys_executable()),
+                version: interpreter.python_version().clone(),
+                implementation: interpreter.implementation_name().to_string(),
+            },
         });
         self
     }

--- a/crates/uv-resolver/src/lock/export/mod.rs
+++ b/crates/uv-resolver/src/lock/export/mod.rs
@@ -17,7 +17,7 @@ use uv_pypi_types::ConflictItem;
 
 use crate::graph_ops::Reachable;
 use crate::lock::LockErrorKind;
-pub use crate::lock::export::metadata::Metadata;
+pub use crate::lock::export::metadata::{Metadata, PythonReport};
 pub(crate) use crate::lock::export::metadata::{
     MetadataNode, MetadataNodeId, MetadataNodeKind, MetadataScript, MetadataWorkspace,
     MetadataWorkspaceMember,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -59,7 +59,7 @@ use crate::fork_strategy::ForkStrategy;
 pub(crate) use crate::lock::export::PylockTomlPackage;
 pub use crate::lock::export::RequirementsTxtExport;
 pub use crate::lock::export::{
-    Metadata, PylockToml, PylockTomlError, PylockTomlErrorKind, cyclonedx_json,
+    Metadata, PylockToml, PylockTomlError, PylockTomlErrorKind, PythonReport, cyclonedx_json,
 };
 pub use crate::lock::installable::Installable;
 pub use crate::lock::map::PackageMap;

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -31,7 +31,9 @@ use uv_python::{
     ConfigDiscovery, PythonDownloads, PythonEnvironment, PythonPreference, PythonRequest,
 };
 use uv_redacted::DisplaySafeUrl;
-use uv_resolver::{FlatIndex, ForkStrategy, Installable, Lock, PrereleaseMode, ResolutionMode};
+use uv_resolver::{
+    FlatIndex, ForkStrategy, Installable, Lock, PrereleaseMode, PythonReport, ResolutionMode,
+};
 use uv_scripts::Pep723Script;
 use uv_settings::{MalwareCheckSettings, PythonInstallMirrors};
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
@@ -1309,32 +1311,6 @@ impl LockAction {
 }
 
 #[derive(Serialize, Debug)]
-struct PythonReport {
-    path: PortablePathBuf,
-    version: uv_pep508::StringVersion,
-    implementation: String,
-}
-
-impl From<&uv_python::Interpreter> for PythonReport {
-    fn from(interpreter: &uv_python::Interpreter) -> Self {
-        Self {
-            path: interpreter.sys_executable().into(),
-            version: interpreter.python_full_version().clone(),
-            implementation: interpreter.implementation_name().to_string(),
-        }
-    }
-}
-
-impl PythonReport {
-    /// Set the path for this Python report.
-    #[must_use]
-    fn with_path(mut self, path: PortablePathBuf) -> Self {
-        self.path = path;
-        self
-    }
-}
-
-#[derive(Serialize, Debug)]
 struct EnvironmentReport {
     /// The path to the environment.
     path: PortablePathBuf,
@@ -1368,8 +1344,7 @@ impl EnvironmentReport {
     /// Set the path for this environment report.
     #[must_use]
     fn with_path(mut self, path: PortablePathBuf) -> Self {
-        let python_path = &self.python.path;
-        if let Ok(python_path) = python_path.as_ref().strip_prefix(self.path) {
+        if let Ok(python_path) = self.python.path().strip_prefix(self.path) {
             let new_path = path.as_ref().to_path_buf().join(python_path);
             self.python = self.python.with_path(new_path.as_path().into());
         }

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -232,7 +232,7 @@ pub(crate) async fn metadata(
                 .await
                 .context("Failed to collect module owners")?;
                 export = export
-                    .with_environment_root(environment.root())
+                    .with_environment(&environment)
                     .with_module_owners(module_owners);
             }
 
@@ -259,7 +259,7 @@ pub(crate) fn metadata_from_target(
         let module_owners = find_module_owners(target, environment, extras, groups, settings)
             .context("Failed to collect module owners")?;
         export = export
-            .with_environment_root(environment.root())
+            .with_environment(environment)
             .with_module_owners(module_owners);
     }
 

--- a/crates/uv/tests/workspace/workspace_metadata.rs
+++ b/crates/uv/tests/workspace/workspace_metadata.rs
@@ -160,7 +160,12 @@ import iniconfig
       },
       "workspace_root": "[TEMP_DIR]/",
       "environment": {
-        "root": "[CACHE_DIR]/environments-v2/script-[HASH]"
+        "root": "[CACHE_DIR]/environments-v2/script-[HASH]",
+        "python": {
+          "path": "[CACHE_DIR]/environments-v2/script-[HASH]/bin/python",
+          "version": "3.12.[X]",
+          "implementation": "cpython"
+        }
       },
       "script": {
         "path": "[TEMP_DIR]/script.py",
@@ -633,7 +638,12 @@ dependencies = [
       },
       "workspace_root": "[TEMP_DIR]/",
       "environment": {
-        "root": "[VENV]/"
+        "root": "[VENV]/",
+        "python": {
+          "path": "[VENV]/bin/python3",
+          "version": "3.12.[X]",
+          "implementation": "cpython"
+        }
       },
       "workspace": {
         "path": "[TEMP_DIR]/",

--- a/crates/uv/tests/workspace/workspace_metadata.rs
+++ b/crates/uv/tests/workspace/workspace_metadata.rs
@@ -131,7 +131,9 @@ fn workspace_metadata_simple() {
 #[test]
 #[cfg(feature = "test-pypi")]
 fn workspace_metadata_script() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin();
     let script = context.temp_dir.child("script.py");
     script.write_str(
         r#"# /// script
@@ -162,7 +164,7 @@ import iniconfig
       "environment": {
         "root": "[CACHE_DIR]/environments-v2/script-[HASH]",
         "python": {
-          "path": "[CACHE_DIR]/environments-v2/script-[HASH]/bin/python",
+          "path": "[CACHE_DIR]/environments-v2/script-[HASH]/[BIN]/[PYTHON]",
           "version": "3.12.[X]",
           "implementation": "cpython"
         }
@@ -579,7 +581,9 @@ fn workspace_metadata_sync_active_environment() -> Result<()> {
 
 #[test]
 fn workspace_metadata_module_owners_from_locked_wheels() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin();
 
     let gpu_a = context.temp_dir.child("gpu_a-0.1.0-py3-none-any.whl");
     write_wheel(gpu_a.path(), "gpu-a", "gpu_a-0.1.0", &[("gpu/a.py", "")])?;
@@ -640,7 +644,7 @@ dependencies = [
       "environment": {
         "root": "[VENV]/",
         "python": {
-          "path": "[VENV]/bin/python3",
+          "path": "[VENV]/[BIN]/[PYTHON]",
           "version": "3.12.[X]",
           "implementation": "cpython"
         }

--- a/docs/reference/internals/metadata.md
+++ b/docs/reference/internals/metadata.md
@@ -171,7 +171,16 @@ Here is a human-readable annotated example:
   // Information about the environment, currently only available with `--sync`
   "environment": {
     // The absolute path to the environment root
-    "root": "/workspace/.venv"
+    "root": "/workspace/.venv",
+    // Information about the Python interpreter in the environment
+    "python": {
+      // The absolute path to the Python executable
+      "path": "/workspace/.venv/bin/python",
+      // The full Python version
+      "version": "3.12.12",
+      // The Python implementation name
+      "implementation": "cpython"
+    }
   },
   // Information about the script target, only present with `--script`.
   // Workspace metadata uses `workspace` and `members` below as graph entry-points instead.


### PR DESCRIPTION
This should be the same format as `uv sync --format json`. Several times it's come up that ty might want this info spoon-fed to it and it's just generally nice to have, so let's add it.

Intentionally no changes to the equivalent `uv tree` json because it doesn't do --sync.
