### PR TITLE
Test separated macOS code signing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             [[ "$file" == "rust-toolchain.toml" || "$file" == "crates/uv-build/rust-toolchain.toml" || "$file" =~ ^\.cargo/ ]] && rust_config_changed=1
             [[ "$file" == "pyproject.toml" || "$file" =~ ^crates/.*/pyproject\.toml$ ]] && python_config_changed=1
             [[ "$file" =~ ^\.github/workflows/.*\.yml$ ]] && workflow_changed=1
-            [[ "$file" == ".github/workflows/build-release-binaries.yml" || "$file" == ".github/workflows/release.yml" ]] && release_workflow_changed=1
+            [[ "$file" == ".github/workflows/build-release-binaries.yml" || "$file" == ".github/workflows/sign-release-binaries.yml" || "$file" == ".github/workflows/release.yml" ]] && release_workflow_changed=1
             [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" ]] && release_build_changed=1
             [[ "$file" == ".github/workflows/ci.yml" ]] && ci_workflow_changed=1
             [[ "$file" == "uv.schema.json" ]] && schema_changed=1
@@ -272,6 +272,14 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.build-release-binaries == 'true' }}
     uses: ./.github/workflows/build-release-binaries.yml
+    secrets: inherit
+
+  sign-release-binaries:
+    needs:
+      - plan
+      - build-release-binaries
+    if: ${{ github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.fork != true && needs.plan.outputs.build-release-binaries == 'true' }}
+    uses: ./.github/workflows/sign-release-binaries.yml
     secrets: inherit
 
   build-docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,14 @@ jobs:
     uses: $/.github/workflows/build-release-binaries.yml
     secrets: inherit
 
+  sign-release-binaries:
+    needs:
+      - plan
+      - build-release-binaries
+    if: ${{ github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.fork != true && needs.plan.outputs.build-release-binaries == 'true' }}
+    uses: $/.github/workflows/sign-release-binaries.yml
+    secrets: inherit
+
   build-docker:
     needs: plan
     if: ${{ needs.plan.outputs.build-docker == 'true' }}

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -137,7 +137,7 @@ jobs:
             [[ "$file" == "pyproject.toml" || "$file" =~ ^crates/.*/pyproject\.toml$ ]] && python_config_changed=1
             [[ "$file" =~ ^\.github/workflows/.*\.yml$ ]] && workflow_changed=1
             [[ "$file" == ".github/workflows/build-release-binaries.yml" || "$file" == ".github/workflows/sign-release-binaries.yml" || "$file" == ".github/workflows/release.yml" ]] && release_workflow_changed=1
-            [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" ]] && release_build_changed=1
+            [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/macos_signing.py" || "$file" == "scripts/test_macos_signing.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" ]] && release_build_changed=1
             [[ "$file" == ".github/workflows/ci.yml" ]] && ci_workflow_changed=1
             [[ "$file" == "uv.schema.json" ]] && schema_changed=1
             [[ "$file" =~ ^crates/uv-publish/ || "$file" =~ ^scripts/publish/ || "$file" == "crates/uv/src/commands/publish.rs" ]] && publish_code_changed=1

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -136,7 +136,7 @@ jobs:
             [[ "$file" == "rust-toolchain.toml" || "$file" == "crates/uv-build/rust-toolchain.toml" || "$file" =~ ^\.cargo/ ]] && rust_config_changed=1
             [[ "$file" == "pyproject.toml" || "$file" =~ ^crates/.*/pyproject\.toml$ ]] && python_config_changed=1
             [[ "$file" =~ ^\.github/workflows/.*\.yml$ ]] && workflow_changed=1
-            [[ "$file" == ".github/workflows/build-release-binaries.yml" || "$file" == ".github/workflows/release.yml" ]] && release_workflow_changed=1
+            [[ "$file" == ".github/workflows/build-release-binaries.yml" || "$file" == ".github/workflows/sign-release-binaries.yml" || "$file" == ".github/workflows/release.yml" ]] && release_workflow_changed=1
             [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" ]] && release_build_changed=1
             [[ "$file" == ".github/workflows/ci.yml" ]] && ci_workflow_changed=1
             [[ "$file" == "uv.schema.json" ]] && schema_changed=1

--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -1,0 +1,262 @@
+# Exercise separated macOS signing and wheel assembly with the self-signed CI certificate.
+name: "Sign release binaries (test)"
+
+on:
+  workflow_call:
+
+permissions: {}
+
+env:
+  TARGET: aarch64-apple-darwin
+  ARTIFACT_SUFFIX: aarch64-apple-darwin
+
+jobs:
+  prepare-macos:
+    name: "prepare macOS signing inputs"
+    runs-on: depot-ubuntu-24.04-4
+    steps:
+      - name: "Download unsigned wheels"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels_*-${{ env.ARTIFACT_SUFFIX }}
+          path: wheels
+          merge-multiple: true
+
+      - name: "Extract executable wheel members"
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          uv_wheels=(wheels/uv-*.whl)
+          uv_build_wheels=(wheels/uv_build-*.whl)
+          if [[ ${#uv_wheels[@]} -ne 1 || ${#uv_build_wheels[@]} -ne 1 ]]; then
+            echo "Expected one uv wheel and one uv-build wheel." >&2
+            exit 1
+          fi
+
+          extract_member() {
+            local wheel="$1"
+            local distribution="$2"
+            local binary="$3"
+            local member
+
+            member="$(unzip -Z1 "$wheel" | grep -E "^${distribution}-[^/]+\.data/scripts/${binary}$")"
+            unzip -p "$wheel" "$member" > "unsigned/$binary"
+            chmod 0755 "unsigned/$binary"
+          }
+
+          mkdir -p unsigned
+          extract_member "${uv_wheels[0]}" uv uv
+          extract_member "${uv_wheels[0]}" uv uvx
+          extract_member "${uv_build_wheels[0]}" uv_build uv-build
+
+      - name: "Upload unsigned executable wheel members"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unsigned-macos-${{ env.TARGET }}
+          path: unsigned/*
+          if-no-files-found: error
+
+  sign-macos:
+    name: "sign macOS binaries"
+    needs: prepare-macos
+    runs-on: namespace-profile-macos-15
+    environment: release-test
+    steps:
+      - name: "Download unsigned executable wheel members"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: unsigned-macos-${{ env.TARGET }}
+          path: unsigned
+
+      - name: "Sign executable wheel members"
+        shell: bash
+        env:
+          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
+          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
+        run: |
+          set -euo pipefail
+
+          certificate="$RUNNER_TEMP/codesign-test.p12"
+          keychain="$RUNNER_TEMP/codesign-test.keychain-db"
+          keychain_password="$(uuidgen | tr -d '-')"
+          trap 'security delete-keychain "$keychain" >/dev/null 2>&1 || true; rm -f "$certificate"' EXIT
+
+          printf '%s' "$CODESIGN_CERTIFICATE_MACOS" | base64 --decode > "$certificate"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -t 21600 -u "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" \
+            -k "$keychain" \
+            -P "$CODESIGN_CERTIFICATE_PASSWORD" \
+            -f pkcs12 \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security >/dev/null
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain" >/dev/null
+
+          existing_keychains=()
+          while IFS= read -r existing_keychain; do
+            existing_keychain="${existing_keychain#\"}"
+            existing_keychain="${existing_keychain%\"}"
+            existing_keychains+=("$existing_keychain")
+          done < <(security list-keychains -d user | sed -E 's/^[[:space:]]+//')
+          security list-keychains -d user -s "$keychain" "${existing_keychains[@]}"
+
+          mkdir -p signed
+          for binary in uv uvx uv-build; do
+            test -f "unsigned/$binary"
+            cp "unsigned/$binary" "signed/$binary"
+            codesign \
+              --force \
+              --keychain "$keychain" \
+              --sign "$CODESIGN_IDENTITY_MACOS" \
+              --options runtime \
+              --timestamp=none \
+              "signed/$binary"
+          done
+
+      - name: "Upload signed executable wheel members"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: signed-macos-${{ env.TARGET }}
+          path: signed/*
+          if-no-files-found: error
+
+  assemble-macos:
+    name: "assemble signed macOS artifacts"
+    needs: sign-macos
+    runs-on: depot-ubuntu-24.04-4
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Download unsigned wheels"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels_*-${{ env.ARTIFACT_SUFFIX }}
+          path: wheels
+          merge-multiple: true
+
+      - name: "Download signed executable wheel members"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: signed-macos-${{ env.TARGET }}
+          path: signed
+
+      - name: "Build uv-dev"
+        run: cargo build --locked --package uv-dev --features dev
+
+      - name: "Assemble signed wheels and archive"
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          uv_wheels=(wheels/uv-*.whl)
+          uv_build_wheels=(wheels/uv_build-*.whl)
+          if [[ ${#uv_wheels[@]} -ne 1 || ${#uv_build_wheels[@]} -ne 1 ]]; then
+            echo "Expected one uv wheel and one uv-build wheel." >&2
+            exit 1
+          fi
+
+          member() {
+            local wheel="$1"
+            local distribution="$2"
+            local binary="$3"
+            unzip -Z1 "$wheel" | grep -E "^${distribution}-[^/]+\.data/scripts/${binary}$"
+          }
+
+          uv_wheel="${uv_wheels[0]}"
+          uv_build_wheel="${uv_build_wheels[0]}"
+          mkdir -p dist/wheels
+          target/debug/uv-dev wheel-replace \
+            --input "$uv_wheel" \
+            --output "dist/wheels/$(basename "$uv_wheel")" \
+            --replace "$(member "$uv_wheel" uv uv)=signed/uv" \
+            --replace "$(member "$uv_wheel" uv uvx)=signed/uvx"
+          target/debug/uv-dev wheel-replace \
+            --input "$uv_build_wheel" \
+            --output "dist/wheels/$(basename "$uv_build_wheel")" \
+            --replace "$(member "$uv_build_wheel" uv_build uv-build)=signed/uv-build"
+          python3 scripts/check_uv_wheel_contents.py dist/wheels/*.whl
+
+          archive_name="uv-$TARGET"
+          mkdir -p "$archive_name"
+          cp signed/uv "$archive_name/uv"
+          cp signed/uvx "$archive_name/uvx"
+          chmod 0755 "$archive_name/uv" "$archive_name/uvx"
+          tar czf "dist/$archive_name.tar.gz" "$archive_name"
+          (cd dist && shasum -a 256 "$archive_name.tar.gz" > "$archive_name.tar.gz.sha256")
+
+      - name: "Upload signed macOS artifacts"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: signed-macos-artifacts-${{ env.TARGET }}
+          path: dist
+          if-no-files-found: error
+
+  verify-macos:
+    name: "verify signed macOS artifacts"
+    needs: assemble-macos
+    runs-on: namespace-profile-macos-15
+    steps:
+      - name: "Download signed macOS artifacts"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: signed-macos-artifacts-${{ env.TARGET }}
+          path: dist
+
+      - name: "Verify signatures and archive checksum"
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          verify() {
+            local binary="$1"
+            local details
+            codesign --verify --strict --verbose=4 "$binary"
+            details="$(codesign -dv --verbose=4 "$binary" 2>&1)"
+            if grep -q 'Signature=adhoc' <<< "$details"; then
+              echo "Expected an identity signature on '$binary'." >&2
+              exit 1
+            fi
+          }
+
+          uv_wheels=(dist/wheels/uv-*.whl)
+          uv_build_wheels=(dist/wheels/uv_build-*.whl)
+          if [[ ${#uv_wheels[@]} -ne 1 || ${#uv_build_wheels[@]} -ne 1 ]]; then
+            echo "Expected one signed uv wheel and one signed uv-build wheel." >&2
+            exit 1
+          fi
+
+          extract_and_verify() {
+            local wheel="$1"
+            local distribution="$2"
+            local binary="$3"
+            local member
+            local extracted
+
+            member="$(unzip -Z1 "$wheel" | grep -E "^${distribution}-[^/]+\.data/scripts/${binary}$")"
+            extracted="$RUNNER_TEMP/$binary"
+            unzip -p "$wheel" "$member" > "$extracted"
+            chmod 0755 "$extracted"
+            verify "$extracted"
+          }
+
+          extract_and_verify "${uv_wheels[0]}" uv uv
+          extract_and_verify "${uv_wheels[0]}" uv uvx
+          extract_and_verify "${uv_build_wheels[0]}" uv_build uv-build
+
+          archive_name="uv-$TARGET"
+          (cd dist && shasum -a 256 --check "$archive_name.tar.gz.sha256")
+          tar xzf "dist/$archive_name.tar.gz" -C "$RUNNER_TEMP"
+          verify "$RUNNER_TEMP/$archive_name/uv"
+          verify "$RUNNER_TEMP/$archive_name/uvx"

--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -14,7 +14,23 @@ jobs:
   prepare-macos:
     name: "prepare macOS signing inputs"
     runs-on: depot-ubuntu-24.04-4
+    outputs:
+      manifest-sha256: ${{ steps.prepare.outputs.manifest-sha256 }}
+      tooling-sha256: ${{ steps.prepare.outputs.tooling-sha256 }}
+      unsigned-artifact: ${{ steps.unsigned.outputs.artifact-id }}
+      assembly-artifact: ${{ steps.assembly.outputs.artifact-id }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Build assembly tooling without signing credentials"
+        run: |
+          python3 -m unittest discover -s scripts -p test_macos_signing.py
+          cargo build --locked --package uv-dev --features dev
+          mkdir tools
+          cp target/debug/uv-dev scripts/macos_signing.py scripts/check_uv_wheel_contents.py tools/
+
       - name: "Download unsigned wheels"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -22,40 +38,32 @@ jobs:
           path: wheels
           merge-multiple: true
 
-      - name: "Extract executable wheel members"
+      - name: "Bind wheels and extract executable members"
+        id: prepare
         shell: bash
         run: |
           set -euo pipefail
-          shopt -s nullglob
-
-          uv_wheels=(wheels/uv-*.whl)
-          uv_build_wheels=(wheels/uv_build-*.whl)
-          if [[ ${#uv_wheels[@]} -ne 1 || ${#uv_build_wheels[@]} -ne 1 ]]; then
-            echo "Expected one uv wheel and one uv-build wheel." >&2
-            exit 1
-          fi
-
-          extract_member() {
-            local wheel="$1"
-            local distribution="$2"
-            local binary="$3"
-            local member
-
-            member="$(unzip -Z1 "$wheel" | grep -E "^${distribution}-[^/]+\.data/scripts/${binary}$")"
-            unzip -p "$wheel" "$member" > "unsigned/$binary"
-            chmod 0755 "unsigned/$binary"
-          }
-
-          mkdir -p unsigned
-          extract_member "${uv_wheels[0]}" uv uv
-          extract_member "${uv_wheels[0]}" uv uvx
-          extract_member "${uv_build_wheels[0]}" uv_build uv-build
+          python3 scripts/macos_signing.py prepare
+          tar cf tooling.tar -C tools .
+          echo "tooling-sha256=$(shasum -a 256 tooling.tar | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - name: "Upload unsigned executable wheel members"
+        id: unsigned
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: unsigned-macos-${{ env.TARGET }}
+          name: unsigned-macos-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.TARGET }}
           path: unsigned/*
+          if-no-files-found: error
+
+      - name: "Upload immutable assembly inputs"
+        id: assembly
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: assembly-macos-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.TARGET }}
+          path: |
+            wheels
+            manifest.json
+            tooling.tar
           if-no-files-found: error
 
   sign-macos:
@@ -63,12 +71,34 @@ jobs:
     needs: prepare-macos
     runs-on: namespace-profile-macos-15
     environment: release-test
+    outputs:
+      artifact: ${{ steps.upload.outputs.artifact-id }}
+      manifest-sha256: ${{ steps.manifest.outputs.manifest-sha256 }}
     steps:
       - name: "Download unsigned executable wheel members"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: unsigned-macos-${{ env.TARGET }}
+          artifact-ids: ${{ needs.prepare-macos.outputs.unsigned-artifact }}
           path: unsigned
+          merge-multiple: true
+
+      - name: "Verify signing inputs"
+        env:
+          INPUT_MANIFEST_SHA256: ${{ needs.prepare-macos.outputs.manifest-sha256 }}
+        run: |
+          set -euo pipefail
+          test "$(shasum -a 256 unsigned/manifest.json | cut -d ' ' -f 1)" = "$INPUT_MANIFEST_SHA256"
+          jq -e --arg repository "$GITHUB_REPOSITORY" --arg workflow "$GITHUB_WORKFLOW_REF" \
+            --arg workflow_sha "$GITHUB_WORKFLOW_SHA" --arg run "$GITHUB_RUN_ID" \
+            --arg attempt "$GITHUB_RUN_ATTEMPT" --arg source "$GITHUB_SHA" --arg target "$TARGET" \
+            '.schema == 1 and .context == {repository: $repository, workflow_ref: $workflow,
+            workflow_sha: $workflow_sha, run_id: $run, run_attempt: $attempt, source_sha: $source,
+            target: $target, signing_workflow: ".github/workflows/sign-release-binaries.yml"}
+            and ([.wheels[].replacements[]] | sort) == ["uv", "uv-build", "uvx"]' unsigned/manifest.json
+          for binary in uv uvx uv-build; do
+            expected=$(jq -r --arg binary "$binary" '.wheels[] | . as $wheel | .replacements | to_entries[] | select(.value == $binary) | $wheel.members[.key].sha256' unsigned/manifest.json)
+            test "$(shasum -a 256 "unsigned/$binary" | cut -d ' ' -f 1)" = "$expected"
+          done
 
       - name: "Sign executable wheel members"
         shell: bash
@@ -121,142 +151,121 @@ jobs:
               "signed/$binary"
           done
 
+      - name: "Bind signed bytes and signing certificate"
+        id: manifest
+        run: |
+          set -euo pipefail
+          cp unsigned/manifest.json signed/manifest.json
+          for binary in uv uvx uv-build; do
+            codesign --verify --strict "signed/$binary"
+            codesign --display --extract-certificates="$RUNNER_TEMP/$binary-cert-" "signed/$binary"
+            certificate_sha256=$(shasum -a 256 "$RUNNER_TEMP/$binary-cert-0" | cut -d ' ' -f 1)
+            digest=$(shasum -a 256 "signed/$binary" | cut -d ' ' -f 1)
+            size=$(wc -c < "signed/$binary" | tr -d '[:space:]')
+            jq --arg binary "$binary" --arg digest "$digest" --argjson size "$size" --arg certificate "$certificate_sha256" \
+              'if .certificate_sha256 != null and .certificate_sha256 != $certificate then error("signing certificate mismatch") else
+              .certificate_sha256 = $certificate | .signed[$binary] = {sha256: $digest, size: $size} end' \
+              signed/manifest.json > signed/manifest.next
+            mv signed/manifest.next signed/manifest.json
+          done
+          echo "manifest-sha256=$(shasum -a 256 signed/manifest.json | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+
       - name: "Upload signed executable wheel members"
+        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: signed-macos-${{ env.TARGET }}
+          name: signed-macos-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.TARGET }}
           path: signed/*
           if-no-files-found: error
 
   assemble-macos:
     name: "assemble signed macOS artifacts"
-    needs: sign-macos
+    needs: [prepare-macos, sign-macos]
     runs-on: depot-ubuntu-24.04-4
+    outputs:
+      artifact: ${{ steps.upload.outputs.artifact-id }}
+      manifest-sha256: ${{ steps.assemble.outputs.manifest-sha256 }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: "Download unsigned wheels"
+      - name: "Download bound assembly inputs"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: wheels_*-${{ env.ARTIFACT_SUFFIX }}
-          path: wheels
+          artifact-ids: ${{ needs.prepare-macos.outputs.assembly-artifact }}
           merge-multiple: true
 
       - name: "Download signed executable wheel members"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: signed-macos-${{ env.TARGET }}
+          artifact-ids: ${{ needs.sign-macos.outputs.artifact }}
           path: signed
+          merge-multiple: true
 
-      - name: "Build uv-dev"
-        run: cargo build --locked --package uv-dev --features dev
-
-      - name: "Assemble signed wheels and archive"
-        shell: bash
+      - name: "Assemble signed wheels and archive without a source checkout"
+        id: assemble
+        env:
+          TOOLING_SHA256: ${{ needs.prepare-macos.outputs.tooling-sha256 }}
+          INPUT_MANIFEST_SHA256: ${{ needs.prepare-macos.outputs.manifest-sha256 }}
+          SIGNED_MANIFEST_SHA256: ${{ needs.sign-macos.outputs.manifest-sha256 }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
-
-          uv_wheels=(wheels/uv-*.whl)
-          uv_build_wheels=(wheels/uv_build-*.whl)
-          if [[ ${#uv_wheels[@]} -ne 1 || ${#uv_build_wheels[@]} -ne 1 ]]; then
-            echo "Expected one uv wheel and one uv-build wheel." >&2
-            exit 1
-          fi
-
-          member() {
-            local wheel="$1"
-            local distribution="$2"
-            local binary="$3"
-            unzip -Z1 "$wheel" | grep -E "^${distribution}-[^/]+\.data/scripts/${binary}$"
-          }
-
-          uv_wheel="${uv_wheels[0]}"
-          uv_build_wheel="${uv_build_wheels[0]}"
-          mkdir -p dist/wheels
-          target/debug/uv-dev wheel-replace \
-            --input "$uv_wheel" \
-            --output "dist/wheels/$(basename "$uv_wheel")" \
-            --replace "$(member "$uv_wheel" uv uv)=signed/uv" \
-            --replace "$(member "$uv_wheel" uv uvx)=signed/uvx"
-          target/debug/uv-dev wheel-replace \
-            --input "$uv_build_wheel" \
-            --output "dist/wheels/$(basename "$uv_build_wheel")" \
-            --replace "$(member "$uv_build_wheel" uv_build uv-build)=signed/uv-build"
-          python3 scripts/check_uv_wheel_contents.py dist/wheels/*.whl
-
-          archive_name="uv-$TARGET"
-          mkdir -p "$archive_name"
-          cp signed/uv "$archive_name/uv"
-          cp signed/uvx "$archive_name/uvx"
-          chmod 0755 "$archive_name/uv" "$archive_name/uvx"
-          tar czf "dist/$archive_name.tar.gz" "$archive_name"
-          (cd dist && shasum -a 256 "$archive_name.tar.gz" > "$archive_name.tar.gz.sha256")
+          test "$(shasum -a 256 tooling.tar | cut -d ' ' -f 1)" = "$TOOLING_SHA256"
+          mkdir tools
+          tar xf tooling.tar -C tools
+          python3 tools/macos_signing.py assemble
 
       - name: "Upload signed macOS artifacts"
+        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: signed-macos-artifacts-${{ env.TARGET }}
+          name: signed-macos-artifacts-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.TARGET }}
           path: dist
           if-no-files-found: error
 
   verify-macos:
     name: "verify signed macOS artifacts"
-    needs: assemble-macos
+    needs: [prepare-macos, sign-macos, assemble-macos]
     runs-on: namespace-profile-macos-15
     steps:
-      - name: "Download signed macOS artifacts"
+      - name: "Download original bindings and independent verification tooling"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: signed-macos-artifacts-${{ env.TARGET }}
-          path: dist
+          artifact-ids: ${{ needs.prepare-macos.outputs.assembly-artifact }}
+          merge-multiple: true
 
-      - name: "Verify signatures and archive checksum"
-        shell: bash
+      - name: "Download signer bindings"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.sign-macos.outputs.artifact }}
+          path: signed
+          merge-multiple: true
+
+      - name: "Download completed artifacts"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.assemble-macos.outputs.artifact }}
+          path: dist
+          merge-multiple: true
+
+      - name: "Independently verify final wheels, members and signatures"
+        env:
+          TOOLING_SHA256: ${{ needs.prepare-macos.outputs.tooling-sha256 }}
+          INPUT_MANIFEST_SHA256: ${{ needs.prepare-macos.outputs.manifest-sha256 }}
+          SIGNED_MANIFEST_SHA256: ${{ needs.sign-macos.outputs.manifest-sha256 }}
+          FINAL_MANIFEST_SHA256: ${{ needs.assemble-macos.outputs.manifest-sha256 }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
-
-          verify() {
-            local binary="$1"
-            local details
-            codesign --verify --strict --verbose=4 "$binary"
-            details="$(codesign -dv --verbose=4 "$binary" 2>&1)"
+          test "$(shasum -a 256 tooling.tar | cut -d ' ' -f 1)" = "$TOOLING_SHA256"
+          mkdir tools
+          tar xf tooling.tar -C tools
+          python3 tools/macos_signing.py verify
+          expected_certificate=$(jq -r .certificate_sha256 signed/manifest.json)
+          for binary in uv uvx uv-build; do
+            path="$RUNNER_TEMP/verified-binaries/$binary"
+            codesign --verify --strict --verbose=4 "$path"
+            details="$(codesign -dv --verbose=4 "$path" 2>&1)"
             if grep -q 'Signature=adhoc' <<< "$details"; then
               echo "Expected an identity signature on '$binary'." >&2
               exit 1
             fi
-          }
-
-          uv_wheels=(dist/wheels/uv-*.whl)
-          uv_build_wheels=(dist/wheels/uv_build-*.whl)
-          if [[ ${#uv_wheels[@]} -ne 1 || ${#uv_build_wheels[@]} -ne 1 ]]; then
-            echo "Expected one signed uv wheel and one signed uv-build wheel." >&2
-            exit 1
-          fi
-
-          extract_and_verify() {
-            local wheel="$1"
-            local distribution="$2"
-            local binary="$3"
-            local member
-            local extracted
-
-            member="$(unzip -Z1 "$wheel" | grep -E "^${distribution}-[^/]+\.data/scripts/${binary}$")"
-            extracted="$RUNNER_TEMP/$binary"
-            unzip -p "$wheel" "$member" > "$extracted"
-            chmod 0755 "$extracted"
-            verify "$extracted"
-          }
-
-          extract_and_verify "${uv_wheels[0]}" uv uv
-          extract_and_verify "${uv_wheels[0]}" uv uvx
-          extract_and_verify "${uv_build_wheels[0]}" uv_build uv-build
-
-          archive_name="uv-$TARGET"
-          (cd dist && shasum -a 256 --check "$archive_name.tar.gz.sha256")
-          tar xzf "dist/$archive_name.tar.gz" -C "$RUNNER_TEMP"
-          verify "$RUNNER_TEMP/$archive_name/uv"
-          verify "$RUNNER_TEMP/$archive_name/uvx"
+            codesign --display --extract-certificates="$RUNNER_TEMP/verified-$binary-cert-" "$path"
+            test "$(shasum -a 256 "$RUNNER_TEMP/verified-$binary-cert-0" | cut -d ' ' -f 1)" = "$expected_certificate"
+          done

--- a/scripts/macos_signing.py
+++ b/scripts/macos_signing.py
@@ -1,0 +1,373 @@
+"""Bind this test workflow's artifacts; wheel rewriting remains in `uv-dev wheel-replace`.
+
+Manifests are integrity bindings carried by job outputs, not signatures or attestations. A retry
+must rerun preparation: artifacts from a different run attempt are deliberately rejected. This
+caller owns uv's wheel layout and platform policy; the Rust helper has no repository knowledge.
+"""
+
+import base64
+import csv
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from check_uv_wheel_contents import check_uv_wheel, uv_build_expected, uv_expected
+
+TARGET = "aarch64-apple-darwin"
+TAG = "py3-none-macosx_11_0_arm64"
+BINARIES = {"uv": ["uv", "uvx"], "uv_build": ["uv-build"]}
+TOOLS = ("uv-dev", "macos_signing.py", "check_uv_wheel_contents.py")
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def digest(stream):
+    hasher = hashlib.sha256()
+    size = 0
+    while chunk := stream.read(128 * 1024):
+        hasher.update(chunk)
+        size += len(chunk)
+    return hasher.hexdigest(), size
+
+
+def file_digest(path):
+    require(stat.S_ISREG(path.lstat().st_mode), f"Not a regular file: {path}")
+    with path.open("rb") as stream:
+        return digest(stream)[0]
+
+
+def context():
+    return {
+        "repository": os.environ["GITHUB_REPOSITORY"],
+        "workflow_ref": os.environ["GITHUB_WORKFLOW_REF"],
+        "workflow_sha": os.environ["GITHUB_WORKFLOW_SHA"],
+        "run_id": os.environ["GITHUB_RUN_ID"],
+        "run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+        "source_sha": os.environ["GITHUB_SHA"],
+        "signing_workflow": ".github/workflows/sign-release-binaries.yml",
+        "target": TARGET,
+    }
+
+
+def load(path, expected_digest):
+    require(file_digest(path) == expected_digest, f"Manifest digest mismatch: {path}")
+    manifest = json.loads(path.read_bytes())
+    require(
+        manifest["schema"] == 1 and manifest["context"] == context(),
+        "Wrong workflow context",
+    )
+    return manifest
+
+
+def save(path, manifest):
+    with path.open("x") as stream:
+        json.dump(manifest, stream, sort_keys=True, separators=(",", ":"))
+        stream.write("\n")
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a") as stream:
+        stream.write(f"manifest-sha256={file_digest(path)}\n")
+
+
+def wheel_members(path):
+    """Independent ZIP/RECORD validation for the fixed uv wheel layout."""
+    check_uv_wheel(path)
+    match = re.fullmatch(r"(uv|uv_build)-(\d+\.\d+\.\d+)-" + TAG + r"\.whl", path.name)
+    require(match is not None, f"Unexpected wheel filename: {path.name}")
+    distribution, version = match.groups()
+    templates = uv_expected if distribution == "uv" else uv_build_expected
+    expected_names = {name.replace("VERSION", version) for name in templates}
+    with ZipFile(path) as wheel:
+        infos = wheel.infolist()
+        require(
+            len(infos) == len({info.filename for info in infos}),
+            "Duplicate ZIP members",
+        )
+        require(
+            {info.filename for info in infos} == expected_names,
+            "Wheel version/layout mismatch",
+        )
+        members = {}
+        for info in infos:
+            require(not info.is_dir(), "Unexpected directory member")
+            require(
+                stat.S_IFMT(info.external_attr >> 16) in (0, stat.S_IFREG),
+                "Special ZIP member",
+            )
+            require(info.file_size <= 512 * 1024 * 1024, "Oversized ZIP member")
+            with wheel.open(info) as stream:
+                sha256, size = digest(stream)
+            members[info.filename] = {
+                "sha256": sha256,
+                "size": size,
+                "method": info.compress_type,
+                "time": list(info.date_time),
+                "mode": info.external_attr,
+                "internal": info.internal_attr,
+                "comment": info.comment.hex(),
+            }
+        record_names = [name for name in members if name.endswith(".dist-info/RECORD")]
+        require(len(record_names) == 1, "Expected one RECORD")
+        record = record_names[0]
+        require(members[record]["size"] <= 8 * 1024 * 1024, "Oversized RECORD")
+        rows = list(csv.reader(io.StringIO(wheel.read(record).decode())))
+        require(all(len(row) == 3 for row in rows), "Invalid RECORD field count")
+        require(
+            len(rows) == len(members) and {row[0] for row in rows} == set(members),
+            "Invalid RECORD membership",
+        )
+        for name, hashed, size in rows:
+            if name == record:
+                require((hashed, size) == ("", ""), "Invalid RECORD self entry")
+                continue
+            algorithm, separator, value = hashed.partition("=")
+            require(
+                separator and algorithm in ("sha256", "sha384", "sha512"),
+                "Insecure RECORD hash",
+            )
+            with wheel.open(name) as stream:
+                hasher = hashlib.new(algorithm)
+                while chunk := stream.read(128 * 1024):
+                    hasher.update(chunk)
+            encoded = base64.urlsafe_b64encode(hasher.digest()).decode().rstrip("=")
+            require(
+                value == encoded and size == str(members[name]["size"]),
+                f"Invalid RECORD row: {name}",
+            )
+    return members
+
+
+def prepare():
+    Path("unsigned").mkdir()
+    manifest = {
+        "schema": 1,
+        "context": context(),
+        "wheels": [],
+        "tools": {name: file_digest(Path("tools") / name) for name in TOOLS},
+    }
+    paths = sorted(Path("wheels").glob("*.whl"))
+    require(len(paths) == 2, "Expected two wheels")
+    distributions = set()
+    for path in paths:
+        match = re.fullmatch(
+            r"(uv|uv_build)-(\d+\.\d+\.\d+)-" + TAG + r"\.whl", path.name
+        )
+        require(match is not None, f"Unexpected wheel filename: {path.name}")
+        distribution, version = match.groups()
+        require(distribution not in distributions, "Duplicate distribution")
+        distributions.add(distribution)
+        members = wheel_members(path)
+        replacements = {
+            f"{distribution}-{version}.data/scripts/{binary}": binary
+            for binary in BINARIES[distribution]
+        }
+        with ZipFile(path) as wheel:
+            wheel_metadata = wheel.read(
+                f"{distribution}-{version}.dist-info/WHEEL"
+            ).decode()
+            require(
+                [
+                    line
+                    for line in wheel_metadata.splitlines()
+                    if line.startswith("Tag:")
+                ]
+                == [f"Tag: {TAG}"],
+                "Unexpected wheel tag",
+            )
+            for member, binary in replacements.items():
+                with (
+                    wheel.open(member) as source,
+                    (Path("unsigned") / binary).open("xb") as output,
+                ):
+                    shutil.copyfileobj(source, output)
+                require(
+                    file_digest(Path("unsigned") / binary) == members[member]["sha256"],
+                    "Extraction changed bytes",
+                )
+        manifest["wheels"].append(
+            {
+                "filename": path.name,
+                "tag": TAG,
+                "input_sha256": file_digest(path),
+                "members": members,
+                "replacements": replacements,
+            }
+        )
+    save(Path("unsigned/manifest.json"), manifest)
+    shutil.copyfile("unsigned/manifest.json", "manifest.json")
+
+
+def signed_manifest():
+    source = load(Path("manifest.json"), os.environ["INPUT_MANIFEST_SHA256"])
+    signed = load(Path("signed/manifest.json"), os.environ["SIGNED_MANIFEST_SHA256"])
+    unsigned_fields = {
+        key: value
+        for key, value in signed.items()
+        if key not in ("signed", "certificate_sha256")
+    }
+    require(unsigned_fields == source, "Signing changed the input manifest")
+    require(
+        set(signed["signed"]) == {"uv", "uvx", "uv-build"}, "Unexpected signed binaries"
+    )
+    require(
+        re.fullmatch(r"[0-9a-f]{64}", signed["certificate_sha256"]),
+        "Invalid signing certificate digest",
+    )
+    return signed
+
+
+def verify_wheels(manifest, directory):
+    require(
+        {path.name for path in directory.iterdir()}
+        == {wheel["filename"] for wheel in manifest["wheels"]},
+        "Unexpected output wheels",
+    )
+    for wheel in manifest["wheels"]:
+        actual = wheel_members(directory / wheel["filename"])
+        require(actual.keys() == wheel["members"].keys(), "Output membership changed")
+        for name, before in wheel["members"].items():
+            after = actual[name]
+            if name.endswith(".dist-info/RECORD"):
+                require(
+                    after["method"] == ZIP_DEFLATED
+                    and after["mode"] >> 16 == 0o100644
+                    and after["time"] == [1980, 1, 1, 0, 0, 0]
+                    and not after["comment"]
+                    and after["internal"] == 0,
+                    "Unexpected RECORD metadata",
+                )
+                continue
+            expected = dict(before)
+            if binary := wheel["replacements"].get(name):
+                expected.update(manifest["signed"][binary])
+            require(after == expected, f"Unexpected output member: {name}")
+
+
+def assemble():
+    manifest = signed_manifest()
+    for name, expected in manifest["tools"].items():
+        require(
+            file_digest(Path("tools") / name) == expected,
+            "Assembly tool digest mismatch",
+        )
+    for binary, expected in manifest["signed"].items():
+        require(
+            file_digest(Path("signed") / binary) == expected["sha256"],
+            "Signed binary digest mismatch",
+        )
+    Path("dist/wheels").mkdir(parents=True)
+    for wheel in manifest["wheels"]:
+        source = Path("wheels") / wheel["filename"]
+        require(
+            file_digest(source) == wheel["input_sha256"], "Input wheel digest mismatch"
+        )
+        command = [
+            str(Path("tools/uv-dev").resolve()),
+            "wheel-replace",
+            "--input",
+            str(source),
+            "--output",
+            str(Path("dist/wheels") / source.name),
+        ]
+        for member, binary in wheel["replacements"].items():
+            command.extend(["--replace", f"{member}=signed/{binary}"])
+        subprocess.run(command, check=True)
+    verify_wheels(manifest, Path("dist/wheels"))
+    archive = f"uv-{TARGET}.tar.gz"
+    with tarfile.open(Path("dist") / archive, "x:gz") as output:
+        for binary in ("uv", "uvx"):
+            path = Path("signed") / binary
+            require(
+                file_digest(path) == manifest["signed"][binary]["sha256"],
+                "Signed binary changed",
+            )
+            info = tarfile.TarInfo(f"uv-{TARGET}/{binary}")
+            info.size = path.stat().st_size
+            info.mode = 0o755
+            with path.open("rb") as stream:
+                output.addfile(info, stream)
+    manifest["output_wheels"] = {
+        wheel["filename"]: file_digest(Path("dist/wheels") / wheel["filename"])
+        for wheel in manifest["wheels"]
+    }
+    manifest["archive"] = {
+        "filename": archive,
+        "sha256": file_digest(Path("dist") / archive),
+    }
+    save(Path("dist/manifest.json"), manifest)
+
+
+def verify():
+    signed = signed_manifest()
+    final = load(Path("dist/manifest.json"), os.environ["FINAL_MANIFEST_SHA256"])
+    require(
+        {
+            key: value
+            for key, value in final.items()
+            if key not in ("output_wheels", "archive")
+        }
+        == signed,
+        "Assembly changed the signing manifest",
+    )
+    require(
+        set(final["output_wheels"])
+        == {wheel["filename"] for wheel in signed["wheels"]},
+        "Unexpected final wheel map",
+    )
+    for filename, expected in final["output_wheels"].items():
+        require(
+            file_digest(Path("dist/wheels") / filename) == expected,
+            "Final wheel digest mismatch",
+        )
+    verify_wheels(signed, Path("dist/wheels"))
+    directory = Path(os.environ["RUNNER_TEMP"]) / "verified-binaries"
+    directory.mkdir()
+    for wheel in signed["wheels"]:
+        with ZipFile(Path("dist/wheels") / wheel["filename"]) as source:
+            for member, binary in wheel["replacements"].items():
+                with (
+                    source.open(member) as stream,
+                    (directory / binary).open("xb") as output,
+                ):
+                    shutil.copyfileobj(stream, output)
+    archive = f"uv-{TARGET}.tar.gz"
+    require(
+        final["archive"]["filename"] == archive
+        and file_digest(Path("dist") / archive) == final["archive"]["sha256"],
+        "Final archive mismatch",
+    )
+    with tarfile.open(Path("dist") / archive) as source:
+        members = source.getmembers()
+        require(
+            len(members) == 2
+            and {member.name for member in members}
+            == {f"uv-{TARGET}/uv", f"uv-{TARGET}/uvx"},
+            "Archive membership changed",
+        )
+        for member in members:
+            require(
+                member.isfile() and member.mode == 0o755,
+                "Invalid archive member type/mode",
+            )
+            binary = member.name.rsplit("/", 1)[1]
+            with source.extractfile(member) as stream:
+                sha256, size = digest(stream)
+            require(
+                {"sha256": sha256, "size": size} == signed["signed"][binary],
+                "Archive binary mismatch",
+            )
+    # Native signature/certificate verification runs separately on this fresh macOS runner.
+
+
+if __name__ == "__main__":
+    {"prepare": prepare, "assemble": assemble, "verify": verify}[sys.argv[1]]()

--- a/scripts/macos_signing.py
+++ b/scripts/macos_signing.py
@@ -1,4 +1,4 @@
-"""Bind this test workflow's artifacts; wheel rewriting remains in `uv-dev wheel-replace`.
+"""Bind this test workflow's artifacts; wheel rewriting remains in `uv-dev inject-signed-wheel-binaries`.
 
 Manifests are integrity bindings carried by job outputs, not signatures or attestations. A retry
 must rerun preparation: artifacts from a different run attempt are deliberately rejected. This
@@ -273,14 +273,14 @@ def assemble():
         )
         command = [
             str(Path("tools/uv-dev").resolve()),
-            "wheel-replace",
+            "inject-signed-wheel-binaries",
             "--input",
             str(source),
             "--output",
             str(Path("dist/wheels") / source.name),
+            "--signed-binaries",
+            "signed",
         ]
-        for member, binary in wheel["replacements"].items():
-            command.extend(["--replace", f"{member}=signed/{binary}"])
         subprocess.run(command, check=True)
     verify_wheels(manifest, Path("dist/wheels"))
     archive = f"uv-{TARGET}.tar.gz"

--- a/scripts/test_macos_signing.py
+++ b/scripts/test_macos_signing.py
@@ -178,10 +178,22 @@ class SigningBindings(unittest.TestCase):
                 signing.subprocess,
                 "run",
                 side_effect=RuntimeError("injected assembly failure"),
-            ),
+            ) as run,
             self.assertRaisesRegex(RuntimeError, "injected"),
         ):
             signing.assemble()
+        self.assertEqual(
+            run.call_args.args[0][1:],
+            [
+                "inject-signed-wheel-binaries",
+                "--input",
+                f"wheels/uv-1.2.3-{signing.TAG}.whl",
+                "--output",
+                f"dist/wheels/uv-1.2.3-{signing.TAG}.whl",
+                "--signed-binaries",
+                "signed",
+            ],
+        )
         self.assertFalse(Path("dist/manifest.json").exists())
 
 

--- a/scripts/test_macos_signing.py
+++ b/scripts/test_macos_signing.py
@@ -1,0 +1,189 @@
+"""Small caller-binding fixtures; no signing identity or compiled helper is needed."""
+
+import base64
+import contextlib
+import csv
+import hashlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+
+import macos_signing as signing
+from check_uv_wheel_contents import uv_build_expected, uv_expected
+
+
+def wheel(path, distribution, *, signed=False, tamper=False):
+    names = uv_expected if distribution == "uv" else uv_build_expected
+    contents = {}
+    for template in sorted(names):
+        name = template.replace("VERSION", "1.2.3")
+        if name.endswith("/RECORD"):
+            continue
+        if ".data/scripts/" in name:
+            contents[name] = (
+                "signed " if signed else "unsigned "
+            ).encode() + name.encode()
+        elif name.endswith("/WHEEL"):
+            contents[name] = f"Wheel-Version: 1.0\nTag: {signing.TAG}\n".encode()
+        else:
+            contents[name] = b"metadata"
+    record = f"{distribution}-1.2.3.dist-info/RECORD"
+    stream = io.StringIO()
+    rows = csv.writer(stream)
+    for name, data in contents.items():
+        hashed = (
+            base64.urlsafe_b64encode(hashlib.sha256(data).digest()).decode().rstrip("=")
+        )
+        rows.writerow([name, "sha256=" + hashed, len(data)])
+    rows.writerow([record, "", ""])
+    contents[record] = stream.getvalue().encode()
+    if tamper:
+        contents[f"{distribution}-1.2.3.dist-info/METADATA"] = b"tampered"
+    with ZipFile(path, "w") as archive:
+        for name, data in contents.items():
+            info = ZipInfo(name, (2001, 2, 3, 4, 5, 6))
+            if signed and name == record:
+                info.date_time = (1980, 1, 1, 0, 0, 0)
+            info.compress_type = ZIP_DEFLATED
+            mode = 0o100755 if ".data/scripts/" in name else 0o100644
+            info.external_attr = mode << 16
+            archive.writestr(info, data)
+
+
+class SigningBindings(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.directory = Path(temporary.name)
+        self.enterContext(contextlib.chdir(self.directory))
+        self.enterContext(
+            patch.dict(
+                os.environ,
+                {
+                    "GITHUB_REPOSITORY": "astral-sh/uv",
+                    "GITHUB_WORKFLOW_REF": "astral-sh/uv/.github/workflows/ci.yml@refs/pull/1/merge",
+                    "GITHUB_WORKFLOW_SHA": "a" * 40,
+                    "GITHUB_RUN_ID": "1",
+                    "GITHUB_RUN_ATTEMPT": "1",
+                    "GITHUB_SHA": "b" * 40,
+                    "GITHUB_OUTPUT": str(self.directory / "job-output"),
+                    "RUNNER_TEMP": str(self.directory),
+                },
+            )
+        )
+        Path("wheels").mkdir()
+        Path("tools").mkdir()
+        for name in signing.TOOLS:
+            (Path("tools") / name).write_bytes(b"tool fixture")
+        for distribution in ("uv", "uv_build"):
+            wheel(
+                Path("wheels") / f"{distribution}-1.2.3-{signing.TAG}.whl", distribution
+            )
+
+    def prepared(self):
+        signing.prepare()
+        os.environ["INPUT_MANIFEST_SHA256"] = signing.file_digest(Path("manifest.json"))
+        return json.loads(Path("manifest.json").read_text())
+
+    def signed(self):
+        manifest = self.prepared()
+        manifest["signed"] = {}
+        manifest["certificate_sha256"] = "c" * 64
+        Path("signed").mkdir()
+        for item in manifest["wheels"]:
+            for member, binary in item["replacements"].items():
+                data = b"signed " + member.encode()
+                (Path("signed") / binary).write_bytes(data)
+                manifest["signed"][binary] = {
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                    "size": len(data),
+                }
+        signing.save(Path("signed/manifest.json"), manifest)
+        os.environ["SIGNED_MANIFEST_SHA256"] = signing.file_digest(
+            Path("signed/manifest.json")
+        )
+        return manifest
+
+    def test_prepare_binds_source_members_and_tools(self):
+        manifest = self.prepared()
+        self.assertEqual(manifest["context"], signing.context())
+        self.assertEqual(set(manifest["tools"]), set(signing.TOOLS))
+        for item in manifest["wheels"]:
+            self.assertEqual(
+                item["input_sha256"],
+                signing.file_digest(Path("wheels") / item["filename"]),
+            )
+            for member, binary in item["replacements"].items():
+                self.assertEqual(
+                    item["members"][member]["sha256"],
+                    signing.file_digest(Path("unsigned") / binary),
+                )
+
+    def test_context_and_manifest_substitution_are_rejected(self):
+        self.prepared()
+        digest = os.environ["INPUT_MANIFEST_SHA256"]
+        with self.assertRaisesRegex(ValueError, "digest mismatch"):
+            signing.load(Path("manifest.json"), "0" * 64)
+        for key in (
+            "GITHUB_RUN_ATTEMPT",
+            "GITHUB_SHA",
+            "GITHUB_REPOSITORY",
+            "GITHUB_WORKFLOW_SHA",
+        ):
+            with (
+                patch.dict(os.environ, {key: "other"}),
+                self.assertRaisesRegex(ValueError, "workflow context"),
+            ):
+                signing.load(Path("manifest.json"), digest)
+
+    def test_signed_manifest_cannot_change_original_binding(self):
+        manifest = self.signed()
+        manifest["wheels"][0]["input_sha256"] = "0" * 64
+        Path("signed/manifest.json").write_text(json.dumps(manifest))
+        os.environ["SIGNED_MANIFEST_SHA256"] = signing.file_digest(
+            Path("signed/manifest.json")
+        )
+        with self.assertRaisesRegex(ValueError, "changed the input manifest"):
+            signing.signed_manifest()
+
+    def test_final_wheels_are_checked_against_signed_bytes(self):
+        manifest = self.signed()
+        Path("output").mkdir()
+        for distribution in ("uv", "uv_build"):
+            wheel(
+                Path("output") / f"{distribution}-1.2.3-{signing.TAG}.whl",
+                distribution,
+                signed=True,
+            )
+        signing.verify_wheels(manifest, Path("output"))
+        wheel(Path("output") / f"uv-1.2.3-{signing.TAG}.whl", "uv")
+        with self.assertRaisesRegex(ValueError, "Unexpected output member"):
+            signing.verify_wheels(manifest, Path("output"))
+
+    def test_bad_untouched_record_is_rejected(self):
+        path = Path("wheels") / f"uv-1.2.3-{signing.TAG}.whl"
+        wheel(path, "uv", tamper=True)
+        with self.assertRaisesRegex(ValueError, "Invalid RECORD row"):
+            signing.prepare()
+
+    def test_assembly_failure_does_not_emit_final_manifest(self):
+        self.signed()
+        with (
+            patch.object(
+                signing.subprocess,
+                "run",
+                side_effect=RuntimeError("injected assembly failure"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "injected"),
+        ):
+            signing.assemble()
+        self.assertFalse(Path("dist/manifest.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is a proof-of-concept for using #20622 for code signing executables in wheels.