### PR TITLE
Add prettier install step to developer docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,9 +271,11 @@ To preview any changes to the documentation locally:
 
 1. Install the [Rust toolchain](https://www.rust-lang.org/tools/install).
 
-2. Run `cargo dev generate-all`, to update any auto-generated documentation.
+2. Install [Node](https://nodejs.org/en/download) - needed to run Prettier to format the docs
 
-3. Run the development server with:
+3. Run `cargo dev generate-all`, to update any auto-generated documentation.
+
+4. Run the development server with:
 
    ```shell
    uv run --only-group docs mkdocs serve -f mkdocs.yml

--- a/agents/hooks/post-edit-format.py
+++ b/agents/hooks/post-edit-format.py
@@ -42,7 +42,7 @@ def format_prettier(file_path: str, cwd: str) -> None:
     """Format files with prettier."""
     try:
         subprocess.run(
-            ["npx", "prettier", "--write", file_path],
+            ["npx", "prettier@3.9.0", "--write", file_path],
             cwd=cwd,
             capture_output=True,
             check=False,

--- a/crates/uv-dev/src/generate_json_schema.rs
+++ b/crates/uv-dev/src/generate_json_schema.rs
@@ -100,7 +100,7 @@ fn generate() -> Result<String> {
 
     // Format with prettier
     let output = Command::new("npx")
-        .args(["prettier", "--stdin-filepath", "uv.schema.json"])
+        .args(["prettier@3.9.0", "--stdin-filepath", "uv.schema.json"])
         .current_dir(ROOT_DIR)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
Currently when doing the steps in contributing.MD under Documentation, the `cargo dev generate-all` fails when prettier is not installed. I have added a step with a link to the node installation documentation so npx is installed and can be used to run prettier. 
Also pins the version of prettier fetched by npx in two additional places – requires double bookkeeping with .github/workflows/check-fmt.yml that defines the version of prettier run in CI. 

@woodruffw  