### PR TITLE
Remove redundant `virtual` from lockfile

### DIFF
--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -264,6 +264,7 @@ pub enum PreviewFeature {
     WorkspaceListScripts = 1 << 37,
     NoDistutilsPatch = 1 << 38,
     IndexHashAlgorithm = 1 << 39,
+    NoLockVirtual = 1 << 40,
 }
 
 impl PreviewFeature {
@@ -310,6 +311,7 @@ impl PreviewFeature {
             Self::WorkspaceListScripts => "workspace-list-scripts",
             Self::NoDistutilsPatch => "no-distutils-patch",
             Self::IndexHashAlgorithm => "index-hash-algorithm",
+            Self::NoLockVirtual => "no-lock-virtual",
         }
     }
 }
@@ -369,6 +371,7 @@ impl FromStr for PreviewFeature {
             "workspace-list-scripts" => Self::WorkspaceListScripts,
             "no-distutils-patch" => Self::NoDistutilsPatch,
             "index-hash-algorithm" => Self::IndexHashAlgorithm,
+            "no-lock-virtual" => Self::NoLockVirtual,
             _ => return Err(PreviewFeatureParseError),
         })
     }
@@ -552,6 +555,9 @@ mod tests {
         let preview = Preview::from_str("tool-install-locks").unwrap();
         assert!(preview.is_enabled(PreviewFeature::ToolInstallLocks));
 
+        let preview = Preview::from_str("no-lock-virtual").unwrap();
+        assert!(preview.is_enabled(PreviewFeature::NoLockVirtual));
+
         // Test with whitespace
         let preview = Preview::from_str("pylock , add-bounds").unwrap();
         assert!(preview.is_enabled(PreviewFeature::Pylock));
@@ -684,6 +690,7 @@ mod tests {
             PreviewFeature::IndexHashAlgorithm.as_str(),
             "index-hash-algorithm"
         );
+        assert_eq!(PreviewFeature::NoLockVirtual.as_str(), "no-lock-virtual");
     }
 
     #[test]

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -34,7 +34,7 @@ use uv_distribution_types::{
     ToUrlError, UrlString,
 };
 use uv_fs::{
-    PortablePath, PortablePathBuf, Simplified, normalize_path, relative_to, try_relative_to_if,
+    CWD, PortablePath, PortablePathBuf, Simplified, normalize_path, relative_to, try_relative_to_if,
 };
 use uv_git::{RepositoryReference, ResolvedRepositoryReference};
 use uv_git_types::{GitLfs, GitOid, GitReference, GitUrl, GitUrlParseError};
@@ -84,6 +84,9 @@ pub const VERSION: u32 = 1;
 
 /// The current revision of the lockfile format.
 const REVISION: u32 = 3;
+
+/// The first revision that permits omitted virtual workspace-member sources.
+const COMPACT_REVISION: u32 = REVISION + 1;
 
 static LINUX_MARKERS: LazyLock<UniversalMarker> = LazyLock::new(|| {
     let pep508 = MarkerTree::from_str("os_name == 'posix' and sys_platform == 'linux'").unwrap();
@@ -809,6 +812,11 @@ impl Lock {
     /// Returns the lockfile revision.
     fn revision(&self) -> u32 {
         self.revision
+    }
+
+    /// Returns `true` if this [`Lock`] uses the compact lockfile format.
+    pub fn uses_compact_format(&self) -> bool {
+        self.revision() >= COMPACT_REVISION
     }
 
     /// Returns the number of packages in the lockfile.
@@ -2745,6 +2753,23 @@ impl TryFrom<LockWire> for Lock {
             unambiguous_package_ids.insert(dist.id.name.clone(), dist.id.clone());
         }
 
+        // Compact lockfiles omit virtual sources from workspace-member requirement metadata.
+        let virtual_members = if wire.revision.unwrap_or_default() >= COMPACT_REVISION {
+            wire.packages
+                .iter()
+                .filter(|package| wire.manifest.members.contains(&package.id.name))
+                .filter_map(|package| {
+                    if let Source::Virtual(path) = &package.id.source {
+                        Some((package.id.name.clone(), path.clone()))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<FxHashMap<_, _>>()
+        } else {
+            FxHashMap::default()
+        };
+
         let fork_markers = wire
             .fork_markers
             .into_iter()
@@ -2768,6 +2793,7 @@ impl TryFrom<LockWire> for Lock {
                     environment,
                     default,
                     &unambiguous_package_ids,
+                    &virtual_members,
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -3724,6 +3750,7 @@ impl PackageWire {
         environment: SimplifiedMarkerTree,
         default: UniversalMarker,
         unambiguous_package_ids: &FxHashMap<PackageName, PackageId>,
+        virtual_members: &FxHashMap<PackageName, Box<Path>>,
     ) -> Result<Package, LockError> {
         // Consistency check
         if !uv_flags::contains(uv_flags::EnvironmentFlags::SKIP_WHEEL_FILENAME_CHECK) {
@@ -3766,9 +3793,54 @@ impl PackageWire {
                 .collect()
         };
 
+        // Reconstruct omitted workspace-member sources before comparing requirement metadata.
+        let restore_virtual_member = |mut requirement: Requirement| {
+            if let RequirementSource::Registry {
+                specifier,
+                index: None,
+                conflict: None,
+            } = &requirement.source
+                && specifier.is_empty()
+                && requirement.name != self.id.name
+                && let Some(install_path) = virtual_members.get(&requirement.name)
+            {
+                let url = VerbatimUrl::from_normalized_path(normalize_path(CWD.join(install_path)))
+                    .map_err(LockErrorKind::RequirementVerbatimUrl)?;
+                requirement.source = RequirementSource::Directory {
+                    install_path: install_path.clone(),
+                    editable: Some(false),
+                    r#virtual: Some(true),
+                    url,
+                };
+            }
+            Ok::<_, LockError>(requirement)
+        };
+        let requires_dist = self
+            .metadata
+            .requires_dist
+            .into_iter()
+            .map(&restore_virtual_member)
+            .collect::<Result<_, _>>()?;
+        let dependency_groups = self
+            .metadata
+            .dependency_groups
+            .into_iter()
+            .map(|(group, requirements)| {
+                let requirements = requirements
+                    .into_iter()
+                    .map(&restore_virtual_member)
+                    .collect::<Result<_, _>>()?;
+                Ok::<_, LockError>((group, requirements))
+            })
+            .collect::<Result<_, _>>()?;
+
         Ok(Package {
             id: self.id,
-            metadata: self.metadata,
+            metadata: PackageMetadata {
+                requires_dist,
+                dependency_groups,
+                ..self.metadata
+            },
             sdist: self.sdist,
             wheels: self.wheels,
             fork_markers: self

--- a/crates/uv-resolver/src/lock/serialize.rs
+++ b/crates/uv-resolver/src/lock/serialize.rs
@@ -1,20 +1,23 @@
 use std::collections::BTreeSet;
 use std::fmt;
+use std::path::Path;
 
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use toml_edit::Value;
 use toml_writer::{TomlWrite, WriteTomlValue};
-use uv_distribution_types::{RequiresPython, SimplifiedMarkerTree};
+use uv_distribution_types::{Requirement, RequirementSource, RequiresPython, SimplifiedMarkerTree};
 use uv_fs::PortablePath;
 use uv_normalize::PackageName;
 use uv_pep508::MarkerTree;
+use uv_preview::PreviewFeature;
 use uv_pypi_types::ConflictKind;
 
 use super::{
-    Dependency, DirectSource, ExcludeNewerOverride, ExcludeNewerValue, ForkStrategy, Lock, Package,
-    PackageId, PrereleaseMode, RegistrySource, ResolutionMode, ResolverManifest, ResolverOptions,
-    Source, SourceDist, Wheel, WheelWireSource, simplified_universal_markers,
+    COMPACT_REVISION, Dependency, DirectSource, ExcludeNewerOverride, ExcludeNewerValue,
+    ForkStrategy, Lock, Package, PackageId, PrereleaseMode, REVISION, RegistrySource,
+    ResolutionMode, ResolverManifest, ResolverOptions, Source, SourceDist, Wheel, WheelWireSource,
+    simplified_universal_markers,
 };
 
 /// Serializes a lockfile directly while preserving the canonical `uv.lock` layout.
@@ -34,9 +37,42 @@ fn write_lock(writer: &mut LockWriter, lock: &Lock) -> Result<(), WriteError> {
     // environments.
     debug_assert!(lock.check_marker_coverage().is_ok());
 
+    let virtual_members = if uv_preview::is_enabled(PreviewFeature::NoLockVirtual) {
+        lock.packages
+            .iter()
+            .filter(|package| lock.manifest.members.contains(&package.id.name))
+            .filter_map(|package| {
+                if let Source::Virtual(path) = &package.id.source {
+                    Some((package.id.name.clone(), path.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    } else {
+        FxHashMap::default()
+    };
+    let compact_lockfile = lock.packages.iter().any(|package| {
+        package
+            .metadata
+            .requires_dist
+            .iter()
+            .chain(package.metadata.dependency_groups.values().flatten())
+            .any(|requirement| {
+                can_omit_virtual_source(requirement, &package.id.name, &virtual_members)
+            })
+    });
+    let revision = if compact_lockfile {
+        lock.revision.max(COMPACT_REVISION)
+    } else if lock.uses_compact_format() {
+        REVISION
+    } else {
+        lock.revision
+    };
+
     writer.key_value("version", lock.version)?;
-    if lock.revision > 0 {
-        writer.key_value("revision", lock.revision)?;
+    if revision > 0 {
+        writer.key_value("revision", revision)?;
     }
     writer.key_value("requires-python", lock.requires_python.to_string())?;
 
@@ -128,6 +164,7 @@ fn write_lock(writer: &mut LockWriter, lock: &Lock) -> Result<(), WriteError> {
             &lock.requires_python,
             simplified_environment,
             &dist_count_by_name,
+            &virtual_members,
         )?;
     }
 
@@ -264,6 +301,7 @@ fn write_package(
     requires_python: &RequiresPython,
     simplified_environment: MarkerTree,
     dist_count_by_name: &FxHashMap<PackageName, u64>,
+    virtual_members: &FxHashMap<PackageName, &Path>,
 ) -> Result<(), WriteError> {
     writer.array_of_tables(&["package"])?;
     write_package_id(writer, &package.id, None, PackageIdLocation::Table)?;
@@ -350,7 +388,15 @@ fn write_package(
         || !metadata.provides_extra.is_empty();
     if has_metadata {
         writer.table(&["package", "metadata"])?;
-        write_serialized_non_empty_array(writer, "requires-dist", &metadata.requires_dist)?;
+        if !metadata.requires_dist.is_empty() {
+            write_package_requirements(
+                writer,
+                "requires-dist",
+                &package.id.name,
+                &metadata.requires_dist,
+                virtual_members,
+            )?;
+        }
         if !metadata.provides_extra.is_empty() {
             writer.key_start("provides-extras")?;
             writer.array(&metadata.provides_extra, |writer, extra| {
@@ -362,12 +408,71 @@ fn write_package(
         if !metadata.dependency_groups.is_empty() {
             writer.table(&["package", "metadata", "requires-dev"])?;
             for (group, requirements) in &metadata.dependency_groups {
-                write_serialized_array(writer, group.as_ref(), requirements)?;
+                write_package_requirements(
+                    writer,
+                    group.as_ref(),
+                    &package.id.name,
+                    requirements,
+                    virtual_members,
+                )?;
             }
         }
     }
 
     Ok(())
+}
+
+/// Writes requirement metadata, omitting virtual sources already recorded for workspace members.
+fn write_package_requirements(
+    writer: &mut LockWriter,
+    key: &str,
+    package_name: &PackageName,
+    requirements: &BTreeSet<Requirement>,
+    virtual_members: &FxHashMap<PackageName, &Path>,
+) -> Result<(), WriteError> {
+    writer.key_start(key)?;
+    let write_requirement = |writer: &mut LockWriter, requirement: &Requirement| {
+        let mut value = serialize_value(requirement)?;
+        if can_omit_virtual_source(requirement, package_name, virtual_members)
+            && let Value::InlineTable(table) = &mut value.0
+        {
+            table.remove("virtual");
+        }
+        writer.value(value)
+    };
+
+    if requirements.len() <= 1 {
+        writer.array(requirements, write_requirement)?;
+        writer.raw("\n");
+    } else {
+        writer.multiline_array(requirements, write_requirement)?;
+    }
+
+    Ok(())
+}
+
+/// Returns `true` if the requirement's virtual source can be inferred from a workspace member.
+fn can_omit_virtual_source(
+    requirement: &Requirement,
+    package_name: &PackageName,
+    virtual_members: &FxHashMap<PackageName, &Path>,
+) -> bool {
+    if &requirement.name == package_name {
+        return false;
+    }
+
+    if let RequirementSource::Directory {
+        install_path,
+        r#virtual: Some(true),
+        ..
+    } = &requirement.source
+    {
+        virtual_members
+            .get(&requirement.name)
+            .is_some_and(|path| *path == install_path.as_ref())
+    } else {
+        false
+    }
 }
 
 /// Writes a package identity, omitting fields that a unique package name makes redundant.

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -453,6 +453,13 @@ impl<'env> LockOperation<'env> {
                 if !matches!(self.mode, LockMode::DryRun(_)) {
                     if let LockResult::Changed(_, lock) = &result {
                         target.commit(lock).await?;
+                    } else if (self.preview.is_enabled(PreviewFeature::NoLockVirtual)
+                        || result.lock().uses_compact_format())
+                        && target.read_bytes().await?.as_deref()
+                            != Some(result.lock().to_toml()?.as_bytes())
+                    {
+                        // The resolved packages are unchanged, but the lockfile format changed.
+                        target.commit(result.lock()).await?;
                     }
                 }
 

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -10914,6 +10914,261 @@ fn lock_no_workspace_source() -> Result<()> {
     Ok(())
 }
 
+/// Omit redundant virtual workspace-member sources from requirement metadata in compact locks.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_compact_virtual_workspace_member() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child", "external"]
+
+        [dependency-groups]
+        dev = ["project", "child", "external"]
+
+        [tool.uv.workspace]
+        members = ["child"]
+
+        [tool.uv.sources]
+        child = { workspace = true }
+        external = { path = "external" }
+        "#,
+    )?;
+
+    context
+        .temp_dir
+        .child("child")
+        .child("pyproject.toml")
+        .write_str(
+            r#"
+            [project]
+            name = "child"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+
+            [tool.uv]
+            package = false
+            "#,
+        )?;
+
+    context
+        .temp_dir
+        .child("external")
+        .child("pyproject.toml")
+        .write_str(
+            r#"
+            [project]
+            name = "external"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+
+            [tool.uv]
+            package = false
+            "#,
+        )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    let standard_lock = context.read("uv.lock");
+    insta::with_settings!({ filters => context.filters() }, {
+        assert_snapshot!(standard_lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child",
+            "project",
+        ]
+
+        [[package]]
+        name = "child"
+        version = "0.1.0"
+        source = { virtual = "child" }
+
+        [[package]]
+        name = "external"
+        version = "0.1.0"
+        source = { virtual = "external" }
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "child" },
+            { name = "external" },
+        ]
+
+        [package.dev-dependencies]
+        dev = [
+            { name = "child" },
+            { name = "external" },
+            { name = "project" },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "child", virtual = "child" },
+            { name = "external", virtual = "external" },
+        ]
+
+        [package.metadata.requires-dev]
+        dev = [
+            { name = "child", virtual = "child" },
+            { name = "external", virtual = "external" },
+            { name = "project" },
+        ]
+        "#);
+    });
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("no-lock-virtual"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    insta::with_settings!({ filters => context.filters() }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 4
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child",
+            "project",
+        ]
+
+        [[package]]
+        name = "child"
+        version = "0.1.0"
+        source = { virtual = "child" }
+
+        [[package]]
+        name = "external"
+        version = "0.1.0"
+        source = { virtual = "external" }
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "child" },
+            { name = "external" },
+        ]
+
+        [package.dev-dependencies]
+        dev = [
+            { name = "child" },
+            { name = "external" },
+            { name = "project" },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "child" },
+            { name = "external", virtual = "external" },
+        ]
+
+        [package.metadata.requires-dev]
+        dev = [
+            { name = "child" },
+            { name = "external", virtual = "external" },
+            { name = "project" },
+        ]
+        "#);
+    });
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    // Disabling compact locks restores the compatible standard format.
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+    assert_eq!(context.read("uv.lock"), standard_lock);
+
+    Ok(())
+}
+
+/// Enabling compact locks should not change lockfiles without a redundant virtual source.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_compact_without_virtual_workspace_member() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    let standard_lock = context.read("uv.lock");
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("no-lock-virtual"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+    assert_eq!(context.read("uv.lock"), standard_lock);
+
+    Ok(())
+}
+
 /// Regression test for <https://github.com/astral-sh/uv/issues/19916>.
 ///
 /// Lock a workspace with a member that also supports standalone installation via platform-specific

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3259,6 +3259,7 @@ fn preview_features() {
     +            WorkspaceListScripts,
     +            NoDistutilsPatch,
     +            IndexHashAlgorithm,
+    +            NoLockVirtual,
     +        ],
          },
          python_preference: Managed,

--- a/docs/concepts/preview.md
+++ b/docs/concepts/preview.md
@@ -73,6 +73,10 @@ The following preview features are available:
 - `centralized-project-envs`: Stores
   [project virtual environments](./projects/layout.md#centralized-project-environments) in the uv
   cache.
+- `no-lock-virtual`: Omits virtual workspace-member sources from lockfile requirement and
+  dependency-group metadata when they can be inferred from the locked workspace members. Compact
+  lockfiles use revision 4 and may be considered outdated by older uv versions; run `uv lock`
+  without this preview feature to restore the standard format.
 - `no-distutils-patch`: Stops installing the `_virtualenv.py` / `_virtualenv.pth` distutils
   configuration monkeypatch in virtual environments for Python 3.10 and later.
 - `json-output`: Allows `--output-format json` for various uv commands.

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1803,7 +1803,8 @@
             "tool-install-locks",
             "workspace-list-scripts",
             "no-distutils-patch",
-            "index-hash-algorithm"
+            "index-hash-algorithm",
+            "no-lock-virtual"
           ]
         },
         {


### PR DESCRIPTION
Remove `virtual` from `uv.lock` to reduce the lockfile size for large workspaces. In a large workspace, `package.metadata` begins dominating the lockfile size. Specifically, `virtual` just repeats the workspace member path that we already know from the workspace member list, so we can omit it and save a good chunk of size.

Notably, this is not backwards compatible: Older uv versions expect the `virtual` field, so activating the preview feature only work when using uv with that preview feature. (We could add it as a setting, but then older uv versions don't see that setting either.)