### PR TITLE
make references explicit when promoting PRs from uv-dev

### DIFF
--- a/.github/workflows/promote-pull-request.yml
+++ b/.github/workflows/promote-pull-request.yml
@@ -125,7 +125,20 @@ jobs:
               jq \
                 --arg base_ref "$BASE_REF" \
                 --arg head_ref "astral-sh:$HEAD_REF" \
-                '{title: .title, body: (.body // ""), base: $base_ref, head: $head_ref, head_repo: "astral-sh/uv-dev"}' \
+                --arg source_repository "$GITHUB_REPOSITORY" \
+                '{
+                  title: .title,
+                  body: (
+                    (.body // "")
+                    | gsub(
+                      "(?<![[:alnum:]_/])#(?<number>[0-9]+)(?![[:alnum:]_])";
+                      "\($source_repository)#\(.number)"
+                    )
+                  ),
+                  base: $base_ref,
+                  head: $head_ref,
+                  head_repo: "astral-sh/uv-dev"
+                }' \
                 "$RUNNER_TEMP/pull-request.json" |
                 gh api \
                   --method POST \


### PR DESCRIPTION
uses a jq substitution to transform references on PR promotion from uv-dev.

`Fixes #123` -> `Fixes astral-sh/uv-dev#123`

skips any such references that do not immediately follow whitespace.