### PR TITLE
Bump open to 5.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ md-5 = { version = "0.10.6" }
 memchr = { version = "2.7.4" }
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 nix = { version = "0.31.2", features = ["resource", "signal"] }
-open = { version = "5.3.2" }
+open = { version = "5.4.0" }
 owo-colors = { version = "4.1.0" }
 papaya = { version = "0.2.4" }
 path-slash = { version = "0.2.1" }


### PR DESCRIPTION
## Summary

Raise the workspace `open` minimum from 5.3.2 to 5.4.0, preventing future resolutions from selecting the vulnerable launcher implementation. `Cargo.lock` already resolves 5.4.0, and the affected auth integration test and Windows Clippy check pass.

Closes https://github.com/astral-sh/uv/issues/20541.
