### PR TITLE
fix(uvx): say --from (not --with) when --from path fails

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -302,7 +302,11 @@ pub(crate) async fn run(
         }
 
         Err(ProjectError::Requirements(err)) => {
-            let err = anyhow::Error::new(err).context("Failed to resolve `--with` requirement");
+            // Prefer `--from` in the context when the user provided it; otherwise `--with`.
+            // (A requirements failure with an explicit `--from` is usually the `--from` package.)
+            let flag = if explicit_from { "--from" } else { "--with" };
+            let err = anyhow::Error::new(err)
+                .context(format!("Failed to resolve `{flag}` requirement"));
             return Err(UvError::user(err).into());
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -305,8 +305,8 @@ pub(crate) async fn run(
             // Prefer `--from` in the context when the user provided it; otherwise `--with`.
             // (A requirements failure with an explicit `--from` is usually the `--from` package.)
             let flag = if explicit_from { "--from" } else { "--with" };
-            let err = anyhow::Error::new(err)
-                .context(format!("Failed to resolve `{flag}` requirement"));
+            let err =
+                anyhow::Error::new(err).context(format!("Failed to resolve `{flag}` requirement"));
             return Err(UvError::user(err).into());
         }
         Err(err) => return Err(err.into()),

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -1938,6 +1938,31 @@ fn tool_run_invalid_with() {
     ");
 }
 
+/// Invalid `--from` paths should mention `--from`, not `--with` (astral-sh/uv#8757).
+#[test]
+fn tool_run_invalid_from() {
+    let context = uv_test::test_context!("3.12");
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context
+        .tool_run()
+        .arg("--from")
+        .arg("./foo")
+        .arg("flask")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to resolve `--from` requirement
+      Caused by: Distribution not found at: file://[TEMP_DIR]/foo
+    ");
+}
+
 #[test]
 fn warn_no_executables_found() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();


### PR DESCRIPTION
## Summary

Fixes #8757.

If `uvx --from ./missing-path …` fails to resolve the package, the error currently says it failed to resolve a `--with` requirement. That is confusing when the user only passed `--from`.

This change uses `--from` in that error context when `--from` was explicit, otherwise keeps `--with`.

## Test plan

- [x] `cargo test -p uv --test tool -- tool_run_invalid_from tool_run_invalid_with` (both passed locally)
- [ ] CI

## Notes

AI tooling helped draft the patch; I reviewed the change and the regression test before opening this PR. Happy to adjust if the maintainers want a different wording.

Made with [Cursor](https://cursor.com)