### PR TITLE
Use the compact automations dispatch policy

### DIFF
--- a/.github/automations-dispatch.json
+++ b/.github/automations-dispatch.json
@@ -1,29 +1,28 @@
 {
-  "version": 1,
-  "delivery_ttl_seconds": 1209600,
+  "version": 2,
+  "repositories": {
+    "uv-dev": {
+      "name": "astral-sh/uv-dev",
+      "id": 1302176231
+    }
+  },
   "rules": [
     {
-      "event": "pull_request",
-      "action": "ready_for_review",
-      "repository": "astral-sh/uv-dev",
-      "repository_id": 1302176231,
-      "conditions": {
-        "/pull_request/draft": false,
-        "/pull_request/state": "open",
-        "/pull_request/base/repo/id": 1302176231,
-        "/pull_request/head/repo/id": 1302176231
+      "repository": "uv-dev",
+      "on": {
+        "pull_request": ["ready_for_review"]
       },
-      "verify_pull_request": true,
-      "workflow": {
-        "repository": "astral-sh/uv-dev",
-        "repository_id": 1302176231,
-        "path": ".github/workflows/promote-pull-request.yml",
-        "ref": "main",
-        "inputs": {
-          "pull_request": "/pull_request/number",
-          "head_sha": "/pull_request/head/sha"
-        }
-      }
+      "workflow": "promote-pull-request.yml"
+    },
+    {
+      "repository": "uv-dev",
+      "on": {
+        "ost_actions_dispatch_v2_canary": ["dispatch"]
+      },
+      "conditions": {
+        "/canary/id": "20260720-c84739f"
+      },
+      "workflow": "sync-uv-dev.yml"
     }
   ]
 }


### PR DESCRIPTION
The dispatcher now supports a compact policy schema that derives the fixed pull-request safeguards and canonical workflow inputs. Migrate the existing promotion route without changing its trigger or target, and add a uniquely gated temporary canary route that exercises dispatch against the `uv-dev`-skipped sync workflow; the canary will be removed after the production check.