### PR TITLE
Skip CLI construction for version-only invocations

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::fmt::Write;
-use std::io::stdout;
+use std::io::{Write as _, stdout};
 #[cfg(feature = "self-update")]
 use std::ops::Bound;
 use std::path::Path;
@@ -3012,6 +3012,29 @@ where
 {
     #[cfg(windows)]
     uv_windows::install_unhandled_exception_handler();
+
+    // Avoid constructing the complete command tree for the common version-only invocation.
+    let mut args = args.into_iter();
+    let executable = args.next();
+    let first = args.next();
+    let second = args.next();
+    if second.is_none()
+        && first.as_ref().is_some_and(|arg| {
+            let arg: OsString = arg.clone().into();
+            arg == "-V" || arg == "--version"
+        })
+    {
+        return if writeln!(stdout().lock(), "uv {}", uv_cli::version::uv_self_version()).is_ok() {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::FAILURE
+        };
+    }
+    let args = executable
+        .into_iter()
+        .chain(first)
+        .chain(second)
+        .chain(args);
 
     // Set the `UV` variable to the current executable so it is implicitly propagated to all child
     // processes, e.g., in `uv run`.

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use anyhow::{Ok, Result};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
@@ -6,6 +8,29 @@ use insta::assert_snapshot;
 
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
+
+#[test]
+fn version_flag() {
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    uv_snapshot!(context.filters(), Command::new(uv_test::get_bin!()).arg("--version"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    uv [VERSION] ([COMMIT] DATE)
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), Command::new(uv_test::get_bin!()).arg("-V"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    uv [VERSION] ([COMMIT] DATE)
+
+    ----- stderr -----
+    ");
+}
 
 // Print the version
 #[test]


### PR DESCRIPTION
## Summary

Skip executable-path resolution and full Clap command construction for the version-only `uv --version` and `uv -V` invocations. All other argument combinations continue through the existing parser, and both spellings have integration snapshot coverage.

## Measurements

Profiling binaries, one pinned CPU, 100 warmups, and 500 alternating pairs:

| Command | Before | After | Change (95% paired CI) |
| --- | ---: | ---: | ---: |
| `uv --version` wall | 9.15 ms | 7.14 ms | -21.8% [-22.2%, -21.3%] |
| `uv --version` CPU | 8.41 ms | 6.42 ms | -23.6% [-24.0%, -23.3%] |

The `--help` and representative basic-command controls were neutral, and output hashes matched.

## Validation

- `cargo clippy --locked -p uv --lib --tests --features test-python,test-pypi -- -D warnings`
- `cargo nextest run --locked -p uv --features test-python,test-pypi --test it -E 'test(version_flag)' --no-capture`
