### PR TITLE
De-duplicate some CLI parsing structures

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3264,23 +3264,8 @@ pub struct VenvArgs {
     #[command(flatten)]
     pub index_args: IndexArgs,
 
-    /// The strategy to use when resolving against multiple index URLs.
-    ///
-    /// By default, uv will stop at the first index on which a given package is available, and
-    /// limit resolutions to those present on that first index (`first-index`). This prevents
-    /// "dependency confusion" attacks, whereby an attacker can upload a malicious package under the
-    /// same name to an alternate index.
-    #[arg(long, value_enum, env = EnvVars::UV_INDEX_STRATEGY)]
-    pub index_strategy: Option<IndexStrategy>,
-
-    /// Attempt to use `keyring` for authentication for index URLs.
-    ///
-    /// At present, only `--keyring-provider subprocess` is supported, which configures uv to use
-    /// the `keyring` CLI to handle authentication.
-    ///
-    /// Defaults to `disabled`.
-    #[arg(long, value_enum, env = EnvVars::UV_KEYRING_PROVIDER)]
-    pub keyring_provider: Option<KeyringProviderType>,
+    #[command(flatten)]
+    pub registry_client: RegistryClientArgs,
 
     /// Limit candidate packages to those that were uploaded prior to the given date.
     ///
@@ -6252,33 +6237,8 @@ pub struct ToolUpgradeArgs {
     #[command(flatten)]
     pub reinstall: ReinstallArgs,
 
-    /// The strategy to use when resolving against multiple index URLs.
-    ///
-    /// By default, uv will stop at the first index on which a given package is available, and limit
-    /// resolutions to those present on that first index (`first-index`). This prevents "dependency
-    /// confusion" attacks, whereby an attacker can upload a malicious package under the same name
-    /// to an alternate index.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_INDEX_STRATEGY,
-        help_heading = "Index options"
-    )]
-    pub index_strategy: Option<IndexStrategy>,
-
-    /// Attempt to use `keyring` for authentication for index URLs.
-    ///
-    /// At present, only `--keyring-provider subprocess` is supported, which configures uv to use
-    /// the `keyring` CLI to handle authentication.
-    ///
-    /// Defaults to `disabled`.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_KEYRING_PROVIDER,
-        help_heading = "Index options"
-    )]
-    pub keyring_provider: Option<KeyringProviderType>,
+    #[command(flatten)]
+    pub registry_client: RegistryClientArgs,
 
     /// The strategy to use when selecting between the different compatible versions for a given
     /// package requirement.
@@ -7265,6 +7225,39 @@ pub struct IndexArgs {
     pub no_index: bool,
 }
 
+/// Arguments that configure the package registry client.
+#[derive(Args)]
+#[group(skip)]
+pub struct RegistryClientArgs {
+    /// The strategy to use when resolving against multiple index URLs.
+    ///
+    /// By default, uv will stop at the first index on which a given package is available, and limit
+    /// resolutions to those present on that first index (`first-index`). This prevents "dependency
+    /// confusion" attacks, whereby an attacker can upload a malicious package under the same name
+    /// to an alternate index.
+    #[arg(
+        long,
+        value_enum,
+        env = EnvVars::UV_INDEX_STRATEGY,
+        help_heading = "Index options"
+    )]
+    pub index_strategy: Option<IndexStrategy>,
+
+    /// Attempt to use `keyring` for authentication for index URLs.
+    ///
+    /// At present, only `--keyring-provider subprocess` is supported, which configures uv to use
+    /// the `keyring` CLI to handle authentication.
+    ///
+    /// Defaults to `disabled`.
+    #[arg(
+        long,
+        value_enum,
+        env = EnvVars::UV_KEYRING_PROVIDER,
+        help_heading = "Index options"
+    )]
+    pub keyring_provider: Option<KeyringProviderType>,
+}
+
 #[derive(Args)]
 pub struct RefreshArgs {
     /// Refresh all cached data.
@@ -7384,33 +7377,8 @@ pub struct InstallerArgs {
     #[command(flatten)]
     reinstall: ReinstallArgs,
 
-    /// The strategy to use when resolving against multiple index URLs.
-    ///
-    /// By default, uv will stop at the first index on which a given package is available, and limit
-    /// resolutions to those present on that first index (`first-index`). This prevents "dependency
-    /// confusion" attacks, whereby an attacker can upload a malicious package under the same name
-    /// to an alternate index.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_INDEX_STRATEGY,
-        help_heading = "Index options"
-    )]
-    index_strategy: Option<IndexStrategy>,
-
-    /// Attempt to use `keyring` for authentication for index URLs.
-    ///
-    /// At present, only `--keyring-provider subprocess` is supported, which configures uv to use
-    /// the `keyring` CLI to handle authentication.
-    ///
-    /// Defaults to `disabled`.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_KEYRING_PROVIDER,
-        help_heading = "Index options"
-    )]
-    keyring_provider: Option<KeyringProviderType>,
+    #[command(flatten)]
+    registry_client: RegistryClientArgs,
 
     /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
     #[arg(
@@ -7582,33 +7550,8 @@ pub struct ResolverArgs {
     #[arg(long, help_heading = "Resolver options")]
     upgrade_group: Vec<GroupName>,
 
-    /// The strategy to use when resolving against multiple index URLs.
-    ///
-    /// By default, uv will stop at the first index on which a given package is available, and limit
-    /// resolutions to those present on that first index (`first-index`). This prevents "dependency
-    /// confusion" attacks, whereby an attacker can upload a malicious package under the same name
-    /// to an alternate index.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_INDEX_STRATEGY,
-        help_heading = "Index options"
-    )]
-    index_strategy: Option<IndexStrategy>,
-
-    /// Attempt to use `keyring` for authentication for index URLs.
-    ///
-    /// At present, only `--keyring-provider subprocess` is supported, which configures uv to use
-    /// the `keyring` CLI to handle authentication.
-    ///
-    /// Defaults to `disabled`.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_KEYRING_PROVIDER,
-        help_heading = "Index options"
-    )]
-    keyring_provider: Option<KeyringProviderType>,
+    #[command(flatten)]
+    registry_client: RegistryClientArgs,
 
     /// The strategy to use when selecting between the different compatible versions for a given
     /// package requirement.
@@ -7807,33 +7750,8 @@ pub struct ResolverInstallerArgs {
     #[command(flatten)]
     pub reinstall: ReinstallArgs,
 
-    /// The strategy to use when resolving against multiple index URLs.
-    ///
-    /// By default, uv will stop at the first index on which a given package is available, and limit
-    /// resolutions to those present on that first index (`first-index`). This prevents "dependency
-    /// confusion" attacks, whereby an attacker can upload a malicious package under the same name
-    /// to an alternate index.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_INDEX_STRATEGY,
-        help_heading = "Index options"
-    )]
-    pub index_strategy: Option<IndexStrategy>,
-
-    /// Attempt to use `keyring` for authentication for index URLs.
-    ///
-    /// At present, only `--keyring-provider subprocess` is supported, which configures uv to use
-    /// the `keyring` CLI to handle authentication.
-    ///
-    /// Defaults to `disabled`.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_KEYRING_PROVIDER,
-        help_heading = "Index options"
-    )]
-    pub keyring_provider: Option<KeyringProviderType>,
+    #[command(flatten)]
+    pub registry_client: RegistryClientArgs,
 
     /// The strategy to use when selecting between the different compatible versions for a given
     /// package requirement.
@@ -8036,33 +7954,8 @@ pub struct FetchArgs {
     #[command(flatten)]
     index_args: IndexArgs,
 
-    /// The strategy to use when resolving against multiple index URLs.
-    ///
-    /// By default, uv will stop at the first index on which a given package is available, and limit
-    /// resolutions to those present on that first index (`first-index`). This prevents "dependency
-    /// confusion" attacks, whereby an attacker can upload a malicious package under the same name
-    /// to an alternate index.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_INDEX_STRATEGY,
-        help_heading = "Index options"
-    )]
-    index_strategy: Option<IndexStrategy>,
-
-    /// Attempt to use `keyring` for authentication for index URLs.
-    ///
-    /// At present, only `--keyring-provider subprocess` is supported, which configures uv to use
-    /// the `keyring` CLI to handle authentication.
-    ///
-    /// Defaults to `disabled`.
-    #[arg(
-        long,
-        value_enum,
-        env = EnvVars::UV_KEYRING_PROVIDER,
-        help_heading = "Index options"
-    )]
-    keyring_provider: Option<KeyringProviderType>,
+    #[command(flatten)]
+    registry_client: RegistryClientArgs,
 
     /// Limit candidate packages to those that were uploaded prior to the given date.
     ///

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6382,35 +6382,8 @@ pub struct ToolUpgradeArgs {
     )]
     pub link_mode: Option<uv_install_wheel::LinkMode>,
 
-    /// Compile Python files to bytecode after installation.
-    ///
-    /// By default, uv does not compile Python (`.py`) files to bytecode (`__pycache__/*.pyc`);
-    /// instead, compilation is performed lazily the first time a module is imported. For use-cases
-    /// in which start time is critical, such as CLI applications and Docker containers, this option
-    /// can be enabled to trade longer installation times for faster start times.
-    ///
-    /// When enabled, install operations (e.g., `uv pip install`) will compile installed or
-    /// reinstalled Python files. Commands that perform a sync operation (e.g., `uv sync` or `uv
-    /// run`) will process the entire site-packages directory including packages that are not being
-    /// modified.
-    #[arg(
-        long,
-        alias = "compile",
-        overrides_with("no_compile_bytecode"),
-        help_heading = "Installer options",
-        env = EnvVars::UV_COMPILE_BYTECODE,
-        value_parser = clap::builder::BoolishValueParser::new(),
-    )]
-    pub compile_bytecode: bool,
-
-    #[arg(
-        long,
-        alias = "no-compile",
-        overrides_with("compile_bytecode"),
-        hide = true,
-        help_heading = "Installer options"
-    )]
-    pub no_compile_bytecode: bool,
+    #[command(flatten)]
+    pub compile_bytecode: CompileBytecodeArgs,
 
     /// Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
     /// standards-compliant, publishable package metadata, as opposed to using any workspace, Git,
@@ -7368,6 +7341,40 @@ pub struct ReinstallArgs {
     pub reinstall_package: Vec<PackageName>,
 }
 
+#[derive(Args)]
+#[group(skip)]
+pub struct CompileBytecodeArgs {
+    /// Compile Python files to bytecode after installation.
+    ///
+    /// By default, uv does not compile Python (`.py`) files to bytecode (`__pycache__/*.pyc`);
+    /// instead, compilation is performed lazily the first time a module is imported. For use-cases
+    /// in which start time is critical, such as CLI applications and Docker containers, this option
+    /// can be enabled to trade longer installation times for faster start times.
+    ///
+    /// When enabled, install operations (e.g., `uv pip install`) will compile installed or
+    /// reinstalled Python files. Commands that perform a sync operation (e.g., `uv sync` or `uv
+    /// run`) will process the entire site-packages directory including packages that are not being
+    /// modified.
+    #[arg(
+        long,
+        alias = "compile",
+        overrides_with("no_compile_bytecode"),
+        help_heading = "Installer options",
+        env = EnvVars::UV_COMPILE_BYTECODE,
+        value_parser = clap::builder::BoolishValueParser::new(),
+    )]
+    compile_bytecode: bool,
+
+    #[arg(
+        long,
+        alias = "no-compile",
+        overrides_with("compile_bytecode"),
+        hide = true,
+        help_heading = "Installer options"
+    )]
+    no_compile_bytecode: bool,
+}
+
 /// Arguments that are used by commands that need to install (but not resolve) packages.
 #[derive(Args)]
 pub struct InstallerArgs {
@@ -7470,35 +7477,8 @@ pub struct InstallerArgs {
     )]
     link_mode: Option<uv_install_wheel::LinkMode>,
 
-    /// Compile Python files to bytecode after installation.
-    ///
-    /// By default, uv does not compile Python (`.py`) files to bytecode (`__pycache__/*.pyc`);
-    /// instead, compilation is performed lazily the first time a module is imported. For use-cases
-    /// in which start time is critical, such as CLI applications and Docker containers, this option
-    /// can be enabled to trade longer installation times for faster start times.
-    ///
-    /// When enabled, install operations (e.g., `uv pip install`) will compile installed or
-    /// reinstalled Python files. Commands that perform a sync operation (e.g., `uv sync` or `uv
-    /// run`) will process the entire site-packages directory including packages that are not being
-    /// modified.
-    #[arg(
-        long,
-        alias = "compile",
-        overrides_with("no_compile_bytecode"),
-        help_heading = "Installer options",
-        env = EnvVars::UV_COMPILE_BYTECODE,
-        value_parser = clap::builder::BoolishValueParser::new(),
-    )]
-    compile_bytecode: bool,
-
-    #[arg(
-        long,
-        alias = "no-compile",
-        overrides_with("compile_bytecode"),
-        hide = true,
-        help_heading = "Installer options"
-    )]
-    no_compile_bytecode: bool,
+    #[command(flatten)]
+    compile_bytecode: CompileBytecodeArgs,
 
     /// Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
     /// standards-compliant, publishable package metadata, as opposed to using any workspace, Git,
@@ -7902,35 +7882,8 @@ pub struct ResolverInstallerArgs {
     )]
     pub link_mode: Option<uv_install_wheel::LinkMode>,
 
-    /// Compile Python files to bytecode after installation.
-    ///
-    /// By default, uv does not compile Python (`.py`) files to bytecode (`__pycache__/*.pyc`);
-    /// instead, compilation is performed lazily the first time a module is imported. For use-cases
-    /// in which start time is critical, such as CLI applications and Docker containers, this option
-    /// can be enabled to trade longer installation times for faster start times.
-    ///
-    /// When enabled, install operations (e.g., `uv pip install`) will compile installed or
-    /// reinstalled Python files. Commands that perform a sync operation (e.g., `uv sync` or `uv
-    /// run`) will process the entire site-packages directory including packages that are not being
-    /// modified.
-    #[arg(
-        long,
-        alias = "compile",
-        overrides_with("no_compile_bytecode"),
-        help_heading = "Installer options",
-        env = EnvVars::UV_COMPILE_BYTECODE,
-        value_parser = clap::builder::BoolishValueParser::new(),
-    )]
-    pub compile_bytecode: bool,
-
-    #[arg(
-        long,
-        alias = "no-compile",
-        overrides_with("compile_bytecode"),
-        hide = true,
-        help_heading = "Installer options"
-    )]
-    pub no_compile_bytecode: bool,
+    #[command(flatten)]
+    pub compile_bytecode: CompileBytecodeArgs,
 
     /// Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
     /// standards-compliant, publishable package metadata, as opposed to using any workspace, Git,

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6249,28 +6249,8 @@ pub struct ToolUpgradeArgs {
     #[command(flatten)]
     pub index_args: IndexArgs,
 
-    /// Reinstall all packages, regardless of whether they're already installed. Implies
-    /// `--refresh`.
-    #[arg(
-        long,
-        alias = "force-reinstall",
-        overrides_with("no_reinstall"),
-        help_heading = "Installer options"
-    )]
-    pub reinstall: bool,
-
-    #[arg(
-        long,
-        overrides_with("reinstall"),
-        hide = true,
-        help_heading = "Installer options"
-    )]
-    pub no_reinstall: bool,
-
-    /// Reinstall a specific package, regardless of whether it's already installed. Implies
-    /// `--refresh-package`.
-    #[arg(long, help_heading = "Installer options", value_hint = ValueHint::Other)]
-    pub reinstall_package: Vec<PackageName>,
+    #[command(flatten)]
+    pub reinstall: ReinstallArgs,
 
     /// The strategy to use when resolving against multiple index URLs.
     ///
@@ -7368,12 +7348,9 @@ pub struct BuildOptionsArgs {
     no_binary_package: Vec<PackageName>,
 }
 
-/// Arguments that are used by commands that need to install (but not resolve) packages.
 #[derive(Args)]
-pub struct InstallerArgs {
-    #[command(flatten)]
-    index_args: IndexArgs,
-
+#[group(skip)]
+pub struct ReinstallArgs {
     /// Reinstall all packages, regardless of whether they're already installed. Implies
     /// `--refresh`.
     #[arg(
@@ -7382,7 +7359,7 @@ pub struct InstallerArgs {
         overrides_with("no_reinstall"),
         help_heading = "Installer options"
     )]
-    reinstall: bool,
+    pub reinstall: bool,
 
     #[arg(
         long,
@@ -7390,12 +7367,22 @@ pub struct InstallerArgs {
         hide = true,
         help_heading = "Installer options"
     )]
-    no_reinstall: bool,
+    pub no_reinstall: bool,
 
     /// Reinstall a specific package, regardless of whether it's already installed. Implies
     /// `--refresh-package`.
     #[arg(long, help_heading = "Installer options", value_hint = ValueHint::Other)]
-    reinstall_package: Vec<PackageName>,
+    pub reinstall_package: Vec<PackageName>,
+}
+
+/// Arguments that are used by commands that need to install (but not resolve) packages.
+#[derive(Args)]
+pub struct InstallerArgs {
+    #[command(flatten)]
+    index_args: IndexArgs,
+
+    #[command(flatten)]
+    reinstall: ReinstallArgs,
 
     /// The strategy to use when resolving against multiple index URLs.
     ///
@@ -7817,28 +7804,8 @@ pub struct ResolverInstallerArgs {
     #[arg(long, help_heading = "Resolver options")]
     pub upgrade_group: Vec<GroupName>,
 
-    /// Reinstall all packages, regardless of whether they're already installed. Implies
-    /// `--refresh`.
-    #[arg(
-        long,
-        alias = "force-reinstall",
-        overrides_with("no_reinstall"),
-        help_heading = "Installer options"
-    )]
-    pub reinstall: bool,
-
-    #[arg(
-        long,
-        overrides_with("reinstall"),
-        hide = true,
-        help_heading = "Installer options"
-    )]
-    pub no_reinstall: bool,
-
-    /// Reinstall a specific package, regardless of whether it's already installed. Implies
-    /// `--refresh-package`.
-    #[arg(long, help_heading = "Installer options", value_hint = ValueHint::Other)]
-    pub reinstall_package: Vec<PackageName>,
+    #[command(flatten)]
+    pub reinstall: ReinstallArgs,
 
     /// The strategy to use when resolving against multiple index URLs.
     ///

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -10,8 +10,8 @@ use uv_settings::{Combine, EnvFlag, PipOptions, ResolverInstallerOptions, Resolv
 use uv_warnings::owo_colors::OwoColorize;
 
 use crate::{
-    BuildOptionsArgs, FetchArgs, IndexArgs, InstallerArgs, Maybe, RefreshArgs, RegistryClientArgs,
-    ReinstallArgs, ResolverArgs, ResolverInstallerArgs,
+    BuildOptionsArgs, CompileBytecodeArgs, FetchArgs, IndexArgs, InstallerArgs, Maybe, RefreshArgs,
+    RegistryClientArgs, ReinstallArgs, ResolverArgs, ResolverInstallerArgs,
 };
 
 /// Given a boolean flag pair (like `--upgrade` and `--no-upgrade`), resolve the value of the flag.
@@ -340,8 +340,11 @@ impl From<InstallerArgs> for PipOptions {
             build_isolation,
             exclude_newer,
             link_mode,
-            compile_bytecode,
-            no_compile_bytecode,
+            compile_bytecode:
+                CompileBytecodeArgs {
+                    compile_bytecode,
+                    no_compile_bytecode,
+                },
             no_sources,
             no_sources_package,
             exclude_newer_package,
@@ -405,8 +408,11 @@ impl From<ResolverInstallerArgs> for PipOptions {
             build_isolation,
             exclude_newer,
             link_mode,
-            compile_bytecode,
-            no_compile_bytecode,
+            compile_bytecode:
+                CompileBytecodeArgs {
+                    compile_bytecode,
+                    no_compile_bytecode,
+                },
             no_sources,
             no_sources_package,
             exclude_newer_package,
@@ -677,8 +683,11 @@ pub fn resolver_installer_options_with_indexes(
         exclude_newer,
         exclude_newer_package,
         link_mode,
-        compile_bytecode,
-        no_compile_bytecode,
+        compile_bytecode:
+            CompileBytecodeArgs {
+                compile_bytecode,
+                no_compile_bytecode,
+            },
         no_sources,
         no_sources_package,
     } = resolver_installer_args;

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -10,8 +10,8 @@ use uv_settings::{Combine, EnvFlag, PipOptions, ResolverInstallerOptions, Resolv
 use uv_warnings::owo_colors::OwoColorize;
 
 use crate::{
-    BuildOptionsArgs, FetchArgs, IndexArgs, InstallerArgs, Maybe, RefreshArgs, ResolverArgs,
-    ResolverInstallerArgs,
+    BuildOptionsArgs, FetchArgs, IndexArgs, InstallerArgs, Maybe, RefreshArgs, ReinstallArgs,
+    ResolverArgs, ResolverInstallerArgs,
 };
 
 /// Given a boolean flag pair (like `--upgrade` and `--no-upgrade`), resolve the value of the flag.
@@ -320,9 +320,12 @@ impl From<InstallerArgs> for PipOptions {
     fn from(args: InstallerArgs) -> Self {
         let InstallerArgs {
             index_args,
-            reinstall,
-            no_reinstall,
-            reinstall_package,
+            reinstall:
+                ReinstallArgs {
+                    reinstall,
+                    no_reinstall,
+                    reinstall_package,
+                },
             index_strategy,
             keyring_provider,
             config_setting,
@@ -374,9 +377,12 @@ impl From<ResolverInstallerArgs> for PipOptions {
             no_upgrade,
             upgrade_package,
             upgrade_group,
-            reinstall,
-            no_reinstall,
-            reinstall_package,
+            reinstall:
+                ReinstallArgs {
+                    reinstall,
+                    no_reinstall,
+                    reinstall_package,
+                },
             index_strategy,
             keyring_provider,
             resolution,
@@ -633,9 +639,12 @@ pub fn resolver_installer_options_with_indexes(
         no_upgrade,
         upgrade_package,
         upgrade_group,
-        reinstall,
-        no_reinstall,
-        reinstall_package,
+        reinstall:
+            ReinstallArgs {
+                reinstall,
+                no_reinstall,
+                reinstall_package,
+            },
         index_strategy,
         keyring_provider,
         resolution,

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -10,8 +10,8 @@ use uv_settings::{Combine, EnvFlag, PipOptions, ResolverInstallerOptions, Resolv
 use uv_warnings::owo_colors::OwoColorize;
 
 use crate::{
-    BuildOptionsArgs, FetchArgs, IndexArgs, InstallerArgs, Maybe, RefreshArgs, ReinstallArgs,
-    ResolverArgs, ResolverInstallerArgs,
+    BuildOptionsArgs, FetchArgs, IndexArgs, InstallerArgs, Maybe, RefreshArgs, RegistryClientArgs,
+    ReinstallArgs, ResolverArgs, ResolverInstallerArgs,
 };
 
 /// Given a boolean flag pair (like `--upgrade` and `--no-upgrade`), resolve the value of the flag.
@@ -253,8 +253,11 @@ impl From<ResolverArgs> for PipOptions {
             no_upgrade,
             upgrade_package,
             upgrade_group,
-            index_strategy,
-            keyring_provider,
+            registry_client:
+                RegistryClientArgs {
+                    index_strategy,
+                    keyring_provider,
+                },
             resolution,
             prerelease,
             pre,
@@ -326,8 +329,11 @@ impl From<InstallerArgs> for PipOptions {
                     no_reinstall,
                     reinstall_package,
                 },
-            index_strategy,
-            keyring_provider,
+            registry_client:
+                RegistryClientArgs {
+                    index_strategy,
+                    keyring_provider,
+                },
             config_setting,
             config_settings_package,
             no_build_isolation,
@@ -383,8 +389,11 @@ impl From<ResolverInstallerArgs> for PipOptions {
                     no_reinstall,
                     reinstall_package,
                 },
-            index_strategy,
-            keyring_provider,
+            registry_client:
+                RegistryClientArgs {
+                    index_strategy,
+                    keyring_provider,
+                },
             resolution,
             prerelease,
             pre,
@@ -455,8 +464,11 @@ impl From<FetchArgs> for PipOptions {
     fn from(args: FetchArgs) -> Self {
         let FetchArgs {
             index_args,
-            index_strategy,
-            keyring_provider,
+            registry_client:
+                RegistryClientArgs {
+                    index_strategy,
+                    keyring_provider,
+                },
             exclude_newer,
         } = args;
 
@@ -512,8 +524,11 @@ pub fn resolver_options(
         no_upgrade,
         upgrade_package,
         upgrade_group,
-        index_strategy,
-        keyring_provider,
+        registry_client:
+            RegistryClientArgs {
+                index_strategy,
+                keyring_provider,
+            },
         resolution,
         prerelease,
         pre,
@@ -645,8 +660,11 @@ pub fn resolver_installer_options_with_indexes(
                 no_reinstall,
                 reinstall_package,
             },
-        index_strategy,
-        keyring_provider,
+        registry_client:
+            RegistryClientArgs {
+                index_strategy,
+                keyring_provider,
+            },
         resolution,
         prerelease,
         pre,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -25,7 +25,7 @@ use uv_cli::{
 };
 use uv_cli::{
     AuthorFrom, BuildArgs, CheckArgs, ExportArgs, FormatArgs, PublishArgs, PythonDirArgs,
-    ResolverInstallerArgs, ToolUpgradeArgs,
+    RegistryClientArgs, ResolverInstallerArgs, ToolUpgradeArgs,
     options::{
         Flag, FlagSource, check_conflicts, flag, indexes_from_args, resolve_flag,
         resolve_flag_pair, resolver_installer_options, resolver_installer_options_with_indexes,
@@ -1172,8 +1172,7 @@ impl ToolUpgradeSettings {
             index_args,
             all,
             reinstall,
-            index_strategy,
-            keyring_provider,
+            registry_client,
             resolution,
             prerelease,
             pre,
@@ -1208,8 +1207,7 @@ impl ToolUpgradeSettings {
             upgrade_package,
             upgrade_group,
             reinstall,
-            index_strategy,
-            keyring_provider,
+            registry_client,
             resolution,
             prerelease,
             pre,
@@ -4193,8 +4191,11 @@ impl VenvSettings {
             relocatable,
             no_relocatable,
             index_args,
-            index_strategy,
-            keyring_provider,
+            registry_client:
+                RegistryClientArgs {
+                    index_strategy,
+                    keyring_provider,
+                },
             exclude_newer,
             no_project,
             link_mode,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -935,7 +935,7 @@ impl ToolRunSettings {
         }
 
         // If `--reinstall` was passed explicitly, warn.
-        if installer.reinstall || !installer.reinstall_package.is_empty() {
+        if installer.reinstall.reinstall || !installer.reinstall.reinstall_package.is_empty() {
             if with.is_empty() && with_requirements.is_empty() {
                 warn_user_once!(
                     "Tools cannot be reinstalled via `{invocation_source}`; use `uv tool upgrade --all --reinstall` to reinstall all installed tools, `{invocation_source} package@latest` to run the latest version of a tool, or `uv cache prune` to clear any cached tool environments."
@@ -1172,8 +1172,6 @@ impl ToolUpgradeSettings {
             index_args,
             all,
             reinstall,
-            no_reinstall,
-            reinstall_package,
             index_strategy,
             keyring_provider,
             resolution,
@@ -1210,8 +1208,6 @@ impl ToolUpgradeSettings {
             upgrade_package,
             upgrade_group,
             reinstall,
-            no_reinstall,
-            reinstall_package,
             index_strategy,
             keyring_provider,
             resolution,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1185,7 +1185,6 @@ impl ToolUpgradeSettings {
             exclude_newer,
             link_mode,
             compile_bytecode,
-            no_compile_bytecode,
             no_sources,
             no_sources_package,
             exclude_newer_package,
@@ -1221,7 +1220,6 @@ impl ToolUpgradeSettings {
             exclude_newer_package,
             link_mode,
             compile_bytecode,
-            no_compile_bytecode,
             no_sources,
             no_sources_package,
         };


### PR DESCRIPTION
## Summary

These are just mental overhead at this point more than anything, this does increase the possibility that we accidentally end up adding an option to more places than intended, but I don't think the changes here are particularly susceptible to that _and_ I'm pretty certain we already have this bug somewhere (I'll find some by the next next breaking release).

Another option may be to split things up at the option level, and then use those as atoms for each CLI, but I'm also not sure it's worth it... I think there may be better (more automated) ways to fix the problem in the long term.