### PR TITLE
Represent invalid marker environments with don't-care nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6900,6 +6900,7 @@ dependencies = [
  "arcstr",
  "astral-version-ranges",
  "boxcar",
+ "hashbrown 0.17.1",
  "indexmap",
  "insta",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6903,6 +6903,7 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools 0.14.0",
+ "papaya",
  "regex",
  "rkyv",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6903,7 +6903,6 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools 0.14.0",
- "papaya",
  "regex",
  "rkyv",
  "rustc-hash",

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -25,6 +25,7 @@ arcstr = { workspace = true}
 boxcar = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
+papaya = { workspace = true }
 regex = { workspace = true }
 rkyv = { workspace = true, optional = true }
 rustc-hash = { workspace = true }

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -23,6 +23,7 @@ uv-redacted = { workspace = true }
 
 arcstr = { workspace = true}
 boxcar = { workspace = true }
+hashbrown = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 regex = { workspace = true }

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -25,7 +25,6 @@ arcstr = { workspace = true}
 boxcar = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-papaya = { workspace = true }
 regex = { workspace = true }
 rkyv = { workspace = true, optional = true }
 rustc-hash = { workspace = true }

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -491,17 +491,7 @@ impl InternerGuard<'_> {
         // A single conflicting variable (or the non-conflicting `os_name` and
         // `platform_system` pair) does not need to be expanded across the validity domain.
         if !self.can_conflict(node) {
-            let current = self.shared.node(node);
-            let projected = if current.children.is_coalesced() {
-                node
-            } else {
-                let children = current.children.clone().coalesce();
-                self.create_node(current.var.clone(), children).negate(node)
-            };
-            self.shared.cache_projection(projected, projected);
-            self.shared
-                .cache_projection(projected.not(), projected.not());
-            return projected;
+            return self.coalesce_boolean(node);
         }
         let validity = self.exclusions().not();
         let masked = self.mask(node, validity);
@@ -574,6 +564,29 @@ impl InternerGuard<'_> {
 
             can_conflict || self.can_conflict(*child)
         })
+    }
+
+    /// Recursively coalesce a Boolean marker tree without performing ternary projection.
+    fn coalesce_boolean(&mut self, value: NodeId) -> NodeId {
+        if value.is_terminal() {
+            return value;
+        }
+        if let Some(projected) = self.shared.projection(value) {
+            return projected;
+        }
+
+        let node = self.shared.node(value);
+        let children = node
+            .children
+            .map(value, |child| self.coalesce_boolean(child))
+            .coalesce();
+        let projected = self.create_node(node.var.clone(), children);
+        self.shared.cache_projection(value, projected);
+        self.shared.cache_projection(value.not(), projected.not());
+        self.shared.cache_projection(projected, projected);
+        self.shared
+            .cache_projection(projected.not(), projected.not());
+        projected
     }
 
     /// Replace all reachable Boolean terminals while retaining unreachable edges.
@@ -2177,25 +2190,6 @@ impl Edges {
             },
             Self::Boolean { .. } => self,
         }
-    }
-
-    /// Returns `true` if no adjacent range edges can be merged.
-    fn is_coalesced(&self) -> bool {
-        match self {
-            Self::Version { edges } => Self::ranges_are_coalesced(edges),
-            Self::String { edges } => Self::ranges_are_coalesced(edges),
-            Self::Boolean { .. } => true,
-        }
-    }
-
-    /// Returns `true` if no adjacent ranges point to the same node.
-    fn ranges_are_coalesced<T>(edges: &SmallVec<(Ranges<T>, NodeId)>) -> bool
-    where
-        T: Clone + Ord,
-    {
-        edges
-            .windows(2)
-            .all(|edges| edges[0].1 != edges[1].1 || !can_conjoin(&edges[0].0, &edges[1].0))
     }
 
     /// Merge adjacent ranges that point to the same node.

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -52,7 +52,7 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use arcstr::ArcStr;
 use itertools::{Either, Itertools};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use version_ranges::Ranges;
 
 use uv_pep440::{Operator, Version, VersionSpecifier, release_specifier_to_range};
@@ -703,80 +703,24 @@ impl InternerGuard<'_> {
 
     /// Returns `true` if a ternary marker can reach a `true` terminal on a valid assignment.
     fn can_be_true(&self, node: NodeId) -> bool {
-        let mut seen = FxHashSet::default();
-        let mut pending = vec![node];
-        while let Some(node) = pending.pop() {
-            if node.is_true() {
-                return true;
-            }
-            if node.is_terminal() || !seen.insert(node) {
-                continue;
-            }
-            pending.extend(
-                self.shared
-                    .node(node)
-                    .children
-                    .nodes()
-                    .map(|child| child.negate(node)),
-            );
+        if node.is_true() {
+            return true;
         }
-        false
+        if node.is_terminal() {
+            return false;
+        }
+
+        self.shared
+            .node(node)
+            .children
+            .nodes()
+            .any(|child| self.can_be_true(child.negate(node)))
     }
 
     /// Returns `true` if there is no environment in which both marker trees can apply,
     /// i.e. their conjunction is always `false`.
     pub(crate) fn is_disjoint(&mut self, xi: NodeId, yi: NodeId) -> bool {
-        if xi.is_dont_care() || yi.is_dont_care() {
-            return true;
-        }
-        // `false` is disjoint with any marker.
-        if xi.is_false() || yi.is_false() {
-            return true;
-        }
-        // `true` is not disjoint with any marker except `false`.
-        if xi.is_true() {
-            return !self.can_be_true(yi);
-        }
-        if yi.is_true() {
-            return !self.can_be_true(xi);
-        }
-        // `X` and `X` are not disjoint.
-        if xi == yi {
-            return !self.can_be_true(xi);
-        }
-        // `X` and `not X` are disjoint by definition.
-        if xi.not() == yi {
-            return true;
-        }
-
-        let (x, y) = (self.shared.node(xi), self.shared.node(yi));
-
-        // Determine whether the conjunction _could_ contain a conflict.
-        //
-        // As an optimization, we only have to perform this check at the top-level, since these
-        // variables are given higher priority in the tree. In other words, if they're present, they
-        // _must_ be at the top; and if they're not at the top, we know they aren't present in any
-        // children.
-        if x.var.is_conflicting_variable() && y.var.is_conflicting_variable() {
-            let node = self.and(xi, yi);
-            return !self.can_be_true(node);
-        }
-
-        // Perform Shannon Expansion of the higher order variable.
-        match x.var.cmp(&y.var) {
-            // X is higher order than Y, Y must be disjoint with every child of X.
-            Ordering::Less => x
-                .children
-                .nodes()
-                .all(|x| self.disjointness(x.negate(xi), yi)),
-            // Y is higher order than X, X must be disjoint with every child of Y.
-            Ordering::Greater => y
-                .children
-                .nodes()
-                .all(|y| self.disjointness(y.negate(yi), xi)),
-            // X and Y represent the same variable, their merged edges must be unsatisfiable.
-            Ordering::Equal => x.children.is_disjoint(xi, &y.children, yi, self),
-        }
+        self.disjointness(xi, yi)
     }
 
     /// Returns `true` if there is no environment in which both marker trees can apply,
@@ -785,11 +729,6 @@ impl InternerGuard<'_> {
         if xi.is_dont_care() || yi.is_dont_care() {
             return true;
         }
-        // NOTE(charlie): This is equivalent to `is_disjoint`, with the exception that it doesn't
-        // perform the mutually-incompatible marker check. If it did, we'd create an infinite loop,
-        // since `is_disjoint` calls `and` (when relevant variables are present) which then calls
-        // `disjointness`.
-
         // `false` is disjoint with any marker.
         if xi.is_false() || yi.is_false() {
             return true;
@@ -2361,6 +2300,19 @@ mod tests {
             let raw = interner.expression_raw(expression);
             assert_eq!(interner.finish(raw), raw);
         }
+    }
+
+    #[test]
+    fn disjointness_does_not_intern_conjunctions() {
+        let windows = expr("os_name == 'nt'");
+        let linux = expr("sys_platform == 'linux'");
+        let netbsd = expr("platform_system == 'NetBSD'");
+
+        let mut interner = INTERNER.lock();
+        let nodes = INTERNER.shared.nodes.count();
+        assert!(interner.is_disjoint(windows, linux));
+        assert!(!interner.is_disjoint(windows, netbsd));
+        assert_eq!(INTERNER.shared.nodes.count(), nodes);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -473,7 +473,7 @@ impl InternerGuard<'_> {
             {
                 projected
             } else {
-                masked
+                self.mask(projected, validity)
             }
         }
     }

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -1447,7 +1447,7 @@ impl Variable {
     ///
     /// For example, `sys_platform == 'win32'` and `platform_system == 'Darwin'` are known to
     /// never be true at the same time.
-    fn is_conflicting_variable(&self) -> bool {
+    pub(super) fn is_conflicting_variable(&self) -> bool {
         let Self::String(marker) = self else {
             return false;
         };

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -1012,6 +1012,16 @@ impl InternerGuard<'_> {
             return self.disjointness(xi, yi);
         }
 
+        // A validity-masked tree compared with an ordinary tree can produce a quadratic number
+        // of distinct requirement/wheel pairs. The ordinary tree cannot distinguish unreachable
+        // platform branches, so compare against the cached Boolean projection and avoid both the
+        // expanded validity diagram and permanent pair-cache retention.
+        if !trees_conflict && left_can_conflict != right_can_conflict {
+            let left = self.shared.projection(xi).unwrap_or(xi);
+            let right = self.shared.projection(yi).unwrap_or(yi);
+            return self.disjointness(left, right);
+        }
+
         let key = if xi <= yi { (xi, yi) } else { (yi, xi) };
         if let Some(&disjoint) = self.state.disjointness_cache.get(&key) {
             return disjoint;
@@ -2994,6 +3004,42 @@ mod tests {
         for (index, left) in markers.iter().enumerate() {
             for right in &markers[index + 1..] {
                 assert!(interner.is_disjoint(*left, *right));
+            }
+        }
+        assert_eq!(INTERNER.shared.nodes.count(), nodes);
+        assert_eq!(interner.state.disjointness_cache.len(), cache);
+    }
+
+    #[test]
+    fn disjointness_does_not_cache_one_sided_platform_checks() {
+        let windows = expr("os_name == 'nt'");
+        let linux = expr("sys_platform == 'linux'");
+        let extras = (0..64)
+            .map(|index| expr(&format!("extra == 'disjoint-extra-{index}'")))
+            .collect::<Vec<_>>();
+        let machines = (0..64)
+            .map(|index| expr(&format!("platform_machine == 'disjoint-machine-{index}'")))
+            .collect::<Vec<_>>();
+
+        let mut interner = INTERNER.lock();
+        let platform = interner.or(windows, linux);
+        let markers = extras
+            .iter()
+            .map(|extra| interner.and(platform, *extra))
+            .collect::<Vec<_>>();
+        assert!(markers.iter().all(|marker| interner.can_conflict(*marker)));
+        assert!(
+            machines
+                .iter()
+                .all(|machine| !interner.can_conflict(*machine))
+        );
+
+        let nodes = INTERNER.shared.nodes.count();
+        let cache = interner.state.disjointness_cache.len();
+        for marker in markers {
+            for machine in &machines {
+                assert!(!interner.is_disjoint(marker, *machine));
+                assert!(!interner.is_disjoint(*machine, marker));
             }
         }
         assert_eq!(INTERNER.shared.nodes.count(), nodes);

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -490,9 +490,18 @@ impl InternerGuard<'_> {
         }
         // A single conflicting variable (or the non-conflicting `os_name` and
         // `platform_system` pair) does not need to be expanded across the validity domain.
-        // Projection also coalesces any redundant range boundaries left by prior operations.
         if !self.can_conflict(node) {
-            return self.project(node);
+            let current = self.shared.node(node);
+            let projected = if current.children.is_coalesced() {
+                node
+            } else {
+                let children = current.children.clone().coalesce();
+                self.create_node(current.var.clone(), children).negate(node)
+            };
+            self.shared.cache_projection(projected, projected);
+            self.shared
+                .cache_projection(projected.not(), projected.not());
+            return projected;
         }
         let validity = self.exclusions().not();
         let masked = self.mask(node, validity);
@@ -521,8 +530,48 @@ impl InternerGuard<'_> {
         }
 
         let node = self.shared.node(node);
-        node.children.nodes().any(|child| {
-            !child.is_terminal() && node.var.conflicts_with(&self.shared.node(child).var)
+        let Edges::String { edges } = &node.children else {
+            return false;
+        };
+
+        let excluded_values: &[&str] = match node.var {
+            Variable::String(CanonicalMarkerValueString::OsName) => &["nt", "posix"],
+            Variable::String(CanonicalMarkerValueString::SysPlatform) => &[
+                "linux",
+                "darwin",
+                "ios",
+                "win32",
+                "aix",
+                "android",
+                "emscripten",
+                "cygwin",
+                "wasi",
+            ],
+            _ => &[],
+        };
+        let references_excluded_value = edges.iter().any(|(range, _)| {
+            range.iter().any(|(start, end)| {
+                [start, end].into_iter().any(|bound| {
+                    matches!(bound, Bound::Included(value) | Bound::Excluded(value)
+                        if excluded_values.contains(&value.as_ref()))
+                })
+            })
+        });
+
+        edges.iter().any(|(_, child)| {
+            if child.is_terminal() {
+                return false;
+            }
+
+            let child_node = self.shared.node(*child);
+            if !child_node.var.is_conflicting_variable() {
+                return false;
+            }
+
+            let can_conflict =
+                references_excluded_value && node.var.conflicts_with(&child_node.var);
+
+            can_conflict || self.can_conflict(*child)
         })
     }
 
@@ -2129,6 +2178,25 @@ impl Edges {
         }
     }
 
+    /// Returns `true` if no adjacent range edges can be merged.
+    fn is_coalesced(&self) -> bool {
+        match self {
+            Self::Version { edges } => Self::ranges_are_coalesced(edges),
+            Self::String { edges } => Self::ranges_are_coalesced(edges),
+            Self::Boolean { .. } => true,
+        }
+    }
+
+    /// Returns `true` if no adjacent ranges point to the same node.
+    fn ranges_are_coalesced<T>(edges: &SmallVec<(Ranges<T>, NodeId)>) -> bool
+    where
+        T: Clone + Ord,
+    {
+        edges
+            .windows(2)
+            .all(|edges| edges[0].1 != edges[1].1 || !can_conjoin(&edges[0].0, &edges[1].0))
+    }
+
     /// Merge adjacent ranges that point to the same node.
     fn coalesce_ranges<T>(edges: SmallVec<(Ranges<T>, NodeId)>) -> SmallVec<(Ranges<T>, NodeId)>
     where
@@ -2556,6 +2624,48 @@ mod tests {
         );
         let raw = interner.and_cached(os_name, platform_system);
         assert_eq!(interner.finish(raw), raw);
+    }
+
+    #[test]
+    fn markers_without_reachable_exclusion_remain_boolean() {
+        let mut interner = INTERNER.lock();
+        let mut custom = NodeId::FALSE;
+        for index in 0..32 {
+            let os_name = interner.expression_raw(
+                MarkerExpression::from_str(&format!("os_name == 'custom-os-{index}'"))
+                    .unwrap()
+                    .unwrap(),
+            );
+            let sys_platform = interner.expression_raw(
+                MarkerExpression::from_str(&format!("sys_platform == 'custom-sys-{index}'"))
+                    .unwrap()
+                    .unwrap(),
+            );
+            let alternative = interner.and_cached(os_name, sys_platform);
+            custom = interner.or_cached(custom, alternative);
+        }
+        assert!(!interner.can_conflict(custom));
+        assert_eq!(interner.finish(custom), custom);
+
+        let os_name = interner.expression_raw(
+            MarkerExpression::from_str("os_name == 'custom-os'")
+                .unwrap()
+                .unwrap(),
+        );
+        let sys_platform = interner.expression_raw(
+            MarkerExpression::from_str("sys_platform == 'linux'")
+                .unwrap()
+                .unwrap(),
+        );
+        let platform_system = interner.expression_raw(
+            MarkerExpression::from_str("platform_system == 'FreeBSD'")
+                .unwrap()
+                .unwrap(),
+        );
+        let nested = interner.and_cached(os_name, sys_platform);
+        let nested = interner.and_cached(nested, platform_system);
+        assert!(interner.can_conflict(nested));
+        assert!(interner.finish(nested).is_false());
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -772,21 +772,29 @@ impl InternerGuard<'_> {
     /// Returns `true` if there is no environment in which both marker trees can apply,
     /// i.e. their conjunction is always `false`.
     pub(crate) fn is_disjoint(&mut self, xi: NodeId, yi: NodeId) -> bool {
+        let roots_conflict = !xi.is_terminal()
+            && !yi.is_terminal()
+            && self
+                .shared
+                .node(xi)
+                .var
+                .conflicts_with(&self.shared.node(yi).var);
+        let left_can_conflict = self.can_conflict(xi);
+        let right_can_conflict = self.can_conflict(yi);
+        let validity_sensitive = left_can_conflict || right_can_conflict || roots_conflict;
+
+        // Ordinary Boolean trees are cheap to compare, and caching every pair can otherwise
+        // retain a quadratic number of entries during requirement and wheel selection.
+        if !validity_sensitive {
+            return self.disjointness(xi, yi);
+        }
+
         let key = if xi <= yi { (xi, yi) } else { (yi, xi) };
         if let Some(&disjoint) = self.state.disjointness_cache.get(&key) {
             return disjoint;
         }
 
-        let disjoint = if !xi.is_terminal()
-            && !yi.is_terminal()
-            && !self.can_conflict(xi)
-            && !self.can_conflict(yi)
-            && self
-                .shared
-                .node(xi)
-                .var
-                .conflicts_with(&self.shared.node(yi).var)
-        {
+        let disjoint = if roots_conflict && !left_can_conflict && !right_can_conflict {
             // Singleton platform predicates remain Boolean until they are combined. Account
             // for the validity domain here without materializing their conjunction.
             let validity = self.exclusions().not();
@@ -2555,6 +2563,8 @@ mod tests {
         let windows = expr("os_name == 'nt'");
         let linux = expr("sys_platform == 'linux'");
         let netbsd = expr("platform_system == 'NetBSD'");
+        let x86 = expr("platform_machine == 'x86_64'");
+        let arm = expr("platform_machine == 'aarch64'");
 
         let mut interner = INTERNER.lock();
         interner.exclusions();
@@ -2573,7 +2583,9 @@ mod tests {
         assert_eq!(interner.state.disjointness_cache.len(), cache + 1);
         assert!(!interner.is_disjoint(windows, netbsd));
         assert!(!interner.is_disjoint(netbsd, windows));
-        assert_eq!(interner.state.disjointness_cache.len(), cache + 2);
+        assert_eq!(interner.state.disjointness_cache.len(), cache + 1);
+        assert!(interner.is_disjoint(x86, arm));
+        assert_eq!(interner.state.disjointness_cache.len(), cache + 1);
         assert_eq!(INTERNER.shared.nodes.count(), nodes);
     }
 

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -100,6 +100,15 @@ struct InternerState {
 
     /// The [`NodeId`] for the disjunction of known, mutually incompatible markers.
     exclusions: Option<NodeId>,
+
+    /// A cache for applying a validity domain to a marker tree.
+    mask_cache: FxHashMap<(NodeId, NodeId), NodeId>,
+
+    /// A cache for replacing reachable terminal values while retaining don't-care edges.
+    terminal_cache: FxHashMap<(NodeId, NodeId), NodeId>,
+
+    /// A cache for projecting ternary trees back to Boolean marker trees.
+    projection_cache: FxHashMap<NodeId, NodeId>,
 }
 
 impl InternerShared {
@@ -130,7 +139,12 @@ impl InternerGuard<'_> {
     /// Creates a decision node with the given variable and children.
     fn create_node(&mut self, var: Variable, children: Edges) -> NodeId {
         let mut node = Node { var, children };
-        let mut first = node.children.nodes().next().unwrap();
+
+        // A don't-care edge is self-complementing and therefore cannot determine the canonical
+        // orientation of a node. Use the first reachable edge as the pivot instead.
+        let Some(mut first) = node.children.nodes().find(|node| !node.is_dont_care()) else {
+            return NodeId::DONT_CARE;
+        };
 
         // With a complemented edge representation, there are two ways to represent the same node:
         // complementing the root and all children edges results in the same node. To ensure markers
@@ -160,6 +174,12 @@ impl InternerGuard<'_> {
 
     /// Returns a decision node for a single marker expression.
     pub(crate) fn expression(&mut self, expr: MarkerExpression) -> NodeId {
+        let node = self.expression_raw(expr);
+        self.finish(node)
+    }
+
+    /// Returns an unmasked decision node for a single marker expression.
+    pub(super) fn expression_raw(&mut self, expr: MarkerExpression) -> NodeId {
         let (var, children) = match expr {
             // A variable representing the output of a version key. Edges correspond
             // to disjoint version ranges.
@@ -349,13 +369,26 @@ impl InternerGuard<'_> {
 
     /// Returns a decision node representing the disjunction of two nodes.
     pub(crate) fn or(&mut self, xi: NodeId, yi: NodeId) -> NodeId {
+        let node = self.or_cached(xi, yi);
+        self.finish(node)
+    }
+
+    pub(super) fn or_cached(&mut self, xi: NodeId, yi: NodeId) -> NodeId {
         // We take advantage of cheap negation here and implement OR in terms
         // of it's De Morgan complement.
-        self.and(xi.not(), yi.not()).not()
+        self.and_cached(xi.not(), yi.not()).not()
     }
 
     /// Returns a decision node representing the conjunction of two nodes.
     pub(crate) fn and(&mut self, xi: NodeId, yi: NodeId) -> NodeId {
+        let node = self.and_cached(xi, yi);
+        self.finish(node)
+    }
+
+    pub(super) fn and_cached(&mut self, xi: NodeId, yi: NodeId) -> NodeId {
+        if xi.is_dont_care() || yi.is_dont_care() {
+            return NodeId::DONT_CARE;
+        }
         if xi.is_true() {
             return yi;
         }
@@ -365,12 +398,15 @@ impl InternerGuard<'_> {
         if xi == yi {
             return xi;
         }
-        if xi.is_false() || yi.is_false() {
-            return NodeId::FALSE;
+        if xi.is_false() {
+            return self.replace_terminals(yi, NodeId::FALSE);
+        }
+        if yi.is_false() {
+            return self.replace_terminals(xi, NodeId::FALSE);
         }
         // `X and not X` is `false` by definition.
         if xi.not() == yi {
-            return NodeId::FALSE;
+            return self.replace_terminals(xi, NodeId::FALSE);
         }
 
         // The operation was memoized.
@@ -380,47 +416,29 @@ impl InternerGuard<'_> {
 
         let (x, y) = (self.shared.node(xi), self.shared.node(yi));
 
-        // Determine whether the conjunction _could_ contain a conflict.
-        //
-        // As an optimization, we only have to perform this check at the top-level, since these
-        // variables are given higher priority in the tree. In other words, if they're present, they
-        // _must_ be at the top; and if they're not at the top, we know they aren't present in any
-        // children.
-        let conflicts = x.var.is_conflicting_variable() && y.var.is_conflicting_variable();
-
         // Perform Shannon Expansion of the higher order variable.
         let (func, children) = match x.var.cmp(&y.var) {
             // X is higher order than Y, apply Y to every child of X.
             Ordering::Less => {
-                let children = x.children.map(xi, |node| self.and(node, yi));
+                let children = x.children.map(xi, |node| self.and_cached(node, yi));
                 (x.var.clone(), children)
             }
             // Y is higher order than X, apply X to every child of Y.
             Ordering::Greater => {
-                let children = y.children.map(yi, |node| self.and(node, xi));
+                let children = y.children.map(yi, |node| self.and_cached(node, xi));
                 (y.var.clone(), children)
             }
             // X and Y represent the same variable, merge their children.
             Ordering::Equal => {
-                let children = x.children.apply(xi, &y.children, yi, |x, y| self.and(x, y));
+                let children = x
+                    .children
+                    .apply(xi, &y.children, yi, |x, y| self.and_cached(x, y));
                 (x.var.clone(), children)
             }
         };
 
         // Create the output node.
         let node = self.create_node(func, children);
-
-        // If the node includes known incompatibilities, map it to `false`.
-        let node = if conflicts {
-            let exclusions = self.exclusions();
-            if self.disjointness(node, exclusions.not()) {
-                NodeId::FALSE
-            } else {
-                node
-            }
-        } else {
-            node
-        };
 
         // Memoize the result of this operation.
         //
@@ -431,62 +449,287 @@ impl InternerGuard<'_> {
         node
     }
 
-    /// Simplify a marker under the assumption that known incompatibilities cannot occur.
-    pub(crate) fn simplify_exclusions(
-        &mut self,
-        node: NodeId,
-        left: NodeId,
-        right: NodeId,
-    ) -> NodeId {
-        if matches!(node, NodeId::TRUE | NodeId::FALSE)
-            || matches!(left, NodeId::TRUE | NodeId::FALSE)
-            || matches!(right, NodeId::TRUE | NodeId::FALSE)
-            || !self.shared.node(node).var.is_conflicting_variable()
-            || !self.shared.node(left).var.is_conflicting_variable()
-            || !self.shared.node(right).var.is_conflicting_variable()
-        {
+    /// Apply the global validity domain and collapse roots that are constant on that domain.
+    pub(crate) fn finish(&mut self, node: NodeId) -> NodeId {
+        if node.is_terminal() {
             return node;
         }
-        let exclusions = self.exclusions();
-        let restricted = self.restrict(node, exclusions.not());
-        // Restricting can introduce decisions from the assumption. Keep the original marker when
-        // that would make the decision diagram larger.
-        if self.node_count(restricted) < self.node_count(node) {
-            restricted
+        let validity = self.exclusions().not();
+        let masked = self.mask(node, validity);
+        if masked == self.mask(NodeId::TRUE, validity) {
+            NodeId::TRUE
+        } else if masked == self.mask(NodeId::FALSE, validity) {
+            NodeId::FALSE
         } else {
-            node
+            masked
         }
     }
 
-    /// Returns the number of unique decision nodes reachable from `node`.
-    fn node_count(&self, node: NodeId) -> usize {
+    /// Replace all reachable Boolean terminals while retaining unreachable edges.
+    fn replace_terminals(&mut self, node: NodeId, replacement: NodeId) -> NodeId {
+        if node.is_dont_care() {
+            return node;
+        }
+        if node.is_terminal() {
+            return replacement;
+        }
+        if let Some(&result) = self.state.terminal_cache.get(&(node, replacement)) {
+            return result;
+        }
+        let current = self.shared.node(node);
+        let children = current
+            .children
+            .map(node, |node| self.replace_terminals(node, replacement));
+        let result = self.create_node(current.var.clone(), children);
+        self.state
+            .terminal_cache
+            .insert((node, replacement), result);
+        result
+    }
+
+    /// Apply a validity domain to a marker, replacing unreachable assignments with the
+    /// self-complementing don't-care terminal.
+    fn mask(&mut self, value: NodeId, validity: NodeId) -> NodeId {
+        if validity.is_false() || value.is_dont_care() {
+            return NodeId::DONT_CARE;
+        }
+        if validity.is_true() {
+            return value;
+        }
+        if let Some(&masked) = self.state.mask_cache.get(&(value, validity)) {
+            return masked;
+        }
+
+        let validity_node = self.shared.node(validity);
+        let masked = if value.is_terminal() {
+            let children = validity_node
+                .children
+                .map(validity, |validity| self.mask(value, validity));
+            self.create_node(validity_node.var.clone(), children)
+        } else {
+            let value_node = self.shared.node(value);
+            match value_node.var.cmp(&validity_node.var) {
+                Ordering::Less => {
+                    let children = value_node
+                        .children
+                        .map(value, |value| self.mask(value, validity));
+                    self.create_node(value_node.var.clone(), children)
+                }
+                Ordering::Greater => {
+                    let children = validity_node
+                        .children
+                        .map(validity, |validity| self.mask(value, validity));
+                    self.create_node(validity_node.var.clone(), children)
+                }
+                Ordering::Equal => {
+                    let children = value_node.children.apply(
+                        value,
+                        &validity_node.children,
+                        validity,
+                        |value, validity| self.mask(value, validity),
+                    );
+                    self.create_node(value_node.var.clone(), children)
+                }
+            }
+        };
+
+        self.state.mask_cache.insert((value, validity), masked);
+        masked
+    }
+
+    /// Project a ternary marker into a Boolean marker by assigning unreachable edges to a
+    /// reachable sibling. This keeps the wildcard choice out of the canonical diagram.
+    pub(crate) fn project(&mut self, value: NodeId) -> NodeId {
+        if value.is_dont_care() {
+            return NodeId::FALSE;
+        }
+        let mut compatible_cache = FxHashMap::default();
+        self.project_cached(value, &mut compatible_cache)
+    }
+
+    fn project_cached(
+        &mut self,
+        value: NodeId,
+        compatible_cache: &mut FxHashMap<(NodeId, NodeId), Option<NodeId>>,
+    ) -> NodeId {
+        if value.is_terminal() {
+            return value;
+        }
+        if let Some(&projected) = self.state.projection_cache.get(&value) {
+            return projected;
+        }
+
+        let node = self.shared.node(value);
+
+        // Extend compatible partial functions so that their don't-care values agree. If every
+        // child can be merged, this eliminates the decision; otherwise, merging compatible
+        // groups still allows disjoint ranges to share a projected subtree.
+        let mut groups = Vec::new();
+        let mut assignments = FxHashMap::default();
+        for child in node.children.nodes().map(|child| child.negate(value)) {
+            let mut assignment = None;
+            for (index, group) in groups.iter_mut().enumerate() {
+                if let Some(merged) = self.merge_compatible(*group, child, compatible_cache) {
+                    *group = merged;
+                    assignment = Some(index);
+                    break;
+                }
+            }
+            assignments.insert(
+                child,
+                assignment.unwrap_or_else(|| {
+                    groups.push(child);
+                    groups.len() - 1
+                }),
+            );
+        }
+        if let [group] = groups.as_slice() {
+            let projected = self.project_cached(*group, compatible_cache);
+            self.state.projection_cache.insert(value, projected);
+            self.state.projection_cache.insert(projected, projected);
+            return projected;
+        }
+
+        let children = node.children.map(value, |child| {
+            self.project_cached(groups[assignments[&child]], compatible_cache)
+        });
+        let projected = self.create_node(node.var.clone(), children);
+        self.state.projection_cache.insert(value, projected);
+        self.state.projection_cache.insert(projected, projected);
+        projected
+    }
+
+    /// Merge two ternary functions when they never disagree on a reachable assignment.
+    fn merge_compatible(
+        &mut self,
+        left: NodeId,
+        right: NodeId,
+        cache: &mut FxHashMap<(NodeId, NodeId), Option<NodeId>>,
+    ) -> Option<NodeId> {
+        if left.is_dont_care() {
+            return Some(right);
+        }
+        if right.is_dont_care() || left == right {
+            return Some(left);
+        }
+        if left.is_terminal() && right.is_terminal() {
+            return None;
+        }
+        if let Some(&result) = cache.get(&(left, right)) {
+            return result;
+        }
+
+        let merged = if left.is_terminal() {
+            let node = self.shared.node(right);
+            let children = Self::try_map(&node.children, right, |right| {
+                self.merge_compatible(left, right, cache)
+            });
+            children.map(|children| self.create_node(node.var.clone(), children))
+        } else if right.is_terminal() {
+            let node = self.shared.node(left);
+            let children = Self::try_map(&node.children, left, |left| {
+                self.merge_compatible(left, right, cache)
+            });
+            children.map(|children| self.create_node(node.var.clone(), children))
+        } else {
+            let left_node = self.shared.node(left);
+            let right_node = self.shared.node(right);
+            match left_node.var.cmp(&right_node.var) {
+                Ordering::Less => {
+                    let children = Self::try_map(&left_node.children, left, |left| {
+                        self.merge_compatible(left, right, cache)
+                    });
+                    children.map(|children| self.create_node(left_node.var.clone(), children))
+                }
+                Ordering::Greater => {
+                    let children = Self::try_map(&right_node.children, right, |right| {
+                        self.merge_compatible(left, right, cache)
+                    });
+                    children.map(|children| self.create_node(right_node.var.clone(), children))
+                }
+                Ordering::Equal => {
+                    let mut compatible = true;
+                    let children = left_node.children.apply(
+                        left,
+                        &right_node.children,
+                        right,
+                        |left, right| {
+                            if let Some(merged) = self.merge_compatible(left, right, cache) {
+                                merged
+                            } else {
+                                compatible = false;
+                                NodeId::FALSE
+                            }
+                        },
+                    );
+                    compatible.then(|| self.create_node(left_node.var.clone(), children))
+                }
+            }
+        };
+
+        cache.insert((left, right), merged);
+        merged
+    }
+
+    fn try_map(
+        edges: &Edges,
+        parent: NodeId,
+        mut map: impl FnMut(NodeId) -> Option<NodeId>,
+    ) -> Option<Edges> {
+        let mut compatible = true;
+        let edges = edges.map(parent, |node| {
+            if let Some(node) = map(node) {
+                node
+            } else {
+                compatible = false;
+                NodeId::FALSE
+            }
+        });
+        compatible.then_some(edges)
+    }
+
+    /// Returns `true` if a ternary marker can reach a `true` terminal on a valid assignment.
+    fn can_be_true(&self, node: NodeId) -> bool {
         let mut seen = FxHashSet::default();
         let mut pending = vec![node];
         while let Some(node) = pending.pop() {
-            if matches!(node, NodeId::TRUE | NodeId::FALSE) {
+            if node.is_true() {
+                return true;
+            }
+            if node.is_terminal() || !seen.insert(node) {
                 continue;
             }
-            if seen.insert(node.index()) {
-                pending.extend(self.shared.node(node).children.nodes());
-            }
+            pending.extend(
+                self.shared
+                    .node(node)
+                    .children
+                    .nodes()
+                    .map(|child| child.negate(node)),
+            );
         }
-        seen.len()
+        false
     }
 
     /// Returns `true` if there is no environment in which both marker trees can apply,
     /// i.e. their conjunction is always `false`.
     pub(crate) fn is_disjoint(&mut self, xi: NodeId, yi: NodeId) -> bool {
+        if xi.is_dont_care() || yi.is_dont_care() {
+            return true;
+        }
         // `false` is disjoint with any marker.
         if xi.is_false() || yi.is_false() {
             return true;
         }
         // `true` is not disjoint with any marker except `false`.
-        if xi.is_true() || yi.is_true() {
-            return false;
+        if xi.is_true() {
+            return !self.can_be_true(yi);
+        }
+        if yi.is_true() {
+            return !self.can_be_true(xi);
         }
         // `X` and `X` are not disjoint.
         if xi == yi {
-            return false;
+            return !self.can_be_true(xi);
         }
         // `X` and `not X` are disjoint by definition.
         if xi.not() == yi {
@@ -502,7 +745,8 @@ impl InternerGuard<'_> {
         // _must_ be at the top; and if they're not at the top, we know they aren't present in any
         // children.
         if x.var.is_conflicting_variable() && y.var.is_conflicting_variable() {
-            return self.and(xi, yi).is_false();
+            let node = self.and(xi, yi);
+            return !self.can_be_true(node);
         }
 
         // Perform Shannon Expansion of the higher order variable.
@@ -525,6 +769,9 @@ impl InternerGuard<'_> {
     /// Returns `true` if there is no environment in which both marker trees can apply,
     /// i.e., their conjunction is always `false`.
     fn disjointness(&mut self, xi: NodeId, yi: NodeId) -> bool {
+        if xi.is_dont_care() || yi.is_dont_care() {
+            return true;
+        }
         // NOTE(charlie): This is equivalent to `is_disjoint`, with the exception that it doesn't
         // perform the mutually-incompatible marker check. If it did, we'd create an infinite loop,
         // since `is_disjoint` calls `and` (when relevant variables are present) which then calls
@@ -535,12 +782,15 @@ impl InternerGuard<'_> {
             return true;
         }
         // `true` is not disjoint with any marker except `false`.
-        if xi.is_true() || yi.is_true() {
-            return false;
+        if xi.is_true() {
+            return !self.can_be_true(yi);
+        }
+        if yi.is_true() {
+            return !self.can_be_true(xi);
         }
         // `X` and `X` are not disjoint.
         if xi == yi {
-            return false;
+            return !self.can_be_true(xi);
         }
         // `X` and `not X` are disjoint by definition.
         if xi.not() == yi {
@@ -576,7 +826,7 @@ impl InternerGuard<'_> {
         i: NodeId,
         f: &impl Fn(&Variable) -> Option<bool>,
     ) -> NodeId {
-        if matches!(i, NodeId::TRUE | NodeId::FALSE) {
+        if i.is_terminal() {
             return i;
         }
 
@@ -611,6 +861,9 @@ impl InternerGuard<'_> {
         assumption: NodeId,
         cache: &mut FxHashMap<(NodeId, NodeId), NodeId>,
     ) -> NodeId {
+        if assumption.is_dont_care() || value.is_dont_care() {
+            return NodeId::DONT_CARE;
+        }
         if assumption.is_true() || matches!(value, NodeId::TRUE | NodeId::FALSE) {
             return value;
         }
@@ -642,7 +895,7 @@ impl InternerGuard<'_> {
                 let mut quantified_assumption = NodeId::FALSE;
                 for child in assumption_node.children.nodes() {
                     quantified_assumption =
-                        self.or(quantified_assumption, child.negate(assumption));
+                        self.or_cached(quantified_assumption, child.negate(assumption));
                 }
                 self.restrict_cached(value, quantified_assumption, cache)
             }
@@ -710,7 +963,7 @@ impl InternerGuard<'_> {
         mut i: NodeId,
         cache: &mut FxHashMap<NodeId, NodeId>,
     ) -> NodeId {
-        if matches!(i, NodeId::TRUE | NodeId::FALSE) {
+        if i.is_terminal() {
             return i;
         }
 
@@ -724,7 +977,7 @@ impl InternerGuard<'_> {
         let result = if matches!(node.var, Variable::Extra(_)) {
             i = NodeId::FALSE;
             for child in node.children.nodes() {
-                i = self.or(i, child.negate(parent));
+                i = self.or_cached(i, child.negate(parent));
             }
             if i.is_true() {
                 NodeId::TRUE
@@ -749,7 +1002,7 @@ impl InternerGuard<'_> {
     ///
     /// This works by assuming all non-`extra` nodes are always true.
     pub(crate) fn only_extras(&mut self, mut i: NodeId) -> NodeId {
-        if matches!(i, NodeId::TRUE | NodeId::FALSE) {
+        if i.is_terminal() {
             return i;
         }
 
@@ -758,7 +1011,7 @@ impl InternerGuard<'_> {
         if !matches!(node.var, Variable::Extra(_)) {
             i = NodeId::FALSE;
             for child in node.children.nodes() {
-                i = self.or(i, child.negate(parent));
+                i = self.or_cached(i, child.negate(parent));
             }
             if i.is_true() {
                 return NodeId::TRUE;
@@ -783,9 +1036,7 @@ impl InternerGuard<'_> {
         py_lower: Bound<&Version>,
         py_upper: Bound<&Version>,
     ) -> NodeId {
-        if matches!(i, NodeId::TRUE | NodeId::FALSE)
-            || matches!((py_lower, py_upper), (Bound::Unbounded, Bound::Unbounded))
-        {
+        if i.is_terminal() || matches!((py_lower, py_upper), (Bound::Unbounded, Bound::Unbounded)) {
             return i;
         }
 
@@ -853,7 +1104,7 @@ impl InternerGuard<'_> {
         py_lower: Bound<&Version>,
         py_upper: Bound<&Version>,
     ) -> NodeId {
-        if matches!(i, NodeId::FALSE)
+        if matches!(i, NodeId::FALSE | NodeId::DONT_CARE)
             || matches!((py_lower, py_upper), (Bound::Unbounded, Bound::Unbounded))
         {
             return i;
@@ -1055,87 +1306,87 @@ impl InternerGuard<'_> {
         let mut cache = FxHashMap::default();
 
         // Create all nodes upfront.
-        let os_name_nt = self.expression(MarkerExpression::String {
+        let os_name_nt = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::OsName,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("nt"),
         });
-        let os_name_posix = self.expression(MarkerExpression::String {
+        let os_name_posix = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::OsName,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("posix"),
         });
-        let sys_platform_linux = self.expression(MarkerExpression::String {
+        let sys_platform_linux = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("linux"),
         });
-        let sys_platform_darwin = self.expression(MarkerExpression::String {
+        let sys_platform_darwin = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("darwin"),
         });
-        let sys_platform_ios = self.expression(MarkerExpression::String {
+        let sys_platform_ios = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("ios"),
         });
-        let sys_platform_win32 = self.expression(MarkerExpression::String {
+        let sys_platform_win32 = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("win32"),
         });
-        let platform_system_freebsd = self.expression(MarkerExpression::String {
+        let platform_system_freebsd = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::PlatformSystem,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("FreeBSD"),
         });
-        let platform_system_netbsd = self.expression(MarkerExpression::String {
+        let platform_system_netbsd = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::PlatformSystem,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("NetBSD"),
         });
-        let platform_system_openbsd = self.expression(MarkerExpression::String {
+        let platform_system_openbsd = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::PlatformSystem,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("OpenBSD"),
         });
-        let platform_system_sunos = self.expression(MarkerExpression::String {
+        let platform_system_sunos = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::PlatformSystem,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("SunOS"),
         });
-        let platform_system_ios = self.expression(MarkerExpression::String {
+        let platform_system_ios = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::PlatformSystem,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("iOS"),
         });
-        let platform_system_ipados = self.expression(MarkerExpression::String {
+        let platform_system_ipados = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::PlatformSystem,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("iPadOS"),
         });
-        let sys_platform_aix = self.expression(MarkerExpression::String {
+        let sys_platform_aix = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("aix"),
         });
-        let sys_platform_android = self.expression(MarkerExpression::String {
+        let sys_platform_android = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("android"),
         });
-        let sys_platform_emscripten = self.expression(MarkerExpression::String {
+        let sys_platform_emscripten = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("emscripten"),
         });
-        let sys_platform_cygwin = self.expression(MarkerExpression::String {
+        let sys_platform_cygwin = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("cygwin"),
         });
-        let sys_platform_wasi = self.expression(MarkerExpression::String {
+        let sys_platform_wasi = self.expression_raw(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("wasi"),
@@ -1285,29 +1536,37 @@ impl NodeId {
     // The terminal node representing `false`, or an unsatisfiable node.
     pub(crate) const FALSE: Self = Self(1);
 
+    // The terminal node representing an unreachable assignment.
+    pub(crate) const DONT_CARE: Self = Self(2);
+
     /// Create a new, optionally complemented, [`NodeId`] with the given index.
     fn new(index: usize, complement: bool) -> Self {
         // Ensure the index does not interfere with the lowest complement bit.
-        let index = (index + 1) << 1;
+        let index = (index + 2) << 1;
         Self(index | usize::from(complement))
     }
 
     /// Returns the index of this ID, ignoring the complemented edge.
     fn index(self) -> usize {
         // Ignore the lowest bit and bring indices back to starting at `0`.
-        (self.0 >> 1) - 1
+        debug_assert!(!self.is_terminal());
+        (self.0 >> 1) - 2
     }
 
     /// Returns `true` if this ID represents a complemented edge.
     fn is_complement(self) -> bool {
         // Whether the lowest bit is set.
-        (self.0 & 1) == 1
+        !self.is_dont_care() && (self.0 & 1) == 1
     }
 
     /// Returns the complement of this node.
     pub(crate) fn not(self) -> Self {
-        // Toggle the lowest bit.
-        Self(self.0 ^ 1)
+        if self.is_dont_care() {
+            self
+        } else {
+            // Toggle the lowest bit.
+            Self(self.0 ^ 1)
+        }
     }
 
     /// Returns the complement of this node, if it's parent is complemented.
@@ -1330,6 +1589,16 @@ impl NodeId {
     /// Returns `true` if this node represents a trivially `true` node.
     pub(crate) fn is_true(self) -> bool {
         self == Self::TRUE
+    }
+
+    /// Returns `true` if this node represents an unreachable assignment.
+    fn is_dont_care(self) -> bool {
+        self == Self::DONT_CARE
+    }
+
+    /// Returns `true` if this ID is one of the terminal nodes.
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::TRUE | Self::FALSE | Self::DONT_CARE)
     }
 }
 
@@ -1925,6 +2194,10 @@ impl fmt::Debug for NodeId {
             return write!(f, "true");
         }
 
+        if self.is_dont_care() {
+            return write!(f, "don't care");
+        }
+
         if self.is_complement() {
             write!(f, "{:?}", INTERNER.shared.node(*self).clone().not())
         } else {
@@ -1935,7 +2208,7 @@ impl fmt::Debug for NodeId {
 
 #[cfg(test)]
 mod tests {
-    use super::{INTERNER, NodeId};
+    use super::{Edges, INTERNER, NodeId};
     use crate::MarkerExpression;
 
     fn expr(s: &str) -> NodeId {
@@ -1981,6 +2254,85 @@ mod tests {
         assert_eq!(os_leq_bar, os_geq_bar);
         assert_eq!(m().and(os_geq_bar, os_leq_bar), os_geq_bar);
         assert_eq!(m().or(os_geq_bar, os_leq_bar), os_geq_bar);
+    }
+
+    #[test]
+    fn dont_care() {
+        assert_eq!(NodeId::DONT_CARE.not(), NodeId::DONT_CARE);
+
+        let extra = expr("extra == 'foo'");
+        let variable = INTERNER.shared.node(extra).var.clone();
+        let mut interner = INTERNER.lock();
+
+        for terminal in [NodeId::TRUE, NodeId::FALSE, NodeId::DONT_CARE] {
+            assert_eq!(
+                interner.and_cached(NodeId::DONT_CARE, terminal),
+                NodeId::DONT_CARE
+            );
+            assert_eq!(
+                interner.or_cached(NodeId::DONT_CARE, terminal),
+                NodeId::DONT_CARE
+            );
+        }
+
+        let node = interner.create_node(
+            variable,
+            Edges::Boolean {
+                high: NodeId::DONT_CARE,
+                low: NodeId::TRUE,
+            },
+        );
+        assert_eq!(interner.project(node), NodeId::TRUE);
+        assert_eq!(interner.project(node.not()), NodeId::FALSE);
+    }
+
+    #[test]
+    fn project_preserves_valid_assignments() {
+        let and = |left, right| INTERNER.lock().and(left, right);
+        let or = |left, right| INTERNER.lock().or(left, right);
+        let fork = or(
+            and(
+                expr("platform_machine != 'aarch64'"),
+                expr("sys_platform == 'linux'"),
+            ),
+            and(
+                expr("sys_platform != 'darwin'"),
+                expr("sys_platform != 'linux'"),
+            ),
+        );
+        let compound = and(expr("os_name == 'nt'"), fork);
+        let markers = [
+            expr("os_name == 'nt'"),
+            and(expr("os_name == 'nt'"), expr("platform_system == 'NetBSD'")),
+            and(
+                expr("os_name == 'nt'"),
+                or(
+                    expr("platform_system == 'NetBSD'"),
+                    and(
+                        expr("sys_platform != 'linux'"),
+                        expr("implementation_name != 'pypy'"),
+                    ),
+                ),
+            ),
+            or(expr("extra == 'a'"), expr("extra == 'b'")),
+            and(
+                expr("extra != 'foo'"),
+                or(expr("extra == 'bar'"), expr("extra == 'baz'")),
+            ),
+            and(expr("'nt' in os_name"), expr("python_version == '3.7'")),
+            compound,
+            compound.not(),
+        ];
+
+        let mut interner = INTERNER.lock();
+        let validity = interner.exclusions().not();
+        for marker in markers {
+            let projected = interner.project(marker);
+            assert_eq!(
+                interner.mask(projected, validity),
+                interner.mask(marker, validity)
+            );
+        }
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -902,6 +902,17 @@ impl InternerGuard<'_> {
             return disjoint;
         }
 
+        // Resolver forks often share a validity-masked platform prefix and differ only in a
+        // lower-order marker. If those suffixes are already disjoint, avoid traversing the
+        // complete validity domain (and retaining a quadratic number of pair-cache entries).
+        if let (Some(left), Some(right)) = (
+            self.non_conflicting_suffix(xi),
+            self.non_conflicting_suffix(yi),
+        ) && self.disjointness(left, right)
+        {
+            return true;
+        }
+
         let disjoint = if trees_conflict && !left_can_conflict && !right_can_conflict {
             // Boolean platform predicates remain unmasked until they are combined. Account
             // for the validity domain here without materializing their conjunction.
@@ -912,6 +923,36 @@ impl InternerGuard<'_> {
         };
         self.state.disjointness_cache.insert(key, disjoint);
         disjoint
+    }
+
+    /// Returns the common non-conflicting subtree implied by every reachable platform branch.
+    fn non_conflicting_suffix(&self, node: NodeId) -> Option<NodeId> {
+        fn visit(interner: &InternerShared, node: NodeId, suffix: &mut Option<NodeId>) -> bool {
+            if node.is_false() || node.is_dont_care() {
+                return true;
+            }
+            if node.is_true() {
+                return false;
+            }
+
+            let current = interner.node(node);
+            if !current.var.is_conflicting_variable() {
+                return if let Some(existing) = suffix {
+                    *existing == node
+                } else {
+                    *suffix = Some(node);
+                    true
+                };
+            }
+
+            current
+                .children
+                .nodes()
+                .all(|child| visit(interner, child.negate(node), suffix))
+        }
+
+        let mut suffix = None;
+        visit(self.shared, node, &mut suffix).then_some(suffix)?
     }
 
     /// Returns `true` if two marker trees are disjoint under the global validity domain.
@@ -2739,6 +2780,40 @@ mod tests {
         assert!(interner.is_disjoint(x86, arm));
         assert_eq!(interner.state.disjointness_cache.len(), cache + 1);
         assert_eq!(INTERNER.shared.nodes.count(), nodes);
+    }
+
+    #[test]
+    fn disjointness_short_circuits_common_suffixes() {
+        let windows = expr("os_name == 'nt'");
+        let linux = expr("sys_platform == 'linux'");
+        let platform = INTERNER.lock().or(windows, linux);
+        let machines = (0..32)
+            .map(|index| expr(&format!("platform_machine == 'suffix-machine-{index}'")))
+            .collect::<Vec<_>>();
+        let markers = machines
+            .iter()
+            .map(|machine| INTERNER.lock().and(platform, *machine))
+            .collect::<Vec<_>>();
+        let negated = INTERNER.lock().and(platform, machines[0].not());
+
+        let mut interner = INTERNER.lock();
+        assert_eq!(interner.non_conflicting_suffix(platform), None);
+        assert_eq!(
+            interner.non_conflicting_suffix(negated),
+            Some(machines[0].not())
+        );
+        for (marker, machine) in markers.iter().zip(&machines) {
+            assert_eq!(interner.non_conflicting_suffix(*marker), Some(*machine));
+        }
+        let nodes = INTERNER.shared.nodes.count();
+        let cache = interner.state.disjointness_cache.len();
+        for (index, left) in markers.iter().enumerate() {
+            for right in &markers[index + 1..] {
+                assert!(interner.is_disjoint(*left, *right));
+            }
+        }
+        assert_eq!(INTERNER.shared.nodes.count(), nodes);
+        assert_eq!(interner.state.disjointness_cache.len(), cache);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -101,6 +101,8 @@ struct InternedNode {
 const OS_NAME_VARIABLE: u8 = 1;
 const SYS_PLATFORM_VARIABLE: u8 = 1 << 1;
 const PLATFORM_SYSTEM_VARIABLE: u8 = 1 << 2;
+const OS_NAME_DOMAIN: u8 = 1;
+const PLATFORM_SYSTEM_DOMAIN: u8 = 1 << 1;
 const BSD_SYSTEMS: &[&str] = &["FreeBSD", "NetBSD", "OpenBSD", "SunOS"];
 const BSD_AND_IOS_SYSTEMS: &[&str] = &["FreeBSD", "NetBSD", "OpenBSD", "SunOS", "iOS", "iPadOS"];
 
@@ -115,8 +117,8 @@ struct InternerState {
     /// Note that `OR` is implemented in terms of `AND`.
     cache: FxHashMap<(NodeId, NodeId), NodeId>,
 
-    /// The [`NodeId`] for the disjunction of known, mutually incompatible markers.
-    exclusions: Option<NodeId>,
+    /// The [`NodeId`]s for the disjunction of known, mutually incompatible markers.
+    exclusions: Option<Exclusions>,
 
     /// A cache for applying a validity domain to a marker tree.
     mask_cache: FxHashMap<(NodeId, NodeId), NodeId>,
@@ -126,6 +128,13 @@ struct InternerState {
 
     /// A cache for disjointness checks between two marker trees.
     disjointness_cache: FxHashMap<(NodeId, NodeId), bool>,
+}
+
+/// The known platform exclusions, split by the variables they constrain.
+struct Exclusions {
+    all: NodeId,
+    os_name: NodeId,
+    platform_system: NodeId,
 }
 
 impl InternerShared {
@@ -146,6 +155,40 @@ impl InternerShared {
         let systems = OS_NAME_VARIABLE | PLATFORM_SYSTEM_VARIABLE;
         (left & SYS_PLATFORM_VARIABLE != 0 && right & systems != 0)
             || (right & SYS_PLATFORM_VARIABLE != 0 && left & systems != 0)
+    }
+
+    /// Returns `true` if combining two trees introduces an exclusion domain neither covers.
+    fn trees_require_validity(&self, left: NodeId, right: NodeId) -> bool {
+        let left_variables = self.conflicting_variables(left);
+        let right_variables = self.conflicting_variables(right);
+        let left_domain = if self.can_conflict(left) {
+            Self::required_domain(left_variables)
+        } else {
+            0
+        };
+        let right_domain = if self.can_conflict(right) {
+            Self::required_domain(right_variables)
+        } else {
+            0
+        };
+        let covered = left_domain | right_domain;
+        Self::required_domain(left_variables | right_variables) & !covered != 0
+    }
+
+    /// Returns the exclusion domains required by the given conflicting variables.
+    fn required_domain(variables: u8) -> u8 {
+        let mut domain = 0;
+        if variables & (OS_NAME_VARIABLE | SYS_PLATFORM_VARIABLE)
+            == OS_NAME_VARIABLE | SYS_PLATFORM_VARIABLE
+        {
+            domain |= OS_NAME_DOMAIN;
+        }
+        if variables & (SYS_PLATFORM_VARIABLE | PLATFORM_SYSTEM_VARIABLE)
+            == SYS_PLATFORM_VARIABLE | PLATFORM_SYSTEM_VARIABLE
+        {
+            domain |= PLATFORM_SYSTEM_DOMAIN;
+        }
+        domain
     }
 
     /// Returns the conflicting variables reachable from a marker tree.
@@ -642,7 +685,7 @@ impl InternerGuard<'_> {
         if !self.can_conflict(node) {
             return self.coalesce_boolean(node);
         }
-        let validity = self.exclusions().not();
+        let validity = self.exclusions_for(node).not();
         let masked = self.mask(node, validity);
         let canonical = if masked == self.mask(NodeId::TRUE, validity) {
             NodeId::TRUE
@@ -657,7 +700,8 @@ impl InternerGuard<'_> {
             if !self.can_conflict(projected) {
                 projected
             } else {
-                self.mask(projected, validity)
+                let projected_validity = self.exclusions_for(projected).not();
+                self.mask(projected, projected_validity)
             }
         };
         let projected = self.project(canonical);
@@ -977,9 +1021,9 @@ impl InternerGuard<'_> {
             return true;
         }
 
-        let disjoint = if trees_conflict && !left_can_conflict && !right_can_conflict {
-            // Boolean platform predicates remain unmasked until they are combined. Account
-            // for the validity domain here without materializing their conjunction.
+        let disjoint = if trees_conflict && self.shared.trees_require_validity(xi, yi) {
+            // Combining platform predicates can introduce an exclusion domain that neither
+            // operand covers. Account for it without materializing their conjunction.
             let validity = self.exclusions().not();
             self.disjointness_under_validity(xi, yi, validity)
         } else {
@@ -1171,6 +1215,16 @@ impl InternerGuard<'_> {
     /// outside of `assumption` is unspecified, which lets us eliminate decisions that are only
     /// needed to restate the assumption.
     pub(crate) fn restrict(&mut self, value: NodeId, assumption: NodeId) -> NodeId {
+        let variables = self.shared.conflicting_variables(value)
+            | self.shared.conflicting_variables(assumption);
+        let assumption = if InternerShared::required_domain(variables)
+            == OS_NAME_DOMAIN | PLATFORM_SYSTEM_DOMAIN
+        {
+            let validity = self.exclusions().not();
+            self.and_cached(assumption, validity)
+        } else {
+            assumption
+        };
         let mut cache = FxHashMap::default();
         self.restrict_cached(value, assumption, &mut cache)
     }
@@ -1617,8 +1671,8 @@ impl InternerGuard<'_> {
             node
         }
 
-        if let Some(exclusions) = self.state.exclusions {
-            return exclusions;
+        if let Some(exclusions) = &self.state.exclusions {
+            return exclusions.all;
         }
         let mut tree = NodeId::FALSE;
         // These operations omit known-incompatibility checks, so their results must not be reused
@@ -1715,12 +1769,18 @@ impl InternerGuard<'_> {
         // Pairs of `os_name` and `sys_platform` that are known to be incompatible.
         //
         // For example: `os_name == 'nt' and sys_platform == 'darwin'`
-        let mut pairs = vec![
+        let os_name_pairs = [
             (os_name_nt, sys_platform_linux),
             (os_name_nt, sys_platform_darwin),
             (os_name_nt, sys_platform_ios),
             (os_name_posix, sys_platform_win32),
         ];
+        for (left, right) in os_name_pairs {
+            let conjunction = conjunction(self, &mut cache, left, right);
+            tree = disjunction(self, &mut cache, tree, conjunction);
+        }
+        let os_name = tree;
+        tree = NodeId::FALSE;
 
         // Pairs of `platform_system` and `sys_platform` that are known to be incompatible.
         //
@@ -1751,17 +1811,34 @@ impl InternerGuard<'_> {
                 {
                     continue;
                 }
-                pairs.push((platform_system, sys_platform));
+                let conjunction = conjunction(self, &mut cache, platform_system, sys_platform);
+                tree = disjunction(self, &mut cache, tree, conjunction);
             }
         }
 
-        for (a, b) in pairs {
-            let a_and_b = conjunction(self, &mut cache, a, b);
-            tree = disjunction(self, &mut cache, tree, a_and_b);
-        }
+        let platform_system = tree;
+        let all = disjunction(self, &mut cache, os_name, platform_system);
 
-        self.state.exclusions = Some(tree);
-        tree
+        self.state.exclusions = Some(Exclusions {
+            all,
+            os_name,
+            platform_system,
+        });
+        all
+    }
+
+    /// The exclusions relevant to the conflicting variables reachable from `node`.
+    fn exclusions_for(&mut self, node: NodeId) -> NodeId {
+        self.exclusions();
+        let Some(exclusions) = &self.state.exclusions else {
+            return NodeId::FALSE;
+        };
+        let domain = InternerShared::required_domain(self.shared.conflicting_variables(node));
+        match domain {
+            OS_NAME_DOMAIN => exclusions.os_name,
+            PLATFORM_SYSTEM_DOMAIN => exclusions.platform_system,
+            _ => exclusions.all,
+        }
     }
 }
 
@@ -2610,7 +2687,9 @@ impl fmt::Debug for NodeId {
 
 #[cfg(test)]
 mod tests {
-    use super::{Edges, INTERNER, NodeId};
+    use super::{
+        Edges, INTERNER, NodeId, OS_NAME_VARIABLE, PLATFORM_SYSTEM_VARIABLE, SYS_PLATFORM_VARIABLE,
+    };
     use crate::MarkerExpression;
 
     fn expr(s: &str) -> NodeId {
@@ -2833,6 +2912,54 @@ mod tests {
         assert!(interner.can_conflict(nested));
         assert!(interner.can_conflict(nested.not()));
         assert!(interner.finish(nested).is_false());
+    }
+
+    #[test]
+    fn markers_only_expand_relevant_exclusion_domains() {
+        let mut interner = INTERNER.lock();
+        let windows = interner.expression_raw(
+            MarkerExpression::from_str("os_name == 'nt'")
+                .unwrap()
+                .unwrap(),
+        );
+        let linux = interner.expression_raw(
+            MarkerExpression::from_str("sys_platform == 'linux'")
+                .unwrap()
+                .unwrap(),
+        );
+        let freebsd = interner.expression_raw(
+            MarkerExpression::from_str("platform_system == 'FreeBSD'")
+                .unwrap()
+                .unwrap(),
+        );
+        let extra = interner.expression_raw(
+            MarkerExpression::from_str("extra != 'scoped-extra'")
+                .unwrap()
+                .unwrap(),
+        );
+
+        let os_name = interner.or_cached(windows, linux);
+        let os_name = interner.and_cached(os_name, extra);
+        let os_name = interner.finish(os_name);
+        assert_eq!(
+            interner.shared.conflicting_variables(os_name),
+            OS_NAME_VARIABLE | SYS_PLATFORM_VARIABLE
+        );
+
+        let platform_system = interner.or_cached(linux, freebsd);
+        let platform_system = interner.and_cached(platform_system, extra);
+        let platform_system = interner.finish(platform_system);
+        assert_eq!(
+            interner.shared.conflicting_variables(platform_system),
+            SYS_PLATFORM_VARIABLE | PLATFORM_SYSTEM_VARIABLE
+        );
+
+        let all = interner.or_cached(os_name, platform_system);
+        let all = interner.finish(all);
+        assert_eq!(
+            interner.shared.conflicting_variables(all),
+            OS_NAME_VARIABLE | SYS_PLATFORM_VARIABLE | PLATFORM_SYSTEM_VARIABLE
+        );
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -562,6 +562,12 @@ impl InternerGuard<'_> {
 
     /// Returns a decision node representing the disjunction of two nodes.
     pub(crate) fn or(&mut self, xi: NodeId, yi: NodeId) -> NodeId {
+        if xi.is_false() {
+            return yi;
+        }
+        if yi.is_false() || xi == yi {
+            return xi;
+        }
         let node = self.or_cached(xi, yi);
         self.finish(node)
     }
@@ -574,6 +580,12 @@ impl InternerGuard<'_> {
 
     /// Returns a decision node representing the conjunction of two nodes.
     pub(crate) fn and(&mut self, xi: NodeId, yi: NodeId) -> NodeId {
+        if xi.is_true() {
+            return yi;
+        }
+        if yi.is_true() || xi == yi {
+            return xi;
+        }
         let node = self.and_cached(xi, yi);
         self.finish(node)
     }
@@ -696,15 +708,14 @@ impl InternerGuard<'_> {
             if projected.is_terminal() || !visited.insert(projected) {
                 continue;
             }
-
-            let node = self.shared.node(projected);
-            pending.extend(node.children.nodes().map(|child| child.negate(projected)));
-
             if !self.can_conflict(projected)
                 || self.shared.canonical_projection(projected).is_some()
             {
                 continue;
             }
+
+            let node = self.shared.node(projected);
+            pending.extend(node.children.nodes().map(|child| child.negate(projected)));
 
             let canonical = self.mask(projected, validity);
             self.shared.cache_canonical_projection(projected, canonical);
@@ -2874,6 +2885,54 @@ mod tests {
         assert!(interner.can_conflict(nested));
         assert!(interner.can_conflict(nested.not()));
         assert!(interner.finish(nested).is_false());
+    }
+
+    #[test]
+    fn cached_marker_combinations_preserve_non_conflicting_suffixes() {
+        let windows = expr("os_name == 'nt'");
+        let linux = expr("sys_platform == 'linux'");
+        let guard = expr("extra != 'cached-guard'");
+
+        let mut interner = INTERNER.lock();
+        let platform = interner.or(windows, linux);
+        let mut suffix = NodeId::FALSE;
+        for index in 0..64 {
+            let machine = interner.expression(
+                MarkerExpression::from_str(&format!("platform_machine == 'cached-{index}'"))
+                    .unwrap()
+                    .unwrap(),
+            );
+            let implementation = interner.expression(
+                MarkerExpression::from_str(&format!("implementation_name == 'cached-{index}'"))
+                    .unwrap()
+                    .unwrap(),
+            );
+            let extra = interner.expression(
+                MarkerExpression::from_str(&format!("extra == 'cached-{index}'"))
+                    .unwrap()
+                    .unwrap(),
+            );
+            let alternative = interner.and_cached(machine, implementation);
+            let alternative = interner.and_cached(alternative, extra);
+            suffix = interner.or_cached(suffix, alternative);
+        }
+        let marker = interner.and(platform, suffix);
+        let combined = interner.and(marker, guard);
+
+        let nodes = INTERNER.shared.nodes.count();
+        let cache = interner.state.cache.len();
+        let mask_cache = interner.state.mask_cache.len();
+        for _ in 0..32 {
+            assert_eq!(interner.and(marker, guard), combined);
+            assert_eq!(interner.and(marker, marker), marker);
+            assert_eq!(interner.and(marker, NodeId::TRUE), marker);
+            assert_eq!(interner.and(NodeId::TRUE, marker), marker);
+            assert_eq!(interner.or(marker, NodeId::FALSE), marker);
+            assert_eq!(interner.or(NodeId::FALSE, marker), marker);
+        }
+        assert_eq!(INTERNER.shared.nodes.count(), nodes);
+        assert_eq!(interner.state.cache.len(), cache);
+        assert_eq!(interner.state.mask_cache.len(), mask_cache);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -99,6 +99,8 @@ struct InternedNode {
 const OS_NAME_VARIABLE: u8 = 1;
 const SYS_PLATFORM_VARIABLE: u8 = 1 << 1;
 const PLATFORM_SYSTEM_VARIABLE: u8 = 1 << 2;
+const BSD_SYSTEMS: &[&str] = &["FreeBSD", "NetBSD", "OpenBSD", "SunOS"];
+const BSD_AND_IOS_SYSTEMS: &[&str] = &["FreeBSD", "NetBSD", "OpenBSD", "SunOS", "iOS", "iPadOS"];
 
 /// The mutable [`Interner`] state, stored behind a lock.
 #[derive(Default)]
@@ -177,29 +179,34 @@ impl InternerShared {
             return false;
         };
 
-        let excluded_values: &[&str] = match node.var {
-            Variable::String(CanonicalMarkerValueString::OsName) => &["nt", "posix"],
+        let excluded_values: &[(&str, &[&str])] = match node.var {
+            Variable::String(CanonicalMarkerValueString::OsName) => {
+                &[("nt", &["linux", "darwin", "ios"]), ("posix", &["win32"])]
+            }
             Variable::String(CanonicalMarkerValueString::SysPlatform) => &[
-                "linux",
-                "darwin",
-                "ios",
-                "win32",
-                "aix",
-                "android",
-                "emscripten",
-                "cygwin",
-                "wasi",
+                ("aix", BSD_AND_IOS_SYSTEMS),
+                ("android", BSD_AND_IOS_SYSTEMS),
+                ("emscripten", BSD_AND_IOS_SYSTEMS),
+                ("ios", BSD_SYSTEMS),
+                ("linux", BSD_AND_IOS_SYSTEMS),
+                ("darwin", BSD_AND_IOS_SYSTEMS),
+                ("win32", BSD_AND_IOS_SYSTEMS),
+                ("cygwin", BSD_AND_IOS_SYSTEMS),
+                ("wasi", BSD_AND_IOS_SYSTEMS),
             ],
             _ => &[],
         };
-        let references_excluded_value = edges.iter().any(|(range, _)| {
-            range.iter().any(|(start, end)| {
-                [start, end].into_iter().any(|bound| {
-                    matches!(bound, Bound::Included(value) | Bound::Excluded(value)
-                        if excluded_values.contains(&value.as_ref()))
-                })
-            })
-        });
+        let referenced_parents =
+            excluded_values
+                .iter()
+                .enumerate()
+                .fold(0_u16, |referenced, (index, (parent, _))| {
+                    if node.children.references_string_value(parent) {
+                        referenced | (1 << index)
+                    } else {
+                        referenced
+                    }
+                });
 
         edges.iter().any(|(range, child)| {
             if child.is_terminal() {
@@ -211,9 +218,26 @@ impl InternerShared {
                 return false;
             }
 
-            let can_conflict = (references_excluded_value
-                || excluded_values.iter().any(|value| range.contains(*value)))
-                && node.var.conflicts_with(&child_node.var);
+            let children_conflict = matches!(
+                (&node.var, &child_node.var),
+                (
+                    Variable::String(CanonicalMarkerValueString::OsName),
+                    Variable::String(CanonicalMarkerValueString::SysPlatform)
+                ) | (
+                    Variable::String(CanonicalMarkerValueString::SysPlatform),
+                    Variable::String(CanonicalMarkerValueString::PlatformSystem)
+                )
+            );
+            let can_conflict = children_conflict
+                && excluded_values
+                    .iter()
+                    .enumerate()
+                    .any(|(index, (parent, children))| {
+                        (range.contains(*parent) || referenced_parents & (1 << index) != 0)
+                            && children
+                                .iter()
+                                .any(|child| child_node.children.references_string_value(child))
+                    });
 
             can_conflict || self.can_conflict(*child)
         })
@@ -1757,24 +1781,6 @@ impl Variable {
         };
         marker.is_conflicting()
     }
-
-    /// Returns `true` if two variables can form a known-incompatible marker pair.
-    fn conflicts_with(&self, other: &Self) -> bool {
-        matches!(
-            (self, other),
-            (
-                Self::String(
-                    CanonicalMarkerValueString::OsName | CanonicalMarkerValueString::PlatformSystem
-                ),
-                Self::String(CanonicalMarkerValueString::SysPlatform)
-            ) | (
-                Self::String(CanonicalMarkerValueString::SysPlatform),
-                Self::String(
-                    CanonicalMarkerValueString::OsName | CanonicalMarkerValueString::PlatformSystem
-                )
-            )
-        )
-    }
 }
 
 /// A decision node in an Algebraic Decision Diagram.
@@ -2278,6 +2284,22 @@ impl Edges {
         }
     }
 
+    /// Returns `true` if these string edges contain a decision boundary for the given value.
+    fn references_string_value(&self, value: &str) -> bool {
+        let Self::String { edges } = self else {
+            return false;
+        };
+
+        edges.iter().any(|(range, _)| {
+            range.iter().any(|(start, end)| {
+                [start, end].into_iter().any(|bound| {
+                    matches!(bound, Bound::Included(bound) | Bound::Excluded(bound)
+                        if bound.as_str() == value)
+                })
+            })
+        })
+    }
+
     /// Merge adjacent ranges that point to the same node.
     fn coalesce_ranges<T>(edges: SmallVec<(Ranges<T>, NodeId)>) -> SmallVec<(Ranges<T>, NodeId)>
     where
@@ -2705,6 +2727,29 @@ mod tests {
         );
         let raw = interner.and_cached(os_name, platform_system);
         assert_eq!(interner.finish(raw), raw);
+
+        for (left, right, can_conflict) in [
+            ("os_name == 'nt'", "sys_platform == 'win32'", false),
+            ("os_name == 'posix'", "sys_platform == 'linux'", false),
+            ("sys_platform == 'ios'", "platform_system == 'iOS'", false),
+            ("os_name == 'nt'", "sys_platform == 'linux'", true),
+            ("os_name == 'posix'", "sys_platform == 'win32'", true),
+            (
+                "sys_platform == 'linux'",
+                "platform_system == 'FreeBSD'",
+                true,
+            ),
+        ] {
+            let left = interner.expression_raw(MarkerExpression::from_str(left).unwrap().unwrap());
+            let right =
+                interner.expression_raw(MarkerExpression::from_str(right).unwrap().unwrap());
+            let raw = interner.and_cached(left, right);
+            assert_eq!(interner.can_conflict(raw), can_conflict);
+            assert_eq!(interner.can_conflict(raw.not()), can_conflict);
+            if !can_conflict {
+                assert_eq!(interner.finish(raw), raw);
+            }
+        }
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -93,7 +93,12 @@ struct InternedNode {
     node: Node,
     projections: [AtomicUsize; 2],
     can_conflict: bool,
+    conflicting_variables: u8,
 }
+
+const OS_NAME_VARIABLE: u8 = 1;
+const SYS_PLATFORM_VARIABLE: u8 = 1 << 1;
+const PLATFORM_SYSTEM_VARIABLE: u8 = 1 << 2;
 
 /// The mutable [`Interner`] state, stored behind a lock.
 #[derive(Default)]
@@ -128,6 +133,39 @@ impl InternerShared {
     /// Returns `true` if the given marker can reach a known-incompatible pair of variables.
     fn can_conflict(&self, id: NodeId) -> bool {
         !id.is_terminal() && self.nodes[id.index()].can_conflict
+    }
+
+    /// Returns `true` if two marker trees can contain a known-incompatible pair of variables.
+    fn trees_can_conflict(&self, left: NodeId, right: NodeId) -> bool {
+        let left = self.conflicting_variables(left);
+        let right = self.conflicting_variables(right);
+        let systems = OS_NAME_VARIABLE | PLATFORM_SYSTEM_VARIABLE;
+        (left & SYS_PLATFORM_VARIABLE != 0 && right & systems != 0)
+            || (right & SYS_PLATFORM_VARIABLE != 0 && left & systems != 0)
+    }
+
+    /// Returns the conflicting variables reachable from a marker tree.
+    fn conflicting_variables(&self, id: NodeId) -> u8 {
+        if id.is_terminal() {
+            0
+        } else {
+            self.nodes[id.index()].conflicting_variables
+        }
+    }
+
+    /// Returns the conflicting variables reachable from a new node.
+    fn node_conflicting_variables(&self, node: &Node) -> u8 {
+        let current = match node.var {
+            Variable::String(CanonicalMarkerValueString::OsName) => OS_NAME_VARIABLE,
+            Variable::String(CanonicalMarkerValueString::SysPlatform) => SYS_PLATFORM_VARIABLE,
+            Variable::String(CanonicalMarkerValueString::PlatformSystem) => {
+                PLATFORM_SYSTEM_VARIABLE
+            }
+            _ => return 0,
+        };
+        node.children.nodes().fold(current, |variables, child| {
+            variables | self.conflicting_variables(child)
+        })
     }
 
     /// Returns `true` if a new node can reach a known-incompatible pair of variables.
@@ -250,11 +288,13 @@ impl InternerGuard<'_> {
         // Insert the node.
         let id = self.state.unique.entry(node.clone()).or_insert_with(|| {
             let can_conflict = self.shared.node_can_conflict(&node);
+            let conflicting_variables = self.shared.node_conflicting_variables(&node);
             NodeId::new(
                 self.shared.nodes.push(InternedNode {
                     node,
                     projections: [AtomicUsize::new(usize::MAX), AtomicUsize::new(usize::MAX)],
                     can_conflict,
+                    conflicting_variables,
                 }),
                 false,
             )
@@ -846,16 +886,10 @@ impl InternerGuard<'_> {
     /// Returns `true` if there is no environment in which both marker trees can apply,
     /// i.e. their conjunction is always `false`.
     pub(crate) fn is_disjoint(&mut self, xi: NodeId, yi: NodeId) -> bool {
-        let roots_conflict = !xi.is_terminal()
-            && !yi.is_terminal()
-            && self
-                .shared
-                .node(xi)
-                .var
-                .conflicts_with(&self.shared.node(yi).var);
+        let trees_conflict = self.shared.trees_can_conflict(xi, yi);
         let left_can_conflict = self.can_conflict(xi);
         let right_can_conflict = self.can_conflict(yi);
-        let validity_sensitive = left_can_conflict || right_can_conflict || roots_conflict;
+        let validity_sensitive = left_can_conflict || right_can_conflict || trees_conflict;
 
         // Ordinary Boolean trees are cheap to compare, and caching every pair can otherwise
         // retain a quadratic number of entries during requirement and wheel selection.
@@ -868,8 +902,8 @@ impl InternerGuard<'_> {
             return disjoint;
         }
 
-        let disjoint = if roots_conflict && !left_can_conflict && !right_can_conflict {
-            // Singleton platform predicates remain Boolean until they are combined. Account
+        let disjoint = if trees_conflict && !left_can_conflict && !right_can_conflict {
+            // Boolean platform predicates remain unmasked until they are combined. Account
             // for the validity domain here without materializing their conjunction.
             let validity = self.exclusions().not();
             self.disjointness_under_validity(xi, yi, validity)

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -451,7 +451,10 @@ impl InternerGuard<'_> {
 
     /// Apply the global validity domain and collapse roots that are constant on that domain.
     pub(crate) fn finish(&mut self, node: NodeId) -> NodeId {
-        if node.is_terminal() {
+        // Conflicting string variables have the highest priority in the tree. If none occurs
+        // at the root, this marker cannot participate in the validity domain and can remain
+        // an ordinary Boolean tree.
+        if node.is_terminal() || !self.shared.node(node).var.is_conflicting_variable() {
             return node;
         }
         let validity = self.exclusions().not();
@@ -461,7 +464,17 @@ impl InternerGuard<'_> {
         } else if masked == self.mask(NodeId::FALSE, validity) {
             NodeId::FALSE
         } else {
-            masked
+            // Platform branches can collapse to a marker that does not itself depend on a
+            // conflicting variable (for example, `(windows and extra) or (not windows and
+            // extra)`). Normalize that result back to its Boolean tree so it remains canonical
+            // with a marker that never mentioned the platform.
+            let projected = self.project(masked);
+            if projected.is_terminal() || !self.shared.node(projected).var.is_conflicting_variable()
+            {
+                projected
+            } else {
+                masked
+            }
         }
     }
 
@@ -2332,6 +2345,21 @@ mod tests {
                 interner.mask(projected, validity),
                 interner.mask(marker, validity)
             );
+        }
+    }
+
+    #[test]
+    fn non_conflicting_markers_remain_boolean() {
+        let mut interner = INTERNER.lock();
+        for marker in [
+            "extra == 'foo'",
+            "python_version >= '3.9'",
+            "platform_machine == 'aarch64'",
+            "implementation_name == 'pypy'",
+        ] {
+            let expression = MarkerExpression::from_str(marker).unwrap().unwrap();
+            let raw = interner.expression_raw(expression);
+            assert_eq!(interner.finish(raw), raw);
         }
     }
 

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -47,13 +47,15 @@
 
 use std::cmp::{Ordering, min};
 use std::fmt;
+use std::hash::BuildHasher;
 use std::ops::Bound;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use arcstr::ArcStr;
+use hashbrown::HashTable;
 use itertools::{Either, Itertools};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use version_ranges::Ranges;
 
 use uv_pep440::{Operator, Version, VersionSpecifier, release_specifier_to_range};
@@ -94,7 +96,6 @@ struct InternedNode {
     projections: [AtomicUsize; 2],
     can_conflict: bool,
     conflicting_variables: u8,
-    contains_dont_care: bool,
 }
 
 const OS_NAME_VARIABLE: u8 = 1;
@@ -108,7 +109,7 @@ const BSD_AND_IOS_SYSTEMS: &[&str] = &["FreeBSD", "NetBSD", "OpenBSD", "SunOS", 
 struct InternerState {
     /// A map from a [`Node`] to a unique [`NodeId`], representing an index
     /// into [`InternerShared`].
-    unique: FxHashMap<Node, NodeId>,
+    unique: HashTable<NodeId>,
 
     /// A cache for `AND` operations between two nodes.
     /// Note that `OR` is implemented in terms of `AND`.
@@ -134,24 +135,8 @@ impl InternerShared {
     }
 
     /// Returns `true` if the given marker can reach a known-incompatible pair of variables.
-    fn can_conflict(&self, id: NodeId) -> bool {
+    pub(crate) fn can_conflict(&self, id: NodeId) -> bool {
         !id.is_terminal() && self.nodes[id.index()].can_conflict
-    }
-
-    /// Returns the canonical marker for a projected child, if one is needed.
-    pub(crate) fn canonical_projection(&self, id: NodeId) -> Option<NodeId> {
-        if id.is_terminal() || self.contains_dont_care(id) || !self.can_conflict(id) {
-            return None;
-        }
-
-        let projection = self.nodes[id.index()].projections[usize::from(id.is_complement())]
-            .load(AtomicOrdering::Acquire);
-        (projection != usize::MAX).then_some(NodeId(projection))
-    }
-
-    /// Returns `true` if the given marker contains a don't-care edge.
-    fn contains_dont_care(&self, id: NodeId) -> bool {
-        id.is_dont_care() || (!id.is_terminal() && self.nodes[id.index()].contains_dont_care)
     }
 
     /// Returns `true` if two marker trees can contain a known-incompatible pair of variables.
@@ -265,9 +250,6 @@ impl InternerShared {
         if id.is_terminal() {
             return Some(id);
         }
-        if !self.contains_dont_care(id) && self.can_conflict(id) {
-            return Some(id);
-        }
 
         let projection = self.nodes[id.index()].projections[usize::from(id.is_complement())]
             .load(AtomicOrdering::Acquire);
@@ -277,19 +259,6 @@ impl InternerShared {
     /// Cache the Boolean projection for the given [`NodeId`].
     fn cache_projection(&self, id: NodeId, projection: NodeId) {
         if id.is_terminal() {
-            return;
-        }
-        if !self.contains_dont_care(id) && self.can_conflict(id) {
-            return;
-        }
-
-        self.nodes[id.index()].projections[usize::from(id.is_complement())]
-            .store(projection.0, AtomicOrdering::Release);
-    }
-
-    /// Cache the canonical marker for a Boolean projected child.
-    fn cache_canonical_projection(&self, id: NodeId, projection: NodeId) {
-        if id.is_terminal() || self.contains_dont_care(id) || !self.can_conflict(id) {
             return;
         }
 
@@ -343,26 +312,33 @@ impl InternerGuard<'_> {
         }
 
         // Insert the node.
-        let id = self.state.unique.entry(node.clone()).or_insert_with(|| {
+        let hasher = FxBuildHasher;
+        let hash = hasher.hash_one(&node);
+        let id = if let Some(&id) = self
+            .state
+            .unique
+            .find(hash, |id| self.shared.node(*id) == &node)
+        {
+            id
+        } else {
             let can_conflict = self.shared.node_can_conflict(&node);
             let conflicting_variables = self.shared.node_conflicting_variables(&node);
-            let contains_dont_care = node
-                .children
-                .nodes()
-                .any(|child| self.shared.contains_dont_care(child));
-            NodeId::new(
+            let id = NodeId::new(
                 self.shared.nodes.push(InternedNode {
                     node,
                     projections: [AtomicUsize::new(usize::MAX), AtomicUsize::new(usize::MAX)],
                     can_conflict,
                     conflicting_variables,
-                    contains_dont_care,
                 }),
                 false,
-            )
-        });
+            );
+            self.state
+                .unique
+                .insert_unique(hash, id, |id| hasher.hash_one(self.shared.node(*id)));
+            id
+        };
 
-        if flipped { id.not() } else { *id }
+        if flipped { id.not() } else { id }
     }
 
     /// Returns a decision node for a single marker expression.
@@ -684,47 +660,10 @@ impl InternerGuard<'_> {
                 self.mask(projected, validity)
             }
         };
-        self.cache_projected_children(canonical, validity);
+        let projected = self.project(canonical);
+        self.shared
+            .cache_projection(canonical.not(), projected.not());
         canonical
-    }
-
-    /// Cache the canonical form of every conflicting subtree in a Boolean projection.
-    fn cache_projected_children(&mut self, value: NodeId, validity: NodeId) {
-        let root = self.project(value);
-        self.shared.cache_projection(value.not(), root.not());
-        if root.is_terminal() {
-            return;
-        }
-        let mut pending = self
-            .shared
-            .node(root)
-            .children
-            .nodes()
-            .map(|child| child.negate(root))
-            .collect_vec();
-        let mut visited = FxHashSet::default();
-
-        while let Some(projected) = pending.pop() {
-            if projected.is_terminal() || !visited.insert(projected) {
-                continue;
-            }
-            if !self.can_conflict(projected)
-                || self.shared.canonical_projection(projected).is_some()
-            {
-                continue;
-            }
-
-            let node = self.shared.node(projected);
-            pending.extend(node.children.nodes().map(|child| child.negate(projected)));
-
-            let canonical = self.mask(projected, validity);
-            self.shared.cache_canonical_projection(projected, canonical);
-            self.shared
-                .cache_canonical_projection(projected.not(), canonical.not());
-            self.shared.cache_projection(canonical, projected);
-            self.shared
-                .cache_projection(canonical.not(), projected.not());
-        }
     }
 
     /// Returns `true` if a marker tree can contain a known-incompatible pair of variables.
@@ -1983,9 +1922,8 @@ impl NodeId {
     }
 }
 
-/// A [`SmallVec`] with enough elements to hold two constant edges, as well as the
-/// ranges in-between.
-type SmallVec<T> = smallvec::SmallVec<[T; 5]>;
+/// A [`SmallVec`] with enough elements to hold a constant edge and its complement.
+type SmallVec<T> = smallvec::SmallVec<[T; 3]>;
 
 /// The edges of a decision node.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -92,6 +92,7 @@ pub(crate) struct InternerShared {
 struct InternedNode {
     node: Node,
     projections: [AtomicUsize; 2],
+    can_conflict: bool,
 }
 
 /// The mutable [`Interner`] state, stored behind a lock.
@@ -122,6 +123,62 @@ impl InternerShared {
     /// Returns the node for the given [`NodeId`].
     pub(crate) fn node(&self, id: NodeId) -> &Node {
         &self.nodes[id.index()].node
+    }
+
+    /// Returns `true` if the given marker can reach a known-incompatible pair of variables.
+    fn can_conflict(&self, id: NodeId) -> bool {
+        !id.is_terminal() && self.nodes[id.index()].can_conflict
+    }
+
+    /// Returns `true` if a new node can reach a known-incompatible pair of variables.
+    fn node_can_conflict(&self, node: &Node) -> bool {
+        if !node.var.is_conflicting_variable() {
+            return false;
+        }
+        let Edges::String { edges } = &node.children else {
+            return false;
+        };
+
+        let excluded_values: &[&str] = match node.var {
+            Variable::String(CanonicalMarkerValueString::OsName) => &["nt", "posix"],
+            Variable::String(CanonicalMarkerValueString::SysPlatform) => &[
+                "linux",
+                "darwin",
+                "ios",
+                "win32",
+                "aix",
+                "android",
+                "emscripten",
+                "cygwin",
+                "wasi",
+            ],
+            _ => &[],
+        };
+        let references_excluded_value = edges.iter().any(|(range, _)| {
+            range.iter().any(|(start, end)| {
+                [start, end].into_iter().any(|bound| {
+                    matches!(bound, Bound::Included(value) | Bound::Excluded(value)
+                        if excluded_values.contains(&value.as_ref()))
+                })
+            })
+        });
+
+        edges.iter().any(|(range, child)| {
+            if child.is_terminal() {
+                return false;
+            }
+
+            let child_node = self.node(*child);
+            if !child_node.var.is_conflicting_variable() {
+                return false;
+            }
+
+            let can_conflict = (references_excluded_value
+                || excluded_values.iter().any(|value| range.contains(*value)))
+                && node.var.conflicts_with(&child_node.var);
+
+            can_conflict || self.can_conflict(*child)
+        })
     }
 
     /// Returns the cached Boolean projection for the given [`NodeId`], if one exists.
@@ -192,10 +249,12 @@ impl InternerGuard<'_> {
 
         // Insert the node.
         let id = self.state.unique.entry(node.clone()).or_insert_with(|| {
+            let can_conflict = self.shared.node_can_conflict(&node);
             NodeId::new(
                 self.shared.nodes.push(InternedNode {
                     node,
                     projections: [AtomicUsize::new(usize::MAX), AtomicUsize::new(usize::MAX)],
+                    can_conflict,
                 }),
                 false,
             )
@@ -515,55 +574,7 @@ impl InternerGuard<'_> {
 
     /// Returns `true` if a marker tree can contain a known-incompatible pair of variables.
     fn can_conflict(&self, node: NodeId) -> bool {
-        if node.is_terminal() {
-            return false;
-        }
-
-        let node = self.shared.node(node);
-        let Edges::String { edges } = &node.children else {
-            return false;
-        };
-
-        let excluded_values: &[&str] = match node.var {
-            Variable::String(CanonicalMarkerValueString::OsName) => &["nt", "posix"],
-            Variable::String(CanonicalMarkerValueString::SysPlatform) => &[
-                "linux",
-                "darwin",
-                "ios",
-                "win32",
-                "aix",
-                "android",
-                "emscripten",
-                "cygwin",
-                "wasi",
-            ],
-            _ => &[],
-        };
-        let references_excluded_value = edges.iter().any(|(range, _)| {
-            range.iter().any(|(start, end)| {
-                [start, end].into_iter().any(|bound| {
-                    matches!(bound, Bound::Included(value) | Bound::Excluded(value)
-                        if excluded_values.contains(&value.as_ref()))
-                })
-            })
-        });
-
-        edges.iter().any(|(range, child)| {
-            if child.is_terminal() {
-                return false;
-            }
-
-            let child_node = self.shared.node(*child);
-            if !child_node.var.is_conflicting_variable() {
-                return false;
-            }
-
-            let can_conflict = (references_excluded_value
-                || excluded_values.iter().any(|value| range.contains(*value)))
-                && node.var.conflicts_with(&child_node.var);
-
-            can_conflict || self.can_conflict(*child)
-        })
+        self.shared.can_conflict(node)
     }
 
     /// Recursively coalesce a Boolean marker tree without performing ternary projection.
@@ -2640,6 +2651,7 @@ mod tests {
             custom = interner.or_cached(custom, alternative);
         }
         assert!(!interner.can_conflict(custom));
+        assert!(!interner.can_conflict(custom.not()));
         assert_eq!(interner.finish(custom), custom);
 
         let os_name = interner.expression_raw(
@@ -2660,6 +2672,7 @@ mod tests {
         let nested = interner.and_cached(os_name, sys_platform);
         let nested = interner.and_cached(nested, platform_system);
         assert!(interner.can_conflict(nested));
+        assert!(interner.can_conflict(nested.not()));
         assert!(interner.finish(nested).is_false());
     }
 

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -45,7 +45,7 @@
 //! or a terminal `true`/`false` node. Interning allows the reduction rule that isomorphic nodes are
 //! merged to be applied globally.
 
-use std::cmp::Ordering;
+use std::cmp::{Ordering, min};
 use std::fmt;
 use std::ops::Bound;
 use std::sync::{LazyLock, Mutex, MutexGuard};
@@ -455,10 +455,15 @@ impl InternerGuard<'_> {
     /// Apply the global validity domain and collapse roots that are constant on that domain.
     pub(crate) fn finish(&mut self, node: NodeId) -> NodeId {
         // Conflicting string variables have the highest priority in the tree. If none occurs
-        // at the root, this marker cannot participate in the validity domain and can remain
-        // an ordinary Boolean tree.
+        // at the root, this marker cannot participate in the validity domain.
         if node.is_terminal() || !self.shared.node(node).var.is_conflicting_variable() {
             return node;
+        }
+        // A single conflicting variable (or the non-conflicting `os_name` and
+        // `platform_system` pair) does not need to be expanded across the validity domain.
+        // Projection also coalesces any redundant range boundaries left by prior operations.
+        if !self.can_conflict(node) {
+            return self.project(node);
         }
         let validity = self.exclusions().not();
         let masked = self.mask(node, validity);
@@ -472,13 +477,24 @@ impl InternerGuard<'_> {
             // extra)`). Normalize that result back to its Boolean tree so it remains canonical
             // with a marker that never mentioned the platform.
             let projected = self.project(masked);
-            if projected.is_terminal() || !self.shared.node(projected).var.is_conflicting_variable()
-            {
+            if !self.can_conflict(projected) {
                 projected
             } else {
                 self.mask(projected, validity)
             }
         }
+    }
+
+    /// Returns `true` if a marker tree can contain a known-incompatible pair of variables.
+    fn can_conflict(&self, node: NodeId) -> bool {
+        if node.is_terminal() {
+            return false;
+        }
+
+        let node = self.shared.node(node);
+        node.children.nodes().any(|child| {
+            !child.is_terminal() && node.var.conflicts_with(&self.shared.node(child).var)
+        })
     }
 
     /// Replace all reachable Boolean terminals while retaining unreachable edges.
@@ -609,7 +625,7 @@ impl InternerGuard<'_> {
         let children = node.children.map(value, |child| {
             self.project_cached(groups[assignments[&child]], compatible_cache)
         });
-        let projected = self.create_node(node.var.clone(), children);
+        let projected = self.create_node(node.var.clone(), children.coalesce());
         self.state.projection_cache.insert(value, projected);
         self.state.projection_cache.insert(projected, projected);
         projected
@@ -728,9 +744,95 @@ impl InternerGuard<'_> {
             return disjoint;
         }
 
-        let disjoint = self.disjointness(xi, yi);
+        let disjoint = if !xi.is_terminal()
+            && !yi.is_terminal()
+            && !self.can_conflict(xi)
+            && !self.can_conflict(yi)
+            && self
+                .shared
+                .node(xi)
+                .var
+                .conflicts_with(&self.shared.node(yi).var)
+        {
+            // Singleton platform predicates remain Boolean until they are combined. Account
+            // for the validity domain here without materializing their conjunction.
+            let validity = self.exclusions().not();
+            self.disjointness_under_validity(xi, yi, validity)
+        } else {
+            self.disjointness(xi, yi)
+        };
         self.state.disjointness_cache.insert(key, disjoint);
         disjoint
+    }
+
+    /// Returns `true` if two marker trees are disjoint under the global validity domain.
+    fn disjointness_under_validity(&mut self, xi: NodeId, yi: NodeId, validity: NodeId) -> bool {
+        if xi.is_dont_care() || yi.is_dont_care() || validity.is_dont_care() {
+            return true;
+        }
+        if xi.is_false() || yi.is_false() || validity.is_false() {
+            return true;
+        }
+        if validity.is_true() {
+            return self.disjointness(xi, yi);
+        }
+        if xi.is_true() {
+            return self.disjointness(yi, validity);
+        }
+        if yi.is_true() || xi == yi {
+            return self.disjointness(xi, validity);
+        }
+        if xi.not() == yi {
+            return true;
+        }
+
+        let x = self.shared.node(xi);
+        let y = self.shared.node(yi);
+        let domain = self.shared.node(validity);
+        let variable = min(&x.var, min(&y.var, &domain.var));
+
+        match (
+            &x.var == variable,
+            &y.var == variable,
+            &domain.var == variable,
+        ) {
+            (true, false, false) => x
+                .children
+                .nodes()
+                .all(|child| self.disjointness_under_validity(child.negate(xi), yi, validity)),
+            (false, true, false) => y
+                .children
+                .nodes()
+                .all(|child| self.disjointness_under_validity(xi, child.negate(yi), validity)),
+            (false, false, true) => domain
+                .children
+                .nodes()
+                .all(|child| self.disjointness_under_validity(xi, yi, child.negate(validity))),
+            (true, true, false) => x.children.is_disjoint(xi, &y.children, yi, |x, y| {
+                self.disjointness_under_validity(x, y, validity)
+            }),
+            (true, false, true) => {
+                x.children
+                    .is_disjoint(xi, &domain.children, validity, |x, validity| {
+                        self.disjointness_under_validity(x, yi, validity)
+                    })
+            }
+            (false, true, true) => {
+                y.children
+                    .is_disjoint(yi, &domain.children, validity, |y, validity| {
+                        self.disjointness_under_validity(xi, y, validity)
+                    })
+            }
+            (true, true, true) => x.children.is_disjoint_three(
+                xi,
+                &y.children,
+                yi,
+                &domain.children,
+                validity,
+                |x, y, validity| self.disjointness_under_validity(x, y, validity),
+            ),
+            (false, false, false) => false,
+        }
     }
 
     /// Returns `true` if there is no environment in which both marker trees can apply,
@@ -774,7 +876,9 @@ impl InternerGuard<'_> {
                 .nodes()
                 .all(|y| self.disjointness(y.negate(yi), xi)),
             // X and Y represent the same variable, their merged edges must be unsatisfiable.
-            Ordering::Equal => x.children.is_disjoint(xi, &y.children, yi, self),
+            Ordering::Equal => x
+                .children
+                .is_disjoint(xi, &y.children, yi, |x, y| self.disjointness(x, y)),
         }
     }
 
@@ -1463,6 +1567,24 @@ impl Variable {
         };
         marker.is_conflicting()
     }
+
+    /// Returns `true` if two variables can form a known-incompatible marker pair.
+    fn conflicts_with(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (
+                Self::String(
+                    CanonicalMarkerValueString::OsName | CanonicalMarkerValueString::PlatformSystem
+                ),
+                Self::String(CanonicalMarkerValueString::SysPlatform)
+            ) | (
+                Self::String(CanonicalMarkerValueString::SysPlatform),
+                Self::String(
+                    CanonicalMarkerValueString::OsName | CanonicalMarkerValueString::PlatformSystem
+                )
+            )
+        )
+    }
 }
 
 /// A decision node in an Algebraic Decision Diagram.
@@ -1859,15 +1981,15 @@ impl Edges {
         parent: NodeId,
         right_edges: &Self,
         right_parent: NodeId,
-        interner: &mut InternerGuard<'_>,
+        mut is_disjoint: impl FnMut(NodeId, NodeId) -> bool,
     ) -> bool {
         match (self, right_edges) {
             // For version or string variables, we have to split and check the overlapping ranges.
             (Self::Version { edges }, Self::Version { edges: right_edges }) => {
-                Self::is_disjoint_ranges(edges, parent, right_edges, right_parent, interner)
+                Self::is_disjoint_ranges(edges, parent, right_edges, right_parent, is_disjoint)
             }
             (Self::String { edges }, Self::String { edges: right_edges }) => {
-                Self::is_disjoint_ranges(edges, parent, right_edges, right_parent, interner)
+                Self::is_disjoint_ranges(edges, parent, right_edges, right_parent, is_disjoint)
             }
             // For boolean variables, we simply check the low and high edges.
             (
@@ -1877,8 +1999,8 @@ impl Edges {
                     low: right_low,
                 },
             ) => {
-                interner.disjointness(high.negate(parent), right_high.negate(right_parent))
-                    && interner.disjointness(low.negate(parent), right_low.negate(right_parent))
+                is_disjoint(high.negate(parent), right_high.negate(right_parent))
+                    && is_disjoint(low.negate(parent), right_low.negate(right_parent))
             }
             _ => unreachable!("cannot merge two `Edges` of different types"),
         }
@@ -1890,7 +2012,7 @@ impl Edges {
         left_parent: NodeId,
         right_edges: &SmallVec<(Ranges<T>, NodeId)>,
         right_parent: NodeId,
-        interner: &mut InternerGuard<'_>,
+        mut is_disjoint: impl FnMut(NodeId, NodeId) -> bool,
     ) -> bool
     where
         T: Clone + Ord,
@@ -1904,7 +2026,7 @@ impl Edges {
                 }
 
                 // Ensure the intersection is disjoint.
-                if !interner.disjointness(
+                if !is_disjoint(
                     left_child.negate(left_parent),
                     right_child.negate(right_parent),
                 ) {
@@ -1914,6 +2036,73 @@ impl Edges {
         }
 
         true
+    }
+
+    /// Returns `true` if every intersecting triple of string edges is disjoint.
+    fn is_disjoint_three(
+        &self,
+        parent: NodeId,
+        middle_edges: &Self,
+        middle_parent: NodeId,
+        right_edges: &Self,
+        right_parent: NodeId,
+        mut callback: impl FnMut(NodeId, NodeId, NodeId) -> bool,
+    ) -> bool {
+        let (
+            Self::String { edges },
+            Self::String {
+                edges: middle_edges,
+            },
+            Self::String { edges: right_edges },
+        ) = (self, middle_edges, right_edges)
+        else {
+            return false;
+        };
+
+        edges.iter().all(|(left_range, left_child)| {
+            middle_edges.iter().all(|(middle_range, middle_child)| {
+                let intersection = left_range.intersection(middle_range);
+                intersection.is_empty()
+                    || right_edges.iter().all(|(right_range, right_child)| {
+                        intersection.is_disjoint(right_range)
+                            || callback(
+                                left_child.negate(parent),
+                                middle_child.negate(middle_parent),
+                                right_child.negate(right_parent),
+                            )
+                    })
+            })
+        })
+    }
+
+    /// Merge adjacent range edges that point to the same node.
+    fn coalesce(self) -> Self {
+        match self {
+            Self::Version { edges } => Self::Version {
+                edges: Self::coalesce_ranges(edges),
+            },
+            Self::String { edges } => Self::String {
+                edges: Self::coalesce_ranges(edges),
+            },
+            Self::Boolean { .. } => self,
+        }
+    }
+
+    /// Merge adjacent ranges that point to the same node.
+    fn coalesce_ranges<T>(edges: SmallVec<(Ranges<T>, NodeId)>) -> SmallVec<(Ranges<T>, NodeId)>
+    where
+        T: Clone + Ord,
+    {
+        let mut combined = SmallVec::new();
+        for (range, node) in edges {
+            match combined.last_mut() {
+                Some((previous, child)) if *child == node && can_conjoin(previous, &range) => {
+                    *previous = previous.union(&range);
+                }
+                _ => combined.push((range, node)),
+            }
+        }
+        combined
     }
 
     // Apply the given function to all direct children of this node.
@@ -2298,11 +2487,14 @@ mod tests {
     }
 
     #[test]
-    fn non_conflicting_markers_remain_boolean() {
+    fn markers_without_conflicting_pair_remain_boolean() {
         let mut interner = INTERNER.lock();
         for marker in [
             "extra == 'foo'",
             "python_version >= '3.9'",
+            "os_name == 'nt'",
+            "sys_platform == 'linux'",
+            "platform_system == 'FreeBSD'",
             "platform_machine == 'aarch64'",
             "implementation_name == 'pypy'",
         ] {
@@ -2310,6 +2502,19 @@ mod tests {
             let raw = interner.expression_raw(expression);
             assert_eq!(interner.finish(raw), raw);
         }
+
+        let os_name = interner.expression_raw(
+            MarkerExpression::from_str("os_name == 'nt'")
+                .unwrap()
+                .unwrap(),
+        );
+        let platform_system = interner.expression_raw(
+            MarkerExpression::from_str("platform_system == 'NetBSD'")
+                .unwrap()
+                .unwrap(),
+        );
+        let raw = interner.and_cached(os_name, platform_system);
+        assert_eq!(interner.finish(raw), raw);
     }
 
     #[test]
@@ -2319,6 +2524,15 @@ mod tests {
         let netbsd = expr("platform_system == 'NetBSD'");
 
         let mut interner = INTERNER.lock();
+        interner.exclusions();
+        for (left, right) in [(windows, linux), (windows, netbsd)] {
+            let key = if left <= right {
+                (left, right)
+            } else {
+                (right, left)
+            };
+            interner.state.disjointness_cache.remove(&key);
+        }
         let nodes = INTERNER.shared.nodes.count();
         let cache = interner.state.disjointness_cache.len();
         assert!(interner.is_disjoint(windows, linux));
@@ -2328,6 +2542,31 @@ mod tests {
         assert!(!interner.is_disjoint(netbsd, windows));
         assert_eq!(interner.state.disjointness_cache.len(), cache + 2);
         assert_eq!(INTERNER.shared.nodes.count(), nodes);
+    }
+
+    #[test]
+    fn disjointness_respects_validity_domain() {
+        let windows = expr("os_name == 'nt'");
+        let posix = expr("os_name == 'posix'");
+        let linux = expr("sys_platform == 'linux'");
+        let win32 = expr("sys_platform == 'win32'");
+        let ios = expr("sys_platform == 'ios'");
+        let not_linux = expr("sys_platform != 'linux'");
+        let netbsd = expr("platform_system == 'NetBSD'");
+        let platform_ios = expr("platform_system == 'iOS'");
+
+        let mut interner = INTERNER.lock();
+        for (left, right, expected) in [
+            (windows, linux, true),
+            (posix, win32, true),
+            (netbsd, linux, true),
+            (platform_ios, ios, false),
+            (windows, netbsd, false),
+            (windows, not_linux, false),
+        ] {
+            assert_eq!(interner.is_disjoint(left, right), expected);
+            assert_eq!(interner.is_disjoint(right, left), expected);
+        }
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -109,6 +109,9 @@ struct InternerState {
 
     /// A cache for projecting ternary trees back to Boolean marker trees.
     projection_cache: FxHashMap<NodeId, NodeId>,
+
+    /// A cache for disjointness checks between two marker trees.
+    disjointness_cache: FxHashMap<(NodeId, NodeId), bool>,
 }
 
 impl InternerShared {
@@ -720,7 +723,14 @@ impl InternerGuard<'_> {
     /// Returns `true` if there is no environment in which both marker trees can apply,
     /// i.e. their conjunction is always `false`.
     pub(crate) fn is_disjoint(&mut self, xi: NodeId, yi: NodeId) -> bool {
-        self.disjointness(xi, yi)
+        let key = if xi <= yi { (xi, yi) } else { (yi, xi) };
+        if let Some(&disjoint) = self.state.disjointness_cache.get(&key) {
+            return disjoint;
+        }
+
+        let disjoint = self.disjointness(xi, yi);
+        self.state.disjointness_cache.insert(key, disjoint);
+        disjoint
     }
 
     /// Returns `true` if there is no environment in which both marker trees can apply,
@@ -2310,8 +2320,13 @@ mod tests {
 
         let mut interner = INTERNER.lock();
         let nodes = INTERNER.shared.nodes.count();
+        let cache = interner.state.disjointness_cache.len();
         assert!(interner.is_disjoint(windows, linux));
+        assert!(interner.is_disjoint(linux, windows));
+        assert_eq!(interner.state.disjointness_cache.len(), cache + 1);
         assert!(!interner.is_disjoint(windows, netbsd));
+        assert!(!interner.is_disjoint(netbsd, windows));
+        assert_eq!(interner.state.disjointness_cache.len(), cache + 2);
         assert_eq!(INTERNER.shared.nodes.count(), nodes);
     }
 

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -1489,7 +1489,7 @@ impl NodeId {
     pub(crate) const FALSE: Self = Self(1);
 
     // The terminal node representing an unreachable assignment.
-    pub(crate) const DONT_CARE: Self = Self(2);
+    const DONT_CARE: Self = Self(2);
 
     /// Create a new, optionally complemented, [`NodeId`] with the given index.
     fn new(index: usize, complement: bool) -> Self {

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -53,7 +53,7 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use arcstr::ArcStr;
 use itertools::{Either, Itertools};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::{FxHashMap, FxHashSet};
 use version_ranges::Ranges;
 
 use uv_pep440::{Operator, Version, VersionSpecifier, release_specifier_to_range};
@@ -86,9 +86,6 @@ pub(crate) struct Interner {
 pub(crate) struct InternerShared {
     /// A list of unique [`Node`]s and their cached Boolean projections.
     nodes: boxcar::Vec<InternedNode>,
-
-    /// Canonical marker trees for projected children that can reach an exclusion.
-    canonical_projections: papaya::HashMap<NodeId, NodeId, FxBuildHasher>,
 }
 
 /// A unique node and the cached projection for each complemented-edge orientation.
@@ -97,6 +94,7 @@ struct InternedNode {
     projections: [AtomicUsize; 2],
     can_conflict: bool,
     conflicting_variables: u8,
+    contains_dont_care: bool,
 }
 
 const OS_NAME_VARIABLE: u8 = 1;
@@ -136,13 +134,24 @@ impl InternerShared {
     }
 
     /// Returns `true` if the given marker can reach a known-incompatible pair of variables.
-    pub(crate) fn can_conflict(&self, id: NodeId) -> bool {
+    fn can_conflict(&self, id: NodeId) -> bool {
         !id.is_terminal() && self.nodes[id.index()].can_conflict
     }
 
-    /// Returns the canonical marker for a projected child, if it has already been computed.
+    /// Returns the canonical marker for a projected child, if one is needed.
     pub(crate) fn canonical_projection(&self, id: NodeId) -> Option<NodeId> {
-        self.canonical_projections.pin().get(&id).copied()
+        if id.is_terminal() || self.contains_dont_care(id) || !self.can_conflict(id) {
+            return None;
+        }
+
+        let projection = self.nodes[id.index()].projections[usize::from(id.is_complement())]
+            .load(AtomicOrdering::Acquire);
+        (projection != usize::MAX).then_some(NodeId(projection))
+    }
+
+    /// Returns `true` if the given marker contains a don't-care edge.
+    fn contains_dont_care(&self, id: NodeId) -> bool {
+        id.is_dont_care() || (!id.is_terminal() && self.nodes[id.index()].contains_dont_care)
     }
 
     /// Returns `true` if two marker trees can contain a known-incompatible pair of variables.
@@ -256,6 +265,9 @@ impl InternerShared {
         if id.is_terminal() {
             return Some(id);
         }
+        if !self.contains_dont_care(id) && self.can_conflict(id) {
+            return Some(id);
+        }
 
         let projection = self.nodes[id.index()].projections[usize::from(id.is_complement())]
             .load(AtomicOrdering::Acquire);
@@ -265,6 +277,19 @@ impl InternerShared {
     /// Cache the Boolean projection for the given [`NodeId`].
     fn cache_projection(&self, id: NodeId, projection: NodeId) {
         if id.is_terminal() {
+            return;
+        }
+        if !self.contains_dont_care(id) && self.can_conflict(id) {
+            return;
+        }
+
+        self.nodes[id.index()].projections[usize::from(id.is_complement())]
+            .store(projection.0, AtomicOrdering::Release);
+    }
+
+    /// Cache the canonical marker for a Boolean projected child.
+    fn cache_canonical_projection(&self, id: NodeId, projection: NodeId) {
+        if id.is_terminal() || self.contains_dont_care(id) || !self.can_conflict(id) {
             return;
         }
 
@@ -321,12 +346,17 @@ impl InternerGuard<'_> {
         let id = self.state.unique.entry(node.clone()).or_insert_with(|| {
             let can_conflict = self.shared.node_can_conflict(&node);
             let conflicting_variables = self.shared.node_conflicting_variables(&node);
+            let contains_dont_care = node
+                .children
+                .nodes()
+                .any(|child| self.shared.contains_dont_care(child));
             NodeId::new(
                 self.shared.nodes.push(InternedNode {
                     node,
                     projections: [AtomicUsize::new(usize::MAX), AtomicUsize::new(usize::MAX)],
                     can_conflict,
                     conflicting_variables,
+                    contains_dont_care,
                 }),
                 false,
             )
@@ -626,7 +656,7 @@ impl InternerGuard<'_> {
         }
         let validity = self.exclusions().not();
         let masked = self.mask(node, validity);
-        if masked == self.mask(NodeId::TRUE, validity) {
+        let canonical = if masked == self.mask(NodeId::TRUE, validity) {
             NodeId::TRUE
         } else if masked == self.mask(NodeId::FALSE, validity) {
             NodeId::FALSE
@@ -641,17 +671,49 @@ impl InternerGuard<'_> {
             } else {
                 self.mask(projected, validity)
             }
-        }
+        };
+        self.cache_projected_children(canonical, validity);
+        canonical
     }
 
-    /// Apply the validity domain to a projected child and cache the canonical result.
-    pub(crate) fn finish_projection(&mut self, node: NodeId) -> NodeId {
-        let canonical = self.finish(node);
-        self.shared
-            .canonical_projections
-            .pin()
-            .insert(node, canonical);
-        canonical
+    /// Cache the canonical form of every conflicting subtree in a Boolean projection.
+    fn cache_projected_children(&mut self, value: NodeId, validity: NodeId) {
+        let root = self.project(value);
+        self.shared.cache_projection(value.not(), root.not());
+        if root.is_terminal() {
+            return;
+        }
+        let mut pending = self
+            .shared
+            .node(root)
+            .children
+            .nodes()
+            .map(|child| child.negate(root))
+            .collect_vec();
+        let mut visited = FxHashSet::default();
+
+        while let Some(projected) = pending.pop() {
+            if projected.is_terminal() || !visited.insert(projected) {
+                continue;
+            }
+
+            let node = self.shared.node(projected);
+            pending.extend(node.children.nodes().map(|child| child.negate(projected)));
+
+            if !self.can_conflict(projected)
+                || self.shared.canonical_projection(projected).is_some()
+            {
+                continue;
+            }
+
+            let canonical = self.mask(projected, validity);
+            self.shared.cache_canonical_projection(projected, canonical);
+            self.shared
+                .cache_canonical_projection(projected.not(), canonical.not());
+            self.shared.cache_projection(canonical, projected);
+            self.shared
+                .cache_projection(canonical.not(), projected.not());
+        }
     }
 
     /// Returns `true` if a marker tree can contain a known-incompatible pair of variables.

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -558,7 +558,7 @@ impl InternerGuard<'_> {
             })
         });
 
-        edges.iter().any(|(_, child)| {
+        edges.iter().any(|(range, child)| {
             if child.is_terminal() {
                 return false;
             }
@@ -568,8 +568,9 @@ impl InternerGuard<'_> {
                 return false;
             }
 
-            let can_conflict =
-                references_excluded_value && node.var.conflicts_with(&child_node.var);
+            let can_conflict = (references_excluded_value
+                || excluded_values.iter().any(|value| range.contains(*value)))
+                && node.var.conflicts_with(&child_node.var);
 
             can_conflict || self.can_conflict(*child)
         })

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -53,7 +53,7 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use arcstr::ArcStr;
 use itertools::{Either, Itertools};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use version_ranges::Ranges;
 
 use uv_pep440::{Operator, Version, VersionSpecifier, release_specifier_to_range};
@@ -86,6 +86,9 @@ pub(crate) struct Interner {
 pub(crate) struct InternerShared {
     /// A list of unique [`Node`]s and their cached Boolean projections.
     nodes: boxcar::Vec<InternedNode>,
+
+    /// Canonical marker trees for projected children that can reach an exclusion.
+    canonical_projections: papaya::HashMap<NodeId, NodeId, FxBuildHasher>,
 }
 
 /// A unique node and the cached projection for each complemented-edge orientation.
@@ -133,8 +136,13 @@ impl InternerShared {
     }
 
     /// Returns `true` if the given marker can reach a known-incompatible pair of variables.
-    fn can_conflict(&self, id: NodeId) -> bool {
+    pub(crate) fn can_conflict(&self, id: NodeId) -> bool {
         !id.is_terminal() && self.nodes[id.index()].can_conflict
+    }
+
+    /// Returns the canonical marker for a projected child, if it has already been computed.
+    pub(crate) fn canonical_projection(&self, id: NodeId) -> Option<NodeId> {
+        self.canonical_projections.pin().get(&id).copied()
     }
 
     /// Returns `true` if two marker trees can contain a known-incompatible pair of variables.
@@ -634,6 +642,16 @@ impl InternerGuard<'_> {
                 self.mask(projected, validity)
             }
         }
+    }
+
+    /// Apply the validity domain to a projected child and cache the canonical result.
+    pub(crate) fn finish_projection(&mut self, node: NodeId) -> NodeId {
+        let canonical = self.finish(node);
+        self.shared
+            .canonical_projections
+            .pin()
+            .insert(node, canonical);
+        canonical
     }
 
     /// Returns `true` if a marker tree can contain a known-incompatible pair of variables.

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -48,6 +48,7 @@
 use std::cmp::{Ordering, min};
 use std::fmt;
 use std::ops::Bound;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use arcstr::ArcStr;
@@ -83,8 +84,14 @@ pub(crate) struct Interner {
 /// The shared part of an [`Interner`], which can be accessed without a lock.
 #[derive(Default)]
 pub(crate) struct InternerShared {
-    /// A list of unique [`Node`]s.
-    nodes: boxcar::Vec<Node>,
+    /// A list of unique [`Node`]s and their cached Boolean projections.
+    nodes: boxcar::Vec<InternedNode>,
+}
+
+/// A unique node and the cached projection for each complemented-edge orientation.
+struct InternedNode {
+    node: Node,
+    projections: [AtomicUsize; 2],
 }
 
 /// The mutable [`Interner`] state, stored behind a lock.
@@ -107,9 +114,6 @@ struct InternerState {
     /// A cache for replacing reachable terminal values while retaining don't-care edges.
     terminal_cache: FxHashMap<(NodeId, NodeId), NodeId>,
 
-    /// A cache for projecting ternary trees back to Boolean marker trees.
-    projection_cache: FxHashMap<NodeId, NodeId>,
-
     /// A cache for disjointness checks between two marker trees.
     disjointness_cache: FxHashMap<(NodeId, NodeId), bool>,
 }
@@ -117,7 +121,28 @@ struct InternerState {
 impl InternerShared {
     /// Returns the node for the given [`NodeId`].
     pub(crate) fn node(&self, id: NodeId) -> &Node {
-        &self.nodes[id.index()]
+        &self.nodes[id.index()].node
+    }
+
+    /// Returns the cached Boolean projection for the given [`NodeId`], if one exists.
+    pub(crate) fn projection(&self, id: NodeId) -> Option<NodeId> {
+        if id.is_terminal() {
+            return Some(id);
+        }
+
+        let projection = self.nodes[id.index()].projections[usize::from(id.is_complement())]
+            .load(AtomicOrdering::Acquire);
+        (projection != usize::MAX).then_some(NodeId(projection))
+    }
+
+    /// Cache the Boolean projection for the given [`NodeId`].
+    fn cache_projection(&self, id: NodeId, projection: NodeId) {
+        if id.is_terminal() {
+            return;
+        }
+
+        self.nodes[id.index()].projections[usize::from(id.is_complement())]
+            .store(projection.0, AtomicOrdering::Release);
     }
 }
 
@@ -166,11 +191,15 @@ impl InternerGuard<'_> {
         }
 
         // Insert the node.
-        let id = self
-            .state
-            .unique
-            .entry(node.clone())
-            .or_insert_with(|| NodeId::new(self.shared.nodes.push(node), false));
+        let id = self.state.unique.entry(node.clone()).or_insert_with(|| {
+            NodeId::new(
+                self.shared.nodes.push(InternedNode {
+                    node,
+                    projections: [AtomicUsize::new(usize::MAX), AtomicUsize::new(usize::MAX)],
+                }),
+                false,
+            )
+        });
 
         if flipped { id.not() } else { *id }
     }
@@ -587,7 +616,7 @@ impl InternerGuard<'_> {
         if value.is_terminal() {
             return value;
         }
-        if let Some(&projected) = self.state.projection_cache.get(&value) {
+        if let Some(projected) = self.shared.projection(value) {
             return projected;
         }
 
@@ -617,8 +646,10 @@ impl InternerGuard<'_> {
         }
         if let [group] = groups.as_slice() {
             let projected = self.project_cached(*group, compatible_cache);
-            self.state.projection_cache.insert(value, projected);
-            self.state.projection_cache.insert(projected, projected);
+            self.shared.cache_projection(value, projected);
+            self.shared.cache_projection(projected, projected);
+            self.shared
+                .cache_projection(projected.not(), projected.not());
             return projected;
         }
 
@@ -626,8 +657,10 @@ impl InternerGuard<'_> {
             self.project_cached(groups[assignments[&child]], compatible_cache)
         });
         let projected = self.create_node(node.var.clone(), children.coalesce());
-        self.state.projection_cache.insert(value, projected);
-        self.state.projection_cache.insert(projected, projected);
+        self.shared.cache_projection(value, projected);
+        self.shared.cache_projection(projected, projected);
+        self.shared
+            .cache_projection(projected.not(), projected.not());
         projected
     }
 

--- a/crates/uv-pep508/src/marker/parse.rs
+++ b/crates/uv-pep508/src/marker/parse.rs
@@ -585,7 +585,7 @@ fn parse_marker_expr<T: Pep508Url>(
         cursor.next_expect_char(')', start_pos)?;
         Ok(marker)
     } else {
-        Ok(parse_marker_key_op_value(cursor, reporter)?.map(MarkerTree::expression))
+        Ok(parse_marker_key_op_value(cursor, reporter)?.map(MarkerTree::expression_raw))
     }
 }
 
@@ -597,7 +597,13 @@ fn parse_marker_and<T: Pep508Url>(
     cursor: &mut Cursor,
     reporter: &mut impl Reporter,
 ) -> Result<Option<MarkerTree>, Pep508Error<T>> {
-    parse_marker_op(cursor, "and", MarkerTree::and, parse_marker_expr, reporter)
+    parse_marker_op(
+        cursor,
+        "and",
+        MarkerTree::and_raw,
+        parse_marker_expr,
+        reporter,
+    )
 }
 
 /// ```text
@@ -611,7 +617,7 @@ fn parse_marker_or<T: Pep508Url>(
     parse_marker_op(
         cursor,
         "or",
-        MarkerTree::or,
+        MarkerTree::or_raw,
         |cursor, reporter| parse_marker_and(cursor, reporter),
         reporter,
     )
@@ -682,7 +688,7 @@ pub(crate) fn parse_markers_cursor<T: Pep508Url>(
         });
     }
 
-    Ok(marker)
+    Ok(marker.map(MarkerTree::finish))
 }
 
 /// Parses markers such as `python_version < '3.8'` or

--- a/crates/uv-pep508/src/marker/simplify.rs
+++ b/crates/uv-pep508/src/marker/simplify.rs
@@ -92,7 +92,7 @@ fn collect_dnf(
             }
         }
         MarkerTreeKind::String(marker) => {
-            for (tree, range) in collect_edges(marker.children()) {
+            for (tree, range) in collect_edges(marker.raw_children()) {
                 // Detect whether the range for this edge can be simplified as an inequality.
                 if let Some(excluded) = range_inequality(&range) {
                     let current = path.len();

--- a/crates/uv-pep508/src/marker/simplify.rs
+++ b/crates/uv-pep508/src/marker/simplify.rs
@@ -92,7 +92,7 @@ fn collect_dnf(
             }
         }
         MarkerTreeKind::String(marker) => {
-            for (tree, range) in collect_edges(marker.raw_children()) {
+            for (tree, range) in collect_edges(marker.projected_children()) {
                 // Detect whether the range for this edge can be simplified as an inequality.
                 if let Some(excluded) = range_inequality(&range) {
                     let current = path.len();

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1480,20 +1480,30 @@ impl MarkerTree {
 
     fn simplify_extras_with_impl(self, is_extra: &impl Fn(&ExtraName) -> bool) -> Self {
         let mut interner = INTERNER.lock();
-        let node = interner.restrict_by(self.0, &|var| match var {
+        let value = self.project_if_needed(&mut interner);
+        let node = interner.restrict_by(value, &|var| match var {
             Variable::Extra(name) => is_extra(name.extra()).then_some(true),
             _ => None,
         });
-        Self(interner.finish(node))
+        if node == value {
+            self
+        } else {
+            Self(interner.finish(node))
+        }
     }
 
     fn simplify_not_extras_with_impl(self, is_extra: &impl Fn(&ExtraName) -> bool) -> Self {
         let mut interner = INTERNER.lock();
-        let node = interner.restrict_by(self.0, &|var| match var {
+        let value = self.project_if_needed(&mut interner);
+        let node = interner.restrict_by(value, &|var| match var {
             Variable::Extra(name) => is_extra(name.extra()).then_some(false),
             _ => None,
         });
-        Self(interner.finish(node))
+        if node == value {
+            self
+        } else {
+            Self(interner.finish(node))
+        }
     }
 }
 
@@ -2618,6 +2628,14 @@ mod test {
 
     #[test]
     fn test_simplify_extras() {
+        let platform = m(
+            "(os_name == 'nt' or sys_platform == 'linux') and platform_machine == 'simplify-extra-machine'",
+        );
+        assert_eq!(
+            platform.simplify_extras(&[ExtraName::from_str("dev").unwrap()]),
+            platform
+        );
+
         // Given `os_name == "nt" and extra == "dev"`, simplify to `os_name == "nt"`.
         let markers = MarkerTree::from_str(r#"os_name == "nt" and extra == "dev""#).unwrap();
         let simplified = markers.simplify_extras(&[ExtraName::from_str("dev").unwrap()]);
@@ -2669,6 +2687,14 @@ mod test {
 
     #[test]
     fn test_simplify_not_extras() {
+        let platform = m(
+            "(os_name == 'nt' or sys_platform == 'linux') and platform_machine == 'simplify-not-extra-machine'",
+        );
+        assert_eq!(
+            platform.simplify_not_extras(&[ExtraName::from_str("dev").unwrap()]),
+            platform
+        );
+
         // Given `os_name == "nt" and extra != "dev"`, simplify to `os_name == "nt"`.
         let markers = MarkerTree::from_str(r#"os_name == "nt" and extra != "dev""#).unwrap();
         let simplified = markers.simplify_not_extras(&[ExtraName::from_str("dev").unwrap()]);

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -12,7 +12,7 @@ use version_ranges::Ranges;
 use uv_normalize::{ExtraName, GroupName};
 use uv_pep440::{Version, VersionParseError, VersionSpecifier};
 
-use super::algebra::{Edges, INTERNER, NodeId, Variable};
+use super::algebra::{Edges, INTERNER, InternerGuard, NodeId, Variable};
 use super::simplify;
 #[cfg(test)]
 use crate::Pep508ErrorSource;
@@ -1310,8 +1310,8 @@ impl MarkerTree {
     #[must_use]
     pub fn restrict(self, assumption: Self) -> Self {
         let mut interner = INTERNER.lock();
-        let value = interner.project(self.0);
-        let assumption = interner.project(assumption.0);
+        let value = self.project_if_needed(&mut interner);
+        let assumption = assumption.project_if_needed(&mut interner);
         let node = interner.restrict(value, assumption);
         Self(interner.finish(node))
     }
@@ -1391,7 +1391,7 @@ impl MarkerTree {
     #[must_use]
     pub fn without_extras(self) -> Self {
         let mut interner = INTERNER.lock();
-        let value = interner.project(self.0);
+        let value = self.project_if_needed(&mut interner);
         let node = interner.without_extras(value);
         Self(interner.finish(node))
     }
@@ -1403,9 +1403,21 @@ impl MarkerTree {
     #[must_use]
     pub fn only_extras(self) -> Self {
         let mut interner = INTERNER.lock();
-        let value = interner.project(self.0);
+        let value = self.project_if_needed(&mut interner);
         let node = interner.only_extras(value);
         Self(interner.finish(node))
+    }
+
+    /// Project this marker only if it can contain don't-care edges.
+    fn project_if_needed(self, interner: &mut InternerGuard<'_>) -> NodeId {
+        if self.is_true()
+            || self.is_false()
+            || !INTERNER.shared.node(self.0).var.is_conflicting_variable()
+        {
+            self.0
+        } else {
+            interner.project(self.0)
+        }
     }
 
     /// Calls the provided function on every `extra` in this tree.
@@ -1953,6 +1965,24 @@ mod test {
         drop(guard);
         thread.join().unwrap();
         assert_eq!(result.unwrap(), [true, true, true, true, true]);
+    }
+
+    #[test]
+    fn non_conflicting_transformations_do_not_project() {
+        let marker = m(
+            "(platform_machine == 'x86_64' and implementation_name == 'cpython' and extra == 'one') \
+             or (platform_machine == 'aarch64' and implementation_name == 'pypy' and extra == 'two')",
+        );
+        let assumption = m("platform_machine == 'x86_64'");
+        assert!(INTERNER.shared.projection(marker.0).is_none());
+        assert!(INTERNER.shared.projection(assumption.0).is_none());
+
+        let _ = marker.without_extras();
+        let _ = marker.only_extras();
+        let _ = marker.restrict(assumption);
+
+        assert!(INTERNER.shared.projection(marker.0).is_none());
+        assert!(INTERNER.shared.projection(assumption.0).is_none());
     }
 
     /// Copied from <https://github.com/pypa/packaging/blob/85ff971a250dc01db188ef9775499c15553a8c95/tests/test_markers.py#L175-L221>

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3126,6 +3126,14 @@ mod test {
         right_win32.and(win32);
         right_linux.or(right_win32);
         assert_eq!(left, right_linux);
+
+        let extra = m("extra == 'foo'");
+        let mut left = windows;
+        left.and(extra);
+        let mut right = windows.negate();
+        right.and(extra);
+        left.or(right);
+        assert_eq!(left, extra);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1077,7 +1077,7 @@ impl MarkerTree {
                 }
             }
             MarkerTreeKind::String(marker) => {
-                for (range, tree) in marker.raw_children() {
+                for (range, tree) in marker.projected_children() {
                     let l_string = env.get_string(marker.key());
 
                     if matches!(
@@ -1152,7 +1152,7 @@ impl MarkerTree {
                 marker.edges().any(|(_, tree)| tree.evaluate_extras(extras))
             }
             MarkerTreeKind::String(marker) => marker
-                .raw_children()
+                .projected_children()
                 .any(|(_, tree)| tree.evaluate_extras(extras)),
             MarkerTreeKind::In(marker) => marker
                 .children()
@@ -1178,7 +1178,7 @@ impl MarkerTree {
                 .edges()
                 .all(|(_, tree)| tree.evaluate_only_extras(extras)),
             MarkerTreeKind::String(marker) => marker
-                .raw_children()
+                .projected_children()
                 .all(|(_, tree)| tree.evaluate_only_extras(extras)),
             MarkerTreeKind::In(marker) => marker
                 .children()
@@ -1444,7 +1444,7 @@ impl MarkerTree {
                     }
                 }
                 MarkerTreeKind::String(kind) => {
-                    for (tree, _) in simplify::collect_edges(kind.raw_children()) {
+                    for (tree, _) in simplify::collect_edges(kind.projected_children()) {
                         imp(tree, f);
                     }
                 }
@@ -1608,7 +1608,7 @@ impl StringMarkerTree<'_> {
 
     /// The edges of this node, corresponding to possible output ranges of the given variable.
     pub fn children(&self) -> impl ExactSizeIterator<Item = (&Ranges<ArcStr>, MarkerTree)> {
-        self.raw_children().map(|(range, child)| {
+        self.projected_children().map(|(range, child)| {
             let child = if INTERNER.shared.can_conflict(child.0) {
                 child.finish()
             } else {
@@ -1619,7 +1619,10 @@ impl StringMarkerTree<'_> {
     }
 
     /// The projected edges of this node for read-only traversal.
-    pub(super) fn raw_children(
+    ///
+    /// The returned children need not be canonical standalone markers. They are suitable for
+    /// structural traversal, but should not be used for marker algebra, equality, or hashing.
+    pub fn projected_children(
         &self,
     ) -> impl ExactSizeIterator<Item = (&Ranges<ArcStr>, MarkerTree)> {
         self.map
@@ -1638,7 +1641,7 @@ impl Ord for StringMarkerTree<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.key()
             .cmp(&other.key())
-            .then_with(|| self.raw_children().cmp(other.raw_children()))
+            .then_with(|| self.projected_children().cmp(other.projected_children()))
     }
 }
 
@@ -2012,7 +2015,7 @@ mod test {
             panic!("expected a string marker");
         };
         let raw_child = kind
-            .raw_children()
+            .projected_children()
             .find_map(|(range, child)| (!range.contains("posix")).then_some(child))
             .unwrap();
         let child = kind
@@ -2045,6 +2048,24 @@ mod test {
 
     #[test]
     fn projected_platform_children_do_not_lock_interner() {
+        fn visit(tree: MarkerTree) -> usize {
+            match tree.kind() {
+                MarkerTreeKind::String(marker) => {
+                    1 + marker
+                        .projected_children()
+                        .map(|(_, tree)| visit(tree))
+                        .sum::<usize>()
+                }
+                MarkerTreeKind::Extra(marker) => {
+                    1 + marker
+                        .children()
+                        .map(|(_, tree)| visit(tree))
+                        .sum::<usize>()
+                }
+                _ => 1,
+            }
+        }
+
         let marker = m(
             "os_name != 'posix' and ((platform_system != 'FreeBSD' and sys_platform != 'darwin') \
              or (sys_platform == 'darwin' and extra == 'y'))",
@@ -2065,6 +2086,8 @@ mod test {
                     negated.evaluate_optional_environment(None, &[]),
                     marker.evaluate_only_extras(&[]),
                     negated.evaluate_only_extras(&[]),
+                    visit(marker) > 1,
+                    visit(negated) > 1,
                 ])
                 .unwrap();
         });
@@ -2072,7 +2095,10 @@ mod test {
         let result = receiver.recv_timeout(Duration::from_secs(5));
         drop(guard);
         thread.join().unwrap();
-        assert_eq!(result.unwrap(), [true, false, true, true, false, false]);
+        assert_eq!(
+            result.unwrap(),
+            [true, false, true, true, false, false, true, true]
+        );
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3268,6 +3268,10 @@ mod test {
         right.or(not_linux);
         right.or(windows);
         assert_eq!(left, right);
+
+        let custom_linux = m("os_name != 'custom' and sys_platform == 'linux'");
+        assert!(custom_linux.is_disjoint(windows));
+        assert!(windows.is_disjoint(custom_linux));
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1592,9 +1592,18 @@ impl StringMarkerTree<'_> {
 
     /// The edges of this node, corresponding to possible output ranges of the given variable.
     pub fn children(&self) -> impl ExactSizeIterator<Item = (&Ranges<ArcStr>, MarkerTree)> {
-        self.map
-            .iter()
-            .map(|(range, node)| (range, MarkerTree(node.negate(self.id))))
+        self.map.iter().map(|(range, node)| {
+            let child = node.negate(self.id);
+            let child = if INTERNER.shared.can_conflict(child) {
+                INTERNER
+                    .shared
+                    .canonical_projection(child)
+                    .unwrap_or_else(|| INTERNER.lock().finish_projection(child))
+            } else {
+                child
+            };
+            (range, MarkerTree(child))
+        })
     }
 }
 
@@ -1970,6 +1979,57 @@ mod test {
         drop(guard);
         thread.join().unwrap();
         assert_eq!(result.unwrap(), [true, true, true, true, true]);
+    }
+
+    #[test]
+    fn projected_platform_children_are_canonical() {
+        let marker = m(
+            "os_name != 'posix' and ((platform_system != 'FreeBSD' and sys_platform != 'darwin') \
+             or (sys_platform == 'darwin' and extra == 'y'))",
+        );
+        let MarkerTreeKind::String(kind) = marker.kind() else {
+            panic!("expected a string marker");
+        };
+        let child = kind
+            .children()
+            .find_map(|(range, child)| (!range.contains("posix")).then_some(child))
+            .unwrap();
+        let reparsed = m(&child.try_to_string().unwrap());
+        let freebsd = m("platform_system == 'FreeBSD'");
+
+        assert_eq!(child, reparsed);
+        assert_eq!(child.cmp(&reparsed), std::cmp::Ordering::Equal);
+        assert_eq!(HashSet::from([child, reparsed]).len(), 1);
+        assert!(child.is_disjoint(freebsd));
+        assert!(freebsd.is_disjoint(child));
+    }
+
+    #[test]
+    fn projected_platform_children_do_not_lock_interner() {
+        let marker = m(
+            "os_name != 'posix' and ((platform_system != 'FreeBSD' and sys_platform != 'darwin') \
+             or (sys_platform == 'darwin' and extra == 'y'))",
+        );
+        let negated = marker.negate();
+        let _ = marker.try_to_string();
+        let _ = negated.try_to_string();
+
+        let guard = INTERNER.lock();
+        let (sender, receiver) = mpsc::channel();
+        let thread = std::thread::spawn(move || {
+            let environment = env37();
+            sender
+                .send([
+                    marker.evaluate(&environment, &[]),
+                    negated.evaluate(&environment, &[]),
+                ])
+                .unwrap();
+        });
+
+        let result = receiver.recv_timeout(Duration::from_secs(5));
+        drop(guard);
+        thread.join().unwrap();
+        assert_eq!(result.unwrap(), [true, false]);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1277,7 +1277,11 @@ impl MarkerTree {
     pub fn simplify_python_versions(self, lower: Bound<&Version>, upper: Bound<&Version>) -> Self {
         let mut interner = INTERNER.lock();
         let node = interner.simplify_python_versions(self.0, lower, upper);
-        Self(interner.finish(node))
+        if node == self.0 {
+            self
+        } else {
+            Self(interner.finish(node))
+        }
     }
 
     /// Complexify marker tree by requiring the given Python version range
@@ -2022,6 +2026,17 @@ mod test {
 
     #[test]
     fn simplify_python_versions() {
+        let platform = m(
+            "(os_name == 'nt' or sys_platform == 'linux') and platform_machine == 'simplify-machine'",
+        );
+        assert_eq!(
+            platform.simplify_python_versions(
+                Bound::Included(Version::new([3, 9])).as_ref(),
+                Bound::Unbounded.as_ref(),
+            ),
+            platform
+        );
+
         assert_eq!(
             m("(extra == 'foo' and sys_platform == 'win32') or extra == 'foo'")
                 .simplify_extras(&["foo".parse().unwrap()]),

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -812,6 +812,16 @@ impl MarkerTree {
         Self(INTERNER.lock().expression(expr))
     }
 
+    /// Returns an unmasked marker tree for use while parsing a compound expression.
+    pub(super) fn expression_raw(expr: MarkerExpression) -> Self {
+        Self(INTERNER.lock().expression_raw(expr))
+    }
+
+    /// Applies the global validity domain after parsing a compound expression.
+    pub(super) fn finish(self) -> Self {
+        Self(INTERNER.lock().finish(self.0))
+    }
+
     /// Whether the marker always evaluates to `true`.
     ///
     /// If this method returns `true`, it is definitively known that the marker will
@@ -841,16 +851,22 @@ impl MarkerTree {
 
     /// Combine this marker tree with the one given via a conjunction.
     pub fn and(&mut self, tree: Self) {
-        let mut interner = INTERNER.lock();
-        let node = interner.and(self.0, tree.0);
-        self.0 = interner.simplify_exclusions(node, self.0, tree.0);
+        self.0 = INTERNER.lock().and(self.0, tree.0);
+    }
+
+    /// Combine two unmasked marker trees while parsing.
+    pub(super) fn and_raw(&mut self, tree: Self) {
+        self.0 = INTERNER.lock().and_cached(self.0, tree.0);
     }
 
     /// Combine this marker tree with the one given via a disjunction.
     pub fn or(&mut self, tree: Self) {
-        let mut interner = INTERNER.lock();
-        let node = interner.or(self.0, tree.0);
-        self.0 = interner.simplify_exclusions(node, self.0, tree.0);
+        self.0 = INTERNER.lock().or(self.0, tree.0);
+    }
+
+    /// Combine two unmasked marker trees while parsing.
+    pub(super) fn or_raw(&mut self, tree: Self) {
+        self.0 = INTERNER.lock().or_cached(self.0, tree.0);
     }
 
     /// Sets this to a marker equivalent to the implication of this one and the
@@ -901,22 +917,23 @@ impl MarkerTree {
 
     /// Returns the underlying [`MarkerTreeKind`] of the root node.
     pub fn kind(self) -> MarkerTreeKind<'static> {
-        if self.is_true() {
+        let tree = Self(INTERNER.lock().project(self.0));
+        if tree.is_true() {
             return MarkerTreeKind::True;
         }
 
-        if self.is_false() {
+        if tree.is_false() {
             return MarkerTreeKind::False;
         }
 
-        let node = INTERNER.shared.node(self.0);
+        let node = INTERNER.shared.node(tree.0);
         match &node.var {
             Variable::Version(key) => {
                 let Edges::Version { edges: ref map } = node.children else {
                     unreachable!()
                 };
                 MarkerTreeKind::Version(VersionMarkerTree {
-                    id: self.0,
+                    id: tree.0,
                     key: *key,
                     map,
                 })
@@ -926,7 +943,7 @@ impl MarkerTree {
                     unreachable!()
                 };
                 MarkerTreeKind::String(StringMarkerTree {
-                    id: self.0,
+                    id: tree.0,
                     key: *key,
                     map,
                 })
@@ -938,8 +955,8 @@ impl MarkerTree {
                 MarkerTreeKind::In(InMarkerTree {
                     key: *key,
                     value,
-                    high: high.negate(self.0),
-                    low: low.negate(self.0),
+                    high: high.negate(tree.0),
+                    low: low.negate(tree.0),
                 })
             }
             Variable::Contains { key, value } => {
@@ -949,8 +966,8 @@ impl MarkerTree {
                 MarkerTreeKind::Contains(ContainsMarkerTree {
                     key: *key,
                     value,
-                    high: high.negate(self.0),
-                    low: low.negate(self.0),
+                    high: high.negate(tree.0),
+                    low: low.negate(tree.0),
                 })
             }
             Variable::List(key) => {
@@ -959,8 +976,8 @@ impl MarkerTree {
                 };
                 MarkerTreeKind::List(ListMarkerTree {
                     pair: key,
-                    high: high.negate(self.0),
-                    low: low.negate(self.0),
+                    high: high.negate(tree.0),
+                    low: low.negate(tree.0),
                 })
             }
             Variable::Extra(name) => {
@@ -969,8 +986,8 @@ impl MarkerTree {
                 };
                 MarkerTreeKind::Extra(ExtraMarkerTree {
                     name,
-                    high: high.negate(self.0),
-                    low: low.negate(self.0),
+                    high: high.negate(tree.0),
+                    low: low.negate(tree.0),
                 })
             }
         }
@@ -1243,11 +1260,9 @@ impl MarkerTree {
     /// should reconstitute all relevant markers from the source data.)
     #[must_use]
     pub fn simplify_python_versions(self, lower: Bound<&Version>, upper: Bound<&Version>) -> Self {
-        Self(
-            INTERNER
-                .lock()
-                .simplify_python_versions(self.0, lower, upper),
-        )
+        let mut interner = INTERNER.lock();
+        let node = interner.simplify_python_versions(self.0, lower, upper);
+        Self(interner.finish(node))
     }
 
     /// Complexify marker tree by requiring the given Python version range
@@ -1263,11 +1278,9 @@ impl MarkerTree {
         lower: Bound<&Version>,
         upper: Bound<&Version>,
     ) -> Self {
-        Self(
-            INTERNER
-                .lock()
-                .complexify_python_versions(self.0, lower, upper),
-        )
+        let mut interner = INTERNER.lock();
+        let node = interner.complexify_python_versions(self.0, lower, upper);
+        Self(interner.finish(node))
     }
 
     /// Restrict this marker by assuming that `assumption` is true.
@@ -1281,7 +1294,11 @@ impl MarkerTree {
     /// `sys_platform == 'linux'` produces `python_version < '3.11'`.
     #[must_use]
     pub fn restrict(self, assumption: Self) -> Self {
-        Self(INTERNER.lock().restrict(self.0, assumption.0))
+        let mut interner = INTERNER.lock();
+        let value = interner.project(self.0);
+        let assumption = interner.project(assumption.0);
+        let node = interner.restrict(value, assumption);
+        Self(interner.finish(node))
     }
 
     /// Remove the extras from a marker, returning `None` if the marker tree evaluates to `true`.
@@ -1358,7 +1375,10 @@ impl MarkerTree {
     /// is always true is returned.
     #[must_use]
     pub fn without_extras(self) -> Self {
-        Self(INTERNER.lock().without_extras(self.0))
+        let mut interner = INTERNER.lock();
+        let value = interner.project(self.0);
+        let node = interner.without_extras(value);
+        Self(interner.finish(node))
     }
 
     /// Returns a new `MarkerTree` where only `extra` expressions are removed.
@@ -1367,7 +1387,10 @@ impl MarkerTree {
     /// that is always true is returned.
     #[must_use]
     pub fn only_extras(self) -> Self {
-        Self(INTERNER.lock().only_extras(self.0))
+        let mut interner = INTERNER.lock();
+        let value = interner.project(self.0);
+        let node = interner.only_extras(value);
+        Self(interner.finish(node))
     }
 
     /// Calls the provided function on every `extra` in this tree.
@@ -1419,17 +1442,21 @@ impl MarkerTree {
     }
 
     fn simplify_extras_with_impl(self, is_extra: &impl Fn(&ExtraName) -> bool) -> Self {
-        Self(INTERNER.lock().restrict_by(self.0, &|var| match var {
+        let mut interner = INTERNER.lock();
+        let node = interner.restrict_by(self.0, &|var| match var {
             Variable::Extra(name) => is_extra(name.extra()).then_some(true),
             _ => None,
-        }))
+        });
+        Self(interner.finish(node))
     }
 
     fn simplify_not_extras_with_impl(self, is_extra: &impl Fn(&ExtraName) -> bool) -> Self {
-        Self(INTERNER.lock().restrict_by(self.0, &|var| match var {
+        let mut interner = INTERNER.lock();
+        let node = interner.restrict_by(self.0, &|var| match var {
             Variable::Extra(name) => is_extra(name.extra()).then_some(false),
             _ => None,
-        }))
+        });
+        Self(interner.finish(node))
     }
 }
 
@@ -3068,6 +3095,37 @@ mod test {
         assert_eq!(marker, m("os_name != 'nt'"));
         let serialized = marker.try_to_string().unwrap();
         assert_eq!(marker, m(&serialized));
+
+        let contents = marker.contents().unwrap();
+        assert_eq!(contents.as_ref(), &marker);
+        assert_eq!(MarkerTree::from(contents), marker);
+
+        let windows = m("os_name == 'nt'");
+        let not_linux = m("sys_platform != 'linux'");
+        let freebsd = m("platform_system == 'FreeBSD'");
+
+        let mut left = windows;
+        left.and(not_linux);
+        left.and(freebsd);
+
+        let mut right = not_linux;
+        right.and(freebsd);
+        right.and(windows);
+        assert_eq!(left, right);
+
+        let linux = m("sys_platform == 'linux'");
+        let win32 = m("sys_platform == 'win32'");
+
+        let mut left = linux;
+        left.or(win32);
+        left.and(windows);
+
+        let mut right_linux = windows;
+        right_linux.and(linux);
+        let mut right_win32 = windows;
+        right_win32.and(win32);
+        right_linux.or(right_win32);
+        assert_eq!(left, right_linux);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3169,6 +3169,23 @@ mod test {
         right.and(extra);
         left.or(right);
         assert_eq!(left, extra);
+
+        let freebsd = m("platform_system == 'FreeBSD'");
+        let netbsd = m("implementation_name == 'pypy' and platform_system == 'NetBSD'");
+        let pypy = m("implementation_name == 'pypy'");
+
+        let mut positive = netbsd;
+        positive.and(extra);
+        let mut negative = netbsd;
+        negative.and(extra.negate());
+
+        let mut combined = freebsd;
+        combined.or(positive);
+        combined.or(negative);
+        combined.or(pypy);
+        let without_extras = combined.without_extras();
+        assert_eq!(combined, without_extras);
+        assert_eq!(combined.cmp(&without_extras), std::cmp::Ordering::Equal);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1276,8 +1276,9 @@ impl MarkerTree {
     #[must_use]
     pub fn simplify_python_versions(self, lower: Bound<&Version>, upper: Bound<&Version>) -> Self {
         let mut interner = INTERNER.lock();
-        let node = interner.simplify_python_versions(self.0, lower, upper);
-        if node == self.0 {
+        let value = self.project_if_needed(&mut interner);
+        let node = interner.simplify_python_versions(value, lower, upper);
+        if node == value {
             self
         } else {
             Self(interner.finish(node))
@@ -1298,8 +1299,13 @@ impl MarkerTree {
         upper: Bound<&Version>,
     ) -> Self {
         let mut interner = INTERNER.lock();
-        let node = interner.complexify_python_versions(self.0, lower, upper);
-        Self(interner.finish(node))
+        let value = self.project_if_needed(&mut interner);
+        let node = interner.complexify_python_versions(value, lower, upper);
+        if node == value {
+            self
+        } else {
+            Self(interner.finish(node))
+        }
     }
 
     /// Restrict this marker by assuming that `assumption` is true.
@@ -3691,6 +3697,17 @@ mod test {
 
     #[test]
     fn complexified_markers() {
+        let lower = Bound::Included(Version::new([3, 9]));
+        let upper = Bound::Excluded(Version::new([3, 13]));
+        let platform = m(
+            "(os_name == 'nt' or sys_platform == 'linux') and platform_machine == 'complexify-machine'",
+        );
+        let complexified = platform.complexify_python_versions(lower.as_ref(), upper.as_ref());
+        assert_eq!(
+            complexified.complexify_python_versions(lower.as_ref(), upper.as_ref()),
+            complexified
+        );
+
         // Takes optional lower (inclusive) and upper (exclusive)
         // bounds representing `requires-python` and a "simplified"
         // marker, and returns the "complexified" marker. That is, a

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1880,6 +1880,7 @@ impl schemars::JsonSchema for MarkerTree {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
     use std::ops::Bound;
     use std::str::FromStr;
     use std::sync::mpsc;
@@ -1970,10 +1971,10 @@ mod test {
     #[test]
     fn non_conflicting_transformations_do_not_project() {
         let marker = m(
-            "(platform_machine == 'x86_64' and implementation_name == 'cpython' and extra == 'one') \
-             or (platform_machine == 'aarch64' and implementation_name == 'pypy' and extra == 'two')",
+            "(platform_machine == 'projection-x86_64' and implementation_name == 'projection-cpython' and extra == 'projection-one') \
+             or (platform_machine == 'projection-aarch64' and implementation_name == 'projection-pypy' and extra == 'projection-two')",
         );
-        let assumption = m("platform_machine == 'x86_64'");
+        let assumption = m("platform_machine == 'projection-x86_64'");
         assert!(INTERNER.shared.projection(marker.0).is_none());
         assert!(INTERNER.shared.projection(assumption.0).is_none());
 
@@ -3272,6 +3273,23 @@ mod test {
         let custom_linux = m("os_name != 'custom' and sys_platform == 'linux'");
         assert!(custom_linux.is_disjoint(windows));
         assert!(windows.is_disjoint(custom_linux));
+
+        let pypy = m("implementation_name == 'pypy'");
+        let pypy_freebsd_or_windows = m(
+            "(implementation_name == 'pypy' and platform_system == 'FreeBSD') or os_name == 'nt'",
+        );
+        let netbsd = m("platform_system == 'NetBSD'");
+
+        let mut left = pypy;
+        left.or(pypy_freebsd_or_windows);
+        left.or(netbsd);
+        let mut right = pypy_freebsd_or_windows;
+        right.or(netbsd);
+        right.or(pypy);
+
+        assert_eq!(left, right);
+        assert_eq!(left.cmp(&right), std::cmp::Ordering::Equal);
+        assert_eq!(HashSet::from([left, right]).len(), 1);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1077,7 +1077,7 @@ impl MarkerTree {
                 }
             }
             MarkerTreeKind::String(marker) => {
-                for (range, tree) in marker.children() {
+                for (range, tree) in marker.raw_children() {
                     let l_string = env.get_string(marker.key());
 
                     if matches!(
@@ -1152,7 +1152,7 @@ impl MarkerTree {
                 marker.edges().any(|(_, tree)| tree.evaluate_extras(extras))
             }
             MarkerTreeKind::String(marker) => marker
-                .children()
+                .raw_children()
                 .any(|(_, tree)| tree.evaluate_extras(extras)),
             MarkerTreeKind::In(marker) => marker
                 .children()
@@ -1178,7 +1178,7 @@ impl MarkerTree {
                 .edges()
                 .all(|(_, tree)| tree.evaluate_only_extras(extras)),
             MarkerTreeKind::String(marker) => marker
-                .children()
+                .raw_children()
                 .all(|(_, tree)| tree.evaluate_only_extras(extras)),
             MarkerTreeKind::In(marker) => marker
                 .children()
@@ -1444,7 +1444,7 @@ impl MarkerTree {
                     }
                 }
                 MarkerTreeKind::String(kind) => {
-                    for (tree, _) in simplify::collect_edges(kind.children()) {
+                    for (tree, _) in simplify::collect_edges(kind.raw_children()) {
                         imp(tree, f);
                     }
                 }
@@ -1608,11 +1608,23 @@ impl StringMarkerTree<'_> {
 
     /// The edges of this node, corresponding to possible output ranges of the given variable.
     pub fn children(&self) -> impl ExactSizeIterator<Item = (&Ranges<ArcStr>, MarkerTree)> {
-        self.map.iter().map(|(range, node)| {
-            let child = node.negate(self.id);
-            let child = INTERNER.shared.canonical_projection(child).unwrap_or(child);
-            (range, MarkerTree(child))
+        self.raw_children().map(|(range, child)| {
+            let child = if INTERNER.shared.can_conflict(child.0) {
+                child.finish()
+            } else {
+                child
+            };
+            (range, child)
         })
+    }
+
+    /// The projected edges of this node for read-only traversal.
+    pub(super) fn raw_children(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (&Ranges<ArcStr>, MarkerTree)> {
+        self.map
+            .iter()
+            .map(|(range, node)| (range, MarkerTree(node.negate(self.id))))
     }
 }
 
@@ -1626,7 +1638,7 @@ impl Ord for StringMarkerTree<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.key()
             .cmp(&other.key())
-            .then_with(|| self.children().cmp(other.children()))
+            .then_with(|| self.raw_children().cmp(other.raw_children()))
     }
 }
 
@@ -1999,6 +2011,10 @@ mod test {
         let MarkerTreeKind::String(kind) = marker.kind() else {
             panic!("expected a string marker");
         };
+        let raw_child = kind
+            .raw_children()
+            .find_map(|(range, child)| (!range.contains("posix")).then_some(child))
+            .unwrap();
         let child = kind
             .children()
             .find_map(|(range, child)| (!range.contains("posix")).then_some(child))
@@ -2006,6 +2022,7 @@ mod test {
         let reparsed = m(&child.try_to_string().unwrap());
         let freebsd = m("platform_system == 'FreeBSD'");
 
+        assert_ne!(raw_child, child);
         assert_eq!(child, reparsed);
         assert_eq!(child.cmp(&reparsed), std::cmp::Ordering::Equal);
         assert_eq!(HashSet::from([child, reparsed]).len(), 1);
@@ -2044,6 +2061,10 @@ mod test {
                 .send([
                     marker.evaluate(&environment, &[]),
                     negated.evaluate(&environment, &[]),
+                    marker.evaluate_optional_environment(None, &[]),
+                    negated.evaluate_optional_environment(None, &[]),
+                    marker.evaluate_only_extras(&[]),
+                    negated.evaluate_only_extras(&[]),
                 ])
                 .unwrap();
         });
@@ -2051,7 +2072,7 @@ mod test {
         let result = receiver.recv_timeout(Duration::from_secs(5));
         drop(guard);
         thread.join().unwrap();
-        assert_eq!(result.unwrap(), [true, false]);
+        assert_eq!(result.unwrap(), [true, false, true, true, false, false]);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -2224,6 +2224,20 @@ mod test {
         let assumption = m("sys_platform == 'linux' or python_version >= '3.12'");
         assert_eq!(marker.restrict(assumption), marker);
 
+        let marker = m(
+            "(extra != 'foo' and platform_system != 'NetBSD' and sys_platform != 'win32') or \
+             (os_name != 'posix' and sys_platform == 'ios')",
+        );
+        let assumption = m("(platform_system != 'NetBSD' or os_name == 'nt') and \
+             (sys_platform != 'wasi' or implementation_name == 'pypy')");
+        let simplified = marker.restrict(assumption);
+        assert_eq!(simplified.restrict(assumption), simplified);
+        let mut reconstructed = simplified;
+        reconstructed.and(assumption);
+        let mut expected = marker;
+        expected.and(assumption);
+        assert_eq!(reconstructed, expected);
+
         for (marker, assumption) in [
             ("python_version < '3.11'", "sys_platform == 'linux'"),
             ("sys_platform == 'linux'", "python_version < '3.11'"),
@@ -3412,6 +3426,41 @@ mod test {
         let custom_linux = m("os_name == 'custom' and sys_platform == 'linux'");
         assert!(freebsd.is_disjoint(custom_linux));
         assert!(custom_linux.is_disjoint(freebsd));
+
+        let scoped_linux = m(
+            "(python_version != '3.8' and sys_platform == 'linux' and extra != 'foo') or \
+             (os_name == 'posix' and sys_platform == 'linux' and extra != 'foo')",
+        );
+        assert!(scoped_linux.is_disjoint(freebsd));
+        assert!(freebsd.is_disjoint(scoped_linux));
+
+        let os_name = m("(os_name == 'nt' or sys_platform == 'linux') and extra == 'foo'");
+        let os_name_with_invalid = m(
+            "((os_name == 'nt' or sys_platform == 'linux') and extra == 'foo') or \
+             (sys_platform == 'linux' and platform_system == 'FreeBSD' and extra != 'foo')",
+        );
+        assert_eq!(os_name, os_name_with_invalid);
+        assert_eq!(
+            os_name.cmp(&os_name_with_invalid),
+            std::cmp::Ordering::Equal
+        );
+        assert_eq!(HashSet::from([os_name, os_name_with_invalid]).len(), 1);
+
+        let platform_system =
+            m("(sys_platform == 'linux' or platform_system == 'FreeBSD') and extra == 'foo'");
+        let platform_system_with_invalid = m(
+            "((sys_platform == 'linux' or platform_system == 'FreeBSD') and extra == 'foo') or \
+             (os_name == 'nt' and sys_platform == 'linux' and extra != 'foo')",
+        );
+        assert_eq!(platform_system, platform_system_with_invalid);
+        assert_eq!(
+            platform_system.cmp(&platform_system_with_invalid),
+            std::cmp::Ordering::Equal
+        );
+        assert_eq!(
+            HashSet::from([platform_system, platform_system_with_invalid]).len(),
+            1
+        );
 
         let pypy = m("implementation_name == 'pypy'");
         let pypy_freebsd_or_windows = m(

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -917,11 +917,22 @@ impl MarkerTree {
 
     /// Returns the underlying [`MarkerTreeKind`] of the root node.
     pub fn kind(self) -> MarkerTreeKind<'static> {
-        let tree = Self(INTERNER.lock().project(self.0));
-        if tree.is_true() {
+        if self.is_true() {
             return MarkerTreeKind::True;
         }
 
+        if self.is_false() {
+            return MarkerTreeKind::False;
+        }
+
+        let tree = if INTERNER.shared.node(self.0).var.is_conflicting_variable() {
+            Self(INTERNER.lock().project(self.0))
+        } else {
+            self
+        };
+        if tree.is_true() {
+            return MarkerTreeKind::True;
+        }
         if tree.is_false() {
             return MarkerTreeKind::False;
         }
@@ -1855,12 +1866,15 @@ impl schemars::JsonSchema for MarkerTree {
 mod test {
     use std::ops::Bound;
     use std::str::FromStr;
+    use std::sync::mpsc;
+    use std::time::Duration;
 
     use insta::assert_snapshot;
 
     use uv_normalize::ExtraName;
     use uv_pep440::Version;
 
+    use super::{INTERNER, MarkerTreeKind};
     use crate::marker::{MarkerEnvironment, MarkerEnvironmentBuilder};
     use crate::{MarkerExpression, MarkerOperator, MarkerTree, MarkerValueString};
 
@@ -1887,6 +1901,27 @@ mod test {
             sys_platform: "linux",
         })
         .unwrap()
+    }
+
+    #[test]
+    fn non_conflicting_kind_does_not_lock_interner() {
+        let extra = m("extra == 'foo'");
+        let guard = INTERNER.lock();
+        let (sender, receiver) = mpsc::channel();
+        let thread = std::thread::spawn(move || {
+            sender
+                .send([
+                    matches!(MarkerTree::TRUE.kind(), MarkerTreeKind::True),
+                    matches!(MarkerTree::FALSE.kind(), MarkerTreeKind::False),
+                    matches!(extra.kind(), MarkerTreeKind::Extra(_)),
+                ])
+                .unwrap();
+        });
+
+        let result = receiver.recv_timeout(Duration::from_secs(5));
+        drop(guard);
+        thread.join().unwrap();
+        assert_eq!(result.unwrap(), [true, true, true]);
     }
 
     /// Copied from <https://github.com/pypa/packaging/blob/85ff971a250dc01db188ef9775499c15553a8c95/tests/test_markers.py#L175-L221>

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -926,7 +926,11 @@ impl MarkerTree {
         }
 
         let tree = if INTERNER.shared.node(self.0).var.is_conflicting_variable() {
-            Self(INTERNER.lock().project(self.0))
+            if let Some(projected) = INTERNER.shared.projection(self.0) {
+                Self(projected)
+            } else {
+                Self(INTERNER.lock().project(self.0))
+            }
         } else {
             self
         };
@@ -1922,6 +1926,33 @@ mod test {
         drop(guard);
         thread.join().unwrap();
         assert_eq!(result.unwrap(), [true, true, true]);
+    }
+
+    #[test]
+    fn projected_platform_kind_does_not_lock_interner() {
+        let singleton = m("sys_platform == 'linux'");
+        let compound = m("sys_platform == 'linux' or platform_system == 'FreeBSD'");
+        let _ = compound.kind();
+
+        let guard = INTERNER.lock();
+        let (sender, receiver) = mpsc::channel();
+        let thread = std::thread::spawn(move || {
+            let environment = env37();
+            sender
+                .send([
+                    matches!(singleton.kind(), MarkerTreeKind::String(_)),
+                    matches!(singleton.negate().kind(), MarkerTreeKind::String(_)),
+                    matches!(compound.kind(), MarkerTreeKind::String(_)),
+                    singleton.evaluate(&environment, &[]),
+                    compound.evaluate(&environment, &[]),
+                ])
+                .unwrap();
+        });
+
+        let result = receiver.recv_timeout(Duration::from_secs(5));
+        drop(guard);
+        thread.join().unwrap();
+        assert_eq!(result.unwrap(), [true, true, true, true, true]);
     }
 
     /// Copied from <https://github.com/pypa/packaging/blob/85ff971a250dc01db188ef9775499c15553a8c95/tests/test_markers.py#L175-L221>

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3274,6 +3274,11 @@ mod test {
         assert!(custom_linux.is_disjoint(windows));
         assert!(windows.is_disjoint(custom_linux));
 
+        let freebsd = m("platform_system == 'FreeBSD'");
+        let custom_linux = m("os_name == 'custom' and sys_platform == 'linux'");
+        assert!(freebsd.is_disjoint(custom_linux));
+        assert!(custom_linux.is_disjoint(freebsd));
+
         let pypy = m("implementation_name == 'pypy'");
         let pypy_freebsd_or_windows = m(
             "(implementation_name == 'pypy' and platform_system == 'FreeBSD') or os_name == 'nt'",

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3217,6 +3217,27 @@ mod test {
         let without_extras = combined.without_extras();
         assert_eq!(combined, without_extras);
         assert_eq!(combined.cmp(&without_extras), std::cmp::Ordering::Equal);
+
+        let custom = m("os_name == 'custom-os' and sys_platform == 'custom-sys'");
+        let mut with_invalid = custom;
+        with_invalid.and(m("extra == 'foo'"));
+        with_invalid.or(m(
+            "os_name == 'nt' and sys_platform == 'linux' and extra != 'foo'",
+        ));
+        let mut expected = custom;
+        expected.and(m("extra == 'foo'"));
+        assert_eq!(with_invalid, expected);
+
+        let windows = m("os_name == 'nt'");
+        let posix = m("os_name == 'posix'");
+        let not_linux = m("sys_platform != 'linux'");
+        let mut left = windows;
+        left.or(posix);
+        left.or(not_linux);
+        let mut right = posix;
+        right.or(not_linux);
+        right.or(windows);
+        assert_eq!(left, right);
     }
 
     #[test]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1594,14 +1594,7 @@ impl StringMarkerTree<'_> {
     pub fn children(&self) -> impl ExactSizeIterator<Item = (&Ranges<ArcStr>, MarkerTree)> {
         self.map.iter().map(|(range, node)| {
             let child = node.negate(self.id);
-            let child = if INTERNER.shared.can_conflict(child) {
-                INTERNER
-                    .shared
-                    .canonical_projection(child)
-                    .unwrap_or_else(|| INTERNER.lock().finish_projection(child))
-            } else {
-                child
-            };
+            let child = INTERNER.shared.canonical_projection(child).unwrap_or(child);
             (range, MarkerTree(child))
         })
     }
@@ -2002,6 +1995,19 @@ mod test {
         assert_eq!(HashSet::from([child, reparsed]).len(), 1);
         assert!(child.is_disjoint(freebsd));
         assert!(freebsd.is_disjoint(child));
+
+        let MarkerTreeKind::String(kind) = marker.negate().kind() else {
+            panic!("expected a string marker");
+        };
+        let child = kind
+            .children()
+            .find_map(|(range, child)| (!range.contains("posix")).then_some(child))
+            .unwrap();
+        let reparsed = m(&child.try_to_string().unwrap());
+
+        assert_eq!(child, reparsed);
+        assert_eq!(child.cmp(&reparsed), std::cmp::Ordering::Equal);
+        assert_eq!(HashSet::from([child, reparsed]).len(), 1);
     }
 
     #[test]
@@ -2011,8 +2017,8 @@ mod test {
              or (sys_platform == 'darwin' and extra == 'y'))",
         );
         let negated = marker.negate();
-        let _ = marker.try_to_string();
-        let _ = negated.try_to_string();
+        assert!(INTERNER.shared.projection(marker.0).is_some());
+        assert!(INTERNER.shared.projection(negated.0).is_some());
 
         let guard = INTERNER.lock();
         let (sender, receiver) = mpsc::channel();

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -3,7 +3,9 @@ use smallvec::SmallVec;
 use std::ops::Bound;
 
 use uv_pep440::{LowerBound, UpperBound, Version};
-use uv_pep508::{CanonicalMarkerValueVersion, MarkerTree, MarkerTreeKind};
+use uv_pep508::{
+    CanonicalMarkerValueString, CanonicalMarkerValueVersion, MarkerTree, MarkerTreeKind,
+};
 
 use uv_distribution_types::RequiresPythonRange;
 
@@ -34,6 +36,18 @@ pub(crate) fn requires_python(tree: MarkerTree) -> Option<RequiresPythonRange> {
                     }
                 }
             },
+            MarkerTreeKind::String(marker)
+                if matches!(
+                    marker.key(),
+                    CanonicalMarkerValueString::OsName
+                        | CanonicalMarkerValueString::SysPlatform
+                        | CanonicalMarkerValueString::PlatformSystem
+                ) =>
+            {
+                for (_, tree) in marker.projected_children() {
+                    collect_python_markers(tree, markers, range);
+                }
+            }
             MarkerTreeKind::String(marker) => {
                 for (_, tree) in marker.children() {
                     collect_python_markers(tree, markers, range);
@@ -185,5 +199,20 @@ mod tests {
             MarkerTree::from_str("python_full_version > '3.8' or python_full_version <= '3.8'")
                 .unwrap();
         assert_eq!(requires_python(tree), None);
+
+        // Python bounds below validity-sensitive string markers are collected without
+        // materializing their projected children.
+        let tree = MarkerTree::from_str(
+            "os_name != 'posix' and ((platform_system != 'FreeBSD' and \
+             sys_platform != 'darwin' and python_full_version >= '3.10') or \
+             (sys_platform == 'darwin' and python_full_version >= '3.11' and extra == 'dev'))",
+        )
+        .unwrap();
+        let range = requires_python(tree).unwrap();
+        assert_eq!(
+            *range.lower(),
+            LowerBound::new(Bound::Included(Version::from_str("3.10").unwrap()))
+        );
+        assert_eq!(*range.upper(), UpperBound::new(Bound::Unbounded));
     }
 }

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -677,7 +677,7 @@ impl ResolverOutput {
                 }
                 MarkerTreeKind::String(marker) => {
                     set.insert(MarkerParam::String(marker.key()));
-                    for (_, tree) in marker.children() {
+                    for (_, tree) in marker.projected_children() {
                         add_marker_params_from_tree(tree, set);
                     }
                 }

--- a/crates/uv-resolver/src/universal_marker.rs
+++ b/crates/uv-resolver/src/universal_marker.rs
@@ -1076,6 +1076,26 @@ mod tests {
             MarkerTree::from_str("sys_platform == 'darwin'").expect("valid marker expression");
         assert!(!UniversalMarker::from_combined(pep508).has_conflict_marker());
         assert!(UniversalMarker::new(pep508, create_extra_marker("foo")).has_conflict_marker());
+
+        let freebsd =
+            MarkerTree::from_str("platform_system == 'FreeBSD'").expect("valid marker expression");
+        let netbsd =
+            MarkerTree::from_str("implementation_name == 'pypy' and platform_system == 'NetBSD'")
+                .expect("valid marker expression");
+        let pypy =
+            MarkerTree::from_str("implementation_name == 'pypy'").expect("valid marker expression");
+        let extra = MarkerTree::from_str("extra == 'x'").expect("valid marker expression");
+
+        let mut positive = netbsd;
+        positive.and(extra);
+        let mut negative = netbsd;
+        negative.and(extra.negate());
+        let mut combined = freebsd;
+        combined.or(positive);
+        combined.or(negative);
+        combined.or(pypy);
+
+        assert!(!UniversalMarker::from_combined(combined).has_conflict_marker());
     }
 
     #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -25115,6 +25115,42 @@ fn lock_multiple_sources_disjoint_platform_markers() -> Result<()> {
     Ok(())
 }
 
+/// Multiple sources remain disjoint when the incompatible platform key is below another marker
+/// decision.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_multiple_sources_disjoint_platform_descendants() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [tool.uv.sources]
+        iniconfig = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", marker = "os_name == 'custom' and sys_platform == 'linux'" },
+            { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", marker = "platform_system == 'FreeBSD'" },
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 #[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_conflict() -> Result<()> {

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -25079,6 +25079,42 @@ fn lock_multiple_sources() -> Result<()> {
     Ok(())
 }
 
+/// Multiple sources can use different platform keys if their markers are disjoint under the
+/// known platform exclusions.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_multiple_sources_disjoint_platform_markers() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [tool.uv.sources]
+        iniconfig = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", marker = "os_name != 'custom' and sys_platform == 'linux'" },
+            { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", marker = "os_name == 'nt'" },
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 #[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_conflict() -> Result<()> {


### PR DESCRIPTION
Stacked on #20503.

Replace the pairwise platform-exclusion restriction heuristic with a persistent ternary marker representation. Invalid platform assignments now terminate in a self-complementing don't-care node, preserving canonical equality and the usual algebra laws while allowing serialization to discard impossible branches.

Project ternary trees back to Boolean markers only where required and construct parsed expressions before applying the validity domain, avoiding repeated restriction work in the marker hot path. The existing lock and fork scenarios retain their simplified snapshots.

Related to https://github.com/astral-sh/uv/issues/16442.