### PR TITLE
Fix more overzealous snapshot filters

### DIFF
--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -153,8 +153,14 @@ fn run_args() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
     let context = context
-        .with_filter((r"Usage: uv(\.exe)? run \[OPTIONS\] (?s).*", "[UV RUN HELP]"))
-        .with_filter((r"usage: .*(\n|.*)*", "usage: [PYTHON HELP]"));
+        .with_filter((
+            r"Usage: uv(?:\.exe)? run \[OPTIONS\] (?s:.*?)(\n----- stderr -----|$)",
+            "[UV RUN HELP]$1",
+        ))
+        .with_filter((
+            r"usage: (?s:.*?)(\n----- stderr -----|$)",
+            "usage: [PYTHON HELP]$1",
+        ));
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -184,6 +190,7 @@ fn run_args() -> Result<()> {
     Run a command or script
 
     [UV RUN HELP]
+    ----- stderr -----
     ");
 
     // We don't treat arguments after the command as uv arguments
@@ -192,6 +199,11 @@ fn run_args() -> Result<()> {
     exit_code: 0
     ----- stdout -----
     usage: [PYTHON HELP]
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + foo==1.0.0 (from file://[TEMP_DIR]/)
     ");
 
     // Can use `--` to separate uv arguments from the command arguments.

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -16,10 +16,13 @@ fn tool_run_args() {
     let context = uv_test::test_context!("3.12").with_filtered_counts();
     let context = context
         .with_filter((
-            r"Usage: uv(\.exe)? tool run \[OPTIONS\] (?s).*",
-            "[UV TOOL RUN HELP]",
+            r"Usage: uv(?:\.exe)? tool run \[OPTIONS\] (?s:.*?)(\n----- stderr -----|$)",
+            "[UV TOOL RUN HELP]$1",
         ))
-        .with_filter((r"usage: pytest \[options\] (?s).*", "[PYTEST HELP]"));
+        .with_filter((
+            r"usage: pytest \[options\] (?s:.*?)(\n----- stderr -----|$)",
+            "[PYTEST HELP]$1",
+        ));
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -35,6 +38,7 @@ fn tool_run_args() {
     Run a command provided by a Python package
 
     [UV TOOL RUN HELP]
+    ----- stderr -----
     ");
 
     // We don't treat arguments after the command as uv tool run arguments
@@ -47,6 +51,14 @@ fn tool_run_args() {
     exit_code: 0
     ----- stdout -----
     [PYTEST HELP]
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + iniconfig==2.0.0
+     + packaging==24.0
+     + pluggy==1.4.0
+     + pytest==8.1.1
     ");
 
     // Can use `--` to separate uv arguments from the command arguments.


### PR DESCRIPTION
## Summary

These were eating the stderr markers. In some cases losing information.

If you're wondering why it matters, well ... just wait until you see my next PR in this series.