### PR TITLE
Add `--package` and `--all-packages` to `uv check`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5263,6 +5263,24 @@ pub struct FormatArgs {
 
 #[derive(Args)]
 pub struct CheckArgs {
+    /// Check all packages in the workspace.
+    ///
+    /// The workspace's environment is synchronized to include all workspace members, and files in
+    /// every member are checked.
+    #[arg(long, conflicts_with_all = ["package", "script", "no_project"])]
+    pub all_packages: bool,
+
+    /// Check specific packages in the workspace.
+    ///
+    /// The workspace's environment is synchronized to include the selected members and their
+    /// dependencies. Only files owned by the selected members are checked.
+    #[arg(
+        long,
+        conflicts_with_all = ["all_packages", "script", "no_project"],
+        value_hint = ValueHint::Other
+    )]
+    pub package: Vec<PackageName>,
+
     /// Run checks for the specified PEP 723 Python script, rather than the current project.
     ///
     /// If provided, uv will use the dependencies based on the script's inline metadata table, in
@@ -5282,6 +5300,8 @@ pub struct CheckArgs {
         conflicts_with = "only_group",
         conflicts_with = "all_groups",
         conflicts_with = "no_project",
+        conflicts_with = "all_packages",
+        conflicts_with = "package",
         value_hint = ValueHint::FilePath,
     )]
     pub script: Option<PathBuf>,

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -112,6 +112,9 @@ pub(crate) async fn check(
                 Some(project)
             }
             Err(err) => {
+                if let WorkspaceErrorKind::NoSuchMember(name, _) = err.as_ref() {
+                    anyhow::bail!("Package `{name}` not found in workspace");
+                }
                 if !all_packages
                     && package.is_empty()
                     && matches!(
@@ -163,13 +166,20 @@ pub(crate) async fn check(
         }
     }
 
+    let is_virtual_workspace = project
+        .as_ref()
+        .is_some_and(|project| project.project_name().is_none());
+    let defacto_all_packages = all_packages || (is_virtual_workspace && package.is_empty());
+
     let target_dir = script
         .as_ref()
         .and_then(|script| script.path.parent())
         .map(Path::to_path_buf)
         .or_else(|| {
             project.as_ref().map(|project| {
-                if all_packages
+                // If multiple packages are selected, or the package is outside the workspace dir,
+                // require analysis to run in the workspace dir.
+                if defacto_all_packages
                     || package.len() > 1
                     || !normalize_path(project.root())
                         .starts_with(project.workspace().install_path())
@@ -185,7 +195,7 @@ pub(crate) async fn check(
     let check_targets = if let Some(script) = script.as_ref() {
         vec![script.path.clone()]
     } else if let Some(project) = project.as_ref() {
-        if all_packages || (package.is_empty() && project.project_name().is_none()) {
+        if defacto_all_packages {
             // In --all-packages mode, and anything equivalent like virtual workspaces,
             // we can't just pass ty the root of the project because:
             //
@@ -236,8 +246,7 @@ pub(crate) async fn check(
     // package will almost always have the other packages nested under it, and we need a
     // way to select just the workspace root.
     let excluded_targets = if let Some(project) = project.as_ref()
-        && !all_packages
-        && (project.project_name().is_some() || !package.is_empty())
+        && !defacto_all_packages
     {
         project
             .workspace()

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -10,6 +10,7 @@ use uv_configuration::{
     Concurrency, DependencyGroups, DependencyGroupsWithDefaults, DryRun, ExtrasSpecification,
     InstallOptions,
 };
+use uv_fs::normalize_path;
 use uv_normalize::{DEV_DEPENDENCIES, DefaultExtras, PackageName};
 use uv_preview::{Preview, PreviewFeature};
 use uv_python::{
@@ -48,6 +49,8 @@ pub(crate) async fn check(
     frozen: Option<FrozenSource>,
     no_sync: bool,
     isolated: bool,
+    all_packages: bool,
+    package: Vec<PackageName>,
     extras: ExtrasSpecification,
     groups: DependencyGroups,
     python: Option<String>,
@@ -80,22 +83,44 @@ pub(crate) async fn check(
     let project = if no_project || script.is_some() {
         None
     } else {
-        match VirtualProject::discover(
-            project_dir,
-            &DiscoveryOptions::default(),
-            cache,
-            workspace_cache,
-        )
-        .await
-        {
-            Ok(project) => Some(project),
+        let discovery = if let [name] = package.as_slice() {
+            VirtualProject::discover_with_package(
+                project_dir,
+                &DiscoveryOptions::default(),
+                cache,
+                workspace_cache,
+                name.clone(),
+            )
+            .await
+        } else {
+            VirtualProject::discover(
+                project_dir,
+                &DiscoveryOptions::default(),
+                cache,
+                workspace_cache,
+            )
+            .await
+        };
+
+        match discovery {
+            Ok(project) => {
+                for name in &package {
+                    if !project.workspace().packages().contains_key(name) {
+                        anyhow::bail!("Package `{name}` not found in workspace");
+                    }
+                }
+                Some(project)
+            }
             Err(err) => {
-                if matches!(
-                    err.as_ref(),
-                    WorkspaceErrorKind::MissingPyprojectToml
-                        | WorkspaceErrorKind::MissingProject(_)
-                        | WorkspaceErrorKind::NonWorkspace(_),
-                ) {
+                if !all_packages
+                    && package.is_empty()
+                    && matches!(
+                        err.as_ref(),
+                        WorkspaceErrorKind::MissingPyprojectToml
+                            | WorkspaceErrorKind::MissingProject(_)
+                            | WorkspaceErrorKind::NonWorkspace(_),
+                    )
+                {
                     None
                 } else {
                     return Err(err.into());
@@ -142,8 +167,98 @@ pub(crate) async fn check(
         .as_ref()
         .and_then(|script| script.path.parent())
         .map(Path::to_path_buf)
-        .or_else(|| project.as_ref().map(|project| project.root().to_owned()))
+        .or_else(|| {
+            project.as_ref().map(|project| {
+                if all_packages
+                    || package.len() > 1
+                    || !normalize_path(project.root())
+                        .starts_with(project.workspace().install_path())
+                {
+                    project.workspace().install_path().to_owned()
+                } else {
+                    project.root().to_owned()
+                }
+            })
+        })
         .unwrap_or_else(|| project_dir.to_owned());
+
+    let check_targets = if let Some(script) = script.as_ref() {
+        vec![script.path.clone()]
+    } else if let Some(project) = project.as_ref() {
+        if all_packages || (package.is_empty() && project.project_name().is_none()) {
+            // In --all-packages mode, and anything equivalent like virtual workspaces,
+            // we can't just pass ty the root of the project because:
+            //
+            // * It excludes members of the workspace that aren't nested under the root,
+            //   as constructs like `members = ["../foo"]` are legal.
+            // * For virtual workspaces, this can include files that are not strictly
+            //   part of any member, such as `scripts/myscript.py`
+            //
+            // The first issue is definitely important to handle, but the second issue
+            // is debatable. It is in fact Useful for ty to find and check all your
+            // random scripts, and indeed this is the default ty behaviour. Attempting
+            // to manually suppress this behaviour is an attempt to maintain "uv-like"
+            // behaviour, but if anyone disagrees we can change this by just always
+            // including the workspace root, even for virtual workspaces.
+            project
+                .workspace()
+                .packages()
+                .values()
+                .map(|member| member.root().clone())
+                .collect()
+        } else if !package.is_empty() {
+            // If the user has specified a list of packages, tell ty to only check those packages.
+            package
+                .iter()
+                .map(|name| {
+                    project
+                        .workspace()
+                        .packages()
+                        .get(name)
+                        .map(|member| member.root().clone())
+                        .ok_or_else(|| anyhow::anyhow!("Package `{name}` not found in workspace"))
+                })
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            // Otherwise we're checking just this one package (nearest ancestor).
+            vec![project.root().to_owned()]
+        }
+    } else {
+        Vec::new()
+    };
+
+    // Any selected package can contain other workspace members, even in a virtual workspace.
+    // Explicitly exclude any workspace members that aren't selected *and are nested under
+    // a selected one*, so ty doesn't emit diagnostics for them (if they're dependencies
+    // of selected packages that's fine, ty will still find them for those purposes).
+    //
+    // The most common case this is handling is a non-virtual workspace, where the root
+    // package will almost always have the other packages nested under it, and we need a
+    // way to select just the workspace root.
+    let excluded_targets = if let Some(project) = project.as_ref()
+        && !all_packages
+        && (project.project_name().is_some() || !package.is_empty())
+    {
+        project
+            .workspace()
+            .packages()
+            .iter()
+            .filter(|(name, member)| {
+                let selected = if package.is_empty() {
+                    project.project_name() == Some(*name)
+                } else {
+                    package.contains(name)
+                };
+                !selected
+                    && check_targets
+                        .iter()
+                        .any(|target| member.root().starts_with(target))
+            })
+            .map(|(_, member)| member.root().clone())
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     let groups = if let Some(project) = &project {
         groups.with_defaults(default_dependency_groups(project.pyproject_toml())?)
@@ -475,17 +590,12 @@ pub(crate) async fn check(
             Err(err) => return Err(err.into()),
         };
 
-        let target = match project {
-            VirtualProject::Project(project) => InstallTarget::Project {
-                workspace: project.workspace(),
-                name: project.project_name(),
-                lock: result.lock(),
-            },
-            VirtualProject::NonProject(workspace) => InstallTarget::NonProjectWorkspace {
-                workspace,
-                lock: result.lock(),
-            },
-        };
+        let target = project::sync::identify_project_installation_target(
+            project,
+            result.lock(),
+            all_packages,
+            &package,
+        );
 
         target.validate_extras(&extras)?;
         target.validate_groups(&groups)?;
@@ -605,7 +715,8 @@ pub(crate) async fn check(
         ty_version,
         ty_path.or(locked_ty_path),
         &target_dir,
-        script.as_ref().map(|script| script.path.as_path()),
+        &check_targets,
+        &excluded_targets,
         venv_path.as_deref(),
         exclude_newer,
         show_version,

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -20,7 +20,8 @@ pub(super) async fn run(
     version: Option<String>,
     ty_path: Option<PathBuf>,
     target_dir: &Path,
-    check_target: Option<&Path>,
+    check_targets: &[PathBuf],
+    excluded_targets: &[PathBuf],
     venv_path: Option<&Path>,
     exclude_newer: Option<jiff::Timestamp>,
     show_version: bool,
@@ -125,15 +126,25 @@ pub(super) async fn run(
     let mut command = Command::new(&ty_path);
     command.current_dir(target_dir);
     command.arg("check");
-    if let Some(check_target) = check_target {
-        // Check only the requested script. Keep the path relative to the working directory for
-        // stable diagnostics, and use `--` so option-like filenames are treated as paths.
-        command.arg("--");
+    for excluded_target in excluded_targets {
+        command.arg("--exclude");
         command.arg(
-            check_target
+            excluded_target
                 .strip_prefix(target_dir)
-                .unwrap_or(check_target),
+                .unwrap_or(excluded_target),
         );
+    }
+    if !check_targets.is_empty() {
+        // Keep paths relative to the working directory for stable diagnostics, and use `--` so
+        // option-like filenames are treated as paths.
+        command.arg("--");
+        for check_target in check_targets {
+            command.arg(
+                check_target
+                    .strip_prefix(target_dir)
+                    .unwrap_or(check_target),
+            );
+        }
     }
     // Opt into ty querying uv for project metadata.
     command.env("TY_UV", "1");

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -513,59 +513,69 @@ fn identify_installation_target<'a>(
     all_packages: bool,
     package: &'a [PackageName],
 ) -> InstallTarget<'a> {
-    match &target {
+    match target {
         SyncTarget::Project(project) => {
-            match &project {
-                VirtualProject::Project(project) => {
-                    if all_packages {
-                        InstallTarget::Workspace {
-                            workspace: project.workspace(),
-                            lock,
-                        }
-                    } else {
-                        match package {
-                            // By default, install the root project.
-                            [] => InstallTarget::Project {
-                                workspace: project.workspace(),
-                                name: project.project_name(),
-                                lock,
-                            },
-                            [name] => InstallTarget::Project {
-                                workspace: project.workspace(),
-                                name,
-                                lock,
-                            },
-                            names => InstallTarget::Projects {
-                                workspace: project.workspace(),
-                                names,
-                                lock,
-                            },
-                        }
-                    }
+            identify_project_installation_target(project, lock, all_packages, package)
+        }
+        SyncTarget::Script(script) => InstallTarget::Script { script, lock },
+    }
+}
+
+/// Select workspace members with the same semantics as `uv sync`.
+pub(crate) fn identify_project_installation_target<'a>(
+    project: &'a VirtualProject,
+    lock: &'a Lock,
+    all_packages: bool,
+    package: &'a [PackageName],
+) -> InstallTarget<'a> {
+    match project {
+        VirtualProject::Project(project) => {
+            if all_packages {
+                InstallTarget::Workspace {
+                    workspace: project.workspace(),
+                    lock,
                 }
-                VirtualProject::NonProject(workspace) => {
-                    if all_packages {
-                        InstallTarget::NonProjectWorkspace { workspace, lock }
-                    } else {
-                        match package {
-                            // By default, install the entire workspace.
-                            [] => InstallTarget::NonProjectWorkspace { workspace, lock },
-                            [name] => InstallTarget::Project {
-                                workspace,
-                                name,
-                                lock,
-                            },
-                            names => InstallTarget::Projects {
-                                workspace,
-                                names,
-                                lock,
-                            },
-                        }
-                    }
+            } else {
+                match package {
+                    // By default, install the current project.
+                    [] => InstallTarget::Project {
+                        workspace: project.workspace(),
+                        name: project.project_name(),
+                        lock,
+                    },
+                    [name] => InstallTarget::Project {
+                        workspace: project.workspace(),
+                        name,
+                        lock,
+                    },
+                    names => InstallTarget::Projects {
+                        workspace: project.workspace(),
+                        names,
+                        lock,
+                    },
                 }
             }
         }
-        SyncTarget::Script(script) => InstallTarget::Script { script, lock },
+        VirtualProject::NonProject(workspace) => {
+            if all_packages {
+                InstallTarget::NonProjectWorkspace { workspace, lock }
+            } else {
+                match package {
+                    // By default, install the entire virtual workspace.
+                    [] => InstallTarget::NonProjectWorkspace { workspace, lock },
+                    [name] => InstallTarget::Project {
+                        workspace,
+                        name,
+                        lock,
+                    },
+                    names => InstallTarget::Projects {
+                        workspace,
+                        names,
+                        lock,
+                    },
+                }
+            }
+        }
     }
 }
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2881,6 +2881,8 @@ async fn run_project(
                 args.frozen,
                 args.no_sync,
                 args.isolated,
+                args.all_packages,
+                args.package,
                 args.extras,
                 args.groups,
                 args.python,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2990,6 +2990,8 @@ pub(crate) struct CheckSettings {
     pub(crate) ty_path: Option<PathBuf>,
     #[expect(dead_code)]
     script: Option<PathBuf>,
+    pub(crate) all_packages: bool,
+    pub(crate) package: Vec<PackageName>,
     pub(crate) extras: ExtrasSpecification,
     pub(crate) groups: DependencyGroups,
     pub(crate) lock_check: LockCheck,
@@ -3014,6 +3016,8 @@ impl CheckSettings {
         environment: EnvironmentOptions,
     ) -> anyhow::Result<Self> {
         let CheckArgs {
+            all_packages,
+            package,
             script,
             extra,
             all_extras,
@@ -3068,6 +3072,8 @@ impl CheckSettings {
         Ok(Self {
             ty_path: environment.ty_path,
             script,
+            all_packages,
+            package,
             extras: ExtrasSpecification::from_args(
                 extra.unwrap_or_default(),
                 no_extra,

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -1352,7 +1352,7 @@ fn check_virtual_root_uses_own_ty() -> Result<()> {
         [dependency-groups]
         dev = ["ty==0.0.16 ; python_version < '3.12'"]
     "#})?;
-    context.temp_dir.child("main.py").write_str("x = 1")?;
+    member.child("main.py").write_str("x = 1")?;
     context
         .lock()
         .arg("--exclude-newer")

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -8,6 +8,17 @@ use uv_static::EnvVars;
 use uv_test::packse::PackseServer;
 use uv_test::{diff_snapshot, uv_snapshot};
 
+fn write_workspace_member(context: &uv_test::TestContext, name: &str, source: &str) -> Result<()> {
+    let member = context.temp_dir.child("packages").child(name);
+    member.create_dir_all()?;
+    member.child("pyproject.toml").write_str(&format!(
+        "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\nrequires-python = \">=3.12\"\ndependencies = []\n"
+    ))?;
+    member.child("main.py").write_str(source)?;
+
+    Ok(())
+}
+
 #[test]
 fn check_project() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -35,6 +46,512 @@ fn check_project() -> Result<()> {
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     ");
+
+    Ok(())
+}
+
+#[test]
+fn check_workspace_member_selection() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["packages/*"]
+        "#})?;
+    write_workspace_member(&context, "member-a", "value: int = 1\n")?;
+    write_workspace_member(&context, "member-b", "value: int = 'wrong'\n")?;
+
+    let member_a = context.temp_dir.child("packages").child("member-a");
+    uv_snapshot!(context.filters(), context.check().current_dir(&member_a), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    ");
+
+    uv_snapshot!(context.filters(), context.check().arg("--package").arg("member-a"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn check_virtual_workspace_checks_all_members_by_default() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["packages/*"]
+        "#})?;
+    write_workspace_member(&context, "member-a", "value: int = 1\n")?;
+    write_workspace_member(&context, "member-b", "value: int = 'wrong'\n")?;
+
+    uv_snapshot!(context.filters(), context.check(), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
+     --> packages/member-b/main.py:1:8
+      |
+    1 | value: int = 'wrong'
+      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
+      |        |
+      |        Declared type
+      |
+    info: rule `invalid-assignment` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn check_virtual_workspace_only_checks_declared_members() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["packages/*"]
+        "#})?;
+    context
+        .temp_dir
+        .child("unowned.py")
+        .write_str("value: int = 'wrong'\n")?;
+    write_workspace_member(&context, "member", "value: int = 1\n")?;
+
+    uv_snapshot!(context.filters(), context.check(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    ");
+
+    uv_snapshot!(context.filters(), context.check().arg("--all-packages"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn check_workspace_all_packages_includes_external_members() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    let workspace = context.temp_dir.child("workspace");
+    workspace.create_dir_all()?;
+    workspace.child("pyproject.toml").write_str(indoc! {r#"
+        [tool.uv.workspace]
+        members = ["../external-package"]
+    "#})?;
+
+    let external = context.temp_dir.child("external-package");
+    external.create_dir_all()?;
+    external.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "external-package"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+    external
+        .child("main.py")
+        .write_str("value: int = 'wrong'\n")?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.check().current_dir(&workspace).arg("--all-packages"),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
+     --> [TEMP_DIR]/external-package/main.py:1:8
+      |
+    1 | value: int = 'wrong'
+      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
+      |        |
+      |        Declared type
+      |
+    info: rule `invalid-assignment` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    "###
+    );
+
+    Ok(())
+}
+
+#[test]
+fn check_external_workspace_member_inherits_workspace_configuration() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    let workspace = context.temp_dir.child("workspace");
+    workspace.create_dir_all()?;
+    workspace.child("pyproject.toml").write_str(indoc! {r#"
+        [tool.uv.workspace]
+        members = ["../external-package"]
+
+        [tool.ty.rules]
+        invalid-assignment = "ignore"
+    "#})?;
+
+    let external = context.temp_dir.child("external-package");
+    external.create_dir_all()?;
+    external.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "external-package"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+    external
+        .child("main.py")
+        .write_str("value: int = 'wrong'\n")?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .current_dir(&workspace)
+            .arg("--package")
+            .arg("external-package"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn check_virtual_workspace_member_excludes_nested_members() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["packages/parent", "packages/parent/child"]
+        "#})?;
+    write_workspace_member(&context, "parent", "value: int = 1\n")?;
+
+    let child = context.temp_dir.child("packages/parent/child");
+    child.create_dir_all()?;
+    child.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+    child.child("main.py").write_str("value: int = 'wrong'\n")?;
+
+    uv_snapshot!(context.filters(), context.check().arg("--package").arg("parent"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    ");
+
+    uv_snapshot!(context.filters(), context.check().arg("--all-packages"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
+     --> packages/parent/child/main.py:1:8
+      |
+    1 | value: int = 'wrong'
+      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
+      |        |
+      |        Declared type
+      |
+    info: rule `invalid-assignment` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn check_virtual_workspace_member_resolves_excluded_nested_dependency() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["packages/parent", "packages/parent/child"]
+        "#})?;
+
+    let parent = context.temp_dir.child("packages/parent");
+    parent.create_dir_all()?;
+    parent.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child"]
+
+        [tool.uv.sources]
+        child = { workspace = true }
+    "#})?;
+    parent.child("main.py").write_str(indoc! {r"
+        from child import exported
+
+        value: str = exported
+    "})?;
+
+    let child = parent.child("child");
+    child.create_dir_all()?;
+    child.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    let child_package = child.child("src/child");
+    child_package.create_dir_all()?;
+    child_package.child("__init__.py").write_str(indoc! {r#"
+        exported: str = "hello"
+        internal_broken: int = "wrong"
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.check().arg("--package").arg("parent"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    Installed 1 package in [TIME]
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn check_workspace_member_inherits_workspace_configuration() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["packages/*"]
+
+            [tool.ty.rules]
+            invalid-assignment = "ignore"
+        "#})?;
+    write_workspace_member(&context, "member", "value: int = 'wrong'\n")?;
+
+    uv_snapshot!(context.filters(), context.check().arg("--package").arg("member"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn check_workspace_missing_package() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["packages/*"]
+        "#})?;
+    write_workspace_member(&context, "member", "value: int = 1\n")?;
+
+    uv_snapshot!(context.filters(), context.check().arg("--package").arg("missing"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    error: The workspace does not have a member missing: [TEMP_DIR]/
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn check_workspace_root_excludes_nested_members() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [project]
+            name = "root"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+            dependencies = []
+
+            [tool.uv.workspace]
+            members = ["packages/*"]
+        "#})?;
+    context
+        .temp_dir
+        .child("main.py")
+        .write_str("value: int = 1\n")?;
+    write_workspace_member(&context, "member", "value: int = 'wrong'\n")?;
+
+    uv_snapshot!(context.filters(), context.check(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    ");
+
+    uv_snapshot!(context.filters(), context.check().arg("--all-packages"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
+     --> packages/member/main.py:1:8
+      |
+    1 | value: int = 'wrong'
+      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
+      |        |
+      |        Declared type
+      |
+    info: rule `invalid-assignment` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn check_workspace_multiple_packages() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [tool.uv.workspace]
+            members = ["packages/*"]
+        "#})?;
+    write_workspace_member(&context, "member-a", "value: int = 1\n")?;
+    write_workspace_member(&context, "member-b", "value: int = 2\n")?;
+    write_workspace_member(&context, "member-c", "value: int = 'wrong'\n")?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--package")
+            .arg("member-a")
+            .arg("--package")
+            .arg("member-b"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "
+    );
+
+    uv_snapshot!(context.filters(), context.check().arg("--all-packages"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
+     --> packages/member-c/main.py:1:8
+      |
+    1 | value: int = 'wrong'
+      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
+      |        |
+      |        Declared type
+      |
+    info: rule `invalid-assignment` is enabled by default
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "###);
 
     Ok(())
 }

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
@@ -7,6 +9,12 @@ use insta::assert_snapshot;
 use uv_static::EnvVars;
 use uv_test::packse::PackseServer;
 use uv_test::{diff_snapshot, uv_snapshot};
+
+fn workspace_check(context: &uv_test::TestContext) -> Command {
+    let mut command = context.check();
+    command.env("TY_OUTPUT_FORMAT", "concise");
+    command
+}
 
 fn write_workspace_member(context: &uv_test::TestContext, name: &str, source: &str) -> Result<()> {
     let member = context.temp_dir.child("packages").child(name);
@@ -50,6 +58,7 @@ fn check_project() -> Result<()> {
     Ok(())
 }
 
+/// Check only the selected workspace member, whether selected implicitly or explicitly.
 #[test]
 fn check_workspace_member_selection() -> Result<()> {
     let context =
@@ -61,33 +70,36 @@ fn check_workspace_member_selection() -> Result<()> {
             [tool.uv.workspace]
             members = ["packages/*"]
         "#})?;
-    write_workspace_member(&context, "member-a", "value: int = 1\n")?;
-    write_workspace_member(&context, "member-b", "value: int = 'wrong'\n")?;
+    write_workspace_member(&context, "member-a", "value: int = 'selected'\n")?;
+    write_workspace_member(&context, "member-b", "value: int = 'excluded'\n")?;
 
     let member_a = context.temp_dir.child("packages").child("member-a");
-    uv_snapshot!(context.filters(), context.check().current_dir(&member_a), @"
-    success: true
-    exit_code: 0
+    uv_snapshot!(context.filters(), workspace_check(&context).current_dir(&member_a), @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
+    Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    ");
+    "#);
 
-    uv_snapshot!(context.filters(), context.check().arg("--package").arg("member-a"), @"
-    success: true
-    exit_code: 0
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--package").arg("member-a"), @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
+    Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    ");
+    "#);
 
     Ok(())
 }
 
+/// Check every member when invoked from the root of a virtual workspace.
 #[test]
 fn check_virtual_workspace_checks_all_members_by_default() -> Result<()> {
     let context =
@@ -99,32 +111,25 @@ fn check_virtual_workspace_checks_all_members_by_default() -> Result<()> {
             [tool.uv.workspace]
             members = ["packages/*"]
         "#})?;
-    write_workspace_member(&context, "member-a", "value: int = 1\n")?;
-    write_workspace_member(&context, "member-b", "value: int = 'wrong'\n")?;
+    write_workspace_member(&context, "member-a", "value: int = 'selected-a'\n")?;
+    write_workspace_member(&context, "member-b", "value: int = 'selected-b'\n")?;
 
-    uv_snapshot!(context.filters(), context.check(), @r###"
+    uv_snapshot!(context.filters(), workspace_check(&context), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
-    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
-     --> packages/member-b/main.py:1:8
-      |
-    1 | value: int = 'wrong'
-      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
-      |        |
-      |        Declared type
-      |
-    info: rule `invalid-assignment` is enabled by default
-
-    Found 1 diagnostic
+    packages/member-a/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected-a"]` is not assignable to `int`
+    packages/member-b/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected-b"]` is not assignable to `int`
+    Found 2 diagnostics
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    "###);
+    "#);
 
     Ok(())
 }
 
+/// Ignore Python files at a virtual workspace root that do not belong to a member.
 #[test]
 fn check_virtual_workspace_only_checks_declared_members() -> Result<()> {
     let context =
@@ -139,32 +144,35 @@ fn check_virtual_workspace_only_checks_declared_members() -> Result<()> {
     context
         .temp_dir
         .child("unowned.py")
-        .write_str("value: int = 'wrong'\n")?;
-    write_workspace_member(&context, "member", "value: int = 1\n")?;
+        .write_str("value: int = 'unowned'\n")?;
+    write_workspace_member(&context, "member", "value: int = 'selected'\n")?;
 
-    uv_snapshot!(context.filters(), context.check(), @"
-    success: true
-    exit_code: 0
+    uv_snapshot!(context.filters(), workspace_check(&context), @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    packages/member/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
+    Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    ");
+    "#);
 
-    uv_snapshot!(context.filters(), context.check().arg("--all-packages"), @"
-    success: true
-    exit_code: 0
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--all-packages"), @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    packages/member/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
+    Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    ");
+    "#);
 
     Ok(())
 }
 
+/// Include workspace members located outside the workspace root with `--all-packages`.
 #[test]
 fn check_workspace_all_packages_includes_external_members() -> Result<()> {
     let context =
@@ -187,37 +195,31 @@ fn check_workspace_all_packages_includes_external_members() -> Result<()> {
     "#})?;
     external
         .child("main.py")
-        .write_str("value: int = 'wrong'\n")?;
+        .write_str("value: int = 'selected'\n")?;
 
     uv_snapshot!(
         context.filters(),
-        context.check().current_dir(&workspace).arg("--all-packages"),
-        @r###"
+        workspace_check(&context)
+            .current_dir(&workspace)
+            .arg("--all-packages"),
+        @r#"
     success: false
     exit_code: 1
     ----- stdout -----
-    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
-     --> [TEMP_DIR]/external-package/main.py:1:8
-      |
-    1 | value: int = 'wrong'
-      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
-      |        |
-      |        Declared type
-      |
-    info: rule `invalid-assignment` is enabled by default
-
+    [TEMP_DIR]/external-package/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
     Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    "###
+    "#
     );
 
     Ok(())
 }
 
+/// Apply workspace configuration when checking an externally located member.
 #[test]
 fn check_external_workspace_member_inherits_workspace_configuration() -> Result<()> {
     let context =
@@ -241,33 +243,37 @@ fn check_external_workspace_member_inherits_workspace_configuration() -> Result<
         requires-python = ">=3.12"
         dependencies = []
     "#})?;
-    external
-        .child("main.py")
-        .write_str("value: int = 'wrong'\n")?;
+    external.child("main.py").write_str(indoc! {r#"
+        value: int = "ignored"
+
+        def broken() -> int:
+            return "reported"
+    "#})?;
 
     uv_snapshot!(
         context.filters(),
-        context
-            .check()
+        workspace_check(&context)
             .current_dir(&workspace)
             .arg("--package")
             .arg("external-package"),
-        @"
-    success: true
-    exit_code: 0
+        @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    [TEMP_DIR]/external-package/main.py:4:12: error[invalid-return-type] Return type does not match returned value: expected `int`, found `Literal["reported"]`
+    Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    "
+    "#
     );
 
     Ok(())
 }
 
+/// Exclude nested workspace members unless all packages are explicitly selected.
 #[test]
 fn check_virtual_workspace_member_excludes_nested_members() -> Result<()> {
     let context =
@@ -279,7 +285,7 @@ fn check_virtual_workspace_member_excludes_nested_members() -> Result<()> {
             [tool.uv.workspace]
             members = ["packages/parent", "packages/parent/child"]
         "#})?;
-    write_workspace_member(&context, "parent", "value: int = 1\n")?;
+    write_workspace_member(&context, "parent", "value: int = 'parent'\n")?;
 
     let child = context.temp_dir.child("packages/parent/child");
     child.create_dir_all()?;
@@ -290,41 +296,35 @@ fn check_virtual_workspace_member_excludes_nested_members() -> Result<()> {
         requires-python = ">=3.12"
         dependencies = []
     "#})?;
-    child.child("main.py").write_str("value: int = 'wrong'\n")?;
+    child.child("main.py").write_str("value: int = 'child'\n")?;
 
-    uv_snapshot!(context.filters(), context.check().arg("--package").arg("parent"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
-
-    ----- stderr -----
-    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    ");
-
-    uv_snapshot!(context.filters(), context.check().arg("--all-packages"), @r###"
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--package").arg("parent"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
-    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
-     --> packages/parent/child/main.py:1:8
-      |
-    1 | value: int = 'wrong'
-      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
-      |        |
-      |        Declared type
-      |
-    info: rule `invalid-assignment` is enabled by default
-
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["parent"]` is not assignable to `int`
     Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    "###);
+    "#);
+
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--all-packages"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    packages/parent/child/main.py:1:14: error[invalid-assignment] Object of type `Literal["child"]` is not assignable to `int`
+    packages/parent/main.py:1:14: error[invalid-assignment] Object of type `Literal["parent"]` is not assignable to `int`
+    Found 2 diagnostics
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "#);
 
     Ok(())
 }
 
+/// Resolve an excluded nested member as a dependency without checking its files.
 #[test]
 fn check_virtual_workspace_member_resolves_excluded_nested_dependency() -> Result<()> {
     let context =
@@ -352,7 +352,7 @@ fn check_virtual_workspace_member_resolves_excluded_nested_dependency() -> Resul
     parent.child("main.py").write_str(indoc! {r"
         from child import exported
 
-        value: str = exported
+        value: int = exported
     "})?;
 
     let child = parent.child("child");
@@ -375,11 +375,12 @@ fn check_virtual_workspace_member_resolves_excluded_nested_dependency() -> Resul
         internal_broken: int = "wrong"
     "#})?;
 
-    uv_snapshot!(context.filters(), context.check().arg("--package").arg("parent"), @"
-    success: true
-    exit_code: 0
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--package").arg("parent"), @"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    main.py:3:14: error[invalid-assignment] Object of type `str` is not assignable to `int`
+    Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
@@ -389,6 +390,7 @@ fn check_virtual_workspace_member_resolves_excluded_nested_dependency() -> Resul
     Ok(())
 }
 
+/// Apply workspace configuration when checking an explicitly selected member.
 #[test]
 fn check_workspace_member_inherits_workspace_configuration() -> Result<()> {
     let context =
@@ -403,21 +405,32 @@ fn check_workspace_member_inherits_workspace_configuration() -> Result<()> {
             [tool.ty.rules]
             invalid-assignment = "ignore"
         "#})?;
-    write_workspace_member(&context, "member", "value: int = 'wrong'\n")?;
+    write_workspace_member(
+        &context,
+        "member",
+        indoc! {r#"
+            value: int = "ignored"
 
-    uv_snapshot!(context.filters(), context.check().arg("--package").arg("member"), @"
-    success: true
-    exit_code: 0
+            def broken() -> int:
+                return "reported"
+        "#},
+    )?;
+
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--package").arg("member"), @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    main.py:4:12: error[invalid-return-type] Return type does not match returned value: expected `int`, found `Literal["reported"]`
+    Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    ");
+    "#);
 
     Ok(())
 }
 
+/// Reject package selections that do not match any workspace member.
 #[test]
 fn check_workspace_missing_package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -430,19 +443,20 @@ fn check_workspace_missing_package() -> Result<()> {
         "#})?;
     write_workspace_member(&context, "member", "value: int = 1\n")?;
 
-    uv_snapshot!(context.filters(), context.check().arg("--package").arg("missing"), @"
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--package").arg("missing"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    error: The workspace does not have a member missing: [TEMP_DIR]/
+    error: Package `missing` not found in workspace
     ");
 
     Ok(())
 }
 
+/// Exclude nested members when checking only a non-virtual workspace's root package.
 #[test]
 fn check_workspace_root_excludes_nested_members() -> Result<()> {
     let context =
@@ -463,42 +477,36 @@ fn check_workspace_root_excludes_nested_members() -> Result<()> {
     context
         .temp_dir
         .child("main.py")
-        .write_str("value: int = 1\n")?;
-    write_workspace_member(&context, "member", "value: int = 'wrong'\n")?;
+        .write_str("value: int = 'selected'\n")?;
+    write_workspace_member(&context, "member", "value: int = 'excluded'\n")?;
 
-    uv_snapshot!(context.filters(), context.check(), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
-
-    ----- stderr -----
-    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    ");
-
-    uv_snapshot!(context.filters(), context.check().arg("--all-packages"), @r###"
+    uv_snapshot!(context.filters(), workspace_check(&context), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
-    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
-     --> packages/member/main.py:1:8
-      |
-    1 | value: int = 'wrong'
-      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
-      |        |
-      |        Declared type
-      |
-    info: rule `invalid-assignment` is enabled by default
-
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
     Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    "###);
+    "#);
+
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--all-packages"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
+    packages/member/main.py:1:14: error[invalid-assignment] Object of type `Literal["excluded"]` is not assignable to `int`
+    Found 2 diagnostics
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "#);
 
     Ok(())
 }
 
+/// Check only explicitly selected packages and include every member with `--all-packages`.
 #[test]
 fn check_workspace_multiple_packages() -> Result<()> {
     let context =
@@ -510,48 +518,42 @@ fn check_workspace_multiple_packages() -> Result<()> {
             [tool.uv.workspace]
             members = ["packages/*"]
         "#})?;
-    write_workspace_member(&context, "member-a", "value: int = 1\n")?;
-    write_workspace_member(&context, "member-b", "value: int = 2\n")?;
-    write_workspace_member(&context, "member-c", "value: int = 'wrong'\n")?;
+    write_workspace_member(&context, "member-a", "value: int = 'selected-a'\n")?;
+    write_workspace_member(&context, "member-b", "value: int = 'selected-b'\n")?;
+    write_workspace_member(&context, "member-c", "value: int = 'excluded'\n")?;
 
     uv_snapshot!(
         context.filters(),
-        context
-            .check()
+        workspace_check(&context)
             .arg("--package")
             .arg("member-a")
             .arg("--package")
             .arg("member-b"),
-        @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
-
-    ----- stderr -----
-    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    "
-    );
-
-    uv_snapshot!(context.filters(), context.check().arg("--all-packages"), @r###"
+        @r#"
     success: false
     exit_code: 1
     ----- stdout -----
-    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
-     --> packages/member-c/main.py:1:8
-      |
-    1 | value: int = 'wrong'
-      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
-      |        |
-      |        Declared type
-      |
-    info: rule `invalid-assignment` is enabled by default
-
-    Found 1 diagnostic
+    packages/member-a/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected-a"]` is not assignable to `int`
+    packages/member-b/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected-b"]` is not assignable to `int`
+    Found 2 diagnostics
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
-    "###);
+    "#
+    );
+
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--all-packages"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    packages/member-a/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected-a"]` is not assignable to `int`
+    packages/member-b/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected-b"]` is not assignable to `int`
+    packages/member-c/main.py:1:14: error[invalid-assignment] Object of type `Literal["excluded"]` is not assignable to `int`
+    Found 3 diagnostics
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "#);
 
     Ok(())
 }


### PR DESCRIPTION
This both adds the CLI flags and makes adjustments to more precisely tell ty what files to check, even in cases where neither of these flags are passed (broadly telling ty to "work like uv does").

Notably:

* We now correctly tell ty about workspace members that aren't nested under the workspace
* We now tell ty to exclude members that shouldn't be selected (e.g. in a non-virtual workspace, only the root member should be selected by default)
* In a virtual workspace the root dir may be excluded, as it's not actually part of any package (this may e.g. result in `./scripts/` no longer being checked
