### PR TITLE
Docs: Clarify which groups are exported by default in `uv export`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1186,6 +1186,9 @@ pub enum ProjectCommand {
     /// At present, `requirements.txt`, `pylock.toml` (PEP 751) and CycloneDX v1.5 JSON output
     /// formats are supported.
     ///
+    /// By default, the exported requirements include the project's default dependency groups
+    /// (such as the standard dependencies and the `dev` group).
+    ///
     /// The project is re-locked before exporting unless the `--locked` or `--frozen` flag is
     /// provided.
     ///

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -544,9 +544,11 @@ requires-dist = ["torch", "einops"]
 
 ## Dynamic metadata
 
-If your project uses dynamic metadata (e.g., to determine the version or dependencies dynamically), uv may need additional configuration to invalidate its cache when the metadata changes.
+If your project uses dynamic metadata (e.g., to determine the version or dependencies dynamically),
+uv may need additional configuration to invalidate its cache when the metadata changes.
 
-See the [caching documentation](../cache.md#dynamic-metadata) for details on configuring cache invalidation for dynamic metadata.
+See the [caching documentation](../cache.md#dynamic-metadata) for details on configuring cache
+invalidation for dynamic metadata.
 
 ## Editable mode
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -542,6 +542,12 @@ version = "2.6.3"
 requires-dist = ["torch", "einops"]
 ```
 
+## Dynamic metadata
+
+If your project uses dynamic metadata (e.g., to determine the version or dependencies dynamically), uv may need additional configuration to invalidate its cache when the metadata changes.
+
+See the [caching documentation](../cache.md#dynamic-metadata) for details on configuring cache invalidation for dynamic metadata.
+
 ## Editable mode
 
 By default, the project will be installed in editable mode, such that changes to the source code are


### PR DESCRIPTION
Closes #16512

Adds a note to the `uv export` help text and documentation to explicitly state that the default behavior exports the project's default dependency groups (i.e. standard dependencies and the `dev` group).