### PR TITLE
Remove the dispatcher policy canary

### DIFF
--- a/.github/automations-dispatch.json
+++ b/.github/automations-dispatch.json
@@ -13,16 +13,6 @@
         "pull_request": ["ready_for_review"]
       },
       "workflow": "promote-pull-request.yml"
-    },
-    {
-      "repository": "uv-dev",
-      "on": {
-        "ost_actions_dispatch_v2_canary": ["dispatch"]
-      },
-      "conditions": {
-        "/canary/id": "20260720-c84739f"
-      },
-      "workflow": "sync-uv-dev.yml"
     }
   ]
 }


### PR DESCRIPTION
The bounded dispatcher canary successfully exercised the compact version 2 policy and workflow-dispatch path. Remove the temporary synthetic route and retain only the unchanged promotion trigger and target in the compact policy.
