### PR TITLE
Remove "unused code" build warnings (Cargo approach))

### DIFF
--- a/crates/uv-keyring/Cargo.toml
+++ b/crates/uv-keyring/Cargo.toml
@@ -16,12 +16,12 @@ workspace = true
 default = ["apple-native", "secret-service", "windows-native"]
 native-auth = []
 
-## Use the built-in Keychain Services on macOS
-apple-native = ["dep:security-framework"]
-## Use the secret-service on *nix.
-secret-service = ["dep:secret-service"]
-## Use the built-in credential store on Windows
-windows-native = ["dep:windows", "dep:byteorder"]
+## Use the built-in Keychain Services on macOS (also enable native-auth tests).
+apple-native = ["dep:security-framework", "native-auth"]
+## Use the secret-service on *nix (also enable native-auth tests).
+secret-service = ["dep:secret-service", "native-auth"]
+## Use the built-in credential store on Windows (also enable native-auth tests).
+windows-native = ["dep:windows", "dep:byteorder", "native-auth"]
 
 [dependencies]
 async-trait = { workspace = true }


### PR DESCRIPTION
When running build with `apple-native` feature enabled, like this:
```
cargo test --package uv-keyring --no-default-features --features apple-native
```

We were getting warnings like so:
```
   Compiling uv-keyring v0.0.62 (/Users/slafs/devel/uv/crates/uv-keyring)
warning: associated items `new_with_target` and `get_credential` are never used
   --> crates/uv-keyring/src/lib.rs:217:8
    |
193 | impl Entry {
    | ---------- associated items in this implementation
...
217 |     fn new_with_target(target: &str, service: &str, user: &str) -> Result<Self> {
    |        ^^^^^^^^^^^^^^^
...
347 |     fn get_credential(&self) -> &dyn std::any::Any {
    |        ^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: method `get_credential` is never used
   --> crates/uv-keyring/src/macos.rs:170:14
    |
163 | impl MacCredential {
    | ------------------ method in this implementation
...
170 |     async fn get_credential(&self) -> Result<Self> {
    |              ^^^^^^^^^^^^^^

warning: `uv-keyring` (lib test) generated 2 warnings
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.55s
     Running unittests src/lib.rs (target/debug/deps/uv_keyring-7043f227f3b1104e)
```

This is a different Cargo.toml-based approach to solve this.
This was discussed with @EliteTK at the EuroPython 2026 sprints.

