### PR TITLE
Support combined upgrade and reinstall in Python install

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6797,6 +6797,8 @@ pub struct PythonInstallArgs {
 
     /// Reinstall the requested Python version, if it's already installed.
     ///
+    /// If a minor version is requested, all matching installed patch versions are reinstalled.
+    ///
     /// By default, uv will exit successfully if the version is already
     /// installed.
     #[arg(long, short)]

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -486,37 +486,32 @@ async fn perform_install(
 
             for installation in matching_installations {
                 changelog.existing.insert(installation.key().clone());
-                if matches!(&request.request, &PythonRequest::Any) {
-                    // Construct an install request matching the existing installation
-                    match InstallRequest::new(
-                        PythonRequest::Key(installation.into()),
-                        &download_list,
-                    ) {
-                        Ok(request) => {
-                            debug!("Will reinstall `{}`", installation.key());
-                            unsatisfied.push(Cow::Owned(request));
-                        }
-                        Err(err) => {
-                            // This shouldn't really happen, but maybe a new version of uv dropped
-                            // support for a key we previously supported
-                            warn_user!(
-                                "Failed to create reinstall request for existing installation `{}`: {err}",
-                                installation.key().green()
-                            );
-                        }
-                    }
-                } else {
-                    // TODO(zanieb): This isn't really right! But we need `--upgrade` or similar
-                    // to handle this case correctly without causing a breaking change.
 
-                    // If we have real requests, just ignore the existing installation
-                    debug!(
-                        "Ignoring match `{}` for request `{}` due to `--reinstall` flag",
-                        installation.key(),
-                        request
-                    );
+                if matches!(
+                    upgrade,
+                    PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade)
+                ) && !matches!(&request.request, &PythonRequest::Any)
+                {
+                    // An upgrade must reinstall the latest patch, not every matching patch.
+                    debug!("Will reinstall the latest patch for `{}`", request);
                     unsatisfied.push(Cow::Borrowed(request));
                     break;
+                }
+
+                // Construct an install request matching the existing installation.
+                match InstallRequest::new(PythonRequest::Key(installation.into()), &download_list) {
+                    Ok(request) => {
+                        debug!("Will reinstall `{}`", installation.key());
+                        unsatisfied.push(Cow::Owned(request));
+                    }
+                    Err(err) => {
+                        // This shouldn't really happen, but maybe a new version of uv dropped
+                        // support for a key we previously supported.
+                        warn_user!(
+                            "Failed to create reinstall request for existing installation `{}`: {err}",
+                            installation.key().green()
+                        );
+                    }
                 }
             }
         }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -487,10 +487,8 @@ async fn perform_install(
             for installation in matching_installations {
                 changelog.existing.insert(installation.key().clone());
 
-                if matches!(
-                    upgrade,
-                    PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade)
-                ) && !matches!(&request.request, &PythonRequest::Any)
+                if matches!(upgrade, PythonUpgrade::Enabled(_))
+                    && !matches!(&request.request, &PythonRequest::Any)
                 {
                     // An upgrade must reinstall the latest patch, not every matching patch.
                     debug!("Will reinstall the latest patch for `{}`", request);

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -596,6 +596,8 @@ fn help_subsubcommand() {
       -r, --reinstall
               Reinstall the requested Python version, if it's already installed.
 
+              If a minor version is requested, all matching installed patch versions are reinstalled.
+
               By default, uv will exit successfully if the version is already installed.
 
       -f, --force

--- a/crates/uv/tests/python/python_install.rs
+++ b/crates/uv/tests/python/python_install.rs
@@ -3604,12 +3604,20 @@ fn python_install_upgrade() {
      + cpython-3.10.17-[PLATFORM] (python3.10)
     ");
 
-    // Ask for an `--upgrade`
-    uv_snapshot!(context.filters(), context.python_install().arg("--upgrade").arg("3.10"), @"
+    // Upgrade an outdated patch even when a reinstall is requested.
+    uv_snapshot!(context.filters(), context.python_install().arg("--upgrade").arg("--reinstall").arg("3.10"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Installed Python 3.10.[LATEST] in [TIME]
      + cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
+    ");
+
+    // Reinstall only the latest patch, leaving older installed patches untouched.
+    uv_snapshot!(context.filters(), context.python_install().arg("--upgrade").arg("--reinstall").arg("3.10"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Installed Python 3.10.[LATEST] in [TIME]
+     ~ cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
     ");
 
     // Request a patch version with `--upgrade`

--- a/crates/uv/tests/python/python_install.rs
+++ b/crates/uv/tests/python/python_install.rs
@@ -186,14 +186,13 @@ fn python_reinstall_patch() {
      + cpython-3.12.7-[PLATFORM] (python3.12)
     ");
 
-    // Reinstall all "3.12" versions
-    // TODO(zanieb): This doesn't work today, because we need this to install the "latest" as there
-    // is no workflow for `--upgrade` yet
+    // Reinstall all "3.12" versions.
     uv_snapshot!(context.filters(), context.python_install().arg("3.12").arg("--reinstall"), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Installed Python 3.12.[LATEST] in [TIME]
-     + cpython-3.12.[LATEST]-[PLATFORM] (python3.12)
+    Installed 2 versions in [TIME]
+     ~ cpython-3.12.6-[PLATFORM]
+     ~ cpython-3.12.7-[PLATFORM] (python3.12)
     ");
 }
 

--- a/crates/uv/tests/python/python_upgrade.rs
+++ b/crates/uv/tests/python/python_upgrade.rs
@@ -31,8 +31,8 @@ fn python_upgrade() {
     error: `uv python upgrade` only accepts minor versions, got: 3.10.17
     ");
 
-    // Upgrade patch version
-    uv_snapshot!(context.filters(), context.python_upgrade().arg("3.10"), @"
+    // Upgrade an outdated patch even when a reinstall is requested.
+    uv_snapshot!(context.filters(), context.python_upgrade().arg("3.10").arg("--reinstall"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Installed Python 3.10.[LATEST] in [TIME]


### PR DESCRIPTION
## Summary

> Note: Not sure if this is bug or enhancement. Someone help.

While perusing the code I noticed this confusing TODO about `uv python install --reinstall`.

In #11072 we changed `uv python install --reinstall` to reinstall all existing Python installations except when a specific minor version was passed, in which case we would instead install the latest available patch. This was justified due to having no `--upgrade` at the time.

Then in #16676 we introduced `uv python install --upgrade` but we didn't change the `--reinstall` behaviour. So we now had two ways to do this one thing, but no way to re-install only specific versions.

This PR completes the deferred change to `--reinstall`. That's the first commit. The second commit restores the behaviour of `--reinstall --upgrade`, which install or reinstalls the latest patch only, not sure if this is a desirable combo, but it _did_ work in the past and I didn't know if it should break too. Without the special case `--reinstall` takes precedence and `--upgrade` is ignored.

This change seems breaking. It's currently just dropped right in (maybe 0.12.0?) but I'm also open to putting it behind a preview flag and adding some warnings.

## Test Plan

Test adjustments, to match/test the new behaviours.