### PR TITLE
Generate the preview feature string forms from their enumeration variant names

### DIFF
--- a/crates/uv-macros/src/lib.rs
+++ b/crates/uv-macros/src/lib.rs
@@ -34,6 +34,20 @@ fn impl_preview_metadata(input: &DeriveInput) -> syn::Result<proc_macro2::TokenS
         ));
     };
 
+    let names = data.variants.iter().map(|variant| {
+        let variant_name = &variant.ident;
+        let mut feature_name = String::new();
+
+        for (index, character) in variant_name.to_string().chars().enumerate() {
+            if index > 0 && character.is_uppercase() {
+                feature_name.push('-');
+            }
+            feature_name.extend(character.to_lowercase());
+        }
+
+        quote! { Self::#variant_name => #feature_name }
+    });
+
     let entries = data
         .variants
         .iter()
@@ -69,6 +83,13 @@ fn impl_preview_metadata(input: &DeriveInput) -> syn::Result<proc_macro2::TokenS
 
     Ok(quote! {
         impl #name {
+            /// Returns the canonical name of a single preview feature.
+            fn as_str(self) -> &'static str {
+                match self {
+                    #(#names),*
+                }
+            }
+
             /// Returns each enum variant, its documentation, and its aliases.
             pub const fn metadata() -> &'static [(Self, &'static str, &'static [&'static str])] {
                 &[#(#entries),*]

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -242,7 +242,7 @@ pub enum PreviewFeature {
     DetectModuleConflicts = 1 << 7,
     /// Allows using `uv format`.
     #[preview(alias = "format")]
-    Format = 1 << 8,
+    FormatCommand = 1 << 8,
     /// Enables storage of credentials in a [system-native location](../concepts/authentication/http.md#the-uv-credentials-store).
     NativeAuth = 1 << 9,
     /// Allows signing requests to configured S3-compatible endpoints.
@@ -282,7 +282,7 @@ pub enum PreviewFeature {
     PublishRequireNormalized = 1 << 25,
     /// Allows using `uv audit`.
     #[preview(alias = "audit")]
-    Audit = 1 << 26,
+    AuditCommand = 1 << 26,
     /// Rejects an invalid `--project` path instead of warning and continuing. Except for `uv init`,
     /// the path must already exist as a directory or point to a `pyproject.toml` file. This feature
     /// takes effect before configuration is loaded.
@@ -302,7 +302,7 @@ pub enum PreviewFeature {
     VenvSafeClear = 1 << 32,
     /// Allows using `uv check`.
     #[preview(alias = "check")]
-    Check = 1 << 33,
+    CheckCommand = 1 << 33,
     /// Makes `uv init` create a packaged application with a `src/` layout, build system, and script
     /// entry point by default.
     PackagedInit = 1 << 34,
@@ -334,7 +334,7 @@ impl PreviewFeature {
             Self::PackageConflicts => "package-conflicts",
             Self::ExtraBuildDependencies => "extra-build-dependencies",
             Self::DetectModuleConflicts => "detect-module-conflicts",
-            Self::Format => "format-command",
+            Self::FormatCommand => "format-command",
             Self::NativeAuth => "native-auth",
             Self::S3Endpoint => "s3-endpoint",
             Self::CacheSize => "cache-size",
@@ -352,14 +352,14 @@ impl PreviewFeature {
             Self::SpecialCondaEnvNames => "special-conda-env-names",
             Self::RelocatableEnvsDefault => "relocatable-envs-default",
             Self::PublishRequireNormalized => "publish-require-normalized",
-            Self::Audit => "audit-command",
+            Self::AuditCommand => "audit-command",
             Self::ProjectDirectoryMustExist => "project-directory-must-exist",
             Self::IndexExcludeNewer => "index-exclude-newer",
             Self::AzureEndpoint => "azure-endpoint",
             Self::TomlBackwardsCompatibility => "toml-backwards-compatibility",
             Self::MalwareCheck => "malware-check",
             Self::VenvSafeClear => "venv-safe-clear",
-            Self::Check => "check-command",
+            Self::CheckCommand => "check-command",
             Self::PackagedInit => "packaged-init",
             Self::CentralizedProjectEnvs => "centralized-project-envs",
             Self::ToolInstallLocks => "tool-install-locks",
@@ -558,11 +558,11 @@ mod tests {
         );
         assert_eq!(
             PreviewFeature::from_str("format").unwrap(),
-            PreviewFeature::Format
+            PreviewFeature::FormatCommand
         );
         assert_eq!(
             PreviewFeature::from_str("format-command").unwrap(),
-            PreviewFeature::Format
+            PreviewFeature::FormatCommand
         );
     }
 
@@ -643,7 +643,7 @@ mod tests {
             PreviewFeature::DetectModuleConflicts.as_str(),
             "detect-module-conflicts"
         );
-        assert_eq!(PreviewFeature::Format.as_str(), "format-command");
+        assert_eq!(PreviewFeature::FormatCommand.as_str(), "format-command");
         assert_eq!(PreviewFeature::NativeAuth.as_str(), "native-auth");
         assert_eq!(PreviewFeature::S3Endpoint.as_str(), "s3-endpoint");
         assert_eq!(PreviewFeature::CacheSize.as_str(), "cache-size");
@@ -694,8 +694,8 @@ mod tests {
         );
         assert_eq!(PreviewFeature::MalwareCheck.as_str(), "malware-check");
         assert_eq!(PreviewFeature::VenvSafeClear.as_str(), "venv-safe-clear");
-        assert_eq!(PreviewFeature::Audit.as_str(), "audit-command");
-        assert_eq!(PreviewFeature::Check.as_str(), "check-command");
+        assert_eq!(PreviewFeature::AuditCommand.as_str(), "audit-command");
+        assert_eq!(PreviewFeature::CheckCommand.as_str(), "check-command");
         assert_eq!(
             PreviewFeature::CentralizedProjectEnvs.as_str(),
             "centralized-project-envs"

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -323,54 +323,6 @@ pub enum PreviewFeature {
     LockfileFormatCheck = 1 << 40,
 }
 
-impl PreviewFeature {
-    /// Returns the string representation of a single preview feature flag.
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::PythonInstallDefault => "python-install-default",
-            Self::JsonOutput => "json-output",
-            Self::Pylock => "pylock",
-            Self::AddBounds => "add-bounds",
-            Self::PackageConflicts => "package-conflicts",
-            Self::ExtraBuildDependencies => "extra-build-dependencies",
-            Self::DetectModuleConflicts => "detect-module-conflicts",
-            Self::FormatCommand => "format-command",
-            Self::NativeAuth => "native-auth",
-            Self::S3Endpoint => "s3-endpoint",
-            Self::CacheSize => "cache-size",
-            Self::InitProjectFlag => "init-project-flag",
-            Self::WorkspaceMetadata => "workspace-metadata",
-            Self::WorkspaceDir => "workspace-dir",
-            Self::WorkspaceList => "workspace-list",
-            Self::SbomExport => "sbom-export",
-            Self::AuthHelper => "auth-helper",
-            Self::DirectPublish => "direct-publish",
-            Self::TargetWorkspaceDiscovery => "target-workspace-discovery",
-            Self::MetadataJson => "metadata-json",
-            Self::GcsEndpoint => "gcs-endpoint",
-            Self::AdjustUlimit => "adjust-ulimit",
-            Self::SpecialCondaEnvNames => "special-conda-env-names",
-            Self::RelocatableEnvsDefault => "relocatable-envs-default",
-            Self::PublishRequireNormalized => "publish-require-normalized",
-            Self::AuditCommand => "audit-command",
-            Self::ProjectDirectoryMustExist => "project-directory-must-exist",
-            Self::IndexExcludeNewer => "index-exclude-newer",
-            Self::AzureEndpoint => "azure-endpoint",
-            Self::TomlBackwardsCompatibility => "toml-backwards-compatibility",
-            Self::MalwareCheck => "malware-check",
-            Self::VenvSafeClear => "venv-safe-clear",
-            Self::CheckCommand => "check-command",
-            Self::PackagedInit => "packaged-init",
-            Self::CentralizedProjectEnvs => "centralized-project-envs",
-            Self::ToolInstallLocks => "tool-install-locks",
-            Self::WorkspaceListScripts => "workspace-list-scripts",
-            Self::NoDistutilsPatch => "no-distutils-patch",
-            Self::IndexHashAlgorithm => "index-hash-algorithm",
-            Self::LockfileFormatCheck => "lockfile-format-check",
-        }
-    }
-}
-
 impl Display for PreviewFeature {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -69,10 +69,10 @@ pub(crate) async fn audit(
     ignore_until_fixed: Vec<VulnerabilityID>,
 ) -> Result<ExitStatus> {
     // Check if the audit feature is in preview
-    if !preview.is_enabled(PreviewFeature::Audit) {
+    if !preview.is_enabled(PreviewFeature::AuditCommand) {
         warn_user!(
             "`uv audit` is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
-            PreviewFeature::Audit
+            PreviewFeature::AuditCommand
         );
     }
     if matches!(output_format, AuditOutputFormat::Json)

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -72,10 +72,10 @@ pub(crate) async fn check(
     config_discovery: ConfigDiscovery,
     malware_settings: MalwareCheckSettings,
 ) -> Result<ExitStatus> {
-    if !preview.is_enabled(PreviewFeature::Check) {
+    if !preview.is_enabled(PreviewFeature::CheckCommand) {
         warn_user!(
             "`uv check` is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
-            PreviewFeature::Check
+            PreviewFeature::CheckCommand
         );
     }
 

--- a/crates/uv/src/commands/project/format.rs
+++ b/crates/uv/src/commands/project/format.rs
@@ -37,10 +37,10 @@ pub(crate) async fn format(
     no_project: bool,
 ) -> Result<ExitStatus> {
     // Check if the format feature is in preview
-    if !preview.is_enabled(PreviewFeature::Format) {
+    if !preview.is_enabled(PreviewFeature::FormatCommand) {
         warn_user!(
             "`uv format` is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
-            PreviewFeature::Format
+            PreviewFeature::FormatCommand
         );
     }
 

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3193,7 +3193,7 @@ fn preview_features() {
     +            PackageConflicts,
     +            ExtraBuildDependencies,
     +            DetectModuleConflicts,
-    +            Format,
+    +            FormatCommand,
     +            NativeAuth,
     +            S3Endpoint,
     +            CacheSize,
@@ -3211,14 +3211,14 @@ fn preview_features() {
     +            SpecialCondaEnvNames,
     +            RelocatableEnvsDefault,
     +            PublishRequireNormalized,
-    +            Audit,
+    +            AuditCommand,
     +            ProjectDirectoryMustExist,
     +            IndexExcludeNewer,
     +            AzureEndpoint,
     +            TomlBackwardsCompatibility,
     +            MalwareCheck,
     +            VenvSafeClear,
-    +            Check,
+    +            CheckCommand,
     +            PackagedInit,
     +            CentralizedProjectEnvs,
     +            ToolInstallLocks,
@@ -3501,7 +3501,7 @@ fn preview_precedence() -> anyhow::Result<()> {
          preview: Preview {
     -        flags: [],
     +        flags: [
-    +            Format,
+    +            FormatCommand,
     +        ],
          },
          python_preference: Managed,
@@ -3552,7 +3552,7 @@ fn preview_precedence() -> anyhow::Result<()> {
          show_settings: true,
          preview: Preview {
              flags: [
-    -            Format,
+    -            FormatCommand,
     +            Pylock,
              ],
          },
@@ -3671,7 +3671,7 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
          preview: Preview {
     -        flags: [],
     +        flags: [
-    +            Format,
+    +            FormatCommand,
     +        ],
          },
          python_preference: Managed,
@@ -3811,7 +3811,7 @@ fn preview_features_pyproject_toml() -> anyhow::Result<()> {
          preview: Preview {
     -        flags: [],
     +        flags: [
-    +            Format,
+    +            FormatCommand,
     +        ],
          },
          python_preference: Managed,
@@ -3943,7 +3943,7 @@ fn run_pep723_script_preview_features() -> anyhow::Result<()> {
          preview: Preview {
     -        flags: [],
     +        flags: [
-    +            Format,
+    +            FormatCommand,
     +        ],
          },
          python_preference: Managed,


### PR DESCRIPTION
## Summary

Since the hyphenated stringified forms of the preview features were just their pascal case variants with lower->upper case transitions turned into hyphenations and lowercased, it is now trivial to generate these using the derive macro, getting rid of yet another denormalised match statement!

This adjusts the `-command` features (which were renamed at some point to avoid confusion) to ensure that their canonical stringified forms could be automatically derived from their names.

## Test Plan

Existing test coverage.