### PR TITLE
Guard `uv upgrade` conflict attribution

### DIFF
--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -18,8 +18,8 @@ use uv_pep440::{Operator, Version, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{MarkerTree, Pep508ErrorSource, Requirement, VerbatimUrl, VersionOrUrl};
 use uv_preview::{Preview, PreviewFeature};
 use uv_pypi_types::{
-    DependencyGroupSpecifier, PyProjectToml, ResolutionMetadata, SupportedEnvironments,
-    VerbatimParsedUrl,
+    ConflictKindRef, Conflicts, DependencyGroupSpecifier, PyProjectToml, ResolutionMetadata,
+    SupportedEnvironments, VerbatimParsedUrl,
 };
 use uv_python::{ConfigDiscovery, Interpreter, PythonDownloads, PythonPreference};
 use uv_redacted::DisplaySafeUrl;
@@ -132,6 +132,7 @@ enum DeclarationOutcome {
 
 enum BlockedReason {
     UnrepresentableRequirement(ProposeRequirementError),
+    ConflictProject,
     ConflictExtra { extra: String },
     ConflictGroup { group: String },
 }
@@ -240,6 +241,7 @@ struct UpgradeLockVersionReport {
 #[serde(rename_all = "snake_case")]
 enum UpgradeReasonCode {
     UnrepresentableRequirement,
+    ConflictProject,
     ConflictExtra,
     ConflictGroup,
     EnvironmentOrPythonRequirement,
@@ -449,6 +451,7 @@ impl BlockedReason {
     fn code(&self) -> UpgradeReasonCode {
         match self {
             Self::UnrepresentableRequirement(_) => UpgradeReasonCode::UnrepresentableRequirement,
+            Self::ConflictProject => UpgradeReasonCode::ConflictProject,
             Self::ConflictExtra { .. } => UpgradeReasonCode::ConflictExtra,
             Self::ConflictGroup { .. } => UpgradeReasonCode::ConflictGroup,
         }
@@ -457,6 +460,7 @@ impl BlockedReason {
     fn message(&self) -> String {
         match self {
             Self::UnrepresentableRequirement(error) => error.to_string(),
+            Self::ConflictProject => "declared under conflicting project".to_string(),
             Self::ConflictExtra { extra } => {
                 format!("declared under conflicting extra `{extra}`")
             }
@@ -677,39 +681,10 @@ pub(crate) async fn upgrade(
     let mut requirements = requirements
         .into_iter()
         .filter_map(|selected| {
-            let blocked_reason =
-                selected
-                    .contexts
-                    .iter()
-                    .find_map(|context| match &context.dependency_type {
-                        DependencyType::Production => context
-                            .marker
-                            .top_level_extra_name()
-                            .map(std::borrow::Cow::into_owned)
-                            .filter(|extra| conflicts.contains(&selected.member, extra))
-                            .map(|extra| BlockedReason::ConflictExtra {
-                                extra: extra.to_string(),
-                            }),
-                        DependencyType::Optional(extra) => {
-                            if conflicts.contains(&selected.member, extra) {
-                                Some(BlockedReason::ConflictExtra {
-                                    extra: extra.to_string(),
-                                })
-                            } else {
-                                None
-                            }
-                        }
-                        DependencyType::Group(group) => {
-                            if conflicts.contains(&selected.member, group) {
-                                Some(BlockedReason::ConflictGroup {
-                                    group: group.to_string(),
-                                })
-                            } else {
-                                None
-                            }
-                        }
-                        DependencyType::Dev => None,
-                    });
+            let blocked_reason = selected
+                .contexts
+                .iter()
+                .find_map(|context| conflict_blocked_reason(&selected.member, context, &conflicts));
             if let Some(reason) = blocked_reason {
                 declaration_outcomes.push(DeclarationOutcome::Blocked {
                     declaration: selected.identity(),
@@ -1865,6 +1840,62 @@ fn apply_requirement_replacements<'a>(
         applied.push((dependency_type, existing, replacement));
     }
     Ok(())
+}
+
+/// Return the conflict that prevents attributing a resolved version to a declaration context.
+fn conflict_blocked_reason(
+    member: &PackageName,
+    context: &DeclarationContext,
+    conflicts: &Conflicts,
+) -> Option<BlockedReason> {
+    match &context.dependency_type {
+        DependencyType::Production => {
+            if conflicts.contains(member, ConflictKindRef::Project) {
+                return Some(BlockedReason::ConflictProject);
+            }
+
+            marker_conflict_extra_blocked_reason(member, context.marker, conflicts)
+        }
+        DependencyType::Optional(extra) => {
+            if conflicts.contains(member, extra) {
+                return Some(BlockedReason::ConflictExtra {
+                    extra: extra.to_string(),
+                });
+            }
+
+            marker_conflict_extra_blocked_reason(member, context.marker, conflicts)
+        }
+        DependencyType::Group(group) => {
+            if conflicts.contains(member, group) {
+                return Some(BlockedReason::ConflictGroup {
+                    group: group.to_string(),
+                });
+            }
+
+            marker_conflict_extra_blocked_reason(member, context.marker, conflicts)
+        }
+        DependencyType::Dev => None,
+    }
+}
+
+/// Return a conflict for an explicit `extra` marker on a declaration.
+fn marker_conflict_extra_blocked_reason(
+    member: &PackageName,
+    marker: MarkerTree,
+    conflicts: &Conflicts,
+) -> Option<BlockedReason> {
+    let mut extras = BTreeSet::new();
+    marker.visit_extras(|_, extra| {
+        if conflicts.contains(member, extra) {
+            extras.insert(extra.clone());
+        }
+    });
+    extras
+        .into_iter()
+        .next()
+        .map(|extra| BlockedReason::ConflictExtra {
+            extra: extra.to_string(),
+        })
 }
 
 /// Return whether a source applies to the selected requirement declaration.

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -537,6 +537,318 @@ fn upgrade_rejects_conflicting_extra_declarations() -> Result<()> {
 }
 
 #[test]
+fn upgrade_rejects_conflicting_project_declarations() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["bar<2", "foo==1"]
+
+        [project.optional-dependencies]
+        cpu = []
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ package = "project" }},
+                {{ extra = "cpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Could not update dependency `bar` in `project.dependencies`: `bar<2` (declared under conflicting project)
+    "
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
+fn upgrade_rejects_conflicting_extra_declaration_with_compound_negated_marker() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "bar<2 ; extra == 'cpu' and extra != 'gpu'",
+            "foo==1",
+        ]
+
+        [project.optional-dependencies]
+        cpu = []
+        gpu = []
+        tpu = []
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ extra = "gpu" }},
+                {{ extra = "tpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Could not update dependency `bar` in `project.dependencies`: `bar<2 ; extra == 'cpu' and extra != 'gpu'` (declared under conflicting extra `gpu`)
+    "
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
+fn upgrade_rejects_optional_declaration_with_conflicting_extra_marker() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["foo==1"]
+
+        [project.optional-dependencies]
+        cpu = ["bar<2 ; extra != 'gpu'"]
+        gpu = []
+        tpu = []
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ extra = "gpu" }},
+                {{ extra = "tpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Could not update dependency `bar` in `project.optional-dependencies.cpu`: `bar<2 ; extra != 'gpu'` (declared under conflicting extra `gpu`)
+    "
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
+fn upgrade_rejects_group_declaration_with_conflicting_extra_marker() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["foo==1"]
+
+        [project.optional-dependencies]
+        gpu = []
+        tpu = []
+
+        [dependency-groups]
+        dev = ["bar<2 ; extra != 'gpu'"]
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ extra = "gpu" }},
+                {{ extra = "tpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Could not update dependency `bar` in `dependency-groups.dev`: `bar<2 ; extra != 'gpu'` (declared under conflicting extra `gpu`)
+    "
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
+fn upgrade_project_conflict_does_not_block_optional_or_group_declarations() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("fork/upgrade-outcomes.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [project.optional-dependencies]
+        cpu = []
+        test = ["bar<2"]
+
+        [dependency-groups]
+        dev = ["baz<2"]
+
+        [tool.uv]
+        conflicts = [
+            [
+                {{ package = "project" }},
+                {{ extra = "cpu" }},
+            ],
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .arg("baz")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
+        @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    warning: Declaring conflicts for packages (`package = ...`) is experimental and may change without warning. Pass `--preview-features package-conflicts` to disable this warning.
+    Resolved 3 packages in [TIME]
+    Add bar v2.0.0
+    Add baz v2.0.0
+    Updated requirement: `bar<2` -> `bar<3`
+    Updated requirement: `baz<2` -> `baz<3`
+    "
+    );
+
+    let updated_pyproject_toml = fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?;
+    insta::with_settings!({ filters => packse_filters(&context) }, {
+        insta::assert_snapshot!(
+            updated_pyproject_toml,
+            @r#"
+
+[project]
+name = "project"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = []
+
+[project.optional-dependencies]
+cpu = []
+test = ["bar<3"]
+
+[dependency-groups]
+dev = ["baz<3"]
+
+[tool.uv]
+conflicts = [
+    [
+        { package = "project" },
+        { extra = "cpu" },
+    ],
+]
+
+[[tool.uv.index]]
+url = "http://[LOCALHOST]/simple/"
+default = true
+"#
+        );
+    });
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
 fn upgrade_rejects_conflicting_included_group_declarations() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let pyproject_toml = r#"


### PR DESCRIPTION
Universal lockfiles can contain forks created by conflicting projects, extras, or dependency groups. Projecting those forks onto ordinary PEP 508 markers can make a version from one conflicting branch appear applicable to an unrelated declaration, causing `uv upgrade` to rewrite the wrong requirement.

This blocks attribution for declarations under a conflicting project, extra, or group, including explicit and compound extra markers and included dependency groups. The affected declaration remains unchanged with a precise warning while other safe declarations can still be upgraded. Conflicts belonging to another declaration or workspace member do not block unrelated optional or group dependencies.