### PR TITLE
Add JSON output to `uv tool upgrade`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -100,6 +100,15 @@ pub enum ListFormat {
     Json,
 }
 
+#[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
+pub enum ToolUpgradeFormat {
+    /// Display the result in a human-readable format.
+    #[default]
+    Text,
+    /// Display the result in JSON format.
+    Json,
+}
+
 fn extra_name_with_clap_error(arg: &str) -> Result<ExtraName> {
     ExtraName::from_str(arg).map_err(|_err| {
         anyhow!(
@@ -6489,6 +6498,10 @@ pub struct ToolUpgradeArgs {
 
     #[command(flatten)]
     pub build: BuildOptionsArgs,
+
+    /// Select the output format.
+    #[arg(long, value_enum, default_value_t = ToolUpgradeFormat::default())]
+    pub output_format: ToolUpgradeFormat,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::str::FromStr;
 use tracing::{debug, trace};
 
 use uv_cache::Cache;
+use uv_cli::ToolUpgradeFormat;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{Concurrency, Constraints, DryRun, HashCheckingMode, TargetTriple};
 use uv_distribution::LoweredExtraBuildDependencies;
@@ -25,6 +27,7 @@ use uv_requirements::RequirementsSpecification;
 use uv_settings::{Combine, PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_tool::{InstalledTools, Tool};
 use uv_types::{HashStrategy, SourceTreeEditablePolicy};
+use uv_warnings::warn_user;
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{
@@ -49,6 +52,7 @@ pub(crate) async fn upgrade(
     install_mirrors: PythonInstallMirrors,
     args: ResolverInstallerOptions,
     filesystem: ResolverInstallerOptions,
+    output_format: ToolUpgradeFormat,
     client_builder: BaseClientBuilder<'_>,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
@@ -59,6 +63,15 @@ pub(crate) async fn upgrade(
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
+    if matches!(output_format, ToolUpgradeFormat::Json)
+        && !preview.is_enabled(PreviewFeature::JsonOutput)
+    {
+        warn_user!(
+            "The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features {}` to disable this warning.",
+            PreviewFeature::JsonOutput
+        );
+    }
+
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = installed_tools.lock().await?;
 
@@ -83,8 +96,18 @@ pub(crate) async fn upgrade(
         }
     };
 
+    let mut reports = Vec::new();
+
     if names.is_empty() {
-        writeln!(printer.stderr(), "Nothing to upgrade")?;
+        match output_format {
+            ToolUpgradeFormat::Text => {
+                writeln!(printer.stderr(), "Nothing to upgrade")?;
+            }
+            ToolUpgradeFormat::Json => {
+                let output = serde_json::to_string_pretty(&Report::new(reports))?;
+                writeln!(printer.stdout_important(), "{output}")?;
+            }
+        }
         return Ok(ExitStatus::Success);
     }
 
@@ -113,15 +136,6 @@ pub(crate) async fn upgrade(
         None
     };
 
-    // Determine whether we applied any upgrades.
-    let mut did_upgrade_tool = vec![];
-
-    // Determine whether we applied any upgrades.
-    let mut did_upgrade_environment = vec![];
-
-    // Constraints that caused upgrades to be skipped or altered.
-    let mut collected_constraints: Vec<(PackageName, UpgradeConstraint)> = Vec::new();
-
     let mut errors = Vec::new();
     for (name, constraints) in &names {
         debug!("Upgrading tool: `{name}`");
@@ -145,23 +159,19 @@ pub(crate) async fn upgrade(
 
         match result {
             Ok(report) => {
-                match report.outcome {
-                    UpgradeOutcome::UpgradeEnvironment => {
-                        did_upgrade_environment.push(name);
-                    }
-                    UpgradeOutcome::UpgradeTool | UpgradeOutcome::UpgradeDependencies => {
-                        did_upgrade_tool.push(name);
-                    }
-                    UpgradeOutcome::NoOp => {
-                        debug!("Upgrading `{name}` was a no-op");
-                    }
+                if matches!(report.outcome, UpgradeOutcome::NoOp) {
+                    debug!("Upgrading `{name}` was a no-op");
                 }
 
-                if let Some(constraint) = report.constraint.clone() {
-                    collected_constraints.push((name.clone(), constraint));
-                }
+                reports.push(report);
             }
             Err(err) => {
+                reports.push(UpgradeReport {
+                    name: name.clone(),
+                    outcome: UpgradeOutcome::Failed,
+                    constraint: None,
+                    error: Some(anstream::adapter::strip_str(&err.to_string()).to_string()),
+                });
                 errors.push((name, err));
             }
         }
@@ -180,41 +190,62 @@ pub(crate) async fn upgrade(
                 ErrorOptions::default().with_stream(printer.stderr()),
             )?;
         }
+
+        if matches!(output_format, ToolUpgradeFormat::Json) {
+            let output = serde_json::to_string_pretty(&Report::new(reports))?;
+            writeln!(printer.stdout_important(), "{output}")?;
+        }
+
         return Ok(ExitStatus::Failure);
     }
 
-    if did_upgrade_tool.is_empty() && did_upgrade_environment.is_empty() {
-        writeln!(printer.stderr(), "Nothing to upgrade")?;
-    }
-
-    if let Some(python_request) = python_request {
-        if !did_upgrade_environment.is_empty() {
-            let tools = did_upgrade_environment
+    match output_format {
+        ToolUpgradeFormat::Text => {
+            if reports
                 .iter()
-                .map(|name| format!("`{}`", name.cyan()))
-                .collect::<Vec<_>>();
-            let s = if tools.len() > 1 { "s" } else { "" };
-            writeln!(
-                printer.stderr(),
-                "Upgraded tool environment{s} for {} to {}",
-                conjunction(tools),
-                python_request.cyan(),
-            )?;
+                .all(|report| matches!(report.outcome, UpgradeOutcome::NoOp))
+            {
+                writeln!(printer.stderr(), "Nothing to upgrade")?;
+            }
+
+            if let Some(python_request) = python_request {
+                let tools = reports
+                    .iter()
+                    .filter(|report| matches!(report.outcome, UpgradeOutcome::UpgradeEnvironment))
+                    .map(|report| format!("`{}`", report.name.cyan()))
+                    .collect_vec();
+                if !tools.is_empty() {
+                    let s = if tools.len() > 1 { "s" } else { "" };
+                    writeln!(
+                        printer.stderr(),
+                        "Upgraded tool environment{s} for {} to {}",
+                        conjunction(tools),
+                        python_request.cyan(),
+                    )?;
+                }
+            }
+
+            if reports.iter().any(|report| report.constraint.is_some()) {
+                writeln!(printer.stderr())?;
+            }
+
+            for report in reports.iter().filter(|report| report.constraint.is_some()) {
+                if let Some(constraint) = &report.constraint {
+                    constraint.print(&report.name, printer)?;
+                }
+            }
         }
-    }
-
-    if !collected_constraints.is_empty() {
-        writeln!(printer.stderr())?;
-    }
-
-    for (name, constraint) in collected_constraints {
-        constraint.print(&name, printer)?;
+        ToolUpgradeFormat::Json => {
+            let output = serde_json::to_string_pretty(&Report::new(reports))?;
+            writeln!(printer.stdout_important(), "{output}")?;
+        }
     }
 
     Ok(ExitStatus::Success)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 enum UpgradeOutcome {
     /// The tool itself was upgraded.
     UpgradeTool,
@@ -224,9 +255,26 @@ enum UpgradeOutcome {
     UpgradeEnvironment,
     /// The tool was already up-to-date.
     NoOp,
+    /// The tool failed to upgrade.
+    Failed,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Debug, Default)]
+#[serde(rename_all = "snake_case")]
+enum SchemaVersion {
+    /// An unstable, experimental schema.
+    #[default]
+    Preview,
+}
+
+#[derive(Serialize, Debug, Default)]
+struct SchemaReport {
+    /// The version of the schema.
+    version: SchemaVersion,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 enum UpgradeConstraint {
     /// The tool remains pinned to an exact version, so an upgrade was skipped.
     PinnedVersion { version: Version },
@@ -253,10 +301,31 @@ impl UpgradeConstraint {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct UpgradeReport {
+    name: PackageName,
     outcome: UpgradeOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
     constraint: Option<UpgradeConstraint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    /// The schema of this report.
+    schema: SchemaReport,
+    /// The reports for the attempted tool upgrades.
+    upgrades: Vec<UpgradeReport>,
+}
+
+impl Report {
+    fn new(upgrades: Vec<UpgradeReport>) -> Self {
+        Self {
+            schema: SchemaReport::default(),
+            upgrades,
+        }
+    }
 }
 
 /// Upgrade a specific tool.
@@ -612,12 +681,16 @@ async fn upgrade_tool(
             pinned_requirement_version(&existing_tool_receipt, name)
                 .map(|version| UpgradeConstraint::PinnedVersion { version })
         }
-        UpgradeOutcome::UpgradeTool | UpgradeOutcome::UpgradeEnvironment => None,
+        UpgradeOutcome::UpgradeTool
+        | UpgradeOutcome::UpgradeEnvironment
+        | UpgradeOutcome::Failed => None,
     };
 
     Ok(UpgradeReport {
+        name: name.clone(),
         outcome,
         constraint,
+        error: None,
     })
 }
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1757,6 +1757,7 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
                 args.install_mirrors,
                 args.args,
                 args.filesystem,
+                args.output_format,
                 client_builder.subcommand(vec!["tool".to_owned(), "upgrade".to_owned()]),
                 globals.python_preference,
                 globals.python_downloads,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -20,8 +20,8 @@ use uv_cli::{
     PipSyncArgs, PipTreeArgs, PipUninstallArgs, PythonFindArgs, PythonInstallArgs, PythonListArgs,
     PythonListFormat, PythonPinArgs, PythonUninstallArgs, PythonUpgradeArgs, RemoveArgs, RunArgs,
     SyncArgs, SyncFormat, ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs,
-    ToolUninstallArgs, TreeArgs, TreeFormat, UpgradeArgs, VenvArgs, VersionArgs, VersionBumpSpec,
-    VersionFormat,
+    ToolUninstallArgs, ToolUpgradeFormat, TreeArgs, TreeFormat, UpgradeArgs, VenvArgs, VersionArgs,
+    VersionBumpSpec, VersionFormat,
 };
 use uv_cli::{
     AuthorFrom, BuildArgs, CheckArgs, ExportArgs, FormatArgs, PublishArgs, PythonDirArgs,
@@ -1154,6 +1154,7 @@ pub(crate) struct ToolUpgradeSettings {
     pub(crate) install_mirrors: PythonInstallMirrors,
     pub(crate) args: ResolverInstallerOptions,
     pub(crate) filesystem: ResolverInstallerOptions,
+    pub(crate) output_format: ToolUpgradeFormat,
 }
 impl ToolUpgradeSettings {
     /// Resolve the [`ToolUpgradeSettings`] from the CLI and filesystem configuration.
@@ -1193,6 +1194,7 @@ impl ToolUpgradeSettings {
             no_sources_package,
             exclude_newer_package,
             build,
+            output_format,
         } = args;
 
         if upgrade {
@@ -1257,6 +1259,7 @@ impl ToolUpgradeSettings {
                 .install_mirrors
                 .clone()
                 .combine(filesystem_install_mirrors),
+            output_format,
         }
     }
 }

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -1928,3 +1928,493 @@ fn tool_upgrade_lock_uses_requested_python() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn tool_upgrade_empty_json() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("--all")
+        .arg("--output-format")
+        .arg("json")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": []
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    "#);
+
+    context
+        .tool_install()
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("--all")
+        .arg("--output-format")
+        .arg("json")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": [
+        {
+          "name": "babel",
+          "outcome": "no_op"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    "#);
+}
+
+#[test]
+fn tool_upgrade_name_json() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("babel")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": [
+        {
+          "name": "babel",
+          "outcome": "upgrade_tool"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Updated babel v2.6.0 -> v2.14.0
+     - babel==2.6.0
+     + babel==2.14.0
+     - pytz==2018.5
+    Installed 1 executable: pybabel
+    "#);
+}
+
+#[test]
+fn tool_upgrade_multiple_names_json() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("python-dotenv")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    context
+        .tool_install()
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("babel")
+        .arg("python-dotenv")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": [
+        {
+          "name": "babel",
+          "outcome": "upgrade_tool"
+        },
+        {
+          "name": "python-dotenv",
+          "outcome": "upgrade_tool"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Updated babel v2.6.0 -> v2.14.0
+     - babel==2.6.0
+     + babel==2.14.0
+     - pytz==2018.5
+    Installed 1 executable: pybabel
+    Updated python-dotenv v0.10.2.post2 -> v1.0.1
+     - python-dotenv==0.10.2.post2
+     + python-dotenv==1.0.1
+    Installed 1 executable: dotenv
+    "#);
+}
+
+#[test]
+fn tool_upgrade_pinned_hint_json() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("babel==2.6.0")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("babel")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": [
+        {
+          "name": "babel",
+          "outcome": "upgrade_dependencies",
+          "constraint": {
+            "kind": "pinned_version",
+            "version": "2.6.0"
+          }
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Modified babel environment
+     - pytz==2018.5
+     + pytz==2024.1
+    "#);
+}
+
+#[test]
+fn tool_upgrade_all_json() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("python-dotenv")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    context
+        .tool_install()
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("--all")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": [
+        {
+          "name": "babel",
+          "outcome": "upgrade_tool"
+        },
+        {
+          "name": "python-dotenv",
+          "outcome": "upgrade_tool"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Updated babel v2.6.0 -> v2.14.0
+     - babel==2.6.0
+     + babel==2.14.0
+     - pytz==2018.5
+    Installed 1 executable: pybabel
+    Updated python-dotenv v0.10.2.post2 -> v1.0.1
+     - python-dotenv==0.10.2.post2
+     + python-dotenv==1.0.1
+    Installed 1 executable: dotenv
+    "#);
+}
+
+#[test]
+fn tool_upgrade_non_existing_package_json() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("black")
+        .arg("--output-format")
+        .arg("json")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": [
+        {
+          "name": "black",
+          "outcome": "failed",
+          "error": "`black` is not installed; run `uv tool install black` to install"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    error: Failed to upgrade black
+      Caused by: `black` is not installed; run `uv tool install black` to install
+    "#);
+}
+
+#[test]
+fn tool_upgrade_not_stop_if_upgrade_fails_json() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("python-dotenv")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    context
+        .tool_install()
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    tool_dir
+        .child("python-dotenv")
+        .child("uv-receipt.toml")
+        .write_str("Invalid receipt")?;
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("--all")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": [
+        {
+          "name": "babel",
+          "outcome": "upgrade_tool"
+        },
+        {
+          "name": "python-dotenv",
+          "outcome": "failed",
+          "error": "`python-dotenv` is missing a valid receipt; run `uv tool install --force python-dotenv` to reinstall"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Updated babel v2.6.0 -> v2.14.0
+     - babel==2.6.0
+     + babel==2.14.0
+     - pytz==2018.5
+    Installed 1 executable: pybabel
+    error: Failed to upgrade python-dotenv
+      Caused by: `python-dotenv` is missing a valid receipt; run `uv tool install --force python-dotenv` to reinstall
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn tool_upgrade_python_json() {
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12"])
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("babel==2.6.0")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .arg("--python")
+        .arg("3.11")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("babel")
+        .arg("--python").arg("3.12")
+        .arg("--output-format")
+        .arg("json")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "upgrades": [
+        {
+          "name": "babel",
+          "outcome": "upgrade_environment"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + babel==2.6.0
+     + pytz==2018.5
+    Installed 1 executable: pybabel
+    "#);
+}


### PR DESCRIPTION
## Summary

Adds `--output-format json` to `uv tool upgrade`. The JSON output looks like this:

```json
{
  "schema": {
    "version": "preview"
  },
  "upgrades": [
    {
      "name": "rust-just",
      "outcome": "no_op"
    },
    {
      "name": "zizmor",
      "outcome": "upgrade_tool"
    },
    {
      "name": "babel",
      "outcome": "upgrade_dependencies",
      "constraint": {
        "kind": "pinned_version",
        "version": "2.6.0"
      }
    },
    {
      "name": "python-dotenv",
      "outcome": "failed",
      "error": "`python-dotenv` is missing a valid receipt; run `uv tool install --force python-dotenv` to reinstall"
    }
  ]
}
```

Some implementation details:
- I extended the existing `UpgradeReport` type to include the information we want for the JSON entries 
- I added a `Failed` enum variant to the `UpgradeOutcome` enum, since it didn't have a state representing an upgrade failing
- I duplicated some of the existing tests, checking for the JSON output instead. They could be combined into a single test for both outputs if desired.

Fixes https://github.com/astral-sh/uv/issues/18877


## Test Plan

Duplicated some of the existing `tool upgrade` integration tests, checking for the JSON output instead

cc @woodruffw 