### PR TITLE
Show page titles instead of `Index` in docs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,23 +183,23 @@ extra:
 nav:
   - Introduction: index.md
   - Getting started:
-      - getting-started/index.md
+      - Getting started: getting-started/index.md
       - Installation: getting-started/installation.md
       - First steps: getting-started/first-steps.md
       - Features: getting-started/features.md
       - Getting help: getting-started/help.md
   - Guides:
-      - guides/index.md
+      - Guides overview: guides/index.md
       - Installing Python: guides/install-python.md
       - Running scripts: guides/scripts.md
       - Using tools: guides/tools.md
       - Working on projects: guides/projects.md
       - Publishing packages: guides/package.md
       - Migration:
-          - guides/migration/index.md
+          - Migration guides: guides/migration/index.md
           - From pip to a uv project: guides/migration/pip-to-project.md
       - Integrations:
-          - guides/integration/index.md
+          - Integration guides: guides/integration/index.md
           - Docker: guides/integration/docker.md
           - Jupyter: guides/integration/jupyter.md
           - marimo: guides/integration/marimo.md
@@ -218,9 +218,9 @@ nav:
           - AWS Lambda: guides/integration/aws-lambda.md
           - Coiled: guides/integration/coiled.md
   - Concepts:
-      - concepts/index.md
+      - Concepts overview: concepts/index.md
       - Projects:
-          - concepts/projects/index.md
+          - Projects: concepts/projects/index.md
           - Structure and files: concepts/projects/layout.md
           - Creating projects: concepts/projects/init.md
           - Managing dependencies: concepts/projects/dependencies.md
@@ -237,7 +237,7 @@ nav:
       - Resolution: concepts/resolution.md
       - Build backend: concepts/build-backend.md
       - Authentication:
-          - concepts/authentication/index.md
+          - Authentication: concepts/authentication/index.md
           - The auth CLI: concepts/authentication/cli.md
           - HTTP credentials: concepts/authentication/http.md
           - Git credentials: concepts/authentication/git.md
@@ -248,7 +248,7 @@ nav:
       # Note:  The `pip` section was moved to the `concepts/` section but the
       # top-level directory structure was retained to ease the transition.
       - The pip interface:
-          - pip/index.md
+          - The pip interface: pip/index.md
           - Using environments: pip/environments.md
           - Managing packages: pip/packages.md
           - Inspecting environments: pip/inspection.md
@@ -256,24 +256,24 @@ nav:
           - Locking environments: pip/compile.md
           - Compatibility with pip: pip/compatibility.md
   - Reference:
-      - reference/index.md
+      - Reference: reference/index.md
       - Commands: reference/cli.md
       - Settings: reference/settings.md
       - Environment variables: reference/environment.md
       - Storage: reference/storage.md
       - Installer options: reference/installer.md
       - Troubleshooting:
-          - reference/troubleshooting/index.md
+          - Troubleshooting: reference/troubleshooting/index.md
           - Build failures: reference/troubleshooting/build-failures.md
           - Reproducible examples: reference/troubleshooting/reproducible-examples.md
       - Contributing: reference/contributing.md
       - Internals:
-          - reference/internals/index.md
+          - Internals: reference/internals/index.md
           - Resolver: reference/internals/resolver.md
           - Workspace Metadata: reference/internals/metadata.md
       - Benchmarks: reference/benchmarks.md
       - Policies:
-          - reference/policies/index.md
+          - Policies: reference/policies/index.md
           - Versioning: reference/policies/versioning.md
           - Platform support: reference/policies/platforms.md
           - Python support: reference/policies/python.md


### PR DESCRIPTION
Closes #16377

## Summary

Nested navigation entries that pointed at a directory index page had no explicit title, so
MkDocs fell back to rendering them as "Index" in the sidebar and in the next/previous page
buttons. This was visible for every section landing page, e.g. "Getting started", "Guides",
"Concepts", "Reference".

Each affected entry now carries an explicit title taken from the target page's own `H1`, so
the navigation label matches the page it links to:

| Page | Was | Now |
| --- | --- | --- |
| `getting-started/index.md` | Index | Getting started |
| `guides/index.md` | Index | Guides overview |
| `guides/migration/index.md` | Index | Migration guides |
| `guides/integration/index.md` | Index | Integration guides |
| `concepts/index.md` | Index | Concepts overview |
| `concepts/projects/index.md` | Index | Projects |
| `concepts/authentication/index.md` | Index | Authentication |
| `pip/index.md` | Index | The pip interface |
| `reference/index.md` | Index | Reference |
| `reference/troubleshooting/index.md` | Index | Troubleshooting |
| `reference/internals/index.md` | Index | Internals |
| `reference/policies/index.md` | Index | Policies |

## Test Plan

- Confirmed every remaining `nav:` entry now has an explicit title (no bare `*/index.md`
  entries are left).
- Parsed `mkdocs.yml` with PyYAML to confirm the file is still valid and that the `nav` tree
  contains zero untitled entries.
- The `index.md` references under the `plugins:` llms.txt section are intentionally untouched,
  since those are file lists rather than navigation labels.