### PR TITLE
Add async tempfile creation

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -906,7 +906,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
                 // Download the wheel to a temporary file.
-                let temp_file = tempfile::tempfile_in(self.build_context.cache().root())
+                let temp_file = tempfile_in_async(self.build_context.cache().root())
                     .map_err(Error::CacheWrite)?;
                 let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
                     // It's an unnamed file on Linux so that's the best approximation.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -906,7 +906,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
                 // Download the wheel to a temporary file.
-                let temp_file = tempfile_in_async(self.build_context.cache().root())
+                let temp_file = tempfile::tempfile_in(self.build_context.cache().root())
                     .map_err(Error::CacheWrite)?;
                 let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
                     // It's an unnamed file on Linux so that's the best approximation.

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -380,10 +380,23 @@ pub fn tempfile_in(path: &Path) -> std::io::Result<NamedTempFile> {
     tempfile::Builder::new().tempfile_in(path)
 }
 
+/// Return a [`NamedTempFile`] in the specified directory without blocking the async runtime.
+#[cfg(feature = "tokio")]
+pub async fn tempfile_in_async(path: &Path) -> io::Result<NamedTempFile<fs_err::tokio::File>> {
+    let path = path.to_path_buf();
+    let temp_file = tokio::task::spawn_blocking(move || tempfile_in(&path))
+        .await
+        .map_err(io::Error::other)??;
+    let (file, path) = temp_file.into_parts();
+    let file = fs_err::File::from_parts(file, path.to_path_buf());
+    let file = fs_err::tokio::File::from_std(file);
+    Ok(NamedTempFile::from_parts(file, path))
+}
+
 /// Write `data` to `path` atomically using a temporary file and atomic rename.
 #[cfg(feature = "tokio")]
 pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std::io::Result<()> {
-    let temp_file = tempfile_in(
+    let temp_file = tempfile_in_async(
         path.as_ref()
             .parent()
             .expect("Write path must have a parent"),

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -382,11 +382,11 @@ pub fn tempfile_in(path: &Path) -> std::io::Result<NamedTempFile> {
 
 /// Return a [`NamedTempFile`] in the specified directory without blocking the async runtime.
 #[cfg(feature = "tokio")]
-pub async fn tempfile_in_async(path: &Path) -> io::Result<NamedTempFile<fs_err::tokio::File>> {
+pub async fn tempfile_in_async(path: &Path) -> std::io::Result<NamedTempFile<fs_err::tokio::File>> {
     let path = path.to_path_buf();
     let temp_file = tokio::task::spawn_blocking(move || tempfile_in(&path))
         .await
-        .map_err(io::Error::other)??;
+        .map_err(std::io::Error::other)??;
     let (file, path) = temp_file.into_parts();
     let file = fs_err::File::from_parts(file, path.to_path_buf());
     let file = fs_err::tokio::File::from_std(file);
@@ -400,7 +400,7 @@ pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std
         path.as_ref()
             .parent()
             .expect("Write path must have a parent"),
-    )?;
+    ).await?;
     fs_err::tokio::write(&temp_file, &data).await?;
     persist_with_retry(temp_file, path.as_ref()).await
 }
@@ -539,8 +539,8 @@ enum PersistRetryError {
 /// Persist a `NamedTempFile`, retrying (on Windows) if it fails due to transient operating system
 /// errors.
 #[cfg(feature = "tokio")]
-async fn persist_with_retry(
-    from: NamedTempFile,
+async fn persist_with_retry<T: AsRef<Path>>(
+    from: T,
     to: impl AsRef<Path>,
 ) -> Result<(), std::io::Error> {
     #[cfg(windows)]


### PR DESCRIPTION
First attempt at fixing [19429](https://github.com/astral-sh/uv/issues/19429)

Calls of  tempfile::tempfile_in in async blocks not changed yet – example in crates/uv-distribution/src/distribution_database.rs:909

Cargo tests run locally (except malo_* tests due to corporate VPN) 

@woodruffw 