### PR TITLE
Allow workspace sources to reference Git repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6444,6 +6444,7 @@ dependencies = [
  "uv-preview",
  "uv-pypi-types",
  "uv-python",
+ "uv-redacted",
  "uv-requirements",
  "uv-resolver",
  "uv-types",

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -31,7 +31,7 @@ use uv_auth::CredentialsCache;
 use uv_cache::Cache;
 use uv_cache_key::cache_digest;
 use uv_configuration::{BuildKind, BuildOutput, NoSources};
-use uv_distribution::BuildRequires;
+use uv_distribution::{BuildRequires, GitWorkspaceSourceContext};
 use uv_distribution_types::{
     ConfigSettings, ExtraBuildRequirement, ExtraBuildRequires, IndexLocations, Requirement,
 };
@@ -327,6 +327,9 @@ impl SourceBuild {
             build_context.cache(),
             workspace_cache,
             credentials_cache,
+            &GitWorkspaceSourceContext::new(build_context.git(), |url| {
+                build_context.git_http_settings(url)
+            }),
         )
         .await
         .map_err(|err| *err)?;
@@ -581,6 +584,7 @@ impl SourceBuild {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<(Pep517Backend, Option<Project>), Box<Error>> {
         let pyproject_toml = match fs::read_to_string(source_tree.join("pyproject.toml")) {
             Ok(toml) => {
@@ -693,6 +697,7 @@ impl SourceBuild {
                     cache,
                     workspace_cache,
                     credentials_cache,
+                    git_workspace,
                 )
                 .await
                 .map_err(Error::Lowering)?;
@@ -1136,6 +1141,9 @@ async fn create_pep517_build_environment(
             build_context.cache(),
             workspace_cache,
             credentials_cache,
+            &GitWorkspaceSourceContext::new(build_context.git(), |url| {
+                build_context.git_http_settings(url)
+            }),
         )
         .await
         .map_err(Error::Lowering)?;

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -421,6 +421,17 @@ impl<'a> BaseClientBuilder<'a> {
         matches!(self.connectivity, Connectivity::Offline)
     }
 
+    /// Return the [`GitHttpSettings`] for fetching from the given URL.
+    pub fn git_http_settings(&self, url: &DisplaySafeUrl) -> GitHttpSettings {
+        GitHttpSettings::default()
+            .with_disabled_ssl(
+                self.allow_insecure_host
+                    .iter()
+                    .any(|allow_insecure_host| allow_insecure_host.matches(url)),
+            )
+            .with_offline(self.connectivity.is_offline())
+    }
+
     /// Create a [`RetryPolicy`] for the client.
     pub fn retry_policy(&self) -> ExponentialBackoff {
         retry_policy(self.retries, self.no_retry_delay)

--- a/crates/uv-dispatch/Cargo.toml
+++ b/crates/uv-dispatch/Cargo.toml
@@ -33,6 +33,7 @@ uv-platform-tags = { workspace = true }
 uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
+uv-redacted = { workspace = true }
 uv-requirements = { workspace = true }
 uv-resolver = { workspace = true }
 uv-types = { workspace = true }

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -27,11 +27,12 @@ use uv_distribution_types::{
     Identifier, IndexCapabilities, IndexLocations, IsBuildBackendError, Name,
     PackageConfigSettings, Requirement, Resolution, SourceDist, VersionOrUrlRef,
 };
-use uv_git::GitResolver;
+use uv_git::{GitHttpSettings, GitResolver};
 use uv_installer::{InstallationStrategy, Installer, Plan, Planner, Preparer, SitePackages};
 use uv_preview::Preview;
 use uv_pypi_types::Conflicts;
 use uv_python::{Interpreter, PythonEnvironment};
+use uv_redacted::DisplaySafeUrl;
 use uv_requirements::LookaheadResolver;
 use uv_resolver::{
     ExcludeNewer, FlatIndex, Flexibility, InMemoryIndex, Manifest, OptionsBuilder,
@@ -219,6 +220,10 @@ impl BuildContext for BuildDispatch<'_> {
 
     fn git(&self) -> &GitResolver {
         &self.shared_state.git
+    }
+
+    fn git_http_settings(&self, url: &DisplaySafeUrl) -> GitHttpSettings {
+        self.client.git_http_settings(url)
     }
 
     fn build_arena(&self) -> &BuildArena<SourceBuild> {

--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -3,9 +3,9 @@ pub use download::LocalWheel;
 pub use error::Error;
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
 pub use metadata::{
-    ArchiveMetadata, BuildRequires, FlatRequiresDist, LoweredExtraBuildDependencies,
-    LoweredRequirement, LoweringError, Metadata, MetadataError, RequiresDist,
-    SourcedDependencyGroups,
+    ArchiveMetadata, BuildRequires, FlatRequiresDist, GitWorkspaceSourceContext,
+    LoweredExtraBuildDependencies, LoweredRequirement, LoweringError, Metadata, MetadataError,
+    RequiresDist, SourcedDependencyGroups,
 };
 pub use reporter::Reporter;
 pub use source::{StaticMetadataDatabase, prune};

--- a/crates/uv-distribution/src/metadata/build_requires.rs
+++ b/crates/uv-distribution/src/metadata/build_requires.rs
@@ -13,7 +13,7 @@ use uv_workspace::{
     DiscoveryOptions, MemberDiscovery, ProjectWorkspace, Workspace, WorkspaceCache,
 };
 
-use crate::metadata::{LoweredRequirement, MetadataError};
+use crate::metadata::{GitWorkspaceSourceContext, LoweredRequirement, MetadataError};
 
 /// Lowered requirements from a `[build-system.requires]` field in a `pyproject.toml` file.
 #[derive(Debug, Clone)]
@@ -48,6 +48,7 @@ impl BuildRequires {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Self, MetadataError> {
         let discovery = DiscoveryOptions {
             stop_discovery_at: stop_discovery_at.map(Path::to_path_buf),
@@ -77,6 +78,7 @@ impl BuildRequires {
             cache,
             workspace_cache,
             credentials_cache,
+            git_workspace,
         )
         .await
     }
@@ -91,6 +93,7 @@ impl BuildRequires {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -149,6 +152,7 @@ impl BuildRequires {
                     cache,
                     workspace_cache,
                     credentials_cache,
+                    git_workspace,
                 )
                 .await
                 .map(|requirement| {
@@ -177,6 +181,7 @@ impl BuildRequires {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -225,6 +230,7 @@ impl BuildRequires {
                     cache,
                     workspace_cache,
                     credentials_cache,
+                    git_workspace,
                 )
                 .await
                 .map(|requirement| {
@@ -267,6 +273,7 @@ impl LoweredExtraBuildDependencies {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Self, MetadataError> {
         match source_strategy {
             NoSources::None => {
@@ -316,6 +323,7 @@ impl LoweredExtraBuildDependencies {
                                 cache,
                                 workspace_cache,
                                 credentials_cache,
+                                git_workspace,
                             )
                             .await
                             .map(|requirement| {

--- a/crates/uv-distribution/src/metadata/dependency_groups.rs
+++ b/crates/uv-distribution/src/metadata/dependency_groups.rs
@@ -13,7 +13,9 @@ use uv_workspace::{
     WorkspaceErrorKind,
 };
 
-use crate::metadata::{GitWorkspaceMember, LoweredRequirement, MetadataError};
+use crate::metadata::{
+    GitWorkspaceMember, GitWorkspaceSourceContext, LoweredRequirement, MetadataError,
+};
 
 /// Like [`crate::RequiresDist`] but only supporting dependency-groups.
 ///
@@ -62,6 +64,7 @@ impl SourcedDependencyGroups {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Self, MetadataError> {
         // If the `pyproject.toml` doesn't exist, fail early.
         if !pyproject_path.is_file() {
@@ -167,6 +170,7 @@ impl SourcedDependencyGroups {
                         cache,
                         workspace_cache,
                         credentials_cache,
+                        git_workspace,
                     )
                     .await
                     .map(|requirement| {

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -6,14 +6,15 @@ use either::Either;
 use futures::future::join_all;
 
 use thiserror::Error;
-use uv_auth::CredentialsCache;
-use uv_cache::Cache;
+use uv_auth::{CredentialsCache, CredentialsFromUrlError};
+use uv_cache::{Cache, CacheBucket};
 use uv_distribution_filename::DistExtension;
 use uv_distribution_types::{
     Index, IndexCredentialsError, IndexLocations, IndexMetadata, IndexName, Origin, Requirement,
     RequirementSource,
 };
 use uv_fs::{Simplified, normalize_absolute_path, normalize_path};
+use uv_git::GitResolverError;
 use uv_git_types::{GitLfs, GitReference, GitUrl, GitUrlParseError};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::VersionSpecifiers;
@@ -23,10 +24,12 @@ use uv_pypi_types::{
     VerbatimParsedUrl,
 };
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
-use uv_workspace::pyproject::{PyProjectToml, Source, Sources, WorkspaceReference};
+use uv_workspace::pyproject::{
+    PyProjectToml, Source, Sources, WorkspaceReference, WorkspaceSource,
+};
 use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache, WorkspaceError};
 
-use crate::metadata::GitWorkspaceMember;
+use crate::metadata::{GitWorkspaceMember, GitWorkspaceSourceContext};
 
 #[derive(Debug, Clone)]
 pub struct LoweredRequirement(Requirement);
@@ -56,6 +59,7 @@ impl LoweredRequirement {
         cache: &'data Cache,
         workspace_cache: &'data WorkspaceCache,
         credentials_cache: &'data CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> impl Iterator<Item = Result<Self, LoweringError>> + use<'data> + 'data {
         // Identify the source from the `tool.uv.sources` table.
         let (sources, origin) = if let Some(source) = project_sources.get(&requirement.name) {
@@ -295,6 +299,7 @@ impl LoweredRequirement {
                                 git_member,
                                 cache,
                                 workspace_cache,
+                                git_workspace,
                             )
                             .await?;
                             (source, marker)
@@ -334,6 +339,7 @@ impl LoweredRequirement {
         cache: &'data Cache,
         workspace_cache: &'data WorkspaceCache,
         credentials_cache: &'data CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> impl Iterator<Item = Result<Self, LoweringError>> + 'data {
         let source = sources.get(&requirement.name).cloned();
 
@@ -475,6 +481,7 @@ impl LoweredRequirement {
                                 None,
                                 cache,
                                 workspace_cache,
+                                git_workspace,
                             )
                             .await?;
                             (source, marker)
@@ -573,6 +580,10 @@ pub enum LoweringError {
     MoreThanOneGitRef,
     #[error(transparent)]
     GitUrlParse(#[from] GitUrlParseError),
+    #[error(transparent)]
+    Git(#[from] GitResolverError),
+    #[error(transparent)]
+    GitCredentials(#[from] CredentialsFromUrlError),
     #[error("Package `{package}` references an undeclared index: `{index}`")]
     MissingIndex {
         package: PackageName,
@@ -682,13 +693,7 @@ fn git_source(
     branch: Option<String>,
     lfs: Option<bool>,
 ) -> Result<RequirementSource, LoweringError> {
-    let reference = match (rev, tag, branch) {
-        (None, None, None) => GitReference::DefaultBranch,
-        (Some(rev), None, None) => GitReference::from_rev(rev),
-        (None, Some(tag), None) => GitReference::Tag(tag),
-        (None, None, Some(branch)) => GitReference::Branch(branch),
-        _ => return Err(LoweringError::MoreThanOneGitRef),
-    };
+    let reference = git_reference(rev, tag, branch)?;
 
     // Create a PEP 508-compatible URL.
     let mut url = DisplaySafeUrl::parse(&format!("git+{git}"))?;
@@ -743,6 +748,21 @@ fn git_source(
             git,
             subdirectory,
         })
+    }
+}
+
+/// Convert the revision fields from a Git source into a [`GitReference`].
+fn git_reference(
+    rev: Option<String>,
+    tag: Option<String>,
+    branch: Option<String>,
+) -> Result<GitReference, LoweringError> {
+    match (rev, tag, branch) {
+        (None, None, None) => Ok(GitReference::DefaultBranch),
+        (Some(rev), None, None) => Ok(GitReference::from_rev(rev)),
+        (None, Some(tag), None) => Ok(GitReference::Tag(tag)),
+        (None, None, Some(branch)) => Ok(GitReference::Branch(branch)),
+        _ => Err(LoweringError::MoreThanOneGitRef),
     }
 }
 
@@ -822,6 +842,7 @@ async fn workspace_source(
     git_member: Option<&GitWorkspaceMember<'_>>,
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
+    git_workspace: &GitWorkspaceSourceContext<'_>,
 ) -> Result<RequirementSource, LoweringError> {
     let base = match origin {
         RequirementOrigin::Project => project_dir,
@@ -855,7 +876,8 @@ async fn workspace_source(
                 false,
             )
         }
-        WorkspaceReference::Path(path) => {
+        WorkspaceReference::Path(path)
+        | WorkspaceReference::Source(WorkspaceSource::Path { path }) => {
             let workspace_path = VerbatimUrl::from_path(path.as_ref(), base)?
                 .to_file_path()
                 .map_err(|()| {
@@ -901,6 +923,53 @@ async fn workspace_source(
                 editable,
                 Some(is_package),
                 true,
+            )
+        }
+        WorkspaceReference::Source(WorkspaceSource::Git {
+            git,
+            rev,
+            tag,
+            branch,
+            lfs,
+        }) => {
+            uv_git::store_credentials_from_url(git)?;
+
+            let reference = git_reference(rev.clone(), tag.clone(), branch.clone())?;
+            let git_url = GitUrl::from_fields(git.clone(), reference, None, GitLfs::from(*lfs))?;
+            let fetch = git_workspace
+                .resolver()
+                .fetch(
+                    &git_url,
+                    git_workspace.http_settings(git),
+                    cache.bucket(CacheBucket::Git),
+                    None,
+                )
+                .await?;
+            let target_workspace = Workspace::discover(
+                fetch.path(),
+                &DiscoveryOptions::default(),
+                cache,
+                workspace_cache,
+            )
+            .await?;
+            let member = target_workspace
+                .packages()
+                .get(&requirement.name)
+                .ok_or_else(|| {
+                    LoweringError::UndeclaredWorkspacePackage(requirement.name.clone())
+                })?;
+            let subdirectory = uv_fs::relative_to(member.root(), fetch.path())
+                .map_err(LoweringError::RelativeTo)?
+                .into_boxed_path();
+
+            git_source(
+                git.clone(),
+                Some(subdirectory),
+                None,
+                rev.clone(),
+                tag.clone(),
+                branch.clone(),
+                *lfs,
             )
         }
     }

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -7,9 +7,11 @@ use uv_auth::CredentialsCache;
 use uv_cache::Cache;
 use uv_configuration::NoSources;
 use uv_distribution_types::{GitDirectorySourceUrl, IndexLocations, Requirement};
+use uv_git::{GitHttpSettings, GitResolver};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pypi_types::{HashDigests, ResolutionMetadata};
+use uv_redacted::DisplaySafeUrl;
 use uv_workspace::dependency_groups::DependencyGroupError;
 use uv_workspace::{WorkspaceCache, WorkspaceError};
 
@@ -23,6 +25,33 @@ mod build_requires;
 mod dependency_groups;
 mod lowering;
 mod requires_dist;
+
+/// The configured Git resolver and HTTP settings used while lowering workspace sources.
+pub struct GitWorkspaceSourceContext<'a> {
+    resolver: &'a GitResolver,
+    http_settings: Box<dyn Fn(&DisplaySafeUrl) -> GitHttpSettings + 'a>,
+}
+
+impl<'a> GitWorkspaceSourceContext<'a> {
+    /// Create a context for lowering Git workspace sources.
+    pub fn new(
+        resolver: &'a GitResolver,
+        http_settings: impl Fn(&DisplaySafeUrl) -> GitHttpSettings + 'a,
+    ) -> Self {
+        Self {
+            resolver,
+            http_settings: Box::new(http_settings),
+        }
+    }
+
+    pub(crate) fn resolver(&self) -> &GitResolver {
+        self.resolver
+    }
+
+    pub(crate) fn http_settings(&self, url: &DisplaySafeUrl) -> GitHttpSettings {
+        (self.http_settings)(url)
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum MetadataError {
@@ -105,6 +134,7 @@ impl Metadata {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Self, MetadataError> {
         // Lower the requirements.
         let requires_dist = uv_pypi_types::RequiresDist {
@@ -129,6 +159,7 @@ impl Metadata {
             cache,
             workspace_cache,
             credentials_cache,
+            git_workspace,
         )
         .await?;
 

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -15,7 +15,9 @@ use uv_workspace::pyproject::{Sources, ToolUvSources};
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, ProjectWorkspace, WorkspaceCache};
 
 use crate::Metadata;
-use crate::metadata::{GitWorkspaceMember, LoweredRequirement, MetadataError};
+use crate::metadata::{
+    GitWorkspaceMember, GitWorkspaceSourceContext, LoweredRequirement, MetadataError,
+};
 
 #[derive(Debug, Clone)]
 pub struct RequiresDist {
@@ -39,6 +41,7 @@ impl RequiresDist {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Self, MetadataError> {
         let discovery = DiscoveryOptions {
             stop_discovery_at: git_member.map(|git_member| {
@@ -75,6 +78,7 @@ impl RequiresDist {
             cache,
             workspace_cache,
             credentials_cache,
+            git_workspace,
         )
         .await
     }
@@ -111,6 +115,7 @@ impl RequiresDist {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -171,6 +176,7 @@ impl RequiresDist {
                         cache,
                         workspace_cache,
                         credentials_cache,
+                        git_workspace,
                     )
                     .await
                     .map(|requirement| {
@@ -216,6 +222,7 @@ impl RequiresDist {
                     cache,
                     workspace_cache,
                     credentials_cache,
+                    git_workspace,
                 )
                 .await
                 .map(|requirement| {
@@ -467,11 +474,13 @@ mod test {
     use uv_cache::Cache;
     use uv_configuration::NoSources;
     use uv_distribution_types::IndexLocations;
+    use uv_git::{GitHttpSettings, GitResolver};
     use uv_normalize::PackageName;
     use uv_pep508::Requirement;
     use uv_workspace::{DiscoveryOptions, ProjectWorkspace, WorkspaceCache};
 
     use crate::RequiresDist;
+    use crate::metadata::GitWorkspaceSourceContext;
     use crate::metadata::requires_dist::FlatRequiresDist;
 
     async fn requires_dist_from_pyproject_toml(
@@ -494,6 +503,7 @@ mod test {
         .await?;
         let pyproject_toml = uv_pypi_types::PyProjectToml::from_toml(contents, "pyproject.toml")?;
         let requires_dist = uv_pypi_types::RequiresDist::from_pyproject_toml(pyproject_toml)?;
+        let git = GitResolver::default();
         Ok(RequiresDist::from_project_workspace(
             requires_dist,
             &project_workspace,
@@ -504,6 +514,7 @@ mod test {
             &cache,
             &workspace_cache,
             &CredentialsCache::new(),
+            &GitWorkspaceSourceContext::new(&git, |_| GitHttpSettings::default()),
         )
         .await?)
     }

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -51,7 +51,7 @@ use uv_workspace::pyproject::ToolUvSources;
 use crate::distribution_database::ManagedClient;
 use crate::error::Error;
 use crate::hash::http_hash_algorithms;
-use crate::metadata::{ArchiveMetadata, GitWorkspaceMember, Metadata};
+use crate::metadata::{ArchiveMetadata, GitWorkspaceMember, GitWorkspaceSourceContext, Metadata};
 use crate::source::built_wheel_metadata::{BuiltWheelFile, BuiltWheelMetadata};
 use crate::source::revision::Revision;
 use crate::{Reporter, RequiresDist};
@@ -1494,6 +1494,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         self.build_context.cache(),
                         self.build_context.workspace_cache(),
                         credentials_cache,
+                        &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                            self.build_context.git_http_settings(url)
+                        }),
                     )
                     .await?,
                 ));
@@ -1550,6 +1553,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                             self.build_context.cache(),
                             self.build_context.workspace_cache(),
                             credentials_cache,
+                            &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                                self.build_context.git_http_settings(url)
+                            }),
                         )
                         .await?,
                     ));
@@ -1602,6 +1608,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     self.build_context.cache(),
                     self.build_context.workspace_cache(),
                     credentials_cache,
+                    &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                        self.build_context.git_http_settings(url)
+                    }),
                 )
                 .await?,
             ));
@@ -1669,6 +1678,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 self.build_context.cache(),
                 self.build_context.workspace_cache(),
                 credentials_cache,
+                &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                    self.build_context.git_http_settings(url)
+                }),
             )
             .await?,
         ))
@@ -1749,6 +1761,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     self.build_context.cache(),
                     self.build_context.workspace_cache(),
                     credentials_cache,
+                    &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                        self.build_context.git_http_settings(url)
+                    }),
                 )
                 .await?;
                 Ok(Some(requires_dist))
@@ -2354,6 +2369,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                             self.build_context.cache(),
                             self.build_context.workspace_cache(),
                             credentials_cache,
+                            &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                                self.build_context.git_http_settings(url)
+                            }),
                         )
                         .await?,
                     ));
@@ -2392,6 +2410,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                                 self.build_context.cache(),
                                 self.build_context.workspace_cache(),
                                 credentials_cache,
+                                &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                                    self.build_context.git_http_settings(url)
+                                }),
                             )
                             .await?,
                         ));
@@ -2449,6 +2470,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     self.build_context.cache(),
                     self.build_context.workspace_cache(),
                     credentials_cache,
+                    &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                        self.build_context.git_http_settings(url)
+                    }),
                 )
                 .await?,
             ));
@@ -2518,6 +2542,9 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 self.build_context.cache(),
                 self.build_context.workspace_cache(),
                 credentials_cache,
+                &GitWorkspaceSourceContext::new(self.build_context.git(), |url| {
+                    self.build_context.git_http_settings(url)
+                }),
             )
             .await?,
         ))

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -14,9 +14,10 @@ use uv_distribution_types::{
     ExtraBuildVariables, IndexCapabilities, IndexLocations, InstalledDist, IsBuildBackendError,
     PackageConfigSettings, Requirement, SourceDist,
 };
-use uv_git::GitResolver;
+use uv_git::{GitHttpSettings, GitResolver};
 use uv_normalize::PackageName;
 use uv_python::{Interpreter, PythonEnvironment};
+use uv_redacted::DisplaySafeUrl;
 use uv_workspace::WorkspaceCache;
 
 use crate::{BuildArena, BuildIsolation, ResolvedRequirements};
@@ -101,6 +102,9 @@ pub trait BuildContext {
 
     /// Return a reference to the Git resolver.
     fn git(&self) -> &GitResolver;
+
+    /// Return the configured HTTP settings for fetching from the given Git URL.
+    fn git_http_settings(&self, url: &DisplaySafeUrl) -> GitHttpSettings;
 
     /// Return a reference to the build arena.
     fn build_arena(&self) -> &BuildArena<Self::SourceDistBuilder>;

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1223,13 +1223,13 @@ pub enum Source {
     },
     /// A dependency on another package in the workspace.
     Workspace {
-        /// `true` selects the current workspace. A string selects another workspace discovered
-        /// from the given path.
+        /// `true` selects the current workspace. A path or Git source selects another workspace
+        /// discovered from that source. A string is shorthand for a path source.
         ///
         /// When set to `false`, the package will be fetched from the remote index, rather than
         /// included as a workspace package.
         workspace: WorkspaceReference,
-        /// Whether the package should be installed as editable. Defaults to `true`.
+        /// Whether a local workspace package should be installed as editable. Defaults to `true`.
         editable: Option<bool>,
         #[serde(
             skip_serializing_if = "uv_pep508::marker::ser::is_empty",
@@ -1242,13 +1242,31 @@ pub enum Source {
     },
 }
 
-/// A reference to either the current workspace or a workspace discovered from a path.
+/// A reference to either the current workspace or a workspace discovered from a source.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema), schemars(untagged))]
 #[serde(untagged)]
 pub enum WorkspaceReference {
     Bool(bool),
     Path(PortablePathBuf),
+    Source(WorkspaceSource),
+}
+
+/// A source from which to discover a workspace.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case", untagged, deny_unknown_fields)]
+pub enum WorkspaceSource {
+    Path {
+        path: PortablePathBuf,
+    },
+    Git {
+        git: DisplaySafeUrl,
+        rev: Option<String>,
+        tag: Option<String>,
+        branch: Option<String>,
+        lfs: Option<bool>,
+    },
 }
 
 /// A custom deserialization implementation for [`Source`]. This is roughly equivalent to

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -18,7 +18,7 @@ use uv_configuration::{
     ExtrasSpecification, Override, Overrides, Reinstall, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
-use uv_distribution::{DistributionDatabase, SourcedDependencyGroups};
+use uv_distribution::{DistributionDatabase, GitWorkspaceSourceContext, SourcedDependencyGroups};
 use uv_distribution_types::{
     CachedDist, ConfigSettings, DependencyMetadata, Diagnostic, Dist, ExtraBuildRequires,
     ExtraBuildVariables, IndexLocations, InstalledDist, InstalledVersion, LocalDist,
@@ -225,6 +225,9 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 build_dispatch.cache(),
                 build_dispatch.workspace_cache(),
                 client.credentials_cache(),
+                &GitWorkspaceSourceContext::new(build_dispatch.git(), |url| {
+                    build_dispatch.git_http_settings(url)
+                }),
             )
             .await
             .with_context(|| {

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -21,7 +21,9 @@ use uv_configuration::{
     InstallOptions, NoSources,
 };
 use uv_dispatch::BuildDispatch;
-use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies};
+use uv_distribution::{
+    DistributionDatabase, GitWorkspaceSourceContext, LoweredExtraBuildDependencies,
+};
 use uv_distribution_types::{
     Identifier, Index, IndexLocations, IndexName, IndexUrl, NameRequirementSpecification,
     Requirement, RequirementSource, UnresolvedRequirement,
@@ -440,6 +442,9 @@ pub(crate) async fn add(
                     cache,
                     &WorkspaceCache::default(),
                     client.credentials_cache(),
+                    &GitWorkspaceSourceContext::new(state.git(), |url| {
+                        client.git_http_settings(url)
+                    }),
                 )
                 .await?
             } else {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -16,7 +16,9 @@ use uv_configuration::{
     ExtrasSpecification, Override, PackageOverride, Reinstall, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
-use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies};
+use uv_distribution::{
+    DistributionDatabase, GitWorkspaceSourceContext, LoweredExtraBuildDependencies,
+};
 use uv_distribution_types::{
     DependencyMetadata, HashGeneration, Index, IndexLocations, NameRequirementSpecification,
     Requirement, RequiresPython, UnresolvedRequirementSpecification,
@@ -517,6 +519,9 @@ async fn do_lock(
     let dependency_groups = target.dependency_groups()?;
     let source_trees = vec![];
 
+    let git_workspace =
+        GitWorkspaceSourceContext::new(state.git(), |url| client_builder.git_http_settings(url));
+
     // If necessary, lower the overrides and constraints.
     let requirements = target
         .lower(
@@ -526,6 +531,7 @@ async fn do_lock(
             cache,
             workspace_cache,
             client_builder.credentials_cache(),
+            &git_workspace,
         )
         .await?;
     let overrides = {
@@ -542,6 +548,7 @@ async fn do_lock(
                                 cache,
                                 workspace_cache,
                                 client_builder.credentials_cache(),
+                                &git_workspace,
                             )
                             .await?
                             .into_iter()
@@ -559,6 +566,7 @@ async fn do_lock(
                                 cache,
                                 workspace_cache,
                                 client_builder.credentials_cache(),
+                                &git_workspace,
                             )
                             .await?
                             .into_boxed_slice(),
@@ -576,6 +584,7 @@ async fn do_lock(
             cache,
             workspace_cache,
             client_builder.credentials_cache(),
+            &git_workspace,
         )
         .await?;
     let build_constraints = target
@@ -586,6 +595,7 @@ async fn do_lock(
             cache,
             workspace_cache,
             client_builder.credentials_cache(),
+            &git_workspace,
         )
         .await?;
     let mut lowered_dependency_groups = BTreeMap::new();
@@ -598,6 +608,7 @@ async fn do_lock(
                 cache,
                 workspace_cache,
                 client_builder.credentials_cache(),
+                &git_workspace,
             )
             .await?;
         lowered_dependency_groups.insert(name, requirements);
@@ -820,6 +831,7 @@ async fn do_lock(
                 cache,
                 workspace_cache,
                 client.credentials_cache(),
+                &git_workspace,
             )
             .await?
         }
@@ -831,6 +843,7 @@ async fn do_lock(
                 cache,
                 workspace_cache,
                 client.credentials_cache(),
+                &git_workspace,
             )
             .await?
         }

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -6,7 +6,7 @@ use tracing::info_span;
 use uv_auth::CredentialsCache;
 use uv_cache::Cache;
 use uv_configuration::{DependencyGroupsWithDefaults, ExcludeDependency, NoSources};
-use uv_distribution::LoweredRequirement;
+use uv_distribution::{GitWorkspaceSourceContext, LoweredRequirement};
 use uv_distribution_types::{Index, IndexLocations, Requirement, RequiresPython};
 use uv_normalize::{GroupName, PackageName};
 use uv_pep508::RequirementOrigin;
@@ -356,6 +356,7 @@ impl<'lock> LockTarget<'lock> {
         cache: &Cache,
         workspace_cache: &WorkspaceCache,
         credentials_cache: &CredentialsCache,
+        git_workspace: &GitWorkspaceSourceContext<'_>,
     ) -> Result<Vec<Requirement>, uv_distribution::MetadataError> {
         match self {
             Self::Workspace(workspace) => {
@@ -378,6 +379,7 @@ impl<'lock> LockTarget<'lock> {
                     cache,
                     workspace_cache,
                     credentials_cache,
+                    git_workspace,
                 )
                 .await?;
 
@@ -426,6 +428,7 @@ impl<'lock> LockTarget<'lock> {
                             cache,
                             workspace_cache,
                             credentials_cache,
+                            git_workspace,
                         )
                         .await
                         .map(|requirement| {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -17,7 +17,10 @@ use uv_configuration::{
     GitLfsSetting, Override, PackageOverride, Reinstall, TargetTriple, Upgrade,
 };
 use uv_dispatch::{BuildDispatch, SharedState};
-use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies, LoweredRequirement};
+use uv_distribution::{
+    DistributionDatabase, GitWorkspaceSourceContext, LoweredExtraBuildDependencies,
+    LoweredRequirement,
+};
 use uv_distribution_types::{
     ExtraBuildRequirement, ExtraBuildRequires, HashGeneration, Index, IndexCredentialsError,
     Requirement, RequiresPython, Resolution, UnresolvedRequirement,
@@ -3148,6 +3151,7 @@ pub(crate) async fn script_specification(
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     credentials_cache: &CredentialsCache,
+    git_workspace: &GitWorkspaceSourceContext<'_>,
 ) -> Result<Option<RequirementsSpecification>, ProjectError> {
     let Some(dependencies) = script.metadata().dependencies.as_ref() else {
         return Ok(None);
@@ -3169,6 +3173,7 @@ pub(crate) async fn script_specification(
                 cache,
                 workspace_cache,
                 credentials_cache,
+                git_workspace,
             )
             .await
             .map_ok(LoweredRequirement::into_inner)
@@ -3196,6 +3201,7 @@ pub(crate) async fn script_specification(
                 cache,
                 workspace_cache,
                 credentials_cache,
+                git_workspace,
             )
             .await
             .map_ok(LoweredRequirement::into_inner)
@@ -3226,6 +3232,7 @@ pub(crate) async fn script_specification(
                             cache,
                             workspace_cache,
                             credentials_cache,
+                            git_workspace,
                         )
                         .await
                         .map_ok(LoweredRequirement::into_inner)
@@ -3246,6 +3253,7 @@ pub(crate) async fn script_specification(
                                 cache,
                                 workspace_cache,
                                 credentials_cache,
+                                git_workspace,
                             )
                             .await
                             .map_ok(LoweredRequirement::into_inner)
@@ -3286,6 +3294,7 @@ pub(crate) async fn script_extra_build_requires(
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     credentials_cache: &CredentialsCache,
+    git_workspace: &GitWorkspaceSourceContext<'_>,
 ) -> Result<LoweredExtraBuildDependencies, ProjectError> {
     let script_dir = script.directory()?;
     let script_indexes = script.indexes(&settings.sources);
@@ -3320,6 +3329,7 @@ pub(crate) async fn script_extra_build_requires(
                     cache,
                     workspace_cache,
                     credentials_cache,
+                    git_workspace,
                 )
                 .await
                 .map_ok(|requirement| ExtraBuildRequirement {

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -24,7 +24,7 @@ use uv_configuration::{
     Concurrency, Constraints, DependencyGroups, DryRun, EditableMode, EnvFile, ExtrasSpecification,
     InstallOptions, TargetTriple,
 };
-use uv_distribution::LoweredExtraBuildDependencies;
+use uv_distribution::{GitWorkspaceSourceContext, LoweredExtraBuildDependencies};
 use uv_distribution_types::Requirement;
 use uv_fs::which::is_executable;
 use uv_fs::{PythonExt, Simplified, create_symlink};
@@ -366,6 +366,9 @@ pub(crate) async fn run(
                 &cache,
                 workspace_cache,
                 client_builder.credentials_cache(),
+                &GitWorkspaceSourceContext::new(sync_state.git(), |url| {
+                    client_builder.git_http_settings(url)
+                }),
             )
             .await?
             {
@@ -375,6 +378,9 @@ pub(crate) async fn run(
                     &cache,
                     workspace_cache,
                     client_builder.credentials_cache(),
+                    &GitWorkspaceSourceContext::new(sync_state.git(), |url| {
+                        client_builder.git_http_settings(url)
+                    }),
                 )
                 .await?
                 .into_inner();

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -19,7 +19,7 @@ use uv_configuration::{
     TargetTriple, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
-use uv_distribution::LoweredExtraBuildDependencies;
+use uv_distribution::{GitWorkspaceSourceContext, LoweredExtraBuildDependencies};
 use uv_distribution_types::{Dist, Index, Name, Requirement, Resolution, ResolvedDist, SourceDist};
 use uv_fs::{PortablePathBuf, Simplified};
 use uv_installer::{InstallationStrategy, SitePackages};
@@ -38,7 +38,7 @@ use uv_scripts::Pep723Script;
 use uv_settings::{MalwareCheckSettings, PythonInstallMirrors};
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::warn_user;
-use uv_workspace::pyproject::Source;
+use uv_workspace::pyproject::{Source, WorkspaceReference, WorkspaceSource};
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, VirtualProject, Workspace, WorkspaceCache};
 
 use crate::commands::editable::apply_editable_mode;
@@ -238,6 +238,11 @@ pub(crate) async fn sync(
                 ));
             }
 
+            let state = PlatformState::default();
+            let git_workspace = GitWorkspaceSourceContext::new(state.git(), |url| {
+                client_builder.git_http_settings(url)
+            });
+
             // Parse the requirements from the script.
             let spec = script_specification(
                 script.into(),
@@ -245,6 +250,7 @@ pub(crate) async fn sync(
                 cache,
                 workspace_cache,
                 client_builder.credentials_cache(),
+                &git_workspace,
             )
             .await?
             .unwrap_or_default();
@@ -254,6 +260,7 @@ pub(crate) async fn sync(
                 cache,
                 workspace_cache,
                 client_builder.credentials_cache(),
+                &git_workspace,
             )
             .await?
             .into_inner();
@@ -286,7 +293,7 @@ pub(crate) async fn sync(
                 script_extra_build_requires,
                 &settings,
                 &client_builder,
-                &PlatformState::default(),
+                &state,
                 Box::new(DefaultResolveLogger),
                 Box::new(DefaultInstallLogger),
                 installer_metadata,
@@ -664,6 +671,9 @@ pub(crate) async fn do_sync(
         sources,
     } = settings;
 
+    let git_workspace =
+        GitWorkspaceSourceContext::new(state.git(), |url| client_builder.git_http_settings(url));
+
     // Lower the extra build dependencies with source resolution.
     let extra_build_requires = match &target {
         InstallTarget::Workspace { workspace, .. }
@@ -678,6 +688,7 @@ pub(crate) async fn do_sync(
                 cache,
                 workspace_cache,
                 client_builder.credentials_cache(),
+                &git_workspace,
             )
             .await?
         }
@@ -711,6 +722,7 @@ pub(crate) async fn do_sync(
                 cache,
                 workspace_cache,
                 client_builder.credentials_cache(),
+                &git_workspace,
             )
             .await?
         }
@@ -1100,6 +1112,12 @@ pub(super) fn store_credentials_from_target(
     for source in target.sources() {
         match source {
             Source::Git { git, .. } => {
+                uv_git::store_credentials_from_url(git)?;
+            }
+            Source::Workspace {
+                workspace: WorkspaceReference::Source(WorkspaceSource::Git { git, .. }),
+                ..
+            } => {
                 uv_git::store_credentials_from_url(git)?;
             }
             Source::Url { url, .. } => {

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use uv_cache::{Cache, Refresh};
 use uv_client::BaseClientBuilder;
 use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun};
-use uv_distribution::{ArchiveMetadata, Metadata};
+use uv_distribution::{ArchiveMetadata, GitWorkspaceSourceContext, Metadata};
 use uv_distribution_types::Identifier;
 use uv_normalize::PackageName;
 use uv_pep440::{Operator, Version, VersionSpecifier, VersionSpecifiers};
@@ -99,6 +99,7 @@ pub(crate) async fn upgrade(
         bail!("`uv upgrade` does not support projects with dynamic versions yet");
     }
     let metadata = ResolutionMetadata::parse_pyproject_toml(pyproject, None)?;
+    let state = UniversalState::default();
     let metadata = Metadata::from_workspace(
         metadata,
         project.project_root(),
@@ -109,6 +110,7 @@ pub(crate) async fn upgrade(
         cache,
         workspace_cache,
         client_builder.credentials_cache(),
+        &GitWorkspaceSourceContext::new(state.git(), |url| client_builder.git_http_settings(url)),
     )
     .await?;
 
@@ -137,7 +139,6 @@ pub(crate) async fn upgrade(
     .await?
     .into_interpreter();
 
-    let state = UniversalState::default();
     let distribution_id = DisplaySafeUrl::from_file_path(project.project_root())
         .map_err(|()| anyhow!("Project root is not a valid file URL"))?
         .distribution_id();

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -10790,7 +10790,7 @@ fn lock_workspace_member_with_standalone_path_source() -> Result<()> {
     Ok(())
 }
 
-/// Lock a project that correctly points at an external workspace via `workspace = "..."`.
+/// Lock a project that correctly points at an external workspace via `workspace = { path = "..." }`.
 #[cfg(feature = "test-universal")]
 #[test]
 fn lock_external_workspace_source() -> Result<()> {
@@ -10806,7 +10806,7 @@ fn lock_external_workspace_source() -> Result<()> {
         dependencies = ["pkg-b"]
 
         [tool.uv.sources]
-        pkg-b = { workspace = "../external-workspace" }
+        pkg-b = { workspace = { path = "../external-workspace" } }
         "#,
     )?;
 
@@ -27628,6 +27628,40 @@ fn lock_group_workspace() -> Result<()> {
 
 #[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
+fn lock_git_workspace_source_respects_offline_mode() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["c"]
+
+        [tool.uv.sources]
+        c = { workspace = { git = "https://github.com/astral-sh/workspace-virtual-root-test" } }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--offline"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × Failed to build `a @ file://[TEMP_DIR]/`
+      ├─▶ Failed to parse entry: `c`
+      ├─▶ Git operation failed
+      ├─▶ failed to clone into: [CACHE_DIR]/git-v0/db/fb733c6c2cd489bf
+      ╰─▶ Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+    ");
+
+    Ok(())
+}
+
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
+#[test]
 fn lock_transitive_git() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -27641,7 +27675,7 @@ fn lock_transitive_git() -> Result<()> {
         dependencies = ["c"]
 
         [tool.uv.sources]
-        c = { git = "https://github.com/astral-sh/workspace-virtual-root-test", subdirectory = "packages/c", rev = "fac39c8d4c5d0ef32744e2bb309bbe34a759fd46" }
+        c = { workspace = { git = "https://github.com/astral-sh/workspace-virtual-root-test", rev = "fac39c8d4c5d0ef32744e2bb309bbe34a759fd46" } }
         "#,
     )?;
 
@@ -27739,9 +27773,8 @@ fn lock_transitive_git() -> Result<()> {
     Resolved 6 packages in [TIME]
     ");
 
-    // Re-run with `--offline`. We shouldn't need a network connection to validate an
-    // already-correct lockfile with immutable metadata.
-    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline").arg("--no-cache"), @"
+    // Re-run with `--offline`. Workspace member discovery can reuse the cached Git checkout.
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline"), @"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -471,11 +471,21 @@ workspace members must be explicitly stated. Workspace members are always
 [editable](#editable-dependencies) . See the [workspace](./workspaces.md) documentation for more
 details on workspaces.
 
-To source a dependency from a different workspace, `workspace` can also be a path string:
+To source a dependency from a different workspace, `workspace` can also be a path source:
 
 ```toml title="pyproject.toml"
 [tool.uv.sources]
-foo = { workspace = "../other-workspace" }
+foo = { workspace = { path = "../other-workspace" } }
+```
+
+A path string, such as `workspace = "../other-workspace"`, is shorthand for a path source.
+
+A Git source can also be used to select a member from a Git-hosted workspace without specifying its
+subdirectory:
+
+```toml title="pyproject.toml"
+[tool.uv.sources]
+foo = { workspace = { git = "https://github.com/example/other-workspace", rev = "..." } }
 ```
 
 ```toml title="pyproject.toml"

--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -82,10 +82,15 @@ build-backend = "uv_build"
 In this example, the `albatross` project depends on the `bird-feeder` project, which is a member of
 the workspace. The `workspace = true` key-value pair in the `tool.uv.sources` table indicates the
 `bird-feeder` dependency should be provided by the workspace, rather than fetched from PyPI or
-another registry. The `workspace` field can also be set to a path string to resolve a dependency
-from a different workspace. The path is resolved relative to the project that declares the source
-(or the workspace root for a workspace-level source) and must point to the external workspace root.
-uv selects the member that matches the dependency name.
+another registry. The `workspace` field can also be set to a path source, for example
+`workspace = { path = "../other-workspace" }`, to resolve a dependency from a different workspace. A
+path string is shorthand for a path source. The path is resolved relative to the project that
+declares the source (or the workspace root for a workspace-level source) and must point to the
+external workspace root. uv selects the member that matches the dependency name.
+
+Git-hosted workspaces can be selected in the same way, for example
+`workspace = { git = "https://github.com/example/other-workspace", rev = "..." }`. uv discovers the
+workspace from the repository root and selects the member that matches the dependency name.
 
 !!! note
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -2133,7 +2133,7 @@
           "type": "object",
           "properties": {
             "editable": {
-              "description": "Whether the package should be installed as editable. Defaults to `true`.",
+              "description": "Whether a local workspace package should be installed as editable. Defaults to `true`.",
               "type": ["boolean", "null"]
             },
             "extra": {
@@ -2160,7 +2160,7 @@
               "$ref": "#/definitions/MarkerTree"
             },
             "workspace": {
-              "description": "`true` selects the current workspace. A string selects another workspace discovered\nfrom the given path.\n\nWhen set to `false`, the package will be fetched from the remote index, rather than\nincluded as a workspace package.",
+              "description": "`true` selects the current workspace. A path or Git source selects another workspace\ndiscovered from that source. A string is shorthand for a path source.\n\nWhen set to `false`, the package will be fetched from the remote index, rather than\nincluded as a workspace package.",
               "allOf": [
                 {
                   "$ref": "#/definitions/WorkspaceReference"
@@ -2792,13 +2792,53 @@
       "additionalProperties": false
     },
     "WorkspaceReference": {
-      "description": "A reference to either the current workspace or a workspace discovered from a path.",
+      "description": "A reference to either the current workspace or a workspace discovered from a source.",
       "anyOf": [
         {
           "type": "boolean"
         },
         {
           "$ref": "#/definitions/PortablePathBuf"
+        },
+        {
+          "$ref": "#/definitions/WorkspaceSource"
+        }
+      ]
+    },
+    "WorkspaceSource": {
+      "description": "A source from which to discover a workspace.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "$ref": "#/definitions/PortablePathBuf"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["path"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "type": ["string", "null"]
+            },
+            "git": {
+              "$ref": "#/definitions/DisplaySafeUrl"
+            },
+            "lfs": {
+              "type": ["boolean", "null"]
+            },
+            "rev": {
+              "type": ["string", "null"]
+            },
+            "tag": {
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["git"]
         }
       ]
     }


### PR DESCRIPTION
## Summary

Allow `workspace` in `tool.uv.sources` to take a structured path or Git source:

```toml
[tool.uv.sources]
foo = { workspace = { path = "../other-workspace" } }
bar = { workspace = { git = "https://github.com/org/workspace", rev = "..." } }
```

The existing `workspace = "../other-workspace"` form remains as path sugar. For Git sources, we fetch the workspace root, discover the named member, and lower it to the corresponding Git subdirectory so transitive workspace members continue to resolve normally. We use the operation's configured Git resolver and HTTP settings, including offline and trusted-host policy; offline validation can reuse a cached checkout, while an uncached workspace source reports the expected offline error.

This does not reuse the referenced workspace's lockfile.