### PR TITLE
Bump version to 0.11.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 <!-- prettier-ignore-start -->
 
 
+## 0.11.31
+
+Released on 2026-07-21.
+
+### Security
+
+- Update `open` to 5.4.0 to avoid vulnerable launcher behavior ([#20584](https://github.com/astral-sh/uv/pull/20584))
+- Update `reqsign` to 0.20.2 and `quick-xml` to 0.41.0 ([#20583](https://github.com/astral-sh/uv/pull/20583))
+
+### Enhancements
+
+- Allow workspace sources to reference members in another workspace by path ([#18401](https://github.com/astral-sh/uv/pull/18401))
+- Support `.venv` files containing paths to centralized project environments ([#20022](https://github.com/astral-sh/uv/pull/20022))
+- Update bundled Windows timezone data to IANA 2026c ([#20554](https://github.com/astral-sh/uv/pull/20554))
+
+### Preview features
+
+- Add an index-specific `hash-algorithm` setting for lockfile generation ([#20605](https://github.com/astral-sh/uv/pull/20605))
+
+### Configuration
+
+- Add `audit.malware-check` and `audit.malware-check-url` settings ([#20587](https://github.com/astral-sh/uv/pull/20587))
+
+### Performance
+
+- Avoid quadratic work when deduplicating transitive conflicts ([#20578](https://github.com/astral-sh/uv/pull/20578))
+
+### Bug fixes
+
+- Suggest `--emit-build-options` for unsupported `uv pip compile --emit-options` ([#20582](https://github.com/astral-sh/uv/pull/20582))
+- Reject source distributions and wheels with mismatched package names ([#20432](https://github.com/astral-sh/uv/pull/20432))
+- Avoid retrying TLS certificate verification failures ([#16245](https://github.com/astral-sh/uv/pull/16245))
+- Avoid warnings about `uv_build` settings for in-tree build backends ([#20153](https://github.com/astral-sh/uv/pull/20153))
+
 ## 0.11.30
 
 Released on 2026-07-20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@
 
 Released on 2026-07-21.
 
-### Security
-
-- Update `open` to 5.4.0 to avoid vulnerable launcher behavior ([#20584](https://github.com/astral-sh/uv/pull/20584))
-- Update `reqsign` to 0.20.2 and `quick-xml` to 0.41.0 ([#20583](https://github.com/astral-sh/uv/pull/20583))
-
 ### Enhancements
 
 - Allow workspace sources to reference members in another workspace by path ([#18401](https://github.com/astral-sh/uv/pull/18401))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5770,7 +5770,7 @@ dependencies = [
 
 [[package]]
 name = "uv"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anstream",
  "anyhow",
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "uv-audit"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "astral-reqwest-middleware",
  "clap",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "uv-bench"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "uv-bin-install"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -6038,7 +6038,7 @@ dependencies = [
 
 [[package]]
 name = "uv-build"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "astral-tokio-tar",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "fs-err",
@@ -6140,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "clap",
  "fs-err",
@@ -6166,7 +6166,7 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -6183,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "hex",
  "memchr",
@@ -6195,7 +6195,7 @@ dependencies = [
 
 [[package]]
 name = "uv-cli"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -6302,7 +6302,7 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "clap",
@@ -6336,14 +6336,14 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dev"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6397,7 +6397,7 @@ dependencies = [
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "assert_fs",
  "etcetera",
@@ -6409,7 +6409,7 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "futures",
@@ -6443,7 +6443,7 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "insta",
  "memchr",
@@ -6512,7 +6512,7 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -6553,7 +6553,7 @@ dependencies = [
 
 [[package]]
 name = "uv-errors"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "uv-fastid"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "rand 0.9.4",
  "serde",
@@ -6606,14 +6606,14 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "backon",
  "clap",
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "percent-encoding",
  "serde",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "fs-err",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6738,7 +6738,7 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "anyhow",
@@ -6782,7 +6782,7 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6798,7 +6798,7 @@ dependencies = [
 
 [[package]]
 name = "uv-logging"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "jiff",
@@ -6809,7 +6809,7 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6819,7 +6819,7 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "uv-netrc"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "fs-err",
  "shellexpand",
@@ -6845,7 +6845,7 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "rkyv",
  "schemars",
@@ -6855,7 +6855,7 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "futures",
  "papaya",
@@ -6864,14 +6864,14 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "astral-version-ranges",
  "indoc",
@@ -6885,7 +6885,7 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -6915,7 +6915,7 @@ dependencies = [
 
 [[package]]
 name = "uv-performance-memory-allocator"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "mimalloc",
  "tikv-jemallocator",
@@ -6923,7 +6923,7 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "fs-err",
  "goblin",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "bitflags 2.13.0",
  "insta",
@@ -6958,7 +6958,7 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -6971,7 +6971,7 @@ dependencies = [
 
 [[package]]
 name = "uv-publish"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "ambient-id",
  "anstream",
@@ -7014,7 +7014,7 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -7047,7 +7047,7 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "ref-cast",
  "schemars",
@@ -7122,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "configparser",
@@ -7156,7 +7156,7 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -7189,7 +7189,7 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -7258,7 +7258,7 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "fs-err",
  "indoc",
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "clap",
  "fs-err",
@@ -7322,7 +7322,7 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -7339,7 +7339,7 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -7349,7 +7349,7 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "tempfile",
  "uv-dirs",
@@ -7357,7 +7357,7 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "thiserror",
  "uv-macros",
@@ -7365,7 +7365,7 @@ dependencies = [
 
 [[package]]
 name = "uv-test"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7410,7 +7410,7 @@ dependencies = [
 
 [[package]]
 name = "uv-toml"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "serde",
  "toml_datetime",
@@ -7419,7 +7419,7 @@ dependencies = [
 
 [[package]]
 name = "uv-tool"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "fs-err",
  "owo-colors",
@@ -7449,7 +7449,7 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "clap",
  "either",
@@ -7469,7 +7469,7 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -7488,7 +7488,7 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "papaya",
@@ -7511,7 +7511,7 @@ dependencies = [
 
 [[package]]
 name = "uv-unix"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "nix 0.31.3",
  "thiserror",
@@ -7519,11 +7519,11 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.30"
+version = "0.11.31"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "console",
  "fs-err",
@@ -7546,7 +7546,7 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anstream",
  "anyhow",
@@ -7558,7 +7558,7 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "arrayvec",
  "windows",
@@ -7566,7 +7566,7 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,82 +16,82 @@ authors = ["uv"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-uv = { version = "0.11.30", path = "crates/uv", default-features = false }
-uv-audit = { version = "0.0.63", path = "crates/uv-audit" }
-uv-auth = { version = "0.0.63", path = "crates/uv-auth" }
-uv-bin-install = { version = "0.0.63", path = "crates/uv-bin-install" }
-uv-build-backend = { version = "0.0.63", path = "crates/uv-build-backend" }
-uv-build-frontend = { version = "0.0.63", path = "crates/uv-build-frontend" }
-uv-cache = { version = "0.0.63", path = "crates/uv-cache" }
-uv-cache-info = { version = "0.0.63", path = "crates/uv-cache-info" }
-uv-cache-key = { version = "0.0.63", path = "crates/uv-cache-key" }
-uv-cli = { version = "0.0.63", path = "crates/uv-cli" }
-uv-client = { version = "0.0.63", path = "crates/uv-client" }
-uv-configuration = { version = "0.0.63", path = "crates/uv-configuration" }
-uv-console = { version = "0.0.63", path = "crates/uv-console" }
-uv-dirs = { version = "0.0.63", path = "crates/uv-dirs" }
-uv-dispatch = { version = "0.0.63", path = "crates/uv-dispatch" }
-uv-distribution = { version = "0.0.63", path = "crates/uv-distribution" }
-uv-distribution-filename = { version = "0.0.63", path = "crates/uv-distribution-filename" }
-uv-distribution-types = { version = "0.0.63", path = "crates/uv-distribution-types" }
-uv-errors = { version = "0.0.63", path = "crates/uv-errors" }
-uv-extract = { version = "0.0.63", path = "crates/uv-extract" }
-uv-fastid = { version = "0.0.63", path = "crates/uv-fastid" }
-uv-flags = { version = "0.0.63", path = "crates/uv-flags" }
-uv-fs = { version = "0.0.63", path = "crates/uv-fs", features = [
+uv = { version = "0.11.31", path = "crates/uv", default-features = false }
+uv-audit = { version = "0.0.64", path = "crates/uv-audit" }
+uv-auth = { version = "0.0.64", path = "crates/uv-auth" }
+uv-bin-install = { version = "0.0.64", path = "crates/uv-bin-install" }
+uv-build-backend = { version = "0.0.64", path = "crates/uv-build-backend" }
+uv-build-frontend = { version = "0.0.64", path = "crates/uv-build-frontend" }
+uv-cache = { version = "0.0.64", path = "crates/uv-cache" }
+uv-cache-info = { version = "0.0.64", path = "crates/uv-cache-info" }
+uv-cache-key = { version = "0.0.64", path = "crates/uv-cache-key" }
+uv-cli = { version = "0.0.64", path = "crates/uv-cli" }
+uv-client = { version = "0.0.64", path = "crates/uv-client" }
+uv-configuration = { version = "0.0.64", path = "crates/uv-configuration" }
+uv-console = { version = "0.0.64", path = "crates/uv-console" }
+uv-dirs = { version = "0.0.64", path = "crates/uv-dirs" }
+uv-dispatch = { version = "0.0.64", path = "crates/uv-dispatch" }
+uv-distribution = { version = "0.0.64", path = "crates/uv-distribution" }
+uv-distribution-filename = { version = "0.0.64", path = "crates/uv-distribution-filename" }
+uv-distribution-types = { version = "0.0.64", path = "crates/uv-distribution-types" }
+uv-errors = { version = "0.0.64", path = "crates/uv-errors" }
+uv-extract = { version = "0.0.64", path = "crates/uv-extract" }
+uv-fastid = { version = "0.0.64", path = "crates/uv-fastid" }
+uv-flags = { version = "0.0.64", path = "crates/uv-flags" }
+uv-fs = { version = "0.0.64", path = "crates/uv-fs", features = [
   "serde",
   "tokio",
 ] }
-uv-git = { version = "0.0.63", path = "crates/uv-git" }
-uv-git-types = { version = "0.0.63", path = "crates/uv-git-types" }
-uv-globfilter = { version = "0.0.63", path = "crates/uv-globfilter" }
-uv-install-wheel = { version = "0.0.63", path = "crates/uv-install-wheel", default-features = false }
-uv-installer = { version = "0.0.63", path = "crates/uv-installer" }
-uv-keyring = { version = "0.0.63", path = "crates/uv-keyring" }
-uv-logging = { version = "0.0.63", path = "crates/uv-logging" }
-uv-macros = { version = "0.0.63", path = "crates/uv-macros" }
-uv-metadata = { version = "0.0.63", path = "crates/uv-metadata" }
-uv-netrc = { version = "0.0.63", path = "crates/uv-netrc" }
-uv-normalize = { version = "0.0.63", path = "crates/uv-normalize" }
-uv-once-map = { version = "0.0.63", path = "crates/uv-once-map" }
-uv-options-metadata = { version = "0.0.63", path = "crates/uv-options-metadata" }
-uv-performance-memory-allocator = { version = "0.0.63", path = "crates/uv-performance-memory-allocator" }
-uv-pep440 = { version = "0.0.63", path = "crates/uv-pep440", features = [
+uv-git = { version = "0.0.64", path = "crates/uv-git" }
+uv-git-types = { version = "0.0.64", path = "crates/uv-git-types" }
+uv-globfilter = { version = "0.0.64", path = "crates/uv-globfilter" }
+uv-install-wheel = { version = "0.0.64", path = "crates/uv-install-wheel", default-features = false }
+uv-installer = { version = "0.0.64", path = "crates/uv-installer" }
+uv-keyring = { version = "0.0.64", path = "crates/uv-keyring" }
+uv-logging = { version = "0.0.64", path = "crates/uv-logging" }
+uv-macros = { version = "0.0.64", path = "crates/uv-macros" }
+uv-metadata = { version = "0.0.64", path = "crates/uv-metadata" }
+uv-netrc = { version = "0.0.64", path = "crates/uv-netrc" }
+uv-normalize = { version = "0.0.64", path = "crates/uv-normalize" }
+uv-once-map = { version = "0.0.64", path = "crates/uv-once-map" }
+uv-options-metadata = { version = "0.0.64", path = "crates/uv-options-metadata" }
+uv-performance-memory-allocator = { version = "0.0.64", path = "crates/uv-performance-memory-allocator" }
+uv-pep440 = { version = "0.0.64", path = "crates/uv-pep440", features = [
   "tracing",
   "rkyv",
   "version-ranges",
 ] }
-uv-pep508 = { version = "0.0.63", path = "crates/uv-pep508", features = [
+uv-pep508 = { version = "0.0.64", path = "crates/uv-pep508", features = [
   "non-pep508-extensions",
 ] }
-uv-platform = { version = "0.0.63", path = "crates/uv-platform" }
-uv-platform-tags = { version = "0.0.63", path = "crates/uv-platform-tags" }
-uv-preview = { version = "0.0.63", path = "crates/uv-preview" }
-uv-publish = { version = "0.0.63", path = "crates/uv-publish" }
-uv-pypi-types = { version = "0.0.63", path = "crates/uv-pypi-types" }
-uv-python = { version = "0.0.63", path = "crates/uv-python" }
-uv-redacted = { version = "0.0.63", path = "crates/uv-redacted" }
-uv-requirements = { version = "0.0.63", path = "crates/uv-requirements" }
-uv-requirements-txt = { version = "0.0.63", path = "crates/uv-requirements-txt" }
-uv-resolver = { version = "0.0.63", path = "crates/uv-resolver" }
-uv-scripts = { version = "0.0.63", path = "crates/uv-scripts" }
-uv-settings = { version = "0.0.63", path = "crates/uv-settings" }
-uv-shell = { version = "0.0.63", path = "crates/uv-shell" }
-uv-small-str = { version = "0.0.63", path = "crates/uv-small-str" }
-uv-state = { version = "0.0.63", path = "crates/uv-state" }
-uv-static = { version = "0.0.63", path = "crates/uv-static" }
-uv-test = { version = "0.0.63", path = "crates/uv-test" }
-uv-toml = { version = "0.0.63", path = "crates/uv-toml" }
-uv-tool = { version = "0.0.63", path = "crates/uv-tool" }
-uv-torch = { version = "0.0.63", path = "crates/uv-torch" }
-uv-trampoline-builder = { version = "0.0.63", path = "crates/uv-trampoline-builder" }
-uv-types = { version = "0.0.63", path = "crates/uv-types" }
-uv-unix = { version = "0.0.63", path = "crates/uv-unix" }
-uv-version = { version = "0.11.30", path = "crates/uv-version" }
-uv-virtualenv = { version = "0.0.63", path = "crates/uv-virtualenv" }
-uv-warnings = { version = "0.0.63", path = "crates/uv-warnings" }
-uv-windows = { version = "0.0.63", path = "crates/uv-windows" }
-uv-workspace = { version = "0.0.63", path = "crates/uv-workspace" }
+uv-platform = { version = "0.0.64", path = "crates/uv-platform" }
+uv-platform-tags = { version = "0.0.64", path = "crates/uv-platform-tags" }
+uv-preview = { version = "0.0.64", path = "crates/uv-preview" }
+uv-publish = { version = "0.0.64", path = "crates/uv-publish" }
+uv-pypi-types = { version = "0.0.64", path = "crates/uv-pypi-types" }
+uv-python = { version = "0.0.64", path = "crates/uv-python" }
+uv-redacted = { version = "0.0.64", path = "crates/uv-redacted" }
+uv-requirements = { version = "0.0.64", path = "crates/uv-requirements" }
+uv-requirements-txt = { version = "0.0.64", path = "crates/uv-requirements-txt" }
+uv-resolver = { version = "0.0.64", path = "crates/uv-resolver" }
+uv-scripts = { version = "0.0.64", path = "crates/uv-scripts" }
+uv-settings = { version = "0.0.64", path = "crates/uv-settings" }
+uv-shell = { version = "0.0.64", path = "crates/uv-shell" }
+uv-small-str = { version = "0.0.64", path = "crates/uv-small-str" }
+uv-state = { version = "0.0.64", path = "crates/uv-state" }
+uv-static = { version = "0.0.64", path = "crates/uv-static" }
+uv-test = { version = "0.0.64", path = "crates/uv-test" }
+uv-toml = { version = "0.0.64", path = "crates/uv-toml" }
+uv-tool = { version = "0.0.64", path = "crates/uv-tool" }
+uv-torch = { version = "0.0.64", path = "crates/uv-torch" }
+uv-trampoline-builder = { version = "0.0.64", path = "crates/uv-trampoline-builder" }
+uv-types = { version = "0.0.64", path = "crates/uv-types" }
+uv-unix = { version = "0.0.64", path = "crates/uv-unix" }
+uv-version = { version = "0.11.31", path = "crates/uv-version" }
+uv-virtualenv = { version = "0.0.64", path = "crates/uv-virtualenv" }
+uv-warnings = { version = "0.0.64", path = "crates/uv-warnings" }
+uv-windows = { version = "0.0.64", path = "crates/uv-windows" }
+uv-workspace = { version = "0.0.64", path = "crates/uv-workspace" }
 
 ambient-id = { version = "0.0.11", default-features = false, features = [
   "reqwest-middleware",

--- a/crates/uv-audit/Cargo.toml
+++ b/crates/uv-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-audit"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/uv-audit/README.md
+++ b/crates/uv-audit/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-audit).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-audit).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-auth"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-auth/README.md
+++ b/crates/uv-auth/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-auth).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-auth).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-bench"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 publish = false
 authors = { workspace = true }

--- a/crates/uv-bench/README.md
+++ b/crates/uv-bench/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-bench).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-bench).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-bin-install/Cargo.toml
+++ b/crates/uv-bin-install/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-bin-install"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-bin-install/README.md
+++ b/crates/uv-bin-install/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-bin-install).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-bin-install).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-build-backend"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-build-backend/README.md
+++ b/crates/uv-build-backend/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-build-backend).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-build-backend).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-build-frontend/Cargo.toml
+++ b/crates/uv-build-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-build-frontend"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-build-frontend/README.md
+++ b/crates/uv-build-frontend/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-build-frontend).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-build-frontend).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-build"
-version = "0.11.30"
+version = "0.11.31"
 description = "A Python build backend"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-build/pyproject.toml
+++ b/crates/uv-build/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uv-build"
-version = "0.11.30"
+version = "0.11.31"
 description = "The uv build backend"
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 requires-python = ">=3.8"

--- a/crates/uv-cache-info/Cargo.toml
+++ b/crates/uv-cache-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-cache-info"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-cache-info/README.md
+++ b/crates/uv-cache-info/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-cache-info).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-cache-info).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-cache-key/Cargo.toml
+++ b/crates/uv-cache-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-cache-key"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-cache-key/README.md
+++ b/crates/uv-cache-key/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-cache-key).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-cache-key).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-cache"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-cache/README.md
+++ b/crates/uv-cache/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-cache).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-cache).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-cli/Cargo.toml
+++ b/crates/uv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-cli"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-cli/README.md
+++ b/crates/uv-cli/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-cli).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-cli).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-client"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-client/README.md
+++ b/crates/uv-client/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-client).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-client).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-configuration"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-configuration/README.md
+++ b/crates/uv-configuration/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-configuration).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-configuration).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-console/Cargo.toml
+++ b/crates/uv-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-console"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-console/README.md
+++ b/crates/uv-console/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-console).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-console).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-dev"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 publish = false
 

--- a/crates/uv-dev/README.md
+++ b/crates/uv-dev/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-dev).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-dev).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-dirs/Cargo.toml
+++ b/crates/uv-dirs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-dirs"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-dirs/README.md
+++ b/crates/uv-dirs/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-dirs).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-dirs).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-dispatch/Cargo.toml
+++ b/crates/uv-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-dispatch"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-dispatch/README.md
+++ b/crates/uv-dispatch/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-dispatch).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-dispatch).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-distribution-filename/Cargo.toml
+++ b/crates/uv-distribution-filename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-distribution-filename"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-distribution-filename/README.md
+++ b/crates/uv-distribution-filename/README.md
@@ -5,9 +5,9 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
 source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-distribution-filename).
+[here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-distribution-filename).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-distribution-types"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-distribution-types/README.md
+++ b/crates/uv-distribution-types/README.md
@@ -5,9 +5,9 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
 source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-distribution-types).
+[here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-distribution-types).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-distribution"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-distribution/README.md
+++ b/crates/uv-distribution/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-distribution).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-distribution).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-errors/Cargo.toml
+++ b/crates/uv-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-errors"
-version = "0.0.63"
+version = "0.0.64"
 description = "Common error traits for uv."
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-errors/README.md
+++ b/crates/uv-errors/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-errors).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-errors).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-extract"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-extract/README.md
+++ b/crates/uv-extract/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-extract).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-extract).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-fastid/Cargo.toml
+++ b/crates/uv-fastid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uv-fastid"
 description = "This is an internal component crate of uv"
-version = "0.0.63"
+version = "0.0.64"
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/uv-fastid/README.md
+++ b/crates/uv-fastid/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-fastid).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-fastid).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-flags/Cargo.toml
+++ b/crates/uv-flags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-flags"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-flags/README.md
+++ b/crates/uv-flags/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-flags).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-flags).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-fs"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-fs/README.md
+++ b/crates/uv-fs/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-fs).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-fs).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-git-types/Cargo.toml
+++ b/crates/uv-git-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-git-types"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-git-types/README.md
+++ b/crates/uv-git-types/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-git-types).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-git-types).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-git/Cargo.toml
+++ b/crates/uv-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-git"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-git/README.md
+++ b/crates/uv-git/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-git).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-git).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-globfilter/Cargo.toml
+++ b/crates/uv-globfilter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-globfilter"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 readme = "README.md"
 edition = { workspace = true }

--- a/crates/uv-install-wheel/Cargo.toml
+++ b/crates/uv-install-wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-install-wheel"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 keywords = ["wheel", "python"]
 

--- a/crates/uv-install-wheel/README.md
+++ b/crates/uv-install-wheel/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-install-wheel).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-install-wheel).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-installer/Cargo.toml
+++ b/crates/uv-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-installer"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-installer/README.md
+++ b/crates/uv-installer/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-installer).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-installer).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-keyring/Cargo.toml
+++ b/crates/uv-keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-keyring"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-logging/Cargo.toml
+++ b/crates/uv-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-logging"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-logging/README.md
+++ b/crates/uv-logging/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-logging).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-logging).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-macros/Cargo.toml
+++ b/crates/uv-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-macros"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-macros/README.md
+++ b/crates/uv-macros/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-macros).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-macros).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-metadata/Cargo.toml
+++ b/crates/uv-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-metadata"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-metadata/README.md
+++ b/crates/uv-metadata/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-metadata).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-metadata).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-netrc/Cargo.toml
+++ b/crates/uv-netrc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-netrc"
-version = "0.0.63"
+version = "0.0.64"
 description = "A vendored netrc parser for uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-normalize/Cargo.toml
+++ b/crates/uv-normalize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-normalize"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-normalize/README.md
+++ b/crates/uv-normalize/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-normalize).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-normalize).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-once-map/Cargo.toml
+++ b/crates/uv-once-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-once-map"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-once-map/README.md
+++ b/crates/uv-once-map/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-once-map).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-once-map).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-options-metadata/Cargo.toml
+++ b/crates/uv-options-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-options-metadata"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-options-metadata/README.md
+++ b/crates/uv-options-metadata/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-options-metadata).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-options-metadata).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-pep440/Cargo.toml
+++ b/crates/uv-pep440/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-pep440"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 license = "Apache-2.0 OR BSD-2-Clause"
 include = ["/src", "Changelog.md", "License-Apache", "License-BSD", "Readme.md", "pyproject.toml"]

--- a/crates/uv-pep440/README.md
+++ b/crates/uv-pep440/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-pep440).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-pep440).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-pep508"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 include = ["/src", "Changelog.md", "License-Apache", "License-BSD", "Readme.md", "pyproject.toml"]
 license = "Apache-2.0 OR BSD-2-Clause"

--- a/crates/uv-pep508/README.md
+++ b/crates/uv-pep508/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-pep508).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-pep508).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-performance-memory-allocator/Cargo.toml
+++ b/crates/uv-performance-memory-allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-performance-memory-allocator"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-performance-memory-allocator/README.md
+++ b/crates/uv-performance-memory-allocator/README.md
@@ -5,9 +5,9 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
 source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-performance-memory-allocator).
+[here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-performance-memory-allocator).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-platform-tags/Cargo.toml
+++ b/crates/uv-platform-tags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-platform-tags"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-platform-tags/README.md
+++ b/crates/uv-platform-tags/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-platform-tags).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-platform-tags).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-platform/Cargo.toml
+++ b/crates/uv-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-platform"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-platform/README.md
+++ b/crates/uv-platform/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-platform).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-platform).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-preview/Cargo.toml
+++ b/crates/uv-preview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-preview"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-preview/README.md
+++ b/crates/uv-preview/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-preview).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-preview).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-publish/Cargo.toml
+++ b/crates/uv-publish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-publish"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-publish/README.md
+++ b/crates/uv-publish/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-publish).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-publish).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-pypi-types"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-pypi-types/README.md
+++ b/crates/uv-pypi-types/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-pypi-types).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-pypi-types).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-python"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-python/README.md
+++ b/crates/uv-python/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-python).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-python).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-redacted/Cargo.toml
+++ b/crates/uv-redacted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-redacted"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-redacted/README.md
+++ b/crates/uv-redacted/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-redacted).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-redacted).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-requirements-txt/Cargo.toml
+++ b/crates/uv-requirements-txt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-requirements-txt"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-requirements-txt/README.md
+++ b/crates/uv-requirements-txt/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-requirements-txt).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-requirements-txt).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-requirements/Cargo.toml
+++ b/crates/uv-requirements/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-requirements"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-requirements/README.md
+++ b/crates/uv-requirements/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-requirements).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-requirements).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-resolver"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-resolver/README.md
+++ b/crates/uv-resolver/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-resolver).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-resolver).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-scripts/Cargo.toml
+++ b/crates/uv-scripts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-scripts"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-scripts/README.md
+++ b/crates/uv-scripts/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-scripts).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-scripts).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-settings"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-settings/README.md
+++ b/crates/uv-settings/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-settings).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-settings).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-shell/Cargo.toml
+++ b/crates/uv-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-shell"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-shell/README.md
+++ b/crates/uv-shell/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-shell).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-shell).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-small-str/Cargo.toml
+++ b/crates/uv-small-str/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-small-str"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-small-str/README.md
+++ b/crates/uv-small-str/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-small-str).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-small-str).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-state/Cargo.toml
+++ b/crates/uv-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-state"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-state/README.md
+++ b/crates/uv-state/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-state).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-state).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-static/Cargo.toml
+++ b/crates/uv-static/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-static"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-static/README.md
+++ b/crates/uv-static/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-static).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-static).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-test/Cargo.toml
+++ b/crates/uv-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-test"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-test/README.md
+++ b/crates/uv-test/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-test).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-test).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-toml/Cargo.toml
+++ b/crates/uv-toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-toml"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-toml/README.md
+++ b/crates/uv-toml/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-toml).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-toml).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-tool"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-tool/README.md
+++ b/crates/uv-tool/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-tool).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-tool).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-torch/Cargo.toml
+++ b/crates/uv-torch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-torch"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-torch/README.md
+++ b/crates/uv-torch/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-torch).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-torch).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-trampoline-builder/Cargo.toml
+++ b/crates/uv-trampoline-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-trampoline-builder"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 
 edition = { workspace = true }

--- a/crates/uv-trampoline-builder/README.md
+++ b/crates/uv-trampoline-builder/README.md
@@ -5,9 +5,9 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
 source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-trampoline-builder).
+[here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-trampoline-builder).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-trampoline/Cargo.lock
+++ b/crates/uv-trampoline/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "uv-macros"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "thiserror",
  "uv-macros",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "windows",
 ]

--- a/crates/uv-types/Cargo.toml
+++ b/crates/uv-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-types"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-types/README.md
+++ b/crates/uv-types/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-types).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-types).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-unix/Cargo.toml
+++ b/crates/uv-unix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-unix"
-version = "0.0.63"
+version = "0.0.64"
 description = "Unix-specific functionality for uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-unix/README.md
+++ b/crates/uv-unix/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-unix).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-unix).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-version/Cargo.toml
+++ b/crates/uv-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-version"
-version = "0.11.30"
+version = "0.11.31"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-version/README.md
+++ b/crates/uv-version/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.11.30) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-version).
+This version (0.11.31) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-version).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-virtualenv"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 keywords = ["virtualenv", "venv", "python"]
 

--- a/crates/uv-warnings/Cargo.toml
+++ b/crates/uv-warnings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-warnings"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-warnings/README.md
+++ b/crates/uv-warnings/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-warnings).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-warnings).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-windows/Cargo.toml
+++ b/crates/uv-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-windows"
-version = "0.0.63"
+version = "0.0.64"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }

--- a/crates/uv-windows/README.md
+++ b/crates/uv-windows/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-windows).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-windows).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-workspace"
-version = "0.0.63"
+version = "0.0.64"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-workspace/README.md
+++ b/crates/uv-workspace/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.63) is a component of [uv 0.11.30](https://crates.io/crates/uv/0.11.30). The
-source can be found [here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv-workspace).
+This version (0.0.64) is a component of [uv 0.11.31](https://crates.io/crates/uv/0.11.31). The
+source can be found [here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv-workspace).
 
 See uv's
 [crate versioning policy](https://docs.astral.sh/uv/reference/policies/versioning/#crate-versioning)

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv"
-version = "0.11.30"
+version = "0.11.31"
 description = "A Python package and project manager"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv/README.md
+++ b/crates/uv/README.md
@@ -10,8 +10,8 @@ for more information.
 This crate is the entry point to the uv command-line interface. The Rust API exposed here is not
 considered public interface.
 
-This is version 0.11.30. The source can be found
-[here](https://github.com/astral-sh/uv/blob/0.11.30/crates/uv).
+This is version 0.11.31. The source can be found
+[here](https://github.com/astral-sh/uv/blob/0.11.31/crates/uv).
 
 The following uv workspace members are also available:
 

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -31,7 +31,7 @@ To use uv as a build backend in an existing project, add `uv_build` to the
 
 ```toml title="pyproject.toml"
 [build-system]
-requires = ["uv_build>=0.11.30,<0.12"]
+requires = ["uv_build>=0.11.31,<0.12"]
 build-backend = "uv_build"
 ```
 

--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -113,7 +113,7 @@ dependencies = []
 example-pkg = "example_pkg:main"
 
 [build-system]
-requires = ["uv_build>=0.11.30,<0.12"]
+requires = ["uv_build>=0.11.31,<0.12"]
 build-backend = "uv_build"
 ```
 
@@ -136,7 +136,7 @@ dependencies = []
 example-pkg = "example_pkg:main"
 
 [build-system]
-requires = ["uv_build>=0.11.30,<0.12"]
+requires = ["uv_build>=0.11.31,<0.12"]
 build-backend = "uv_build"
 ```
 
@@ -197,7 +197,7 @@ requires-python = ">=3.11"
 dependencies = []
 
 [build-system]
-requires = ["uv_build>=0.11.30,<0.12"]
+requires = ["uv_build>=0.11.31,<0.12"]
 build-backend = "uv_build"
 ```
 

--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -75,7 +75,7 @@ bird-feeder = { workspace = true }
 members = ["packages/*"]
 
 [build-system]
-requires = ["uv_build>=0.11.30,<0.12"]
+requires = ["uv_build>=0.11.31,<0.12"]
 build-backend = "uv_build"
 ```
 
@@ -109,7 +109,7 @@ tqdm = { git = "https://github.com/tqdm/tqdm" }
 members = ["packages/*"]
 
 [build-system]
-requires = ["uv_build>=0.11.30,<0.12"]
+requires = ["uv_build>=0.11.31,<0.12"]
 build-backend = "uv_build"
 ```
 
@@ -191,7 +191,7 @@ dependencies = ["bird-feeder", "tqdm>=4,<5"]
 bird-feeder = { path = "packages/bird-feeder" }
 
 [build-system]
-requires = ["uv_build>=0.11.30,<0.12"]
+requires = ["uv_build>=0.11.31,<0.12"]
 build-backend = "uv_build"
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ uv provides a standalone installer to download and install uv:
     Request a specific version by including it in the URL:
 
     ```console
-    $ curl -LsSf https://astral.sh/uv/0.11.30/install.sh | sh
+    $ curl -LsSf https://astral.sh/uv/0.11.31/install.sh | sh
     ```
 
 === "Windows"
@@ -41,7 +41,7 @@ uv provides a standalone installer to download and install uv:
     Request a specific version by including it in the URL:
 
     ```pwsh-session
-    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.11.30/install.ps1 | iex"
+    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.11.31/install.ps1 | iex"
     ```
 
 !!! tip

--- a/docs/guides/integration/aws-lambda.md
+++ b/docs/guides/integration/aws-lambda.md
@@ -92,7 +92,7 @@ the second stage, we'll copy this directory over to the final image, omitting th
 other unnecessary files.
 
 ```dockerfile title="Dockerfile"
-FROM ghcr.io/astral-sh/uv:0.11.30 AS uv
+FROM ghcr.io/astral-sh/uv:0.11.31 AS uv
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder
@@ -334,7 +334,7 @@ And confirm that opening http://127.0.0.1:8000/ in a web browser displays, "Hell
 Finally, we'll update the Dockerfile to include the local library in the deployment package:
 
 ```dockerfile title="Dockerfile"
-FROM ghcr.io/astral-sh/uv:0.11.30 AS uv
+FROM ghcr.io/astral-sh/uv:0.11.31 AS uv
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -31,7 +31,7 @@ $ docker run --rm -it ghcr.io/astral-sh/uv:debian uv --help
 The following distroless images are available:
 
 - `ghcr.io/astral-sh/uv:latest`
-- `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/uv:0.11.30`
+- `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/uv:0.11.31`
 - `ghcr.io/astral-sh/uv:{major}.{minor}`, e.g., `ghcr.io/astral-sh/uv:0.8` (the latest patch
   version)
 
@@ -94,7 +94,7 @@ And the following derived images are available:
 
 As with the distroless image, each derived image is published with uv version tags as
 `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}-{base}` and
-`ghcr.io/astral-sh/uv:{major}.{minor}-{base}`, e.g., `ghcr.io/astral-sh/uv:0.11.30-alpine`.
+`ghcr.io/astral-sh/uv:{major}.{minor}-{base}`, e.g., `ghcr.io/astral-sh/uv:0.11.31-alpine`.
 
 In addition, starting with `0.8` each derived image also sets `UV_TOOL_BIN_DIR` to `/usr/local/bin`
 to allow `uv tool install` to work as expected with the default user.
@@ -135,7 +135,7 @@ Note this requires `curl` to be available.
 In either case, it is best practice to pin to a specific uv version, e.g., with:
 
 ```dockerfile
-COPY --from=ghcr.io/astral-sh/uv:0.11.30 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.31 /uv /uvx /bin/
 ```
 
 !!! tip
@@ -153,7 +153,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.30 /uv /uvx /bin/
 Or, with the installer:
 
 ```dockerfile
-ADD https://astral.sh/uv/0.11.30/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.11.31/install.sh /uv-installer.sh
 ```
 
 ### Installing a project
@@ -621,5 +621,5 @@ Verified OK
 !!! tip
 
     These examples use `latest`, but best practice is to verify the attestation for a specific
-    version tag, e.g., `ghcr.io/astral-sh/uv:0.11.30`, or (even better) the specific image digest,
+    version tag, e.g., `ghcr.io/astral-sh/uv:0.11.31`, or (even better) the specific image digest,
     such as `ghcr.io/astral-sh/uv:0.5.27@sha256:5adf09a5a526f380237408032a9308000d14d5947eafa687ad6c6a2476787b4f`.

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -47,7 +47,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           # Install a specific version of uv.
-          version: "0.11.30"
+          version: "0.11.31"
 ```
 
 ## Setting up Python

--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -13,7 +13,7 @@ Select a variant that is suitable for your workflow.
 
 ```yaml title=".gitlab-ci.yml"
 variables:
-  UV_VERSION: "0.11.30"
+  UV_VERSION: "0.11.31"
   PYTHON_VERSION: "3.12"
   BASE_LAYER: trixie-slim
   # GitLab CI creates a separate mountpoint for the build directory,

--- a/docs/guides/integration/pre-commit.md
+++ b/docs/guides/integration/pre-commit.md
@@ -19,7 +19,7 @@ To make sure your `uv.lock` file is up to date even if your `pyproject.toml` fil
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.30
+    rev: 0.11.31
     hooks:
       - id: uv-lock
 ```
@@ -30,7 +30,7 @@ To keep a `requirements.txt` file in sync with your `uv.lock` file:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.30
+    rev: 0.11.31
     hooks:
       - id: uv-export
 ```
@@ -41,7 +41,7 @@ To compile requirements files:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.30
+    rev: 0.11.31
     hooks:
       # Compile requirements
       - id: pip-compile
@@ -54,7 +54,7 @@ To compile alternative requirements files, modify `args` and `files`:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.30
+    rev: 0.11.31
     hooks:
       # Compile requirements
       - id: pip-compile
@@ -68,7 +68,7 @@ To run the hook over multiple files at the same time, add additional entries:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.30
+    rev: 0.11.31
     hooks:
       # Compile requirements
       - id: pip-compile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "uv"
-version = "0.11.30"
+version = "0.11.31"
 description = "An extremely fast Python package and project manager, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 requires-python = ">=3.8"

--- a/uv.lock
+++ b/uv.lock
@@ -1544,7 +1544,7 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.11.30"
+version = "0.11.31"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Prepare uv 0.11.31 with an editorialized changelog, updated workspace crate versions and READMEs, and synchronized lockfiles.