### PR TITLE
Ensure documentation links use relative paths

### DIFF
--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -46,11 +46,10 @@ the `pyproject.toml`, `setup.py`, or `setup.cfg` file in the directory root has 
 re-installs than desired.
 
 To incorporate additional information into the cache key for a given package, you can add cache key
-entries under [`tool.uv.cache-keys`](https://docs.astral.sh/uv/reference/settings/#cache-keys),
-which covers both file paths and Git commit hashes. Setting
-[`tool.uv.cache-keys`](https://docs.astral.sh/uv/reference/settings/#cache-keys) will replace
-defaults, so any necessary files (like `pyproject.toml`) should still be included in the
-user-defined cache keys.
+entries under [`tool.uv.cache-keys`](../reference/settings.md#cache-keys), which covers both file
+paths and Git commit hashes. Setting [`tool.uv.cache-keys`](../reference/settings.md#cache-keys)
+will replace defaults, so any necessary files (like `pyproject.toml`) should still be included in
+the user-defined cache keys.
 
 For example, if a project specifies dependencies in `pyproject.toml` but uses
 [`setuptools-scm`](https://pypi.org/project/setuptools-scm/) to manage its version, and should thus

--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -302,7 +302,7 @@ Hello from example-ext!
 
 !!! important
 
-    When creating a project with maturin or scikit-build-core, uv configures [`tool.uv.cache-keys`](https://docs.astral.sh/uv/reference/settings/#cache-keys)
+    When creating a project with maturin or scikit-build-core, uv configures [`tool.uv.cache-keys`](../../reference/settings.md#cache-keys)
     to include common source file types. To force a rebuild, e.g. when changing files outside
     `cache-keys` or when not using `cache-keys`, use `--reinstall`.
 

--- a/docs/reference/internals/metadata.md
+++ b/docs/reference/internals/metadata.md
@@ -29,7 +29,7 @@ There are 5 kinds of node in the graph:
 - `{ "group": "groupname" }` -- a dependency group a package or workspace root defines
 
 (In the future we will add "build" nodes for the dependencies of
-[build environments](https://docs.astral.sh/uv/concepts/projects/config/#build-isolation).)
+[build environments](../../concepts/projects/config.md#build-isolation).)
 
 If you want to install `mypackage`, find its `"kind": "package"` node. This node will also include
 information on its sdist, its wheels, its extras (`optional_dependencies`), and dependency groups
@@ -56,15 +56,15 @@ The first way is for
 to have conflicting requirements that force different versions of a package to be used.
 
 The second way is when a workspace has
-[conflicts](https://docs.astral.sh/uv/concepts/resolution/#conflicting-dependencies), implying some
-workspace members or their extras are mutually exclusive, and only one of them can be installed at a
-time. Information about conflicts can be found in the top-level `conflicts` field.
+[conflicts](../../concepts/resolution.md#conflicting-dependencies), implying some workspace members
+or their extras are mutually exclusive, and only one of them can be installed at a time. Information
+about conflicts can be found in the top-level `conflicts` field.
 
 The specific guarantee we provide is that **for any concrete choice of
 [markers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers),
 if you select a set of packages to install that has no
-[conflicts](https://docs.astral.sh/uv/concepts/resolution/#conflicting-dependencies), then the
-resulting set of packages to install will not have multiple versions of a package**.
+[conflicts](../../concepts/resolution.md#conflicting-dependencies), then the resulting set of
+packages to install will not have multiple versions of a package**.
 
 If you just want to get "every version of pydantic this workspace uses" you're free to iterate
 through the list of nodes and collect up every instance. If however you want to specifically analyze

--- a/docs/reference/internals/resolver.md
+++ b/docs/reference/internals/resolver.md
@@ -181,10 +181,10 @@ security concern (`C` has not been reviewed, neither was `B==3`). It's possible 
 installation if that happens, but a late error, possibly during deployment, is a bad user
 experience. There is already a case where uv fails on installation, packages with no source
 distribution and only platform specific wheels incompatible with the current platform. While uv has
-[required environments](https://docs.astral.sh/uv/concepts/resolution/#required-environments) as
-mitigation, this requires a not well known configuration option, and questions around (un)supported
-environments are one of the most common problem for uv users. A similar situation with source
-distributions should be avoided.
+[required environments](../../concepts/resolution.md#required-environments) as mitigation, this
+requires a not well known configuration option, and questions around (un)supported environments are
+one of the most common problem for uv users. A similar situation with source distributions should be
+avoided.
 
 While older versions of torch and tensorflow had inconsistent metadata, all recent versions have
 consistent metadata, and we are not aware of any major package with inconsistent metadata. There is
@@ -198,7 +198,7 @@ are constrained to a specific torch version, and the runtime torch version must 
 version. These are currently a pain point across all package managers, as all major package managers
 from pip to uv cache source distribution builds. uv supports multiple builds depending on the
 version of the already installed package using
-[ `tool.uv.extra-build-dependencies`](https://docs.astral.sh/uv/concepts/projects/config/#augmenting-build-dependencies)
+[ `tool.uv.extra-build-dependencies`](../../concepts/projects/config.md#augmenting-build-dependencies)
 with `match-runtime = true`. This is a workaround that needs to be made on the user side for each
 affected package, instead of library developers declaring this requirement, which would be possible
 with native standards support.


### PR DESCRIPTION
There should be only source of through for the docs base URL.