### PR TITLE
Fix discrepancies in argument parsing of exclude-newer

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3147,41 +3147,8 @@ pub struct VenvArgs {
     #[command(flatten)]
     pub registry_client: RegistryClientArgs,
 
-    /// Limit candidate packages to those that were uploaded prior to the given date.
-    ///
-    /// The date is compared against the upload time of each individual distribution artifact
-    /// (i.e., when each file was uploaded to the package index), not the release date of the
-    /// package version.
-    ///
-    /// Accepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), local dates in the same format
-    /// (e.g., `2006-12-02`) resolved based on your system's configured time zone, a "friendly"
-    /// duration (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`,
-    /// `P7D`, `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Use `false` to disable `exclude-newer`.
-    #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER)]
-    pub exclude_newer: Option<ExcludeNewerOverride>,
-
-    /// Limit candidate packages for a specific package to those that were uploaded prior to the
-    /// given date.
-    ///
-    /// Accepts package-date pairs in the format `PACKAGE=DATE`, where `DATE` is an RFC 3339
-    /// timestamp (e.g., `2006-12-02T02:07:43Z`), a local date in the same format (e.g.,
-    /// `2006-12-02`) resolved based on your system's configured time zone, a "friendly" duration
-    /// (e.g., `24 hours`, `1 week`, `30 days`), or a ISO 8601 duration (e.g., `PT24H`, `P7D`,
-    /// `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Can be provided multiple times for different packages.
-    #[arg(long)]
-    pub exclude_newer_package: Option<Vec<ExcludeNewerPackageEntry>>,
+    #[command(flatten)]
+    pub exclude_newer: PackageExcludeNewerArgs,
 
     /// The method to use when installing packages from the global cache.
     ///
@@ -5096,7 +5063,7 @@ pub struct FormatArgs {
     /// durations relative to "now" (e.g., `-1 week`).
     ///
     /// Use `false` to disable `exclude-newer`.
-    #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER)]
+    #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, value_hint = ValueHint::Other)]
     pub exclude_newer: Option<ExcludeNewerOverride>,
 
     /// Additional arguments to pass to Ruff.
@@ -6013,20 +5980,8 @@ pub struct ToolListArgs {
     #[arg(long, overrides_with("outdated"), hide = true)]
     pub no_outdated: bool,
 
-    /// Limit candidate packages to those that were uploaded prior to the given date.
-    ///
-    /// Accepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), local dates in the same format
-    /// (e.g., `2006-12-02`) resolved based on your system's configured time zone, a "friendly"
-    /// duration (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`,
-    /// `P7D`, `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Use `false` to disable `exclude-newer`.
-    #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    pub exclude_newer: Option<ExcludeNewerOverride>,
+    #[command(flatten)]
+    pub exclude_newer: PackageExcludeNewerArgs,
 
     // Hide unused global Python options.
     #[arg(long, hide = true)]
@@ -6163,41 +6118,8 @@ pub struct ToolUpgradeArgs {
     #[command(flatten)]
     pub build_isolation: PackageBuildIsolationArgs,
 
-    /// Limit candidate packages to those that were uploaded prior to the given date.
-    ///
-    /// The date is compared against the upload time of each individual distribution artifact
-    /// (i.e., when each file was uploaded to the package index), not the release date of the
-    /// package version.
-    ///
-    /// Accepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), local dates in the same format
-    /// (e.g., `2006-12-02`) resolved based on your system's configured time zone, a "friendly"
-    /// duration (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`,
-    /// `P7D`, `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Use `false` to disable `exclude-newer`.
-    #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    pub exclude_newer: Option<ExcludeNewerOverride>,
-
-    /// Limit candidate packages for specific packages to those that were uploaded prior to the
-    /// given date.
-    ///
-    /// Accepts package-date pairs in the format `PACKAGE=DATE`, where `DATE` is an RFC 3339
-    /// timestamp (e.g., `2006-12-02T02:07:43Z`), a local date in the same format (e.g.,
-    /// `2006-12-02`) resolved based on your system's configured time zone, a "friendly" duration
-    /// (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`,
-    /// `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Can be provided multiple times for different packages.
-    #[arg(long, help_heading = "Resolver options")]
-    pub exclude_newer_package: Option<Vec<ExcludeNewerPackageEntry>>,
+    #[command(flatten)]
+    pub exclude_newer: PackageExcludeNewerArgs,
 
     /// The method to use when installing packages from the global cache.
     ///
@@ -7168,6 +7090,60 @@ pub struct HashCheckingArgs {
     pub no_verify_hashes: bool,
 }
 
+/// Arguments that filter packages by upload date.
+#[derive(Args)]
+#[group(skip)]
+pub struct ExcludeNewerArgs {
+    /// Limit candidate packages to those that were uploaded prior to the given date.
+    ///
+    /// The date is compared against the upload time of each individual distribution artifact
+    /// (i.e., when each file was uploaded to the package index), not the release date of the
+    /// package version.
+    ///
+    /// Accepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), local dates in the same format
+    /// (e.g., `2006-12-02`) resolved based on your system's configured time zone, a "friendly"
+    /// duration (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`,
+    /// `P7D`, `P30D`).
+    ///
+    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
+    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
+    /// Calendar units such as months and years are not allowed.
+    ///
+    /// Use `false` to disable `exclude-newer`.
+    #[arg(
+        long,
+        env = EnvVars::UV_EXCLUDE_NEWER,
+        help_heading = "Resolver options",
+        value_hint = ValueHint::Other,
+    )]
+    pub exclude_newer: Option<ExcludeNewerOverride>,
+}
+
+/// Arguments that filter packages by global and package-specific upload dates.
+#[derive(Args)]
+#[group(skip)]
+pub struct PackageExcludeNewerArgs {
+    #[command(flatten)]
+    pub exclude_newer: ExcludeNewerArgs,
+
+    /// Limit candidate packages for specific packages to those that were uploaded prior to the
+    /// given date.
+    ///
+    /// Accepts package-date pairs in the format `PACKAGE=DATE`, where `DATE` is an RFC 3339
+    /// timestamp (e.g., `2006-12-02T02:07:43Z`), a local date in the same format (e.g.,
+    /// `2006-12-02`) resolved based on your system's configured time zone, a "friendly" duration
+    /// (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`,
+    /// `P30D`).
+    ///
+    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
+    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
+    /// Calendar units such as months and years are not allowed.
+    ///
+    /// Can be provided multiple times for different packages.
+    #[arg(long, help_heading = "Resolver options", value_hint = ValueHint::Other)]
+    pub exclude_newer_package: Option<Vec<ExcludeNewerPackageEntry>>,
+}
+
 #[derive(Args)]
 pub struct RefreshArgs {
     /// Refresh all cached data.
@@ -7383,41 +7359,8 @@ pub struct InstallerArgs {
     #[command(flatten)]
     build_isolation: BuildIsolationArgs,
 
-    /// Limit candidate packages to those that were uploaded prior to the given date.
-    ///
-    /// The date is compared against the upload time of each individual distribution artifact
-    /// (i.e., when each file was uploaded to the package index), not the release date of the
-    /// package version.
-    ///
-    /// Accepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), local dates in the same format
-    /// (e.g., `2006-12-02`) resolved based on your system's configured time zone, a "friendly"
-    /// duration (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`,
-    /// `P7D`, `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Use `false` to disable `exclude-newer`.
-    #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    exclude_newer: Option<ExcludeNewerOverride>,
-
-    /// Limit candidate packages for specific packages to those that were uploaded prior to the
-    /// given date.
-    ///
-    /// Accepts package-date pairs in the format `PACKAGE=DATE`, where `DATE` is an RFC 3339
-    /// timestamp (e.g., `2006-12-02T02:07:43Z`), a local date in the same format (e.g.,
-    /// `2006-12-02`) resolved based on your system's configured time zone, a "friendly" duration
-    /// (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`,
-    /// `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Can be provided multiple times for different packages.
-    #[arg(long, help_heading = "Resolver options")]
-    exclude_newer_package: Option<Vec<ExcludeNewerPackageEntry>>,
+    #[command(flatten)]
+    exclude_newer: PackageExcludeNewerArgs,
 
     /// The method to use when installing packages from the global cache.
     ///
@@ -7503,41 +7446,8 @@ pub struct ResolverArgs {
     #[command(flatten)]
     build_isolation: PackageBuildIsolationArgs,
 
-    /// Limit candidate packages to those that were uploaded prior to the given date.
-    ///
-    /// The date is compared against the upload time of each individual distribution artifact
-    /// (i.e., when each file was uploaded to the package index), not the release date of the
-    /// package version.
-    ///
-    /// Accepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), local dates in the same format
-    /// (e.g., `2006-12-02`) resolved based on your system's configured time zone, a "friendly"
-    /// duration (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`,
-    /// `P7D`, `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Use `false` to disable `exclude-newer`.
-    #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    exclude_newer: Option<ExcludeNewerOverride>,
-
-    /// Limit candidate packages for specific packages to those that were uploaded prior to the
-    /// given date.
-    ///
-    /// Accepts package-date pairs in the format `PACKAGE=DATE`, where `DATE` is an RFC 3339
-    /// timestamp (e.g., `2006-12-02T02:07:43Z`), a local date in the same format (e.g.,
-    /// `2006-12-02`) resolved based on your system's configured time zone, a "friendly" duration
-    /// (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`,
-    /// `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Can be provided multiple times for different packages.
-    #[arg(long, help_heading = "Resolver options")]
-    exclude_newer_package: Option<Vec<ExcludeNewerPackageEntry>>,
+    #[command(flatten)]
+    exclude_newer: PackageExcludeNewerArgs,
 
     /// The method to use when installing packages from the global cache.
     ///
@@ -7627,46 +7537,8 @@ pub struct ResolverInstallerArgs {
     #[command(flatten)]
     pub build_isolation: PackageBuildIsolationArgs,
 
-    /// Limit candidate packages to those that were uploaded prior to the given date.
-    ///
-    /// The date is compared against the upload time of each individual distribution artifact
-    /// (i.e., when each file was uploaded to the package index), not the release date of the
-    /// package version.
-    ///
-    /// Accepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), local dates in the same format
-    /// (e.g., `2006-12-02`) resolved based on your system's configured time zone, a "friendly"
-    /// duration (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`,
-    /// `P7D`, `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Use `false` to disable `exclude-newer`.
-    #[arg(
-        long,
-        env = EnvVars::UV_EXCLUDE_NEWER,
-        help_heading = "Resolver options",
-        value_hint = ValueHint::Other,
-    )]
-    pub exclude_newer: Option<ExcludeNewerOverride>,
-
-    /// Limit candidate packages for specific packages to those that were uploaded prior to the
-    /// given date.
-    ///
-    /// Accepts package-date pairs in the format `PACKAGE=DATE`, where `DATE` is an RFC 3339
-    /// timestamp (e.g., `2006-12-02T02:07:43Z`), a local date in the same format (e.g.,
-    /// `2006-12-02`) resolved based on your system's configured time zone, a "friendly" duration
-    /// (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`,
-    /// `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Can be provided multiple times for different packages.
-    #[arg(long, help_heading = "Resolver options", value_hint = ValueHint::Other)]
-    pub exclude_newer_package: Option<Vec<ExcludeNewerPackageEntry>>,
+    #[command(flatten)]
+    pub exclude_newer: PackageExcludeNewerArgs,
 
     /// The method to use when installing packages from the global cache.
     ///
@@ -7701,24 +7573,8 @@ pub struct FetchArgs {
     #[command(flatten)]
     registry_client: RegistryClientArgs,
 
-    /// Limit candidate packages to those that were uploaded prior to the given date.
-    ///
-    /// The date is compared against the upload time of each individual distribution artifact
-    /// (i.e., when each file was uploaded to the package index), not the release date of the
-    /// package version.
-    ///
-    /// Accepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), local dates in the same format
-    /// (e.g., `2006-12-02`) resolved based on your system's configured time zone, a "friendly"
-    /// duration (e.g., `24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`,
-    /// `P7D`, `P30D`).
-    ///
-    /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
-    /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
-    /// Calendar units such as months and years are not allowed.
-    ///
-    /// Use `false` to disable `exclude-newer`.
-    #[arg(long, env = EnvVars::UV_EXCLUDE_NEWER, help_heading = "Resolver options")]
-    exclude_newer: Option<ExcludeNewerOverride>,
+    #[command(flatten)]
+    exclude_newer: PackageExcludeNewerArgs,
 }
 
 #[derive(Args)]

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -11,9 +11,10 @@ use uv_settings::{Combine, EnvFlag, PipOptions, ResolverInstallerOptions, Resolv
 use uv_warnings::owo_colors::OwoColorize;
 
 use crate::{
-    BuildIsolationArgs, BuildOptionsArgs, CompileBytecodeArgs, FetchArgs, IndexArgs, InstallerArgs,
-    Maybe, PackageBuildIsolationArgs, RefreshArgs, RegistryClientArgs, ReinstallArgs, ResolverArgs,
-    ResolverInstallerArgs, SourcesArgs, VersionSelectionArgs,
+    BuildIsolationArgs, BuildOptionsArgs, CompileBytecodeArgs, ExcludeNewerArgs, FetchArgs,
+    IndexArgs, InstallerArgs, Maybe, PackageBuildIsolationArgs, PackageExcludeNewerArgs,
+    RefreshArgs, RegistryClientArgs, ReinstallArgs, ResolverArgs, ResolverInstallerArgs,
+    SourcesArgs, VersionSelectionArgs,
 };
 
 /// An error caused by an invalid combination of command-line arguments.
@@ -285,14 +286,17 @@ impl TryFrom<ResolverArgs> for PipOptions {
                         },
                     no_build_isolation_package,
                 },
-            exclude_newer,
+            exclude_newer:
+                PackageExcludeNewerArgs {
+                    exclude_newer: ExcludeNewerArgs { exclude_newer },
+                    exclude_newer_package,
+                },
             link_mode,
             sources:
                 SourcesArgs {
                     no_sources,
                     no_sources_package,
                 },
-            exclude_newer_package,
         } = args;
 
         if !upgrade_group.is_empty() {
@@ -361,7 +365,11 @@ impl TryFrom<InstallerArgs> for PipOptions {
                     no_build_isolation,
                     build_isolation,
                 },
-            exclude_newer,
+            exclude_newer:
+                PackageExcludeNewerArgs {
+                    exclude_newer: ExcludeNewerArgs { exclude_newer },
+                    exclude_newer_package,
+                },
             link_mode,
             compile_bytecode:
                 CompileBytecodeArgs {
@@ -373,7 +381,6 @@ impl TryFrom<InstallerArgs> for PipOptions {
                     no_sources,
                     no_sources_package,
                 },
-            exclude_newer_package,
         } = args;
 
         Ok(Self {
@@ -443,7 +450,11 @@ impl TryFrom<ResolverInstallerArgs> for PipOptions {
                         },
                     no_build_isolation_package,
                 },
-            exclude_newer,
+            exclude_newer:
+                PackageExcludeNewerArgs {
+                    exclude_newer: ExcludeNewerArgs { exclude_newer },
+                    exclude_newer_package,
+                },
             link_mode,
             compile_bytecode:
                 CompileBytecodeArgs {
@@ -455,7 +466,6 @@ impl TryFrom<ResolverInstallerArgs> for PipOptions {
                     no_sources,
                     no_sources_package,
                 },
-            exclude_newer_package,
         } = args;
 
         if !upgrade_group.is_empty() {
@@ -512,13 +522,18 @@ impl From<FetchArgs> for PipOptions {
                     index_strategy,
                     keyring_provider,
                 },
-            exclude_newer,
+            exclude_newer:
+                PackageExcludeNewerArgs {
+                    exclude_newer: ExcludeNewerArgs { exclude_newer },
+                    exclude_newer_package,
+                },
         } = args;
 
         Self {
             index_strategy,
             keyring_provider,
             exclude_newer,
+            exclude_newer_package: exclude_newer_package.map(ExcludeNewerPackage::from_iter),
             ..Self::from(index_args)
         }
     }
@@ -590,13 +605,16 @@ pub fn resolver_options(
                     },
                 no_build_isolation_package,
             },
-        exclude_newer,
+        exclude_newer:
+            PackageExcludeNewerArgs {
+                exclude_newer: ExcludeNewerArgs { exclude_newer },
+                exclude_newer_package,
+            },
         link_mode,
         sources: SourcesArgs {
             no_sources,
             no_sources_package,
         },
-        exclude_newer_package,
     } = resolver_args;
 
     let BuildOptionsArgs {
@@ -737,8 +755,11 @@ pub fn resolver_installer_options_with_indexes(
                     },
                 no_build_isolation_package,
             },
-        exclude_newer,
-        exclude_newer_package,
+        exclude_newer:
+            PackageExcludeNewerArgs {
+                exclude_newer: ExcludeNewerArgs { exclude_newer },
+                exclude_newer_package,
+            },
         link_mode,
         compile_bytecode:
             CompileBytecodeArgs {

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -24,8 +24,9 @@ use uv_cli::{
     VersionFormat,
 };
 use uv_cli::{
-    AuthorFrom, BuildArgs, CheckArgs, ExportArgs, FormatArgs, HashCheckingArgs, PublishArgs,
-    PythonDirArgs, RegistryClientArgs, ResolverInstallerArgs, ToolUpgradeArgs,
+    AuthorFrom, BuildArgs, CheckArgs, ExcludeNewerArgs, ExportArgs, FormatArgs, HashCheckingArgs,
+    PackageExcludeNewerArgs, PublishArgs, PythonDirArgs, RegistryClientArgs, ResolverInstallerArgs,
+    ToolUpgradeArgs,
     options::{
         Flag, FlagSource, check_conflicts, flag, indexes_from_args, resolve_flag,
         resolve_flag_pair, resolver_installer_options, resolver_installer_options_with_indexes,
@@ -1182,7 +1183,6 @@ impl ToolUpgradeSettings {
             link_mode,
             compile_bytecode,
             sources,
-            exclude_newer_package,
             build,
         } = args;
 
@@ -1207,7 +1207,6 @@ impl ToolUpgradeSettings {
             config_settings_package,
             build_isolation,
             exclude_newer,
-            exclude_newer_package,
             link_mode,
             compile_bytecode,
             sources,
@@ -1269,14 +1268,21 @@ impl ToolListSettings {
             show_python,
             outdated,
             no_outdated,
-            exclude_newer,
+            exclude_newer:
+                PackageExcludeNewerArgs {
+                    exclude_newer: ExcludeNewerArgs { exclude_newer },
+                    exclude_newer_package,
+                },
             python_preference: _,
             no_python_downloads: _,
         } = args;
 
-        let filesystem = filesystem.map(FilesystemOptions::into_options);
+        let filesystem = filesystem
+            .map(FilesystemOptions::into_options)
+            .unwrap_or_default();
         let filesystem = ResolverInstallerOptions {
-            exclude_newer: filesystem.and_then(|options| options.top_level.exclude_newer),
+            exclude_newer: filesystem.top_level.exclude_newer,
+            exclude_newer_package: filesystem.top_level.exclude_newer_package,
             ..ResolverInstallerOptions::default()
         };
 
@@ -1289,6 +1295,7 @@ impl ToolListSettings {
             outdated: flag(outdated, no_outdated, "outdated")?.unwrap_or(false),
             args: ResolverInstallerOptions {
                 exclude_newer,
+                exclude_newer_package: exclude_newer_package.map(ExcludeNewerPackage::from_iter),
                 ..ResolverInstallerOptions::default()
             },
             filesystem,
@@ -4201,12 +4208,15 @@ impl VenvSettings {
                     index_strategy,
                     keyring_provider,
                 },
-            exclude_newer,
+            exclude_newer:
+                PackageExcludeNewerArgs {
+                    exclude_newer: ExcludeNewerArgs { exclude_newer },
+                    exclude_newer_package,
+                },
             no_project,
             link_mode,
             refresh,
             compat_args: _,
-            exclude_newer_package,
         } = args;
 
         // Resolve flags from CLI and environment variables.


### PR DESCRIPTION
## Summary

This PR unifies exclude-newer and related args into a common struct, this avoids duplication of documentation and ensures that related changes get reflected everywhere.

This change ends up fixing the following discrepancies:

* Adds `--exclude-newer-package` to `uv pip list`, `uv pip tree`, and `uv tool list --outdated`, they already take `--exclude-newer` and are able to support `--exclude-newer-package` but never did.
* Make `uv tool list --outdated` also now respect per-package cutoffs from the filesystem configuration (it .
* Prevents completion for `--exclude-newer` and `--exclude-newer-package` from suggesting paths. The value hint wasn't applied uniformly before.
* Help output is now consistent (including grouping, which differed with `uv venv`, they're now always under `Resolver options`)


## Test Plan

The deviation checks were manual, for anything which should not deviate, an over-engineered regression detecting test system was vibecoded for the occasion (for the purpose of broader fixes).