### PR TITLE
Update jiff-tzdb to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"


### PR DESCRIPTION
Jiff 0.2.32 updates its bundled timezone database to `2026c`, but `jiff-tzdb-platform` still permits the `jiff-tzdb` 0.1.6 entry already in uv's lockfile. Windows builds therefore continued to embed `2026a`.

This updates `jiff-tzdb` to 0.1.8 so Windows builds bundle `2026c`.

The main improvements `2026c` brings over the previously shipped `2026a` are:

- **British Columbia:** `America/Vancouver` / `Canada/Pacific` stays on UTC−07 permanently instead of falling back to UTC−08 on November 1, 2026.
- **Alberta:** `America/Edmonton` / `Canada/Mountain` stays on UTC−06 permanently instead of falling back to UTC−07.
- **Morocco and Western Sahara:** `Africa/Casablanca` and `Africa/El_Aaiun` move to permanent UTC on September 20, 2026, ending the recurring DST/Ramadan transitions.

Sources: [IANA 2026b announcement](https://lists.iana.org/hyperkitty/list/tz-announce@iana.org/thread/VX2Z3CBO6KHTYZNBBKFFWM7ZCI6TVCXP/), [IANA 2026c announcement](https://lists.iana.org/hyperkitty/list/tz-announce@iana.org/thread/NVHSX2PAQIT44U5FCCEVNJJYXQMMTJSA/).

## Test plan (on top of CI)

Ran:

```console
$ cargo test --offline --locked --package uv-distribution-types --lib exclude_newer
$ cargo xwin clippy --package uv-distribution-types --lib --locked --target x86_64-pc-windows-msvc -- -D warnings
```