### PR TITLE
Simplify metadata-free lockfile validation

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -501,26 +501,14 @@ impl Lock {
                 )
             });
 
-            // Add all dependencies
-            for edge in resolution.graph.edges(node_index) {
-                let ResolutionGraphNode::Dist(dependency_dist) = &resolution.graph[edge.target()]
-                else {
-                    continue;
-                };
-                let marker = simplify_dependency_marker(
-                    &requires_python,
-                    environment,
-                    dist.marker,
-                    *edge.weight(),
-                );
-                package.add_dependency(
-                    DependencyContext::Production,
-                    &requires_python,
-                    dependency_dist,
-                    marker,
-                    root,
-                )?;
-            }
+            package.add_dependencies(
+                DependencyContext::Production,
+                &requires_python,
+                resolution,
+                node_index,
+                environment,
+                root,
+            )?;
 
             let id = package.id.clone();
             if let Some(locked_dist) = packages.insert(id, package) {
@@ -545,26 +533,14 @@ impl Lock {
                     }
                     .into());
                 };
-                for edge in resolution.graph.edges(node_index) {
-                    let ResolutionGraphNode::Dist(dependency_dist) =
-                        &resolution.graph[edge.target()]
-                    else {
-                        continue;
-                    };
-                    let marker = simplify_dependency_marker(
-                        &requires_python,
-                        environment,
-                        dist.marker,
-                        *edge.weight(),
-                    );
-                    package.add_dependency(
-                        DependencyContext::Extra(extra),
-                        &requires_python,
-                        dependency_dist,
-                        marker,
-                        root,
-                    )?;
-                }
+                package.add_dependencies(
+                    DependencyContext::Extra(extra),
+                    &requires_python,
+                    resolution,
+                    node_index,
+                    environment,
+                    root,
+                )?;
             }
             if let Some(group) = dist.group.as_ref() {
                 let id = PackageId::from_annotated_dist(dist, root)?;
@@ -575,26 +551,14 @@ impl Lock {
                     }
                     .into());
                 };
-                for edge in resolution.graph.edges(node_index) {
-                    let ResolutionGraphNode::Dist(dependency_dist) =
-                        &resolution.graph[edge.target()]
-                    else {
-                        continue;
-                    };
-                    let marker = simplify_dependency_marker(
-                        &requires_python,
-                        environment,
-                        dist.marker,
-                        *edge.weight(),
-                    );
-                    package.add_dependency(
-                        DependencyContext::Group(group),
-                        &requires_python,
-                        dependency_dist,
-                        marker,
-                        root,
-                    )?;
-                }
+                package.add_dependencies(
+                    DependencyContext::Group(group),
+                    &requires_python,
+                    resolution,
+                    node_index,
+                    environment,
+                    root,
+                )?;
             }
         }
 
@@ -2942,6 +2906,33 @@ impl Package {
                 dependency_groups,
             },
         })
+    }
+
+    /// Add the dependencies of a resolution node to the [`Package`] in the given context.
+    fn add_dependencies(
+        &mut self,
+        context: DependencyContext<'_>,
+        requires_python: &RequiresPython,
+        resolution: &ResolverOutput,
+        node_index: NodeIndex,
+        environment: SimplifiedMarkerTree,
+        root: &Path,
+    ) -> Result<(), LockError> {
+        let parent_marker = *resolution.graph[node_index].marker();
+        for edge in resolution.graph.edges(node_index) {
+            let ResolutionGraphNode::Dist(dependency_dist) = &resolution.graph[edge.target()]
+            else {
+                continue;
+            };
+            let marker = simplify_dependency_marker(
+                requires_python,
+                environment,
+                parent_marker,
+                *edge.weight(),
+            );
+            self.add_dependency(context, requires_python, dependency_dist, marker, root)?;
+        }
+        Ok(())
     }
 
     /// Add the [`AnnotatedDist`] as a dependency of the [`Package`] in the given context.

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18542,6 +18542,129 @@ fn lock_rename_project() -> Result<()> {
     Ok(())
 }
 
+/// Preserve merged extras when equivalent dependency edges appear in every dependency context.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_dependency_context_edges_merge() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "httpx",
+            "httpx[http2] ; python_version >= '3.12'",
+        ]
+
+        [project.optional-dependencies]
+        test = [
+            "httpx",
+            "httpx[http2] ; python_version >= '3.12'",
+        ]
+
+        [dependency-groups]
+        dev = [
+            "httpx",
+            "httpx[http2] ; python_version >= '3.12'",
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--index-url").arg(server.index_url()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "h2"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        sdist = { url = "http://[LOCALHOST]/files/h2-1.0.0.tar.gz", hash = "sha256:6647256773f689a545c76cd7a714ff21277543a3b6ede25a2b9a46fc874ceae5", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/h2-1.0.0-py3-none-any.whl", hash = "sha256:33a63cbe8d76a8ee81d34a146d0140aaa55d29187aef7f00e5e8a922e03c7bde", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [[package]]
+        name = "httpx"
+        version = "1.0.0"
+        source = { registry = "http://[LOCALHOST]/simple/" }
+        sdist = { url = "http://[LOCALHOST]/files/httpx-1.0.0.tar.gz", hash = "sha256:fa888edbf5bf960e7e6920012e870d9e32bcee4d201210189a4e9be81a49407d", upload-time = "2024-03-24T00:00:00Z" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/httpx-1.0.0-py3-none-any.whl", hash = "sha256:4154c3c1f739176378d6865841d67718bc624c0f2f0ccf87364c8141a0c93603", upload-time = "2024-03-24T00:00:00Z" },
+        ]
+
+        [package.optional-dependencies]
+        http2 = [
+            { name = "h2" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "httpx", extra = ["http2"] },
+        ]
+
+        [package.optional-dependencies]
+        test = [
+            { name = "httpx", extra = ["http2"] },
+        ]
+
+        [package.dev-dependencies]
+        dev = [
+            { name = "httpx", extra = ["http2"] },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "httpx" },
+            { name = "httpx", marker = "extra == 'test'" },
+            { name = "httpx", extras = ["http2"], marker = "python_full_version >= '3.12'" },
+            { name = "httpx", extras = ["http2"], marker = "python_full_version >= '3.12' and extra == 'test'" },
+        ]
+        provides-extras = ["test"]
+
+        [package.metadata.requires-dev]
+        dev = [
+            { name = "httpx" },
+            { name = "httpx", extras = ["http2"], marker = "python_full_version >= '3.12'" },
+        ]
+        "#);
+    });
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--index-url").arg(server.index_url()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Test backwards compatibility for `[package.metadata]`.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/test/scenarios/extras/lock-without-metadata.toml
+++ b/test/scenarios/extras/lock-without-metadata.toml
@@ -1,0 +1,54 @@
+name = "lock-without-metadata"
+description = "A workspace with platform forks, recursive extras, development groups, and a lockfile without package metadata."
+
+[root]
+requires = ["tqdm", "httpx", "six"]
+
+[expected]
+satisfiable = true
+
+[expected.packages]
+anyio = "4.4.0"
+h2 = "1.0.0"
+httpx = "1.0.0"
+idna = "1.0.0"
+packaging = "26.1"
+six = "1.0.0"
+sniffio = "1.0.0"
+tqdm = "4.0.0"
+urllib3 = "1.0.0"
+
+[packages.anyio.versions."4.3.0"]
+requires = ["idna", "sniffio"]
+
+[packages.anyio.versions."4.4.0"]
+requires = ["idna", "sniffio"]
+
+[packages.h2.versions."1.0.0"]
+
+[packages.httpx.versions."1.0.0".extras]
+http2 = ["h2"]
+
+[packages.idna.versions."1.0.0"]
+
+[packages.packaging.versions."26.0"]
+
+[packages.packaging.versions."26.1"]
+
+[packages.pandas.versions."1.0.0"]
+
+[packages.six.versions."1.0.0"]
+
+[packages.sniffio.versions."1.0.0"]
+
+[packages.tqdm.versions."4.0.0"]
+
+[packages.urllib3.versions."1.0.0"]
+
+[resolver_options]
+universal = true
+
+[testgen]
+# The handwritten lock test must edit the generated lockfile between commands, which generated
+# Packse scenarios cannot express.
+disable = true


### PR DESCRIPTION
## Summary

Stacked on astral-sh/uv#20625, which adds support for lockfiles without `package.metadata`.

- Extract the shared locked-dependency insertion and resolution-dependency collection paths so production, optional, and dependency-group edges keep identical merging and marker behavior when `package.dependencies` and related sections are generated.
- Preserve metadata-backed freshness semantics and fast paths; overrides and excludes can legitimately make resolved edges differ from declaration metadata, so revalidating those edges would incorrectly reject existing lockfiles.
- Tighten metadata-free edge validation for scoped overrides, excluded dependencies, requested extras, and independent conflict sets, with focused regression coverage for each case.
