### PR TITLE
Use `regex!` for static patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
 ref-cast = { version = "1.0.24" }
 reflink-copy = { version = "0.1.19" }
-regex = { version = "1.10.6" }
+regex = { version = "1.13.0" }
 regex-automata = { version = "0.4.8", default-features = false, features = [
   "dfa-build",
   "dfa-search",

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -479,7 +479,7 @@ mod tests {
     use indoc::indoc;
     use insta::assert_snapshot;
     use itertools::Itertools;
-    use regex::Regex;
+    use regex::regex;
     use sha2::Digest;
     use std::io::BufReader;
     use std::iter;
@@ -756,8 +756,7 @@ mod tests {
 
         // Redact the uv_build version to keep the hash stable across releases
         let pyproject_toml = fs_err::read_to_string(src.path().join("pyproject.toml")).unwrap();
-        let current_requires =
-            Regex::new(r#"requires = \["uv_build>=[0-9.]+,<[0-9.]+"\]"#).unwrap();
+        let current_requires = regex!(r#"requires = \["uv_build>=[0-9.]+,<[0-9.]+"\]"#);
         let mocked_requires = r#"requires = ["uv_build>=1,<2"]"#;
         let pyproject_toml = current_requires.replace(pyproject_toml.as_str(), mocked_requires);
         fs_err::write(src.path().join("pyproject.toml"), pyproject_toml.as_bytes()).unwrap();

--- a/crates/uv-build-frontend/src/error.rs
+++ b/crates/uv-build-frontend/src/error.rs
@@ -3,11 +3,10 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::path::PathBuf;
 use std::process::ExitStatus;
-use std::sync::LazyLock;
 
 use crate::PythonRunnerOutput;
 use owo_colors::OwoColorize;
-use regex::Regex;
+use regex::regex;
 use thiserror::Error;
 use uv_configuration::BuildOutput;
 use uv_distribution_types::IsBuildBackendError;
@@ -16,44 +15,6 @@ use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_types::AnyErrorBuild;
-
-/// e.g. `pygraphviz/graphviz_wrap.c:3020:10: fatal error: graphviz/cgraph.h: No such file or directory`
-static MISSING_HEADER_RE_GCC: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r".*\.(?:c|c..|h|h..):\d+:\d+: fatal error: (.*\.(?:h|h..)): No such file or directory",
-    )
-    .unwrap()
-});
-
-/// e.g. `pygraphviz/graphviz_wrap.c:3023:10: fatal error: 'graphviz/cgraph.h' file not found`
-static MISSING_HEADER_RE_CLANG: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r".*\.(?:c|c..|h|h..):\d+:\d+: fatal error: '(.*\.(?:h|h..))' file not found")
-        .unwrap()
-});
-
-/// e.g. `pygraphviz/graphviz_wrap.c(3023): fatal error C1083: Cannot open include file: 'graphviz/cgraph.h': No such file or directory`
-static MISSING_HEADER_RE_MSVC: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r".*\.(?:c|c..|h|h..)\(\d+\): fatal error C1083: Cannot open include file: '(.*\.(?:h|h..))': No such file or directory")
-        .unwrap()
-});
-
-/// e.g. `/usr/bin/ld: cannot find -lncurses: No such file or directory`
-static LD_NOT_FOUND_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"/usr/bin/ld: cannot find -l([a-zA-Z10-9]+): No such file or directory").unwrap()
-});
-
-/// e.g. `error: invalid command 'bdist_wheel'`
-static WHEEL_NOT_FOUND_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"error: invalid command 'bdist_wheel'").unwrap());
-
-/// e.g. `ModuleNotFoundError`
-static MODULE_NOT_FOUND: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new("ModuleNotFoundError: No module named ['\"]([^'\"]+)['\"]").unwrap()
-});
-
-/// e.g. `ModuleNotFoundError: No module named 'distutils'`
-static DISTUTILS_NOT_FOUND_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"ModuleNotFoundError: No module named 'distutils'").unwrap());
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -382,27 +343,48 @@ impl Error {
         version: Option<&Version>,
         version_id: Option<&str>,
     ) -> Self {
+        // e.g. `pygraphviz/graphviz_wrap.c:3020:10: fatal error: graphviz/cgraph.h: No such file or directory`
+        let missing_header_re_gcc = regex!(
+            r".*\.(?:c|c..|h|h..):\d+:\d+: fatal error: (.*\.(?:h|h..)): No such file or directory"
+        );
+        // e.g. `pygraphviz/graphviz_wrap.c:3023:10: fatal error: 'graphviz/cgraph.h' file not found`
+        let missing_header_re_clang =
+            regex!(r".*\.(?:c|c..|h|h..):\d+:\d+: fatal error: '(.*\.(?:h|h..))' file not found");
+        // e.g. `pygraphviz/graphviz_wrap.c(3023): fatal error C1083: Cannot open include file: 'graphviz/cgraph.h': No such file or directory`
+        let missing_header_re_msvc = regex!(
+            r".*\.(?:c|c..|h|h..)\(\d+\): fatal error C1083: Cannot open include file: '(.*\.(?:h|h..))': No such file or directory"
+        );
+        // e.g. `/usr/bin/ld: cannot find -lncurses: No such file or directory`
+        let ld_not_found_re =
+            regex!(r"/usr/bin/ld: cannot find -l([a-zA-Z10-9]+): No such file or directory");
+        // e.g. `error: invalid command 'bdist_wheel'`
+        let wheel_not_found_re = regex!(r"error: invalid command 'bdist_wheel'");
+        // e.g. `ModuleNotFoundError: No module named 'distutils'`
+        let distutils_not_found_re = regex!(r"ModuleNotFoundError: No module named 'distutils'");
+        // e.g. `ModuleNotFoundError`
+        let module_not_found = regex!(r#"ModuleNotFoundError: No module named ['"]([^'"]+)['"]"#);
+
         // In the cases I've seen it was the 5th and 3rd last line (see test case), 10 seems like a reasonable cutoff.
         let missing_library = output.stderr.iter().rev().take(10).find_map(|line| {
-            if let Some((_, [header])) = MISSING_HEADER_RE_GCC
+            if let Some((_, [header])) = missing_header_re_gcc
                 .captures(line.trim())
-                .or(MISSING_HEADER_RE_CLANG.captures(line.trim()))
-                .or(MISSING_HEADER_RE_MSVC.captures(line.trim()))
+                .or(missing_header_re_clang.captures(line.trim()))
+                .or(missing_header_re_msvc.captures(line.trim()))
                 .map(|c| c.extract())
             {
                 Some(MissingLibrary::Header(header.to_string()))
             } else if let Some((_, [library])) =
-                LD_NOT_FOUND_RE.captures(line.trim()).map(|c| c.extract())
+                ld_not_found_re.captures(line.trim()).map(|c| c.extract())
             {
                 Some(MissingLibrary::Linker(library.to_string()))
-            } else if WHEEL_NOT_FOUND_RE.is_match(line.trim()) {
+            } else if wheel_not_found_re.is_match(line.trim()) {
                 Some(MissingLibrary::BuildDependency("wheel".to_string()))
-            } else if DISTUTILS_NOT_FOUND_RE.is_match(line.trim()) {
+            } else if distutils_not_found_re.is_match(line.trim()) {
                 Some(MissingLibrary::DeprecatedModule(
                     "distutils".to_string(),
                     Version::new([3, 12]),
                 ))
-            } else if let Some(caps) = MODULE_NOT_FOUND.captures(line.trim()) {
+            } else if let Some(caps) = module_not_found.captures(line.trim()) {
                 if let Some(module_match) = caps.get(1) {
                     let module_name = module_match.as_str();
                     let package_name = match crate::pipreqs::MODULE_MAPPING.lookup(module_name) {

--- a/crates/uv-extract/src/lib.rs
+++ b/crates/uv-extract/src/lib.rs
@@ -1,7 +1,7 @@
-use std::{fmt::Display, sync::LazyLock};
+use std::fmt::Display;
 
 pub use error::Error;
-use regex::Regex;
+use regex::regex;
 pub use sync::*;
 use uv_static::EnvVars;
 
@@ -11,7 +11,6 @@ pub mod stream;
 mod sync;
 mod vendor;
 
-static CONTROL_CHARACTERS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\p{C}").unwrap());
 static REPLACEMENT_CHARACTER: &str = "\u{FFFD}";
 
 /// Compression methods that we consider supported.
@@ -77,7 +76,7 @@ pub(crate) fn validate_archive_member_name(name: &str) -> Result<(), Error> {
         return Err(Error::EmptyFilename);
     }
 
-    match CONTROL_CHARACTERS_RE.replace_all(name, REPLACEMENT_CHARACTER) {
+    match regex!(r"\p{C}").replace_all(name, REPLACEMENT_CHARACTER) {
         // No replacements mean no control characters.
         std::borrow::Cow::Borrowed(_) => Ok(()),
         std::borrow::Cow::Owned(sanitized) => Err(Error::UnacceptableFilename {

--- a/crates/uv-install-wheel/src/script.rs
+++ b/crates/uv-install-wheel/src/script.rs
@@ -1,10 +1,9 @@
 use configparser::ini::{Ini, IniDefault};
-use regex::Regex;
+use regex::regex;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
 use std::io;
 use std::path::Path;
-use std::sync::LazyLock;
 
 use crate::{Error, wheel};
 
@@ -32,11 +31,9 @@ impl Script {
         //  between the object reference and the left square bracket, between the extra names and the square brackets and colons delimiting them,
         //  and after the right square bracket."
         // – https://packaging.python.org/en/latest/specifications/entry-points/#file-format
-        static SCRIPT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"^(?P<module>[\w\d_\-.]+)\s*:\s*(?P<function>[\w\d_\-.]+)(?:\s*\[\s*(?P<extras>(?:[^,]+,?\s*)+)\])?\s*$").unwrap()
-        });
-
-        let captures = SCRIPT_REGEX
+        let captures = regex!(
+            r"^(?P<module>[\w\d_\-.]+)\s*:\s*(?P<function>[\w\d_\-.]+)(?:\s*\[\s*(?P<extras>(?:[^,]+,?\s*)+)\])?\s*$"
+        )
             .captures(value)
             .ok_or_else(|| Error::InvalidWheel(format!("invalid console script: '{value}'")))?;
         if let Some(script_extras) = captures.name("extras") {

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use arcstr::ArcStr;
-use regex::Regex;
+use regex::regex;
 use thiserror::Error;
 use url::Url;
 use uv_cache_key::{CacheKey, CacheKeyHasher};
@@ -536,10 +536,7 @@ pub fn expand_env_vars(s: &str) -> Cow<'_, str> {
         project_root.to_string_lossy().to_string()
     });
 
-    static RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?P<var>\$\{(?P<name>[A-Z0-9_]+)})").unwrap());
-
-    RE.replace_all(s, |caps: &regex::Captures<'_>| {
+    regex!(r"(?P<var>\$\{(?P<name>[A-Z0-9_]+)})").replace_all(s, |caps: &regex::Captures<'_>| {
         let name = caps.name("name").unwrap().as_str();
         std::env::var(name).unwrap_or_else(|_| match name {
             "PROJECT_ROOT" => PROJECT_ROOT_FRAGMENT.to_string(),

--- a/crates/uv-platform/src/libc.rs
+++ b/crates/uv-platform/src/libc.rs
@@ -6,13 +6,12 @@
 use crate::{Arch, cpuinfo::detect_hardware_floating_point_support};
 use fs_err as fs;
 use goblin::elf::Elf;
-use regex::Regex;
+use regex::regex;
 use std::fmt::Display;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
-use std::sync::LazyLock;
 use std::{env, fmt};
 use target_lexicon::Endianness;
 use tracing::trace;
@@ -208,12 +207,11 @@ fn detect_glibc_version_from_ld(ld_so: &Path) -> Result<LibcVersion, LibcDetecti
 ///
 /// Example: `ld.so (Ubuntu GLIBC 2.39-0ubuntu8.3) stable release version 2.39.`.
 fn glibc_ld_output_to_version(kind: &str, output: &[u8]) -> Option<LibcVersion> {
-    static RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"ld.so \(.+\) .* ([0-9]+\.[0-9]+)").unwrap());
-
     let output = String::from_utf8_lossy(output);
     trace!("{kind} output from `ld.so --version`: {output:?}");
-    let (_, [version]) = RE.captures(output.as_ref()).map(|c| c.extract())?;
+    let (_, [version]) = regex!(r"ld.so \(.+\) .* ([0-9]+\.[0-9]+)")
+        .captures(output.as_ref())
+        .map(|c| c.extract())?;
     // Parse the input as "x.y" glibc version.
     let mut parsed_ints = version.split('.').map(str::parse).fuse();
     let major = parsed_ints.next()?.ok()?;
@@ -223,15 +221,12 @@ fn glibc_ld_output_to_version(kind: &str, output: &[u8]) -> Option<LibcVersion> 
 }
 
 fn detect_linux_libc_from_ld_symlink(path: &Path) -> Result<LibcVersion, LibcDetectionError> {
-    static RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"^ld-([0-9]{1,3})\.([0-9]{1,3})\.so$").unwrap());
-
     let ld_path = fs::read_link(path)?;
     let filename = ld_path
         .file_name()
         .ok_or_else(|| LibcDetectionError::MissingBasePath(ld_path.clone()))?
         .to_string_lossy();
-    let (_, [major, minor]) = RE
+    let (_, [major, minor]) = regex!(r"^ld-([0-9]{1,3})\.([0-9]{1,3})\.so$")
         .captures(&filename)
         .map(|c| c.extract())
         .ok_or_else(|| LibcDetectionError::GlibcExtractionMismatch(ld_path.clone()))?;
@@ -278,12 +273,11 @@ fn detect_musl_version(ld_path: impl AsRef<Path>) -> Result<LibcVersion, LibcDet
 ///
 /// Example: `Version 1.2.5`.
 fn musl_ld_output_to_version(kind: &str, output: &[u8]) -> Option<LibcVersion> {
-    static RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"Version ([0-9]{1,4})\.([0-9]{1,4})").unwrap());
-
     let output = String::from_utf8_lossy(output);
     trace!("{kind} output from `ld`: {output:?}");
-    let (_, [major, minor]) = RE.captures(output.as_ref()).map(|c| c.extract())?;
+    let (_, [major, minor]) = regex!(r"Version ([0-9]{1,4})\.([0-9]{1,4})")
+        .captures(output.as_ref())
+        .map(|c| c.extract())?;
     // unwrap-safety: Since we are guaranteed to have between 1 and 4 ASCII digits and the
     // maximum possible value, 9999, fits into a u16.
     let major = major.parse().expect("valid major version");

--- a/crates/uv-pypi-types/src/lenient_requirement.rs
+++ b/crates/uv-pypi-types/src/lenient_requirement.rs
@@ -1,32 +1,13 @@
-use regex::Regex;
+use regex::regex;
 use serde::{Deserialize, Deserializer, Serialize, de};
 use std::borrow::Cow;
 use std::str::FromStr;
-use std::sync::LazyLock;
 use tracing::warn;
 
 use uv_pep440::{VersionSpecifiers, VersionSpecifiersParseError};
 use uv_pep508::{Pep508Error, Pep508Url, Requirement};
 
 use crate::VerbatimParsedUrl;
-
-/// Ex) `>=7.2.0<8.0.0`
-static MISSING_COMMA: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(\d)([<>=~^!])").unwrap());
-/// Ex) `!=~5.0`
-static NOT_EQUAL_TILDE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"!=~((?:\d\.)*\d)").unwrap());
-/// Ex) `>=1.9.*`, `<3.4.*`
-static INVALID_TRAILING_DOT_STAR: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(<=|>=|<|>)(\d+(\.\d+)*)\.\*").unwrap());
-/// Ex) `!=3.0*`
-static MISSING_DOT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(\d\.\d)+\*").unwrap());
-/// Ex) `>=3.6,`
-static TRAILING_COMMA: LazyLock<Regex> = LazyLock::new(|| Regex::new(r",\s*$").unwrap());
-/// Ex) `>dev`
-static GREATER_THAN_DEV: LazyLock<Regex> = LazyLock::new(|| Regex::new(r">dev").unwrap());
-/// Ex) `>=9.0.0a1.0`
-static TRAILING_ZERO: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(\d+(\.\d)*(a|b|rc|post|dev)\d+)\.0").unwrap());
 
 // Search and replace functions that fix invalid specifiers.
 type FixUp = for<'a> fn(&'a str) -> Cow<'a, str>;
@@ -35,37 +16,37 @@ type FixUp = for<'a> fn(&'a str) -> Cow<'a, str>;
 static FIXUPS: &[(FixUp, &str)] = &[
     // Given `>=7.2.0<8.0.0`, rewrite to `>=7.2.0,<8.0.0`.
     (
-        |input| MISSING_COMMA.replace_all(input, r"$1,$2"),
+        |input| regex!(r"(\d)([<>=~^!])").replace_all(input, r"$1,$2"),
         "inserting missing comma",
     ),
     // Given `!=~5.0,>=4.12`, rewrite to `!=5.0.*,>=4.12`.
     (
-        |input| NOT_EQUAL_TILDE.replace_all(input, r"!=${1}.*"),
+        |input| regex!(r"!=~((?:\d\.)*\d)").replace_all(input, r"!=${1}.*"),
         "replacing invalid tilde with wildcard",
     ),
     // Given `>=1.9.*`, rewrite to `>=1.9`.
     (
-        |input| INVALID_TRAILING_DOT_STAR.replace_all(input, r"${1}${2}"),
+        |input| regex!(r"(<=|>=|<|>)(\d+(\.\d+)*)\.\*").replace_all(input, r"${1}${2}"),
         "removing star after comparison operator other than equal and not equal",
     ),
     // Given `!=3.0*`, rewrite to `!=3.0.*`.
     (
-        |input| MISSING_DOT.replace_all(input, r"${1}.*"),
+        |input| regex!(r"(\d\.\d)+\*").replace_all(input, r"${1}.*"),
         "inserting missing dot",
     ),
     // Given `>=3.6,`, rewrite to `>=3.6`
     (
-        |input| TRAILING_COMMA.replace_all(input, r"${1}"),
+        |input| regex!(r",\s*$").replace_all(input, r"${1}"),
         "removing trailing comma",
     ),
     // Given `>dev`, rewrite to `>0.0.0dev`
     (
-        |input| GREATER_THAN_DEV.replace_all(input, r">0.0.0dev"),
+        |input| regex!(r">dev").replace_all(input, r">0.0.0dev"),
         "assuming 0.0.0dev",
     ),
     // Given `>=9.0.0a1.0`, rewrite to `>=9.0.0a1`
     (
-        |input| TRAILING_ZERO.replace_all(input, r"${1}"),
+        |input| regex!(r"(\d+(\.\d)*(a|b|rc|post|dev)\d+)\.0").replace_all(input, r"${1}"),
         "removing trailing zero",
     ),
     (remove_stray_quotes, "removing stray quotes"),
@@ -73,16 +54,16 @@ static FIXUPS: &[(FixUp, &str)] = &[
 
 // Given `>= 2.7'`, rewrite to `>= 2.7`
 fn remove_stray_quotes(input: &str) -> Cow<'_, str> {
-    /// Ex) `'>= 2.7'`, `>=3.6'`
-    static STRAY_QUOTES: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"['"]"#).unwrap());
+    // Ex) `'>= 2.7'`, `>=3.6'`
+    let stray_quotes = regex!(r#"['"]"#);
 
     // make sure not to touch markers, which can have quotes (e.g. `python_version >= '3.7'`)
     match input.find(';') {
         Some(markers) => {
-            let requirement = STRAY_QUOTES.replace_all(&input[..markers], "");
+            let requirement = stray_quotes.replace_all(&input[..markers], "");
             format!("{}{}", requirement, &input[markers..]).into()
         }
-        None => STRAY_QUOTES.replace_all(input, ""),
+        None => stray_quotes.replace_all(input, ""),
     }
 }
 

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -291,7 +291,7 @@ impl Pep723Script {
                 // Issue a warning for users who might not know that.
                 // TODO: There are a lot of mistakes we could consider detecting here, like
                 // `uv run` without `--script` when the file doesn't end in `.py`.
-                if !regex::Regex::new(r"\buv\b").unwrap().is_match(&shebang) {
+                if !regex::regex!(r"\buv\b").is_match(&shebang) {
                     warn_user!(
                         "If you execute {} directly, it might ignore its inline metadata.\nConsider replacing its shebang with: {}",
                         file.to_string_lossy().cyan(),

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -27,7 +27,7 @@ use futures::StreamExt;
 use indoc::{formatdoc, indoc};
 use itertools::Itertools;
 use predicates::prelude::predicate;
-use regex::Regex;
+use regex::{Regex, regex};
 use tokio::io::AsyncWriteExt;
 
 use uv_cache::{Cache, CacheBucket};
@@ -1909,9 +1909,6 @@ impl TestContext {
     ///
     /// This assumes that a lock has already been performed.
     pub fn diff_lock(&self, change: impl Fn(&Self) -> Command) -> String {
-        static TRIM_TRAILING_WHITESPACE: std::sync::LazyLock<Regex> =
-            std::sync::LazyLock::new(|| Regex::new(r"(?m)^\s+$").unwrap());
-
         let lock_path = ChildPath::new(self.temp_dir.join("uv.lock"));
         let old_lock = fs_err::read_to_string(&lock_path).unwrap();
         let (snapshot, output) = run_and_format(
@@ -1982,9 +1979,6 @@ impl TestContext {
 /// Creates a "unified" diff between the two line-oriented strings suitable
 /// for snapshotting.
 pub fn diff_snapshot(old: &str, new: &str, context_radius: usize) -> String {
-    static TRIM_TRAILING_WHITESPACE: std::sync::LazyLock<Regex> =
-        std::sync::LazyLock::new(|| Regex::new(r"(?m)^\s+$").unwrap());
-
     let diff = similar::TextDiff::from_lines(old, new);
     let unified = diff
         .unified_diff()
@@ -1994,9 +1988,7 @@ pub fn diff_snapshot(old: &str, new: &str, context_radius: usize) -> String {
     // Not totally clear why, but some lines end up containing only
     // whitespace in the diff, even though they don't appear in the
     // original data. So just strip them here.
-    TRIM_TRAILING_WHITESPACE
-        .replace_all(&unified, "")
-        .into_owned()
+    regex!(r"(?m)^\s+$").replace_all(&unified, "").into_owned()
 }
 
 /// Assert a snapshot of the diff between `old` and a command's output.


### PR DESCRIPTION
`regex` 1.13 adds `regex!`, which lazily compiles and reuses literal patterns. This replaces the existing `LazyLock<Regex>` boilerplate and direct `Regex::new` calls, including the shebang check that previously recompiled its pattern on every call.