### PR TITLE
Remove "unused code" build warnings

### DIFF
--- a/crates/uv-keyring/src/lib.rs
+++ b/crates/uv-keyring/src/lib.rs
@@ -213,7 +213,7 @@ impl Entry {
     /// Create an entry for the given target, service, and user.
     ///
     /// The default credential builder is used.
-    #[cfg(all(test, target_os = "macos", feature = "apple-native"))]
+    #[cfg(all(test, target_os = "macos", feature = "native-auth"))]
     fn new_with_target(target: &str, service: &str, user: &str) -> Result<Self> {
         let entry = build_default_credential(Some(target), service, user)?;
         Ok(entry)
@@ -340,7 +340,7 @@ impl Entry {
                 any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"),
                 feature = "secret-service"
             ),
-            all(target_os = "macos", feature = "apple-native"),
+            all(target_os = "macos", feature = "native-auth"),
             all(target_os = "windows", feature = "windows-native"),
         )
     ))]

--- a/crates/uv-keyring/src/macos.rs
+++ b/crates/uv-keyring/src/macos.rs
@@ -166,7 +166,7 @@ impl MacCredential {
     /// On Mac, this is basically a no-op, because we represent any attributes
     /// other than the ones we use to find the generic credential.
     /// But at least this checks whether the underlying credential exists.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "native-auth"))]
     async fn get_credential(&self) -> Result<Self> {
         let service = self.service.clone();
         let account = self.account.clone();


### PR DESCRIPTION
When running build with `apple-native` feature enabled, like this:
```
cargo test --package uv-keyring --no-default-features --features apple-native
```

We were getting warnings like so:
```
   Compiling uv-keyring v0.0.62 (/Users/slafs/devel/uv/crates/uv-keyring)
warning: associated items `new_with_target` and `get_credential` are never used
   --> crates/uv-keyring/src/lib.rs:217:8
    |
193 | impl Entry {
    | ---------- associated items in this implementation
...
217 |     fn new_with_target(target: &str, service: &str, user: &str) -> Result<Self> {
    |        ^^^^^^^^^^^^^^^
...
347 |     fn get_credential(&self) -> &dyn std::any::Any {
    |        ^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: method `get_credential` is never used
   --> crates/uv-keyring/src/macos.rs:170:14
    |
163 | impl MacCredential {
    | ------------------ method in this implementation
...
170 |     async fn get_credential(&self) -> Result<Self> {
    |              ^^^^^^^^^^^^^^

warning: `uv-keyring` (lib test) generated 2 warnings
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.55s
     Running unittests src/lib.rs (target/debug/deps/uv_keyring-7043f227f3b1104e)
```

This is a naive approach to solve this.
This was discussed with @EliteTK at the EuroPython 2026 sprints.

