### PR TITLE
Fix validate-pyproject-schema-store 2026.07.20 regression

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -86,7 +86,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "0.11.28"
-      - run: uvx --from 'validate-pyproject[all,store]' validate-pyproject pyproject.toml
+      - run: uvx --from 'validate-pyproject[all,store]' --with validate-pyproject-schema-store==2026.7.17 validate-pyproject pyproject.toml
 
   readme:
     timeout-minutes: 10


### PR DESCRIPTION
henryiii/validate-pyproject-schema-store#267 incorporates changes we made to our schema. The schema seems valid, instead it looks like there is a bug in fastjsonschema (a dependency of validate-pyproject) that is triggered by this new schema.

Pin the version temporarily to ensure CI doesn't explode.