### PR TITLE
Support frozen installs from metadata-free lockfiles

### DIFF
--- a/crates/uv-dev/src/generate_preview_features_reference.rs
+++ b/crates/uv-dev/src/generate_preview_features_reference.rs
@@ -115,6 +115,7 @@ mod tests {
         - `centralized-project-envs`: Stores [project virtual environments](./projects/layout.md#centralized-project-environments)
           in the uv cache.
         - `check-command`: Allows using `uv check`.
+        - `correct-extra-markers`: Split extra-dependent requirement markers to their production or extra context.
         - `detect-module-conflicts`: Warns when multiple packages would install conflicting Python modules into the same
           environment.
         - `direct-publish`: Allows publishing directly to a package index.

--- a/crates/uv-dev/src/generate_preview_features_reference.rs
+++ b/crates/uv-dev/src/generate_preview_features_reference.rs
@@ -115,7 +115,6 @@ mod tests {
         - `centralized-project-envs`: Stores [project virtual environments](./projects/layout.md#centralized-project-environments)
           in the uv cache.
         - `check-command`: Allows using `uv check`.
-        - `correct-extra-markers`: Split extra-dependent requirement markers to their production or extra context.
         - `detect-module-conflicts`: Warns when multiple packages would install conflicting Python modules into the same
           environment.
         - `direct-publish`: Allows publishing directly to a package index.

--- a/crates/uv-dev/src/generate_preview_features_reference.rs
+++ b/crates/uv-dev/src/generate_preview_features_reference.rs
@@ -125,6 +125,7 @@ mod tests {
         - `index-hash-algorithm`: Allows requiring a hash algorithm for configured package indexes.
         - `init-project-flag`: Rejects the deprecated `--project` option in `uv init`.
         - `json-output`: Allows `--output-format json` for various uv commands.
+        - `lock-without-metadata`: Allows frozen installations from lockfiles that omit package declaration metadata.
         - `lockfile-format-check`: Rejects non-canonical lockfile formatting when using `--locked` or `--check`.
         - `malware-check`: Allows `uv sync` and other commands to check for malware using [OSV](https://osv.dev) before
           installing packages.

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -325,8 +325,6 @@ pub enum PreviewFeature {
     IndexHashAlgorithm,
     /// Rejects non-canonical lockfile formatting when using `--locked` or `--check`.
     LockfileFormatCheck,
-    /// Split extra-dependent requirement markers to their production or extra context.
-    CorrectExtraMarkers,
 }
 
 impl Display for PreviewFeature {

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -325,6 +325,8 @@ pub enum PreviewFeature {
     IndexHashAlgorithm,
     /// Rejects non-canonical lockfile formatting when using `--locked` or `--check`.
     LockfileFormatCheck,
+    /// Split extra-dependent requirement markers to their production or extra context.
+    CorrectExtraMarkers,
 }
 
 impl Display for PreviewFeature {

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -325,6 +325,8 @@ pub enum PreviewFeature {
     IndexHashAlgorithm,
     /// Rejects non-canonical lockfile formatting when using `--locked` or `--check`.
     LockfileFormatCheck,
+    /// Allows frozen installations from lockfiles that omit package declaration metadata.
+    LockWithoutMetadata,
 }
 
 impl Display for PreviewFeature {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1566,8 +1566,21 @@ impl Lock {
         requires_dist: Box<[Requirement]>,
         dependency_groups: BTreeMap<GroupName, Box<[Requirement]>>,
         package: &'lock Package,
+        remotes: &mut Option<BTreeSet<UrlString>>,
+        locals: &mut Option<BTreeSet<Box<Path>>>,
         root: &Path,
     ) -> Result<SatisfiesResult<'lock>, LockError> {
+        let indexes = requires_dist
+            .iter()
+            .chain(dependency_groups.values().flatten())
+            .filter_map(|requirement| match &requirement.source {
+                RequirementSource::Registry {
+                    index: Some(index), ..
+                } => Some(index.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
         // Special-case: if the version is dynamic, compare the flattened requirements.
         let flattened = if package.is_dynamic() {
             Some(
@@ -1646,22 +1659,24 @@ impl Lock {
             ));
         }
 
+        // Add any explicit indexes to the list of known locals or remotes. These indexes may
+        // not be available as top-level configuration (i.e., if they're defined within a
+        // workspace member), but we already validated that the dependencies are up-to-date, so
+        // we can consider them "available". Recording indexes only after validating refreshed
+        // requirements prevents stale static metadata from authorizing an unrelated locked source.
+        for index in &indexes {
+            Self::record_index(index, remotes, locals, root);
+        }
+
         Ok(SatisfiesResult::Satisfied)
     }
 
     fn record_index(
-        requirement: &Requirement,
+        index: &IndexMetadata,
         remotes: &mut Option<BTreeSet<UrlString>>,
         locals: &mut Option<BTreeSet<Box<Path>>>,
         root: &Path,
     ) {
-        let RequirementSource::Registry {
-            index: Some(index), ..
-        } = &requirement.source
-        else {
-            return;
-        };
-
         match &index.url {
             IndexUrl::Pypi(_) | IndexUrl::Url(_) => {
                 if let Some(remotes) = remotes.as_mut() {
@@ -1968,7 +1983,12 @@ impl Lock {
             .collect::<Vec<_>>();
 
         for requirement in &root_requirements {
-            Self::record_index(requirement, &mut remotes, &mut locals, root);
+            if let RequirementSource::Registry {
+                index: Some(index), ..
+            } = &requirement.source
+            {
+                Self::record_index(index, &mut remotes, &mut locals, root);
+            }
         }
 
         if !root_requirements.is_empty() {
@@ -2103,6 +2123,8 @@ impl Lock {
                             metadata.requires_dist,
                             metadata.dependency_groups,
                             package,
+                            &mut remotes,
+                            &mut locals,
                             root,
                         )? {
                             SatisfiesResult::Satisfied => true,
@@ -2189,6 +2211,8 @@ impl Lock {
                         metadata.requires_dist,
                         metadata.dependency_groups,
                         package,
+                        &mut remotes,
+                        &mut locals,
                         root,
                     )? {
                         SatisfiesResult::Satisfied => {}
@@ -2226,7 +2250,14 @@ impl Lock {
                     }
 
                     // Validate that the requirements are unchanged.
-                    match self.satisfies_requires_dist(metadata.requires_dist, metadata.dependency_groups, package, root) {
+                    match self.satisfies_requires_dist(
+                        metadata.requires_dist,
+                        metadata.dependency_groups,
+                        package,
+                        &mut remotes,
+                        &mut locals,
+                        root,
+                    ) {
                         Ok(SatisfiesResult::Satisfied) => {
                             debug!("Static `requires-dist` for `{}` is up-to-date", package.id);
                         },
@@ -2310,6 +2341,8 @@ impl Lock {
                         metadata.requires_dist,
                         metadata.dependency_groups,
                         package,
+                        &mut remotes,
+                        &mut locals,
                         root,
                     )? {
                         SatisfiesResult::Satisfied => {}
@@ -2318,19 +2351,6 @@ impl Lock {
                 }
             } else {
                 return Ok(SatisfiesResult::MissingVersion(&package.id.name));
-            }
-
-            // Add any explicit indexes to the list of known locals or remotes. These indexes may
-            // not be available as top-level configuration (i.e., if they're defined within a
-            // workspace member), but we already validated that the dependencies are up-to-date, so
-            // we can consider them "available".
-            for requirement in package
-                .metadata
-                .requires_dist
-                .iter()
-                .chain(package.metadata.dependency_groups.values().flatten())
-            {
-                Self::record_index(requirement, &mut remotes, &mut locals, root);
             }
 
             // Recurse.

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -845,6 +845,11 @@ impl Lock {
         (self.version(), self.revision()) >= (1, 1)
     }
 
+    /// Returns `true` if this [`Lock`] can validate packages without declaration metadata.
+    pub fn supports_missing_package_metadata(&self) -> bool {
+        (self.version(), self.revision()) >= (1, 4)
+    }
+
     /// Returns `true` if this [`Lock`] includes entries for empty `dependency-group` metadata.
     fn includes_empty_groups(&self) -> bool {
         // Empty dependency groups are included as of https://github.com/astral-sh/uv/pull/8598,
@@ -3598,6 +3603,11 @@ impl Package {
     /// Returns `true` if the package is a dynamic source tree.
     fn is_dynamic(&self) -> bool {
         self.id.version.is_none()
+    }
+
+    /// Returns `true` if the package contains the validation-only package metadata.
+    pub fn has_metadata(&self) -> bool {
+        self.metadata != PackageMetadata::default()
     }
 
     /// Returns the extras the package provides, if any.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -35,7 +35,6 @@ use uv_pep508::{
     MarkerEnvironment, MarkerExpression, MarkerOperator, MarkerTree, MarkerValueString,
 };
 use uv_platform_tags::{IncompatibleTag, Tags};
-use uv_preview::PreviewFeature;
 use uv_pypi_types::{ConflictItem, ConflictItemRef, ConflictKindRef, Conflicts, VerbatimParsedUrl};
 use uv_static::EnvVars;
 use uv_torch::TorchStrategy;
@@ -2332,8 +2331,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
     where
         'data: 'parameters,
     {
-        let correct_extra_markers = uv_preview::is_enabled(PreviewFeature::CorrectExtraMarkers);
-
         self.overrides
             .apply_for_package(override_package, dependencies)
             .filter(move |requirement| {
@@ -2342,10 +2339,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     .contains_for_package(exclusion_package, &requirement.name)
             })
             .map(move |mut requirement| {
-                if !correct_extra_markers {
-                    return requirement;
-                }
-
                 // Split the marker into production and optional components. If we have e.g.
                 // `foo; sys_platform == 'win32' or extra == 'feature'`
                 // we split it into
@@ -2384,7 +2377,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     env,
                     python_marker,
                     python_requirement,
-                    correct_extra_markers,
                 )
             })
             .flat_map(move |requirement| {
@@ -2406,24 +2398,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         env: &ResolverEnvironment,
         python_marker: MarkerTree,
         python_requirement: &PythonRequirement,
-        correct_extra_markers: bool,
     ) -> bool {
         // If the requirement isn't relevant for the current platform, skip it.
         match extra {
             Some(source_extra) => {
-                if correct_extra_markers {
-                    if !requirement.evaluate_markers(env.marker_environment(), &[]) {
-                        return false;
-                    }
-                } else {
-                    if requirement.evaluate_markers(env.marker_environment(), &[]) {
-                        return false;
-                    }
-                    if !requirement
-                        .evaluate_markers(env.marker_environment(), slice::from_ref(source_extra))
-                    {
-                        return false;
-                    }
+                if !requirement.evaluate_markers(env.marker_environment(), &[]) {
+                    return false;
                 }
 
                 if !env.included_by_group(ConflictItemRef::from((&requirement.name, source_extra)))

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -35,6 +35,7 @@ use uv_pep508::{
     MarkerEnvironment, MarkerExpression, MarkerOperator, MarkerTree, MarkerValueString,
 };
 use uv_platform_tags::{IncompatibleTag, Tags};
+use uv_preview::PreviewFeature;
 use uv_pypi_types::{ConflictItem, ConflictItemRef, ConflictKindRef, Conflicts, VerbatimParsedUrl};
 use uv_static::EnvVars;
 use uv_torch::TorchStrategy;
@@ -2331,12 +2332,50 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
     where
         'data: 'parameters,
     {
+        let correct_extra_markers = uv_preview::is_enabled(PreviewFeature::CorrectExtraMarkers);
+
         self.overrides
             .apply_for_package(override_package, dependencies)
             .filter(move |requirement| {
                 !self
                     .excludes
                     .contains_for_package(exclusion_package, &requirement.name)
+            })
+            .map(move |mut requirement| {
+                if !correct_extra_markers {
+                    return requirement;
+                }
+
+                // Split the marker into production and optional components. If we have e.g.
+                // `foo; sys_platform == 'win32' or extra == 'feature'`
+                // we split it into
+                // `foo; sys_platform == 'win32'` (production) when `extra` is `None`,
+                // `foo; extra == 'feature'` (optional) when `extra` is `Some("feature")`.
+                // The requirements are then separately tracked in production and optional
+                // dependencies respectively.
+
+                let marker = match extra {
+                    Some(extra) => {
+                        let mut marker = requirement
+                            .marker
+                            .simplify_extras(slice::from_ref(extra))
+                            .simplify_not_extras_with(|candidate| candidate != extra);
+                        marker.and(
+                            requirement
+                                .marker
+                                .simplify_not_extras_with(|_| true)
+                                .negate(),
+                        );
+                        marker
+                    }
+                    None => requirement.marker.simplify_not_extras_with(|_| true),
+                };
+
+                if requirement.marker != marker {
+                    requirement.to_mut().marker = marker;
+                }
+
+                requirement
             })
             .filter(move |requirement| {
                 Self::is_requirement_applicable(
@@ -2345,6 +2384,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     env,
                     python_marker,
                     python_requirement,
+                    correct_extra_markers,
                 )
             })
             .flat_map(move |requirement| {
@@ -2366,19 +2406,26 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         env: &ResolverEnvironment,
         python_marker: MarkerTree,
         python_requirement: &PythonRequirement,
+        correct_extra_markers: bool,
     ) -> bool {
         // If the requirement isn't relevant for the current platform, skip it.
         match extra {
             Some(source_extra) => {
-                // Only include requirements that are relevant for the current extra.
-                if requirement.evaluate_markers(env.marker_environment(), &[]) {
-                    return false;
+                if correct_extra_markers {
+                    if !requirement.evaluate_markers(env.marker_environment(), &[]) {
+                        return false;
+                    }
+                } else {
+                    if requirement.evaluate_markers(env.marker_environment(), &[]) {
+                        return false;
+                    }
+                    if !requirement
+                        .evaluate_markers(env.marker_environment(), slice::from_ref(source_extra))
+                    {
+                        return false;
+                    }
                 }
-                if !requirement
-                    .evaluate_markers(env.marker_environment(), slice::from_ref(source_extra))
-                {
-                    return false;
-                }
+
                 if !env.included_by_group(ConflictItemRef::from((&requirement.name, source_extra)))
                 {
                     return false;

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2348,19 +2348,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 // dependencies respectively.
 
                 let marker = match extra {
-                    Some(extra) => {
-                        let mut marker = requirement
-                            .marker
-                            .simplify_extras(slice::from_ref(extra))
-                            .simplify_not_extras_with(|candidate| candidate != extra);
-                        marker.and(
+                    Some(extra) => requirement
+                        .marker
+                        .simplify_extras(slice::from_ref(extra))
+                        .simplify_not_extras_with(|candidate| candidate != extra)
+                        .and(
                             requirement
                                 .marker
                                 .simplify_not_extras_with(|_| true)
                                 .negate(),
-                        );
-                        marker
-                    }
+                        ),
                     None => requirement.marker.simplify_not_extras_with(|_| true),
                 };
 

--- a/crates/uv/src/commands/project/install_target.rs
+++ b/crates/uv/src/commands/project/install_target.rs
@@ -11,8 +11,9 @@ use uv_configuration::{
     ExtrasSpecificationWithDefaults, InstallOptions,
 };
 use uv_distribution_types::{Index, Resolution};
-use uv_normalize::{ExtraName, PackageName};
+use uv_normalize::{DEV_DEPENDENCIES, ExtraName, PackageName};
 use uv_platform_tags::Tags;
+use uv_preview::PreviewFeature;
 use uv_pypi_types::{
     DependencyGroupSpecifier, LenientRequirement, ResolverMarkerEnvironment, VerbatimParsedUrl,
 };
@@ -332,21 +333,49 @@ impl<'lock> InstallTarget<'lock> {
             return Ok(());
         }
         match self {
-            Self::Project { lock, .. }
-            | Self::Projects { lock, .. }
-            | Self::Workspace { lock, .. }
-            | Self::NonProjectWorkspace { lock, .. } => {
+            Self::Project {
+                lock, workspace, ..
+            }
+            | Self::Projects {
+                lock, workspace, ..
+            }
+            | Self::Workspace { lock, workspace }
+            | Self::NonProjectWorkspace { lock, workspace } => {
                 if !lock.supports_provides_extra() {
                     return Ok(());
                 }
 
+                let metadata_free_lock = lock.supports_missing_package_metadata()
+                    && uv_preview::is_enabled(PreviewFeature::LockWithoutMetadata);
                 let roots = self.roots().collect::<FxHashSet<_>>();
                 // Collect all known extras from the member packages.
                 let known_extras = lock
                     .packages()
                     .iter()
                     .filter(|package| roots.contains(package.name()))
-                    .flat_map(|package| package.provides_extras().iter())
+                    .flat_map(|package| {
+                        // Extras that are empty or where the dependencies are filtered out through
+                        // their marker have no locked edges, so we read the workspace instead.
+                        let declared_extras = metadata_free_lock
+                            .then_some(package)
+                            .filter(|package| !package.has_metadata())
+                            .and_then(|package| workspace.packages().get(package.name()))
+                            .and_then(|member| member.pyproject_toml().project.as_ref())
+                            .and_then(|project| project.optional_dependencies.as_ref())
+                            .into_iter()
+                            .flat_map(|dependencies| dependencies.keys());
+
+                        package
+                            .provides_extras()
+                            .iter()
+                            .chain(
+                                metadata_free_lock
+                                    .then(|| package.optional_dependencies().keys())
+                                    .into_iter()
+                                    .flatten(),
+                            )
+                            .chain(declared_extras)
+                    })
                     .collect::<FxHashSet<_>>();
 
                 for extra in extras.explicit_names() {
@@ -397,12 +426,51 @@ impl<'lock> InstallTarget<'lock> {
             }
             | Self::Workspace { lock, workspace }
             | Self::NonProjectWorkspace { lock, workspace } => {
+                let metadata_free_lock = lock.supports_missing_package_metadata()
+                    && uv_preview::is_enabled(PreviewFeature::LockWithoutMetadata);
                 let roots = self.roots().collect::<FxHashSet<_>>();
                 let member_groups = lock
                     .packages()
                     .iter()
                     .filter(|package| roots.contains(package.name()))
-                    .flat_map(|package| package.dependency_groups().keys().map(Cow::Borrowed));
+                    .flat_map(|package| {
+                        // Groups that are empty or where the dependencies are filtered out through
+                        // their marker have no locked edges, so we read the workspace instead.
+                        let declared_groups = metadata_free_lock
+                            .then_some(package)
+                            .filter(|package| !package.has_metadata())
+                            .and_then(|package| workspace.packages().get(package.name()))
+                            .into_iter()
+                            .flat_map(|member| {
+                                let pyproject = member.pyproject_toml();
+                                let declared_groups = pyproject
+                                    .dependency_groups
+                                    .as_ref()
+                                    .into_iter()
+                                    .flatten()
+                                    .map(|(group, _)| group);
+                                let legacy_dev = pyproject
+                                    .tool
+                                    .as_ref()
+                                    .and_then(|tool| tool.uv.as_ref())
+                                    .and_then(|uv| uv.dev_dependencies.as_ref())
+                                    .is_some()
+                                    .then_some(&*DEV_DEPENDENCIES);
+                                declared_groups.chain(legacy_dev)
+                            });
+
+                        package
+                            .dependency_groups()
+                            .keys()
+                            .chain(
+                                metadata_free_lock
+                                    .then(|| package.resolved_dependency_groups().keys())
+                                    .into_iter()
+                                    .flatten(),
+                            )
+                            .chain(declared_groups)
+                            .map(Cow::Borrowed)
+                    });
 
                 // Groups defined directly on a non-project workspace root are not members.
                 let workspace_groups = matches!(

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -25,6 +25,20 @@ use uv_test::{READ_ONLY_GITHUB_TOKEN, decode_token};
 #[cfg(feature = "test-universal")]
 use uv_test::{download_to_disk, venv_bin_path};
 
+/// Generate the preview lock without package metadata.
+#[cfg(feature = "test-universal")]
+fn lock_without_package_metadata(lock: &str) -> Result<toml_edit::DocumentMut> {
+    let mut lock = lock.parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    for package in packages.iter_mut() {
+        package.remove("metadata");
+    }
+    lock["revision"] = toml_edit::value(4);
+    Ok(lock)
+}
+
 #[cfg(feature = "test-universal")]
 #[test]
 fn lock_wheel_registry() -> Result<()> {
@@ -17346,6 +17360,274 @@ fn lock_rename_project() -> Result<()> {
         "#
         );
     });
+
+    Ok(())
+}
+
+/// An empty extra remains selectable when its lockfile omits package metadata.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_frozen_empty_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        empty = []
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    let lock = lock_without_package_metadata(&context.read("uv.lock"))?;
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--frozen")
+        .arg("--extra")
+        .arg("empty"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Checked in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Removing an empty extra invalidates the lockfile that recorded it.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_removed_empty_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        empty = []
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+
+        [package.metadata]
+        provides-extras = ["empty"]
+        "#
+        );
+    });
+
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Extras and groups remain selectable when all of their requirements resolve to no edges.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_frozen_filtered_dependency_selections() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        empty = []
+        excluded = ["excluded-dependency"]
+        inapplicable = ["inapplicable-dependency ; python_version < '3.0'"]
+
+        [dependency-groups]
+        empty = []
+        excluded = ["excluded-dependency"]
+        inapplicable = ["inapplicable-dependency ; python_version < '3.0'"]
+        included = [{ include-group = "empty" }]
+
+        [tool.uv]
+        dev-dependencies = []
+        exclude-dependencies = ["excluded-dependency"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
+    Resolved 1 package in [TIME]
+    ");
+
+    let lock = lock_without_package_metadata(&context.read("uv.lock"))?;
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--frozen")
+        .arg("--extra")
+        .arg("empty")
+        .arg("--extra")
+        .arg("excluded")
+        .arg("--extra")
+        .arg("inapplicable")
+        .arg("--group")
+        .arg("empty")
+        .arg("--group")
+        .arg("excluded")
+        .arg("--group")
+        .arg("inapplicable")
+        .arg("--group")
+        .arg("included")
+        .arg("--group")
+        .arg("dev"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
+    Checked in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Lockfile revision 1.4 must retain frozen selection semantics.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_frozen_preserves_recorded_selections() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    let original_pyproject = indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["dependency"]
+
+        [project.optional-dependencies]
+        original = ["dependency"]
+
+        [dependency-groups]
+        original = ["dependency"]
+
+        [tool.uv.sources]
+        dependency = { path = "dependency" }
+        "#};
+    pyproject_toml.write_str(original_pyproject)?;
+    context
+        .temp_dir
+        .child("dependency/pyproject.toml")
+        .write_str(indoc! {r#"
+            [project]
+            name = "dependency"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    let mut lock = context.read("uv.lock").parse::<toml_edit::DocumentMut>()?;
+    lock["revision"] = toml_edit::value(4);
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    pyproject_toml.write_str(&original_pyproject.replace("original =", "added ="))?;
+
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--extra").arg("original"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + dependency==1.0.0 (from file://[TEMP_DIR]/dependency)
+    ");
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--extra").arg("added"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Extra `added` is not defined in the `optional-dependencies` table for `project`
+    ");
+
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--group").arg("original"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Checked 1 package in [TIME]
+    ");
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--group").arg("added"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Group `added` is not defined in the project's `dependency-groups` table
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -24528,6 +24528,112 @@ fn lock_multiple_sources_respect_marker() -> Result<()> {
     Ok(())
 }
 
+/// Ensure that unreachable extras are split off, but the marker itself remains.
+///
+/// In this case,
+/// `foo; sys_platform == 'win32' or extra == 'feature'`
+/// is split into
+/// `foo; sys_platform == 'win32'` (production)
+/// and
+/// `foo; extra == 'feature'` (extra)
+/// which are tracked in production and optional dependencies respectively.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_extra_marker_preserves_production_platform() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "marker-leaf ; sys_platform == 'win32' or extra == 'feature'",
+        ]
+
+        [project.optional-dependencies]
+        feature = []
+
+        [tool.uv.sources]
+        marker-leaf = { path = "leaf" }
+        "#,
+    )?;
+
+    context
+        .temp_dir
+        .child("leaf")
+        .child("pyproject.toml")
+        .write_str(
+            r#"
+            [project]
+            name = "marker-leaf"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+
+            [build-system]
+            requires = ["uv_build>=0.7,<10000"]
+            build-backend = "uv_build"
+            "#,
+        )?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("correct-extra-markers").arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "marker-leaf"
+        version = "1.0.0"
+        source = { directory = "leaf" }
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "marker-leaf", marker = "sys_platform == 'win32'" },
+        ]
+
+        [package.optional-dependencies]
+        feature = [
+            { name = "marker-leaf", marker = "sys_platform != 'win32'" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "marker-leaf", marker = "sys_platform == 'win32' or extra == 'feature'", directory = "leaf" }]
+        provides-extras = ["feature"]
+        "#);
+    });
+
+    uv_snapshot!(context.filters(), context.export().arg("--frozen").arg("--no-header"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    ./leaf ; sys_platform == 'win32'
+        # via project
+    ");
+    uv_snapshot!(context.filters(), context.export().arg("--frozen").arg("--no-header").arg("--extra").arg("feature"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    ./leaf
+        # via project
+    ");
+
+    Ok(())
+}
+
 #[cfg(feature = "test-universal")]
 #[test]
 fn lock_multiple_sources_extra() -> Result<()> {

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -24577,7 +24577,7 @@ fn lock_extra_marker_preserves_production_platform() -> Result<()> {
             "#,
         )?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("correct-extra-markers").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock().arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -24690,6 +24690,9 @@ fn lock_multiple_sources_extra() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { virtual = "." }
+        dependencies = [
+            { name = "iniconfig" },
+        ]
 
         [package.optional-dependencies]
         cpu = [

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3226,6 +3226,7 @@ fn preview_features() {
     +            NoDistutilsPatch,
     +            IndexHashAlgorithm,
     +            LockfileFormatCheck,
+    +            LockWithoutMetadata,
     +        ],
          },
          python_preference: Managed,

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3226,7 +3226,6 @@ fn preview_features() {
     +            NoDistutilsPatch,
     +            IndexHashAlgorithm,
     +            LockfileFormatCheck,
-    +            CorrectExtraMarkers,
     +        ],
          },
          python_preference: Managed,

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3226,6 +3226,7 @@ fn preview_features() {
     +            NoDistutilsPatch,
     +            IndexHashAlgorithm,
     +            LockfileFormatCheck,
+    +            CorrectExtraMarkers,
     +        ],
          },
          python_preference: Managed,

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1803,7 +1803,8 @@
             "workspace-list-scripts",
             "no-distutils-patch",
             "index-hash-algorithm",
-            "lockfile-format-check"
+            "lockfile-format-check",
+            "lock-without-metadata"
           ]
         },
         {

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1803,7 +1803,8 @@
             "workspace-list-scripts",
             "no-distutils-patch",
             "index-hash-algorithm",
-            "lockfile-format-check"
+            "lockfile-format-check",
+            "correct-extra-markers"
           ]
         },
         {

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1803,8 +1803,7 @@
             "workspace-list-scripts",
             "no-distutils-patch",
             "index-hash-algorithm",
-            "lockfile-format-check",
-            "correct-extra-markers"
+            "lockfile-format-check"
           ]
         },
         {


### PR DESCRIPTION
Support validation extras and dependency groups with `uv sync --frozen` for a `package.metadata`-free lockfile by reading from the workspace too.

Note that uv fails  when selecting an empty extra or group that was previously locked, but has since been removed from `pyproject.toml`. This is the case for main too