### PR TITLE
Widen resolver singletons using adjacent versions

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -366,6 +366,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         match result {
                             Err(err) => {
                                 // If unit propagation failed, there is no solution.
+                                for package in derivation_tree_packages(&err) {
+                                    Self::known_versions(
+                                        &self.index,
+                                        &self.installed_packages,
+                                        &state.fork_urls,
+                                        &state.fork_indexes,
+                                        &mut state.known_versions,
+                                        package,
+                                    );
+                                }
                                 return Err(self.convert_no_solution_err(
                                     err,
                                     state.fork_urls,
@@ -1160,6 +1170,47 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             known_versions.insert(name.clone(), versions.into());
         }
         Some(&known_versions[name][..])
+    }
+
+    /// Widen a selected registry version using only its immediate included neighbors.
+    ///
+    /// A single index without installed distributions is already sorted and unique, so widening a
+    /// singleton does not require cloning, sorting, and deduplicating the complete version map.
+    fn widened_singleton_dependency_versions(
+        index: &InMemoryIndex,
+        installed_packages: &InstalledPackages,
+        fork_urls: &ForkUrls,
+        fork_indexes: &ForkIndexes,
+        package: &PubGrubPackage,
+        version: &Version,
+    ) -> Option<Range<Version>> {
+        let name = package.name_no_root()?;
+        if fork_urls.get(name).is_some() || !installed_packages.get_packages(name).is_empty() {
+            return None;
+        }
+        let response = if let Some(index_metadata) = fork_indexes.get(name) {
+            index
+                .explicit()
+                .get(&(name.clone(), index_metadata.url().clone()))?
+        } else {
+            index.implicit().get(name)?
+        };
+        let VersionsResponse::Found(version_maps) = &*response else {
+            return None;
+        };
+        let [version_map] = version_maps.as_slice() else {
+            return None;
+        };
+        let (previous, next) = version_map.neighboring_included_versions(version)?;
+        Some(match (previous, next) {
+            (Some(previous), Some(next)) => Range::from_range_bounds((
+                Bound::Excluded(previous.clone()),
+                Bound::Excluded(next.clone()),
+            )),
+            (Some(previous), None) => Range::strictly_higher_than(previous.clone()),
+            (None, Some(next)) => Range::strictly_lower_than(next.clone()),
+            (None, None) => Range::full(),
+        })
     }
 
     /// Given a candidate package, choose the next version in range to try.
@@ -3249,23 +3300,31 @@ impl ForkState {
 
         // Widen across gaps so rejected adjacent versions merge into contiguous ranges rather
         // than leaving one hole per version.
-        let versions = Range::singleton(for_version.clone());
-        let versions = if let Some(known_versions) =
-            ResolverState::<InstalledPackages>::known_versions(
+        let versions = if let Some(versions) =
+            ResolverState::<InstalledPackages>::widened_singleton_dependency_versions(
                 index,
                 installed_packages,
                 &self.fork_urls,
                 &self.fork_indexes,
-                &mut self.known_versions,
                 &self.pubgrub.package_store[self.next],
-            )
-            .filter(|versions| !versions.is_empty())
+                for_version,
+            ) {
+            versions
+        } else if let Some(known_versions) = ResolverState::<InstalledPackages>::known_versions(
+            index,
+            installed_packages,
+            &self.fork_urls,
+            &self.fork_indexes,
+            &mut self.known_versions,
+            &self.pubgrub.package_store[self.next],
+        )
+        .filter(|versions| !versions.is_empty())
         {
-            versions.widen_versions(known_versions)
+            Range::singleton(for_version.clone()).widen_versions(known_versions)
         } else {
             // A decided version is always selectable and thus in the list, but an empty list
             // would unsoundly widen to the full range.
-            versions
+            Range::singleton(for_version.clone())
         };
         let conflict = self.pubgrub.add_package_version_dependencies(
             self.next,

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -174,6 +174,50 @@ impl VersionMap {
         }
     }
 
+    /// Return the included versions immediately before and after `version`, without materializing
+    /// distributions or cloning the complete version map.
+    pub(crate) fn neighboring_included_versions(
+        &self,
+        version: &Version,
+    ) -> Option<(Option<&Version>, Option<&Version>)> {
+        match &self.inner {
+            VersionMapInner::Eager(eager) => {
+                eager.map.get(version)?;
+                let previous = eager
+                    .map
+                    .range::<Version, _>((Bound::Unbounded, Bound::Excluded(version)))
+                    .next_back()
+                    .map(|(version, _)| version);
+                let next = eager
+                    .map
+                    .range::<Version, _>((Bound::Excluded(version), Bound::Unbounded))
+                    .next()
+                    .map(|(version, _)| version);
+                Some((previous, next))
+            }
+            VersionMapInner::Lazy(lazy) => {
+                let position = lazy
+                    .map
+                    .entries
+                    .binary_search_by(|entry| entry.version.cmp(version))
+                    .ok()?;
+                if !lazy.entry_is_included(&lazy.map.entries[position]) {
+                    return None;
+                }
+                let previous = lazy.map.entries[..position]
+                    .iter()
+                    .rev()
+                    .find(|entry| lazy.entry_is_included(entry))
+                    .map(|entry| &entry.version);
+                let next = lazy.map.entries[position + 1..]
+                    .iter()
+                    .find(|entry| lazy.entry_is_included(entry))
+                    .map(|entry| &entry.version);
+                Some((previous, next))
+            }
+        }
+    }
+
     /// Return the index URL where this package came from.
     pub(crate) fn index(&self) -> Option<&IndexUrl> {
         match &self.inner {
@@ -547,15 +591,21 @@ impl VersionMapLazy {
     /// Returns an iterator over the versions with at least one file within the exclude-newer
     /// cutoffs, without materializing the distributions.
     fn included_versions(&self) -> impl DoubleEndedIterator<Item = &Version> {
-        self.map.entries.iter().filter_map(move |entry| {
-            let included = match (&entry.dist.flat, &entry.dist.simple) {
-                // Flat index files have no upload times and bypass the cutoffs.
-                (Some(_), _) => true,
-                (None, Some(simple)) => self.any_file_included(simple),
-                (None, None) => false,
-            };
-            included.then_some(&entry.version)
-        })
+        self.map
+            .entries
+            .iter()
+            .filter(|entry| self.entry_is_included(entry))
+            .map(|entry| &entry.version)
+    }
+
+    /// Return whether an entry has at least one file within the exclude-newer cutoffs.
+    fn entry_is_included(&self, entry: &VersionMapLazyEntry) -> bool {
+        match (&entry.dist.flat, &entry.dist.simple) {
+            // Flat index files have no upload times and bypass the cutoffs.
+            (Some(_), _) => true,
+            (None, Some(simple)) => self.any_file_included(simple),
+            (None, None) => false,
+        }
     }
 
     /// Returns whether at least one file keeps this version inside the candidate universe.
@@ -904,5 +954,47 @@ impl<'a> RangeBounds<Version> for BoundingRange<'a> {
 
     fn end_bound(&self) -> Bound<&'a Version> {
         self.max
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use uv_distribution_types::PrioritizedDist;
+    use uv_pep440::Version;
+
+    use super::{VersionMap, VersionMapEager, VersionMapInner};
+
+    #[test]
+    fn neighboring_included_versions() {
+        let first = Version::new([1]);
+        let second = Version::new([2]);
+        let third = Version::new([3]);
+        let map = VersionMap {
+            inner: VersionMapInner::Eager(VersionMapEager {
+                map: BTreeMap::from([
+                    (first.clone(), PrioritizedDist::default()),
+                    (second.clone(), PrioritizedDist::default()),
+                    (third.clone(), PrioritizedDist::default()),
+                ]),
+                stable: true,
+                local: false,
+            }),
+        };
+
+        assert_eq!(
+            map.neighboring_included_versions(&first),
+            Some((None, Some(&second)))
+        );
+        assert_eq!(
+            map.neighboring_included_versions(&second),
+            Some((Some(&first), Some(&third)))
+        );
+        assert_eq!(
+            map.neighboring_included_versions(&third),
+            Some((Some(&second), None))
+        );
+        assert_eq!(map.neighboring_included_versions(&Version::new([4])), None);
     }
 }


### PR DESCRIPTION
## Summary

Every selected registry version currently clones, sorts, and deduplicates the full candidate universe before widening a singleton dependency incompatibility. For the common single-index/no-installed case, use the immediately included neighboring versions directly, skipping cutoff-excluded entries without materializing distributions. Preserve the full-universe path for installed, multi-index, and URL candidates, and reconstruct complete sets before narrowing no-solution diagnostics.

## Measurements

Warm offline caches, profiling binaries, pinned CPUs, alternating pairs, and identical lock hashes for every pair:

| Workload | Pairs | CPU change (95% paired CI) |
| --- | ---: | ---: |
| Jupyter | 200 | -1.22% [-1.71%, -0.73%] |
| Airflow | 200 | -0.92% [-1.54%, -0.29%] |
| large-index | 200 | -1.15% [-1.70%, -0.58%] |
| Boto | 80 | -0.27% [-3.22%, +2.76%] |

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p uv-resolver --lib --tests -- -D warnings`
- `cargo test --locked -p uv-resolver --lib -- --nocapture` (66 passed)
- focused exclude-newer, offline/backtracking, invalid-metadata, and no-solution integration tests (7 passed)
