### PR TITLE
Returns new markers from marker operations

### DIFF
--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -618,12 +618,12 @@ impl PyProjectToml {
                             .iter()
                             .flat_map(|(extra, requirements)| {
                                 requirements.iter().cloned().map(|mut requirement| {
-                                    requirement.marker.and(MarkerTree::expression(
-                                        MarkerExpression::Extra {
+                                    requirement.marker = requirement.marker.and(
+                                        MarkerTree::expression(MarkerExpression::Extra {
                                             operator: ExtraOperator::Equal,
                                             name: MarkerValueExtra::Extra(extra.clone()),
-                                        },
-                                    ));
+                                        }),
+                                    );
                                     requirement
                                 })
                             })

--- a/crates/uv-configuration/src/constraints.rs
+++ b/crates/uv-configuration/src/constraints.rs
@@ -74,8 +74,8 @@ impl Constraints {
             Either::Right(Either::Left(std::iter::once(requirement).chain(
                 constraints.iter().cloned().map(move |constraint| {
                     // Add the extra to the override marker.
-                    let mut joint_marker = MarkerTree::expression(extra_expression.clone());
-                    joint_marker.and(constraint.marker);
+                    let joint_marker =
+                        MarkerTree::expression(extra_expression.clone()).and(constraint.marker);
                     Cow::Owned(Requirement {
                         marker: joint_marker,
                         ..constraint

--- a/crates/uv-configuration/src/overrides.rs
+++ b/crates/uv-configuration/src/overrides.rs
@@ -356,8 +356,8 @@ impl Overrides {
         Either::Right(Either::Left(overrides.iter().map(
             move |override_requirement| {
                 // Add the extra to the override marker.
-                let mut joint_marker = MarkerTree::expression(extra_expression.clone());
-                joint_marker.and(override_requirement.marker);
+                let joint_marker = MarkerTree::expression(extra_expression.clone())
+                    .and(override_requirement.marker);
                 Cow::Owned(Requirement {
                     marker: joint_marker,
                     ..override_requirement.clone()

--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -380,7 +380,7 @@ impl PrioritizedDist {
         // Track the implied markers.
         if compatibility.is_compatible() {
             if !self.0.markers.is_true() {
-                self.0.markers.or(implied_markers(&dist.filename));
+                self.0.markers = self.0.markers.or(implied_markers(&dist.filename));
             }
         }
         // Track the hashes.
@@ -809,10 +809,7 @@ impl IncompatibleWheel {
 
 /// Given a wheel filename, determine the set of supported markers.
 pub fn implied_markers(filename: &WheelFilename) -> MarkerTree {
-    let mut marker = implied_platform_markers(filename);
-    marker.and(implied_python_markers(filename));
-
-    marker
+    implied_platform_markers(filename).and(implied_python_markers(filename))
 }
 
 /// Given a wheel filename, determine the set of supported platforms, in terms of their markers.
@@ -834,12 +831,12 @@ fn implied_platform_markers(filename: &WheelFilename) -> MarkerTree {
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("win32"),
                 });
-                tag_marker.and(MarkerTree::expression(MarkerExpression::String {
+                tag_marker = tag_marker.and(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::PlatformMachine,
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("x86"),
                 }));
-                marker.or(tag_marker);
+                marker = marker.or(tag_marker);
             }
             PlatformTag::WinAmd64 => {
                 let mut tag_marker = MarkerTree::expression(MarkerExpression::String {
@@ -847,12 +844,12 @@ fn implied_platform_markers(filename: &WheelFilename) -> MarkerTree {
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("win32"),
                 });
-                tag_marker.and(MarkerTree::expression(MarkerExpression::String {
+                tag_marker = tag_marker.and(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::PlatformMachine,
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("AMD64"),
                 }));
-                marker.or(tag_marker);
+                marker = marker.or(tag_marker);
             }
             PlatformTag::WinArm64 => {
                 let mut tag_marker = MarkerTree::expression(MarkerExpression::String {
@@ -860,12 +857,12 @@ fn implied_platform_markers(filename: &WheelFilename) -> MarkerTree {
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("win32"),
                 });
-                tag_marker.and(MarkerTree::expression(MarkerExpression::String {
+                tag_marker = tag_marker.and(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::PlatformMachine,
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("ARM64"),
                 }));
-                marker.or(tag_marker);
+                marker = marker.or(tag_marker);
             }
 
             // macOS
@@ -879,15 +876,16 @@ fn implied_platform_markers(filename: &WheelFilename) -> MarkerTree {
                 // Extract the architecture from the end of the tag.
                 let mut arch_marker = MarkerTree::FALSE;
                 for arch in binary_format.platform_machine() {
-                    arch_marker.or(MarkerTree::expression(MarkerExpression::String {
-                        key: MarkerValueString::PlatformMachine,
-                        operator: MarkerOperator::Equal,
-                        value: ArcStr::from(arch.name()),
-                    }));
+                    arch_marker =
+                        arch_marker.or(MarkerTree::expression(MarkerExpression::String {
+                            key: MarkerValueString::PlatformMachine,
+                            operator: MarkerOperator::Equal,
+                            value: ArcStr::from(arch.name()),
+                        }));
                 }
-                tag_marker.and(arch_marker);
+                tag_marker = tag_marker.and(arch_marker);
 
-                marker.or(tag_marker);
+                marker = marker.or(tag_marker);
             }
 
             // Linux
@@ -902,12 +900,12 @@ fn implied_platform_markers(filename: &WheelFilename) -> MarkerTree {
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("linux"),
                 });
-                tag_marker.and(MarkerTree::expression(MarkerExpression::String {
+                tag_marker = tag_marker.and(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::PlatformMachine,
                     operator: MarkerOperator::Equal,
                     value: ArcStr::from(arch.name()),
                 }));
-                marker.or(tag_marker);
+                marker = marker.or(tag_marker);
             }
 
             tag => {
@@ -997,28 +995,28 @@ fn implied_python_markers(filename: &WheelFilename) -> MarkerTree {
                 // No implementation marker needed
             }
             LanguageTag::CPython { .. } | LanguageTag::CPythonMajor { .. } => {
-                tree.and(MarkerTree::expression(MarkerExpression::String {
+                tree = tree.and(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::PlatformPythonImplementation,
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("CPython"),
                 }));
             }
             LanguageTag::PyPy { .. } => {
-                tree.and(MarkerTree::expression(MarkerExpression::String {
+                tree = tree.and(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::PlatformPythonImplementation,
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("PyPy"),
                 }));
             }
             LanguageTag::GraalPy { .. } => {
-                tree.and(MarkerTree::expression(MarkerExpression::String {
+                tree = tree.and(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::PlatformPythonImplementation,
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("GraalPy"),
                 }));
             }
             LanguageTag::Pyston { .. } => {
-                tree.and(MarkerTree::expression(MarkerExpression::String {
+                tree = tree.and(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::PlatformPythonImplementation,
                     operator: MarkerOperator::Equal,
                     value: arcstr::literal!("Pyston"),
@@ -1026,7 +1024,7 @@ fn implied_python_markers(filename: &WheelFilename) -> MarkerTree {
             }
         }
 
-        marker.or(tree);
+        marker = marker.or(tree);
     }
 
     marker

--- a/crates/uv-distribution-types/src/requires_python.rs
+++ b/crates/uv-distribution-types/src/requires_python.rs
@@ -165,7 +165,7 @@ impl RequiresPython {
                     key: MarkerValueVersion::PythonFullVersion,
                     specifier: VersionSpecifier::less_than_equal_version(upper.clone()),
                 });
-                lower.and(upper);
+                lower = lower.and(upper);
                 lower
             }
             (Bound::Included(lower), Bound::Excluded(upper)) => {
@@ -177,7 +177,7 @@ impl RequiresPython {
                     key: MarkerValueVersion::PythonFullVersion,
                     specifier: VersionSpecifier::less_than_version(upper.clone()),
                 });
-                lower.and(upper);
+                lower = lower.and(upper);
                 lower
             }
             (Bound::Excluded(lower), Bound::Included(upper)) => {
@@ -189,7 +189,7 @@ impl RequiresPython {
                     key: MarkerValueVersion::PythonFullVersion,
                     specifier: VersionSpecifier::less_than_equal_version(upper.clone()),
                 });
-                lower.and(upper);
+                lower = lower.and(upper);
                 lower
             }
             (Bound::Excluded(lower), Bound::Excluded(upper)) => {
@@ -201,7 +201,7 @@ impl RequiresPython {
                     key: MarkerValueVersion::PythonFullVersion,
                     specifier: VersionSpecifier::less_than_version(upper.clone()),
                 });
-                lower.and(upper);
+                lower = lower.and(upper);
                 lower
             }
             (Bound::Unbounded, Bound::Unbounded) => MarkerTree::TRUE,
@@ -615,7 +615,7 @@ impl SimplifiedMarkerTree {
 
     /// Combine this simplified marker with another via a conjunction.
     pub fn and(&mut self, marker: Self) {
-        self.0.and(marker.0);
+        self.0 = self.0.and(marker.0);
     }
 }
 

--- a/crates/uv-distribution-types/src/specified_requirement.rs
+++ b/crates/uv-distribution-types/src/specified_requirement.rs
@@ -93,7 +93,7 @@ impl UnresolvedRequirement {
             Self::Named(mut requirement) => Self::Named(Requirement {
                 marker: marker
                     .map(|marker| {
-                        requirement.marker.and(marker);
+                        requirement.marker = requirement.marker.and(marker);
                         requirement.marker
                     })
                     .unwrap_or(requirement.marker),
@@ -149,7 +149,7 @@ impl UnresolvedRequirement {
             Self::Unnamed(mut requirement) => Self::Unnamed(UnnamedRequirement {
                 marker: marker
                     .map(|marker| {
-                        requirement.marker.and(marker);
+                        requirement.marker = requirement.marker.and(marker);
                         requirement.marker
                     })
                     .unwrap_or(requirement.marker),

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -165,12 +165,12 @@ impl LoweredRequirement {
             // Determine the space covered by the sources.
             let mut total = MarkerTree::FALSE;
             for source in sources.iter() {
-                total.or(source.marker());
+                total = total.or(source.marker());
             }
 
             // Determine the space covered by the requirement.
             let mut remaining = total.negate();
-            remaining.and(requirement.marker);
+            remaining = remaining.and(requirement.marker);
 
             Self(Requirement {
                 marker: remaining,
@@ -301,7 +301,7 @@ impl LoweredRequirement {
                         }
                     };
 
-                    marker.and(requirement.marker);
+                    marker = marker.and(requirement.marker);
 
                     Ok(Self(Requirement {
                         name: requirement.name.clone(),
@@ -361,12 +361,12 @@ impl LoweredRequirement {
             // Determine the space covered by the sources.
             let mut total = MarkerTree::FALSE;
             for source in source.iter() {
-                total.or(source.marker());
+                total = total.or(source.marker());
             }
 
             // Determine the space covered by the requirement.
             let mut remaining = total.negate();
-            remaining.and(requirement.marker);
+            remaining = remaining.and(requirement.marker);
 
             Self(Requirement {
                 marker: remaining,
@@ -481,7 +481,7 @@ impl LoweredRequirement {
                         }
                     };
 
-                    marker.and(requirement.marker);
+                    marker = marker.and(requirement.marker);
 
                     Ok(Self(Requirement {
                         name: requirement.name.clone(),

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -393,7 +393,7 @@ impl FlatRequiresDist {
                 }
                 let requirement = {
                     let mut marker = marker;
-                    marker.and(requirement.marker);
+                    marker = marker.and(requirement.marker);
                     Requirement {
                         name: requirement.name.clone(),
                         extras: requirement.extras.clone(),

--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -284,7 +284,8 @@ impl<T: Pep508Url> Requirement<T> {
     /// `flask >= 2.0.2 ; extra == "dotenv"`.
     #[must_use]
     pub fn with_extra_marker(mut self, extra: ExtraName) -> Self {
-        self.marker
+        self.marker = self
+            .marker
             .and(MarkerTree::expression(MarkerExpression::Extra {
                 operator: ExtraOperator::Equal,
                 name: MarkerValueExtra::Extra(extra),
@@ -1500,17 +1501,17 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        let mut a = MarkerTree::expression(MarkerExpression::Version {
+        let a = MarkerTree::expression(MarkerExpression::Version {
             key: MarkerValueVersion::PythonVersion,
             specifier: VersionSpecifier::from_pattern(Operator::Equal, "2.7".parse().unwrap())
                 .unwrap(),
         });
-        let mut b = MarkerTree::expression(MarkerExpression::String {
+        let b = MarkerTree::expression(MarkerExpression::String {
             key: MarkerValueString::SysPlatform,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("win32"),
         });
-        let mut c = MarkerTree::expression(MarkerExpression::String {
+        let c = MarkerTree::expression(MarkerExpression::String {
             key: MarkerValueString::OsName,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("linux"),
@@ -1521,9 +1522,9 @@ mod tests {
             value: arcstr::literal!("cpython"),
         });
 
-        c.and(d);
-        b.or(c);
-        a.and(b);
+        let c = c.and(d);
+        let b = b.or(c);
+        let a = a.and(b);
 
         assert_eq!(a, actual);
     }

--- a/crates/uv-pep508/src/marker/parse.rs
+++ b/crates/uv-pep508/src/marker/parse.rs
@@ -622,7 +622,7 @@ fn parse_marker_or<T: Pep508Url>(
 fn parse_marker_op<T: Pep508Url, R: Reporter>(
     cursor: &mut Cursor,
     op: &str,
-    apply: fn(&mut MarkerTree, MarkerTree),
+    apply: fn(MarkerTree, MarkerTree) -> MarkerTree,
     parse_inner: fn(&mut Cursor, &mut R) -> Result<Option<MarkerTree>, Pep508Error<T>>,
     reporter: &mut R,
 ) -> Result<Option<MarkerTree>, Pep508Error<T>> {
@@ -632,10 +632,10 @@ fn parse_marker_op<T: Pep508Url, R: Reporter>(
     let first_element = parse_inner(cursor, reporter)?;
 
     if let Some(expression) = first_element {
-        match tree {
-            Some(ref mut tree) => apply(tree, expression),
-            None => tree = Some(expression),
-        }
+        tree = Some(match tree {
+            Some(tree) => apply(tree, expression),
+            None => expression,
+        });
     }
 
     loop {
@@ -648,10 +648,10 @@ fn parse_marker_op<T: Pep508Url, R: Reporter>(
                 cursor.take_while(|c| !c.is_whitespace());
 
                 if let Some(expression) = parse_inner(cursor, reporter)? {
-                    match tree {
-                        Some(ref mut tree) => apply(tree, expression),
-                        None => tree = Some(expression),
-                    }
+                    tree = Some(match tree {
+                        Some(tree) => apply(tree, expression),
+                        None => expression,
+                    });
                 }
             }
             _ => return Ok(tree),

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -839,26 +839,27 @@ impl MarkerTree {
         Self(self.0.not())
     }
 
-    /// Combine this marker tree with the one given via a conjunction.
-    pub fn and(&mut self, tree: Self) {
-        self.0 = INTERNER.lock().and(self.0, tree.0);
+    /// Returns a new marker tree that combines this one with the given one via a conjunction.
+    #[must_use]
+    pub fn and(self, tree: Self) -> Self {
+        Self(INTERNER.lock().and(self.0, tree.0))
     }
 
-    /// Combine this marker tree with the one given via a disjunction.
-    pub fn or(&mut self, tree: Self) {
-        self.0 = INTERNER.lock().or(self.0, tree.0);
+    /// Returns a new marker tree that combines this one with the given one via a disjunction.
+    #[must_use]
+    pub fn or(self, tree: Self) -> Self {
+        Self(INTERNER.lock().or(self.0, tree.0))
     }
 
-    /// Sets this to a marker equivalent to the implication of this one and the
-    /// given consequent.
+    /// Returns a marker equivalent to the implication of this one and the given consequent.
     ///
     /// If the marker set is always `true`, then it can be said that `self`
     /// implies `consequent`.
-    pub fn implies(&mut self, consequent: Self) {
+    #[must_use]
+    pub fn implies(self, consequent: Self) -> Self {
         // This could probably be optimized, but is clearly
         // correct, since logical implication is `-P or Q`.
-        *self = self.negate();
-        self.or(consequent);
+        self.negate().or(consequent)
     }
 
     /// Returns `true` if there is no environment in which both marker trees can apply,
@@ -1969,8 +1970,7 @@ mod test {
         let simplified = marker.restrict(environment);
         assert_eq!(simplified, m("python_version < '3.11'"));
 
-        let mut reconstructed = simplified;
-        reconstructed.and(environment);
+        let reconstructed = simplified.and(environment);
         assert_eq!(reconstructed, marker);
         assert_eq!(environment.restrict(environment), MarkerTree::TRUE);
 
@@ -1995,10 +1995,8 @@ mod test {
             let assumption = m(assumption);
             let simplified = marker.restrict(assumption);
 
-            let mut expected = marker;
-            expected.and(assumption);
-            let mut reconstructed = simplified;
-            reconstructed.and(assumption);
+            let expected = marker.and(assumption);
+            let reconstructed = simplified.and(assumption);
             assert_eq!(reconstructed, expected);
         }
     }
@@ -3342,9 +3340,7 @@ mod test {
     }
 
     fn implies(antecedent: &str, consequent: &str) -> bool {
-        let mut marker = m(antecedent);
-        marker.implies(m(consequent));
-        marker.is_true()
+        m(antecedent).implies(m(consequent)).is_true()
     }
 
     #[test]

--- a/crates/uv-resolver/src/graph_ops.rs
+++ b/crates/uv-resolver/src/graph_ops.rs
@@ -335,10 +335,10 @@ impl Boolean for UniversalMarker {
 
 impl Boolean for MarkerTree {
     fn and(&mut self, other: Self) {
-        self.and(other);
+        *self = Self::and(*self, other);
     }
 
     fn or(&mut self, other: Self) {
-        self.or(other);
+        *self = Self::or(*self, other);
     }
 }

--- a/crates/uv-resolver/src/lock/export/metadata.rs
+++ b/crates/uv-resolver/src/lock/export/metadata.rs
@@ -386,7 +386,7 @@ impl MetadataNode {
         parent_reachability: MarkerTree,
     ) {
         let mut marker = dependency.simplified_marker.as_simplified_marker_tree();
-        marker.and(parent_reachability);
+        marker = marker.and(parent_reachability);
         let marker = marker.try_to_string();
         let extras = dependency.extra();
         if extras.is_empty() {
@@ -654,7 +654,7 @@ fn metadata_reachability(
         for dependency in dependencies {
             let mut dependency_reachability =
                 dependency.simplified_marker.as_simplified_marker_tree();
-            dependency_reachability.and(parent_reachability);
+            dependency_reachability = dependency_reachability.and(parent_reachability);
             let dependency_package = lock.find_by_id(&dependency.package_id);
             if dependency.extra.is_empty() {
                 add_metadata_reachability(
@@ -694,7 +694,7 @@ fn add_metadata_reachability<'lock>(
     let id = MetadataNodeId::from_package_id(workspace_root, &package.id, kind.clone()).to_flat();
     let changed = if let Some(existing) = reachability.get_mut(&id) {
         let previous = *existing;
-        existing.or(marker);
+        *existing = existing.or(marker);
         *existing != previous
     } else {
         reachability.insert(id, marker);

--- a/crates/uv-resolver/src/lock/export/mod.rs
+++ b/crates/uv-resolver/src/lock/export/mod.rs
@@ -456,7 +456,7 @@ fn conflict_marker_reachability<'lock>(
         fork_markers
             .iter()
             .fold(MarkerTree::FALSE, |mut acc, edge| {
-                acc.or(*edge.marker());
+                acc = acc.or(*edge.marker());
                 acc
             })
     };
@@ -508,11 +508,11 @@ fn conflict_marker_reachability<'lock>(
 
                     // Propagate the edge to the known conflicts.
                     for value in parent_map.values_mut() {
-                        value.and(marker);
+                        *value = value.and(marker);
                     }
 
                     // Propagate the edge to the node itself.
-                    parent_marker.and(marker);
+                    parent_marker = parent_marker.and(marker);
                 }
                 Edge::Optional { extra, marker, .. } => {
                     // The optional edge is only active when its extra is active. Preserve the
@@ -527,15 +527,15 @@ fn conflict_marker_reachability<'lock>(
 
                     // Resolve any active extras on the edge.
                     let mut marker = resolve_activated_extras(*marker, scope_package, &parent_map);
-                    marker.and(active_marker);
+                    marker = marker.and(active_marker);
 
                     // Propagate the edge to the known conflicts.
                     for value in parent_map.values_mut() {
-                        value.and(marker);
+                        *value = value.and(marker);
                     }
 
                     // Propagate the edge to the node itself.
-                    parent_marker.and(marker);
+                    parent_marker = parent_marker.and(marker);
                 }
                 Edge::Dev { group, marker, .. } => {
                     // The dependency group is active for this edge itself, so add it before
@@ -550,11 +550,11 @@ fn conflict_marker_reachability<'lock>(
 
                     // Propagate the edge to the known conflicts.
                     for value in parent_map.values_mut() {
-                        value.and(marker);
+                        *value = value.and(marker);
                     }
 
                     // Propagate the edge to the node itself.
-                    parent_marker.and(marker);
+                    parent_marker = parent_marker.and(marker);
                 }
             }
 
@@ -564,8 +564,9 @@ fn conflict_marker_reachability<'lock>(
                     let child_map = existing.get_mut();
                     for (key, value) in parent_map {
                         let mut after = child_map.get(&key).copied().unwrap_or(MarkerTree::FALSE);
-                        after.or(value);
-                        child_map.entry(key).or_insert(MarkerTree::FALSE).or(value);
+                        after = after.or(value);
+                        let child_marker = child_map.entry(key).or_insert(MarkerTree::FALSE);
+                        *child_marker = child_marker.or(value);
                     }
                 }
                 Entry::Vacant(vacant) => {
@@ -578,7 +579,7 @@ fn conflict_marker_reachability<'lock>(
                 Entry::Occupied(mut existing) => {
                     // If the marker is a subset of the existing marker (A ⊆ B exactly if
                     // A ∪ B = A), updating the child wouldn't change child's marker.
-                    parent_marker.or(*existing.get());
+                    parent_marker = parent_marker.or(*existing.get());
                     if parent_marker != *existing.get() {
                         existing.insert(parent_marker);
                         queue.push(child_edge.target());

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -314,11 +314,11 @@ pub fn implicit_constraints_marker(
     } else {
         let mut environments_union = MarkerTree::FALSE;
         for environment in supported_environments {
-            environments_union.or(*environment);
+            environments_union = environments_union.or(*environment);
         }
         environments_union
     };
-    environments_union.and(requires_python);
+    environments_union = environments_union.and(requires_python);
     environments_union
 }
 
@@ -448,7 +448,7 @@ impl Lock {
         } else {
             let mut combined = MarkerTree::FALSE;
             for marker in &supported_environments {
-                combined.or(*marker);
+                combined = combined.or(*marker);
             }
             Some(UniversalMarker::new(combined, ConflictMarker::TRUE))
         };
@@ -919,9 +919,9 @@ impl Lock {
         } else {
             let mut combined = MarkerTree::FALSE;
             for fork_marker in &package.fork_markers {
-                combined.or(fork_marker.pep508());
+                combined = combined.or(fork_marker.pep508());
             }
-            combined.and(requirement.marker);
+            combined = combined.and(requirement.marker);
             combined
         };
 
@@ -1943,9 +1943,9 @@ impl Lock {
                     } else {
                         let mut combined = MarkerTree::FALSE;
                         for fork_marker in &package.fork_markers {
-                            combined.or(fork_marker.pep508());
+                            combined = combined.or(fork_marker.pep508());
                         }
-                        combined.and(requirement.marker);
+                        combined = combined.and(requirement.marker);
                         combined
                     };
                     if marker.is_false() {
@@ -6572,7 +6572,7 @@ fn fork_markers_union(
     }
     let mut environment = MarkerTree::FALSE;
     for fork_marker in fork_markers {
-        environment.or(fork_marker.pep508());
+        environment = environment.or(fork_marker.pep508());
     }
     environment
 }

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -234,9 +234,9 @@ impl<'env> TreeDisplay<'env> {
                     } else {
                         let mut combined = MarkerTree::FALSE;
                         for fork_marker in &package.fork_markers {
-                            combined.or(fork_marker.pep508());
+                            combined = combined.or(fork_marker.pep508());
                         }
-                        combined.and(requirement.marker);
+                        combined = combined.and(requirement.marker);
                         combined
                     };
                     if marker.is_false() {
@@ -286,9 +286,9 @@ impl<'env> TreeDisplay<'env> {
                         } else {
                             let mut combined = MarkerTree::FALSE;
                             for fork_marker in &package.fork_markers {
-                                combined.or(fork_marker.pep508());
+                                combined = combined.or(fork_marker.pep508());
                             }
-                            combined.and(requirement.marker);
+                            combined = combined.and(requirement.marker);
                             combined
                         };
                         if marker.is_false() {

--- a/crates/uv-resolver/src/resolution/display.rs
+++ b/crates/uv-resolver/src/resolution/display.rs
@@ -434,7 +434,7 @@ fn strip_extras<'dist>(graph: &IntermediatePetGraph<'dist>) -> RequirementsTxtGr
                 // foo==1.0.0; sys_platform != 'linux'
                 // ```
                 // In this case, we want to write `foo==1.0.0; sys_platform == 'linux' or sys_platform == 'windows'`
-                node.markers.or(dist.markers);
+                node.markers = node.markers.or(dist.markers);
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
                 let index = next.add_node(dist.clone());

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -762,7 +762,7 @@ impl ResolverOutput {
                     }
                 }
             };
-            conjunction.and(MarkerTree::expression(expr));
+            conjunction = conjunction.and(MarkerTree::expression(expr));
         }
         Ok(conjunction)
     }

--- a/crates/uv-resolver/src/resolver/environment.rs
+++ b/crates/uv-resolver/src/resolver/environment.rs
@@ -265,7 +265,7 @@ impl ResolverEnvironment {
                 ref exclude,
             } => {
                 let mut markers = *lhs;
-                markers.and(rhs);
+                markers = markers.and(rhs);
                 let kind = Kind::Universal {
                     initial_forks: Arc::clone(initial_forks),
                     markers,
@@ -598,7 +598,7 @@ impl Forker<'_> {
         envs.push(env.narrow_environment(self.marker));
 
         let mut remaining_marker = self.marker;
-        remaining_marker.and(env_marker.negate());
+        remaining_marker = remaining_marker.and(env_marker.negate());
         let remaining_forker = Forker {
             package: self.package,
             marker: remaining_marker,

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1704,7 +1704,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         // ...and the non-local version has greater platform support...
         let mut remainder = {
             let mut remainder = base_dist.implied_markers();
-            remainder.and(dist.implied_markers().negate());
+            remainder = remainder.and(dist.implied_markers().negate());
             remainder
         };
         if remainder.is_false() {
@@ -1773,7 +1773,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             if dist.implied_markers().is_disjoint(sys_platform)
                 && !remainder.is_disjoint(sys_platform)
             {
-                remainder.or(sys_platform);
+                remainder = remainder.or(sys_platform);
             }
         }
 
@@ -2259,12 +2259,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 ) {
                     let requirement = match requirement {
                         Cow::Owned(mut requirement) => {
-                            requirement.marker.and(marker);
+                            requirement.marker = requirement.marker.and(marker);
                             requirement
                         }
                         Cow::Borrowed(requirement) => {
                             let mut marker = marker;
-                            marker.and(requirement.marker);
+                            marker = marker.and(requirement.marker);
                             Requirement {
                                 name: requirement.name.clone(),
                                 extras: requirement.extras.clone(),
@@ -2439,7 +2439,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         Cow::Borrowed(constraint)
                     } else {
                         let mut marker = constraint.marker;
-                        marker.and(requirement.marker);
+                        marker = marker.and(requirement.marker);
 
                         if marker.is_false() {
                             trace!(
@@ -2463,7 +2463,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     let requires_python = python_requirement.target();
 
                     let mut marker = constraint.marker;
-                    marker.and(requirement.marker);
+                    marker = marker.and(requirement.marker);
 
                     if marker.is_false() {
                         trace!(
@@ -4479,11 +4479,11 @@ fn find_environments(id: Id<PubGrubPackage>, state: &State<UvDependencyProvider>
             }
 
             let mut next_environment = state.package_store[*child].marker();
-            next_environment.and(current_environment);
+            next_environment = next_environment.and(current_environment);
 
             let entry = environments.entry(*child).or_insert(MarkerTree::FALSE);
             let mut combined = *entry;
-            combined.or(next_environment);
+            combined = combined.or(next_environment);
             if combined != *entry {
                 *entry = combined;
                 queue.push_back(*child);

--- a/crates/uv-resolver/src/universal_marker.rs
+++ b/crates/uv-resolver/src/universal_marker.rs
@@ -96,7 +96,7 @@ impl UniversalMarker {
 
     /// Creates a new universal marker from its constituent pieces.
     pub(crate) fn new(mut pep508_marker: MarkerTree, conflict_marker: ConflictMarker) -> Self {
-        pep508_marker.and(conflict_marker.marker);
+        pep508_marker = pep508_marker.and(conflict_marker.marker);
         Self::from_combined(pep508_marker)
     }
 
@@ -113,16 +113,16 @@ impl UniversalMarker {
     /// them. That is, the updated marker will evaluate to `true` if `self` or
     /// `other` evaluate to `true`.
     pub(crate) fn or(&mut self, other: Self) {
-        self.marker.or(other.marker);
-        self.pep508.or(other.pep508);
+        self.marker = self.marker.or(other.marker);
+        self.pep508 = self.pep508.or(other.pep508);
     }
 
     /// Combine this universal marker with the one given in a way that
     /// intersects them. That is, the updated marker will evaluate to `true` if
     /// `self` and `other` evaluate to `true`.
     pub(crate) fn and(&mut self, other: Self) {
-        self.marker.and(other.marker);
-        self.pep508.and(other.pep508);
+        self.marker = self.marker.and(other.marker);
+        self.pep508 = self.pep508.and(other.pep508);
     }
 
     /// Imbibes the world knowledge expressed by `conflicts` into this marker.
@@ -137,7 +137,7 @@ impl UniversalMarker {
         }
         let self_marker = self.marker;
         self.marker = conflicts.marker;
-        self.marker.implies(self_marker);
+        self.marker = self.marker.implies(self_marker);
         self.pep508 = self.marker.without_extras();
     }
 
@@ -404,7 +404,7 @@ impl UniversalMarker {
             for expression in conjunction {
                 match expression {
                     expression @ MarkerExpression::Extra { .. } => {
-                        conflict.and(MarkerTree::expression(expression));
+                        conflict = conflict.and(MarkerTree::expression(expression));
                     }
                     expression => {
                         if !MarkerTree::expression(expression).evaluate(env, &[]) {
@@ -413,7 +413,7 @@ impl UniversalMarker {
                     }
                 }
             }
-            remaining.or(conflict);
+            remaining = remaining.or(conflict);
         }
 
         ConflictMarker { marker: remaining }
@@ -510,18 +510,18 @@ impl ConflictMarker {
     /// `other`.
     #[must_use]
     fn or(self, other: Self) -> Self {
-        let mut marker = self.marker;
-        marker.or(other.marker);
-        Self { marker }
+        Self {
+            marker: self.marker.or(other.marker),
+        }
     }
 
     /// Returns a new conflict marker corresponding to the intersection of
     /// `self` and `other`.
     #[must_use]
     pub(crate) fn and(self, other: Self) -> Self {
-        let mut marker = self.marker;
-        marker.and(other.marker);
-        Self { marker }
+        Self {
+            marker: self.marker.and(other.marker),
+        }
     }
 
     /// Returns true if this conflict marker will always evaluate to `true`.
@@ -759,12 +759,12 @@ pub(crate) fn resolve_activated_extras(
                 ref name,
             } = marker
             else {
-                or.and(MarkerTree::expression(marker));
+                or = or.and(MarkerTree::expression(marker));
                 continue;
             };
 
             let Some(name) = name.as_extra() else {
-                or.and(MarkerTree::expression(marker));
+                or = or.and(MarkerTree::expression(marker));
                 continue;
             };
 
@@ -780,12 +780,12 @@ pub(crate) fn resolve_activated_extras(
                     if encoded == *name {
                         match operator {
                             ExtraOperator::Equal => {
-                                or.and(*conflict_marker);
+                                or = or.and(*conflict_marker);
                                 found = true;
                                 break;
                             }
                             ExtraOperator::NotEqual => {
-                                or.and(conflict_marker.negate());
+                                or = or.and(conflict_marker.negate());
                                 found = true;
                                 break;
                             }
@@ -800,12 +800,12 @@ pub(crate) fn resolve_activated_extras(
                     if encoded == *name {
                         match operator {
                             ExtraOperator::Equal => {
-                                or.and(*conflict_marker);
+                                or = or.and(*conflict_marker);
                                 found = true;
                                 break;
                             }
                             ExtraOperator::NotEqual => {
-                                or.and(conflict_marker.negate());
+                                or = or.and(conflict_marker.negate());
                                 found = true;
                                 break;
                             }
@@ -820,12 +820,12 @@ pub(crate) fn resolve_activated_extras(
                     if encoded == *name {
                         match operator {
                             ExtraOperator::Equal => {
-                                or.and(*conflict_marker);
+                                or = or.and(*conflict_marker);
                                 found = true;
                                 break;
                             }
                             ExtraOperator::NotEqual => {
-                                or.and(conflict_marker.negate());
+                                or = or.and(conflict_marker.negate());
                                 found = true;
                                 break;
                             }
@@ -841,11 +841,11 @@ pub(crate) fn resolve_activated_extras(
                     if let Some(conflict_marker) = known_conflicts.get(&conflict_item) {
                         match operator {
                             ExtraOperator::Equal => {
-                                or.and(*conflict_marker);
+                                or = or.and(*conflict_marker);
                                 found = true;
                             }
                             ExtraOperator::NotEqual => {
-                                or.and(conflict_marker.negate());
+                                or = or.and(conflict_marker.negate());
                                 found = true;
                             }
                         }
@@ -858,16 +858,16 @@ pub(crate) fn resolve_activated_extras(
             if !found {
                 match operator {
                     ExtraOperator::Equal => {
-                        or.and(MarkerTree::FALSE);
+                        or = or.and(MarkerTree::FALSE);
                     }
                     ExtraOperator::NotEqual => {
-                        or.and(MarkerTree::TRUE);
+                        or = or.and(MarkerTree::TRUE);
                     }
                 }
             }
         }
 
-        transformed.or(or);
+        transformed = transformed.or(or);
     }
 
     transformed

--- a/crates/uv-workspace/src/dependency_groups.rs
+++ b/crates/uv-workspace/src/dependency_groups.rs
@@ -181,7 +181,7 @@ impl FlatDependencyGroups {
                 for requirement in &mut requirements {
                     let extra_markers =
                         RequiresPython::from_specifiers(requires_python.clone()).to_marker_tree();
-                    requirement.marker.and(extra_markers);
+                    requirement.marker = requirement.marker.and(extra_markers);
                 }
             }
 

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1110,8 +1110,7 @@ impl TryFrom<SourcesWire> for Sources {
                             return Err(SourceError::MissingMarkers);
                         };
 
-                        let mut hint = lhs.negate();
-                        hint.and(rhs);
+                        let hint = lhs.negate().and(rhs);
                         let hint = hint
                             .contents()
                             .map(|contents| contents.to_string())

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -675,8 +675,7 @@ async fn do_lock(
         if let Some(environments) = &environments {
             for [lhs, rhs] in environments.as_markers().array_windows() {
                 if !lhs.is_disjoint(*rhs) {
-                    let mut hint = lhs.negate();
-                    hint.and(*rhs);
+                    let hint = lhs.negate().and(*rhs);
 
                     let lhs = lhs
                         .contents()
@@ -705,8 +704,7 @@ async fn do_lock(
         // Ensure that the environments are disjoint.
         for [lhs, rhs] in required_environments.as_markers().array_windows() {
             if !lhs.is_disjoint(*rhs) {
-                let mut hint = lhs.negate();
-                hint.and(*rhs);
+                let hint = lhs.negate().and(*rhs);
 
                 let lhs = lhs
                     .contents()

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -392,8 +392,7 @@ fn select_requirements(
             })?;
         if requirement.name == *package {
             found_matching_name = true;
-            let mut effective_marker = requirement.marker;
-            effective_marker.and(resolution_marker);
+            let mut effective_marker = requirement.marker.and(resolution_marker);
             if effective_marker.is_false() {
                 skipped.push(SkippedRequirement {
                     package: package.clone(),


### PR DESCRIPTION
Combining two markers with `and`, `or` and `implies` currently requires cloning one of the two markers into a mutable variable, then modifying it with the conjunction, disjunction or implies. We can avoid the copying and the interior mutability by returning a new marker for combining operations instead, which also makes chaining easier.