### PR TITLE
Remove stray slash before anchors in docs cross-references

### DIFF
--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -59,10 +59,10 @@ check the user-level configuration directory. Any of the request formats describ
 used, though use of a version number is recommended for interoperability with other tools.
 
 A `.python-version` file can be created in the current directory with the
-[`uv python pin`](../reference/cli.md/#uv-python-pin) command.
+[`uv python pin`](../reference/cli.md#uv-python-pin) command.
 
 A global `.python-version` file can be created in the user configuration directory with the
-[`uv python pin --global`](../reference/cli.md/#uv-python-pin) command.
+[`uv python pin --global`](../reference/cli.md#uv-python-pin) command.
 
 Discovery of `.python-version` files can be disabled with `--no-config`.
 

--- a/docs/guides/integration/renovate.md
+++ b/docs/guides/integration/renovate.md
@@ -37,7 +37,7 @@ option:
 ## Inline script metadata
 
 Renovate supports updating dependencies defined using
-[inline script metadata](../scripts.md/#declaring-script-dependencies).
+[inline script metadata](../scripts.md#declaring-script-dependencies).
 
 Since it cannot automatically detect which Python files use inline script metadata, their locations
 need to be explicitly defined using


### PR DESCRIPTION
Three documentation cross-references use the form `file.md/#anchor` — with a stray `/` between the page and the fragment:

- `docs/concepts/python-versions.md` (×2): `../reference/cli.md/#uv-python-pin`
- `docs/guides/integration/renovate.md`: `../scripts.md/#declaring-script-dependencies`

The slash breaks the fragment. Every other cross-reference in the docs uses `file.md#anchor` (e.g. the many `../reference/cli.md#…` links), so this drops the extra slash to match. Verified the `#declaring-script-dependencies` anchor exists in `scripts.md`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)