### PR TITLE
Make `uv init --app` conflict with `--build-backend` and `--package`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3427,9 +3427,9 @@ pub struct InitArgs {
     /// `packaged-init` preview feature is enabled. It will become the default unconditionally in
     /// the future.
     ///
-    /// When using `--app`, this will include a `[project.scripts]` entrypoint and use a `src/`
-    /// project structure.
-    #[arg(long, overrides_with = "no_package")]
+    /// For an application (the default project kind), this will include a `[project.scripts]`
+    /// entrypoint and use a `src/` project structure.
+    #[arg(long, overrides_with = "no_package", conflicts_with_all = ["app"])]
     pub r#package: bool,
 
     /// Do not set up the project to be built as a Python package.
@@ -3447,9 +3447,9 @@ pub struct InitArgs {
     /// This project kind is for web servers, scripts, and command-line interfaces.
     ///
     /// By default, an application is not intended to be built and distributed as a Python package.
-    /// The `--package` option can be used to create an application that is distributable, e.g., if
-    /// you want to distribute a command-line interface via PyPI.
-    #[arg(long, alias = "application", conflicts_with_all = ["lib", "script"])]
+    /// Use `--package` (without `--app`) to create a distributable application, e.g., if you want
+    /// to distribute a command-line interface via PyPI.
+    #[arg(long, alias = "application", conflicts_with_all = ["lib", "script", "package", "build_backend"])]
     pub r#app: bool,
 
     /// Create a project for a library.
@@ -3488,7 +3488,7 @@ pub struct InitArgs {
     /// Initialize a build-backend of choice for the project.
     ///
     /// Implicitly sets `--package`.
-    #[arg(long, value_enum, conflicts_with_all=["script", "no_package"], env = EnvVars::UV_INIT_BUILD_BACKEND)]
+    #[arg(long, value_enum, conflicts_with_all=["script", "no_package", "app"], env = EnvVars::UV_INIT_BUILD_BACKEND)]
     pub build_backend: Option<ProjectBuildBackend>,
 
     /// Invalid option name for build backend.

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -289,7 +289,7 @@ fn init_application_other_python_exists() -> Result<()> {
     Ok(())
 }
 
-/// Run `uv init --app --package` to create a packaged application project
+/// Run `uv init --package` to create a packaged application project
 #[test]
 fn init_application_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -300,7 +300,7 @@ fn init_application_package() -> Result<()> {
     let pyproject_toml = child.join("pyproject.toml");
     let init_py = child.join("src").join("foo").join("__init__.py");
 
-    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--package"), @"
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--package"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -359,6 +359,81 @@ fn init_application_package() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + foo==0.1.0 (from file://[TEMP_DIR]/foo)
+    ");
+
+    Ok(())
+}
+
+/// Using `uv init --app --package` isn't allowed, since `--app` requests an unpackaged
+/// application while `--package` requests a packaged one.
+#[test]
+fn init_app_conflicts_with_package() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let child = context.temp_dir.child("foo");
+    child.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--package"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--app' cannot be used with '--package'
+
+    Usage: uv init --cache-dir [CACHE_DIR] --app [PATH]
+
+    For more information, try '--help'.
+    ");
+
+    Ok(())
+}
+
+/// Using `uv init --app --build-backend` isn't allowed, since `--build-backend` implies a
+/// packaged project.
+#[test]
+fn init_app_conflicts_with_build_backend() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let child = context.temp_dir.child("foo");
+    child.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--build-backend").arg("uv"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--app' cannot be used with '--build-backend <BUILD_BACKEND>'
+
+    Usage: uv init --cache-dir [CACHE_DIR] --app [PATH]
+
+    For more information, try '--help'.
+    ");
+
+    Ok(())
+}
+
+/// Using `uv init --app` with `UV_INIT_BUILD_BACKEND` isn't allowed, since the build backend
+/// implies a packaged project. See <https://github.com/astral-sh/uv/issues/17335>.
+#[test]
+fn init_app_conflicts_with_build_backend_env() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let child = context.temp_dir.child("foo");
+    child.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").env(EnvVars::UV_INIT_BUILD_BACKEND, "uv"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--app' cannot be used with '--build-backend <BUILD_BACKEND>'
+
+    Usage: uv init --cache-dir [CACHE_DIR] --app [PATH]
+
+    For more information, try '--help'.
     ");
 
     Ok(())
@@ -3165,7 +3240,7 @@ fn init_with_author() {
     });
 }
 
-/// Run `uv init --app --package --build-backend flit` to create a packaged application project
+/// Run `uv init --package --build-backend flit` to create a packaged application project
 #[test]
 fn init_application_package_flit() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3176,7 +3251,7 @@ fn init_application_package_flit() -> Result<()> {
     let pyproject_toml = child.join("pyproject.toml");
     let init_py = child.join("src").join("foo").join("__init__.py");
 
-    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--package").arg("--build-backend").arg("flit"), @"
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--package").arg("--build-backend").arg("flit"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3440,7 +3515,7 @@ fn init_library_poetry() -> Result<()> {
     Ok(())
 }
 
-/// Run `uv init --app --package --build-backend maturin` to create a packaged application project
+/// Run `uv init --package --build-backend maturin` to create a packaged application project
 #[test]
 #[cfg(feature = "test-crates-io")]
 fn init_app_build_backend_maturin() -> Result<()> {
@@ -3455,7 +3530,7 @@ fn init_app_build_backend_maturin() -> Result<()> {
     let lib_core = child.join("src").join("lib.rs");
     let build_file = child.join("Cargo.toml");
 
-    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--package").arg("--build-backend").arg("maturin"), @"
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--package").arg("--build-backend").arg("maturin"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3571,7 +3646,7 @@ fn init_app_build_backend_maturin() -> Result<()> {
     Ok(())
 }
 
-/// Run `uv init --app --package --build-backend scikit` to create a packaged application project
+/// Run `uv init --package --build-backend scikit` to create a packaged application project
 #[test]
 fn init_app_build_backend_scikit() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3585,7 +3660,7 @@ fn init_app_build_backend_scikit() -> Result<()> {
     let lib_core = child.join("src").join("main.cpp");
     let build_file = child.join("CMakeLists.txt");
 
-    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--package").arg("--build-backend").arg("scikit"), @"
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--package").arg("--build-backend").arg("scikit"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3942,7 +4017,7 @@ fn init_lib_build_backend_scikit() -> Result<()> {
     Ok(())
 }
 
-/// Run `uv init --app --package --build-backend hatchling` to create a packaged application project
+/// Run `uv init --package --build-backend hatchling` to create a packaged application project
 #[test]
 fn init_application_package_hatchling() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3953,7 +4028,7 @@ fn init_application_package_hatchling() -> Result<()> {
     let pyproject_toml = child.join("pyproject.toml");
     let init_py = child.join("src").join("foo").join("__init__.py");
 
-    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--package").arg("--build-backend").arg("hatchling"), @"
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--package").arg("--build-backend").arg("hatchling"), @"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
Fixes #17335.

## Summary

When `UV_INIT_BUILD_BACKEND` is set in the environment, `uv init --app` silently produces a packaged project layout (with `src/` and `[build-system]`) instead of an unpackaged application, ignoring the `--app` flag.

Per @konstin's direction in the issue:

> I think what is missing here is that `--app` should conflict with `--build-backend` and `--package`.

## Behavior

Before:

- `uv init --app --package` → silently produced a packaged project (`--package` won)
- `uv init --app --build-backend uv` → silently produced a packaged project
- `UV_INIT_BUILD_BACKEND=uv uv init --app` → silently produced a packaged project (the original bug report)

After:

- All three cases now fail at argument parsing with a clap conflict error, e.g.:
  ```
  error: the argument '--app' cannot be used with '--build-backend <BUILD_BACKEND>'
  ```

## Tests

Three snapshot tests added in `crates/uv/tests/project/init.rs` covering the CLI and env-var cases; all pass locally with `cargo test --package uv --test project --no-default-features --features test-defaults init::init_app_conflicts`. Red→green verified by stashing the `lib.rs` change.

Existing tests that previously combined `--app --package` were updated to use only `--package` (which is the closest valid invocation preserving the original intent of testing packaged app initialization).

## Note

#19906 is changing the default for `uv init` to packaged, which makes the `--app` opt-out more important to keep functional.