### PR TITLE
Avoid duplicate security review comments

### DIFF
--- a/.github/workflows/pull-request-security-review.yml
+++ b/.github/workflows/pull-request-security-review.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: "Collect pull request context"
         run: |
+          set -o pipefail
+
           gh pr view "$PULL_REQUEST_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
             --json number,title,body,author,baseRefName,baseRefOid,headRefName,headRefOid,isDraft,labels,files,additions,deletions,changedFiles \

--- a/.github/workflows/pull-request-security-review.yml
+++ b/.github/workflows/pull-request-security-review.yml
@@ -50,6 +50,11 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             > .pull-request-review.diff
 
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST_NUMBER/comments?per_page=100" \
+            | jq '[.[][] | {author: .user.login, body, path, line, original_line, side, start_line, original_start_line, start_side, commit_id, original_commit_id, in_reply_to_id, created_at, html_url}]' \
+            > .pull-request-review-comments.json
+
           {
             printf 'Pull request security review for #%s: %s\n\n' \
               "$(jq -r '.number' .pull-request-review-event.json)" \

--- a/agents/prompts/pull-request-security-review.md
+++ b/agents/prompts/pull-request-security-review.md
@@ -22,8 +22,11 @@ numbers, repository-name shorthand, Markdown link syntax, or backticks around re
 Complete the security diff scan, including finding discovery, validation, and attack-path analysis,
 then translate the reportable findings into the review schema. Report only actionable security
 regressions introduced by this pull request. Do not report pre-existing problems, speculative
-concerns, or style nits. Use the authenticated `gh` CLI for linked issues, earlier reviews,
-comments, and other context that is not available locally.
+concerns, or style nits. Before reporting a finding, inspect `.pull-request-review-comments.json`
+for existing inline review comments, including comments on earlier commits and outdated diff
+positions. Do not repeat a defect already identified in an existing comment, even if its wording,
+line number, or commit differs. Use the authenticated `gh` CLI for linked issues, earlier reviews,
+and other context that is not available locally.
 
 For each finding, provide a concise title without a priority prefix, a clear one-paragraph
 explanation of the defect and its impact, and a priority from 0 (highest) to 3 (lowest). Map


### PR DESCRIPTION
The security review can repeat a finding after a pull request is rebased because previous inline comments are not included in its context.

Collect existing review comments, including comments attached to earlier commits, and instruct the reviewer not to report issues that have already been identified. Enable `pipefail` so a failed comment request cannot silently produce incomplete review context.
