### PR TITLE
Compile installed wheels in parallel

### DIFF
--- a/crates/uv-installer/src/compile.rs
+++ b/crates/uv-installer/src/compile.rs
@@ -4,12 +4,12 @@ use std::process::Stdio;
 use std::time::Duration;
 use std::{env, io, panic};
 
-use async_channel::{Receiver, SendError};
-use tempfile::tempdir_in;
+use async_channel::{Receiver, SendError, Sender};
+use tempfile::{TempDir, tempdir_in};
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
-use tokio::sync::oneshot;
+use tokio::sync::{Mutex, oneshot};
 use tracing::{debug, instrument};
 use walkdir::WalkDir;
 
@@ -158,6 +158,120 @@ async fn wait_for_workers(
     Ok(())
 }
 
+fn python_source_files(
+    dir: &Path,
+    skip_wheel_data: bool,
+) -> impl Iterator<Item = Result<PathBuf, walkdir::Error>> + '_ {
+    // https://github.com/pypa/pip/blob/3820b0e52c7fed2b2c43ba731b718f316e6816d1/src/pip/_internal/operations/install/wheel.py#L593-L604
+    WalkDir::new(dir)
+        .into_iter()
+        // Otherwise we stumble over temporary files from `compileall`.
+        .filter_entry(move |entry| {
+            entry.file_name() != "__pycache__"
+                && !(skip_wheel_data
+                    && entry.depth() == 1
+                    && entry
+                        .path()
+                        .extension()
+                        .is_some_and(|extension| extension.eq_ignore_ascii_case("data")))
+        })
+        .filter_map(|entry| {
+            let (entry, metadata) =
+                match entry.and_then(|entry| entry.metadata().map(|metadata| (entry, metadata))) {
+                    Ok((entry, metadata)) => (entry, metadata),
+                    Err(err)
+                        if err
+                            .io_error()
+                            .is_some_and(|err| err.kind() == io::ErrorKind::NotFound) =>
+                    {
+                        return None;
+                    }
+                    Err(err) => return Some(Err(err)),
+                };
+            (metadata.is_file() && entry.path().extension().is_some_and(|ext| ext == "py"))
+                .then(|| Ok(entry.into_path()))
+        })
+}
+
+/// A shared pool of Python interpreters for compiling unpacked wheels.
+pub(crate) struct WheelCompiler {
+    sender: Sender<PathBuf>,
+    send_error: Mutex<Option<SendError<PathBuf>>>,
+    worker_handles: Vec<WorkerHandle>,
+    tempdir: TempDir,
+}
+
+impl WheelCompiler {
+    pub(crate) fn new(
+        python_executable: &Path,
+        concurrency: &Concurrency,
+        cache: &Path,
+    ) -> Result<Self, CompileError> {
+        let worker_count = concurrency.installs;
+        // A larger buffer is significantly faster than just 1 or the worker count.
+        let (sender, receiver) = async_channel::bounded::<PathBuf>(worker_count * 10);
+
+        // Running Python with an actual file will produce better error messages.
+        let tempdir = tempdir_in(cache).map_err(CompileError::TempFile)?;
+        let pip_compileall_py = tempdir.path().join("pip_compileall.py");
+        let timeout = compile_timeout()?;
+        let worker_handles = spawn_workers(
+            cache,
+            python_executable,
+            &pip_compileall_py,
+            &receiver,
+            worker_count,
+            timeout,
+        );
+        // Make sure the channel gets closed when all workers exit.
+        drop(receiver);
+
+        Ok(Self {
+            sender,
+            send_error: Mutex::new(None),
+            worker_handles,
+            tempdir,
+        })
+    }
+
+    /// Queue the Python source files in an unpacked wheel for bytecode compilation.
+    pub(crate) async fn compile_wheel(&self, dir: &Path) -> Result<usize, CompileError> {
+        debug_assert!(
+            dir.is_absolute(),
+            "compileall doesn't work with relative paths: `{}`",
+            dir.display()
+        );
+
+        let mut source_files = 0;
+        for source_file in python_source_files(dir, true) {
+            source_files += 1;
+            if let Err(err) = self.sender.send(source_file?).await {
+                let mut send_error = self.send_error.lock().await;
+                if send_error.is_none() {
+                    *send_error = Some(err);
+                }
+                break;
+            }
+        }
+        Ok(source_files)
+    }
+
+    /// Finish all queued compilation tasks and shut down the worker pool.
+    pub(crate) async fn finish(self) -> Result<(), CompileError> {
+        let Self {
+            sender,
+            send_error,
+            worker_handles,
+            tempdir,
+        } = self;
+        drop(sender);
+        let result = wait_for_workers(worker_handles, send_error.into_inner()).await;
+        // Keep the compile script alive until all workers have exited.
+        drop(tempdir);
+        result
+    }
+}
+
 /// Bytecode compile all file in `dir` using a pool of Python interpreters running a Python script
 /// that calls `compileall.compile_file`.
 ///
@@ -176,20 +290,7 @@ pub async fn compile_tree(
     concurrency: &Concurrency,
     cache: &Path,
 ) -> Result<usize, CompileError> {
-    compile_tree_inner(dir, python_executable, concurrency, cache, false).await
-}
-
-/// Bytecode compile Python source files in an unpacked wheel.
-///
-/// Files in the wheel's `.data` directory are skipped. Their bytecode files would not be listed in
-/// `RECORD`, which prevents the installer from relocating them safely.
-pub(crate) async fn compile_wheel(
-    dir: &Path,
-    python_executable: &Path,
-    concurrency: &Concurrency,
-    cache: &Path,
-) -> Result<usize, CompileError> {
-    compile_tree_inner(dir, python_executable, concurrency, cache, true).await
+    compile_tree_inner(dir, python_executable, concurrency, cache).await
 }
 
 async fn compile_tree_inner(
@@ -197,7 +298,6 @@ async fn compile_tree_inner(
     python_executable: &Path,
     concurrency: &Concurrency,
     cache: &Path,
-    skip_wheel_data: bool,
 ) -> Result<usize, CompileError> {
     debug_assert!(
         dir.is_absolute(),
@@ -227,45 +327,15 @@ async fn compile_tree_inner(
     // Start the producer, sending all `.py` files to workers.
     let mut source_files = 0;
     let mut send_error = None;
-    let walker = WalkDir::new(dir)
-        .into_iter()
-        // Otherwise we stumble over temporary files from `compileall`.
-        .filter_entry(|entry| {
-            entry.file_name() != "__pycache__"
-                && !(skip_wheel_data
-                    && entry.depth() == 1
-                    && entry
-                        .path()
-                        .extension()
-                        .is_some_and(|extension| extension.eq_ignore_ascii_case("data")))
-        });
-    for entry in walker {
-        // Retrieve the entry and its metadata, with shared handling for IO errors
-        let (entry, metadata) =
-            match entry.and_then(|entry| entry.metadata().map(|metadata| (entry, metadata))) {
-                Ok((entry, metadata)) => (entry, metadata),
-                Err(err) => {
-                    if err
-                        .io_error()
-                        .is_some_and(|err| err.kind() == io::ErrorKind::NotFound)
-                    {
-                        // The directory was removed, just ignore it
-                        continue;
-                    }
-                    return Err(err.into());
-                }
-            };
-        // https://github.com/pypa/pip/blob/3820b0e52c7fed2b2c43ba731b718f316e6816d1/src/pip/_internal/operations/install/wheel.py#L593-L604
-        if metadata.is_file() && entry.path().extension().is_some_and(|ext| ext == "py") {
-            source_files += 1;
-            if let Err(err) = sender.send(entry.path().to_owned()).await {
-                // The workers exited.
-                // If e.g. something with the Python interpreter is wrong, the workers have exited
-                // with an error. We try to report this informative error and only if that fails,
-                // report the send error.
-                send_error = Some(err);
-                break;
-            }
+    for source_file in python_source_files(dir, false) {
+        source_files += 1;
+        if let Err(err) = sender.send(source_file?).await {
+            // The workers exited.
+            // If e.g. something with the Python interpreter is wrong, the workers have exited
+            // with an error. We try to report this informative error and only if that fails,
+            // report the send error.
+            send_error = Some(err);
+            break;
         }
     }
 
@@ -569,10 +639,10 @@ mod tests {
     use uv_configuration::Concurrency;
     use uv_python::{EnvironmentPreference, PythonEnvironment, PythonPreference, PythonRequest};
 
-    use super::compile_wheel;
+    use super::WheelCompiler;
 
     #[tokio::test]
-    async fn wheel_compilation_skips_data_directory() {
+    async fn wheel_compiler_reuses_pool_and_skips_data_directory() {
         let cache = Cache::temp().expect("cache should be available");
         let wheel = tempfile::tempdir_in(cache.root()).expect("wheel directory should exist");
         let package = wheel.path().join("package");
@@ -593,17 +663,29 @@ mod tests {
         .expect("Python environment should be available");
         let concurrency = Concurrency::new(1, 1, 1, 1);
 
-        let compiled = compile_wheel(
-            wheel.path(),
-            environment.python_executable(),
-            &concurrency,
-            cache.root(),
-        )
-        .await
-        .expect("wheel should compile");
+        let other_wheel = tempfile::tempdir_in(cache.root()).expect("wheel directory should exist");
+        let other_package = other_wheel.path().join("other_package");
+        fs_err::create_dir_all(&other_package).expect("package directory should exist");
+        fs_err::write(other_package.join("__init__.py"), "VALUE = 2\n")
+            .expect("package source should be written");
+
+        let compiler =
+            WheelCompiler::new(environment.python_executable(), &concurrency, cache.root())
+                .expect("compiler should start");
+        let compiled = compiler
+            .compile_wheel(wheel.path())
+            .await
+            .expect("wheel should be queued");
+        let other_compiled = compiler
+            .compile_wheel(other_wheel.path())
+            .await
+            .expect("wheel should be queued");
+        compiler.finish().await.expect("wheels should compile");
 
         assert_eq!(compiled, 1);
+        assert_eq!(other_compiled, 1);
         assert!(package.join("__pycache__").exists());
+        assert!(other_package.join("__pycache__").exists());
         assert!(!scripts.join("__pycache__").exists());
     }
 }

--- a/crates/uv-installer/src/compile.rs
+++ b/crates/uv-installer/src/compile.rs
@@ -1,20 +1,26 @@
+use std::collections::HashSet;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use std::{env, io, panic};
 
+use anyhow::anyhow;
 use async_channel::{Receiver, SendError, Sender};
 use tempfile::{TempDir, tempdir_in};
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
-use tokio::sync::{Mutex, oneshot};
+use tokio::sync::oneshot;
 use tracing::{debug, instrument};
 use walkdir::WalkDir;
 
 use uv_configuration::Concurrency;
-use uv_fs::Simplified;
+use uv_distribution_types::CachedDist;
+use uv_fs::{CWD, Simplified};
+use uv_install_wheel::{Layout, installed_dist_info_path};
 use uv_static::EnvVars;
 use uv_warnings::warn_user;
 
@@ -95,7 +101,7 @@ fn spawn_workers(
     dir: &Path,
     python_executable: &Path,
     pip_compileall_py: &Path,
-    receiver: &Receiver<PathBuf>,
+    receiver: &Arc<Receiver<PathBuf>>,
     worker_count: usize,
     timeout: Option<Duration>,
 ) -> Vec<WorkerHandle> {
@@ -103,12 +109,13 @@ fn spawn_workers(
     let mut worker_handles = Vec::with_capacity(worker_count);
     for _ in 0..worker_count {
         let (tx, rx) = oneshot::channel();
+        let receiver = Arc::clone(receiver);
 
         let worker = worker(
             dir.to_path_buf(),
             python_executable.to_path_buf(),
             pip_compileall_py.to_path_buf(),
-            receiver.clone(),
+            receiver.as_ref().clone(),
             timeout,
         );
 
@@ -116,6 +123,9 @@ fn spawn_workers(
         std::thread::Builder::new()
             .name("uv-compile".to_owned())
             .spawn(move || {
+                // Keep the shared receiver alive only while a worker is running. This lets the
+                // wheel compiler grow its pool without hiding the disappearance of every worker.
+                let _receiver = receiver;
                 // Report panics back to the main thread.
                 let result = panic::catch_unwind(AssertUnwindSafe(|| {
                     tokio::runtime::Builder::new_current_thread()
@@ -193,82 +203,180 @@ fn python_source_files(
         })
 }
 
-/// A shared pool of Python interpreters for compiling unpacked wheels.
-pub(crate) struct WheelCompiler {
+struct WheelCompilerWorkers {
     sender: Sender<PathBuf>,
-    send_error: Mutex<Option<SendError<PathBuf>>>,
+    receiver: Weak<Receiver<PathBuf>>,
     worker_handles: Vec<WorkerHandle>,
     tempdir: TempDir,
+    timeout: Option<Duration>,
+}
+
+/// A shared pool of Python interpreters for compiling installed wheels.
+pub struct WheelCompiler {
+    python_executable: PathBuf,
+    cache: PathBuf,
+    worker_count: usize,
+    workers: Mutex<Option<WheelCompilerWorkers>>,
+    send_error: Mutex<Option<SendError<PathBuf>>>,
+    queued: Mutex<HashSet<PathBuf>>,
+    source_files: AtomicUsize,
 }
 
 impl WheelCompiler {
-    pub(crate) fn new(
+    /// Create a shared pool that starts Python workers when the first source is queued.
+    pub fn new(
         python_executable: &Path,
         concurrency: &Concurrency,
         cache: &Path,
     ) -> Result<Self, CompileError> {
-        let worker_count = concurrency.installs;
-        // A larger buffer is significantly faster than just 1 or the worker count.
-        let (sender, receiver) = async_channel::bounded::<PathBuf>(worker_count * 10);
+        Ok(Self {
+            python_executable: python_executable.to_path_buf(),
+            cache: cache.to_path_buf(),
+            worker_count: concurrency.installs.max(1),
+            workers: Mutex::new(None),
+            send_error: Mutex::new(None),
+            queued: Mutex::new(HashSet::new()),
+            source_files: AtomicUsize::new(0),
+        })
+    }
 
+    fn sender(&self, worker_count: usize) -> Result<Sender<PathBuf>, CompileError> {
+        let mut workers = self.workers.lock().map_err(|_| CompileError::Join)?;
+        if let Some(workers) = workers.as_mut() {
+            let additional = worker_count.saturating_sub(workers.worker_handles.len());
+            if additional > 0
+                && let Some(receiver) = workers.receiver.upgrade()
+            {
+                workers.worker_handles.extend(spawn_workers(
+                    &self.cache,
+                    &self.python_executable,
+                    &workers.tempdir.path().join("pip_compileall.py"),
+                    &receiver,
+                    additional,
+                    workers.timeout,
+                ));
+            }
+            return Ok(workers.sender.clone());
+        }
+
+        // A larger buffer is significantly faster than just 1 or the worker count.
+        let (sender, receiver) =
+            async_channel::bounded::<PathBuf>(self.worker_count.saturating_mul(10));
+        let receiver = Arc::new(receiver);
         // Running Python with an actual file will produce better error messages.
-        let tempdir = tempdir_in(cache).map_err(CompileError::TempFile)?;
+        let tempdir = tempdir_in(&self.cache).map_err(CompileError::TempFile)?;
         let pip_compileall_py = tempdir.path().join("pip_compileall.py");
         let timeout = compile_timeout()?;
         let worker_handles = spawn_workers(
-            cache,
-            python_executable,
+            &self.cache,
+            &self.python_executable,
             &pip_compileall_py,
             &receiver,
             worker_count,
             timeout,
         );
-        // Make sure the channel gets closed when all workers exit.
-        drop(receiver);
-
-        Ok(Self {
-            sender,
-            send_error: Mutex::new(None),
+        let shared_receiver = Arc::downgrade(&receiver);
+        *workers = Some(WheelCompilerWorkers {
+            sender: sender.clone(),
+            receiver: shared_receiver,
             worker_handles,
             tempdir,
-        })
+            timeout,
+        });
+        Ok(sender)
     }
 
-    /// Queue the Python source files in an unpacked wheel for bytecode compilation.
-    pub(crate) async fn compile_wheel(&self, dir: &Path) -> Result<usize, CompileError> {
+    /// Queue an installed Python source file for bytecode compilation.
+    pub fn queue_file(&self, source_file: PathBuf) -> Result<(), CompileError> {
         debug_assert!(
-            dir.is_absolute(),
+            source_file.is_absolute(),
             "compileall doesn't work with relative paths: `{}`",
-            dir.display()
+            source_file.display()
         );
 
-        let mut source_files = 0;
-        for source_file in python_source_files(dir, true) {
-            source_files += 1;
-            if let Err(err) = self.sender.send(source_file?).await {
-                let mut send_error = self.send_error.lock().await;
-                if send_error.is_none() {
-                    *send_error = Some(err);
-                }
-                break;
-            }
+        let mut queued = self.queued.lock().map_err(|_| CompileError::Join)?;
+        if !queued.insert(source_file.clone()) {
+            return Ok(());
         }
-        Ok(source_files)
+        let worker_count = queued.len().min(self.worker_count);
+        drop(queued);
+
+        if let Err(err) = self.sender(worker_count)?.send_blocking(source_file) {
+            let mut send_error = self.send_error.lock().map_err(|_| CompileError::Join)?;
+            if send_error.is_none() {
+                *send_error = Some(err);
+            }
+        } else {
+            self.source_files.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+
+    /// Queue the root Python source files belonging to an installed wheel.
+    pub(crate) fn queue_wheel(
+        &self,
+        layout: &Layout,
+        wheel: &CachedDist,
+    ) -> Result<(), CompileError> {
+        let dist_info = installed_dist_info_path(layout, wheel.path())
+            .map_err(|err| CompileError::SourceFiles(err.into()))?;
+        let site_packages = dist_info.parent().ok_or_else(|| {
+            CompileError::SourceFiles(anyhow!(
+                "Installed distribution has no site-packages parent: `{wheel}`"
+            ))
+        })?;
+
+        // Files in `.data` are relocated during installation. They are queued from the installed
+        // RECORD after all wheels have been installed.
+        for source_file in python_source_files(wheel.path(), true) {
+            let source_file = source_file?;
+            let relative = source_file.strip_prefix(wheel.path()).map_err(|_| {
+                CompileError::SourceFiles(anyhow!(
+                    "Python source is outside its cached wheel: `{}`",
+                    source_file.display()
+                ))
+            })?;
+            self.queue_file(CWD.join(site_packages.join(relative)))?;
+        }
+        Ok(())
+    }
+
+    /// Queue the Python source files in an installed directory.
+    pub fn queue_tree(&self, dir: &Path) -> Result<(), CompileError> {
+        for source_file in python_source_files(dir, false) {
+            self.queue_file(source_file?)?;
+        }
+        Ok(())
     }
 
     /// Finish all queued compilation tasks and shut down the worker pool.
-    pub(crate) async fn finish(self) -> Result<(), CompileError> {
+    pub async fn finish(self: Arc<Self>) -> Result<usize, CompileError> {
+        let compiler = Arc::try_unwrap(self).map_err(|_| CompileError::Join)?;
         let Self {
-            sender,
+            python_executable: _,
+            cache: _,
+            worker_count: _,
+            workers,
             send_error,
+            queued: _,
+            source_files,
+        } = compiler;
+        if let Some(WheelCompilerWorkers {
+            sender,
+            receiver: _,
             worker_handles,
             tempdir,
-        } = self;
-        drop(sender);
-        let result = wait_for_workers(worker_handles, send_error.into_inner()).await;
-        // Keep the compile script alive until all workers have exited.
-        drop(tempdir);
-        result
+            timeout: _,
+        }) = workers.into_inner().map_err(|_| CompileError::Join)?
+        {
+            drop(sender);
+            let send_error = send_error.into_inner().map_err(|_| CompileError::Join)?;
+            let result = wait_for_workers(worker_handles, send_error).await;
+            // Keep the compile script alive until all workers have exited.
+            drop(tempdir);
+            result?;
+        }
+        Ok(source_files.into_inner())
     }
 }
 
@@ -308,6 +416,7 @@ async fn compile_tree_inner(
 
     // A larger buffer is significantly faster than just 1 or the worker count.
     let (sender, receiver) = async_channel::bounded::<PathBuf>(worker_count * 10);
+    let receiver = Arc::new(receiver);
 
     // Running Python with an actual file will produce better error messages.
     let tempdir = tempdir_in(cache).map_err(CompileError::TempFile)?;
@@ -370,6 +479,7 @@ pub async fn compile_files(
 
     let worker_count = initial_files.len();
     let (sender, receiver) = async_channel::bounded::<PathBuf>(worker_count * 10);
+    let receiver = Arc::new(receiver);
 
     // Running Python with an actual file will produce better error messages.
     let tempdir = tempdir_in(cache).map_err(CompileError::TempFile)?;
@@ -635,6 +745,8 @@ async fn worker_main_loop(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use uv_cache::Cache;
     use uv_configuration::Concurrency;
     use uv_python::{EnvironmentPreference, PythonEnvironment, PythonPreference, PythonRequest};
@@ -642,17 +754,13 @@ mod tests {
     use super::WheelCompiler;
 
     #[tokio::test]
-    async fn wheel_compiler_reuses_pool_and_skips_data_directory() {
+    async fn wheel_compiler_reuses_pool_and_deduplicates_files() {
         let cache = Cache::temp().expect("cache should be available");
         let wheel = tempfile::tempdir_in(cache.root()).expect("wheel directory should exist");
         let package = wheel.path().join("package");
-        let scripts = wheel.path().join("package-1.0.0.data/scripts");
         fs_err::create_dir_all(&package).expect("package directory should exist");
-        fs_err::create_dir_all(&scripts).expect("scripts directory should exist");
         fs_err::write(package.join("__init__.py"), "VALUE = 1\n")
             .expect("package source should be written");
-        fs_err::write(scripts.join("script.py"), "VALUE = 1\n")
-            .expect("script source should be written");
 
         let environment = PythonEnvironment::find(
             &PythonRequest::Any,
@@ -661,7 +769,7 @@ mod tests {
             &cache,
         )
         .expect("Python environment should be available");
-        let concurrency = Concurrency::new(1, 1, 1, 1);
+        let concurrency = Concurrency::new(1, 1, 4, 1);
 
         let other_wheel = tempfile::tempdir_in(cache.root()).expect("wheel directory should exist");
         let other_package = other_wheel.path().join("other_package");
@@ -669,23 +777,52 @@ mod tests {
         fs_err::write(other_package.join("__init__.py"), "VALUE = 2\n")
             .expect("package source should be written");
 
-        let compiler =
+        let compiler = Arc::new(
             WheelCompiler::new(environment.python_executable(), &concurrency, cache.root())
-                .expect("compiler should start");
-        let compiled = compiler
-            .compile_wheel(wheel.path())
-            .await
-            .expect("wheel should be queued");
-        let other_compiled = compiler
-            .compile_wheel(other_wheel.path())
-            .await
-            .expect("wheel should be queued");
-        compiler.finish().await.expect("wheels should compile");
+                .expect("compiler should start"),
+        );
+        assert!(
+            compiler
+                .workers
+                .lock()
+                .expect("worker state should be available")
+                .is_none()
+        );
+        compiler
+            .queue_file(package.join("__init__.py"))
+            .expect("source should be queued");
+        assert_eq!(
+            compiler
+                .workers
+                .lock()
+                .expect("worker state should be available")
+                .as_ref()
+                .expect("worker should start for the first source")
+                .worker_handles
+                .len(),
+            1
+        );
+        compiler
+            .queue_file(package.join("__init__.py"))
+            .expect("duplicate source should be ignored");
+        compiler
+            .queue_file(other_package.join("__init__.py"))
+            .expect("source should be queued");
+        assert_eq!(
+            compiler
+                .workers
+                .lock()
+                .expect("worker state should be available")
+                .as_ref()
+                .expect("worker should remain available")
+                .worker_handles
+                .len(),
+            2
+        );
+        let compiled = compiler.finish().await.expect("sources should compile");
 
-        assert_eq!(compiled, 1);
-        assert_eq!(other_compiled, 1);
+        assert_eq!(compiled, 2);
         assert!(package.join("__pycache__").exists());
         assert!(other_package.join("__pycache__").exists());
-        assert!(!scripts.join("__pycache__").exists());
     }
 }

--- a/crates/uv-installer/src/compile.rs
+++ b/crates/uv-installer/src/compile.rs
@@ -176,6 +176,29 @@ pub async fn compile_tree(
     concurrency: &Concurrency,
     cache: &Path,
 ) -> Result<usize, CompileError> {
+    compile_tree_inner(dir, python_executable, concurrency, cache, false).await
+}
+
+/// Bytecode compile Python source files in an unpacked wheel.
+///
+/// Files in the wheel's `.data` directory are skipped. Their bytecode files would not be listed in
+/// `RECORD`, which prevents the installer from relocating them safely.
+pub(crate) async fn compile_wheel(
+    dir: &Path,
+    python_executable: &Path,
+    concurrency: &Concurrency,
+    cache: &Path,
+) -> Result<usize, CompileError> {
+    compile_tree_inner(dir, python_executable, concurrency, cache, true).await
+}
+
+async fn compile_tree_inner(
+    dir: &Path,
+    python_executable: &Path,
+    concurrency: &Concurrency,
+    cache: &Path,
+    skip_wheel_data: bool,
+) -> Result<usize, CompileError> {
     debug_assert!(
         dir.is_absolute(),
         "compileall doesn't work with relative paths: `{}`",
@@ -207,7 +230,15 @@ pub async fn compile_tree(
     let walker = WalkDir::new(dir)
         .into_iter()
         // Otherwise we stumble over temporary files from `compileall`.
-        .filter_entry(|dir| dir.file_name() != "__pycache__");
+        .filter_entry(|entry| {
+            entry.file_name() != "__pycache__"
+                && !(skip_wheel_data
+                    && entry.depth() == 1
+                    && entry
+                        .path()
+                        .extension()
+                        .is_some_and(|extension| extension.eq_ignore_ascii_case("data")))
+        });
     for entry in walker {
         // Retrieve the entry and its metadata, with shared handling for IO errors
         let (entry, metadata) =
@@ -530,4 +561,49 @@ async fn worker_main_loop(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use uv_cache::Cache;
+    use uv_configuration::Concurrency;
+    use uv_python::{EnvironmentPreference, PythonEnvironment, PythonPreference, PythonRequest};
+
+    use super::compile_wheel;
+
+    #[tokio::test]
+    async fn wheel_compilation_skips_data_directory() {
+        let cache = Cache::temp().expect("cache should be available");
+        let wheel = tempfile::tempdir_in(cache.root()).expect("wheel directory should exist");
+        let package = wheel.path().join("package");
+        let scripts = wheel.path().join("package-1.0.0.data/scripts");
+        fs_err::create_dir_all(&package).expect("package directory should exist");
+        fs_err::create_dir_all(&scripts).expect("scripts directory should exist");
+        fs_err::write(package.join("__init__.py"), "VALUE = 1\n")
+            .expect("package source should be written");
+        fs_err::write(scripts.join("script.py"), "VALUE = 1\n")
+            .expect("script source should be written");
+
+        let environment = PythonEnvironment::find(
+            &PythonRequest::Any,
+            EnvironmentPreference::Any,
+            PythonPreference::System,
+            &cache,
+        )
+        .expect("Python environment should be available");
+        let concurrency = Concurrency::new(1, 1, 1, 1);
+
+        let compiled = compile_wheel(
+            wheel.path(),
+            environment.python_executable(),
+            &concurrency,
+            cache.root(),
+        )
+        .await
+        .expect("wheel should compile");
+
+        assert_eq!(compiled, 1);
+        assert!(package.join("__pycache__").exists());
+        assert!(!scripts.join("__pycache__").exists());
+    }
 }

--- a/crates/uv-installer/src/installer.rs
+++ b/crates/uv-installer/src/installer.rs
@@ -13,10 +13,13 @@ use uv_install_wheel::{Layout, LinkMode};
 use uv_preview::Preview;
 use uv_python::PythonEnvironment;
 
+use crate::WheelCompiler;
+
 pub struct Installer<'a> {
     venv: &'a PythonEnvironment,
     link_mode: LinkMode,
     cache: Option<&'a Cache>,
+    bytecode_compiler: Option<Arc<WheelCompiler>>,
     reporter: Option<Arc<dyn Reporter>>,
     /// The name of the [`Installer`].
     name: Option<String>,
@@ -33,10 +36,20 @@ impl<'a> Installer<'a> {
             venv,
             link_mode: LinkMode::default(),
             cache: None,
+            bytecode_compiler: None,
             reporter: None,
             name: Some("uv".to_string()),
             metadata: true,
             preview,
+        }
+    }
+
+    /// Queue each wheel for bytecode compilation immediately after it is installed.
+    #[must_use]
+    pub fn with_bytecode_compiler(self, bytecode_compiler: Arc<WheelCompiler>) -> Self {
+        Self {
+            bytecode_compiler: Some(bytecode_compiler),
+            ..self
         }
     }
 
@@ -88,6 +101,7 @@ impl<'a> Installer<'a> {
         let Self {
             venv,
             cache,
+            bytecode_compiler,
             link_mode,
             reporter,
             name: installer_name,
@@ -113,6 +127,7 @@ impl<'a> Installer<'a> {
             let result = install(
                 wheels,
                 &layout,
+                bytecode_compiler.as_deref(),
                 installer_name.as_deref(),
                 link_mode,
                 reporter.as_ref(),
@@ -144,6 +159,7 @@ impl<'a> Installer<'a> {
         install(
             wheels,
             &self.venv.interpreter().layout(),
+            self.bytecode_compiler.as_deref(),
             self.name.as_deref(),
             self.link_mode,
             self.reporter.as_ref(),
@@ -159,6 +175,7 @@ impl<'a> Installer<'a> {
 fn install(
     wheels: Vec<CachedDist>,
     layout: &Layout,
+    bytecode_compiler: Option<&WheelCompiler>,
     installer_name: Option<&str>,
     link_mode: LinkMode,
     reporter: Option<&Arc<dyn Reporter>>,
@@ -191,6 +208,14 @@ fn install(
             &state,
         )
         .with_context(|| format!("Failed to install: {} ({wheel})", wheel.filename()))?;
+
+        if let Some(bytecode_compiler) = bytecode_compiler {
+            bytecode_compiler
+                .queue_wheel(layout, wheel)
+                .with_context(|| {
+                    format!("Failed to queue installed wheel for bytecode compilation: {wheel}")
+                })?;
+        }
 
         if let Some(reporter) = reporter.as_ref() {
             reporter.on_install_progress(wheel);

--- a/crates/uv-installer/src/lib.rs
+++ b/crates/uv-installer/src/lib.rs
@@ -1,4 +1,4 @@
-pub use compile::{CompileError, compile_files, compile_tree};
+pub use compile::{CompileError, WheelCompiler, compile_files, compile_tree};
 pub use installer::{Installer, Reporter as InstallReporter};
 pub use plan::{IncompatibleWheelError, Plan, Planner};
 pub use preparer::{Error as PrepareError, Preparer, Reporter as PrepareReporter};

--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -1,12 +1,11 @@
 use std::cmp::Reverse;
-use std::path::Path;
 use std::sync::Arc;
 
 use futures::{FutureExt, Stream, TryFutureExt, TryStreamExt, stream::FuturesUnordered};
 use tracing::{debug, instrument};
 
 use uv_cache::Cache;
-use uv_configuration::{BuildOptions, Concurrency};
+use uv_configuration::BuildOptions;
 use uv_distribution::{DistributionDatabase, LocalWheel};
 use uv_distribution_types::{
     BuildableSource, CachedDist, DerivationChain, Dist, DistErrorKind, Hashed, Identifier, Name,
@@ -27,7 +26,6 @@ pub struct Preparer<'a, Context: BuildContext> {
     build_options: &'a BuildOptions,
     database: DistributionDatabase<'a, Context>,
     reporter: Option<Arc<dyn Reporter>>,
-    bytecode_compilation: Option<(&'a Path, &'a Concurrency)>,
 }
 
 impl<'a, Context: BuildContext> Preparer<'a, Context> {
@@ -45,7 +43,6 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
             build_options,
             database,
             reporter: None,
-            bytecode_compilation: None,
         }
     }
 
@@ -61,20 +58,6 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                 .database
                 .with_reporter(reporter.clone().into_distribution_reporter()),
             reporter: Some(reporter),
-            bytecode_compilation: self.bytecode_compilation,
-        }
-    }
-
-    /// Bytecode-compile each unpacked wheel before the next installation phase.
-    #[must_use]
-    pub fn with_bytecode_compilation(
-        self,
-        python_executable: &'a Path,
-        concurrency: &'a Concurrency,
-    ) -> Self {
-        Self {
-            bytecode_compilation: Some((python_executable, concurrency)),
-            ..self
         }
     }
 
@@ -84,18 +67,14 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
         distributions: Vec<Arc<Dist>>,
         in_flight: &'stream InFlight,
         resolution: &'stream Resolution,
-        compiler: Option<&'stream crate::compile::WheelCompiler>,
     ) -> impl Stream<Item = Result<CachedDist, Error>> + 'stream {
         distributions
             .into_iter()
-            .map(move |dist| async move {
+            .map(async |dist| {
                 let wheel = self
                     .get_wheel((*dist).clone(), in_flight, resolution)
                     .boxed_local()
                     .await?;
-                if let Some(compiler) = compiler {
-                    compiler.compile_wheel(wheel.path()).await?;
-                }
                 if let Some(reporter) = self.reporter.as_ref() {
                     reporter.on_progress(&wheel);
                 }
@@ -116,27 +95,10 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
         distributions
             .sort_unstable_by_key(|distribution| Reverse(distribution.size().unwrap_or(u64::MAX)));
 
-        let compiler = self
-            .bytecode_compilation
-            .map(|(python_executable, concurrency)| {
-                crate::compile::WheelCompiler::new(
-                    python_executable,
-                    concurrency,
-                    self.cache.root(),
-                )
-            })
-            .transpose()?;
         let wheels = self
-            .prepare_stream(distributions, in_flight, resolution, compiler.as_ref())
+            .prepare_stream(distributions, in_flight, resolution)
             .try_collect()
-            .await;
-        let compilation = if let Some(compiler) = compiler {
-            compiler.finish().await
-        } else {
-            Ok(())
-        };
-        let wheels = wheels?;
-        compilation?;
+            .await?;
 
         if let Some(reporter) = self.reporter.as_ref() {
             reporter.on_complete();
@@ -257,8 +219,6 @@ pub enum Error {
     ),
     #[error("Cyclic build dependency detected for `{0}`")]
     CyclicBuildDependency(PackageName),
-    #[error("Failed to bytecode-compile a prepared wheel")]
-    Bytecode(#[from] crate::CompileError),
     #[error("Unzip failed in another thread: {0}")]
     Thread(String),
 }

--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -1,11 +1,13 @@
 use std::cmp::Reverse;
+use std::path::Path;
 use std::sync::Arc;
 
 use futures::{FutureExt, Stream, TryFutureExt, TryStreamExt, stream::FuturesUnordered};
+use tokio::sync::Mutex;
 use tracing::{debug, instrument};
 
 use uv_cache::Cache;
-use uv_configuration::BuildOptions;
+use uv_configuration::{BuildOptions, Concurrency};
 use uv_distribution::{DistributionDatabase, LocalWheel};
 use uv_distribution_types::{
     BuildableSource, CachedDist, DerivationChain, Dist, DistErrorKind, Hashed, Identifier, Name,
@@ -26,6 +28,8 @@ pub struct Preparer<'a, Context: BuildContext> {
     build_options: &'a BuildOptions,
     database: DistributionDatabase<'a, Context>,
     reporter: Option<Arc<dyn Reporter>>,
+    bytecode_compilation: Option<(&'a Path, &'a Concurrency)>,
+    bytecode_lock: Mutex<()>,
 }
 
 impl<'a, Context: BuildContext> Preparer<'a, Context> {
@@ -43,6 +47,8 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
             build_options,
             database,
             reporter: None,
+            bytecode_compilation: None,
+            bytecode_lock: Mutex::new(()),
         }
     }
 
@@ -58,6 +64,21 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                 .database
                 .with_reporter(reporter.clone().into_distribution_reporter()),
             reporter: Some(reporter),
+            bytecode_compilation: self.bytecode_compilation,
+            bytecode_lock: self.bytecode_lock,
+        }
+    }
+
+    /// Bytecode-compile each unpacked wheel before the next installation phase.
+    #[must_use]
+    pub fn with_bytecode_compilation(
+        self,
+        python_executable: &'a Path,
+        concurrency: &'a Concurrency,
+    ) -> Self {
+        Self {
+            bytecode_compilation: Some((python_executable, concurrency)),
+            ..self
         }
     }
 
@@ -75,6 +96,19 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                     .get_wheel((*dist).clone(), in_flight, resolution)
                     .boxed_local()
                     .await?;
+                if let Some((python_executable, concurrency)) = self.bytecode_compilation {
+                    // Each compilation uses the install concurrency limit internally. Keep one
+                    // wheel compiling at a time so downloads can continue without starting a
+                    // worker pool for every completed wheel.
+                    let _guard = self.bytecode_lock.lock().await;
+                    crate::compile::compile_wheel(
+                        wheel.path(),
+                        python_executable,
+                        concurrency,
+                        self.cache.root(),
+                    )
+                    .await?;
+                }
                 if let Some(reporter) = self.reporter.as_ref() {
                     reporter.on_progress(&wheel);
                 }
@@ -219,6 +253,8 @@ pub enum Error {
     ),
     #[error("Cyclic build dependency detected for `{0}`")]
     CyclicBuildDependency(PackageName),
+    #[error("Failed to bytecode-compile a prepared wheel")]
+    Bytecode(#[from] crate::CompileError),
     #[error("Unzip failed in another thread: {0}")]
     Thread(String),
 }

--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use futures::{FutureExt, Stream, TryFutureExt, TryStreamExt, stream::FuturesUnordered};
-use tokio::sync::Mutex;
 use tracing::{debug, instrument};
 
 use uv_cache::Cache;
@@ -29,7 +28,6 @@ pub struct Preparer<'a, Context: BuildContext> {
     database: DistributionDatabase<'a, Context>,
     reporter: Option<Arc<dyn Reporter>>,
     bytecode_compilation: Option<(&'a Path, &'a Concurrency)>,
-    bytecode_lock: Mutex<()>,
 }
 
 impl<'a, Context: BuildContext> Preparer<'a, Context> {
@@ -48,7 +46,6 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
             database,
             reporter: None,
             bytecode_compilation: None,
-            bytecode_lock: Mutex::new(()),
         }
     }
 
@@ -65,7 +62,6 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                 .with_reporter(reporter.clone().into_distribution_reporter()),
             reporter: Some(reporter),
             bytecode_compilation: self.bytecode_compilation,
-            bytecode_lock: self.bytecode_lock,
         }
     }
 
@@ -88,26 +84,17 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
         distributions: Vec<Arc<Dist>>,
         in_flight: &'stream InFlight,
         resolution: &'stream Resolution,
+        compiler: Option<&'stream crate::compile::WheelCompiler>,
     ) -> impl Stream<Item = Result<CachedDist, Error>> + 'stream {
         distributions
             .into_iter()
-            .map(async |dist| {
+            .map(move |dist| async move {
                 let wheel = self
                     .get_wheel((*dist).clone(), in_flight, resolution)
                     .boxed_local()
                     .await?;
-                if let Some((python_executable, concurrency)) = self.bytecode_compilation {
-                    // Each compilation uses the install concurrency limit internally. Keep one
-                    // wheel compiling at a time so downloads can continue without starting a
-                    // worker pool for every completed wheel.
-                    let _guard = self.bytecode_lock.lock().await;
-                    crate::compile::compile_wheel(
-                        wheel.path(),
-                        python_executable,
-                        concurrency,
-                        self.cache.root(),
-                    )
-                    .await?;
+                if let Some(compiler) = compiler {
+                    compiler.compile_wheel(wheel.path()).await?;
                 }
                 if let Some(reporter) = self.reporter.as_ref() {
                     reporter.on_progress(&wheel);
@@ -129,10 +116,27 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
         distributions
             .sort_unstable_by_key(|distribution| Reverse(distribution.size().unwrap_or(u64::MAX)));
 
+        let compiler = self
+            .bytecode_compilation
+            .map(|(python_executable, concurrency)| {
+                crate::compile::WheelCompiler::new(
+                    python_executable,
+                    concurrency,
+                    self.cache.root(),
+                )
+            })
+            .transpose()?;
         let wheels = self
-            .prepare_stream(distributions, in_flight, resolution)
+            .prepare_stream(distributions, in_flight, resolution, compiler.as_ref())
             .try_collect()
-            .await?;
+            .await;
+        let compilation = if let Some(compiler) = compiler {
+            compiler.finish().await
+        } else {
+            Ok(())
+        };
+        let wheels = wheels?;
+        compilation?;
 
         if let Some(reporter) = self.reporter.as_ref() {
             reporter.on_complete();

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{fmt::Write, process::ExitCode};
 
 use anstream::AutoStream;
-use anyhow::{Context, bail};
+use anyhow::bail;
 use owo_colors::OwoColorize;
 use tracing::debug;
 use uv_warnings::warn_user;
@@ -63,12 +63,8 @@ pub(crate) use tool::run::run as tool_run;
 pub(crate) use tool::uninstall::uninstall as tool_uninstall;
 pub(crate) use tool::update_shell::update_shell as tool_update_shell;
 pub(crate) use tool::upgrade::upgrade as tool_upgrade;
-use uv_cache::Cache;
-use uv_configuration::Concurrency;
 pub(crate) use uv_console::human_readable_bytes;
-use uv_fs::{CWD, Simplified};
-use uv_installer::{compile_files, compile_tree};
-use uv_python::PythonEnvironment;
+use uv_fs::Simplified;
 use uv_scripts::Pep723Script;
 pub(crate) use venv::venv;
 pub(crate) use workspace::dir::dir;
@@ -269,65 +265,6 @@ pub(super) enum ChangeEventKind {
 pub(super) struct ChangeEvent<'a> {
     dist: &'a ChangedDist,
     kind: ChangeEventKind,
-}
-
-/// Compile all Python source files in site-packages to bytecode, to speed up the
-/// initial run of any subsequent executions.
-///
-/// See the `--compile` option on `pip sync` and `pip install`.
-pub(super) async fn compile_bytecode(
-    venv: &PythonEnvironment,
-    concurrency: &Concurrency,
-    cache: &Cache,
-    printer: Printer,
-) -> anyhow::Result<()> {
-    let start = std::time::Instant::now();
-    let mut files = 0;
-    for site_packages in venv.site_packages() {
-        let site_packages = CWD.join(site_packages);
-        if !site_packages.exists() {
-            debug!(
-                "Skipping non-existent site-packages directory: {}",
-                site_packages.display()
-            );
-            continue;
-        }
-        files += compile_tree(
-            &site_packages,
-            venv.python_executable(),
-            concurrency,
-            cache.root(),
-        )
-        .await
-        .with_context(|| {
-            format!(
-                "Failed to bytecode-compile Python file in: {}",
-                site_packages.user_display()
-            )
-        })?;
-    }
-    write_bytecode_summary(files, start, printer)?;
-    Ok(())
-}
-
-/// Compile the given Python source files to bytecode.
-pub(super) async fn compile_bytecode_files(
-    files: impl IntoIterator<Item = anyhow::Result<PathBuf>>,
-    venv: &PythonEnvironment,
-    concurrency: &Concurrency,
-    cache: &Cache,
-    printer: Printer,
-) -> anyhow::Result<()> {
-    let start = std::time::Instant::now();
-    let files = compile_files(files, venv.python_executable(), concurrency, cache.root())
-        .await
-        .context("Failed to bytecode-compile installed packages")?;
-    if files == 0 {
-        return Ok(());
-    }
-
-    write_bytecode_summary(files, start, printer)?;
-    Ok(())
 }
 
 fn write_bytecode_summary(

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -51,7 +51,7 @@ use uv_warnings::warn_user;
 
 use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
 use crate::commands::reporters::{InstallReporter, PrepareReporter, ResolverReporter};
-use crate::commands::{compile_bytecode, compile_bytecode_files};
+use crate::commands::write_bytecode_summary;
 use crate::printer::Printer;
 
 /// Consolidate the requirements for an installation.
@@ -805,6 +805,24 @@ impl InstallationPlan {
 
         let has_isolated_phase = !isolated_phase.is_empty();
         let has_shared_phase = !shared_phase.is_empty();
+        let has_installs = !isolated_phase.cached.is_empty()
+            || !isolated_phase.remote.is_empty()
+            || !shared_phase.cached.is_empty()
+            || !shared_phase.remote.is_empty();
+        let compiler = if matches!(compile, Some(BytecodeCompilation::All))
+            || (compile.is_some() && has_installs)
+        {
+            Some(Arc::new(
+                uv_installer::WheelCompiler::new(
+                    venv.python_executable(),
+                    concurrency,
+                    cache.root(),
+                )
+                .map_err(anyhow::Error::new)?,
+            ))
+        } else {
+            None
+        };
 
         let mut installs = vec![];
         let mut uninstalls = vec![];
@@ -817,7 +835,7 @@ impl InstallationPlan {
                 resolution,
                 build_options,
                 link_mode,
-                matches!(compile, Some(BytecodeCompilation::All)),
+                compiler.as_ref(),
                 hasher,
                 tags,
                 client,
@@ -847,7 +865,7 @@ impl InstallationPlan {
                 resolution,
                 build_options,
                 link_mode,
-                matches!(compile, Some(BytecodeCompilation::All)),
+                compiler.as_ref(),
                 hasher,
                 tags,
                 client,
@@ -866,15 +884,41 @@ impl InstallationPlan {
             uninstalls.extend(shared_uninstalls);
         }
 
-        if let Some(compile) = compile {
+        if let (Some(compile), Some(compiler)) = (compile, compiler) {
+            let start = Instant::now();
             match compile {
                 BytecodeCompilation::All => {
-                    compile_bytecode(venv, concurrency, cache, printer).await?;
+                    for site_packages in venv.site_packages() {
+                        let site_packages = CWD.join(site_packages);
+                        if !site_packages.exists() {
+                            debug!(
+                                "Skipping non-existent site-packages directory: {}",
+                                site_packages.display()
+                            );
+                            continue;
+                        }
+                        compiler.queue_tree(&site_packages).with_context(|| {
+                            format!(
+                                "Failed to bytecode-compile Python file in: {}",
+                                site_packages.user_display()
+                            )
+                        })?;
+                    }
                 }
                 BytecodeCompilation::Installed => {
-                    let files = python_source_files_for_installs(venv, &installs);
-                    compile_bytecode_files(files, venv, concurrency, cache, printer).await?;
+                    for source_file in python_source_files_for_installs(venv, &installs) {
+                        compiler
+                            .queue_file(source_file?)
+                            .context("Failed to bytecode-compile installed packages")?;
+                    }
                 }
+            }
+            let files = compiler
+                .finish()
+                .await
+                .context("Failed to bytecode-compile installed packages")?;
+            if files > 0 || matches!(compile, BytecodeCompilation::All) {
+                write_bytecode_summary(files, start, printer)?;
             }
         }
 
@@ -1018,7 +1062,7 @@ async fn execute_plan(
     resolution: &Resolution,
     build_options: &BuildOptions,
     link_mode: LinkMode,
-    compile_bytecode: bool,
+    bytecode_compiler: Option<&Arc<uv_installer::WheelCompiler>>,
     hasher: &HashStrategy,
     tags: &Tags,
     client: &RegistryClient,
@@ -1059,12 +1103,6 @@ async fn execute_plan(
         .with_reporter(Arc::new(
             PrepareReporter::from(printer).with_length(remote.len() as u64),
         ));
-        let preparer = if compile_bytecode {
-            preparer.with_bytecode_compilation(venv.python_executable(), concurrency)
-        } else {
-            preparer
-        };
-
         let wheels = preparer
             .prepare(remote.clone(), in_flight, resolution)
             .await?;
@@ -1125,13 +1163,19 @@ async fn execute_plan(
     let mut installs = wheels.into_iter().chain(cached).collect::<Vec<_>>();
     if !installs.is_empty() {
         let start = std::time::Instant::now();
-        installs = uv_installer::Installer::new(venv, preview)
+        let installer = uv_installer::Installer::new(venv, preview)
             .with_link_mode(link_mode)
             .with_cache(cache)
             .with_installer_metadata(installer_metadata)
             .with_reporter(Arc::new(
                 InstallReporter::from(printer).with_length(installs.len() as u64),
-            ))
+            ));
+        let installer = if let Some(bytecode_compiler) = bytecode_compiler {
+            installer.with_bytecode_compiler(Arc::clone(bytecode_compiler))
+        } else {
+            installer
+        };
+        installs = installer
             // This technically can block the runtime, but we are on the main thread and
             // have no other running tasks at this point, so this lets us avoid spawning a blocking
             // task.

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -817,6 +817,7 @@ impl InstallationPlan {
                 resolution,
                 build_options,
                 link_mode,
+                matches!(compile, Some(BytecodeCompilation::All)),
                 hasher,
                 tags,
                 client,
@@ -846,6 +847,7 @@ impl InstallationPlan {
                 resolution,
                 build_options,
                 link_mode,
+                matches!(compile, Some(BytecodeCompilation::All)),
                 hasher,
                 tags,
                 client,
@@ -1016,6 +1018,7 @@ async fn execute_plan(
     resolution: &Resolution,
     build_options: &BuildOptions,
     link_mode: LinkMode,
+    compile_bytecode: bool,
     hasher: &HashStrategy,
     tags: &Tags,
     client: &RegistryClient,
@@ -1056,6 +1059,11 @@ async fn execute_plan(
         .with_reporter(Arc::new(
             PrepareReporter::from(printer).with_length(remote.len() as u64),
         ));
+        let preparer = if compile_bytecode {
+            preparer.with_bytecode_compilation(venv.python_executable(), concurrency)
+        } else {
+            preparer
+        };
 
         let wheels = preparer
             .prepare(remote.clone(), in_flight, resolution)

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -7,14 +7,11 @@ use predicates::prelude::predicate;
 use serde_json::json;
 #[cfg(feature = "test-git")]
 use std::process::Command;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 use tempfile::tempdir_in;
 use url::Url;
 use walkdir::WalkDir;
 use wiremock::matchers::{basic_auth, body_string_contains, method, path};
-use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use uv_fs::Simplified;
 use uv_static::EnvVars;
@@ -55,18 +52,18 @@ fn sync() -> Result<()> {
     Ok(())
 }
 
-/// Compile a prepared wheel in the cache while another wheel is still downloading.
+/// Compile installed wheels without modifying their immutable source archives.
 #[tokio::test]
-async fn sync_compile_bytecode_while_preparing() -> Result<()> {
+async fn sync_compile_bytecode_per_wheel() -> Result<()> {
     let context = uv_test::test_context!("3.13");
     let server = MockServer::start().await;
 
-    let fast_wheel = fs_err::read(
+    let basic_wheel = fs_err::read(
         context
             .workspace_root
             .join("test/links/basic_package-0.1.0-py3-none-any.whl"),
     )?;
-    let slow_wheel = fs_err::read(
+    let validation_wheel = fs_err::read(
         context
             .workspace_root
             .join("test/links/validation-1.0.0-py3-none-any.whl"),
@@ -74,34 +71,13 @@ async fn sync_compile_bytecode_while_preparing() -> Result<()> {
 
     Mock::given(method("GET"))
         .and(path("/files/basic_package-0.1.0-py3-none-any.whl"))
-        .respond_with(ResponseTemplate::new(200).set_body_bytes(fast_wheel))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(basic_wheel))
         .mount(&server)
         .await;
 
-    let delay_download = Arc::new(AtomicBool::new(false));
-    let compiled_while_downloading = Arc::new(AtomicBool::new(false));
-    let cache_dir = context.cache_dir.to_path_buf();
     Mock::given(method("GET"))
         .and(path("/files/validation-1.0.0-py3-none-any.whl"))
-        .respond_with({
-            let delay_download = Arc::clone(&delay_download);
-            let compiled_while_downloading = Arc::clone(&compiled_while_downloading);
-            move |_request: &Request| {
-                if delay_download.load(Ordering::Relaxed) {
-                    std::thread::sleep(Duration::from_secs(2));
-                    let compiled = WalkDir::new(&cache_dir)
-                        .into_iter()
-                        .filter_map(Result::ok)
-                        .any(|entry| {
-                            entry
-                                .path()
-                                .ends_with("basic_package/__pycache__/__init__.cpython-313.pyc")
-                        });
-                    compiled_while_downloading.store(compiled, Ordering::Relaxed);
-                }
-                ResponseTemplate::new(200).set_body_bytes(slow_wheel.clone())
-            }
-        })
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(validation_wheel))
         .mount(&server)
         .await;
 
@@ -124,7 +100,6 @@ async fn sync_compile_bytecode_while_preparing() -> Result<()> {
 
     context.lock().assert().success();
     fs_err::remove_dir_all(&context.cache_dir)?;
-    delay_download.store(true, Ordering::Relaxed);
 
     uv_snapshot!(context.filters(), context.sync()
         .arg("--frozen")
@@ -143,12 +118,21 @@ async fn sync_compile_bytecode_while_preparing() -> Result<()> {
      + validation==1.0.0 (from http://[LOCALHOST]/files/validation-1.0.0-py3-none-any.whl)
     ");
 
-    assert!(compiled_while_downloading.load(Ordering::Relaxed));
     assert!(
         context
             .site_packages()
             .join("basic_package/__pycache__/__init__.cpython-313.pyc")
             .exists()
+    );
+    assert!(
+        !WalkDir::new(context.cache_dir.join("archive-v0"))
+            .into_iter()
+            .filter_map(Result::ok)
+            .any(|entry| entry
+                .path()
+                .extension()
+                .is_some_and(|extension| extension == "pyc")),
+        "cached source wheel archives must not contain installed bytecode"
     );
 
     Ok(())
@@ -255,6 +239,64 @@ fn sync_reuses_pip_install_wheel_cache() -> Result<()> {
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     ");
+
+    Ok(())
+}
+
+/// Compile cached wheels during parallel installation without modifying their source archives.
+#[test]
+fn sync_compile_bytecode_for_cached_wheels() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+        "#,
+    )?;
+
+    context.lock().assert().success();
+    context
+        .pip_install()
+        .arg("iniconfig==2.0.0")
+        .assert()
+        .success();
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--offline")
+        .arg("--compile-bytecode"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    Resolved 2 packages in [TIME]
+    Installed 1 package in [TIME]
+    Bytecode compiled 5 files in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    assert!(
+        context
+            .site_packages()
+            .join("iniconfig/__pycache__/__init__.cpython-312.pyc")
+            .exists()
+    );
+    assert!(
+        !WalkDir::new(context.cache_dir.join("archive-v0"))
+            .into_iter()
+            .filter_map(Result::ok)
+            .any(|entry| entry
+                .path()
+                .extension()
+                .is_some_and(|extension| extension == "pyc")),
+        "cached source wheel archives must remain immutable"
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -7,10 +7,14 @@ use predicates::prelude::predicate;
 use serde_json::json;
 #[cfg(feature = "test-git")]
 use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use tempfile::tempdir_in;
 use url::Url;
+use walkdir::WalkDir;
 use wiremock::matchers::{basic_auth, body_string_contains, method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 use uv_fs::Simplified;
 use uv_static::EnvVars;
@@ -47,6 +51,105 @@ fn sync() -> Result<()> {
     ");
 
     assert!(context.temp_dir.child("uv.lock").exists());
+
+    Ok(())
+}
+
+/// Compile a prepared wheel in the cache while another wheel is still downloading.
+#[tokio::test]
+async fn sync_compile_bytecode_while_preparing() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+    let server = MockServer::start().await;
+
+    let fast_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/basic_package-0.1.0-py3-none-any.whl"),
+    )?;
+    let slow_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/validation-1.0.0-py3-none-any.whl"),
+    )?;
+
+    Mock::given(method("GET"))
+        .and(path("/files/basic_package-0.1.0-py3-none-any.whl"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(fast_wheel))
+        .mount(&server)
+        .await;
+
+    let delay_download = Arc::new(AtomicBool::new(false));
+    let compiled_while_downloading = Arc::new(AtomicBool::new(false));
+    let cache_dir = context.cache_dir.to_path_buf();
+    Mock::given(method("GET"))
+        .and(path("/files/validation-1.0.0-py3-none-any.whl"))
+        .respond_with({
+            let delay_download = Arc::clone(&delay_download);
+            let compiled_while_downloading = Arc::clone(&compiled_while_downloading);
+            move |_request: &Request| {
+                if delay_download.load(Ordering::Relaxed) {
+                    std::thread::sleep(Duration::from_secs(2));
+                    let compiled = WalkDir::new(&cache_dir)
+                        .into_iter()
+                        .filter_map(Result::ok)
+                        .any(|entry| {
+                            entry
+                                .path()
+                                .ends_with("basic_package/__pycache__/__init__.cpython-313.pyc")
+                        });
+                    compiled_while_downloading.store(compiled, Ordering::Relaxed);
+                }
+                ResponseTemplate::new(200).set_body_bytes(slow_wheel.clone())
+            }
+        })
+        .mount(&server)
+        .await;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {
+            r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = [
+            "basic-package @ {server}/files/basic_package-0.1.0-py3-none-any.whl",
+            "validation @ {server}/files/validation-1.0.0-py3-none-any.whl",
+        ]
+        "#,
+            server = server.uri(),
+        })?;
+
+    context.lock().assert().success();
+    fs_err::remove_dir_all(&context.cache_dir)?;
+    delay_download.store(true, Ordering::Relaxed);
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--frozen")
+        .arg("--compile-bytecode")
+        .env(EnvVars::UV_CONCURRENT_DOWNLOADS, "2")
+        .env(EnvVars::UV_CONCURRENT_INSTALLS, "2"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+    Bytecode compiled 3 files in [TIME]
+     + basic-package==0.1.0 (from http://[LOCALHOST]/files/basic_package-0.1.0-py3-none-any.whl)
+     + validation==1.0.0 (from http://[LOCALHOST]/files/validation-1.0.0-py3-none-any.whl)
+    ");
+
+    assert!(compiled_while_downloading.load(Ordering::Relaxed));
+    assert!(
+        context
+            .site_packages()
+            .join("basic_package/__pycache__/__init__.cpython-313.pyc")
+            .exists()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Bytecode compilation currently starts after every wheel has already been installed, serializing Python compilation with wheel installation and creating separate worker pools for later compilation passes.

Move the existing `--compile-bytecode` path into the wheel installer: as each parallel wheel installation completes, enqueue its installed Python sources into a single shared compiler. The pool starts lazily, grows only as distinct source files arrive, and is bounded by the configured installation concurrency. It spans isolated and non-isolated installation phases and deduplicates the final environment or installed-distribution scan, including relocated `.data` files.

Compile only the destination paths in `site-packages`; cached wheel archives remain immutable and no persistent bytecode cache is introduced. This preserves existing compilation scope, interpreter optimization and invalidation settings, symlink installs, relative installation roots, and already-cached wheel behavior.

On a warm 93-wheel Jupyter fixture containing 2,998 Python files, Hyperfine measured 665.6 ± 32.2 ms before versus 667.3 ± 20.1 ms after with the default link mode, statistically indistinguishable. With physical copies forced, installation improved from 1.264 ± 0.052 s to 1.190 ± 0.042 s, 5.9% faster; both comparisons used ten runs and two warmups.

This is the standalone foundation for the interpreter-specific persistent bytecode cache in #20607.