### PR TITLE
Better test guidance for codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,10 @@
 - ALWAYS write `SAFETY` comments following our usual style when writing `unsafe` code
 - PREFER `#[expect()]` over `[allow()]` if clippy must be disabled
 - PREFER let chains (`if let` combined with `&&`) over nested `if let` statements
-- NEVER update all dependencies in the lockfile and ALWAYS use `cargo update --precise` to make lockfile changes
-- NEVER assume clippy warnings or test failures are pre-existing, it is very rare that `main` has warnings
+- NEVER update all dependencies in the lockfile and ALWAYS use `cargo update --precise` to make
+  lockfile changes
+- NEVER assume clippy warnings or test failures are pre-existing, it is very rare that `main` has
+  warnings
 - PREFER top-level imports over local imports or fully qualified names
 - AVOID shortening variable names, e.g., use `version` instead of `ver`, and `requires_python`
   instead of `rp`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,18 @@
 - Read CONTRIBUTING.md for guidelines on how to run tools
-- ALWAYS attempt to add a test case for changed behavior
+- ALWAYS ensure that new tests use the same style as existing tests for all parts of the test
+- ALWAYS check whether the behavior of a new test is already covered by an existing test
 - PREFER integration tests, e.g., at `it/...` over unit tests
+- PREFER running specific tests over running the entire test suite
 - PREFER `insta` snapshots following patterns in nearby tests over substring assertions
 - When making changes for Windows from Unix, use `cargo xwin clippy` to check compilation
 - NEVER perform builds with the release profile, unless asked or reproducing performance issues
-- PREFER running specific tests over running the entire test suite
 - AVOID using `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and clippy rule ignores
 - PREFER patterns like `if let` to handle fallibility
 - ALWAYS write `SAFETY` comments following our usual style when writing `unsafe` code
 - PREFER `#[expect()]` over `[allow()]` if clippy must be disabled
 - PREFER let chains (`if let` combined with `&&`) over nested `if let` statements
-- NEVER update all dependencies in the lockfile and ALWAYS use `cargo update --precise` to make
-  lockfile changes
-- NEVER assume clippy warnings are pre-existing, it is very rare that `main` has warnings
-- ALWAYS read and copy the style of similar tests when adding new cases
+- NEVER update all dependencies in the lockfile and ALWAYS use `cargo update --precise` to make lockfile changes
+- NEVER assume clippy warnings or test failures are pre-existing, it is very rare that `main` has warnings
 - PREFER top-level imports over local imports or fully qualified names
 - AVOID shortening variable names, e.g., use `version` instead of `ver`, and `requires_python`
   instead of `rp`


### PR DESCRIPTION
When making multi-staged changes with codex, it has a tendency to add tests that check trivial properties or check what is already covered in other tests. The new tests roughly follow our existing patterns, but diverge from our usual snapshot testing through toml parsing or not snapshotting output, unless you remind the model to go check existing tests explicitly.