### PR TITLE
Skip conflict expansion when there is nothing to infer

### DIFF
--- a/crates/uv-pypi-types/src/conflicts.rs
+++ b/crates/uv-pypi-types/src/conflicts.rs
@@ -1,8 +1,9 @@
+use indexmap::IndexSet;
 use petgraph::{
     algo::toposort,
     graph::{DiGraph, NodeIndex},
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 #[cfg(feature = "schemars")]
 use std::borrow::Cow;
 use std::fmt;
@@ -87,6 +88,22 @@ impl Conflicts {
         package: &PackageName,
         groups: &DependencyGroups,
     ) {
+        // Nothing to infer without a conflicting group and at least one
+        // group include.
+        if !self.0.iter().any(|set| {
+            set.iter()
+                .any(|item| matches!(item.kind(), ConflictKind::Group(_)))
+        }) {
+            return;
+        }
+        if !groups.iter().any(|(_, specifiers)| {
+            specifiers
+                .iter()
+                .any(|specifier| matches!(specifier, DependencyGroupSpecifier::IncludeGroup { .. }))
+        }) {
+            return;
+        }
+
         let mut graph = DiGraph::new();
         let mut group_node_idxs: FxHashMap<&GroupName, NodeIndex> = FxHashMap::default();
         let mut node_conflict_items: FxHashMap<NodeIndex, Rc<ConflictItem>> = FxHashMap::default();
@@ -97,7 +114,7 @@ impl Conflicts {
             FxHashMap::default();
 
         // Track all existing conflict sets to avoid duplicates.
-        let mut conflict_sets: FxHashSet<ConflictSet> = FxHashSet::default();
+        let mut conflict_sets: IndexSet<ConflictSet, FxBuildHasher> = IndexSet::default();
 
         // Add groups in directly defined conflict sets to the graph.
         let mut seen: FxHashSet<&GroupName> = FxHashSet::default();
@@ -120,6 +137,7 @@ impl Conflicts {
                 node_conflict_items.insert(node_id, item.clone());
             }
         }
+        let seeded = conflict_sets.len();
 
         // Create conflict items for remaining groups and add them to the graph.
         for group in groups.keys() {
@@ -199,11 +217,8 @@ impl Conflicts {
             conflict_sets.extend(new_conflict_sets);
         }
 
-        // Add all newly discovered conflict sets (excluding the originals already in self.0)
-        for set in &self.0 {
-            conflict_sets.remove(set);
-        }
-        self.0.extend(conflict_sets);
+        // Everything past the seeded originals is newly inferred.
+        self.0.extend(conflict_sets.into_iter().skip(seeded));
     }
 }
 

--- a/crates/uv-pypi-types/src/dependency_groups.rs
+++ b/crates/uv-pypi-types/src/dependency_groups.rs
@@ -24,7 +24,9 @@ impl DependencyGroups {
     }
 
     /// Returns an iterator over the dependency groups.
-    pub fn iter(&self) -> impl Iterator<Item = (&GroupName, &Vec<DependencyGroupSpecifier>)> {
+    pub(crate) fn iter(
+        &self,
+    ) -> impl Iterator<Item = (&GroupName, &Vec<DependencyGroupSpecifier>)> {
         self.0.iter()
     }
 }

--- a/hawk.toml
+++ b/hawk.toml
@@ -284,14 +284,6 @@ reason = "read by the AWS request signer"
 
 [[override]]
 lint = "hawk::dead_public"
-crate = "uv_pypi_types"
-item = "dependency_groups::DependencyGroups::iter"
-kind = "inherent_method"
-level = "expect"
-reason = "required alongside IntoIterator by Clippy"
-
-[[override]]
-lint = "hawk::dead_public"
 crate = "uv_resolver"
 item = "lock::Lock::is_empty"
 kind = "inherent_method"


### PR DESCRIPTION
I was taking a look at #20578 and noticed that for the common scenario of having no conflicts, the PR did not improve things, and when there are only a few declared conflicts with nothing to infer, the dedup is consistently slower (although not significant in absolute terms).

We can optimize these scenarios though: when no declared conflict names a group, or nothing uses `include-group`, no sets can be inferred and the whole step can be skipped.

![common cases](https://raw.githubusercontent.com/notatallshaw/uv/351df721d800201535fd8b306c1abc424b2d3467/chart_common_case.png)

Note: inferred sets are now appended in insertion order instead of hash order, and lock validation compares `conflicts` order-sensitively, so a project with inferred sets can relock once. I don't know if this is a backwards compatibility issue or not, but also a rustc-hash change re-rolls the inferred set order. An MRE of this issue:

<details>
<summary>MRE</summary>

```toml
[project]
name = "demo"
version = "0.1.0"
requires-python = ">=3.12"

[dependency-groups]
cpu = []
gpu = []
dev = [{ include-group = "cpu" }]
test = [{ include-group = "cpu" }]
docs = [{ include-group = "gpu" }]
ci = [{ include-group = "gpu" }]

[tool.uv]
conflicts = [
    [{ group = "cpu" }, { group = "gpu" }],
]
```

One declared set, 8 inferred; they come out in a different order, so the first lock after upgrading rewrites the array once.

</details>


