### PR TITLE
Regenerate the `uv.lock` TOML with `uv lock --refresh`

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -219,6 +219,8 @@ pub(crate) async fn lock(
             preview,
         )
         .with_refresh(&refresh)
+        // We only want to check the contents with `--refresh` specifically.
+        .with_lockfile_contents_check(matches!(&refresh, Refresh::All(..)))
         .execute(target),
     )
     .await
@@ -298,6 +300,7 @@ pub(crate) struct LockOperation<'env> {
     mode: LockMode<'env>,
     constraints: Vec<NameRequirementSpecification>,
     refresh: Option<&'env Refresh>,
+    check_lockfile_contents: bool,
     settings: &'env ResolverSettings,
     client_builder: &'env BaseClientBuilder<'env>,
     state: &'env UniversalState,
@@ -327,6 +330,7 @@ impl<'env> LockOperation<'env> {
             mode,
             constraints: vec![],
             refresh: None,
+            check_lockfile_contents: false,
             settings,
             client_builder,
             state,
@@ -353,6 +357,13 @@ impl<'env> LockOperation<'env> {
     #[must_use]
     pub(crate) fn with_refresh(mut self, refresh: &'env Refresh) -> Self {
         self.refresh = Some(refresh);
+        self
+    }
+
+    /// Compare the serialized lock against the existing lockfile contents.
+    #[must_use]
+    pub(crate) fn with_lockfile_contents_check(mut self, enabled: bool) -> Self {
+        self.check_lockfile_contents = enabled;
         self
     }
 
@@ -383,7 +394,7 @@ impl<'env> LockOperation<'env> {
             LockMode::Locked(interpreter, lock_source) => {
                 // Read the existing lockfile.
                 let lock_filename = target.lock_filename();
-                let Some((existing, contents)) = target.read_with_contents().await? else {
+                let Some((existing, existing_contents)) = target.read_with_contents().await? else {
                     return Err(ProjectError::MissingLockfile(
                         lock_source.into(),
                         lock_filename,
@@ -391,16 +402,17 @@ impl<'env> LockOperation<'env> {
                 };
 
                 if self.preview.is_enabled(PreviewFeature::LockfileFormatCheck)
-                    && let Some(line) = find_lock_format_error(&contents)
+                    && let Some(line) = find_lock_format_error(&existing_contents)
                 {
                     return Err(ProjectError::LockFormat(lock_filename, line, lock_source));
                 }
-
                 // Perform the lock operation, but don't write the lockfile to disk.
                 let result = Box::pin(do_lock(
                     target,
                     interpreter,
                     Some(existing),
+                    Some(existing_contents),
+                    self.check_lockfile_contents,
                     self.constraints,
                     self.refresh,
                     self.settings,
@@ -428,14 +440,16 @@ impl<'env> LockOperation<'env> {
             }
             LockMode::Write(interpreter) | LockMode::DryRun(interpreter) => {
                 // Read the existing lockfile.
-                let existing = match target.read().await {
-                    Ok(Some(existing)) => Some(existing),
-                    Ok(None) => None,
+                let (existing, existing_contents) = match target.read_with_contents().await {
+                    Ok(Some((existing, existing_contents))) => {
+                        (Some(existing), Some(existing_contents))
+                    }
+                    Ok(None) => (None, None),
                     Err(ProjectError::Lock(err)) => {
                         warn_user!(
                             "Failed to read existing lockfile; ignoring locked requirements: {err}"
                         );
-                        None
+                        (None, None)
                     }
                     Err(err) => return Err(err),
                 };
@@ -445,6 +459,8 @@ impl<'env> LockOperation<'env> {
                     target,
                     interpreter,
                     existing,
+                    existing_contents,
+                    self.check_lockfile_contents,
                     self.constraints,
                     self.refresh,
                     self.settings,
@@ -477,6 +493,8 @@ async fn do_lock(
     target: LockTarget<'_>,
     interpreter: &Interpreter,
     existing_lock: Option<Lock>,
+    existing_lock_contents: Option<String>,
+    check_lockfile_contents: bool,
     external: Vec<NameRequirementSpecification>,
     refresh: Option<&Refresh>,
     settings: &ResolverSettings,
@@ -1077,7 +1095,14 @@ async fn do_lock(
             .with_conflicts(conflicts)
             .with_required_environments(lock_required_environments.into_markers());
 
-            if previous.as_ref().is_some_and(|previous| *previous == lock) {
+            let unchanged = if check_lockfile_contents {
+                previous.is_some()
+                    && existing_lock_contents.as_deref() == Some(lock.to_toml()?.as_str())
+            } else {
+                previous.as_ref().is_some_and(|previous| *previous == lock)
+            };
+
+            if unchanged {
                 Ok(LockResult::Unchanged(lock))
             } else {
                 Ok(LockResult::Changed(previous, lock))

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -219,8 +219,10 @@ pub(crate) async fn lock(
             preview,
         )
         .with_refresh(&refresh)
-        // We only want to check the contents with `--refresh` specifically.
-        .with_lockfile_contents_check(matches!(&refresh, Refresh::All(..)))
+        .with_lockfile_contents_check(
+            matches!(&refresh, Refresh::All(..))
+                && preview.is_enabled(PreviewFeature::LockfileFormatCheck),
+        )
         .execute(target),
     )
     .await

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -406,13 +406,19 @@ impl<'env> LockOperation<'env> {
                 {
                     return Err(ProjectError::LockFormat(lock_filename, line, lock_source));
                 }
+
+                let check_lockfile_contents = if self.check_lockfile_contents {
+                    Some(existing_contents)
+                } else {
+                    None
+                };
+
                 // Perform the lock operation, but don't write the lockfile to disk.
                 let result = Box::pin(do_lock(
                     target,
                     interpreter,
                     Some(existing),
-                    Some(existing_contents),
-                    self.check_lockfile_contents,
+                    check_lockfile_contents,
                     self.constraints,
                     self.refresh,
                     self.settings,
@@ -454,13 +460,18 @@ impl<'env> LockOperation<'env> {
                     Err(err) => return Err(err),
                 };
 
+                let check_lockfile_contents = if self.check_lockfile_contents {
+                    existing_contents
+                } else {
+                    None
+                };
+
                 // Perform the lock operation.
                 let result = Box::pin(do_lock(
                     target,
                     interpreter,
                     existing,
-                    existing_contents,
-                    self.check_lockfile_contents,
+                    check_lockfile_contents,
                     self.constraints,
                     self.refresh,
                     self.settings,
@@ -493,8 +504,7 @@ async fn do_lock(
     target: LockTarget<'_>,
     interpreter: &Interpreter,
     existing_lock: Option<Lock>,
-    existing_lock_contents: Option<String>,
-    check_lockfile_contents: bool,
+    check_lockfile_contents: Option<String>,
     external: Vec<NameRequirementSpecification>,
     refresh: Option<&Refresh>,
     settings: &ResolverSettings,
@@ -1095,9 +1105,8 @@ async fn do_lock(
             .with_conflicts(conflicts)
             .with_required_environments(lock_required_environments.into_markers());
 
-            let unchanged = if check_lockfile_contents {
-                previous.is_some()
-                    && existing_lock_contents.as_deref() == Some(lock.to_toml()?.as_str())
+            let unchanged = if let Some(check_lockfile_contents) = check_lockfile_contents {
+                previous.is_some() && check_lockfile_contents == lock.to_toml()?.as_str()
             } else {
                 previous.as_ref().is_some_and(|previous| *previous == lock)
             };

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -362,7 +362,7 @@ impl<'env> LockOperation<'env> {
 
     /// Compare the serialized lock against the existing lockfile contents.
     #[must_use]
-    pub(crate) fn with_lockfile_contents_check(mut self, enabled: bool) -> Self {
+    fn with_lockfile_contents_check(mut self, enabled: bool) -> Self {
         self.check_lockfile_contents = enabled;
         self
     }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -412,9 +412,9 @@ impl uv_errors::Hint for ProjectError {
             Self::LockMismatch(..) | Self::LockWorkspaceMismatch(..) => {
                 uv_errors::Hints::from("To update the lockfile, run `uv lock`.")
             }
-            Self::LockFormat(..) => uv_errors::Hints::from(
-                "To restore the lockfile's formatting, run `uv lock --refresh`.",
-            ),
+            Self::LockFormat(..) => {
+                uv_errors::Hints::from("To regenerate the lockfile, run `uv lock --refresh`.")
+            }
             Self::OverlappingMarkers(_, rhs, replacement) => {
                 uv_errors::Hints::from(format!("replace `{rhs}` with `{replacement}`"))
             }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -412,6 +412,9 @@ impl uv_errors::Hint for ProjectError {
             Self::LockMismatch(..) | Self::LockWorkspaceMismatch(..) => {
                 uv_errors::Hints::from("To update the lockfile, run `uv lock`.")
             }
+            Self::LockFormat(..) => uv_errors::Hints::from(
+                "To restore the lockfile's formatting, run `uv lock --refresh`.",
+            ),
             Self::OverlappingMarkers(_, rhs, replacement) => {
                 uv_errors::Hints::from(format!("replace `{rhs}` with `{replacement}`"))
             }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -412,9 +412,9 @@ impl uv_errors::Hint for ProjectError {
             Self::LockMismatch(..) | Self::LockWorkspaceMismatch(..) => {
                 uv_errors::Hints::from("To update the lockfile, run `uv lock`.")
             }
-            Self::LockFormat(..) => {
-                uv_errors::Hints::from("To regenerate the lockfile, run `uv lock --refresh`.")
-            }
+            Self::LockFormat(..) => uv_errors::Hints::from(
+                "To regenerate the lockfile, run `uv lock --refresh --preview-features lockfile-format-check`.",
+            ),
             Self::OverlappingMarkers(_, rhs, replacement) => {
                 uv_errors::Hints::from(format!("replace `{rhs}` with `{replacement}`"))
             }

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -34800,6 +34800,86 @@ fn lock_refresh() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_refresh_deindents_lockfile() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    let original_lock = context.read("uv.lock");
+    let dedented_lock = original_lock
+        .lines()
+        .map(str::trim_start)
+        .collect::<Vec<_>>()
+        .join("\n");
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&dedented_lock)?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Lockfile changes detected
+    ");
+    assert_eq!(context.read("uv.lock"), dedented_lock);
+
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+    assert_snapshot!(context.read("uv.lock"), @r#"
+    version = 1
+    revision = 3
+    requires-python = ">=3.12"
+
+    [options]
+    exclude-newer = "2024-03-25T00:00:00Z"
+
+    [[package]]
+    name = "project"
+    version = "0.1.0"
+    source = { virtual = "." }
+    "#);
+
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    No lockfile changes detected
+    ");
+
+    Ok(())
+}
+
 /// Ensure conflicts on virtual packages (such as markers) give good error messages.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -34811,6 +34811,9 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
+        dependencies = [
+            "sniffio"
+        ]
         "#,
     )?;
 
@@ -34820,7 +34823,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
+    Resolved 2 packages in [TIME]
     ");
 
     let original_lock = context.read("uv.lock");
@@ -34840,7 +34843,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
+    Resolved 2 packages in [TIME]
     Lockfile changes detected
     ");
     assert_eq!(context.read("uv.lock"), dedented_lock);
@@ -34851,7 +34854,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
+    Resolved 2 packages in [TIME]
     ");
     assert_snapshot!(context.read("uv.lock"), @r#"
     version = 1
@@ -34865,6 +34868,21 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     name = "project"
     version = "0.1.0"
     source = { virtual = "." }
+    dependencies = [
+        { name = "sniffio" },
+    ]
+
+    [package.metadata]
+    requires-dist = [{ name = "sniffio" }]
+
+    [[package]]
+    name = "sniffio"
+    version = "1.3.1"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+    ]
     "#);
 
     uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
@@ -34873,7 +34891,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
+    Resolved 2 packages in [TIME]
     No lockfile changes detected
     ");
 

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -15553,12 +15553,16 @@ fn check_unformatted_lock() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--check` was provided.
+
+    hint: To restore the lockfile's formatting, run `uv lock --refresh`.
     ");
 
     uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--offline").arg("--preview-features").arg("lockfile-format-check"), @"
     exit_code: 1 (failure)
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--locked` was provided.
+
+    hint: To restore the lockfile's formatting, run `uv lock --refresh`.
     ");
 
     assert_eq!(context.read("uv.lock"), unformatted);
@@ -34838,6 +34842,8 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--check` was provided.
+
+    hint: To restore the lockfile's formatting, run `uv lock --refresh`.
     ");
 
     uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -15554,7 +15554,7 @@ fn check_unformatted_lock() -> Result<()> {
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--check` was provided.
 
-    hint: To restore the lockfile's formatting, run `uv lock --refresh`.
+    hint: To regenerate the lockfile, run `uv lock --refresh`.
     ");
 
     uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--offline").arg("--preview-features").arg("lockfile-format-check"), @"
@@ -15562,7 +15562,7 @@ fn check_unformatted_lock() -> Result<()> {
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--locked` was provided.
 
-    hint: To restore the lockfile's formatting, run `uv lock --refresh`.
+    hint: To regenerate the lockfile, run `uv lock --refresh`.
     ");
 
     assert_eq!(context.read("uv.lock"), unformatted);
@@ -34838,12 +34838,12 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
         .child("uv.lock")
         .write_str(&dedented_lock)?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--check").arg("--offline").arg("--preview-features").arg("lockfile-format-check"), @"
+    uv_snapshot!(context.filters(), context.lock().arg("--check").arg("--preview-features").arg("lockfile-format-check"), @"
     exit_code: 1 (failure)
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--check` was provided.
 
-    hint: To restore the lockfile's formatting, run `uv lock --refresh`.
+    hint: To regenerate the lockfile, run `uv lock --refresh`.
     ");
 
     uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
@@ -34888,7 +34888,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     ]
     "#);
 
-    uv_snapshot!(context.filters(), context.lock().arg("--check").arg("--offline").arg("--preview-features").arg("lockfile-format-check"), @"
+    uv_snapshot!(context.filters(), context.lock().arg("--check").arg("--preview-features").arg("lockfile-format-check"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -34818,10 +34818,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
+    exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
     ");
@@ -34837,11 +34834,14 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
         .child("uv.lock")
         .write_str(&dedented_lock)?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
+    uv_snapshot!(context.filters(), context.lock().arg("--check").arg("--offline").arg("--preview-features").arg("lockfile-format-check"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--check` was provided.
+    ");
 
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
+    exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
     Lockfile changes detected
@@ -34849,10 +34849,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     assert_eq!(context.read("uv.lock"), dedented_lock);
 
     uv_snapshot!(context.filters(), context.lock().arg("--refresh"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
+    exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
     ");
@@ -34885,11 +34882,14 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     ]
     "#);
 
-    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
+    uv_snapshot!(context.filters(), context.lock().arg("--check").arg("--offline").arg("--preview-features").arg("lockfile-format-check"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
 
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
+    exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
     No lockfile changes detected

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -15554,7 +15554,7 @@ fn check_unformatted_lock() -> Result<()> {
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--check` was provided.
 
-    hint: To regenerate the lockfile, run `uv lock --refresh`.
+    hint: To regenerate the lockfile, run `uv lock --refresh --preview-features lockfile-format-check`.
     ");
 
     uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--offline").arg("--preview-features").arg("lockfile-format-check"), @"
@@ -15562,7 +15562,7 @@ fn check_unformatted_lock() -> Result<()> {
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--locked` was provided.
 
-    hint: To regenerate the lockfile, run `uv lock --refresh`.
+    hint: To regenerate the lockfile, run `uv lock --refresh --preview-features lockfile-format-check`.
     ");
 
     assert_eq!(context.read("uv.lock"), unformatted);
@@ -34843,10 +34843,25 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     ----- stderr -----
     error: The lockfile at `uv.lock` has non-canonical formatting at line 13, but `--check` was provided.
 
-    hint: To regenerate the lockfile, run `uv lock --refresh`.
+    hint: To regenerate the lockfile, run `uv lock --refresh --preview-features lockfile-format-check`.
     ");
 
     uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    No lockfile changes detected
+    ");
+    assert_eq!(context.read("uv.lock"), dedented_lock);
+
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+    assert_eq!(context.read("uv.lock"), dedented_lock);
+
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run").arg("--preview-features").arg("lockfile-format-check"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -34854,7 +34869,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     ");
     assert_eq!(context.read("uv.lock"), dedented_lock);
 
-    uv_snapshot!(context.filters(), context.lock().arg("--refresh"), @"
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--preview-features").arg("lockfile-format-check"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -34894,7 +34909,7 @@ fn lock_refresh_deindents_lockfile() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
-    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run"), @"
+    uv_snapshot!(context.filters(), context.lock().arg("--refresh").arg("--dry-run").arg("--preview-features").arg("lockfile-format-check"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/astral-sh/uv/pull/15994.

It's possible to accidentally change the formatting in the lockfile. To restore the canonical formatting of the lockfile, `uv lock --refresh` updates `uv.lock` if there is a difference in formatting. This also upgrades the lock to a newer revision if applicable.

Note that the exact formatting isn't guaranteed across versions, but uv only changes the lockfile if required for an operation.