### PR TITLE
Include best-effort `environment` info by default in `uv workspace metadata`

### DIFF
--- a/crates/uv-resolver/src/lock/export/metadata.rs
+++ b/crates/uv-resolver/src/lock/export/metadata.rs
@@ -65,7 +65,7 @@ pub struct Metadata {
     /// Ideally absolute paths to things that are found in subdirs of this should have exactly
     /// this as a prefix so it can be stripped to get relative paths if one wants.
     workspace_root: PortablePathBuf,
-    /// Information about the synchronized environment, when `--sync` was used.
+    /// Information about the existing or synchronized environment, when available.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     environment: Option<MetadataEnvironment>,
     /// Information about the script root, when metadata was requested for a script.
@@ -109,7 +109,7 @@ struct SchemaReport {
     version: SchemaVersion,
 }
 
-/// Information about the environment synchronized for the workspace.
+/// Information about the existing or synchronized environment for the workspace.
 #[derive(Debug, serde::Serialize)]
 struct MetadataEnvironment {
     /// Absolute path to the environment root.
@@ -118,7 +118,7 @@ struct MetadataEnvironment {
     python: PythonReport,
 }
 
-/// Information about the Python interpreter in a synchronized environment.
+/// Information about the Python interpreter in an existing environment.
 #[derive(Debug, serde::Serialize)]
 pub struct PythonReport {
     /// Absolute path to the Python executable.

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -785,6 +785,23 @@ impl ScriptInterpreter {
         cache_env
     }
 
+    /// Discover an existing script environment without selecting or downloading an interpreter.
+    pub(crate) fn discover_existing(
+        script: Pep723ItemRef<'_>,
+        active: Option<bool>,
+        cache: &Cache,
+    ) -> Option<PythonEnvironment> {
+        let root = Self::root(script, active, cache);
+        match PythonEnvironment::from_root(&root, cache) {
+            Ok(environment) => Some(environment),
+            Err(uv_python::Error::MissingEnvironment(_)) => None,
+            Err(err) => {
+                warn!("Ignoring existing script environment: {err}");
+                None
+            }
+        }
+    }
+
     /// Discover the interpreter to use for the current [`Pep723Item`].
     pub(crate) async fn discover(
         script: Pep723ItemRef<'_>,
@@ -808,34 +825,29 @@ impl ScriptInterpreter {
             requires_python,
         } = ScriptPython::from_request(python_request, workspace, script, config_discovery).await?;
 
-        let root = Self::root(script, active, cache);
-        match PythonEnvironment::from_root(&root, cache) {
-            Ok(venv) => {
-                match check_environment_compatibility(
-                    &venv,
-                    EnvironmentKind::Script,
-                    python_request.as_ref(),
-                    python_preference,
-                    requires_python
-                        .as_ref()
-                        .map(|(requires_python, _)| requires_python),
-                    cache,
-                ) {
-                    Ok(()) => return Ok(Self::Environment(venv)),
-                    Err(err) if keep_incompatible => {
-                        warn_user!(
-                            "Using incompatible environment (`{}`) due to `--no-sync` ({err})",
-                            root.user_display().cyan(),
-                        );
-                        return Ok(Self::Environment(venv));
-                    }
-                    Err(err) => {
-                        debug!("{err}");
-                    }
+        if let Some(environment) = Self::discover_existing(script, active, cache) {
+            match check_environment_compatibility(
+                &environment,
+                EnvironmentKind::Script,
+                python_request.as_ref(),
+                python_preference,
+                requires_python
+                    .as_ref()
+                    .map(|(requires_python, _)| requires_python),
+                cache,
+            ) {
+                Ok(()) => return Ok(Self::Environment(environment)),
+                Err(err) if keep_incompatible => {
+                    warn_user!(
+                        "Using incompatible environment (`{}`) due to `--no-sync` ({err})",
+                        environment.root().user_display().cyan(),
+                    );
+                    return Ok(Self::Environment(environment));
+                }
+                Err(err) => {
+                    debug!("{err}");
                 }
             }
-            Err(uv_python::Error::MissingEnvironment(_)) => {}
-            Err(err) => warn!("Ignoring existing script environment: {err}"),
         }
 
         let reporter = PythonDownloadReporter::single(printer);
@@ -1006,13 +1018,9 @@ fn check_environment_compatibility(
     Ok(())
 }
 
-/// Discover a compatible project environment at `root`.
-fn discover_project_environment(
+/// Discover an existing project environment at `root` without validating its compatibility.
+fn existing_project_environment(
     root: &Path,
-    python_request: Option<&PythonRequest>,
-    python_preference: PythonPreference,
-    requires_python: Option<&RequiresPython>,
-    keep_incompatible: bool,
     centralized: bool,
     cache: &Cache,
 ) -> Result<Option<PythonEnvironment>, ProjectError> {
@@ -1068,6 +1076,23 @@ fn discover_project_environment(
             return Ok(None);
         }
         Err(err) => return Err(err.into()),
+    };
+
+    Ok(Some(environment))
+}
+
+/// Discover a compatible project environment at `root`.
+fn discover_project_environment(
+    root: &Path,
+    python_request: Option<&PythonRequest>,
+    python_preference: PythonPreference,
+    requires_python: Option<&RequiresPython>,
+    keep_incompatible: bool,
+    centralized: bool,
+    cache: &Cache,
+) -> Result<Option<PythonEnvironment>, ProjectError> {
+    let Some(environment) = existing_project_environment(root, centralized, cache)? else {
+        return Ok(None);
     };
 
     match check_environment_compatibility(
@@ -1313,6 +1338,28 @@ pub(crate) enum ProjectInterpreter {
 }
 
 impl ProjectInterpreter {
+    /// Discover an existing project environment without selecting or downloading an interpreter.
+    pub(crate) fn discover_existing(
+        workspace: &Workspace,
+        active: Option<bool>,
+        cache: &Cache,
+    ) -> Result<Option<PythonEnvironment>, ProjectError> {
+        let selection = workspace.environment_selection(active);
+        let root = selection
+            .explicit_path()
+            .map_or_else(|| workspace.install_path().join(".venv"), Path::to_path_buf);
+        let root = read_environment_path_file(&root).unwrap_or(root);
+        let centralized = centralized_environments_enabled(&selection, cache)
+            || is_centralized_environment_reference(&root, cache);
+        let root = if centralized {
+            fs_err::canonicalize(&root).unwrap_or(root)
+        } else {
+            root
+        };
+
+        existing_project_environment(&root, centralized, cache)
+    }
+
     /// Discover the interpreter to use in the current [`Workspace`].
     pub(crate) async fn discover(
         workspace: &Workspace,

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -169,8 +169,8 @@ pub(crate) async fn metadata(
                 },
             };
             let mut export = metadata_for_target(install_target)?;
-            if sync {
-                let environment = match target {
+            let environment = if sync {
+                Some(match target {
                     LockTarget::Workspace(workspace) => ProjectEnvironment::get_or_init(
                         workspace,
                         &groups,
@@ -205,7 +205,19 @@ pub(crate) async fn metadata(
                     )
                     .await?
                     .into_environment()?,
-                };
+                })
+            } else {
+                match target {
+                    LockTarget::Workspace(workspace) => {
+                        ProjectInterpreter::discover_existing(workspace, Some(active), cache)?
+                    }
+                    LockTarget::Script(script) => {
+                        ScriptInterpreter::discover_existing(script.into(), Some(active), cache)
+                    }
+                }
+            };
+
+            if let Some(environment) = environment {
                 let _lock = environment
                     .lock()
                     .await
@@ -224,6 +236,7 @@ pub(crate) async fn metadata(
                     workspace_cache,
                     preview,
                     &malware_settings,
+                    sync,
                 )
                 .await
                 .context("Failed to collect module owners")?;

--- a/crates/uv/src/commands/workspace/module_owners.rs
+++ b/crates/uv/src/commands/workspace/module_owners.rs
@@ -27,7 +27,7 @@ use crate::commands::project::sync::do_sync;
 use crate::printer::Printer;
 use crate::settings::{InstallerSettingsRef, ResolverSettings};
 
-/// Sync all locked extras and groups as needed, then map importable modules to package IDs.
+/// Map importable modules to package IDs, optionally syncing all locked extras and groups first.
 ///
 /// This uses a sufficient (inexact) sync so required distributions are available to inspect
 /// without removing unrelated packages from an existing environment. Only distributions in the
@@ -43,54 +43,57 @@ pub(crate) async fn collect_module_owners(
     workspace_cache: &WorkspaceCache,
     preview: Preview,
     malware_settings: &MalwareCheckSettings,
+    sync: bool,
 ) -> Result<BTreeMap<ModuleName, Vec<String>>> {
     let (extras, groups) = target_selection(target);
     let Some(package_ids) = selected_package_ids(target, venv, &extras, &groups, settings)? else {
         return Ok(BTreeMap::new());
     };
 
-    let reinstall = Reinstall::None;
-    let installer_settings = InstallerSettingsRef {
-        index_locations: &settings.index_locations,
-        index_strategy: settings.index_strategy,
-        keyring_provider: settings.keyring_provider,
-        dependency_metadata: &settings.dependency_metadata,
-        config_setting: &settings.config_setting,
-        config_settings_package: &settings.config_settings_package,
-        build_isolation: &settings.build_isolation,
-        extra_build_dependencies: &settings.extra_build_dependencies,
-        extra_build_variables: &settings.extra_build_variables,
-        exclude_newer: &settings.exclude_newer,
-        link_mode: settings.link_mode,
-        compile_bytecode: false,
-        reinstall: &reinstall,
-        build_options: &settings.build_options,
-        sources: settings.sources.clone(),
-    };
+    if sync {
+        let reinstall = Reinstall::None;
+        let installer_settings = InstallerSettingsRef {
+            index_locations: &settings.index_locations,
+            index_strategy: settings.index_strategy,
+            keyring_provider: settings.keyring_provider,
+            dependency_metadata: &settings.dependency_metadata,
+            config_setting: &settings.config_setting,
+            config_settings_package: &settings.config_settings_package,
+            build_isolation: &settings.build_isolation,
+            extra_build_dependencies: &settings.extra_build_dependencies,
+            extra_build_variables: &settings.extra_build_variables,
+            exclude_newer: &settings.exclude_newer,
+            link_mode: settings.link_mode,
+            compile_bytecode: false,
+            reinstall: &reinstall,
+            build_options: &settings.build_options,
+            sources: settings.sources.clone(),
+        };
 
-    do_sync(
-        target,
-        venv,
-        &extras,
-        &groups,
-        None,
-        InstallOptions::default(),
-        Modifications::Sufficient,
-        None,
-        installer_settings,
-        client_builder,
-        &state.fork(),
-        Box::new(DefaultInstallLogger),
-        false,
-        concurrency,
-        cache,
-        workspace_cache,
-        DryRun::Disabled,
-        Printer::Silent,
-        preview,
-        malware_settings,
-    )
-    .await?;
+        do_sync(
+            target,
+            venv,
+            &extras,
+            &groups,
+            None,
+            InstallOptions::default(),
+            Modifications::Sufficient,
+            None,
+            installer_settings,
+            client_builder,
+            &state.fork(),
+            Box::new(DefaultInstallLogger),
+            false,
+            concurrency,
+            cache,
+            workspace_cache,
+            DryRun::Disabled,
+            Printer::Silent,
+            preview,
+            malware_settings,
+        )
+        .await?;
+    }
 
     find_module_owners_in_environment(venv, &package_ids)
 }

--- a/crates/uv/tests/workspace/workspace_metadata.rs
+++ b/crates/uv/tests/workspace/workspace_metadata.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
-use assert_fs::fixture::{FileWriteStr, PathChild};
+use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 use async_zip::base::write::ZipFileWriter;
 use async_zip::{Compression, ZipEntryBuilder};
 use futures::executor::block_on;
@@ -126,6 +126,50 @@ fn workspace_metadata_simple() {
     Resolved 1 package in [TIME]
     "#
     );
+
+    assert!(!workspace.child(".venv").exists());
+}
+
+#[test]
+fn workspace_metadata_ignores_unusable_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.init().arg("foo").assert().success();
+
+    let workspace = context.temp_dir.child("foo");
+    let environment = workspace.child(".venv");
+    environment.create_dir_all()?;
+
+    let empty_output = context
+        .workspace_metadata()
+        .current_dir(&workspace)
+        .assert()
+        .success();
+    let empty_metadata: serde_json::Value =
+        serde_json::from_slice(&empty_output.get_output().stdout)?;
+
+    environment
+        .child("pyvenv.cfg")
+        .write_str("home = /missing-python\n")?;
+
+    let broken_output = context
+        .workspace_metadata()
+        .current_dir(&workspace)
+        .assert()
+        .success();
+    let broken_metadata: serde_json::Value =
+        serde_json::from_slice(&broken_output.get_output().stdout)?;
+
+    insta::assert_json_snapshot!(serde_json::json!({
+        "broken_environment": broken_metadata.get("environment"),
+        "empty_environment": empty_metadata.get("environment"),
+    }), @r#"
+    {
+      "broken_environment": null,
+      "empty_environment": null
+    }
+    "#);
+
+    Ok(())
 }
 
 #[test]
@@ -306,6 +350,52 @@ print("Hello, world!")
     );
 
     assert!(!context.temp_dir.child("script.py.lock").exists());
+
+    Ok(())
+}
+
+#[test]
+fn workspace_metadata_script_includes_existing_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin();
+    let script = context.temp_dir.child("script.py");
+    script.write_str(
+        r#"# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"#,
+    )?;
+
+    context
+        .workspace_metadata()
+        .arg("--script")
+        .arg(script.path())
+        .arg("--sync")
+        .assert()
+        .success();
+
+    let assert = context
+        .workspace_metadata()
+        .arg("--script")
+        .arg(script.path())
+        .assert()
+        .success();
+    let metadata: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
+
+    insta::with_settings!({ filters => context.filters() }, {
+        insta::assert_json_snapshot!(metadata["environment"], @r#"
+        {
+          "python": {
+            "implementation": "cpython",
+            "path": "[CACHE_DIR]/environments-v2/script-[HASH]/[BIN]/[PYTHON]",
+            "version": "3.12.[X]"
+          },
+          "root": "[CACHE_DIR]/environments-v2/script-[HASH]"
+        }
+        "#);
+    });
 
     Ok(())
 }
@@ -530,6 +620,20 @@ fn workspace_metadata_sync_centralized_environment() -> Result<()> {
         target.parent(),
         Some(context.cache_dir.child("environments-v2").path())
     );
+
+    let assert = context
+        .workspace_metadata()
+        .arg("--preview-features")
+        .arg("workspace-metadata,centralized-project-envs")
+        .assert()
+        .success();
+    let metadata: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
+
+    assert_eq!(
+        metadata["environment"]["root"].as_str().map(Path::new),
+        Some(target.as_path())
+    );
+
     Ok(())
 }
 
@@ -575,6 +679,112 @@ fn workspace_metadata_sync_active_environment() -> Result<()> {
         metadata["environment"]["root"].as_str().map(Path::new),
         Some(active.path())
     );
+
+    let assert = context
+        .workspace_metadata()
+        .arg("--active")
+        .env(EnvVars::VIRTUAL_ENV, active.path())
+        .assert()
+        .success();
+    let metadata: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
+
+    assert_eq!(
+        metadata["environment"]["root"].as_str().map(Path::new),
+        Some(active.path())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn workspace_metadata_includes_existing_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin();
+
+    let installed_owner = context
+        .temp_dir
+        .child("installed_owner-0.1.0-py3-none-any.whl");
+    write_wheel(
+        installed_owner.path(),
+        "installed-owner",
+        "installed_owner-0.1.0",
+        &[("installed_module.py", "")],
+    )?;
+
+    let missing_owner = context
+        .temp_dir
+        .child("missing_owner-0.1.0-py3-none-any.whl");
+    write_wheel(
+        missing_owner.path(),
+        "missing-owner",
+        "missing_owner-0.1.0",
+        &[("missing_module.py", "")],
+    )?;
+
+    let installed_owner_url = Url::from_file_path(installed_owner.path())
+        .map_err(|()| anyhow::anyhow!("failed to convert wheel path to file URL"))?;
+    let missing_owner_url = Url::from_file_path(missing_owner.path())
+        .map_err(|()| anyhow::anyhow!("failed to convert wheel path to file URL"))?;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&format!(
+            r#"[project]
+name = "module-owner-root"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "installed-owner @ {installed_owner_url}",
+  "missing-owner @ {missing_owner_url}",
+]
+"#
+        ))?;
+
+    context.lock().assert().success();
+    context
+        .pip_install()
+        .arg(installed_owner.path())
+        .assert()
+        .success();
+
+    // Removing the uninstalled wheel makes any accidental synchronization fail.
+    fs_err::remove_file(missing_owner.path())?;
+
+    let assert = context
+        .workspace_metadata()
+        .arg("--frozen")
+        .assert()
+        .success();
+    let metadata: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
+
+    insta::with_settings!({ filters => context.filters() }, {
+        insta::assert_json_snapshot!(serde_json::json!({
+            "environment": metadata["environment"],
+            "module_owners": metadata["module_owners"],
+        }), @r#"
+        {
+          "environment": {
+            "python": {
+              "implementation": "cpython",
+              "path": "[VENV]/[BIN]/[PYTHON]",
+              "version": "3.12.[X]"
+            },
+            "root": "[VENV]/"
+          },
+          "module_owners": {
+            "installed_module": [
+              {
+                "package_id": "installed-owner==0.1.0@path+[TEMP_DIR]/installed_owner-0.1.0-py3-none-any.whl"
+              }
+            ]
+          }
+        }
+        "#);
+    });
+
+    context.pip_show().arg("missing-owner").assert().failure();
 
     Ok(())
 }

--- a/docs/reference/internals/metadata.md
+++ b/docs/reference/internals/metadata.md
@@ -168,7 +168,7 @@ Here is a human-readable annotated example:
   },
   // The directory the uv.lock can be found in
   "workspace_root": "/workspace",
-  // Information about the environment, currently only available with `--sync`
+  // Information about the environment, available when an environment exists or `--sync` is used
   "environment": {
     // The absolute path to the environment root
     "root": "/workspace/.venv",


### PR DESCRIPTION
This produces the extra metadata we gate behind `--sync` while just trusting whatever's in the venv. The specific usecase of interest is `uv check` is forced to sync anyway, and knows what *precisely* to sync (i.e. only selected members), while `uv workspace metadata --sync` forces a sync of the whole workspace, which would clobber it.

Rather than trying to forward along package-selection args for ty to replay, we can just have ty rely on the fact that uv already sync'd and ask for the metadata. Notably for pep723 scripts we don't have this same problem, so it's fine for ty to pass `--sync` on-demand if it wants.

Also for the lsp case `uv workspace metadata --sync` being full workspace is desirable so that works well.