### PR TITLE
Fix up `uv-fs::path::Simplified::simple_canonicalize` comment

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -27,9 +27,7 @@ pub trait Simplified {
     /// equivalent to [`std::path::Display`].
     fn simplified_display(&self) -> impl std::fmt::Display;
 
-    /// Canonicalize a path without a `\\?\` prefix on Windows.
-    /// For a path that can't be canonicalized (e.g. on network drive or RAM drive on Windows),
-    /// this will return the absolute path if it exists.
+    /// Canonicalize a path, stripping the `\\?\` prefix on Windows when possible.
     fn simple_canonicalize(&self) -> std::io::Result<PathBuf>;
 
     /// Render a [`Path`] for user-facing display.


### PR DESCRIPTION
## Summary

This doc comment was inaccurate, the function doesn't fall back to an absolute.

I checked and it looks like we weren't relying on the incorrectly documented features anywhere, so I've adjusted the comment.