### PR TITLE
Refactor locked dependency construction

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -501,26 +501,14 @@ impl Lock {
                 )
             });
 
-            // Add all dependencies
-            for edge in resolution.graph.edges(node_index) {
-                let ResolutionGraphNode::Dist(dependency_dist) = &resolution.graph[edge.target()]
-                else {
-                    continue;
-                };
-                let marker = simplify_dependency_marker(
-                    &requires_python,
-                    environment,
-                    dist.marker,
-                    *edge.weight(),
-                );
-                package.add_dependency(
-                    DependencyContext::Production,
-                    &requires_python,
-                    dependency_dist,
-                    marker,
-                    root,
-                )?;
-            }
+            package.add_dependencies(
+                DependencyContext::Production,
+                &requires_python,
+                resolution,
+                node_index,
+                environment,
+                root,
+            )?;
 
             let id = package.id.clone();
             if let Some(locked_dist) = packages.insert(id, package) {
@@ -545,26 +533,14 @@ impl Lock {
                     }
                     .into());
                 };
-                for edge in resolution.graph.edges(node_index) {
-                    let ResolutionGraphNode::Dist(dependency_dist) =
-                        &resolution.graph[edge.target()]
-                    else {
-                        continue;
-                    };
-                    let marker = simplify_dependency_marker(
-                        &requires_python,
-                        environment,
-                        dist.marker,
-                        *edge.weight(),
-                    );
-                    package.add_dependency(
-                        DependencyContext::Extra(extra),
-                        &requires_python,
-                        dependency_dist,
-                        marker,
-                        root,
-                    )?;
-                }
+                package.add_dependencies(
+                    DependencyContext::Extra(extra),
+                    &requires_python,
+                    resolution,
+                    node_index,
+                    environment,
+                    root,
+                )?;
             }
             if let Some(group) = dist.group.as_ref() {
                 let id = PackageId::from_annotated_dist(dist, root)?;
@@ -575,26 +551,14 @@ impl Lock {
                     }
                     .into());
                 };
-                for edge in resolution.graph.edges(node_index) {
-                    let ResolutionGraphNode::Dist(dependency_dist) =
-                        &resolution.graph[edge.target()]
-                    else {
-                        continue;
-                    };
-                    let marker = simplify_dependency_marker(
-                        &requires_python,
-                        environment,
-                        dist.marker,
-                        *edge.weight(),
-                    );
-                    package.add_dependency(
-                        DependencyContext::Group(group),
-                        &requires_python,
-                        dependency_dist,
-                        marker,
-                        root,
-                    )?;
-                }
+                package.add_dependencies(
+                    DependencyContext::Group(group),
+                    &requires_python,
+                    resolution,
+                    node_index,
+                    environment,
+                    root,
+                )?;
             }
         }
 
@@ -2942,6 +2906,33 @@ impl Package {
                 dependency_groups,
             },
         })
+    }
+
+    /// Add the dependencies of a resolution node to the [`Package`] in the given context.
+    fn add_dependencies(
+        &mut self,
+        context: DependencyContext<'_>,
+        requires_python: &RequiresPython,
+        resolution: &ResolverOutput,
+        node_index: NodeIndex,
+        environment: SimplifiedMarkerTree,
+        root: &Path,
+    ) -> Result<(), LockError> {
+        let parent_marker = *resolution.graph[node_index].marker();
+        for edge in resolution.graph.edges(node_index) {
+            let ResolutionGraphNode::Dist(dependency_dist) = &resolution.graph[edge.target()]
+            else {
+                continue;
+            };
+            let marker = simplify_dependency_marker(
+                requires_python,
+                environment,
+                parent_marker,
+                *edge.weight(),
+            );
+            self.add_dependency(context, requires_python, dependency_dist, marker, root)?;
+        }
+        Ok(())
     }
 
     /// Add the [`AnnotatedDist`] as a dependency of the [`Package`] in the given context.

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -390,6 +390,14 @@ impl<'lock> DependencySelectionContext<'lock> {
     }
 }
 
+/// The dependency section in which a locked edge is stored.
+#[derive(Clone, Copy, Debug)]
+enum DependencyContext<'a> {
+    Production,
+    Extra(&'a ExtraName),
+    Group(&'a GroupName),
+}
+
 /// Direct dependency selections from a [`Lock`] for a named package.
 ///
 /// The dependency can come from the lock manifest, a dependency group, the production packages,
@@ -505,7 +513,13 @@ impl Lock {
                     dist.marker,
                     *edge.weight(),
                 );
-                package.add_dependency(&requires_python, dependency_dist, marker, root)?;
+                package.add_dependency(
+                    DependencyContext::Production,
+                    &requires_python,
+                    dependency_dist,
+                    marker,
+                    root,
+                )?;
             }
 
             let id = package.id.clone();
@@ -543,9 +557,9 @@ impl Lock {
                         dist.marker,
                         *edge.weight(),
                     );
-                    package.add_optional_dependency(
+                    package.add_dependency(
+                        DependencyContext::Extra(extra),
                         &requires_python,
-                        extra.clone(),
                         dependency_dist,
                         marker,
                         root,
@@ -573,9 +587,9 @@ impl Lock {
                         dist.marker,
                         *edge.weight(),
                     );
-                    package.add_group_dependency(
+                    package.add_dependency(
+                        DependencyContext::Group(group),
                         &requires_python,
-                        group.clone(),
                         dependency_dist,
                         marker,
                         root,
@@ -2930,18 +2944,28 @@ impl Package {
         })
     }
 
-    /// Add the [`AnnotatedDist`] as a dependency of the [`Package`].
+    /// Add the [`AnnotatedDist`] as a dependency of the [`Package`] in the given context.
     fn add_dependency(
         &mut self,
+        context: DependencyContext<'_>,
         requires_python: &RequiresPython,
         annotated_dist: &AnnotatedDist,
         marker: UniversalMarker,
         root: &Path,
     ) -> Result<(), LockError> {
-        let new_dep =
+        let new_dependency =
             Dependency::from_annotated_dist(requires_python, annotated_dist, marker, root)?;
-        for existing_dep in &mut self.dependencies {
-            if existing_dep.package_id == new_dep.package_id
+        let dependencies = match context {
+            DependencyContext::Production => &mut self.dependencies,
+            DependencyContext::Extra(extra) => {
+                self.optional_dependencies.entry(extra.clone()).or_default()
+            }
+            DependencyContext::Group(group) => {
+                self.dependency_groups.entry(group.clone()).or_default()
+            }
+        };
+        for existing_dependency in &mut *dependencies {
+            if existing_dependency.package_id == new_dependency.package_id
                 // It's important that we do a comparison on
                 // *simplified* markers here. In particular, when
                 // we write markers out to the lock file, we use
@@ -2964,66 +2988,14 @@ impl Package {
                 // how to do that. I think `pep508` would need to
                 // grow a concept of "requires python" and provide an
                 // operation specifically for that.
-                && existing_dep.simplified_marker == new_dep.simplified_marker
+                && existing_dependency.simplified_marker == new_dependency.simplified_marker
             {
-                existing_dep.extra.extend(new_dep.extra);
+                existing_dependency.extra.extend(new_dependency.extra);
                 return Ok(());
             }
         }
 
-        self.dependencies.push(new_dep);
-        Ok(())
-    }
-
-    /// Add the [`AnnotatedDist`] as an optional dependency of the [`Package`].
-    fn add_optional_dependency(
-        &mut self,
-        requires_python: &RequiresPython,
-        extra: ExtraName,
-        annotated_dist: &AnnotatedDist,
-        marker: UniversalMarker,
-        root: &Path,
-    ) -> Result<(), LockError> {
-        let dep = Dependency::from_annotated_dist(requires_python, annotated_dist, marker, root)?;
-        let optional_deps = self.optional_dependencies.entry(extra).or_default();
-        for existing_dep in &mut *optional_deps {
-            if existing_dep.package_id == dep.package_id
-                // See note in add_dependency for why we use
-                // simplified markers here.
-                && existing_dep.simplified_marker == dep.simplified_marker
-            {
-                existing_dep.extra.extend(dep.extra);
-                return Ok(());
-            }
-        }
-
-        optional_deps.push(dep);
-        Ok(())
-    }
-
-    /// Add the [`AnnotatedDist`] to a dependency group of the [`Package`].
-    fn add_group_dependency(
-        &mut self,
-        requires_python: &RequiresPython,
-        group: GroupName,
-        annotated_dist: &AnnotatedDist,
-        marker: UniversalMarker,
-        root: &Path,
-    ) -> Result<(), LockError> {
-        let dep = Dependency::from_annotated_dist(requires_python, annotated_dist, marker, root)?;
-        let deps = self.dependency_groups.entry(group).or_default();
-        for existing_dep in &mut *deps {
-            if existing_dep.package_id == dep.package_id
-                // See note in add_dependency for why we use
-                // simplified markers here.
-                && existing_dep.simplified_marker == dep.simplified_marker
-            {
-                existing_dep.extra.extend(dep.extra);
-                return Ok(());
-            }
-        }
-
-        deps.push(dep);
+        dependencies.push(new_dependency);
         Ok(())
     }
 

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -693,39 +693,13 @@ impl Lock {
         // it implies we somehow have a dependency with no corresponding locked
         // package.
         for dist in &packages {
-            for dep in &dist.dependencies {
-                if !by_id.contains_key(&dep.package_id) {
+            for dependency in dist.all_dependencies() {
+                if !by_id.contains_key(&dependency.package_id) {
                     return Err(LockErrorKind::UnrecognizedDependency {
                         id: dist.id.clone(),
-                        dependency: dep.clone(),
+                        dependency: dependency.clone(),
                     }
                     .into());
-                }
-            }
-
-            // Perform the same validation for optional dependencies.
-            for dependencies in dist.optional_dependencies.values() {
-                for dep in dependencies {
-                    if !by_id.contains_key(&dep.package_id) {
-                        return Err(LockErrorKind::UnrecognizedDependency {
-                            id: dist.id.clone(),
-                            dependency: dep.clone(),
-                        }
-                        .into());
-                    }
-                }
-            }
-
-            // Perform the same validation for dev dependencies.
-            for dependencies in dist.dependency_groups.values() {
-                for dep in dependencies {
-                    if !by_id.contains_key(&dep.package_id) {
-                        return Err(LockErrorKind::UnrecognizedDependency {
-                            id: dist.id.clone(),
-                            dependency: dep.clone(),
-                        }
-                        .into());
-                    }
                 }
             }
 
@@ -2292,28 +2266,10 @@ impl Lock {
             }
 
             // Recurse.
-            for dep in &package.dependencies {
-                if seen.insert(&dep.package_id) {
-                    let dep_dist = self.find_by_id(&dep.package_id);
-                    queue.push_back(dep_dist);
-                }
-            }
-
-            for dependencies in package.optional_dependencies.values() {
-                for dep in dependencies {
-                    if seen.insert(&dep.package_id) {
-                        let dep_dist = self.find_by_id(&dep.package_id);
-                        queue.push_back(dep_dist);
-                    }
-                }
-            }
-
-            for dependencies in package.dependency_groups.values() {
-                for dep in dependencies {
-                    if seen.insert(&dep.package_id) {
-                        let dep_dist = self.find_by_id(&dep.package_id);
-                        queue.push_back(dep_dist);
-                    }
+            for dependency in package.all_dependencies() {
+                if seen.insert(&dependency.package_id) {
+                    let dependency_package = self.find_by_id(&dependency.package_id);
+                    queue.push_back(dependency_package);
                 }
             }
         }
@@ -3621,6 +3577,14 @@ impl Package {
     /// Returns the dependencies of the package.
     pub fn dependencies(&self) -> &[Dependency] {
         &self.dependencies
+    }
+
+    /// Returns all production, optional, and development dependencies of the [`Package`].
+    fn all_dependencies(&self) -> impl Iterator<Item = &Dependency> {
+        self.dependencies
+            .iter()
+            .chain(self.optional_dependencies.values().flatten())
+            .chain(self.dependency_groups.values().flatten())
     }
 
     /// Returns the optional dependencies of the package.


### PR DESCRIPTION
We currently duplicate code across production, optional and group dependencies. This PR unifies their paths through a dependency type enum, so we can later apply more operations on all three together with the same code.