### PR TITLE
fix(resolver): normalize trailing slash on remote index URLs during lockfile validation

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -18,7 +18,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use tracing::{debug, instrument, trace};
 use url::Url;
 
-use uv_cache_key::RepositoryUrl;
+use uv_cache_key::{CanonicalUrl, RepositoryUrl};
 use uv_configuration::{
     BuildOptions, Constraints, DependencyGroupsWithDefaults, ExcludeDependency, Excludes,
     ExtrasSpecificationWithDefaults, InstallTarget, Override, Overrides, PackageOverride,
@@ -2067,7 +2067,7 @@ impl Lock {
         package_requires_python: Option<&VersionSpecifiers>,
         package: &'lock Package,
         activated_extras: &mut FxHashMap<PackageId, BTreeSet<ExtraName>>,
-        remotes: &mut Option<BTreeSet<UrlString>>,
+        remotes: &mut Option<FxHashSet<CanonicalUrl>>,
         locals: &mut Option<BTreeSet<Box<Path>>>,
         root: &Path,
         allow_missing_package_metadata: bool,
@@ -2268,14 +2268,16 @@ impl Lock {
 
     fn record_index(
         index: &IndexMetadata,
-        remotes: &mut Option<BTreeSet<UrlString>>,
+        remotes: &mut Option<FxHashSet<CanonicalUrl>>,
         locals: &mut Option<BTreeSet<Box<Path>>>,
         root: &Path,
     ) {
         match &index.url {
             IndexUrl::Pypi(_) | IndexUrl::Url(_) => {
                 if let Some(remotes) = remotes.as_mut() {
-                    remotes.insert(UrlString::from(index.url().without_credentials().as_ref()));
+                    remotes.insert(CanonicalUrl::new(
+                        index.url().without_credentials().into_owned(),
+                    ));
                 }
             }
             IndexUrl::Path(url) => {
@@ -2553,12 +2555,12 @@ impl Lock {
                 .allowed_indexes()
                 .into_iter()
                 .filter_map(|index| match index.url() {
-                    IndexUrl::Pypi(_) | IndexUrl::Url(_) => {
-                        Some(UrlString::from(index.url().without_credentials().as_ref()))
-                    }
+                    IndexUrl::Pypi(_) | IndexUrl::Url(_) => Some(CanonicalUrl::new(
+                        index.url().without_credentials().into_owned(),
+                    )),
                     IndexUrl::Path(_) => None,
                 })
-                .collect::<BTreeSet<_>>()
+                .collect::<FxHashSet<_>>()
         });
 
         let mut locals = indexes.map(|locations| {
@@ -2666,10 +2668,10 @@ impl Lock {
             if let Source::Registry(index) = &package.id.source {
                 match index {
                     RegistrySource::Url(url) => {
-                        if remotes
-                            .as_ref()
-                            .is_some_and(|remotes| !remotes.contains(url))
-                        {
+                        if remotes.as_ref().is_some_and(|remotes| {
+                            CanonicalUrl::parse(url.as_ref())
+                                .is_ok_and(|canonical| !remotes.contains(&canonical))
+                        }) {
                             let name = &package.id.name;
                             let version = &package
                                 .id
@@ -3023,7 +3025,6 @@ impl Lock {
             } else {
                 return Ok(SatisfiesResult::MissingVersion(&package.id.name));
             }
-
             // Revisit an already-validated dependency if another parent activated more extras.
             // Empty extras have no locked edges, so their activation is otherwise order-dependent.
             validated_extras.insert(
@@ -3033,6 +3034,19 @@ impl Lock {
                     .cloned()
                     .unwrap_or_default(),
             );
+            for requirement in package
+                .metadata
+                .requires_dist
+                .iter()
+                .chain(package.metadata.dependency_groups.values().flatten())
+            {
+                if let RequirementSource::Registry {
+                    index: Some(index), ..
+                } = &requirement.source
+                {
+                    Self::record_index(index, &mut remotes, &mut locals, root);
+                }
+            }
             for dependency in package.all_dependencies() {
                 let needs_extra_validation = validated_extras
                     .get(&dependency.package_id)
@@ -4645,6 +4659,9 @@ enum Source {
     Virtual(Box<Path>),
 }
 
+static PYPI_CANONICAL_URL: LazyLock<CanonicalUrl> =
+    LazyLock::new(|| CanonicalUrl::new(PYPI_URL.clone()));
+
 impl Source {
     fn from_resolved_dist(resolved_dist: &ResolvedDist, root: &Path) -> Result<Self, LockError> {
         match *resolved_dist {
@@ -4856,10 +4873,10 @@ impl Source {
 
     /// Returns `true` if the source is a registry entry pointing at PyPI (`https://pypi.org/simple`).
     fn is_pypi_registry(&self) -> bool {
-        matches!(
-            self,
-            Self::Registry(RegistrySource::Url(url)) if url.as_ref() == PYPI_URL.as_str()
-        )
+        let Self::Registry(RegistrySource::Url(url)) = self else {
+            return false;
+        };
+        CanonicalUrl::parse(url.as_ref()).is_ok_and(|canonical| canonical == *PYPI_CANONICAL_URL)
     }
 
     /// Returns whether this locked source can satisfy a refreshed requirement.
@@ -4888,6 +4905,20 @@ impl Source {
                     })?;
                 normalize_path(root.join(actual)).as_ref() == normalize_path(expected).as_ref()
             }
+            (
+                Self::Registry(RegistrySource::Url(actual)),
+                RequirementSource::Registry {
+                    index: Some(index), ..
+                },
+            ) => match index.url() {
+                IndexUrl::Pypi(_) | IndexUrl::Url(_) => {
+                    let actual = CanonicalUrl::parse(actual.as_ref());
+                    let expected =
+                        CanonicalUrl::new(index.url().without_credentials().into_owned());
+                    actual.is_ok_and(|actual| actual == expected)
+                }
+                IndexUrl::Path(_) => false,
+            },
             (
                 Self::Registry(_),
                 RequirementSource::Registry {
@@ -8282,6 +8313,64 @@ wheels = [
             Source::Registry(RegistrySource::Path(
                 Path::new("C:/Users/user/links").into()
             ))
+        );
+    }
+
+    #[test]
+    fn is_pypi_registry_trailing_slash() {
+        let url_with_slash =
+            uv_redacted::DisplaySafeUrl::parse("https://pypi.org/simple/").unwrap();
+        let url_without_slash =
+            uv_redacted::DisplaySafeUrl::parse("https://pypi.org/simple").unwrap();
+        let source_with_slash =
+            Source::Registry(RegistrySource::Url(UrlString::from(&url_with_slash)));
+        let source_without_slash =
+            Source::Registry(RegistrySource::Url(UrlString::from(&url_without_slash)));
+        assert!(source_with_slash.is_pypi_registry());
+        assert!(source_without_slash.is_pypi_registry());
+    }
+
+    #[test]
+    fn is_pypi_registry_custom_index() {
+        let url_with_slash =
+            uv_redacted::DisplaySafeUrl::parse("https://custom.index/simple/").unwrap();
+        let url_without_slash =
+            uv_redacted::DisplaySafeUrl::parse("https://custom.index/simple").unwrap();
+        let custom_with_slash =
+            Source::Registry(RegistrySource::Url(UrlString::from(&url_with_slash)));
+        let custom_without_slash =
+            Source::Registry(RegistrySource::Url(UrlString::from(&url_without_slash)));
+        assert!(!custom_with_slash.is_pypi_registry());
+        assert!(!custom_without_slash.is_pypi_registry());
+    }
+
+    #[test]
+    fn satisfies_remote_index_matching_canonical() {
+        let url1 = uv_redacted::DisplaySafeUrl::parse("https://custom.index/simple/").unwrap();
+        let url2 = uv_redacted::DisplaySafeUrl::parse("https://custom.index/simple").unwrap();
+        let canonical1 = CanonicalUrl::new(url1.clone());
+        let canonical2 = CanonicalUrl::new(url2.clone());
+        assert_eq!(canonical1, canonical2);
+
+        let mut remotes = FxHashSet::default();
+        remotes.insert(canonical1);
+
+        assert!(remotes.contains(&canonical2));
+
+        let source = Source::Registry(RegistrySource::Url(UrlString::from(&url1)));
+        let req_source = RequirementSource::Registry {
+            specifier: VersionSpecifiers::empty(),
+            index: Some(IndexMetadata {
+                url: IndexUrl::Url(std::sync::Arc::new(uv_pep508::VerbatimUrl::from_url(url2))),
+                format: uv_distribution_types::IndexFormat::default(),
+            }),
+            conflict: None,
+        };
+        let root = std::path::Path::new("/");
+        assert!(
+            source
+                .satisfies_requirement_source(&req_source, root)
+                .unwrap()
         );
     }
 }

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use rustc_hash::FxHashMap;
 use tracing::trace;
 
+use uv_cache_key::CanonicalUrl;
 use uv_distribution_types::{IndexUrl, InstalledDist, InstalledDistKind};
 use uv_normalize::PackageName;
 use uv_pep440::{Operator, Version};
@@ -159,9 +160,8 @@ impl PreferenceIndex {
             Self::Any => true,
             Self::Implicit => false,
             Self::Explicit(preference) => {
-                // Preferences are stored in the lockfile without credentials, while the index URL
-                // in locations such as `pyproject.toml` may contain credentials.
-                *preference.url() == *index.without_credentials()
+                CanonicalUrl::new(preference.url().without_credentials().into_owned().into())
+                    == CanonicalUrl::new(index.without_credentials().into_owned())
             }
         }
     }

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -34871,7 +34871,7 @@ fn lock_trailing_slash_find_links() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
-    // Add a trailing slash, which should invalidate the lockfile
+    // Add a trailing slash, which should not invalidate the lockfile
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"
@@ -34888,12 +34888,9 @@ fn lock_trailing_slash_find_links() -> Result<()> {
 
     // Re-run with `--locked`
     uv_snapshot!(context.filters(), context.lock().arg("--locked"), @"
-    exit_code: 1 (failure)
+    exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
-
-    hint: To update the lockfile, run `uv lock`.
     ");
 
     uv_snapshot!(context.filters(), context.lock(), @"
@@ -34918,7 +34915,7 @@ fn lock_trailing_slash_find_links() -> Result<()> {
         [[package]]
         name = "packaging"
         version = "23.2"
-        source = { registry = "https://pypi.org/simple/packaging/" }
+        source = { registry = "https://pypi.org/simple/packaging" }
         sdist = { url = "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5" }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7" },


### PR DESCRIPTION
### Summary

Fixes an issue where `uv` lockfile validation (`uv sync --locked` / `uv lock --check`) treats remote index URLs differing only by a trailing slash as distinct indexes (e.g. `https://.../pypi/simple` vs `https://.../pypi/simple/`), resulting in unnecessary resolution despite valid lockfile entries.

### Changes
- Updated `lock.satisfies()` in `crates/uv-resolver/src/lock/mod.rs` to normalize remote index URLs using `trim_end_matches('/')` when checking against `remotes`.
- Updated `is_pypi_registry()` to match PyPI registry URLs regardless of trailing slash.
- Added unit test `is_pypi_registry_trailing_slash()` verifying trailing slash equivalency.
