### PR TITLE
Restrict resolver fork markers under their parent environment

### DIFF
--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -448,14 +448,7 @@ impl InternerGuard<'_> {
             return node;
         }
         let exclusions = self.exclusions();
-        let restricted = self.restrict(node, exclusions.not());
-        // Restricting can introduce decisions from the assumption. Keep the original marker when
-        // that would make the decision diagram larger.
-        if self.node_count(restricted) < self.node_count(node) {
-            restricted
-        } else {
-            node
-        }
+        self.restrict_bounded(node, exclusions.not())
     }
 
     /// Returns the number of unique decision nodes reachable from `node`.
@@ -603,6 +596,19 @@ impl InternerGuard<'_> {
     pub(crate) fn restrict(&mut self, value: NodeId, assumption: NodeId) -> NodeId {
         let mut cache = FxHashMap::default();
         self.restrict_cached(value, assumption, &mut cache)
+    }
+
+    /// Restricts a marker without increasing the size of its decision diagram.
+    pub(crate) fn restrict_bounded(&mut self, value: NodeId, assumption: NodeId) -> NodeId {
+        if assumption.is_true() || matches!(value, NodeId::TRUE | NodeId::FALSE) {
+            return value;
+        }
+        let restricted = self.restrict(value, assumption);
+        if self.node_count(restricted) < self.node_count(value) {
+            restricted
+        } else {
+            value
+        }
     }
 
     fn restrict_cached(

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1284,6 +1284,12 @@ impl MarkerTree {
         Self(INTERNER.lock().restrict(self.0, assumption.0))
     }
 
+    /// Restricts this marker like [`Self::restrict`] without increasing the size of its tree.
+    #[must_use]
+    pub fn restrict_bounded(self, assumption: Self) -> Self {
+        Self(INTERNER.lock().restrict_bounded(self.0, assumption.0))
+    }
+
     /// Remove the extras from a marker, returning `None` if the marker tree evaluates to `true`.
     ///
     /// Any `extra` markers that are always `true` given the provided extras will be removed.
@@ -1972,6 +1978,7 @@ mod test {
 
         let simplified = marker.restrict(environment);
         assert_eq!(simplified, m("python_version < '3.11'"));
+        assert_eq!(marker.restrict_bounded(environment), simplified);
 
         let mut reconstructed = simplified;
         reconstructed.and(environment);
@@ -1981,6 +1988,11 @@ mod test {
         let marker = m("python_version >= '3.12'");
         let assumption = m("sys_platform == 'linux' or python_version >= '3.12'");
         assert_eq!(marker.restrict(assumption), marker);
+
+        let marker = m("python_version >= '3.10' and python_version < '3.13'");
+        let assumption = m("python_version >= '3.10'");
+        assert_eq!(marker.restrict(assumption), m("python_version < '3.13'"));
+        assert_eq!(marker.restrict_bounded(assumption), marker);
 
         for (marker, assumption) in [
             ("python_version < '3.11'", "sys_platform == 'linux'"),

--- a/crates/uv-resolver/src/resolver/environment.rs
+++ b/crates/uv-resolver/src/resolver/environment.rs
@@ -525,7 +525,7 @@ impl std::fmt::Display for ResolverEnvironment {
 ///
 /// 1. Forking cannot be ruled out.
 /// 2. The dependency is excluded by the "parent" fork.
-/// 3. The dependency is unconditional and thus cannot provoke new forks.
+/// 3. The dependency is unconditional in the "parent" fork and thus cannot provoke new forks.
 ///
 /// This enum encapsulates those possibilities. In the first case, a helper is
 /// returned to help management the nuts and bolts of forking.
@@ -541,9 +541,14 @@ impl<'d> ForkingPossibility<'d> {
         let marker = dep.package.marker();
         if !env.included_by_marker(marker) {
             ForkingPossibility::DependencyAlwaysExcluded
-        } else if marker.is_true() {
+        } else if marker.is_true() || !env.included_by_marker(marker.negate()) {
             ForkingPossibility::NoForkingPossible
         } else {
+            // All forks visited by this forker are contained within the original parent, so the
+            // forker can drop conditions implied by the parent while the dependency keeps its original.
+            let marker = env
+                .fork_markers()
+                .map_or(marker, |parent| marker.restrict_bounded(parent));
             let forker = Forker {
                 package: &dep.package,
                 marker,

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -3997,7 +3997,7 @@ impl Forks {
                         continue;
                     }
                     ForkingPossibility::NoForkingPossible => {
-                        // Or, if the markers are always true, then we just
+                        // Or, if the markers are always true within the parent fork, then we just
                         // add the dependency to every fork unconditionally.
                         for fork in &mut forks {
                             fork.add_dependency(dep.clone());

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -1449,6 +1449,138 @@ fn fork_marker_accrue() -> Result<()> {
     Ok(())
 }
 
+/// The Linux branch selects two versions of `b` on complementary architecture and Python markers.
+/// Both dependency markers also include a Darwin branch, which is unreachable from the Linux
+/// parent and should not produce additional forks or leak into the serialized dependency markers.
+#[test]
+fn fork_marker_restrict_context() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/marker-restrict-context.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''a<2 ; sys_platform == 'linux'''',
+          '''a>=2 ; sys_platform != 'linux'''',
+        ]
+        requires-python = ">=3.12"
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
+            "sys_platform != 'linux'",
+        ]
+
+        [[package]]
+        name = "a"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
+        ]
+        dependencies = [
+            { name = "b", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version < '3.13' or platform_machine != 'x86_64'" },
+            { name = "b", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version >= '3.13' and platform_machine == 'x86_64'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/a-1.0.0.tar.gz", hash = "sha256:56b651e6dc2f66bd4b76142bf6c3b9ccd119d7dea6299779d53fb036e2ce43bb", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl", hash = "sha256:02038cb16423a695b074aedd0e375db4b1e506b1f61e8d40c2ec889b14379ddf", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "a"
+        version = "2.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform != 'linux'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/a-2.0.0.tar.gz", hash = "sha256:80ec95a66cff82a78a3333e3f5702e4254cf80533f21762933252eec58c9869a", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/a-2.0.0-py3-none-any.whl", hash = "sha256:833374310e0a15880f3be9e6d082f527c9ac70129b2054d733da9b754315361f", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "b"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/b-1.0.0.tar.gz", hash = "sha256:b532bd9c3ccd69c4d5e915542dc50fb748c91c7a8e204c75387178d68fca113f", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/b-1.0.0-py3-none-any.whl", hash = "sha256:a4c65510001153cab97a29ff219ad86e0d4330653ca89d9d4c84187ccf14c621", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "b"
+        version = "2.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/b-2.0.0.tar.gz", hash = "sha256:18fb09ba28eba255186405065e027093a6e952fa71eb565b4c46d619fdb60809", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/b-2.0.0-py3-none-any.whl", hash = "sha256:04cc57f7563029528b6d23283933b244b6f52ba1543fad54687c586d6e639fc4", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "a", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'linux'" },
+            { name = "a", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'linux'" },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "a", marker = "sys_platform != 'linux'", specifier = ">=2" },
+            { name = "a", marker = "sys_platform == 'linux'", specifier = "<2" },
+        ]
+        "#);
+    });
+
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 /// A basic test that ensures, at least in this one basic case, that forking in
 /// universal resolution happens only when the corresponding marker expressions are
 /// completely disjoint. Here, we provide two completely incompatible dependency

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -1449,138 +1449,6 @@ fn fork_marker_accrue() -> Result<()> {
     Ok(())
 }
 
-/// The Linux branch selects two versions of `b` on complementary architecture and Python markers.
-/// Both dependency markers also include a Darwin branch, which is unreachable from the Linux
-/// parent and should not produce additional forks or leak into the serialized dependency markers.
-#[test]
-fn fork_marker_restrict_context() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let server = PackseServer::new("fork/marker-restrict-context.toml");
-
-    let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(
-        r###"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        dependencies = [
-          '''a<2 ; sys_platform == 'linux'''',
-          '''a>=2 ; sys_platform != 'linux'''',
-        ]
-        requires-python = ">=3.12"
-        "###,
-    )?;
-
-    let filters = context.filters();
-
-    let mut cmd = context.lock();
-    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
-    cmd.arg("--index-url").arg(server.index_url());
-    uv_snapshot!(filters, cmd, @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Resolved 5 packages in [TIME]
-    ");
-
-    let lock = context.read("uv.lock");
-    insta::with_settings!({
-        filters => filters,
-    }, {
-        assert_snapshot!(lock, @r#"
-        version = 1
-        revision = 3
-        requires-python = ">=3.12"
-        resolution-markers = [
-            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
-            "sys_platform != 'linux'",
-        ]
-
-        [[package]]
-        name = "a"
-        version = "1.0.0"
-        source = { registry = "http://[LOCALHOST]/simple/" }
-        resolution-markers = [
-            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
-        ]
-        dependencies = [
-            { name = "b", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version < '3.13' or platform_machine != 'x86_64'" },
-            { name = "b", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version >= '3.13' and platform_machine == 'x86_64'" },
-        ]
-        sdist = { url = "http://[LOCALHOST]/files/a-1.0.0.tar.gz", hash = "sha256:56b651e6dc2f66bd4b76142bf6c3b9ccd119d7dea6299779d53fb036e2ce43bb", upload-time = "2024-03-24T00:00:00Z" }
-        wheels = [
-            { url = "http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl", hash = "sha256:02038cb16423a695b074aedd0e375db4b1e506b1f61e8d40c2ec889b14379ddf", upload-time = "2024-03-24T00:00:00Z" },
-        ]
-
-        [[package]]
-        name = "a"
-        version = "2.0.0"
-        source = { registry = "http://[LOCALHOST]/simple/" }
-        resolution-markers = [
-            "sys_platform != 'linux'",
-        ]
-        sdist = { url = "http://[LOCALHOST]/files/a-2.0.0.tar.gz", hash = "sha256:80ec95a66cff82a78a3333e3f5702e4254cf80533f21762933252eec58c9869a", upload-time = "2024-03-24T00:00:00Z" }
-        wheels = [
-            { url = "http://[LOCALHOST]/files/a-2.0.0-py3-none-any.whl", hash = "sha256:833374310e0a15880f3be9e6d082f527c9ac70129b2054d733da9b754315361f", upload-time = "2024-03-24T00:00:00Z" },
-        ]
-
-        [[package]]
-        name = "b"
-        version = "1.0.0"
-        source = { registry = "http://[LOCALHOST]/simple/" }
-        resolution-markers = [
-            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
-        ]
-        sdist = { url = "http://[LOCALHOST]/files/b-1.0.0.tar.gz", hash = "sha256:b532bd9c3ccd69c4d5e915542dc50fb748c91c7a8e204c75387178d68fca113f", upload-time = "2024-03-24T00:00:00Z" }
-        wheels = [
-            { url = "http://[LOCALHOST]/files/b-1.0.0-py3-none-any.whl", hash = "sha256:a4c65510001153cab97a29ff219ad86e0d4330653ca89d9d4c84187ccf14c621", upload-time = "2024-03-24T00:00:00Z" },
-        ]
-
-        [[package]]
-        name = "b"
-        version = "2.0.0"
-        source = { registry = "http://[LOCALHOST]/simple/" }
-        resolution-markers = [
-            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-        ]
-        sdist = { url = "http://[LOCALHOST]/files/b-2.0.0.tar.gz", hash = "sha256:18fb09ba28eba255186405065e027093a6e952fa71eb565b4c46d619fdb60809", upload-time = "2024-03-24T00:00:00Z" }
-        wheels = [
-            { url = "http://[LOCALHOST]/files/b-2.0.0-py3-none-any.whl", hash = "sha256:04cc57f7563029528b6d23283933b244b6f52ba1543fad54687c586d6e639fc4", upload-time = "2024-03-24T00:00:00Z" },
-        ]
-
-        [[package]]
-        name = "project"
-        version = "0.1.0"
-        source = { virtual = "." }
-        dependencies = [
-            { name = "a", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'linux'" },
-            { name = "a", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'linux'" },
-        ]
-
-        [package.metadata]
-        requires-dist = [
-            { name = "a", marker = "sys_platform != 'linux'", specifier = ">=2" },
-            { name = "a", marker = "sys_platform == 'linux'", specifier = "<2" },
-        ]
-        "#);
-    });
-
-    context
-        .lock()
-        .arg("--locked")
-        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
-        .arg("--index-url")
-        .arg(server.index_url())
-        .assert()
-        .success();
-
-    Ok(())
-}
-
 /// A basic test that ensures, at least in this one basic case, that forking in
 /// universal resolution happens only when the corresponding marker expressions are
 /// completely disjoint. Here, we provide two completely incompatible dependency
@@ -2745,6 +2613,165 @@ fn fork_marker_limited_inherit() -> Result<()> {
             { name = "a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "a", marker = "sys_platform == 'linux'", specifier = ">=2" },
             { name = "b" },
+        ]
+        "#
+        );
+    });
+
+    // Assert the idempotence of `uv lock` when resolving from the lockfile (`--locked`).
+    context
+        .lock()
+        .arg("--locked")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .arg("--index-url")
+        .arg(server.index_url())
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+/// This scenario checks that dependency markers are simplified using the parent
+/// fork before creating child forks. The Linux branch selects two versions of
+/// `b` on complementary architecture and Python markers, while both dependencies
+/// also include a Darwin branch that cannot be reached from the Linux parent.
+///
+///
+/// ```text
+/// fork-marker-restrict-context
+/// ├── environment
+/// │   └── python3.12
+/// ├── root
+/// │   ├── requires a<2 ; sys_platform == 'linux'
+/// │   │   └── satisfied by a-1.0.0
+/// │   └── requires a>=2 ; sys_platform != 'linux'
+/// │       └── satisfied by a-2.0.0
+/// ├── a
+/// │   ├── a-1.0.0
+/// │   │   ├── requires b<2 ; (python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
+/// │   │   │   └── satisfied by b-1.0.0
+/// │   │   └── requires b>=2 ; (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
+/// │   │       └── satisfied by b-2.0.0
+/// │   └── a-2.0.0
+/// └── b
+///     ├── b-1.0.0
+///     └── b-2.0.0
+/// ```
+#[test]
+fn fork_marker_restrict_context() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/marker-restrict-context.toml");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''a<2 ; sys_platform == 'linux'''',
+          '''a>=2 ; sys_platform != 'linux'''',
+        ]
+        requires-python = ">=3.12"
+        "###,
+    )?;
+
+    let filters = context.filters();
+
+    let mut cmd = context.lock();
+    cmd.env_remove(EnvVars::UV_EXCLUDE_NEWER);
+    cmd.arg("--index-url").arg(server.index_url());
+    uv_snapshot!(filters, cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
+            "sys_platform != 'linux'",
+        ]
+
+        [[package]]
+        name = "a"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
+        ]
+        dependencies = [
+            { name = "b", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version < '3.13' or platform_machine != 'x86_64'" },
+            { name = "b", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "python_full_version >= '3.13' and platform_machine == 'x86_64'" },
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/a-1.0.0.tar.gz", hash = "sha256:56b651e6dc2f66bd4b76142bf6c3b9ccd119d7dea6299779d53fb036e2ce43bb", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl", hash = "sha256:02038cb16423a695b074aedd0e375db4b1e506b1f61e8d40c2ec889b14379ddf", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "a"
+        version = "2.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "sys_platform != 'linux'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/a-2.0.0.tar.gz", hash = "sha256:80ec95a66cff82a78a3333e3f5702e4254cf80533f21762933252eec58c9869a", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/a-2.0.0-py3-none-any.whl", hash = "sha256:833374310e0a15880f3be9e6d082f527c9ac70129b2054d733da9b754315361f", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "b"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "(python_full_version < '3.13' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/b-1.0.0.tar.gz", hash = "sha256:b532bd9c3ccd69c4d5e915542dc50fb748c91c7a8e204c75387178d68fca113f", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/b-1.0.0-py3-none-any.whl", hash = "sha256:a4c65510001153cab97a29ff219ad86e0d4330653ca89d9d4c84187ccf14c621", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "b"
+        version = "2.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        resolution-markers = [
+            "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+        ]
+        sdist = { url = "http://[LOCALHOST]/files/b-2.0.0.tar.gz", hash = "sha256:18fb09ba28eba255186405065e027093a6e952fa71eb565b4c46d619fdb60809", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/b-2.0.0-py3-none-any.whl", hash = "sha256:04cc57f7563029528b6d23283933b244b6f52ba1543fad54687c586d6e639fc4", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "a", version = "1.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform == 'linux'" },
+            { name = "a", version = "2.0.0", source = { registry = "http://[LOCALHOST]/simple/" }, marker = "sys_platform != 'linux'" },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "a", marker = "sys_platform != 'linux'", specifier = ">=2" },
+            { name = "a", marker = "sys_platform == 'linux'", specifier = "<2" },
         ]
         "#
         );

--- a/test/scenarios/fork/marker-restrict-context.toml
+++ b/test/scenarios/fork/marker-restrict-context.toml
@@ -1,0 +1,29 @@
+name = "fork-marker-restrict-context"
+description = '''
+This scenario checks that dependency markers are simplified using the parent
+fork before creating child forks. The Linux branch selects two versions of
+`b` on complementary architecture and Python markers, while both dependencies
+also include a Darwin branch that cannot be reached from the Linux parent.
+'''
+
+[resolver_options]
+universal = true
+
+[expected]
+satisfiable = true
+
+[root]
+requires = [
+  "a<2 ; sys_platform == 'linux'",
+  "a>=2 ; sys_platform != 'linux'",
+]
+
+[packages.a.versions."1.0.0"]
+requires = [
+  "b<2 ; (sys_platform == 'linux' and (platform_machine != 'x86_64' or python_version < '3.13')) or sys_platform == 'darwin'",
+  "b>=2 ; (sys_platform == 'linux' and platform_machine == 'x86_64' and python_version >= '3.13') or sys_platform == 'darwin'",
+]
+[packages.a.versions."2.0.0"]
+
+[packages.b.versions."1.0.0"]
+[packages.b.versions."2.0.0"]


### PR DESCRIPTION
## Summary

Simplify conditional dependency markers under the original resolver-fork environment before constructing child forks. The dependency retains its standalone marker, while the forker drops decisions that cannot affect any child; exclusion-aware fast paths still handle wholly included or excluded dependencies.

Add a bounded restriction variant so this hot path never enlarges a decision diagram without changing the existing lockfile-oriented restriction behavior. Add a Packse lock snapshot covering complementary Linux architecture/Python forks with an unreachable Darwin branch and the `--locked` round-trip.

Stacked on https://github.com/astral-sh/uv/pull/20503.