### PR TITLE
Simplify markers under known platform exclusions

### DIFF
--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -52,7 +52,7 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use arcstr::ArcStr;
 use itertools::{Either, Itertools};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use version_ranges::Ranges;
 
 use uv_pep440::{Operator, Version, VersionSpecifier, release_specifier_to_range};
@@ -429,6 +429,48 @@ impl InternerGuard<'_> {
         self.state.cache.insert((xi, yi), node);
 
         node
+    }
+
+    /// Simplify a marker under the assumption that known incompatibilities cannot occur.
+    pub(crate) fn simplify_exclusions(
+        &mut self,
+        node: NodeId,
+        left: NodeId,
+        right: NodeId,
+    ) -> NodeId {
+        if matches!(node, NodeId::TRUE | NodeId::FALSE)
+            || matches!(left, NodeId::TRUE | NodeId::FALSE)
+            || matches!(right, NodeId::TRUE | NodeId::FALSE)
+            || !self.shared.node(node).var.is_conflicting_variable()
+            || !self.shared.node(left).var.is_conflicting_variable()
+            || !self.shared.node(right).var.is_conflicting_variable()
+        {
+            return node;
+        }
+        let exclusions = self.exclusions();
+        let restricted = self.restrict(node, exclusions.not());
+        // Restricting can introduce decisions from the assumption. Keep the original marker when
+        // that would make the decision diagram larger.
+        if self.node_count(restricted) < self.node_count(node) {
+            restricted
+        } else {
+            node
+        }
+    }
+
+    /// Returns the number of unique decision nodes reachable from `node`.
+    fn node_count(&self, node: NodeId) -> usize {
+        let mut seen = FxHashSet::default();
+        let mut pending = vec![node];
+        while let Some(node) = pending.pop() {
+            if matches!(node, NodeId::TRUE | NodeId::FALSE) {
+                continue;
+            }
+            if seen.insert(node.index()) {
+                pending.extend(self.shared.node(node).children.nodes());
+            }
+        }
+        seen.len()
     }
 
     /// Returns `true` if there is no environment in which both marker trees can apply,

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -841,12 +841,16 @@ impl MarkerTree {
 
     /// Combine this marker tree with the one given via a conjunction.
     pub fn and(&mut self, tree: Self) {
-        self.0 = INTERNER.lock().and(self.0, tree.0);
+        let mut interner = INTERNER.lock();
+        let node = interner.and(self.0, tree.0);
+        self.0 = interner.simplify_exclusions(node, self.0, tree.0);
     }
 
     /// Combine this marker tree with the one given via a disjunction.
     pub fn or(&mut self, tree: Self) {
-        self.0 = INTERNER.lock().or(self.0, tree.0);
+        let mut interner = INTERNER.lock();
+        let node = interner.or(self.0, tree.0);
+        self.0 = interner.simplify_exclusions(node, self.0, tree.0);
     }
 
     /// Sets this to a marker equivalent to the implication of this one and the
@@ -3034,6 +3038,36 @@ mod test {
             "(os_name == 'nt' and sys_platform == 'win32') or (os_name != 'nt' and (sys_platform == 'win32' or sys_platform == 'win64'))",
             "(os_name != 'nt' and sys_platform == 'win64') or sys_platform == 'win32'",
         );
+    }
+
+    #[test]
+    fn test_marker_exclusion_domain() {
+        assert_simplifies(
+            "os_name == 'nt' and sys_platform != 'linux'",
+            "os_name == 'nt'",
+        );
+        assert_true("os_name != 'nt' or sys_platform != 'linux'");
+        assert_true("sys_platform != 'linux' or platform_system != 'FreeBSD'");
+
+        let mut marker = m("os_name == 'nt'");
+        marker.and(m(
+            "(platform_machine != 'aarch64' and sys_platform == 'linux') or \
+             (sys_platform != 'darwin' and sys_platform != 'linux')",
+        ));
+
+        assert_eq!(marker, m("os_name == 'nt'"));
+        let serialized = marker.try_to_string().unwrap();
+        assert_eq!(marker, m(&serialized));
+        assert_eq!(marker.negate(), m("os_name != 'nt'"));
+
+        let mut marker = m("os_name != 'nt'");
+        marker.or(m(
+            "(platform_machine == 'aarch64' or sys_platform != 'linux') and \
+             (sys_platform == 'darwin' or sys_platform == 'linux')",
+        ));
+        assert_eq!(marker, m("os_name != 'nt'"));
+        let serialized = marker.try_to_string().unwrap();
+        assert_eq!(marker, m(&serialized));
     }
 
     #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -16395,6 +16395,107 @@ fn lock_impossible_platform_markers() -> Result<()> {
     Ok(())
 }
 
+/// Check that a Windows-only dependency doesn't retain impossible branches from platform forks.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_simplifies_impossible_platform_branches() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let dependency = context.temp_dir.child("dependency");
+    dependency.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "dependency"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+        "#,
+    )?;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["dependency ; os_name == 'nt'"]
+
+        [tool.uv]
+        environments = [
+            "sys_platform == 'darwin'",
+            "platform_machine == 'aarch64' and sys_platform == 'linux'",
+            "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
+        ]
+
+        [tool.uv.sources]
+        dependency = { path = "./dependency" }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--check"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "sys_platform == 'darwin'",
+            "platform_machine == 'aarch64' and sys_platform == 'linux'",
+            "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
+        ]
+        supported-markers = [
+            "sys_platform == 'darwin'",
+            "platform_machine == 'aarch64' and sys_platform == 'linux'",
+            "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
+        ]
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "dependency"
+        version = "0.1.0"
+        source = { directory = "dependency" }
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "dependency", marker = "os_name == 'nt'" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "dependency", marker = "os_name == 'nt'", directory = "dependency" }]
+        "#);
+    });
+
+    Ok(())
+}
+
 /// Change indexes between locking operations.
 #[cfg(feature = "test-universal")]
 #[tokio::test]


### PR DESCRIPTION
## Summary

Treat known-incompatible platform combinations as don't-care environments when combining marker trees. This lets us discard impossible branches inside otherwise-valid expressions while retaining the original tree when restriction would grow the diagram.

For example, a Windows-only dependency reaching the non-Darwin/non-Linux remainder fork now remains `os_name == 'nt'` instead of carrying an impossible `sys_platform == 'linux'` branch. Add a lock/check snapshot covering the round-trip.

Related to https://github.com/astral-sh/uv/issues/16442.