### PR TITLE
Preserve configured settings for duplicate index URLs

### DIFF
--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -17,7 +17,7 @@ use uv_pypi_types::HashAlgorithm;
 use uv_redacted::DisplaySafeUrl;
 use uv_warnings::warn_user;
 
-use crate::{ExcludeNewerOverride, Index, IndexStatusCodeStrategy, Verbatim};
+use crate::{ExcludeNewerOverride, Index, IndexStatusCodeStrategy, Origin, Verbatim};
 
 pub static PYPI_URL: LazyLock<DisplaySafeUrl> =
     LazyLock::new(|| DisplaySafeUrl::parse("https://pypi.org/simple").unwrap());
@@ -493,11 +493,19 @@ impl<'a> IndexLocations {
         Either::Right(non_default.into_iter().chain(default))
     }
 
-    /// Return the configured index matching the given URL.
+    /// Return the configured index matching the given URL, preferring file-defined indexes.
     fn index_for_url(&self, url: &IndexUrl) -> Option<&Index> {
         self.indexes
             .iter()
-            .find(|index| is_same_index(index.url(), url))
+            .find(|index| {
+                !matches!(index.origin, Some(Origin::Cli | Origin::RequirementsTxt))
+                    && is_same_index(index.url(), url)
+            })
+            .or_else(|| {
+                self.indexes
+                    .iter()
+                    .find(|index| is_same_index(index.url(), url))
+            })
     }
 
     /// Return the [`IndexStatusCodeStrategy`] for an [`IndexUrl`].
@@ -541,6 +549,7 @@ impl<'a> IndexLocations {
 impl From<&IndexLocations> for uv_auth::Indexes {
     fn from(index_locations: &IndexLocations) -> Self {
         Self::from_indexes(index_locations.allowed_indexes().into_iter().map(|index| {
+            let configured_index = index_locations.index_for_url(index.url()).unwrap_or(index);
             let mut url = index.url().url().clone();
             url.set_username("").ok();
             url.set_password(None).ok();
@@ -550,7 +559,7 @@ impl From<&IndexLocations> for uv_auth::Indexes {
             uv_auth::Index {
                 url,
                 root_url,
-                auth_policy: index.authenticate,
+                auth_policy: configured_index.authenticate,
             }
         }))
     }
@@ -749,6 +758,60 @@ mod tests {
         let url3 = IndexUrl::from_str("https://index3.example.com/simple").unwrap();
         assert_eq!(index_locations.simple_api_cache_control_for(&url3), None);
         assert_eq!(index_locations.artifact_cache_control_for(&url3), None);
+    }
+
+    #[test]
+    fn configured_index_settings_take_precedence_over_duplicate_index() {
+        let cli = Index::from_str("cli=https://index.example.com/simple")
+            .unwrap()
+            .with_origin(Origin::Cli);
+        let project = toml::from_str::<Index>(
+            r#"
+            url = "https://index.example.com/simple/"
+            authenticate = "always"
+            ignore-error-codes = [403]
+            cache-control = { api = "max-age=300", files = "max-age=1800" }
+            hash-algorithm = "sha256"
+            exclude-newer = false
+            "#,
+        )
+        .unwrap();
+        let user = toml::from_str::<Index>(
+            r#"
+            name = "user"
+            url = "https://index.example.com/simple"
+            authenticate = "never"
+            ignore-error-codes = [401]
+            cache-control = { api = "max-age=600", files = "max-age=3600" }
+            hash-algorithm = "sha512"
+            exclude-newer = "2025-01-01T00:00:00Z"
+            "#,
+        )
+        .unwrap()
+        .with_origin(Origin::User);
+        let locations = IndexLocations::new(vec![cli, project.clone(), user], Vec::new(), false);
+        let url = IndexUrl::from_str("https://index.example.com/simple").unwrap();
+
+        assert_eq!(locations.index_for_url(&url), Some(&project));
+        assert_eq!(
+            locations.status_code_strategy_for(&url),
+            project.status_code_strategy()
+        );
+        assert!(locations.ignores_error_code_for(&url, StatusCode::FORBIDDEN));
+        assert!(!locations.ignores_error_code_for(&url, StatusCode::UNAUTHORIZED));
+        assert_eq!(
+            locations.simple_api_cache_control_for(&url),
+            Some(HeaderValue::from_static("max-age=300"))
+        );
+        assert_eq!(
+            locations.artifact_cache_control_for(&url),
+            Some(HeaderValue::from_static("max-age=1800"))
+        );
+        assert_eq!(
+            locations.hash_algorithm_for(&url),
+            Some(HashAlgorithm::Sha256)
+        );
+        assert_eq!(locations.exclude_newer_for(&url), project.exclude_newer());
     }
 
     #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -10038,6 +10038,39 @@ async fn lock_index_hash_algorithm_missing() -> Result<()> {
     error: The index `http://[LOCALHOST]/simple` requires `sha256` hashes, but `basic_package-0.1.0-py3-none-any.whl` does not provide one
     ");
 
+    let index_url = format!("{}/simple", server.uri());
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .arg("--index")
+        .arg(&index_url)
+        .arg("--preview-features")
+        .arg("index-hash-algorithm")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The index `http://[LOCALHOST]/simple` requires `sha256` hashes, but `basic_package-0.1.0-py3-none-any.whl` does not provide one
+    ");
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env(EnvVars::UV_DEFAULT_INDEX, index_url)
+        .arg("--preview-features")
+        .arg("index-hash-algorithm")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The index `http://[LOCALHOST]/simple` requires `sha256` hashes, but `basic_package-0.1.0-py3-none-any.whl` does not provide one
+    ");
+
     Ok(())
 }
 
@@ -35955,6 +35988,118 @@ async fn lock_exclude_newer_index_value() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Test that repeating a configured index URL does not bypass its `exclude-newer` value.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_exclude_newer_duplicate_index() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig>=2"]
+
+        [tool.uv.sources]
+        iniconfig = {{ index = "internal" }}
+
+        [[tool.uv.index]]
+        name = "internal"
+        url = "{proxy_uri}/no-upload-time/simple"
+        explicit = true
+        exclude-newer = "2025-01-01T00:00:00Z"
+        "#,
+        proxy_uri = proxy.uri()
+    ))?;
+
+    let index_url = proxy.url("/no-upload-time/simple");
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .arg("--index")
+        .arg(&index_url)
+        .arg("--preview-features")
+        .arg("index-exclude-newer"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: iniconfig-2.0.0.tar.gz is missing an upload date, but user provided: 2025-01-01T00:00:00Z
+    warning: iniconfig-2.0.0-py3-none-any.whl is missing an upload date, but user provided: 2025-01-01T00:00:00Z
+      × No solution found when resolving dependencies:
+      ╰─▶ Because there are no versions of iniconfig and your project depends on iniconfig>=2, we can conclude that your project's requirements are unsatisfiable.
+
+    hint: `iniconfig` was found on http://[LOCALHOST]/no-upload-time/simple, but not at the requested version (iniconfig>=2). A compatible version may be available on a subsequent index (e.g., https://pypi.org/simple). By default, uv will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `--index-strategy unsafe-best-match` to consider all versions from all indexes, regardless of the order in which they were defined.
+    hint: `iniconfig` was filtered by the index-specific `exclude-newer` setting to only include packages uploaded before 2025-01-01T00:00:00Z. The latest version satisfying the requirement is v2.0.0. Consider updating that index's cutoff, setting it to `false`, or using `exclude-newer-package` to override the cutoff for this package.
+    ");
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env(EnvVars::UV_DEFAULT_INDEX, index_url)
+        .arg("--preview-features")
+        .arg("index-exclude-newer"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: iniconfig-2.0.0.tar.gz is missing an upload date, but user provided: 2025-01-01T00:00:00Z
+    warning: iniconfig-2.0.0-py3-none-any.whl is missing an upload date, but user provided: 2025-01-01T00:00:00Z
+      × No solution found when resolving dependencies:
+      ╰─▶ Because there are no versions of iniconfig and your project depends on iniconfig>=2, we can conclude that your project's requirements are unsatisfiable.
+
+    hint: `iniconfig` was filtered by the index-specific `exclude-newer` setting to only include packages uploaded before 2025-01-01T00:00:00Z. The latest version satisfying the requirement is v2.0.0. Consider updating that index's cutoff, setting it to `false`, or using `exclude-newer-package` to override the cutoff for this package.
+    ");
+
+    Ok(())
+}
+
+/// Test that repeating a configured index URL does not bypass its authentication policy.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_authenticate_duplicate_index() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig>=2"]
+
+        [[tool.uv.index]]
+        name = "internal"
+        url = "{proxy_uri}/simple"
+        authenticate = "always"
+        explicit = true
+        "#,
+        proxy_uri = proxy.uri()
+    ))?;
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .arg("--index")
+        .arg(proxy.url("/simple")), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to fetch: `http://[LOCALHOST]/simple/iniconfig/`
+      Caused by: Missing credentials for http://[LOCALHOST]/simple/iniconfig/
     ");
 
     Ok(())

--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -50,6 +50,10 @@ $ uv lock --index pytorch=https://download.pytorch.org/whl/cpu
 $ UV_INDEX=pytorch=https://download.pytorch.org/whl/cpu uv lock
 ```
 
+If an index provided via the command line or environment uses the same URL as an index in the
+configuration file, index-specific settings from the configuration file still apply. The command
+line or environment index continues to take precedence when ordering indexes for resolution.
+
 ## Pinning a package to an index
 
 A package can be pinned to a specific index by specifying the index in its `tool.uv.sources` entry.


### PR DESCRIPTION
## Summary

Preserve file-defined index settings when `--index`, `UV_INDEX`, `--default-index`, or `UV_DEFAULT_INDEX` repeats the same index URL. The CLI or environment index still determines resolution priority, but it no longer shadows `authenticate`, `ignore-error-codes`, `cache-control`, `hash-algorithm`, or `exclude-newer` from the configured index.

This follows #20605 and prevents a duplicate index URL from silently bypassing the newly added hash requirement. It also makes authentication use the same URL-scoped selection rule, avoiding conflicting policies for duplicate indexes, and documents the resulting precedence behavior.
