### PR TITLE
Use ty's `--exclude-scripts` flag in `uv check`

### DIFF
--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use tracing::debug;
 
 use uv_cache::Cache;
@@ -10,7 +10,7 @@ use uv_configuration::{
     Concurrency, DependencyGroups, DependencyGroupsWithDefaults, DryRun, ExtrasSpecification,
     InstallOptions,
 };
-use uv_fs::{Simplified, normalize_path};
+use uv_fs::normalize_path;
 use uv_normalize::{DEV_DEPENDENCIES, DefaultExtras, PackageName};
 use uv_preview::{Preview, PreviewFeature};
 use uv_python::{
@@ -727,6 +727,9 @@ pub(crate) async fn check(
         ty_version,
         ty_path.or(locked_ty_path),
         &target_dir,
+        project
+            .as_ref()
+            .map(|project| project.workspace().install_path().as_path()),
         &check_targets,
         &excluded_targets,
         venv_path.as_deref(),

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -34,7 +34,6 @@ use crate::commands::project::{
     validate_project_requires_python,
 };
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::workspace::list::{ScriptDiscoveryError, find_scripts};
 use crate::commands::{ExitStatus, diagnostics, project};
 use crate::printer::Printer;
 use crate::settings::{FrozenSource, LockCheck, ResolverInstallerSettings};
@@ -246,7 +245,7 @@ pub(crate) async fn check(
     // The most common case this is handling is a non-virtual workspace, where the root
     // package will almost always have the other packages nested under it, and we need a
     // way to select just the workspace root.
-    let mut excluded_targets = if let Some(project) = project.as_ref()
+    let excluded_targets = if let Some(project) = project.as_ref()
         && !defacto_all_packages
     {
         project
@@ -269,40 +268,6 @@ pub(crate) async fn check(
     } else {
         Vec::new()
     };
-
-    // PEP 723 scripts have independent environments and must be checked explicitly with
-    // `uv check --script`. Reuse `uv workspace list --scripts` discovery so scripts nested in
-    // selected workspace members are not checked against the project environment.
-    if let Some(project) = project.as_ref() {
-        excluded_targets.extend(
-            find_scripts(project.workspace().install_path(), cache)
-                .filter_map(|script| match script {
-                    Ok(script) => check_targets
-                        .iter()
-                        .any(|target| script.starts_with(target))
-                        .then_some(Ok(script)),
-                    Err(ScriptDiscoveryError::Parse { path, source }) => {
-                        debug!(
-                            "Excluding invalid PEP 723 script `{}` while checking project root `{}`: {source}",
-                            path.simplified_display(),
-                            project.root().simplified_display(),
-                        );
-                        check_targets
-                            .iter()
-                            .any(|target| path.starts_with(target))
-                            .then_some(Ok(path))
-                    }
-                    Err(err) => Some(Err(err)),
-                })
-                .collect::<Result<Vec<_>, _>>()
-                .with_context(|| {
-                    format!(
-                        "Failed to discover PEP 723 scripts while checking project root `{}`",
-                        project.root().simplified_display()
-                    )
-                })?,
-        );
-    }
 
     let groups = if let Some(project) = &project {
         groups.with_defaults(default_dependency_groups(project.pyproject_toml())?)

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -9,10 +9,13 @@ use tracing::debug;
 use uv_bin_install::{BinVersion, Binary, ResolvedVersion, bin_install, find_matching_version};
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
+use uv_fs::Simplified;
+use uv_pep440::Version;
 
 use crate::child::run_to_completion;
 use crate::commands::ExitStatus;
 use crate::commands::reporters::BinaryDownloadReporter;
+use crate::commands::workspace::list::{ScriptDiscoveryError, find_scripts};
 use crate::printer::Printer;
 
 /// Run a type check powered by ty.
@@ -20,6 +23,7 @@ pub(super) async fn run(
     version: Option<String>,
     ty_path: Option<PathBuf>,
     target_dir: &Path,
+    workspace_root: Option<&Path>,
     check_targets: &[PathBuf],
     excluded_targets: &[PathBuf],
     venv_path: Option<&Path>,
@@ -29,20 +33,28 @@ pub(super) async fn run(
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    let ty_path = if let Some(ty_path) = ty_path {
+    let (ty_path, ty_version) = if let Some(ty_path) = ty_path {
+        let output = Command::new(&ty_path)
+            .arg("--version")
+            .output()
+            .await
+            .context("Failed to query ty version")?;
+        if !output.status.success() {
+            anyhow::bail!("Failed to query ty version");
+        }
+        let version = String::from_utf8_lossy(&output.stdout);
+        let ty_version = version
+            .split_whitespace()
+            .nth(1)
+            .context("Failed to parse ty version")?
+            .parse::<Version>()
+            .context("Failed to parse ty version")?;
+
         if show_version {
-            let output = Command::new(&ty_path)
-                .arg("--version")
-                .output()
-                .await
-                .context("Failed to query ty version")?;
-            if !output.status.success() {
-                anyhow::bail!("Failed to query ty version");
-            }
-            let version = String::from_utf8_lossy(&output.stdout);
             writeln!(printer.stderr(), "Using {}", version.trim())?;
         }
-        ty_path
+
+        (ty_path, ty_version)
     } else {
         let retry_policy = client_builder.retry_policy();
         let ty_client = client_builder.clone().retries(0).build()?;
@@ -111,7 +123,7 @@ pub(super) async fn run(
             writeln!(printer.stderr(), "Using ty {}", resolved.version)?;
         }
 
-        bin_install(
+        let ty_path = bin_install(
             Binary::Ty,
             &resolved,
             &ty_client,
@@ -120,7 +132,9 @@ pub(super) async fn run(
             &reporter,
         )
         .await
-        .with_context(|| format!("Failed to install ty {}", resolved.version))?
+        .with_context(|| format!("Failed to install ty {}", resolved.version))?;
+
+        (ty_path, resolved.version)
     };
 
     let mut command = Command::new(&ty_path);
@@ -128,8 +142,43 @@ pub(super) async fn run(
     command.arg("check");
     // PEP 723 scripts have independent environments and must be checked explicitly with
     // `uv check --script`. This still allows explicitly selected script paths to be checked.
-    command.arg("--exclude-scripts");
-    for excluded_target in excluded_targets {
+    // Older versions of ty do not support `--exclude-scripts`, so discover and exclude their
+    // workspace scripts individually instead.
+    let mut excluded_scripts = Vec::new();
+    if ty_version >= Version::new([0, 0, 64]) {
+        command.arg("--exclude-scripts");
+    } else if let Some(workspace_root) = workspace_root {
+        excluded_scripts.extend(
+            find_scripts(workspace_root, cache)
+                .filter_map(|script| match script {
+                    Ok(script) => check_targets
+                        .iter()
+                        .any(|target| script.starts_with(target))
+                        .then_some(Ok(script)),
+                    Err(ScriptDiscoveryError::Parse { path, source }) => {
+                        debug!(
+                            "Excluding invalid PEP 723 script `{}` while checking project root `{}`: {source}",
+                            path.simplified_display(),
+                            target_dir.simplified_display(),
+                        );
+                        check_targets
+                            .iter()
+                            .any(|target| path.starts_with(target))
+                            .then_some(Ok(path))
+                    }
+                    Err(error) => Some(Err(error)),
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .with_context(|| {
+                    format!(
+                        "Failed to discover PEP 723 scripts while checking project root `{}`",
+                        target_dir.simplified_display()
+                    )
+                })?,
+        );
+    }
+
+    for excluded_target in excluded_targets.iter().chain(&excluded_scripts) {
         command.arg("--exclude");
         command.arg(
             excluded_target

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -126,6 +126,9 @@ pub(super) async fn run(
     let mut command = Command::new(&ty_path);
     command.current_dir(target_dir);
     command.arg("check");
+    // PEP 723 scripts have independent environments and must be checked explicitly with
+    // `uv check --script`. This still allows explicitly selected script paths to be checked.
+    command.arg("--exclude-scripts");
     for excluded_target in excluded_targets {
         command.arg("--exclude");
         command.arg(

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -112,6 +112,20 @@ fn check_workspace_excludes_pep723_scripts() -> Result<()> {
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     "#);
 
+    uv_snapshot!(
+        context.filters(),
+        workspace_check(&context).arg("--ty-version").arg("0.0.64"),
+        @r#"
+        exit_code: 1 (failure)
+        ----- stdout -----
+        main.py:1:14: error[invalid-assignment] Object of type `Literal["project"]` is not assignable to `int`
+        Found 1 diagnostic
+
+        ----- stderr -----
+        warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+        "#
+    );
+
     uv_snapshot!(context.filters(), workspace_check(&context).arg("--package").arg("member"), @r#"
     exit_code: 1 (failure)
     ----- stdout -----


### PR DESCRIPTION
This is a followup to https://github.com/astral-sh/uv/pull/20676 that should presumably be more efficient and clean but requires ty to cut a release with this feature first.