### PR TITLE
Use .tar.gz archive for Pyodide installs

### DIFF
--- a/crates/uv-python/download-metadata.json
+++ b/crates/uv-python/download-metadata.json
@@ -21431,10 +21431,10 @@
     "minor": 14,
     "patch": 2,
     "prerelease": "",
-    "url": "https://github.com/pyodide/pyodide/releases/download/314.0.0/xbuildenv-314.0.0.tar.bz2",
+    "url": "https://github.com/pyodide/pyodide/releases/download/314.0.3/xbuildenv-314.0.3.tar.gz",
     "sha256": null,
     "variant": null,
-    "build": "314.0.0"
+    "build": "314.0.3"
   },
   "cpython-3.14.2-linux-aarch64-gnu": {
     "name": "cpython",
@@ -52932,7 +52932,7 @@
     "minor": 13,
     "patch": 2,
     "prerelease": "",
-    "url": "https://github.com/pyodide/pyodide/releases/download/0.29.4/xbuildenv-0.29.4.tar.bz2",
+    "url": "https://github.com/pyodide/pyodide/releases/download/0.29.4/xbuildenv-0.29.4.tar.gz",
     "sha256": null,
     "variant": null,
     "build": "0.29.4"
@@ -59970,7 +59970,7 @@
     "minor": 12,
     "patch": 7,
     "prerelease": "",
-    "url": "https://github.com/pyodide/pyodide/releases/download/0.27.7/xbuildenv-0.27.7.tar.bz2",
+    "url": "https://github.com/pyodide/pyodide/releases/download/0.27.7/xbuildenv-0.27.7.tar.gz",
     "sha256": null,
     "variant": null,
     "build": "0.27.7"
@@ -62367,7 +62367,7 @@
     "minor": 12,
     "patch": 1,
     "prerelease": "",
-    "url": "https://github.com/pyodide/pyodide/releases/download/0.26.4/xbuildenv-0.26.4.tar.bz2",
+    "url": "https://github.com/pyodide/pyodide/releases/download/0.26.4/xbuildenv-0.26.4.tar.gz",
     "sha256": null,
     "variant": null,
     "build": "0.26.4"
@@ -68691,7 +68691,7 @@
     "minor": 11,
     "patch": 3,
     "prerelease": "",
-    "url": "https://github.com/pyodide/pyodide/releases/download/0.25.1/xbuildenv-0.25.1.tar.bz2",
+    "url": "https://github.com/pyodide/pyodide/releases/download/0.25.1/xbuildenv-0.25.1.tar.gz",
     "sha256": null,
     "variant": null,
     "build": "0.25.1"


### PR DESCRIPTION
## Summary

We (pyodide) have updated our releases that uv uses to `.tar.gz` format, following the request (https://github.com/pyodide/pyodide/issues/6343)

Newer releases will be released with .tar.gz by default, and I backported older ones manually.

cc: @woodruffw


## Test Plan

I just verified that all the archives are valid + URLs are correct.
