### PR TITLE
Isolate automated regression test generation

### DIFF
--- a/.github/actions/codex-cgroup/action.yml
+++ b/.github/actions/codex-cgroup/action.yml
@@ -1,0 +1,94 @@
+name: "Run Codex in a dedicated cgroup"
+description: "Run Codex under a dedicated, unprivileged systemd service on hosted Linux."
+
+inputs:
+  openai-api-key:
+    description: "OpenAI API key used by the Responses API proxy."
+    required: true
+  prompt-file:
+    description: "Path to the Codex prompt."
+    required: true
+  output-schema-file:
+    description: "Path to the JSON schema for the final Codex message."
+    required: true
+  permission-profile:
+    description: "Named Codex permission profile."
+    required: true
+  codex-home:
+    description: "Path to the trusted Codex configuration."
+    required: false
+    default: "agents/codex"
+  safety-strategy:
+    description: "Safety strategy used for the macOS fallback."
+    required: false
+    default: "drop-sudo"
+  allow-users:
+    description: "GitHub users permitted to invoke Codex."
+    required: false
+    default: "*"
+
+outputs:
+  final-message:
+    description: "Schema-constrained final message emitted by Codex."
+    value: ${{ steps.linux.outputs.final-message || steps.macos.outputs.final-message }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Reject unsupported runners"
+      if: ${{ runner.os != 'Linux' && runner.os != 'macOS' }}
+      shell: bash
+      run: |
+        echo 'Codex cgroup isolation requires a GitHub-hosted Linux or macOS runner.' >&2
+        exit 1
+
+    - name: "Prepare dedicated Codex user"
+      id: prepare
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      env:
+        RUNNER_ENVIRONMENT: ${{ runner.environment }}
+        CODEX_CONFIG_HOME: ${{ inputs.codex-home }}
+        CODEX_PERMISSION_PROFILE: ${{ inputs.permission-profile }}
+      run: bash "$GITHUB_ACTION_PATH/run.sh" prepare
+
+    - name: "Bootstrap Codex and the Responses API proxy"
+      if: ${{ runner.os == 'Linux' }}
+      uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+      with:
+        openai-api-key: ${{ inputs.openai-api-key }}
+        codex-home: ${{ inputs.codex-home }}
+        permission-profile: ${{ inputs.permission-profile }}
+        safety-strategy: "unprivileged-user"
+        codex-user: ${{ steps.prepare.outputs.codex-user }}
+        allow-users: ${{ inputs.allow-users }}
+
+    - name: "Run Codex in a supervised cgroup"
+      id: linux
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      env:
+        RUNNER_ENVIRONMENT: ${{ runner.environment }}
+        CODEX_GUEST_USER: ${{ steps.prepare.outputs.codex-user }}
+        CODEX_GUEST_TEMP: ${{ steps.prepare.outputs.guest-temp }}
+        CODEX_SERVICE_UNIT: ${{ steps.prepare.outputs.service-unit }}
+        CODEX_RUSTUP_HOME: ${{ steps.prepare.outputs.rustup-home }}
+        CODEX_UV_PYTHON_INSTALL_DIR: ${{ steps.prepare.outputs.uv-python-install-dir }}
+        CODEX_CONFIG_HOME: ${{ inputs.codex-home }}
+        CODEX_PROMPT_FILE: ${{ inputs.prompt-file }}
+        CODEX_OUTPUT_SCHEMA_FILE: ${{ inputs.output-schema-file }}
+        CODEX_PERMISSION_PROFILE: ${{ inputs.permission-profile }}
+      run: bash "$GITHUB_ACTION_PATH/run.sh" run
+
+    - name: "Run Codex with macOS process protections"
+      id: macos
+      if: ${{ runner.os == 'macOS' }}
+      uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+      with:
+        openai-api-key: ${{ inputs.openai-api-key }}
+        prompt-file: ${{ inputs.prompt-file }}
+        output-schema-file: ${{ inputs.output-schema-file }}
+        permission-profile: ${{ inputs.permission-profile }}
+        codex-home: ${{ inputs.codex-home }}
+        safety-strategy: ${{ inputs.safety-strategy }}
+        allow-users: ${{ inputs.allow-users }}

--- a/.github/actions/codex-cgroup/run.sh
+++ b/.github/actions/codex-cgroup/run.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+
+fail() {
+    printf 'codex-cgroup: %s\n' "$*" >&2
+    return 1
+}
+
+validate_codex_user() {
+    [[ ${1:-} =~ ^uvcodex[[:xdigit:]]{16}$ ]]
+}
+
+validate_permission_profile() {
+    [[ ${1:-} =~ ^[[:alnum:]_:][[:alnum:]_.:-]*$ ]]
+}
+
+validate_service_unit() {
+    [[ ${1:-} =~ ^uv-codex-[[:digit:]]+-[[:digit:]]+-[[:xdigit:]]{16}$ ]]
+}
+
+append_service_environment() {
+    local name=${1:-}
+    local value=${2:-}
+
+    case "$name" in
+        PATH | CODEX_HOME | CODEX_INTERNAL_ORIGINATOR_OVERRIDE | CI | FORCE_COLOR | \
+            RUNNER_TEMP | TMPDIR | UV_CACHE_DIR | CARGO_HOME | CARGO_TARGET_DIR | \
+            RUSTUP_HOME | UV_PYTHON_INSTALL_DIR | INSTA_UPDATE) ;;
+        *) return 1 ;;
+    esac
+
+    [[ $value != *$'\n'* && $value != *$'\r'* ]] || return 1
+    SERVICE_ENVIRONMENT+=("--setenv=${name}=${value}")
+}
+
+build_service_environment() {
+    local trusted_path=$1
+    local codex_home=$2
+    local guest_temp=$3
+    local rustup_home=${CODEX_RUSTUP_HOME:-${RUSTUP_HOME:-}}
+    local uv_python_install_dir=${CODEX_UV_PYTHON_INSTALL_DIR:-${UV_PYTHON_INSTALL_DIR:-}}
+
+    SERVICE_ENVIRONMENT=()
+    append_service_environment PATH "$trusted_path" || return
+    append_service_environment CODEX_HOME "$codex_home" || return
+    append_service_environment CODEX_INTERNAL_ORIGINATOR_OVERRIDE codex_github_action || return
+    append_service_environment RUNNER_TEMP "$guest_temp" || return
+    append_service_environment TMPDIR "$guest_temp/tmp" || return
+    append_service_environment UV_CACHE_DIR "$guest_temp/uv-cache" || return
+    append_service_environment CARGO_HOME "$guest_temp/cargo" || return
+    append_service_environment CARGO_TARGET_DIR "$guest_temp/target" || return
+    append_service_environment CI true || return
+    append_service_environment FORCE_COLOR 1 || return
+
+    if [[ -n ${INSTA_UPDATE:-} ]]; then
+        append_service_environment INSTA_UPDATE "$INSTA_UPDATE" || return
+    fi
+    if [[ -n $rustup_home ]]; then
+        append_service_environment RUSTUP_HOME "$rustup_home" || return
+    fi
+    if [[ -n $uv_python_install_dir ]]; then
+        append_service_environment UV_PYTHON_INSTALL_DIR "$uv_python_install_dir" || return
+    fi
+}
+
+build_service_arguments() {
+    local service_unit=$1
+    local codex_user=$2
+
+    validate_service_unit "$service_unit" || return
+    validate_codex_user "$codex_user" || return
+
+    SERVICE_ARGUMENTS=(
+        --quiet
+        --pipe
+        --wait
+        "--unit=${service_unit}"
+        "--uid=${codex_user}"
+        --property=Type=exec
+        --property=ExitType=main
+        --property=KillMode=control-group
+        --property=TimeoutStopSec=10s
+        --property=RuntimeMaxSec=45min
+        --property=SendSIGKILL=yes
+        --property=NoNewPrivileges=yes
+        --property=ProtectControlGroups=yes
+        --property=ProtectProc=invisible
+    )
+    SERVICE_ARGUMENTS+=("${SERVICE_ENVIRONMENT[@]}")
+}
+
+require_hosted_linux() {
+    [[ ${RUNNER_OS:-} == Linux ]] || fail "a Linux runner is required"
+    [[ ${RUNNER_ENVIRONMENT:-} == github-hosted ]] || fail "a GitHub-hosted Linux runner is required"
+    [[ $(stat --file-system --format=%T /sys/fs/cgroup) == cgroup2fs ]] ||
+        fail "cgroup v2 is unavailable"
+    [[ $(ps -p 1 -o comm= | xargs) == systemd ]] || fail "systemd is not PID 1"
+
+    local tool
+    for tool in sudo setfacl getfacl openssl realpath jq; do
+        command -v "$tool" >/dev/null || fail "$tool is unavailable"
+    done
+
+    [[ -x /usr/bin/systemd-run && -x /usr/bin/systemctl ]] ||
+        fail "the host systemd tools are unavailable"
+    sudo -n true || fail "passwordless sudo is unavailable"
+}
+
+grant_traversal() {
+    local path=$1
+    local codex_user=$2
+
+    while [[ $path != / ]]; do
+        sudo -n setfacl --modify "u:${codex_user}:--x" "$path"
+        path=$(dirname -- "$path")
+    done
+}
+
+grant_writable_tree() {
+    local path=$1
+    local codex_user=$2
+    local runner_user=$3
+
+    [[ -d $path ]] || fail "writable directory does not exist: $path"
+    sudo -n setfacl --recursive --modify "u:${codex_user}:rwX" "$path"
+    sudo -n find "$path" -type d -exec \
+        setfacl --modify "d:u:${codex_user}:rwX,d:u:${runner_user}:rwX" '{}' +
+}
+
+resolve_workspace_path() {
+    local input=$1
+    local workspace=$2
+    local resolved
+
+    if [[ $input == /* ]]; then
+        resolved=$(realpath --canonicalize-missing -- "$input") || return
+    else
+        resolved=$(realpath --canonicalize-missing -- "$workspace/$input") || return
+    fi
+
+    case "$resolved" in
+        "$workspace"/*) printf '%s\n' "$resolved" ;;
+        *) return 1 ;;
+    esac
+}
+
+prepare() {
+    require_hosted_linux
+    validate_permission_profile "${CODEX_PERMISSION_PROFILE:-}" ||
+        fail "invalid Codex permission profile"
+
+    local workspace
+    local runner_temp
+    local codex_home
+    local nonce
+    local codex_user
+    local guest_temp
+    local service_unit
+    local runner_user
+    local runner_group
+    local rustup_home
+    local uv_python_install_dir
+
+    workspace=$(realpath -- "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}")
+    runner_temp=$(realpath -- "${RUNNER_TEMP:?RUNNER_TEMP is required}")
+    codex_home=$(resolve_workspace_path "${CODEX_CONFIG_HOME:?codex-home is required}" "$workspace") ||
+        fail "codex-home must be inside the workspace"
+    [[ -f $codex_home/config.toml ]] || fail "trusted Codex configuration is missing"
+
+    nonce=$(openssl rand -hex 8)
+    codex_user="uvcodex${nonce}"
+    validate_codex_user "$codex_user" || fail "invalid generated Codex user"
+    service_unit="uv-codex-${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}-${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}-${nonce}"
+    validate_service_unit "$service_unit" || fail "invalid generated systemd unit"
+
+    runner_user=$(id -un)
+    runner_group=$(id -gn)
+    guest_temp="$runner_temp/$service_unit"
+
+    sudo -n useradd --system --create-home --user-group \
+        --shell /usr/sbin/nologin -- "$codex_user"
+
+    grant_traversal "$workspace" "$codex_user"
+    grant_traversal "$runner_temp" "$codex_user"
+    sudo -n setfacl --recursive --modify "u:${codex_user}:rX" "$workspace"
+
+    grant_writable_tree "$workspace/crates/uv/tests/it" "$codex_user" "$runner_user"
+    grant_writable_tree "$workspace/crates/uv-client/tests/it" "$codex_user" "$runner_user"
+
+    sudo -n install --directory --owner="$codex_user" --group="$runner_group" \
+        --mode=0750 "$guest_temp" "$guest_temp/tmp" "$guest_temp/uv-cache" \
+        "$guest_temp/cargo" "$guest_temp/target"
+
+    sudo -n install --directory --owner="$runner_user" --group="$runner_group" \
+        --mode=0755 "$codex_home/sessions"
+    grant_writable_tree "$codex_home/sessions" "$codex_user" "$runner_user"
+
+    local source
+    for source in issue-triage-event.json bug-reproduction-result.json; do
+        if [[ -f $runner_temp/$source ]]; then
+            sudo -n install --owner="$codex_user" --group="$runner_group" \
+                --mode=0640 "$runner_temp/$source" "$guest_temp/$source"
+        fi
+    done
+
+    rustup_home=${RUSTUP_HOME:-${HOME:?HOME is required}/.rustup}
+    if [[ -d $rustup_home ]]; then
+        rustup_home=$(realpath -- "$rustup_home")
+        grant_traversal "$rustup_home" "$codex_user"
+        sudo -n setfacl --recursive --modify "u:${codex_user}:rX" "$rustup_home"
+    else
+        rustup_home=
+    fi
+    uv_python_install_dir=${UV_PYTHON_INSTALL_DIR:-${HOME:?HOME is required}/.local/share/uv/python}
+    if [[ -d $uv_python_install_dir ]]; then
+        uv_python_install_dir=$(realpath -- "$uv_python_install_dir")
+        grant_traversal "$uv_python_install_dir" "$codex_user"
+        sudo -n setfacl --recursive --modify "u:${codex_user}:rX" "$uv_python_install_dir"
+    else
+        uv_python_install_dir=
+    fi
+
+    {
+        printf 'codex-user=%s\n' "$codex_user"
+        printf 'guest-temp=%s\n' "$guest_temp"
+        printf 'service-unit=%s\n' "$service_unit"
+        printf 'rustup-home=%s\n' "$rustup_home"
+        printf 'uv-python-install-dir=%s\n' "$uv_python_install_dir"
+    } >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+}
+
+build_trusted_path() {
+    local workspace=$1
+    local runner_temp=$2
+    local command_name
+    local command_path
+    local directory
+    local trusted_path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+    for command_name in node codex uv cargo rustup; do
+        if command_path=$(command -v "$command_name" 2>/dev/null); then
+            [[ $command_path == /* ]] || fail "$command_name is not an absolute executable"
+            directory=$(realpath -- "$(dirname -- "$command_path")") ||
+                fail "$command_name is not in a resolvable executable directory"
+            case "$directory" in
+                "$workspace" | "$workspace"/* | "$runner_temp" | "$runner_temp"/*)
+                    fail "$command_name is inside an untrusted writable directory"
+                    ;;
+            esac
+            case ":$trusted_path:" in
+                *":$directory:"*) ;;
+                *) trusted_path="$directory:$trusted_path" ;;
+            esac
+        elif [[ $command_name == node || $command_name == codex || $command_name == uv ]]; then
+            fail "$command_name is unavailable"
+        fi
+    done
+
+    printf '%s\n' "$trusted_path"
+}
+
+grant_trusted_path_access() {
+    local trusted_path=$1
+    local workspace=$2
+    local runner_temp=$3
+    local codex_user=$4
+    local runner_home
+    local directory
+    local -a directories
+
+    runner_home=$(realpath -- "${HOME:?HOME is required}") ||
+        fail "the runner home could not be resolved"
+    IFS=: read -r -a directories <<< "$trusted_path"
+
+    for directory in "${directories[@]}"; do
+        [[ -d $directory ]] || fail "trusted executable directory does not exist"
+
+        case "$directory" in
+            "$workspace" | "$workspace"/* | "$runner_temp" | "$runner_temp"/*)
+                fail "an executable directory is inside an untrusted writable directory"
+                ;;
+        esac
+
+        case "$directory" in
+            "$runner_home" | "$runner_home"/*)
+                grant_traversal "$directory" "$codex_user"
+                sudo -n setfacl --recursive --modify "u:${codex_user}:rX" "$directory"
+                ;;
+        esac
+    done
+}
+
+stop_service() {
+    local service_unit=$1
+
+    sudo -n /usr/bin/systemctl kill --kill-whom=all --signal=SIGKILL \
+        "$service_unit" >/dev/null 2>&1 || true
+    sudo -n /usr/bin/systemctl stop --no-block "$service_unit" >/dev/null 2>&1 || true
+}
+
+run_codex() {
+    require_hosted_linux
+
+    local codex_user=${CODEX_GUEST_USER:?CODEX_GUEST_USER is required}
+    local guest_temp=${CODEX_GUEST_TEMP:?CODEX_GUEST_TEMP is required}
+    local service_unit=${CODEX_SERVICE_UNIT:?CODEX_SERVICE_UNIT is required}
+    local profile=${CODEX_PERMISSION_PROFILE:?CODEX_PERMISSION_PROFILE is required}
+    local workspace
+    local runner_temp
+    local codex_home
+    local prompt_file
+    local schema_file
+    local codex_path
+    local trusted_path
+    local output_file
+
+    validate_codex_user "$codex_user" || fail "invalid Codex user"
+    validate_service_unit "$service_unit" || fail "invalid systemd unit"
+    validate_permission_profile "$profile" || fail "invalid Codex permission profile"
+
+    workspace=$(realpath -- "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}")
+    runner_temp=$(realpath -- "${RUNNER_TEMP:?RUNNER_TEMP is required}")
+    [[ $guest_temp == "$runner_temp/$service_unit" && -d $guest_temp && ! -L $guest_temp ]] ||
+        fail "the guest directory must be the dedicated service temporary directory"
+
+    codex_home=$(resolve_workspace_path "${CODEX_CONFIG_HOME:?codex-home is required}" "$workspace") ||
+        fail "codex-home must be inside the workspace"
+    prompt_file=$(resolve_workspace_path \
+        "${CODEX_PROMPT_FILE:?prompt-file is required}" "$workspace") ||
+        fail "the Codex prompt must be inside the workspace"
+    [[ -f $prompt_file ]] || fail "the Codex prompt does not exist"
+    schema_file=$(resolve_workspace_path \
+        "${CODEX_OUTPUT_SCHEMA_FILE:?output-schema-file is required}" "$workspace") ||
+        fail "the output schema must be inside the workspace"
+    [[ -f $schema_file ]] || fail "the Codex output schema does not exist"
+
+    trusted_path=$(build_trusted_path "$workspace" "$runner_temp") ||
+        fail "could not construct a safe Codex executable path"
+    grant_trusted_path_access "$trusted_path" "$workspace" "$runner_temp" "$codex_user"
+    codex_path=$(command -v codex) || fail "Codex was not installed during bootstrap"
+    [[ $codex_path == /* ]] || fail "Codex executable must have an absolute path"
+
+    build_service_environment "$trusted_path" "$codex_home" "$guest_temp" ||
+        fail "invalid Codex service environment"
+    build_service_arguments "$service_unit" "$codex_user" ||
+        fail "invalid Codex service arguments"
+
+    output_file="$guest_temp/final-message.json"
+
+    trap 'stop_service "$service_unit"' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
+    {
+        sudo -n /usr/bin/systemd-run "${SERVICE_ARGUMENTS[@]}" \
+            -- "$codex_path" exec \
+            --skip-git-repo-check \
+            --cd "$workspace" \
+            --output-last-message "$output_file" \
+            --output-schema "$schema_file" \
+            --config "default_permissions=\"${profile}\""
+    } < "$prompt_file"
+
+    [[ -f $output_file && ! -L $output_file ]] ||
+        fail "Codex did not produce a regular final-message file"
+    [[ $(stat --format=%s -- "$output_file") -le 65536 ]] ||
+        fail "the Codex final message exceeds its 64 KiB limit"
+
+    local message
+    message=$(jq --slurp --compact-output --exit-status \
+        'if length == 1 and (.[0] | type == "object") then .[0] else empty end' \
+        "$output_file") ||
+        fail "Codex did not produce a valid JSON final message"
+    printf 'final-message=%s\n' "$message" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+    trap - EXIT INT TERM
+}
+
+main() {
+    set -euo pipefail
+
+    case ${1:-} in
+        prepare) prepare ;;
+        run) run_codex ;;
+        *) fail "expected prepare or run" ;;
+    esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    main "$@"
+fi

--- a/.github/actions/codex-cgroup/test_run.py
+++ b/.github/actions/codex-cgroup/test_run.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+RUN_SCRIPT = Path(__file__).with_name("run.sh")
+
+
+def run_bash(statement: str, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'set -euo pipefail\nsource "$1"\nshift\n{statement}',
+            "bash",
+            str(RUN_SCRIPT),
+            *arguments,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+class CodexCgroupTests(unittest.TestCase):
+    def test_accepts_generated_dedicated_user(self) -> None:
+        result = run_bash('validate_codex_user "$1"', "uvcodex0123456789abcdef")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_runner_and_invalid_user_names(self) -> None:
+        for username in (
+            "runner",
+            "root",
+            "uvcodex",
+            "uvcodex0123456789abcde",
+            "uvcodex0123456789abcdef0",
+            "uvcodex0123456789abcdeg",
+            "uvcodex01234567;runner",
+        ):
+            with self.subTest(username=username):
+                result = run_bash('validate_codex_user "$1"', username)
+
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_accepts_named_permission_profiles(self) -> None:
+        for profile in ("create-bug-test", ":workspace", "issue-triage"):
+            with self.subTest(profile=profile):
+                result = run_bash('validate_permission_profile "$1"', profile)
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_permission_profile_injection(self) -> None:
+        for profile in (
+            "",
+            "create bug test",
+            "create-bug-test\nGH_TOKEN=secret",
+            "create-bug-test;runner",
+            "../create-bug-test",
+        ):
+            with self.subTest(profile=profile):
+                result = run_bash('validate_permission_profile "$1"', profile)
+
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_accepts_generated_transient_service(self) -> None:
+        result = run_bash(
+            'validate_service_unit "$1"',
+            "uv-codex-123456-2-0123456789abcdef",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_service_name_injection(self) -> None:
+        for service in (
+            "",
+            "runner.service",
+            "uv-codex-123456-2",
+            "uv-codex-123456-2-0123456789abcdeg",
+            "uv-codex-123456-2-0123456789abcdef.service",
+            "uv-codex-123456-2-0123456789abcdef\nrunner.service",
+            "../uv-codex-123456-2-0123456789abcdef",
+        ):
+            with self.subTest(service=service):
+                result = run_bash('validate_service_unit "$1"', service)
+
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_credentials_and_runner_command_files(self) -> None:
+        result = run_bash(
+            """
+            SERVICE_ENVIRONMENT=()
+            for name in "$@"; do
+                if append_service_environment "$name" secret; then
+                    printf 'Unexpectedly accepted %s\\n' "$name" >&2
+                    exit 1
+                fi
+            done
+            """,
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+            "ACTIONS_ID_TOKEN_REQUEST_URL",
+            "ACTIONS_RUNTIME_TOKEN",
+            "GITHUB_OUTPUT",
+            "GITHUB_ENV",
+            "GITHUB_PATH",
+            "LD_PRELOAD",
+            "BASH_ENV",
+            "HOME",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_environment_value_injection(self) -> None:
+        for value in ("safe\nGH_TOKEN=secret", "safe\rGH_TOKEN=secret"):
+            with self.subTest(value=value):
+                result = run_bash(
+                    'SERVICE_ENVIRONMENT=(); append_service_environment PATH "$1"',
+                    value,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_builds_an_explicit_service_environment(self) -> None:
+        result = run_bash(
+            """
+            unset RUSTUP_HOME UV_PYTHON_INSTALL_DIR INSTA_UPDATE
+            SERVICE_ENVIRONMENT=()
+            build_service_environment "$1" "$2" "$3"
+            printf '%s\\n' "${SERVICE_ENVIRONMENT[@]}"
+            """,
+            "/usr/bin:/bin",
+            "/workspace/agents/codex",
+            "/runner-temp/uv-codex-123456-2-0123456789abcdef",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        arguments = result.stdout.splitlines()
+        self.assertIn("--setenv=PATH=/usr/bin:/bin", arguments)
+        self.assertIn("--setenv=CODEX_HOME=/workspace/agents/codex", arguments)
+        self.assertIn(
+            "--setenv=RUNNER_TEMP=/runner-temp/uv-codex-123456-2-0123456789abcdef",
+            arguments,
+        )
+        self.assertFalse(
+            any(
+                "TOKEN" in argument or "GITHUB_OUTPUT" in argument
+                for argument in arguments
+            ),
+        )
+
+    def test_builds_a_killable_unprivileged_transient_service(self) -> None:
+        result = run_bash(
+            """
+            SERVICE_ENVIRONMENT=()
+            build_service_arguments "$1" "$2"
+            printf '%s\\n' "${SERVICE_ARGUMENTS[@]}"
+            """,
+            "uv-codex-123456-2-0123456789abcdef",
+            "uvcodex0123456789abcdef",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        arguments = result.stdout.splitlines()
+        self.assertIn("--pipe", arguments)
+        self.assertIn("--wait", arguments)
+        self.assertIn("--uid=uvcodex0123456789abcdef", arguments)
+        self.assertIn("--property=KillMode=control-group", arguments)
+        self.assertIn("--property=SendSIGKILL=yes", arguments)
+        self.assertIn("--property=NoNewPrivileges=yes", arguments)
+        self.assertIn("--property=ProtectControlGroups=yes", arguments)
+        self.assertNotIn("--scope", arguments)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/reproduce-bug.yml
+++ b/.github/workflows/reproduce-bug.yml
@@ -22,7 +22,7 @@ on:
         value: ${{ jobs.create-integration-test.outputs.result }}
       pull-request:
         description: "The draft integration-test pull request URL"
-        value: ${{ jobs.create-integration-test.outputs.pull-request }}
+        value: ${{ jobs.publish-integration-test.outputs.pull-request }}
   workflow_dispatch:
     inputs:
       issue:
@@ -121,11 +121,14 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      id-token: write # for the uv-dev credential broker
       issues: read
     outputs:
       result: ${{ steps.create-test.outputs.final-message }}
-      pull-request: ${{ steps.open-pr.outputs.url }}
+      artifact-id: ${{ steps.upload-test.outputs.artifact-id }}
+      artifact-digest: ${{ steps.upload-test.outputs.artifact-digest }}
+      base-sha: ${{ steps.commit-test.outputs.base-sha }}
+      head-sha: ${{ steps.commit-test.outputs.head-sha }}
+      issue-number: ${{ steps.commit-test.outputs.issue-number }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -157,9 +160,8 @@ jobs:
 
       - name: "Create integration test"
         id: create-test
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: ./.github/actions/codex-cgroup
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INSTA_UPDATE: "no"
           TMPDIR: ${{ runner.temp }}
           UV_CACHE_DIR: ${{ runner.temp }}/uv-create-test-cache
@@ -204,21 +206,136 @@ jobs:
 
           git diff --cached --check
           issue_number="$(jq --raw-output '.number' "$RUNNER_TEMP/issue-triage-event.json")"
+          case "$issue_number" in
+            ''|*[!0-9]*|0)
+              echo "The issue number must be a positive integer." >&2
+              exit 1
+              ;;
+          esac
+
+          base_sha="$(git rev-parse 'HEAD^{commit}')"
           git \
             -c core.hooksPath=/dev/null \
             -c user.name="github-actions[bot]" \
             -c user.email="github-actions[bot]@users.noreply.github.com" \
             commit --message "Add regression test for uv#${issue_number}"
 
-          git_dir="$(git rev-parse --absolute-git-dir)"
-          mv "$git_dir/config" "$RUNNER_TEMP/untrusted-git-config"
-          echo "created=true" >> "$GITHUB_OUTPUT"
+          git -c core.hooksPath=/dev/null bundle create \
+            "$RUNNER_TEMP/integration-test.bundle" HEAD^..HEAD
+
+          {
+            echo "created=true"
+            echo "base-sha=$base_sha"
+            echo "head-sha=$(git rev-parse 'HEAD^{commit}')"
+            echo "issue-number=$issue_number"
+          } >> "$GITHUB_OUTPUT"
         env:
           CREATE_TEST_OUTCOME: ${{ fromJSON(steps.create-test.outputs.final-message).outcome }}
           CREATE_TEST_SUMMARY: ${{ fromJSON(steps.create-test.outputs.final-message).summary }}
 
-      - name: "Get uv-dev token"
+      - name: "Upload integration test"
         if: steps.commit-test.outputs.created == 'true'
+        id: upload-test
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-test-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/integration-test.bundle
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  publish-integration-test:
+    needs: create-integration-test
+    if: needs.create-integration-test.outputs.artifact-id != ''
+    runs-on: ubuntu-latest
+    environment: automations
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      pull-request: ${{ steps.open-pr.outputs.url }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: "Download integration test"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.create-integration-test.outputs.artifact-id }}
+          path: ${{ runner.temp }}/integration-test
+          digest-mismatch: error
+
+      - name: "Verify integration test"
+        id: verify-test
+        env:
+          EXPECTED_BASE_SHA: ${{ needs.create-integration-test.outputs.base-sha }}
+          EXPECTED_HEAD_SHA: ${{ needs.create-integration-test.outputs.head-sha }}
+          GIT_CONFIG_GLOBAL: /dev/null
+          GIT_CONFIG_NOSYSTEM: "1"
+          LC_ALL: C
+        run: |
+          bundle="$RUNNER_TEMP/integration-test/integration-test.bundle"
+          trusted_base="$(git rev-parse 'HEAD^{commit}')"
+
+          if [ "$trusted_base" != "$GITHUB_SHA" ] || [ "$trusted_base" != "$EXPECTED_BASE_SHA" ]; then
+            echo "The integration test was not based on the trusted workflow revision." >&2
+            exit 1
+          fi
+
+          git bundle verify "$bundle"
+          git -c core.hooksPath=/dev/null -c fetch.fsckObjects=true \
+            fetch --no-tags "$bundle" HEAD
+          candidate="$(git rev-parse 'FETCH_HEAD^{commit}')"
+
+          if [ "$candidate" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "The integration test bundle does not contain the expected commit." >&2
+            exit 1
+          fi
+          if [ "$(git rev-parse "$candidate^")" != "$trusted_base" ]; then
+            echo "The integration test commit does not have the trusted revision as its parent." >&2
+            exit 1
+          fi
+          if git rev-parse --quiet --verify "$candidate^2" > /dev/null; then
+            echo "The integration test bundle must contain exactly one non-merge commit." >&2
+            exit 1
+          fi
+
+          changed_files=0
+          while IFS= read -r -d '' change && IFS= read -r -d '' file; do
+            read -r old_mode new_mode _old_object _new_object status <<< "$change"
+            case "$old_mode:$new_mode:$status" in
+              :000000:100644:A|:100644:100644:M) ;;
+              *)
+                echo "Integration tests must only add or modify regular non-executable files." >&2
+                exit 1
+                ;;
+            esac
+
+            case "$file" in
+              crates/uv/tests/it/*.rs|crates/uv/tests/it/*.snap|\
+              crates/uv-client/tests/it/*.rs|crates/uv-client/tests/it/*.snap) ;;
+              *)
+                echo "The integration test changes a disallowed path." >&2
+                exit 1
+                ;;
+            esac
+
+            changed_files=$((changed_files + 1))
+          done < <(git diff-tree --no-commit-id --no-renames -r --raw -z \
+            "$trusted_base" "$candidate")
+
+          if [ "$changed_files" -eq 0 ]; then
+            echo "The integration test bundle does not contain any test changes." >&2
+            exit 1
+          fi
+
+          git diff-tree --check "$trusted_base" "$candidate"
+          echo "head-sha=$candidate" >> "$GITHUB_OUTPUT"
+
+      - name: "Get uv-dev token"
         id: token
         uses: open-security-tools/ost-simple-sts@9e012247e07c39080fb6a832dbfbcfeacebc19c4
         with:
@@ -230,22 +347,28 @@ jobs:
             pull_requests: write
 
       - name: "Open draft pull request"
-        if: steps.commit-test.outputs.created == 'true'
         id: open-pr
         run: |
-          issue_number="$(jq --raw-output '.number' "$RUNNER_TEMP/issue-triage-event.json")"
-          branch="zb/reproduce-bug/${issue_number}"
-          git -c core.hooksPath=/dev/null push \
-            "https://x-access-token:${GH_TOKEN}@github.com/astral-sh/uv-dev.git" \
-            HEAD:"$branch"
+          case "$ISSUE_NUMBER" in
+            ''|*[!0-9]*|0)
+              echo "The issue number must be a positive integer." >&2
+              exit 1
+              ;;
+          esac
+          branch="zb/reproduce-bug/${ISSUE_NUMBER}"
+          git -c core.hooksPath=/dev/null \
+            -c credential.helper= \
+            -c 'credential.helper=!gh auth git-credential' \
+            push https://github.com/astral-sh/uv-dev.git \
+            "$HEAD_SHA:refs/heads/$branch"
           pull_request="$(
             gh pr create \
               --repo astral-sh/uv-dev \
               --base main \
               --head "$branch" \
               --draft \
-              --title "Add regression test for uv#${issue_number}" \
-              --body "Add a minimal integration test that reproduces astral-sh/uv#${issue_number}."
+              --title "Add regression test for uv#${ISSUE_NUMBER}" \
+              --body "Add a minimal integration test that reproduces astral-sh/uv#${ISSUE_NUMBER}."
           )"
           echo "url=$pull_request" >> "$GITHUB_OUTPUT"
           {
@@ -257,4 +380,6 @@ jobs:
           GIT_CONFIG_GLOBAL: /dev/null
           GIT_CONFIG_NOSYSTEM: "1"
           GH_TOKEN: ${{ steps.token.outputs.token }}
-          CREATE_TEST_SUMMARY: ${{ fromJSON(steps.create-test.outputs.final-message).summary }}
+          HEAD_SHA: ${{ steps.verify-test.outputs.head-sha }}
+          ISSUE_NUMBER: ${{ needs.create-integration-test.outputs.issue-number }}
+          CREATE_TEST_SUMMARY: ${{ fromJSON(needs.create-integration-test.outputs.result).summary }}


### PR DESCRIPTION
## Summary

The regression-test automation generates an integration test and requests the `uv-dev` write token in the same job. This exposes the OIDC capability to Codex and allows generated background processes to outlive the agent.

Move publication into a fresh job with the only `id-token: write` permission. Transfer a single commit as an immutable Git bundle, then verify the artifact identity, digest, trusted base, commit ancestry, regular-file modes, and allowed regression-test paths before requesting the token.

On Linux, run Codex as a dedicated user in a transient systemd cgroup with an explicit environment, scoped filesystem access, and cancellation cleanup. Preserve the existing macOS execution path without granting either generator publishing credentials.

## Test plan (on top of CI)

- `python3 .github/actions/codex-cgroup/test_run.py` (10 security regressions).
- `uvx --offline --from shellcheck-py shellcheck --shell bash --severity style .github/actions/codex-cgroup/run.sh`.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -oneline .github/workflows/reproduce-bug.yml`.
- `uvx --offline zizmor --offline --no-progress .github/workflows/reproduce-bug.yml .github/actions/codex-cgroup/action.yml`.
- `npm exec --offline --package=prettier@3.9.0 -- prettier --check .github/workflows/reproduce-bug.yml .github/actions/codex-cgroup/action.yml`.
- `uvx --offline ruff check .github/actions/codex-cgroup/test_run.py`.
- `uvx --offline ruff format --check .github/actions/codex-cgroup/test_run.py`.