### PR TITLE
Bump Hawk to 0.1.9 and Rust to 1.97.1

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -16,7 +16,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   # renovate: datasource=github-releases depName=astral-sh/hawk
-  HAWK_VERSION: 0.1.8
+  HAWK_VERSION: 0.1.9
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
@@ -173,13 +173,13 @@ jobs:
           cache-workspace-crates: "false"
           save-if: ${{ inputs.save-rust-cache == 'true' }}
       - name: "Install Rust toolchain"
-        run: rustup toolchain install 1.97.0
+        run: rustup toolchain install 1.97.1
       - name: "Install Hawk"
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
       - name: "Hawk"
-        run: cargo +1.97.0 hawk check --target-dir target/hawk -D warnings
+        run: cargo +1.97.1 hawk check --target-dir target/hawk -D warnings
 
   shear:
     name: "cargo shear"


### PR DESCRIPTION
## Summary

Bump the Hawk CI check from 0.1.8 to [0.1.9](https://github.com/astral-sh/hawk/releases/tag/0.1.9), which is built against Rust 1.97.1. Update the Hawk toolchain installation and invocation to 1.97.1 so the check stays aligned with the root and `uv-build` toolchain pins.