### PR TITLE
Make requirement lowering async

### DIFF
--- a/crates/uv-distribution/src/metadata/build_requires.rs
+++ b/crates/uv-distribution/src/metadata/build_requires.rs
@@ -76,10 +76,11 @@ impl BuildRequires {
             editable,
             credentials_cache,
         )
+        .await
     }
 
     /// Lower the `build-system.requires` field from a `pyproject.toml` file.
-    fn from_project_workspace(
+    async fn from_project_workspace(
         metadata: uv_pypi_types::BuildRequires,
         project_workspace: &ProjectWorkspace,
         locations: &IndexLocations,
@@ -119,46 +120,41 @@ impl BuildRequires {
         };
 
         // Lower the requirements.
-        let requires_dist = metadata.requires_dist.into_iter();
-        let requires_dist = if sources.all() {
-            requires_dist.into_iter().map(Requirement::from).collect()
-        } else {
-            requires_dist
-                .flat_map(|requirement| {
-                    // Check if sources should be disabled for this specific package
-                    if sources.for_package(&requirement.name) {
-                        vec![Ok(Requirement::from(requirement))].into_iter()
-                    } else {
-                        let requirement_name = requirement.name.clone();
-                        let extra = requirement.marker.top_level_extra_name();
-                        let group = None;
-                        LoweredRequirement::from_requirement(
-                            requirement,
-                            metadata.name.as_ref(),
-                            project_workspace.project_root(),
-                            project_sources,
-                            project_indexes,
-                            extra.as_deref(),
-                            group,
-                            locations,
-                            project_workspace.workspace(),
-                            None,
-                            editable,
-                            credentials_cache,
-                        )
-                        .map(move |requirement| match requirement {
-                            Ok(requirement) => Ok(requirement.into_inner()),
-                            Err(err) => Err(MetadataError::LoweringError(
-                                requirement_name.clone(),
-                                Box::new(err),
-                            )),
+        let mut requires_dist = Vec::new();
+        for requirement in metadata.requires_dist {
+            if sources.for_package(&requirement.name) {
+                requires_dist.push(Requirement::from(requirement));
+                continue;
+            }
+
+            let requirement_name = requirement.name.clone();
+            let extra = requirement.marker.top_level_extra_name();
+            requires_dist.extend(
+                LoweredRequirement::from_requirement(
+                    requirement,
+                    metadata.name.as_ref(),
+                    project_workspace.project_root(),
+                    project_sources,
+                    project_indexes,
+                    extra.as_deref(),
+                    None,
+                    locations,
+                    project_workspace.workspace(),
+                    None,
+                    editable,
+                    credentials_cache,
+                )
+                .await
+                .map(|requirement| {
+                    requirement
+                        .map(LoweredRequirement::into_inner)
+                        .map_err(|err| {
+                            MetadataError::LoweringError(requirement_name.clone(), Box::new(err))
                         })
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                    }
                 })
-                .collect::<Result<Vec<_>, _>>()?
-        };
+                .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
 
         Ok(Self {
             name: metadata.name,
@@ -167,7 +163,7 @@ impl BuildRequires {
     }
 
     /// Lower the `build-system.requires` field from a `pyproject.toml` file.
-    pub fn from_workspace(
+    pub async fn from_workspace(
         metadata: uv_pypi_types::BuildRequires,
         workspace: &Workspace,
         locations: &IndexLocations,
@@ -196,43 +192,41 @@ impl BuildRequires {
             .unwrap_or(&empty);
 
         // Lower the requirements.
-        let requires_dist = metadata.requires_dist.into_iter();
-        let requires_dist = requires_dist
-            .flat_map(|requirement| {
-                // Check if sources should be disabled for this specific package
-                if sources.for_package(&requirement.name) {
-                    vec![Ok(Requirement::from(requirement))].into_iter()
-                } else {
-                    let requirement_name = requirement.name.clone();
-                    let extra = requirement.marker.top_level_extra_name();
-                    let group = None;
+        let mut requires_dist = Vec::new();
+        for requirement in metadata.requires_dist {
+            if sources.for_package(&requirement.name) {
+                requires_dist.push(Requirement::from(requirement));
+                continue;
+            }
 
-                    LoweredRequirement::from_requirement(
-                        requirement,
-                        None,
-                        workspace.install_path(),
-                        project_sources,
-                        project_indexes,
-                        extra.as_deref(),
-                        group,
-                        locations,
-                        workspace,
-                        None,
-                        true,
-                        credentials_cache,
-                    )
-                    .map(move |requirement| match requirement {
-                        Ok(requirement) => Ok(requirement.into_inner()),
-                        Err(err) => Err(MetadataError::LoweringError(
-                            requirement_name.clone(),
-                            Box::new(err),
-                        )),
-                    })
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            let requirement_name = requirement.name.clone();
+            let extra = requirement.marker.top_level_extra_name();
+            requires_dist.extend(
+                LoweredRequirement::from_requirement(
+                    requirement,
+                    None,
+                    workspace.install_path(),
+                    project_sources,
+                    project_indexes,
+                    extra.as_deref(),
+                    None,
+                    locations,
+                    workspace,
+                    None,
+                    true,
+                    credentials_cache,
+                )
+                .await
+                .map(|requirement| {
+                    requirement
+                        .map(LoweredRequirement::into_inner)
+                        .map_err(|err| {
+                            MetadataError::LoweringError(requirement_name.clone(), Box::new(err))
+                        })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
 
         Ok(Self {
             name: metadata.name,
@@ -255,7 +249,7 @@ impl LoweredExtraBuildDependencies {
     }
 
     /// Create from a workspace, lowering the extra build dependencies.
-    pub fn from_workspace(
+    pub async fn from_workspace(
         extra_build_dependencies: ExtraBuildDependencies,
         workspace: &Workspace,
         index_locations: &IndexLocations,
@@ -286,45 +280,46 @@ impl LoweredExtraBuildDependencies {
                 // Lower each package's extra build dependencies
                 let mut build_requires = ExtraBuildRequires::default();
                 for (package_name, requirements) in extra_build_dependencies {
-                    let lowered: Vec<ExtraBuildRequirement> = requirements
-                        .into_iter()
-                        .flat_map(
-                            |ExtraBuildDependency {
-                                 requirement,
-                                 match_runtime,
-                             }| {
-                                let requirement_name = requirement.name.clone();
-                                let extra = requirement.marker.top_level_extra_name();
-                                let group = None;
-                                LoweredRequirement::from_requirement(
-                                    requirement,
-                                    None,
-                                    workspace.install_path(),
-                                    project_sources,
-                                    project_indexes,
-                                    extra.as_deref(),
-                                    group,
-                                    index_locations,
-                                    workspace,
-                                    None,
-                                    true,
-                                    credentials_cache,
-                                )
-                                .map(move |requirement| {
-                                    match requirement {
-                                        Ok(requirement) => Ok(ExtraBuildRequirement {
-                                            requirement: requirement.into_inner(),
-                                            match_runtime,
-                                        }),
-                                        Err(err) => Err(MetadataError::LoweringError(
+                    let mut lowered = Vec::new();
+                    for ExtraBuildDependency {
+                        requirement,
+                        match_runtime,
+                    } in requirements
+                    {
+                        let requirement_name = requirement.name.clone();
+                        let extra = requirement.marker.top_level_extra_name();
+                        lowered.extend(
+                            LoweredRequirement::from_requirement(
+                                requirement,
+                                None,
+                                workspace.install_path(),
+                                project_sources,
+                                project_indexes,
+                                extra.as_deref(),
+                                None,
+                                index_locations,
+                                workspace,
+                                None,
+                                true,
+                                credentials_cache,
+                            )
+                            .await
+                            .map(|requirement| {
+                                requirement
+                                    .map(|requirement| ExtraBuildRequirement {
+                                        requirement: requirement.into_inner(),
+                                        match_runtime,
+                                    })
+                                    .map_err(|err| {
+                                        MetadataError::LoweringError(
                                             requirement_name.clone(),
                                             Box::new(err),
-                                        )),
-                                    }
-                                })
-                            },
-                        )
-                        .collect::<Result<Vec<_>, _>>()?;
+                                        )
+                                    })
+                            })
+                            .collect::<Result<Vec<_>, _>>()?,
+                        );
+                    }
                     build_requires.insert(package_name, lowered);
                 }
                 Ok(Self(build_requires))

--- a/crates/uv-distribution/src/metadata/dependency_groups.rs
+++ b/crates/uv-distribution/src/metadata/dependency_groups.rs
@@ -141,55 +141,52 @@ impl SourcedDependencyGroups {
         Self::validate_sources(project_sources, &dependency_groups)?;
 
         // Lower the dependency groups.
-        let dependency_groups = dependency_groups
-            .into_iter()
-            .map(|(name, group)| {
-                let requirements = group
-                    .requirements
-                    .into_iter()
-                    .flat_map(|requirement| {
-                        // Check if sources should be disabled for this specific package
-                        if no_sources.for_package(&requirement.name) {
-                            vec![Ok(Requirement::from(requirement))].into_iter()
-                        } else {
-                            let requirement_name = requirement.name.clone();
-                            let group = name.clone();
-                            let extra = None;
+        let mut lowered_dependency_groups = BTreeMap::new();
+        for (name, group) in dependency_groups {
+            let mut requirements = Vec::new();
+            for requirement in group.requirements {
+                if no_sources.for_package(&requirement.name) {
+                    requirements.push(Requirement::from(requirement));
+                    continue;
+                }
 
-                            LoweredRequirement::from_requirement(
-                                requirement,
-                                project.project_name(),
-                                project.root(),
-                                project_sources,
-                                project_indexes,
-                                extra,
-                                Some(&group),
-                                locations,
-                                project.workspace(),
-                                git_member,
-                                true,
-                                credentials_cache,
-                            )
-                            .map(move |requirement| match requirement {
-                                Ok(requirement) => Ok(requirement.into_inner()),
-                                Err(err) => Err(MetadataError::GroupLoweringError(
-                                    group.clone(),
+                let requirement_name = requirement.name.clone();
+                requirements.extend(
+                    LoweredRequirement::from_requirement(
+                        requirement,
+                        project.project_name(),
+                        project.root(),
+                        project_sources,
+                        project_indexes,
+                        None,
+                        Some(&name),
+                        locations,
+                        project.workspace(),
+                        git_member,
+                        true,
+                        credentials_cache,
+                    )
+                    .await
+                    .map(|requirement| {
+                        requirement
+                            .map(LoweredRequirement::into_inner)
+                            .map_err(|err| {
+                                MetadataError::GroupLoweringError(
+                                    name.clone(),
                                     requirement_name.clone(),
                                     Box::new(err),
-                                )),
+                                )
                             })
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                        }
                     })
-                    .collect::<Result<Box<_>, _>>()?;
-                Ok::<(GroupName, Box<_>), MetadataError>((name, requirements))
-            })
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
+                    .collect::<Result<Vec<_>, _>>()?,
+                );
+            }
+            lowered_dependency_groups.insert(name, requirements.into_boxed_slice());
+        }
 
         Ok(Self {
             name: project.project_name().cloned(),
-            dependency_groups,
+            dependency_groups: lowered_dependency_groups,
         })
     }
 

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -39,7 +39,8 @@ enum RequirementOrigin {
 
 impl LoweredRequirement {
     /// Combine `project.dependencies` or `project.optional-dependencies` with `tool.uv.sources`.
-    pub(crate) fn from_requirement<'data>(
+    #[expect(clippy::unused_async, reason = "Requirement lowering is an async API")]
+    pub(crate) async fn from_requirement<'data>(
         requirement: uv_pep508::Requirement<VerbatimParsedUrl>,
         project_name: Option<&'data PackageName>,
         project_dir: &'data Path,
@@ -367,7 +368,8 @@ impl LoweredRequirement {
 
     /// Lower a [`uv_pep508::Requirement`] in a non-workspace setting (for example, in a PEP 723
     /// script, which runs in an isolated context).
-    pub fn from_non_workspace_requirement<'data>(
+    #[expect(clippy::unused_async, reason = "Requirement lowering is an async API")]
+    pub async fn from_non_workspace_requirement<'data>(
         requirement: uv_pep508::Requirement<VerbatimParsedUrl>,
         dir: &'data Path,
         sources: &'data BTreeMap<PackageName, Sources>,

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -74,6 +74,7 @@ impl RequiresDist {
             editable,
             credentials_cache,
         )
+        .await
     }
 
     fn from_metadata23_with_source_context(
@@ -98,7 +99,7 @@ impl RequiresDist {
         })
     }
 
-    fn from_project_workspace(
+    async fn from_project_workspace(
         metadata: uv_pypi_types::RequiresDist,
         project_workspace: &ProjectWorkspace,
         git_member: Option<&GitWorkspaceMember<'_>>,
@@ -140,95 +141,90 @@ impl RequiresDist {
         Self::validate_sources(project_sources, &metadata, &dependency_groups)?;
 
         // Lower the dependency groups.
-        let dependency_groups = dependency_groups
-            .into_iter()
-            .map(|(name, flat_group)| {
-                let requirements = flat_group
-                    .requirements
-                    .into_iter()
-                    .flat_map(|requirement| {
-                        // Check if sources should be disabled for this specific package
-                        if no_sources.for_package(&requirement.name) {
-                            vec![Ok(Requirement::from(requirement))].into_iter()
-                        } else {
-                            let requirement_name = requirement.name.clone();
-                            let group = name.clone();
-                            let extra = None;
-
-                            LoweredRequirement::from_requirement(
-                                requirement,
-                                Some(&metadata.name),
-                                project_workspace.project_root(),
-                                project_sources,
-                                project_indexes,
-                                extra,
-                                Some(&group),
-                                locations,
-                                project_workspace.workspace(),
-                                git_member,
-                                editable,
-                                credentials_cache,
-                            )
-                            .map(move |requirement| match requirement {
-                                Ok(requirement) => Ok(requirement.into_inner()),
-                                Err(err) => Err(MetadataError::GroupLoweringError(
-                                    group.clone(),
-                                    requirement_name.clone(),
-                                    Box::new(err),
-                                )),
-                            })
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                        }
-                    })
-                    .collect::<Result<Box<_>, _>>()?;
-                Ok::<(GroupName, Box<_>), MetadataError>((name, requirements))
-            })
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
-
-        // Lower the requirements.
-        let requires_dist = Box::into_iter(metadata.requires_dist);
-        let requires_dist = requires_dist
-            .flat_map(|requirement| {
-                // Check if sources should be disabled for this specific package
+        let mut lowered_dependency_groups = BTreeMap::new();
+        for (name, flat_group) in dependency_groups {
+            let mut requirements = Vec::new();
+            for requirement in flat_group.requirements {
                 if no_sources.for_package(&requirement.name) {
-                    vec![Ok(Requirement::from(requirement))].into_iter()
-                } else {
-                    let requirement_name = requirement.name.clone();
-                    let extra = requirement.marker.top_level_extra_name();
-                    let group = None;
+                    requirements.push(Requirement::from(requirement));
+                    continue;
+                }
 
+                let requirement_name = requirement.name.clone();
+                requirements.extend(
                     LoweredRequirement::from_requirement(
                         requirement,
                         Some(&metadata.name),
                         project_workspace.project_root(),
                         project_sources,
                         project_indexes,
-                        extra.as_deref(),
-                        group,
+                        None,
+                        Some(&name),
                         locations,
                         project_workspace.workspace(),
                         git_member,
                         editable,
                         credentials_cache,
                     )
-                    .map(move |requirement| match requirement {
-                        Ok(requirement) => Ok(requirement.into_inner()),
-                        Err(err) => Err(MetadataError::LoweringError(
-                            requirement_name.clone(),
-                            Box::new(err),
-                        )),
+                    .await
+                    .map(|requirement| {
+                        requirement
+                            .map(LoweredRequirement::into_inner)
+                            .map_err(|err| {
+                                MetadataError::GroupLoweringError(
+                                    name.clone(),
+                                    requirement_name.clone(),
+                                    Box::new(err),
+                                )
+                            })
                     })
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                }
-            })
-            .collect::<Result<Box<_>, _>>()?;
+                    .collect::<Result<Vec<_>, _>>()?,
+                );
+            }
+            lowered_dependency_groups.insert(name, requirements.into_boxed_slice());
+        }
+
+        // Lower the requirements.
+        let mut requires_dist = Vec::new();
+        for requirement in Box::into_iter(metadata.requires_dist) {
+            if no_sources.for_package(&requirement.name) {
+                requires_dist.push(Requirement::from(requirement));
+                continue;
+            }
+
+            let requirement_name = requirement.name.clone();
+            let extra = requirement.marker.top_level_extra_name();
+            requires_dist.extend(
+                LoweredRequirement::from_requirement(
+                    requirement,
+                    Some(&metadata.name),
+                    project_workspace.project_root(),
+                    project_sources,
+                    project_indexes,
+                    extra.as_deref(),
+                    None,
+                    locations,
+                    project_workspace.workspace(),
+                    git_member,
+                    editable,
+                    credentials_cache,
+                )
+                .await
+                .map(|requirement| {
+                    requirement
+                        .map(LoweredRequirement::into_inner)
+                        .map_err(|err| {
+                            MetadataError::LoweringError(requirement_name.clone(), Box::new(err))
+                        })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
 
         Ok(Self {
             name: metadata.name,
-            requires_dist,
-            dependency_groups,
+            requires_dist: requires_dist.into_boxed_slice(),
+            dependency_groups: lowered_dependency_groups,
             provides_extra: metadata.provides_extra,
             dynamic: metadata.dynamic,
         })
@@ -496,7 +492,8 @@ mod test {
             &NoSources::default(),
             true,
             &CredentialsCache::new(),
-        )?)
+        )
+        .await?)
     }
 
     async fn format_err(input: &str) -> String {

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -438,7 +438,8 @@ pub(crate) async fn add(
                     &settings.resolver.index_locations,
                     &settings.resolver.sources,
                     client.credentials_cache(),
-                )?
+                )
+                .await?
             } else {
                 LoweredExtraBuildDependencies::from_non_lowered(
                     settings.resolver.extra_build_dependencies.clone(),

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -518,12 +518,14 @@ async fn do_lock(
     let source_trees = vec![];
 
     // If necessary, lower the overrides and constraints.
-    let requirements = target.lower(
-        requirements,
-        index_locations,
-        sources,
-        client_builder.credentials_cache(),
-    )?;
+    let requirements = target
+        .lower(
+            requirements,
+            index_locations,
+            sources,
+            client_builder.credentials_cache(),
+        )
+        .await?;
     let overrides = {
         let mut lowered_overrides = Vec::new();
         for entry in overrides {
@@ -536,7 +538,8 @@ async fn do_lock(
                                 index_locations,
                                 sources,
                                 client_builder.credentials_cache(),
-                            )?
+                            )
+                            .await?
                             .into_iter()
                             .map(Override::Requirement),
                     );
@@ -550,7 +553,8 @@ async fn do_lock(
                                 index_locations,
                                 sources,
                                 client_builder.credentials_cache(),
-                            )?
+                            )
+                            .await?
                             .into_boxed_slice(),
                     }));
                 }
@@ -558,30 +562,35 @@ async fn do_lock(
         }
         lowered_overrides
     };
-    let constraints = target.lower(
-        constraints,
-        index_locations,
-        sources,
-        client_builder.credentials_cache(),
-    )?;
-    let build_constraints = target.lower(
-        build_constraints,
-        index_locations,
-        sources,
-        client_builder.credentials_cache(),
-    )?;
-    let dependency_groups = dependency_groups
-        .into_iter()
-        .map(|(name, group)| {
-            let requirements = target.lower(
+    let constraints = target
+        .lower(
+            constraints,
+            index_locations,
+            sources,
+            client_builder.credentials_cache(),
+        )
+        .await?;
+    let build_constraints = target
+        .lower(
+            build_constraints,
+            index_locations,
+            sources,
+            client_builder.credentials_cache(),
+        )
+        .await?;
+    let mut lowered_dependency_groups = BTreeMap::new();
+    for (name, group) in dependency_groups {
+        let requirements = target
+            .lower(
                 group.requirements,
                 index_locations,
                 sources,
                 client_builder.credentials_cache(),
-            )?;
-            Ok((name, requirements))
-        })
-        .collect::<Result<BTreeMap<_, _>, ProjectError>>()?;
+            )
+            .await?;
+        lowered_dependency_groups.insert(name, requirements);
+    }
+    let dependency_groups = lowered_dependency_groups;
 
     // Collect the conflicts.
     let mut conflicts = target.conflicts()?;
@@ -790,16 +799,20 @@ async fn do_lock(
 
     // Lower the extra build dependencies.
     let extra_build_requires = match &target {
-        LockTarget::Workspace(workspace) => LoweredExtraBuildDependencies::from_workspace(
-            extra_build_dependencies.clone(),
-            workspace,
-            index_locations,
-            sources,
-            client.credentials_cache(),
-        )?,
+        LockTarget::Workspace(workspace) => {
+            LoweredExtraBuildDependencies::from_workspace(
+                extra_build_dependencies.clone(),
+                workspace,
+                index_locations,
+                sources,
+                client.credentials_cache(),
+            )
+            .await?
+        }
         LockTarget::Script(script) => {
             // Try to get extra build dependencies from the script metadata
-            script_extra_build_requires((*script).into(), settings, client.credentials_cache())?
+            script_extra_build_requires((*script).into(), settings, client.credentials_cache())
+                .await?
         }
     }
     .into_inner();

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -347,7 +347,7 @@ impl<'lock> LockTarget<'lock> {
     }
 
     /// Lower the requirements for the [`LockTarget`], relative to the target root.
-    pub(crate) fn lower(
+    pub(crate) async fn lower(
         self,
         requirements: Vec<uv_pep508::Requirement<VerbatimParsedUrl>>,
         locations: &IndexLocations,
@@ -373,7 +373,8 @@ impl<'lock> LockTarget<'lock> {
                     locations,
                     sources,
                     credentials_cache,
-                )?;
+                )
+                .await?;
 
                 Ok(metadata
                     .requires_dist
@@ -402,34 +403,38 @@ impl<'lock> LockTarget<'lock> {
                     .and_then(|uv| uv.sources.as_ref())
                     .unwrap_or(&empty);
 
-                Ok(requirements
-                    .into_iter()
-                    .flat_map(|requirement| {
-                        // Check if sources should be disabled for this specific package
-                        if sources.for_package(&requirement.name) {
-                            vec![Ok(Requirement::from(requirement))].into_iter()
-                        } else {
-                            let requirement_name = requirement.name.clone();
-                            LoweredRequirement::from_non_workspace_requirement(
-                                requirement,
-                                script.path.parent().unwrap(),
-                                sources_map,
-                                indexes,
-                                locations,
-                                credentials_cache,
-                            )
-                            .map(move |requirement| match requirement {
-                                Ok(requirement) => Ok(requirement.into_inner()),
-                                Err(err) => Err(uv_distribution::MetadataError::LoweringError(
-                                    requirement_name.clone(),
-                                    Box::new(err),
-                                )),
-                            })
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                        }
-                    })
-                    .collect::<Result<_, _>>()?)
+                let mut lowered = Vec::new();
+                for requirement in requirements {
+                    if sources.for_package(&requirement.name) {
+                        lowered.push(Requirement::from(requirement));
+                        continue;
+                    }
+
+                    let requirement_name = requirement.name.clone();
+                    lowered.extend(
+                        LoweredRequirement::from_non_workspace_requirement(
+                            requirement,
+                            script.path.parent().unwrap(),
+                            sources_map,
+                            indexes,
+                            locations,
+                            credentials_cache,
+                        )
+                        .await
+                        .map(|requirement| {
+                            requirement
+                                .map(LoweredRequirement::into_inner)
+                                .map_err(|err| {
+                                    uv_distribution::MetadataError::LoweringError(
+                                        requirement_name.clone(),
+                                        Box::new(err),
+                                    )
+                                })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                    );
+                }
+                Ok(lowered)
             }
         }
     }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -3142,7 +3142,7 @@ pub(crate) fn detect_conflicts(
 }
 
 /// Determine the [`RequirementsSpecification`] for a script.
-pub(crate) fn script_specification(
+pub(crate) async fn script_specification(
     script: Pep723ItemRef<'_>,
     settings: &ResolverSettings,
     credentials_cache: &CredentialsCache,
@@ -3155,10 +3155,9 @@ pub(crate) fn script_specification(
     let script_indexes = script.indexes(&settings.sources);
     let script_sources = script.sources(&settings.sources);
 
-    let requirements = dependencies
-        .iter()
-        .cloned()
-        .flat_map(|requirement| {
+    let mut requirements = Vec::new();
+    for requirement in dependencies.iter().cloned() {
+        requirements.extend(
             LoweredRequirement::from_non_workspace_requirement(
                 requirement,
                 script_dir.as_ref(),
@@ -3167,10 +3166,12 @@ pub(crate) fn script_specification(
                 &settings.index_locations,
                 credentials_cache,
             )
+            .await
             .map_ok(LoweredRequirement::into_inner)
-        })
-        .collect::<Result<_, _>>()?;
-    let constraints = script
+            .collect::<Result<Vec<_>, _>>()?,
+        );
+    }
+    let constraint_dependencies = script
         .metadata()
         .tool
         .as_ref()
@@ -3178,8 +3179,10 @@ pub(crate) fn script_specification(
         .and_then(|uv| uv.constraint_dependencies.as_ref())
         .into_iter()
         .flatten()
-        .cloned()
-        .flat_map(|requirement| {
+        .cloned();
+    let mut constraints = Vec::new();
+    for requirement in constraint_dependencies {
+        constraints.extend(
             LoweredRequirement::from_non_workspace_requirement(
                 requirement,
                 script_dir.as_ref(),
@@ -3188,9 +3191,11 @@ pub(crate) fn script_specification(
                 &settings.index_locations,
                 credentials_cache,
             )
+            .await
             .map_ok(LoweredRequirement::into_inner)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?,
+        );
+    }
     let overrides = {
         let override_entries = script
             .metadata()
@@ -3214,17 +3219,16 @@ pub(crate) fn script_specification(
                             &settings.index_locations,
                             credentials_cache,
                         )
+                        .await
                         .map_ok(LoweredRequirement::into_inner)
                         .map_ok(Override::Requirement)
                         .collect::<Result<Vec<_>, _>>()?,
                     );
                 }
                 Override::Package(package) => {
-                    let dependencies = package
-                        .dependencies
-                        .into_vec()
-                        .into_iter()
-                        .flat_map(|requirement| {
+                    let mut dependencies = Vec::new();
+                    for requirement in package.dependencies.into_vec() {
+                        dependencies.extend(
                             LoweredRequirement::from_non_workspace_requirement(
                                 requirement,
                                 script_dir.as_ref(),
@@ -3233,9 +3237,11 @@ pub(crate) fn script_specification(
                                 &settings.index_locations,
                                 credentials_cache,
                             )
+                            .await
                             .map_ok(LoweredRequirement::into_inner)
-                        })
-                        .collect::<Result<Vec<_>, _>>()?;
+                            .collect::<Result<Vec<_>, _>>()?,
+                        );
+                    }
                     overrides.push(Override::Package(PackageOverride {
                         package: package.package,
                         dependencies: dependencies.into_boxed_slice(),
@@ -3264,7 +3270,7 @@ pub(crate) fn script_specification(
 }
 
 /// Determine the extra build requires for a script.
-pub(crate) fn script_extra_build_requires(
+pub(crate) async fn script_extra_build_requires(
     script: Pep723ItemRef<'_>,
     settings: &ResolverSettings,
     credentials_cache: &CredentialsCache,
@@ -3286,29 +3292,29 @@ pub(crate) fn script_extra_build_requires(
     // Lower the extra build dependencies.
     let mut extra_build_requires = ExtraBuildRequires::default();
     for (name, requirements) in script_extra_build_dependencies {
-        let lowered_requirements: Vec<_> = requirements
-            .iter()
-            .cloned()
-            .flat_map(
-                |ExtraBuildDependency {
-                     requirement,
-                     match_runtime,
-                 }| {
-                    LoweredRequirement::from_non_workspace_requirement(
-                        requirement,
-                        script_dir.as_ref(),
-                        script_sources.as_ref(),
-                        script_indexes,
-                        &settings.index_locations,
-                        credentials_cache,
-                    )
-                    .map_ok(move |requirement| ExtraBuildRequirement {
-                        requirement: requirement.into_inner(),
-                        match_runtime,
-                    })
-                },
-            )
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut lowered_requirements = Vec::new();
+        for ExtraBuildDependency {
+            requirement,
+            match_runtime,
+        } in requirements.iter().cloned()
+        {
+            lowered_requirements.extend(
+                LoweredRequirement::from_non_workspace_requirement(
+                    requirement,
+                    script_dir.as_ref(),
+                    script_sources.as_ref(),
+                    script_indexes,
+                    &settings.index_locations,
+                    credentials_cache,
+                )
+                .await
+                .map_ok(|requirement| ExtraBuildRequirement {
+                    requirement: requirement.into_inner(),
+                    match_runtime,
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
         extra_build_requires.insert(name.clone(), lowered_requirements);
     }
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -364,12 +364,15 @@ pub(crate) async fn run(
                 (&script).into(),
                 &settings.resolver,
                 client_builder.credentials_cache(),
-            )? {
+            )
+            .await?
+            {
                 let script_extra_build_requires = script_extra_build_requires(
                     (&script).into(),
                     &settings.resolver,
                     client_builder.credentials_cache(),
-                )?
+                )
+                .await?
                 .into_inner();
                 let environment = ScriptEnvironment::get_or_init(
                     (&script).into(),

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -243,13 +243,15 @@ pub(crate) async fn sync(
                 script.into(),
                 &settings.resolver,
                 client_builder.credentials_cache(),
-            )?
+            )
+            .await?
             .unwrap_or_default();
             let script_extra_build_requires = script_extra_build_requires(
                 script.into(),
                 &settings.resolver,
                 client_builder.credentials_cache(),
-            )?
+            )
+            .await?
             .into_inner();
 
             // Parse the build constraints from the script.
@@ -670,7 +672,8 @@ pub(crate) async fn do_sync(
                 index_locations,
                 &sources,
                 client_builder.credentials_cache(),
-            )?
+            )
+            .await?
         }
         InstallTarget::Script { script, .. } => {
             // Try to get extra build dependencies from the script metadata
@@ -700,7 +703,8 @@ pub(crate) async fn do_sync(
                 (*script).into(),
                 &resolver_settings,
                 client_builder.credentials_cache(),
-            )?
+            )
+            .await?
         }
     }
     .into_inner();


### PR DESCRIPTION
## Summary

Requirement lowering currently returns synchronous iterators, which prevents source lowering from performing asynchronous work such as workspace discovery. Make the workspace and non-workspace lowering APIs async and move flattening into their callers while preserving requirement order and existing error context.

This is a preparatory change for #18401, allowing workspace sources to use the existing async discovery path without duplicating synchronous workspace traversal.