### PR TITLE
Store preview feature aliases in metadata

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -327,9 +327,6 @@ pub struct GlobalArgs {
     /// Preview features may change without warning.
     ///
     /// Use comma-separated values or pass multiple times to enable multiple features.
-    ///
-    /// The following features are available: `python-install-default`, `json-output`, `pylock`,
-    /// `add-bounds`.
     #[arg(
         global = true,
         long = "preview-features",

--- a/crates/uv-dev/src/generate_preview_features_reference.rs
+++ b/crates/uv-dev/src/generate_preview_features_reference.rs
@@ -49,11 +49,11 @@ pub(crate) fn main(args: &Args) -> Result<()> {
 
 fn generate() -> String {
     let mut features = PreviewFeature::metadata().to_vec();
-    features.sort_unstable_by_key(|(feature, _)| feature.to_string());
+    features.sort_unstable_by_key(|(feature, _, _)| feature.to_string());
 
     features
         .into_iter()
-        .map(|(feature, description)| render(feature, description))
+        .map(|(feature, description, _)| render(feature, description))
         .collect()
 }
 

--- a/crates/uv-macros/src/lib.rs
+++ b/crates/uv-macros/src/lib.rs
@@ -15,7 +15,7 @@ pub fn derive_options_metadata(input: TokenStream) -> TokenStream {
         .into()
 }
 
-#[proc_macro_derive(PreviewMetadata)]
+#[proc_macro_derive(PreviewMetadata, attributes(preview))]
 pub fn derive_preview_metadata(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
@@ -46,15 +46,31 @@ fn impl_preview_metadata(input: &DeriveInput) -> syn::Result<proc_macro2::TokenS
                 ));
             }
 
+            let mut aliases = Vec::new();
+            for attribute in variant
+                .attrs
+                .iter()
+                .filter(|attribute| attribute.path().is_ident("preview"))
+            {
+                attribute.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("alias") {
+                        aliases.push(meta.value()?.parse::<LitStr>()?);
+                        Ok(())
+                    } else {
+                        Err(meta.error("expected `alias`"))
+                    }
+                })?;
+            }
+
             let variant_name = &variant.ident;
-            Ok(quote! { (Self::#variant_name, #documentation) })
+            Ok(quote! { (Self::#variant_name, #documentation, &[#(#aliases),*]) })
         })
         .collect::<syn::Result<Vec<_>>>()?;
 
     Ok(quote! {
         impl #name {
-            /// Returns each enum variant and its documentation.
-            pub const fn metadata() -> &'static [(Self, &'static str)] {
+            /// Returns each enum variant, its documentation, and its aliases.
+            pub const fn metadata() -> &'static [(Self, &'static str, &'static [&'static str])] {
                 &[#(#entries),*]
             }
         }

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -241,6 +241,7 @@ pub enum PreviewFeature {
     /// environment.
     DetectModuleConflicts = 1 << 7,
     /// Allows using `uv format`.
+    #[preview(alias = "format")]
     Format = 1 << 8,
     /// Enables storage of credentials in a [system-native location](../concepts/authentication/http.md#the-uv-credentials-store).
     NativeAuth = 1 << 9,
@@ -280,6 +281,7 @@ pub enum PreviewFeature {
     /// not normalized.
     PublishRequireNormalized = 1 << 25,
     /// Allows using `uv audit`.
+    #[preview(alias = "audit")]
     Audit = 1 << 26,
     /// Rejects an invalid `--project` path instead of warning and continuing. Except for `uv init`,
     /// the path must already exist as a directory or point to a `pyproject.toml` file. This feature
@@ -299,6 +301,7 @@ pub enum PreviewFeature {
     /// unless `--force` is provided.
     VenvSafeClear = 1 << 32,
     /// Allows using `uv check`.
+    #[preview(alias = "check")]
     Check = 1 << 33,
     /// Makes `uv init` create a packaged application with a `src/` layout, build system, and script
     /// entry point by default.
@@ -382,49 +385,11 @@ impl FromStr for PreviewFeature {
     type Err = PreviewFeatureParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "python-install-default" => Self::PythonInstallDefault,
-            "json-output" => Self::JsonOutput,
-            "pylock" => Self::Pylock,
-            "add-bounds" => Self::AddBounds,
-            "package-conflicts" => Self::PackageConflicts,
-            "extra-build-dependencies" => Self::ExtraBuildDependencies,
-            "detect-module-conflicts" => Self::DetectModuleConflicts,
-            "format" | "format-command" => Self::Format,
-            "native-auth" => Self::NativeAuth,
-            "s3-endpoint" => Self::S3Endpoint,
-            "gcs-endpoint" => Self::GcsEndpoint,
-            "cache-size" => Self::CacheSize,
-            "init-project-flag" => Self::InitProjectFlag,
-            "workspace-metadata" => Self::WorkspaceMetadata,
-            "workspace-dir" => Self::WorkspaceDir,
-            "workspace-list" => Self::WorkspaceList,
-            "sbom-export" => Self::SbomExport,
-            "auth-helper" => Self::AuthHelper,
-            "direct-publish" => Self::DirectPublish,
-            "target-workspace-discovery" => Self::TargetWorkspaceDiscovery,
-            "metadata-json" => Self::MetadataJson,
-            "adjust-ulimit" => Self::AdjustUlimit,
-            "special-conda-env-names" => Self::SpecialCondaEnvNames,
-            "relocatable-envs-default" => Self::RelocatableEnvsDefault,
-            "publish-require-normalized" => Self::PublishRequireNormalized,
-            "audit" | "audit-command" => Self::Audit,
-            "project-directory-must-exist" => Self::ProjectDirectoryMustExist,
-            "index-exclude-newer" => Self::IndexExcludeNewer,
-            "azure-endpoint" => Self::AzureEndpoint,
-            "toml-backwards-compatibility" => Self::TomlBackwardsCompatibility,
-            "malware-check" => Self::MalwareCheck,
-            "venv-safe-clear" => Self::VenvSafeClear,
-            "check" | "check-command" => Self::Check,
-            "packaged-init" => Self::PackagedInit,
-            "centralized-project-envs" => Self::CentralizedProjectEnvs,
-            "tool-install-locks" => Self::ToolInstallLocks,
-            "workspace-list-scripts" => Self::WorkspaceListScripts,
-            "no-distutils-patch" => Self::NoDistutilsPatch,
-            "index-hash-algorithm" => Self::IndexHashAlgorithm,
-            "lockfile-format-check" => Self::LockfileFormatCheck,
-            _ => return Err(PreviewFeatureParseError),
-        })
+        Self::metadata()
+            .iter()
+            .find(|(feature, _, aliases)| feature.as_str() == s || aliases.contains(&s))
+            .map(|(feature, _, _)| *feature)
+            .ok_or(PreviewFeatureParseError)
     }
 }
 
@@ -587,8 +552,18 @@ mod tests {
 
     #[test]
     fn test_preview_feature_from_str() {
-        let features = PreviewFeature::from_str("python-install-default").unwrap();
-        assert_eq!(features, PreviewFeature::PythonInstallDefault);
+        assert_eq!(
+            PreviewFeature::from_str("python-install-default").unwrap(),
+            PreviewFeature::PythonInstallDefault
+        );
+        assert_eq!(
+            PreviewFeature::from_str("format").unwrap(),
+            PreviewFeature::Format
+        );
+        assert_eq!(
+            PreviewFeature::from_str("format-command").unwrap(),
+            PreviewFeature::Format
+        );
     }
 
     #[test]

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3262,6 +3262,25 @@ fn preview_features() {
     "
     );
 
+    let canonical_command_features = capture_uv_snapshot!(
+        context.filters(),
+        add_shared_args(context.version())
+            .arg("--show-settings")
+            .arg("--preview-features")
+            .arg("format-command,audit-command,check-command")
+    );
+
+    // Preview feature aliases select the same settings as their canonical names.
+    diff_uv_snapshot!(
+        context.filters(),
+        &canonical_command_features,
+        add_shared_args(context.version())
+            .arg("--show-settings")
+            .arg("--preview-features")
+            .arg("format,audit,check"),
+        @""
+    );
+
     diff_uv_snapshot!(
         context.filters(),
         &preview_features,


### PR DESCRIPTION
## Summary

Use the newly added `PreviewMetadata` derive macro to put the existing aliases into the generated metadata. This also allows the string->feature mapping to use this information instead. Finally this removes the stale variant doc on the option, it's hidden everywhere anyway.

## Test Plan

Some adjustments to existing test coverage and a new snapshot test which verifies the aliases.