### PR TITLE
Remove obsolete Python upgrade preview feature

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -328,8 +328,8 @@ pub struct GlobalArgs {
     ///
     /// Use comma-separated values or pass multiple times to enable multiple features.
     ///
-    /// The following features are available: `python-install-default`, `python-upgrade`,
-    /// `json-output`, `pylock`, `add-bounds`.
+    /// The following features are available: `python-install-default`, `json-output`, `pylock`,
+    /// `add-bounds`.
     #[arg(
         global = true,
         long = "preview-features",

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -225,7 +225,6 @@ pub mod test {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreviewFeature {
     PythonInstallDefault = 1 << 0,
-    PythonUpgrade = 1 << 1,
     JsonOutput = 1 << 2,
     Pylock = 1 << 3,
     AddBounds = 1 << 4,
@@ -271,7 +270,6 @@ impl PreviewFeature {
     fn as_str(self) -> &'static str {
         match self {
             Self::PythonInstallDefault => "python-install-default",
-            Self::PythonUpgrade => "python-upgrade",
             Self::JsonOutput => "json-output",
             Self::Pylock => "pylock",
             Self::AddBounds => "add-bounds",
@@ -330,7 +328,6 @@ impl FromStr for PreviewFeature {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
             "python-install-default" => Self::PythonInstallDefault,
-            "python-upgrade" => Self::PythonUpgrade,
             "json-output" => Self::JsonOutput,
             "pylock" => Self::Pylock,
             "add-bounds" => Self::AddBounds,
@@ -544,9 +541,9 @@ mod tests {
         assert_eq!(preview.flags, PreviewFeature::PythonInstallDefault);
 
         // Test multiple features
-        let preview = Preview::from_str("python-upgrade,json-output").unwrap();
-        assert!(preview.is_enabled(PreviewFeature::PythonUpgrade));
+        let preview = Preview::from_str("json-output,pylock").unwrap();
         assert!(preview.is_enabled(PreviewFeature::JsonOutput));
+        assert!(preview.is_enabled(PreviewFeature::Pylock));
         assert_eq!(preview.flags.bits().count_ones(), 2);
 
         let preview = Preview::from_str("tool-install-locks").unwrap();
@@ -585,8 +582,8 @@ mod tests {
         assert_eq!(preview.to_string(), "python-install-default");
 
         // Test multiple features
-        let preview = Preview::new(&[PreviewFeature::PythonUpgrade, PreviewFeature::Pylock]);
-        assert_eq!(preview.to_string(), "python-upgrade,pylock");
+        let preview = Preview::new(&[PreviewFeature::JsonOutput, PreviewFeature::Pylock]);
+        assert_eq!(preview.to_string(), "json-output,pylock");
     }
 
     #[test]
@@ -595,7 +592,6 @@ mod tests {
             PreviewFeature::PythonInstallDefault.as_str(),
             "python-install-default"
         );
-        assert_eq!(PreviewFeature::PythonUpgrade.as_str(), "python-upgrade");
         assert_eq!(PreviewFeature::JsonOutput.as_str(), "json-output");
         assert_eq!(PreviewFeature::Pylock.as_str(), "pylock");
         assert_eq!(

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -2926,7 +2926,7 @@ struct PreviewOptionsDefinition {
         example = r#"
             preview-features = true
             # or
-            preview-features = ["python-upgrade"]
+            preview-features = ["json-output"]
         "#
     )]
     preview_features: Option<PreviewFeaturesOption>,

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3187,7 +3187,6 @@ fn preview_features() {
     -        flags: [],
     +        flags: [
     +            PythonInstallDefault,
-    +            PythonUpgrade,
     +            JsonOutput,
     +            Pylock,
     +            AddBounds,
@@ -3245,7 +3244,7 @@ fn preview_features() {
     diff_uv_snapshot!(context.filters(), &preview, add_shared_args(context.version()).arg("--show-settings").arg("--preview").arg("--preview-features").arg("python-install-default"), @""
     );
 
-    let preview_features = diff_uv_snapshot!(context.filters(), &baseline, add_shared_args(context.version()).arg("--show-settings").arg("--preview-features").arg("python-install-default,python-upgrade"), @"
+    let preview_features = diff_uv_snapshot!(context.filters(), &baseline, add_shared_args(context.version()).arg("--show-settings").arg("--preview-features").arg("python-install-default,json-output"), @"
     ...
          },
          show_settings: true,
@@ -3253,7 +3252,7 @@ fn preview_features() {
     -        flags: [],
     +        flags: [
     +            PythonInstallDefault,
-    +            PythonUpgrade,
+    +            JsonOutput,
     +        ],
          },
          python_preference: Managed,
@@ -3268,7 +3267,7 @@ fn preview_features() {
         add_shared_args(context.version())
             .arg("--show-settings")
             .arg("--preview-features")
-            .arg("python-install-default,unknown-preview-feature,python-upgrade"),
+            .arg("python-install-default,unknown-preview-feature,json-output"),
         @"
     ...
              malware_check_url: None,
@@ -3288,7 +3287,7 @@ fn preview_features() {
             .arg("--show-settings")
             .env(
                 EnvVars::UV_PREVIEW_FEATURES,
-                "python-install-default,unknown-preview-feature,python-upgrade",
+                "python-install-default,unknown-preview-feature,json-output",
             ),
         @"
     ...
@@ -3303,14 +3302,14 @@ fn preview_features() {
     );
 
     // Compare against output with both features passed to one `--preview-features` option.
-    diff_uv_snapshot!(context.filters(), &preview_features, add_shared_args(context.version()).arg("--show-settings").arg("--preview-features").arg("python-install-default").arg("--preview-feature").arg("python-upgrade"), @""
+    diff_uv_snapshot!(context.filters(), &preview_features, add_shared_args(context.version()).arg("--show-settings").arg("--preview-features").arg("python-install-default").arg("--preview-feature").arg("json-output"), @""
     );
 
     diff_uv_snapshot!(
         context.filters(),
         &baseline,
         add_shared_args(context.version()).arg("--show-settings")
-        .arg("--preview-features").arg("python-install-default").arg("--preview-feature").arg("python-upgrade")
+        .arg("--preview-features").arg("python-install-default").arg("--preview-feature").arg("json-output")
         .arg("--no-preview"),
         @""
     );
@@ -3320,7 +3319,7 @@ fn preview_features() {
         add_shared_args(context.version())
             .arg("--show-settings")
             .arg("--preview-features")
-            .arg("python-install-default,,python-upgrade"),
+            .arg("python-install-default,,json-output"),
         @"
     exit_code: 2 (failure)
     ----- stderr -----
@@ -3336,7 +3335,7 @@ fn preview_features() {
             .arg("--show-settings")
             .env(
                 EnvVars::UV_PREVIEW_FEATURES,
-                "python-install-default,,python-upgrade",
+                "python-install-default,,json-output",
             ),
         @"
     exit_code: 2 (failure)

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1765,7 +1765,6 @@
         {
           "enum": [
             "python-install-default",
-            "python-upgrade",
             "json-output",
             "pylock",
             "add-bounds",


### PR DESCRIPTION
## Summary

We stabilised this ages ago but we still handle the preview feature.

Ignore the diff on the CLI arg which implies we don't have many preview features, fixing that separately.

Also, is this internal? Who knows... Doesn't seem CHANGELOG worthy.