### PR TITLE
Add dry-run and JSON output to `uv upgrade`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4141,6 +4141,14 @@ pub struct UpgradeArgs {
     /// Upgrade dependencies in a specific package in the workspace.
     #[arg(long, conflicts_with = "all_packages", value_hint = ValueHint::Other)]
     pub package: Option<PackageName>,
+
+    /// Perform a dry run, without writing the project manifest.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Select the output format.
+    #[arg(long, value_enum, default_value_t = SyncFormat::default())]
+    pub output_format: SyncFormat,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -1598,6 +1598,16 @@ pub(super) struct LockEventVersion<'lock> {
     sha: Option<&'lock str>,
 }
 
+impl LockEventVersion<'_> {
+    pub(super) fn version(&self) -> Option<&Version> {
+        self.version
+    }
+
+    pub(super) fn sha(&self) -> Option<&str> {
+        self.sha
+    }
+}
+
 impl<'lock> From<&'lock Package> for LockEventVersion<'lock> {
     fn from(value: &'lock Package) -> Self {
         Self {
@@ -1629,6 +1639,13 @@ pub(super) enum LockEvent<'lock> {
     ),
     Add(DryRun, PackageName, BTreeSet<LockEventVersion<'lock>>),
     Remove(DryRun, PackageName, BTreeSet<LockEventVersion<'lock>>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum LockEventAction {
+    Update,
+    Add,
+    Remove,
 }
 
 impl<'lock> LockEvent<'lock> {
@@ -1700,6 +1717,32 @@ impl<'lock> LockEvent<'lock> {
             Self::Update(_, package, ..)
             | Self::Add(_, package, ..)
             | Self::Remove(_, package, ..) => package,
+        }
+    }
+
+    pub(super) fn action(&self) -> LockEventAction {
+        match self {
+            Self::Update(..) => LockEventAction::Update,
+            Self::Add(..) => LockEventAction::Add,
+            Self::Remove(..) => LockEventAction::Remove,
+        }
+    }
+
+    pub(super) fn previous_versions(&self) -> Option<&BTreeSet<LockEventVersion<'lock>>> {
+        match self {
+            Self::Update(_, _, previous_versions, _) | Self::Remove(_, _, previous_versions) => {
+                Some(previous_versions)
+            }
+            Self::Add(..) => None,
+        }
+    }
+
+    pub(super) fn current_versions(&self) -> Option<&BTreeSet<LockEventVersion<'lock>>> {
+        match self {
+            Self::Update(_, _, _, current_versions) | Self::Add(_, _, current_versions) => {
+                Some(current_versions)
+            }
+            Self::Remove(..) => None,
         }
     }
 }

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -35,7 +35,9 @@ use uv_workspace::{
 };
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
-use crate::commands::project::lock::{LockEvent, LockMode, LockOperation, LockResult};
+use crate::commands::project::lock::{
+    LockEvent, LockEventAction, LockEventVersion, LockMode, LockOperation, LockResult,
+};
 use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{ProjectError, ProjectInterpreter, UniversalState, WorkspacePython};
 use crate::commands::{ExitStatus, diagnostics};
@@ -96,7 +98,7 @@ struct DeclarationIdentity {
     member: PackageName,
     package: PackageName,
     dependency_type: DependencyType,
-    text: String,
+    display_text: String,
     resolved_versions: BTreeSet<Version>,
 }
 
@@ -151,6 +153,7 @@ struct UpgradeReport {
     dry_run: bool,
     packages: Vec<PackageName>,
     declarations: Vec<UpgradeDeclarationReport>,
+    lock_changes: Vec<UpgradeLockChangeReport>,
 }
 
 #[derive(Serialize, Debug, Default)]
@@ -209,6 +212,30 @@ struct UpgradeReasonReport {
     message: String,
 }
 
+#[derive(Serialize, Debug)]
+struct UpgradeLockChangeReport {
+    action: UpgradeLockChangeAction,
+    package: PackageName,
+    previous_versions: Vec<UpgradeLockVersionReport>,
+    current_versions: Vec<UpgradeLockVersionReport>,
+}
+
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum UpgradeLockChangeAction {
+    Update,
+    Add,
+    Remove,
+}
+
+#[derive(Serialize, Debug)]
+struct UpgradeLockVersionReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<Version>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sha: Option<String>,
+}
+
 #[derive(Serialize, Debug, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 enum UpgradeReasonCode {
@@ -246,7 +273,11 @@ impl DeclarationOutcome {
 }
 
 impl UpgradeReport {
-    fn from_outcomes(outcomes: &[DeclarationOutcome], dry_run: DryRun) -> Self {
+    fn from_outcomes(
+        outcomes: &[DeclarationOutcome],
+        events: &[LockEvent<'_>],
+        dry_run: DryRun,
+    ) -> Self {
         let mut packages = Vec::new();
         for outcome in outcomes {
             if !packages.contains(outcome.package()) {
@@ -261,6 +292,10 @@ impl UpgradeReport {
             declarations: outcomes
                 .iter()
                 .map(UpgradeDeclarationReport::from_outcome)
+                .collect(),
+            lock_changes: events
+                .iter()
+                .map(UpgradeLockChangeReport::from_event)
                 .collect(),
         }
     }
@@ -322,7 +357,7 @@ impl UpgradeDeclarationReport {
             location: dependency_location(&declaration.dependency_type),
             extra: dependency_extra(&declaration.dependency_type),
             group: dependency_group(&declaration.dependency_type),
-            original_requirement: declaration.text.clone(),
+            original_requirement: declaration.display_text.clone(),
             new_requirement,
             resolved_versions: declaration.resolved_versions.iter().cloned().collect(),
             status,
@@ -346,6 +381,46 @@ impl UpgradeDeclarationReport {
                 code: declaration.reason.code(),
                 message: declaration.reason.message().to_string(),
             }),
+        }
+    }
+}
+
+impl UpgradeLockChangeReport {
+    fn from_event(event: &LockEvent<'_>) -> Self {
+        Self {
+            action: UpgradeLockChangeAction::from(event.action()),
+            package: event.package().clone(),
+            previous_versions: event
+                .previous_versions()
+                .into_iter()
+                .flatten()
+                .map(UpgradeLockVersionReport::from_version)
+                .collect(),
+            current_versions: event
+                .current_versions()
+                .into_iter()
+                .flatten()
+                .map(UpgradeLockVersionReport::from_version)
+                .collect(),
+        }
+    }
+}
+
+impl From<LockEventAction> for UpgradeLockChangeAction {
+    fn from(value: LockEventAction) -> Self {
+        match value {
+            LockEventAction::Update => Self::Update,
+            LockEventAction::Add => Self::Add,
+            LockEventAction::Remove => Self::Remove,
+        }
+    }
+}
+
+impl UpgradeLockVersionReport {
+    fn from_version(version: &LockEventVersion<'_>) -> Self {
+        Self {
+            version: version.version().cloned(),
+            sha: version.sha().map(ToString::to_string),
         }
     }
 }
@@ -441,7 +516,7 @@ impl UpgradableRequirement {
             member: self.member.clone(),
             package: self.package.clone(),
             dependency_type: self.dependency_type.clone(),
-            text: self.original_text.clone(),
+            display_text: self.original_text.clone(),
             resolved_versions: self.resolved_versions.clone(),
         }
     }
@@ -889,15 +964,11 @@ pub(crate) async fn upgrade(
     }
 
     let events = match &result {
-        LockResult::Changed(previous, lock) => {
-            LockEvent::detect_changes(previous.as_ref(), lock, DryRun::Enabled)
-                .filter(|event| {
-                    selected_packages
-                        .iter()
-                        .any(|package| event.package() == package)
-                })
-                .collect::<Vec<_>>()
-        }
+        LockResult::Changed(previous, lock) => reportable_lock_events(
+            &declaration_outcomes,
+            &selected_packages,
+            LockEvent::detect_changes(previous.as_ref(), lock, DryRun::Enabled),
+        ),
         LockResult::Unchanged(_) => Vec::new(),
     };
     render_upgrade_report(
@@ -1600,7 +1671,7 @@ fn render_upgrade_report(
         SyncFormat::Json => {
             render_declaration_outcomes(outcomes, display_members, printer)?;
             if let Some(output) =
-                UpgradeReport::from_outcomes(outcomes, dry_run).format(output_format)
+                UpgradeReport::from_outcomes(outcomes, events, dry_run).format(output_format)
             {
                 writeln!(printer.stdout_important(), "{output}")?;
             }
@@ -1618,10 +1689,7 @@ fn render_upgrade_report_text(
     printer: Printer,
 ) -> Result<()> {
     for package in selected_packages {
-        if !outcomes
-            .iter()
-            .any(|outcome| outcome.package() == package && outcome.supports_lock_event())
-        {
+        if !package_supports_lock_event(outcomes, package) {
             continue;
         }
         if let Some(event) = events.iter().find(|event| event.package() == package) {
@@ -1676,6 +1744,28 @@ fn render_upgrade_report_text(
     Ok(())
 }
 
+fn reportable_lock_events<'lock>(
+    outcomes: &[DeclarationOutcome],
+    selected_packages: &[PackageName],
+    events: impl IntoIterator<Item = LockEvent<'lock>>,
+) -> Vec<LockEvent<'lock>> {
+    events
+        .into_iter()
+        .filter(|event| {
+            selected_packages
+                .iter()
+                .any(|package| event.package() == package)
+                && package_supports_lock_event(outcomes, event.package())
+        })
+        .collect()
+}
+
+fn package_supports_lock_event(outcomes: &[DeclarationOutcome], package: &PackageName) -> bool {
+    outcomes
+        .iter()
+        .any(|outcome| outcome.package() == package && outcome.supports_lock_event())
+}
+
 fn render_declaration_outcomes(
     outcomes: &[DeclarationOutcome],
     display_members: bool,
@@ -1694,7 +1784,7 @@ fn render_declaration_outcomes(
                         declaration.package,
                         declaration.member,
                         declaration.dependency_type.toml_table_name(),
-                        declaration.text,
+                        declaration.display_text,
                         reason.message()
                     )?;
                 } else {
@@ -1703,7 +1793,7 @@ fn render_declaration_outcomes(
                         "warning: Could not update dependency `{}` in {}: `{}` ({})",
                         declaration.package,
                         declaration.dependency_type.toml_table_name(),
-                        declaration.text,
+                        declaration.display_text,
                         reason.message()
                     )?;
                 }

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -6,15 +6,17 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow, bail};
 use itertools::Itertools;
+use serde::Serialize;
 use uv_cache::{Cache, Refresh};
+use uv_cli::SyncFormat;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun, NoSources, Upgrade};
 use uv_distribution::{ArchiveMetadata, Metadata};
 use uv_distribution_types::{Identifier, RequiresPython};
-use uv_normalize::{GroupName, PackageName};
+use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Operator, Version, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{MarkerTree, Pep508ErrorSource, Requirement, VerbatimUrl, VersionOrUrl};
-use uv_preview::Preview;
+use uv_preview::{Preview, PreviewFeature};
 use uv_pypi_types::{
     DependencyGroupSpecifier, PyProjectToml, ResolutionMetadata, SupportedEnvironments,
     VerbatimParsedUrl,
@@ -23,6 +25,7 @@ use uv_python::{ConfigDiscovery, Interpreter, PythonDownloads, PythonPreference}
 use uv_redacted::DisplaySafeUrl;
 use uv_resolver::{MetadataResponse, implicit_constraints_marker};
 use uv_settings::PythonInstallMirrors;
+use uv_warnings::warn_user;
 use uv_workspace::dependency_groups::FlatDependencyGroups;
 use uv_workspace::pyproject::{DependencyType, PyProjectToml as WorkspacePyProjectToml, Source};
 use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
@@ -52,6 +55,7 @@ struct UpgradableRequirement {
 }
 
 /// A selected requirement that cannot apply to the project.
+#[derive(Clone)]
 struct SkippedRequirement {
     member: PackageName,
     package: PackageName,
@@ -62,6 +66,7 @@ struct SkippedRequirement {
     reason: SkippedReason,
 }
 
+#[derive(Clone)]
 enum SkippedReason {
     EnvironmentOrPythonRequirement,
     UndefinedExtra,
@@ -92,6 +97,7 @@ struct DeclarationIdentity {
     package: PackageName,
     dependency_type: DependencyType,
     text: String,
+    resolved_versions: BTreeSet<Version>,
 }
 
 /// An existing requirement and its proposed replacement.
@@ -103,6 +109,7 @@ struct RequirementUpdate {
     original_text: String,
     existing: Requirement<VerbatimUrl>,
     replacement: Requirement<VerbatimUrl>,
+    resolved_versions: BTreeSet<Version>,
 }
 
 struct UpgradeWorkspace {
@@ -118,6 +125,7 @@ enum DeclarationOutcome {
         declaration: DeclarationIdentity,
         reason: BlockedReason,
     },
+    Skipped(SkippedRequirement),
 }
 
 enum BlockedReason {
@@ -137,6 +145,80 @@ enum ProposeRequirementError {
     Rewrite(#[from] anyhow::Error),
 }
 
+#[derive(Serialize, Debug)]
+struct UpgradeReport {
+    schema: SchemaReport,
+    dry_run: bool,
+    packages: Vec<PackageName>,
+    declarations: Vec<UpgradeDeclarationReport>,
+}
+
+#[derive(Serialize, Debug, Default)]
+struct SchemaReport {
+    version: SchemaVersion,
+}
+
+#[derive(Serialize, Debug, Default)]
+#[serde(rename_all = "snake_case")]
+enum SchemaVersion {
+    #[default]
+    Preview,
+}
+
+#[derive(Serialize, Debug)]
+struct UpgradeDeclarationReport {
+    member: PackageName,
+    package: PackageName,
+    dependency_type: UpgradeDependencyType,
+    location: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra: Option<ExtraName>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    group: Option<GroupName>,
+    original_requirement: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_requirement: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    resolved_versions: Vec<Version>,
+    status: UpgradeDeclarationStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<UpgradeReasonReport>,
+}
+
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum UpgradeDependencyType {
+    Production,
+    Optional,
+    Group,
+    Dev,
+}
+
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum UpgradeDeclarationStatus {
+    Changed,
+    Unchanged,
+    Blocked,
+    Skipped,
+}
+
+#[derive(Serialize, Debug)]
+struct UpgradeReasonReport {
+    code: UpgradeReasonCode,
+    message: String,
+}
+
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum UpgradeReasonCode {
+    UnrepresentableRequirement,
+    ConflictExtra,
+    ConflictGroup,
+    EnvironmentOrPythonRequirement,
+    UndefinedExtra,
+}
+
 impl DeclarationOutcome {
     fn package(&self) -> &PackageName {
         match self {
@@ -144,6 +226,7 @@ impl DeclarationOutcome {
             Self::Unchanged(declaration) | Self::Blocked { declaration, .. } => {
                 &declaration.package
             }
+            Self::Skipped(declaration) => &declaration.package,
         }
     }
 
@@ -162,7 +245,140 @@ impl DeclarationOutcome {
     }
 }
 
+impl UpgradeReport {
+    fn from_outcomes(outcomes: &[DeclarationOutcome], dry_run: DryRun) -> Self {
+        let mut packages = Vec::new();
+        for outcome in outcomes {
+            if !packages.contains(outcome.package()) {
+                packages.push(outcome.package().clone());
+            }
+        }
+
+        Self {
+            schema: SchemaReport::default(),
+            dry_run: dry_run.enabled(),
+            packages,
+            declarations: outcomes
+                .iter()
+                .map(UpgradeDeclarationReport::from_outcome)
+                .collect(),
+        }
+    }
+
+    fn format(&self, output_format: SyncFormat) -> Option<String> {
+        match output_format {
+            SyncFormat::Json => serde_json::to_string_pretty(self).ok(),
+            SyncFormat::Text => None,
+        }
+    }
+}
+
+impl UpgradeDeclarationReport {
+    fn from_outcome(outcome: &DeclarationOutcome) -> Self {
+        match outcome {
+            DeclarationOutcome::Changed(update) => Self::from_changed(update),
+            DeclarationOutcome::Unchanged(declaration) => {
+                Self::from_identity(declaration, UpgradeDeclarationStatus::Unchanged, None, None)
+            }
+            DeclarationOutcome::Blocked {
+                declaration,
+                reason,
+            } => Self::from_identity(
+                declaration,
+                UpgradeDeclarationStatus::Blocked,
+                Some(UpgradeReasonReport::from(reason)),
+                None,
+            ),
+            DeclarationOutcome::Skipped(declaration) => Self::from_skipped(declaration),
+        }
+    }
+
+    fn from_changed(update: &RequirementUpdate) -> Self {
+        Self {
+            member: update.member.clone(),
+            package: update.package.clone(),
+            dependency_type: UpgradeDependencyType::from(&update.dependency_type),
+            location: dependency_location(&update.dependency_type),
+            extra: dependency_extra(&update.dependency_type),
+            group: dependency_group(&update.dependency_type),
+            original_requirement: update.original_text.clone(),
+            new_requirement: Some(update.replacement.to_string()),
+            resolved_versions: update.resolved_versions.iter().cloned().collect(),
+            status: UpgradeDeclarationStatus::Changed,
+            reason: None,
+        }
+    }
+
+    fn from_identity(
+        declaration: &DeclarationIdentity,
+        status: UpgradeDeclarationStatus,
+        reason: Option<UpgradeReasonReport>,
+        new_requirement: Option<String>,
+    ) -> Self {
+        Self {
+            member: declaration.member.clone(),
+            package: declaration.package.clone(),
+            dependency_type: UpgradeDependencyType::from(&declaration.dependency_type),
+            location: dependency_location(&declaration.dependency_type),
+            extra: dependency_extra(&declaration.dependency_type),
+            group: dependency_group(&declaration.dependency_type),
+            original_requirement: declaration.text.clone(),
+            new_requirement,
+            resolved_versions: declaration.resolved_versions.iter().cloned().collect(),
+            status,
+            reason,
+        }
+    }
+
+    fn from_skipped(declaration: &SkippedRequirement) -> Self {
+        Self {
+            member: declaration.member.clone(),
+            package: declaration.package.clone(),
+            dependency_type: UpgradeDependencyType::from(&declaration.dependency_type),
+            location: dependency_location(&declaration.dependency_type),
+            extra: dependency_extra(&declaration.dependency_type),
+            group: dependency_group(&declaration.dependency_type),
+            original_requirement: declaration.display_text.clone(),
+            new_requirement: None,
+            resolved_versions: Vec::new(),
+            status: UpgradeDeclarationStatus::Skipped,
+            reason: Some(UpgradeReasonReport {
+                code: declaration.reason.code(),
+                message: declaration.reason.message().to_string(),
+            }),
+        }
+    }
+}
+
+impl From<&DependencyType> for UpgradeDependencyType {
+    fn from(value: &DependencyType) -> Self {
+        match value {
+            DependencyType::Production => Self::Production,
+            DependencyType::Optional(_) => Self::Optional,
+            DependencyType::Group(_) => Self::Group,
+            DependencyType::Dev => Self::Dev,
+        }
+    }
+}
+
+impl From<&BlockedReason> for UpgradeReasonReport {
+    fn from(value: &BlockedReason) -> Self {
+        Self {
+            code: value.code(),
+            message: value.message(),
+        }
+    }
+}
+
 impl BlockedReason {
+    fn code(&self) -> UpgradeReasonCode {
+        match self {
+            Self::UnrepresentableRequirement(_) => UpgradeReasonCode::UnrepresentableRequirement,
+            Self::ConflictExtra { .. } => UpgradeReasonCode::ConflictExtra,
+            Self::ConflictGroup { .. } => UpgradeReasonCode::ConflictGroup,
+        }
+    }
+
     fn message(&self) -> String {
         match self {
             Self::UnrepresentableRequirement(error) => error.to_string(),
@@ -176,6 +392,49 @@ impl BlockedReason {
     }
 }
 
+impl SkippedReason {
+    fn code(&self) -> UpgradeReasonCode {
+        match self {
+            Self::EnvironmentOrPythonRequirement => {
+                UpgradeReasonCode::EnvironmentOrPythonRequirement
+            }
+            Self::UndefinedExtra => UpgradeReasonCode::UndefinedExtra,
+        }
+    }
+
+    fn message(&self) -> &'static str {
+        match self {
+            Self::EnvironmentOrPythonRequirement => {
+                "excluded by the project's environments or Python requirement"
+            }
+            Self::UndefinedExtra => "references an extra that the project does not provide",
+        }
+    }
+}
+
+fn dependency_location(dependency_type: &DependencyType) -> String {
+    match dependency_type {
+        DependencyType::Production => "project.dependencies".to_string(),
+        DependencyType::Optional(extra) => format!("project.optional-dependencies.{extra}"),
+        DependencyType::Group(group) => format!("dependency-groups.{group}"),
+        DependencyType::Dev => "tool.uv.dev-dependencies".to_string(),
+    }
+}
+
+fn dependency_extra(dependency_type: &DependencyType) -> Option<ExtraName> {
+    match dependency_type {
+        DependencyType::Optional(extra) => Some(extra.clone()),
+        DependencyType::Production | DependencyType::Group(_) | DependencyType::Dev => None,
+    }
+}
+
+fn dependency_group(dependency_type: &DependencyType) -> Option<GroupName> {
+    match dependency_type {
+        DependencyType::Group(group) => Some(group.clone()),
+        DependencyType::Production | DependencyType::Optional(_) | DependencyType::Dev => None,
+    }
+}
+
 impl UpgradableRequirement {
     fn identity(&self) -> DeclarationIdentity {
         DeclarationIdentity {
@@ -183,6 +442,7 @@ impl UpgradableRequirement {
             package: self.package.clone(),
             dependency_type: self.dependency_type.clone(),
             text: self.original_text.clone(),
+            resolved_versions: self.resolved_versions.clone(),
         }
     }
 }
@@ -193,6 +453,8 @@ pub(crate) async fn upgrade(
     exclude: Vec<PackageName>,
     package: Option<PackageName>,
     all_packages: bool,
+    dry_run: DryRun,
+    output_format: SyncFormat,
     install_mirrors: PythonInstallMirrors,
     mut settings: ResolverSettings,
     client_builder: BaseClientBuilder<'_>,
@@ -205,6 +467,14 @@ pub(crate) async fn upgrade(
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
+    if matches!(output_format, SyncFormat::Json) && !preview.is_enabled(PreviewFeature::JsonOutput)
+    {
+        warn_user!(
+            "The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features {}` to disable this warning.",
+            PreviewFeature::JsonOutput
+        );
+    }
+
     let upgrade_workspace =
         discover_upgrade_workspace(project_dir, package, all_packages, cache, workspace_cache)
             .await?;
@@ -225,6 +495,20 @@ pub(crate) async fn upgrade(
             render_skipped_requirements(
                 &selection.skipped,
                 upgrade_workspace.display_members,
+                printer,
+            )?;
+            let outcomes = selection
+                .skipped
+                .into_iter()
+                .map(DeclarationOutcome::Skipped)
+                .collect::<Vec<_>>();
+            render_upgrade_report(
+                &outcomes,
+                &[],
+                &[],
+                upgrade_workspace.display_members,
+                dry_run,
+                output_format,
                 printer,
             )?;
             return Ok(ExitStatus::Success);
@@ -300,7 +584,11 @@ pub(crate) async fn upgrade(
         &selected_packages,
         &settings.sources,
     )?;
-    let mut declaration_outcomes = Vec::new();
+    let mut declaration_outcomes = skipped
+        .iter()
+        .cloned()
+        .map(DeclarationOutcome::Skipped)
+        .collect::<Vec<_>>();
     let mut conflicts = upgrade_workspace.target.workspace().conflicts()?;
     for selected_project in &upgrade_workspace.selected_projects {
         if let Some(groups) = &selected_project
@@ -364,9 +652,13 @@ pub(crate) async fn upgrade(
             .any(|selected| selected.package == *package)
     });
     if requirements.is_empty() {
-        render_declaration_outcomes(
+        render_upgrade_report(
             &declaration_outcomes,
+            &[],
+            &selected_packages,
             upgrade_workspace.display_members,
+            dry_run,
+            output_format,
             printer,
         )?;
         return Ok(ExitStatus::Success);
@@ -393,6 +685,7 @@ pub(crate) async fn upgrade(
                     relax_requirement(selected.requirement.clone()),
                     &selected.package,
                 )?,
+                resolved_versions: BTreeSet::new(),
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -539,6 +832,7 @@ pub(crate) async fn upgrade(
             original_text: selected.original_text.clone(),
             existing,
             replacement,
+            resolved_versions: selected.resolved_versions.clone(),
         };
         declaration_outcomes.push(DeclarationOutcome::Changed(Box::new(update.clone())));
         updated_requirements
@@ -567,7 +861,7 @@ pub(crate) async fn upgrade(
         );
     }
 
-    if !updated_requirements.is_empty() {
+    if !dry_run.enabled() && !updated_requirements.is_empty() {
         let mut pyproject_writes = Vec::new();
         for selected_project in &upgrade_workspace.selected_projects {
             if !updated_requirements
@@ -606,42 +900,15 @@ pub(crate) async fn upgrade(
         }
         LockResult::Unchanged(_) => Vec::new(),
     };
-    for package in &selected_packages {
-        if !declaration_outcomes
-            .iter()
-            .any(|outcome| outcome.package() == package && outcome.supports_lock_event())
-        {
-            continue;
-        }
-        if let Some(event) = events.iter().find(|event| event.package() == package) {
-            writeln!(printer.stderr(), "{event}")?;
-        } else {
-            writeln!(printer.stderr(), "No version change for {package}")?;
-        }
-    }
-    render_declaration_outcomes(
+    render_upgrade_report(
         &declaration_outcomes,
+        &events,
+        &selected_packages,
         upgrade_workspace.display_members,
+        dry_run,
+        output_format,
         printer,
     )?;
-    for update in updated_requirements.into_values() {
-        if upgrade_workspace.display_members {
-            writeln!(
-                printer.stderr(),
-                "Updated requirement in package `{}`: `{}` -> `{}`",
-                update.member,
-                update.original_text,
-                update.replacement
-            )?;
-        } else {
-            writeln!(
-                printer.stderr(),
-                "Updated requirement: `{}` -> `{}`",
-                update.original_text,
-                update.replacement
-            )?;
-        }
-    }
 
     Ok(ExitStatus::Success)
 }
@@ -1162,14 +1429,7 @@ fn render_skipped_requirements(
     printer: Printer,
 ) -> Result<()> {
     for requirement in skipped {
-        let reason = match requirement.reason {
-            SkippedReason::EnvironmentOrPythonRequirement => {
-                "excluded by the project's environments or Python requirement"
-            }
-            SkippedReason::UndefinedExtra => {
-                "references an extra that the project does not provide"
-            }
-        };
+        let reason = requirement.reason.message();
         if display_members {
             writeln!(
                 printer.stderr(),
@@ -1317,6 +1577,105 @@ fn dependency_group_requires_python_marker(
         })
 }
 
+fn render_upgrade_report(
+    outcomes: &[DeclarationOutcome],
+    events: &[LockEvent<'_>],
+    selected_packages: &[PackageName],
+    display_members: bool,
+    dry_run: DryRun,
+    output_format: SyncFormat,
+    printer: Printer,
+) -> Result<()> {
+    match output_format {
+        SyncFormat::Text => {
+            render_upgrade_report_text(
+                outcomes,
+                events,
+                selected_packages,
+                display_members,
+                dry_run,
+                printer,
+            )?;
+        }
+        SyncFormat::Json => {
+            render_declaration_outcomes(outcomes, display_members, printer)?;
+            if let Some(output) =
+                UpgradeReport::from_outcomes(outcomes, dry_run).format(output_format)
+            {
+                writeln!(printer.stdout_important(), "{output}")?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_upgrade_report_text(
+    outcomes: &[DeclarationOutcome],
+    events: &[LockEvent<'_>],
+    selected_packages: &[PackageName],
+    display_members: bool,
+    dry_run: DryRun,
+    printer: Printer,
+) -> Result<()> {
+    for package in selected_packages {
+        if !outcomes
+            .iter()
+            .any(|outcome| outcome.package() == package && outcome.supports_lock_event())
+        {
+            continue;
+        }
+        if let Some(event) = events.iter().find(|event| event.package() == package) {
+            writeln!(printer.stderr(), "{event}")?;
+        } else {
+            writeln!(printer.stderr(), "No version change for {package}")?;
+        }
+    }
+    render_declaration_outcomes(outcomes, display_members, printer)?;
+
+    let action = if dry_run.enabled() {
+        "Would update"
+    } else {
+        "Updated"
+    };
+    let mut rendered_updates = Vec::new();
+    for outcome in outcomes {
+        let DeclarationOutcome::Changed(update) = outcome else {
+            continue;
+        };
+        let update = update.as_ref();
+        if rendered_updates
+            .iter()
+            .any(|rendered: &&RequirementUpdate| {
+                rendered.member == update.member
+                    && rendered.dependency_type == update.dependency_type
+                    && rendered.existing == update.existing
+                    && rendered.replacement == update.replacement
+            })
+        {
+            continue;
+        }
+        if display_members {
+            writeln!(
+                printer.stderr(),
+                "{action} requirement in package `{}`: `{}` -> `{}`",
+                update.member,
+                update.original_text,
+                update.replacement
+            )?;
+        } else {
+            writeln!(
+                printer.stderr(),
+                "{action} requirement: `{}` -> `{}`",
+                update.original_text,
+                update.replacement
+            )?;
+        }
+        rendered_updates.push(update);
+    }
+
+    Ok(())
+}
+
 fn render_declaration_outcomes(
     outcomes: &[DeclarationOutcome],
     display_members: bool,
@@ -1349,7 +1708,9 @@ fn render_declaration_outcomes(
                     )?;
                 }
             }
-            DeclarationOutcome::Changed(_) | DeclarationOutcome::Unchanged(_) => {}
+            DeclarationOutcome::Changed(_)
+            | DeclarationOutcome::Unchanged(_)
+            | DeclarationOutcome::Skipped(_) => {}
         }
     }
     Ok(())

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2480,6 +2480,8 @@ async fn run_project(
                 args.exclude,
                 args.package,
                 args.all_packages,
+                args.dry_run,
+                args.output_format,
                 args.install_mirrors,
                 args.settings,
                 client_builder.subcommand(vec!["upgrade".to_owned()]),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2055,6 +2055,8 @@ pub(crate) struct UpgradeSettings {
     pub(crate) exclude: Vec<PackageName>,
     pub(crate) package: Option<PackageName>,
     pub(crate) all_packages: bool,
+    pub(crate) dry_run: DryRun,
+    pub(crate) output_format: SyncFormat,
     pub(crate) install_mirrors: PythonInstallMirrors,
     pub(crate) settings: ResolverSettings,
 }
@@ -2074,6 +2076,8 @@ impl UpgradeSettings {
         let exclude = args.exclude;
         let package = args.package;
         let all_packages = args.all_packages;
+        let dry_run = DryRun::from_args(args.dry_run);
+        let output_format = args.output_format;
         let mut settings =
             ResolverSettings::combine(ResolverOptions::default(), filesystem, &environment);
         settings.upgrade = if packages.is_empty() {
@@ -2087,6 +2091,8 @@ impl UpgradeSettings {
             exclude,
             package,
             all_packages,
+            dry_run,
+            output_format,
             install_mirrors: environment
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
@@ -5210,6 +5216,8 @@ mod tests {
                 exclude: Vec::new(),
                 all_packages: false,
                 package: None,
+                dry_run: false,
+                output_format: SyncFormat::Text,
             },
             None,
             EnvironmentOptions::new()?,

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -257,6 +257,18 @@ fn upgrade_dry_run_outputs_json_without_mutation() -> Result<()> {
           ],
           "status": "changed"
         }
+      ],
+      "lock_changes": [
+        {
+          "action": "add",
+          "package": "anyio",
+          "previous_versions": [],
+          "current_versions": [
+            {
+              "version": "4.3.0"
+            }
+          ]
+        }
       ]
     }
 
@@ -320,6 +332,18 @@ fn upgrade_quiet_json_reports_unchanged_declaration() -> Result<()> {
             "4.3.0"
           ],
           "status": "unchanged"
+        }
+      ],
+      "lock_changes": [
+        {
+          "action": "add",
+          "package": "anyio",
+          "previous_versions": [],
+          "current_versions": [
+            {
+              "version": "4.3.0"
+            }
+          ]
         }
       ]
     }
@@ -1415,6 +1439,56 @@ fn upgrade_without_package_rejects_direct_url_requirement() -> Result<()> {
 }
 
 #[test]
+fn upgrade_without_package_skips_inapplicable_direct_url_and_updates_registry() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "foo @ https://example.com/foo-1.0.0-py3-none-any.whl ; python_version < '3.12'",
+            "bar<2",
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context.upgrade().env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Skipping dependency `foo` in `project.dependencies`: `foo @ https://example.com/foo-1.0.0-py3-none-any.whl ; python_full_version < '3.12'` (excluded by the project's environments or Python requirement)
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
+    Add bar v2.0.0
+    Updated requirement: `bar<2` -> `bar<3`
+    "
+    );
+
+    assert_eq!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        pyproject_toml.replace("bar<2", "bar<3")
+    );
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
 fn upgrade_without_package_rejects_non_registry_source() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let pyproject_toml = r#"
@@ -1772,6 +1846,18 @@ fn upgrade_json_reports_partial_blocked_outcome() -> Result<()> {
           ],
           "status": "changed"
         }
+      ],
+      "lock_changes": [
+        {
+          "action": "add",
+          "package": "baz",
+          "previous_versions": [],
+          "current_versions": [
+            {
+              "version": "2.0.0"
+            }
+          ]
+        }
       ]
     }
 
@@ -1779,6 +1865,210 @@ fn upgrade_json_reports_partial_blocked_outcome() -> Result<()> {
     warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 5 packages in [TIME]
+    warning: Could not update dependency `bar` in `project.dependencies`: `bar>=1 ; extra == 'cpu'` (declared under conflicting extra `cpu`)
+    "#
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
+fn upgrade_reports_same_package_mixed_blocked_and_changed_outcomes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/upgrade-outcomes.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "bar>=1 ; extra == 'cpu'",
+            "bar<2",
+        ]
+
+        [project.optional-dependencies]
+        cpu = []
+        gpu = []
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ extra = "cpu" }},
+                {{ extra = "gpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
+    Add bar v2.0.0
+    warning: Could not update dependency `bar` in `project.dependencies`: `bar>=1 ; extra == 'cpu'` (declared under conflicting extra `cpu`)
+    Updated requirement: `bar<2` -> `bar<3`
+    "
+    );
+
+    let updated_pyproject_toml = fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?;
+    insta::with_settings!({ filters => packse_filters(&context) }, {
+        insta::assert_snapshot!(
+            updated_pyproject_toml,
+            @r#"
+
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "bar>=1 ; extra == 'cpu'",
+    "bar<3",
+]
+
+[project.optional-dependencies]
+cpu = []
+gpu = []
+
+[tool.uv]
+conflicts = [
+    [
+        { extra = "cpu" },
+        { extra = "gpu" },
+    ],
+]
+
+[[tool.uv.index]]
+url = "http://[LOCALHOST]/simple/"
+default = true
+"#
+        );
+    });
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
+fn upgrade_json_reports_same_package_mixed_blocked_and_changed_outcomes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/upgrade-outcomes.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "bar>=1 ; extra == 'cpu'",
+            "bar<2",
+        ]
+
+        [project.optional-dependencies]
+        cpu = []
+        gpu = []
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ extra = "cpu" }},
+                {{ extra = "gpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("--dry-run")
+            .arg("--output-format")
+            .arg("json")
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": true,
+      "packages": [
+        "bar"
+      ],
+      "declarations": [
+        {
+          "member": "example",
+          "package": "bar",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "bar>=1 ; extra == 'cpu'",
+          "status": "blocked",
+          "reason": {
+            "code": "conflict_extra",
+            "message": "declared under conflicting extra `cpu`"
+          }
+        },
+        {
+          "member": "example",
+          "package": "bar",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "bar<2",
+          "new_requirement": "bar<3",
+          "resolved_versions": [
+            "2.0.0"
+          ],
+          "status": "changed"
+        }
+      ],
+      "lock_changes": [
+        {
+          "action": "add",
+          "package": "bar",
+          "previous_versions": [],
+          "current_versions": [
+            {
+              "version": "2.0.0"
+            }
+          ]
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
     warning: Could not update dependency `bar` in `project.dependencies`: `bar>=1 ; extra == 'cpu'` (declared under conflicting extra `cpu`)
     "#
     );
@@ -1834,6 +2124,8 @@ fn upgrade_updates_requirement_constrained_by_conflicting_groups() -> Result<()>
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 3 packages in [TIME]
     Add baz v1.0.0, v2.0.0
+    warning: Could not update dependency `baz` in `dependency-groups.new`: `baz==2` (declared under conflicting dependency group `new`)
+    warning: Could not update dependency `baz` in `dependency-groups.old`: `baz==1` (declared under conflicting dependency group `old`)
     Updated requirement: `baz<2` -> `baz<3`
     "
     );
@@ -1887,6 +2179,87 @@ fn upgrade_succeeds_when_all_selected_declarations_are_blocked() -> Result<()> {
     Resolved 4 packages in [TIME]
     warning: Could not update dependency `bar` in `project.dependencies`: `bar==1.*` (Dependency `bar` resolved to `1.0.0`, `2.0.0` which cannot be represented by the upgraded requirement; this is not supported yet)
     "
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)?;
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
+fn upgrade_json_suppresses_lock_changes_when_all_declarations_are_blocked() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/upgrade-outcomes.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "foo==1",
+            "bar==1.*",
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("--output-format")
+            .arg("json")
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": false,
+      "packages": [
+        "bar"
+      ],
+      "declarations": [
+        {
+          "member": "example",
+          "package": "bar",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "bar==1.*",
+          "resolved_versions": [
+            "1.0.0",
+            "2.0.0"
+          ],
+          "status": "blocked",
+          "reason": {
+            "code": "unrepresentable_requirement",
+            "message": "Dependency `bar` resolved to `1.0.0`, `2.0.0` which cannot be represented by the upgraded requirement; this is not supported yet"
+          }
+        }
+      ],
+      "lock_changes": []
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    warning: Could not update dependency `bar` in `project.dependencies`: `bar==1.*` (Dependency `bar` resolved to `1.0.0`, `2.0.0` which cannot be represented by the upgraded requirement; this is not supported yet)
+    "#
     );
 
     assert_project_unchanged(&context, &pyproject_toml)?;
@@ -3393,6 +3766,18 @@ fn upgrade_json_preview_feature_suppresses_warning() -> Result<()> {
           ],
           "status": "changed"
         }
+      ],
+      "lock_changes": [
+        {
+          "action": "add",
+          "package": "bar",
+          "previous_versions": [],
+          "current_versions": [
+            {
+              "version": "2.0.0"
+            }
+          ]
+        }
       ]
     }
 
@@ -3403,6 +3788,109 @@ fn upgrade_json_preview_feature_suppresses_warning() -> Result<()> {
     );
 
     assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
+fn upgrade_json_reports_existing_lockfile_changes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/upgrade-outcomes.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["bar==1"]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context.lock().env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
+    "
+    );
+    let lock = fs_err::read(context.temp_dir.child("uv.lock"))?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("--output-format")
+            .arg("json")
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": false,
+      "packages": [
+        "bar"
+      ],
+      "declarations": [
+        {
+          "member": "project",
+          "package": "bar",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "bar==1",
+          "new_requirement": "bar==2.0.0",
+          "resolved_versions": [
+            "2.0.0"
+          ],
+          "status": "changed"
+        }
+      ],
+      "lock_changes": [
+        {
+          "action": "update",
+          "package": "bar",
+          "previous_versions": [
+            {
+              "version": "1.0.0"
+            }
+          ],
+          "current_versions": [
+            {
+              "version": "2.0.0"
+            }
+          ]
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
+    "#
+    );
+
+    assert_eq!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        pyproject_toml.replace("bar==1", "bar==2.0.0")
+    );
+    assert_eq!(fs_err::read(context.temp_dir.child("uv.lock"))?, lock);
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
 }
 
 #[test]
@@ -4159,6 +4647,18 @@ fn upgrade_workspace_json_reports_member_locations_without_mutation() -> Result<
           ],
           "status": "changed"
         }
+      ],
+      "lock_changes": [
+        {
+          "action": "add",
+          "package": "foo",
+          "previous_versions": [],
+          "current_versions": [
+            {
+              "version": "2.0.0"
+            }
+          ]
+        }
       ]
     }
 
@@ -4266,6 +4766,195 @@ fn upgrade_all_packages_skips_inapplicable_member_and_updates_other() -> Result<
     assert!(!context.temp_dir.child("uv.lock").exists());
     assert!(!context.temp_dir.child(".venv").exists());
     Ok(())
+}
+
+#[test]
+fn upgrade_workspace_json_reports_skipped_requirement_without_lock_change() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let workspace_pyproject_toml = format!(
+        r#"
+        [tool.uv.workspace]
+        members = ["member-a", "member-b"]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&workspace_pyproject_toml)?;
+
+    let member_a = context.temp_dir.child("member-a");
+    member_a.create_dir_all()?;
+    let member_a_pyproject_toml = r#"
+        [project]
+        name = "member-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["foo @ https://user:secret@example.com/foo-1.0.0-py3-none-any.whl?token=secret ; python_version < '3.12'"]
+    "#;
+    member_a
+        .child("pyproject.toml")
+        .write_str(member_a_pyproject_toml)?;
+
+    let member_b = context.temp_dir.child("member-b");
+    member_b.create_dir_all()?;
+    let member_b_pyproject_toml = r#"
+        [project]
+        name = "member-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["bar<2"]
+    "#;
+    member_b
+        .child("pyproject.toml")
+        .write_str(member_b_pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("--all-packages")
+            .arg("--dry-run")
+            .arg("--output-format")
+            .arg("json")
+            .arg("foo")
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": true,
+      "packages": [
+        "foo",
+        "bar"
+      ],
+      "declarations": [
+        {
+          "member": "member-a",
+          "package": "foo",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "foo @ https://user:****@example.com/foo-1.0.0-py3-none-any.whl ; python_full_version < '3.12'",
+          "status": "skipped",
+          "reason": {
+            "code": "environment_or_python_requirement",
+            "message": "excluded by the project's environments or Python requirement"
+          }
+        },
+        {
+          "member": "member-b",
+          "package": "bar",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "bar<2",
+          "new_requirement": "bar<3",
+          "resolved_versions": [
+            "2.0.0"
+          ],
+          "status": "changed"
+        }
+      ],
+      "lock_changes": [
+        {
+          "action": "add",
+          "package": "bar",
+          "previous_versions": [],
+          "current_versions": [
+            {
+              "version": "2.0.0"
+            }
+          ]
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    warning: Skipping dependency `foo` in package `member-a` `project.dependencies`: `foo @ https://user:****@example.com/foo-1.0.0-py3-none-any.whl ; python_full_version < '3.12'` (excluded by the project's environments or Python requirement)
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 3 packages in [TIME]
+    "#
+    );
+
+    assert_project_unchanged(&context, &workspace_pyproject_toml)?;
+    assert_eq!(
+        fs_err::read_to_string(member_a.child("pyproject.toml"))?,
+        member_a_pyproject_toml
+    );
+    assert_eq!(
+        fs_err::read_to_string(member_b.child("pyproject.toml"))?,
+        member_b_pyproject_toml
+    );
+    Ok(())
+}
+
+#[test]
+fn upgrade_json_reports_all_skipped_requirements() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]);
+    let pyproject_toml = r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        dependencies = ["foo>=1 ; extra == 'does-not-exist'"]
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .upgrade()
+            .arg("--dry-run")
+            .arg("--output-format")
+            .arg("json")
+            .arg("foo"),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": true,
+      "packages": [
+        "foo"
+      ],
+      "declarations": [
+        {
+          "member": "example",
+          "package": "foo",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "foo>=1 ; extra == 'does-not-exist'",
+          "status": "skipped",
+          "reason": {
+            "code": "undefined_extra",
+            "message": "references an extra that the project does not provide"
+          }
+        }
+      ],
+      "lock_changes": []
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    warning: Skipping dependency `foo` in `project.dependencies`: `foo>=1 ; extra == 'does-not-exist'` (references an extra that the project does not provide)
+    "#
+    );
+
+    assert_project_unchanged(&context, pyproject_toml)
 }
 
 #[test]

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -70,9 +70,12 @@ fn upgrade_help() {
       [PACKAGES]...  The packages to upgrade
 
     Options:
-          --exclude <EXCLUDE>  Exclude the named package from upgrades
-          --all-packages       Upgrade dependencies in all workspace members
-          --package <PACKAGE>  Upgrade dependencies in a specific package in the workspace
+          --exclude <EXCLUDE>              Exclude the named package from upgrades
+          --all-packages                   Upgrade dependencies in all workspace members
+          --package <PACKAGE>              Upgrade dependencies in a specific package in the workspace
+          --dry-run                        Perform a dry run, without writing the project manifest
+          --output-format <OUTPUT_FORMAT>  Select the output format [default: text] [possible values:
+                                           text, json]
 
     Cache options:
       -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary
@@ -164,6 +167,167 @@ exclude-newer = "2024-03-25T00:00:00Z"
     assert!(!context.temp_dir.child("uv.lock").exists());
     assert!(!context.temp_dir.child(".venv").exists());
     Ok(())
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn upgrade_dry_run_reports_changed_requirement_without_mutation() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["AnyIO>=2,<3,!=2.1 ; python_version >= '3.12'"]
+
+        [tool.uv]
+        exclude-newer = "2024-03-25T00:00:00Z"
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.upgrade().arg("--dry-run").arg("anyio"),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    Add anyio v4.3.0
+    Would update requirement: `AnyIO>=2,<3,!=2.1 ; python_version >= '3.12'` -> `anyio>=2,!=2.1,<5 ; python_full_version >= '3.12'`
+    "
+    );
+
+    assert_project_unchanged(&context, pyproject_toml)
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn upgrade_dry_run_outputs_json_without_mutation() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["AnyIO>=2,<3,!=2.1 ; python_version >= '3.12'"]
+
+        [tool.uv]
+        exclude-newer = "2024-03-25T00:00:00Z"
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .upgrade()
+            .arg("--dry-run")
+            .arg("--output-format")
+            .arg("json")
+            .arg("anyio"),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": true,
+      "packages": [
+        "anyio"
+      ],
+      "declarations": [
+        {
+          "member": "example",
+          "package": "anyio",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "AnyIO>=2,<3,!=2.1 ; python_version >= '3.12'",
+          "new_requirement": "anyio>=2,!=2.1,<5 ; python_full_version >= '3.12'",
+          "resolved_versions": [
+            "4.3.0"
+          ],
+          "status": "changed"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    "#
+    );
+
+    assert_project_unchanged(&context, pyproject_toml)
+}
+
+#[test]
+#[cfg(feature = "test-pypi")]
+fn upgrade_quiet_json_reports_unchanged_declaration() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio>=2"]
+
+        [tool.uv]
+        exclude-newer = "2024-03-25T00:00:00Z"
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .upgrade()
+            .arg("--quiet")
+            .arg("--output-format")
+            .arg("json")
+            .arg("anyio"),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": false,
+      "packages": [
+        "anyio"
+      ],
+      "declarations": [
+        {
+          "member": "example",
+          "package": "anyio",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "anyio>=2",
+          "resolved_versions": [
+            "4.3.0"
+          ],
+          "status": "unchanged"
+        }
+      ]
+    }
+
+    "#
+    );
+
+    assert_project_unchanged(&context, pyproject_toml)
 }
 
 #[test]
@@ -1519,6 +1683,107 @@ fn upgrade_updates_safe_declarations_and_warns_for_blocked_declarations() -> Res
     assert!(!context.temp_dir.child("uv.lock").exists());
     assert!(!context.temp_dir.child(".venv").exists());
     Ok(())
+}
+
+#[test]
+fn upgrade_json_reports_partial_blocked_outcome() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/upgrade-outcomes.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "foo==1",
+            "bar>=1 ; extra == 'cpu'",
+            "baz<2",
+        ]
+
+        [project.optional-dependencies]
+        cpu = []
+        gpu = []
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ extra = "cpu" }},
+                {{ extra = "gpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("--dry-run")
+            .arg("--output-format")
+            .arg("json")
+            .arg("bar")
+            .arg("baz")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": true,
+      "packages": [
+        "bar",
+        "baz"
+      ],
+      "declarations": [
+        {
+          "member": "example",
+          "package": "bar",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "bar>=1 ; extra == 'cpu'",
+          "status": "blocked",
+          "reason": {
+            "code": "conflict_extra",
+            "message": "declared under conflicting extra `cpu`"
+          }
+        },
+        {
+          "member": "example",
+          "package": "baz",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "baz<2",
+          "new_requirement": "baz<3",
+          "resolved_versions": [
+            "2.0.0"
+          ],
+          "status": "changed"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 5 packages in [TIME]
+    warning: Could not update dependency `bar` in `project.dependencies`: `bar>=1 ; extra == 'cpu'` (declared under conflicting extra `cpu`)
+    "#
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
 }
 
 #[test]
@@ -3070,6 +3335,77 @@ fn upgrade_redacts_malformed_direct_url_optional_and_group_dependencies() -> Res
 }
 
 #[test]
+fn upgrade_json_preview_feature_suppresses_warning() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["bar<2"]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("--preview-features")
+            .arg("json-output")
+            .arg("--dry-run")
+            .arg("--output-format")
+            .arg("json")
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": true,
+      "packages": [
+        "bar"
+      ],
+      "declarations": [
+        {
+          "member": "project",
+          "package": "bar",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "bar<2",
+          "new_requirement": "bar<3",
+          "resolved_versions": [
+            "2.0.0"
+          ],
+          "status": "changed"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
+    "#
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
 fn upgrade_rejects_workspace_root_non_registry_source() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let workspace_pyproject_toml = r#"
@@ -3716,6 +4052,130 @@ fn upgrade_without_package_skips_current_workspace_member_self_reference() -> Re
     assert_eq!(
         fs_err::read_to_string(member_a.child("pyproject.toml"))?,
         member_a_pyproject_toml.replace("foo==1", "foo==2.0.0")
+    );
+    assert_eq!(
+        fs_err::read_to_string(member_b.child("pyproject.toml"))?,
+        member_b_pyproject_toml
+    );
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    assert!(!member_a.child("uv.lock").exists());
+    assert!(!member_a.child(".venv").exists());
+    assert!(!member_b.child("uv.lock").exists());
+    assert!(!member_b.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
+fn upgrade_workspace_json_reports_member_locations_without_mutation() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let workspace_pyproject_toml = format!(
+        r#"
+        [tool.uv.workspace]
+        members = ["member-a", "member-b"]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&workspace_pyproject_toml)?;
+
+    let member_a = context.temp_dir.child("member-a");
+    member_a.create_dir_all()?;
+    let member_a_pyproject_toml = r#"
+        [project]
+        name = "member-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["foo==1"]
+    "#;
+    member_a
+        .child("pyproject.toml")
+        .write_str(member_a_pyproject_toml)?;
+
+    let member_b = context.temp_dir.child("member-b");
+    member_b.create_dir_all()?;
+    let member_b_pyproject_toml = r#"
+        [project]
+        name = "member-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["foo==1"]
+    "#;
+    member_b
+        .child("pyproject.toml")
+        .write_str(member_b_pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("--all-packages")
+            .arg("--dry-run")
+            .arg("--output-format")
+            .arg("json")
+            .arg("foo")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "dry_run": true,
+      "packages": [
+        "foo"
+      ],
+      "declarations": [
+        {
+          "member": "member-a",
+          "package": "foo",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "foo==1",
+          "new_requirement": "foo==2.0.0",
+          "resolved_versions": [
+            "2.0.0"
+          ],
+          "status": "changed"
+        },
+        {
+          "member": "member-b",
+          "package": "foo",
+          "dependency_type": "production",
+          "location": "project.dependencies",
+          "original_requirement": "foo==1",
+          "new_requirement": "foo==2.0.0",
+          "resolved_versions": [
+            "2.0.0"
+          ],
+          "status": "changed"
+        }
+      ]
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    "#
+    );
+
+    assert_eq!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        workspace_pyproject_toml
+    );
+    assert_eq!(
+        fs_err::read_to_string(member_a.child("pyproject.toml"))?,
+        member_a_pyproject_toml
     );
     assert_eq!(
         fs_err::read_to_string(member_b.child("pyproject.toml"))?,


### PR DESCRIPTION
`uv upgrade` currently writes changed requirements immediately and only reports text output. That makes it difficult to preview an upgrade or consume its result programmatically.

This adds `--dry-run` and preview `--output-format json`. The report identifies each declaration and workspace member, its location, resolved versions, changed/unchanged/blocked/skipped status, and the applicable reason. Lock changes are limited to packages with an applicable declaration. Dry runs leave `pyproject.toml`, the lockfile, and the environment unchanged.

URL credentials and query parameters are redacted from warnings and JSON output. Mixed outcomes update safe declarations where possible, while an unrepresentable requirement prevents writes that would leave the manifest inconsistent with the resolution.