### PR TITLE
Add shell activation test matrix, repair support for yash, dash, ash, and nushell

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -73,7 +73,10 @@ jobs:
           curl -sSL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJf -
           sudo mv "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/
       - name: "Run shellcheck"
-        run: find . -name '*.sh' -type f | xargs shellcheck --shell bash --severity style
+        run: |
+          find . -type f \
+            \( -name '*.sh' -o -path './crates/uv-virtualenv/src/activator/activate' \) |
+            xargs shellcheck --shell bash --severity style
 
   validate-pyproject:
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,15 @@ jobs:
     with:
       sha: ${{ github.sha }}
 
+  test-shell-activation:
+    needs:
+      - plan
+      - build-dev-binaries
+    if: ${{ needs.plan.outputs.test-shell-activation == 'true' }}
+    uses: ./.github/workflows/test-shell-activation.yml
+    with:
+      sha: ${{ github.sha }}
+
   test-integration:
     needs:
       - plan
@@ -301,6 +310,7 @@ jobs:
       - check-generated-files
       - test
       - build-dev-binaries
+      - test-shell-activation
     runs-on: ubuntu-slim
     steps:
       - name: "Check required jobs passed"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -45,6 +45,9 @@ on:
       test-smoke:
         description: "Whether smoke tests should run"
         value: ${{ jobs.plan.outputs.test-smoke }}
+      test-shell-activation:
+        description: "Whether shell activation tests should run"
+        value: ${{ jobs.plan.outputs.test-shell-activation }}
       test-ecosystem:
         description: "Whether ecosystem tests should run"
         value: ${{ jobs.plan.outputs.test-ecosystem }}
@@ -81,6 +84,7 @@ jobs:
       save-rust-cache: ${{ steps.plan.outputs.save_rust_cache }}
       run-bench: ${{ steps.plan.outputs.run_bench }}
       test-smoke: ${{ steps.plan.outputs.test_smoke }}
+      test-shell-activation: ${{ steps.plan.outputs.test_shell_activation }}
       test-ecosystem: ${{ steps.plan.outputs.test_ecosystem }}
       test-integration: ${{ steps.plan.outputs.test_integration }}
       test-system: ${{ steps.plan.outputs.test_system }}
@@ -149,6 +153,7 @@ jobs:
             [[ "$file" == "Dockerfile" ]] && dockerfile_changed=1
             [[ "$file" == ".github/workflows/build-docker.yml" ]] && docker_workflow_changed=1
             [[ "$file" == ".github/workflows/bench.yml" ]] && bench_workflow_changed=1
+            [[ "$file" == ".github/workflows/test-shell-activation.yml" || "$file" == ".github/workflows/build-dev-binaries.yml" || "$file" == "crates/uv/tests/python/venv.rs" || "$file" =~ ^crates/uv-virtualenv/src/activator/ || "$file" == "crates/uv-virtualenv/src/virtualenv.rs" ]] && shell_activation_changed=1
             [[ "$file" == ".github/workflows/test-integration.yml" || "$file" =~ ^test/integration/ || "$file" == "scripts/check_registry.py" || "$file" == "scripts/check_cache_compat.py" || "$file" == "scripts/registries-test.py" ]] && integration_changed=1
             [[ "$file" == ".github/workflows/test-system.yml" ]] && system_workflow_changed=1
             [[ "$file" == "scripts/check_system_python.py" || "$file" == "scripts/check_embedded_python.py" ]] && system_test_changed=1
@@ -175,6 +180,7 @@ jobs:
           [[ $on_main_branch || $cache_relevant_changed ]] && save_rust_cache=1
           [[ ! $has_skip_label && ($any_rust_changed || $bench_workflow_changed || $on_main_branch) ]] && run_bench=1
           [[ ! $has_skip_label ]] && test_smoke=1
+          [[ ! $has_skip_label && ($shell_activation_changed || $has_integration_label || $has_extended_label || $on_main_branch) ]] && test_shell_activation=1
           [[ ! $has_skip_label ]] && test_ecosystem=1
           [[ $has_integration_label || $has_extended_label || $on_main_branch || $integration_changed ]] && test_integration=1
           [[ $has_system_label || $has_extended_label || $on_main_branch || $system_workflow_changed || $system_test_changed ]] && test_system=1
@@ -196,6 +202,7 @@ jobs:
             out save_rust_cache         "$save_rust_cache"
             out run_bench               "$run_bench"
             out test_smoke              "$test_smoke"
+            out test_shell_activation   "$test_shell_activation"
             out test_ecosystem          "$test_ecosystem"
             out test_integration        "$test_integration"
             out test_system             "$test_system"

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -16,53 +16,6 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
-  integration-test-nushell:
-    name: "nushell"
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install nushell
-        env:
-          # This token only needs read access to the GitHub repository nushell/nushell.
-          # This token is used (via gh-cli) to avoid hitting GitHub REST API rate limits.
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |-
-          # get latest nushell tag name
-          nu_latest=$(gh release list --repo nushell/nushell --limit 1 --exclude-pre-releases --exclude-drafts --json "tagName" --jq '.[0].tagName')
-          # trim any trailing whitespace from output
-          nu_tag=${nu_latest%%[[:space:]]*}
-
-          # download binary for x86_64-unknown-linux-gnu target
-          gh release download ${nu_tag} --repo nushell/nushell --pattern "nu-${nu_tag}-x86_64-unknown-linux-gnu.tar.gz"
-
-          # extract nu binary from tar.gz
-          tar -xf "nu-${nu_tag}-x86_64-unknown-linux-gnu.tar.gz"
-          # make the binary executable
-          chmod +x "./nu-${nu_tag}-x86_64-unknown-linux-gnu/nu"
-          # add it to PATH
-          echo "${{ github.workspace }}/nu-${nu_tag}-x86_64-unknown-linux-gnu" >> "${GITHUB_PATH}"
-
-      - name: Download binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: uv-linux-libc-${{ inputs.sha }}
-
-      - name: Prepare binary
-        run: chmod +x ./uv
-
-      - name: Create venv
-        # The python version is arbitrary for this test.
-        # We only want to ensure the activation script behaves properly
-        run: ./uv venv
-
-      - name: Activate venv
-        shell: nu {0}
-        run: overlay use ${{ github.workspace }}/.venv/bin/activate.nu
-
   integration-test-conda:
     name: "conda on linux"
     timeout-minutes: 10

--- a/.github/workflows/test-shell-activation.yml
+++ b/.github/workflows/test-shell-activation.yml
@@ -505,48 +505,51 @@ jobs:
         with:
           name: uv-windows-x86_64-${{ inputs.sha }}
 
+      - name: "Prepare batch activation test"
+        run: |
+          $activationTest = @'
+          @echo off
+          set "ORIGINAL_PATH=%PATH%"
+
+          call "%~1\Scripts\activate.bat"
+          if errorlevel 1 exit /b 1
+
+          if /I not "%VIRTUAL_ENV%"=="%CD%\%~1" exit /b 1
+
+          python -c "import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ['VIRTUAL_ENV'])"
+          if errorlevel 1 exit /b 1
+
+          call "%~1\Scripts\deactivate.bat"
+          if errorlevel 1 exit /b 1
+
+          if not "%PATH%"=="%ORIGINAL_PATH%" exit /b 1
+          if defined VIRTUAL_ENV exit /b 1
+          '@
+
+          Set-Content -Path activation-test.cmd -Value $activationTest -Encoding ascii
+
       - name: "Create virtual environment"
-        shell: cmd
-        run: .\uv.exe venv
+        run: ./uv.exe venv
 
       - name: "Activate and deactivate virtual environment"
-        shell: cmd
         run: |
-          @set "ORIGINAL_PATH=%PATH%"
-
-          @call .venv\Scripts\activate.bat
-          @if errorlevel 1 exit /b 1
-
-          @if /I not "%VIRTUAL_ENV%"=="%CD%\.venv" exit /b 1
-
-          @python -c "import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ['VIRTUAL_ENV'])"
-          @if errorlevel 1 exit /b 1
-
-          @call .venv\Scripts\deactivate.bat
-          @if errorlevel 1 exit /b 1
-
-          @if not "%PATH%"=="%ORIGINAL_PATH%" exit /b 1
-          @if defined VIRTUAL_ENV exit /b 1
+          cmd.exe /d /c .\activation-test.cmd .venv
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to activate and deactivate the virtual environment in cmd.exe"
+          }
 
       - name: "Create relocatable virtual environment"
-        shell: cmd
         run: |
-          @.\uv.exe venv --relocatable .relocatable
-          @if errorlevel 1 exit /b 1
+          ./uv.exe venv --relocatable .relocatable
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to create relocatable virtual environment"
+          }
 
-          @move .relocatable relocated
-          @if errorlevel 1 exit /b 1
+          Move-Item .relocatable relocated
 
       - name: "Activate relocated virtual environment"
-        shell: cmd
         run: |
-          @call relocated\Scripts\activate.bat
-          @if errorlevel 1 exit /b 1
-
-          @if /I not "%VIRTUAL_ENV%"=="%CD%\relocated" exit /b 1
-
-          @python -c "import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ['VIRTUAL_ENV'])"
-          @if errorlevel 1 exit /b 1
-
-          @call relocated\Scripts\deactivate.bat
-          @if errorlevel 1 exit /b 1
+          cmd.exe /d /c .\activation-test.cmd relocated
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to activate and deactivate the relocated virtual environment in cmd.exe"
+          }

--- a/.github/workflows/test-shell-activation.yml
+++ b/.github/workflows/test-shell-activation.yml
@@ -149,6 +149,7 @@ jobs:
           set -eu
 
           original_path=$PATH
+          original_directory=$PWD
           SCRIPT_PATH=original-script-path
           export SCRIPT_PATH
 
@@ -167,16 +168,19 @@ jobs:
             exit 1
           fi
 
-          test "$VIRTUAL_ENV" = "$PWD/$ACTIVATION_DIRECTORY"
+          test "$PWD" = "$original_directory"
+          test "$VIRTUAL_ENV" = "$original_directory/$ACTIVATION_DIRECTORY"
           test "$SCRIPT_PATH" = original-script-path
 
           python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
 
           deactivate
 
+          test "$PWD" = "$original_directory"
           test "$PATH" = "$original_path"
           test "$SCRIPT_PATH" = original-script-path
           test -z "${VIRTUAL_ENV-}"
+          test -z "${VIRTUAL_ENV_PROMPT-}"
           ACTIVATION
 
           if [ "$activation_status" -ne 0 ]; then
@@ -223,6 +227,7 @@ jobs:
           set -eu
 
           original_path=$PATH
+          original_directory=$PWD
           if [ "$ACTIVATION_OSTYPE" = absent ]; then
             unset OSTYPE
           else
@@ -242,14 +247,17 @@ jobs:
             exit 1
           fi
 
-          test "$VIRTUAL_ENV" = "$PWD/.venv"
+          test "$PWD" = "$original_directory"
+          test "$VIRTUAL_ENV" = "$original_directory/.venv"
 
           python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
 
           deactivate
 
+          test "$PWD" = "$original_directory"
           test "$PATH" = "$original_path"
           test -z "${VIRTUAL_ENV-}"
+          test -z "${VIRTUAL_ENV_PROMPT-}"
 
   activation-fish:
     name: "Fish activation"
@@ -280,11 +288,15 @@ jobs:
         shell: fish {0}
         run: |
           set original_path $PATH
+          set original_directory $PWD
 
           source ./.venv/bin/activate.fish
           or exit 1
 
-          test "$VIRTUAL_ENV" = "$PWD/.venv"
+          test "$PWD" = "$original_directory"
+          or exit 1
+
+          test "$VIRTUAL_ENV" = "$original_directory/.venv"
           or exit 1
 
           python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
@@ -293,10 +305,17 @@ jobs:
           deactivate
           or exit 1
 
+          test "$PWD" = "$original_directory"
+          or exit 1
+
           test (string join : $PATH) = (string join : $original_path)
           or exit 1
 
           if set -q VIRTUAL_ENV
+              exit 1
+          end
+
+          if set -q VIRTUAL_ENV_PROMPT
               exit 1
           end
 
@@ -308,10 +327,16 @@ jobs:
       - name: "Activate relocated virtual environment"
         shell: fish {0}
         run: |
+          set original_path $PATH
+          set original_directory $PWD
+
           source ./relocated/bin/activate.fish
           or exit 1
 
-          test "$VIRTUAL_ENV" = "$PWD/relocated"
+          test "$PWD" = "$original_directory"
+          or exit 1
+
+          test "$VIRTUAL_ENV" = "$original_directory/relocated"
           or exit 1
 
           python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
@@ -319,6 +344,20 @@ jobs:
 
           deactivate
           or exit 1
+
+          test "$PWD" = "$original_directory"
+          or exit 1
+
+          test (string join : $PATH) = (string join : $original_path)
+          or exit 1
+
+          if set -q VIRTUAL_ENV
+              exit 1
+          end
+
+          if set -q VIRTUAL_ENV_PROMPT
+              exit 1
+          end
 
   activation-nushell:
     name: "Nushell activation (${{ matrix.environment }})"
@@ -361,7 +400,16 @@ jobs:
         if: matrix.environment == 'standard'
         shell: nu {0}
         run: |
+          let original_path = $env.PATH
+          let original_directory = $env.PWD
+          let original_virtual_env = $env | get --optional VIRTUAL_ENV
+          let original_virtual_env_prompt = $env | get --optional VIRTUAL_ENV_PROMPT
+
           overlay use ${{ github.workspace }}/.venv/bin/activate.nu
+
+          if $env.PWD != $original_directory {
+              error make { msg: "activation changed the working directory" }
+          }
 
           if ($env.VIRTUAL_ENV | path expand) != (".venv" | path expand) {
               error make { msg: "VIRTUAL_ENV does not identify the activated environment" }
@@ -371,8 +419,20 @@ jobs:
 
           deactivate
 
-          if "VIRTUAL_ENV" in $env {
-              error make { msg: "deactivate did not remove VIRTUAL_ENV" }
+          if $env.PWD != $original_directory {
+              error make { msg: "deactivation changed the working directory" }
+          }
+
+          if $env.PATH != $original_path {
+              error make { msg: "deactivate did not restore PATH" }
+          }
+
+          if ($env | get --optional VIRTUAL_ENV) != $original_virtual_env {
+              error make { msg: "deactivate did not restore VIRTUAL_ENV" }
+          }
+
+          if ($env | get --optional VIRTUAL_ENV_PROMPT) != $original_virtual_env_prompt {
+              error make { msg: "deactivate did not restore VIRTUAL_ENV_PROMPT" }
           }
 
       - name: "Create relocatable virtual environment"
@@ -385,7 +445,16 @@ jobs:
         if: matrix.environment == 'relocatable'
         shell: nu {0}
         run: |
+          let original_path = $env.PATH
+          let original_directory = $env.PWD
+          let original_virtual_env = $env | get --optional VIRTUAL_ENV
+          let original_virtual_env_prompt = $env | get --optional VIRTUAL_ENV_PROMPT
+
           overlay use ${{ github.workspace }}/relocated/bin/activate.nu
+
+          if $env.PWD != $original_directory {
+              error make { msg: "activation changed the working directory" }
+          }
 
           if ($env.VIRTUAL_ENV | path expand) != ("relocated" | path expand) {
               error make { msg: "VIRTUAL_ENV does not identify the relocated environment" }
@@ -394,6 +463,22 @@ jobs:
           python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
 
           deactivate
+
+          if $env.PWD != $original_directory {
+              error make { msg: "deactivation changed the working directory" }
+          }
+
+          if $env.PATH != $original_path {
+              error make { msg: "deactivate did not restore PATH" }
+          }
+
+          if ($env | get --optional VIRTUAL_ENV) != $original_virtual_env {
+              error make { msg: "deactivate did not restore VIRTUAL_ENV" }
+          }
+
+          if ($env | get --optional VIRTUAL_ENV_PROMPT) != $original_virtual_env_prompt {
+              error make { msg: "deactivate did not restore VIRTUAL_ENV_PROMPT" }
+          }
 
   activation-cshell:
     name: "C shell activation"
@@ -424,18 +509,22 @@ jobs:
         shell: tcsh {0}
         run: |
           set original_path = "$PATH"
+          set original_directory = "$cwd"
 
           source ./.venv/bin/activate.csh
 
-          if ("$VIRTUAL_ENV" != "$cwd/.venv") exit 1
+          if ("$cwd" != "$original_directory") exit 1
+          if ("$VIRTUAL_ENV" != "$original_directory/.venv") exit 1
 
           python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
           if ($status != 0) exit 1
 
           deactivate
 
+          if ("$cwd" != "$original_directory") exit 1
           if ("$PATH" != "$original_path") exit 1
           if ($?VIRTUAL_ENV) exit 1
+          if ($?VIRTUAL_ENV_PROMPT) exit 1
 
       - name: "Verify relocatable environments omit the C shell activator"
         run: |
@@ -465,8 +554,13 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $originalPath = $env:PATH
+          $originalDirectory = (Get-Location).Path
 
           . .\.venv\Scripts\activate.ps1
+
+          if ((Get-Location).Path -ne $originalDirectory) {
+            throw "activation changed the working directory"
+          }
 
           if ($env:VIRTUAL_ENV -ne (Resolve-Path .\.venv).Path) {
             throw "VIRTUAL_ENV does not identify the activated environment"
@@ -479,12 +573,20 @@ jobs:
 
           deactivate
 
+          if ((Get-Location).Path -ne $originalDirectory) {
+            throw "deactivation changed the working directory"
+          }
+
           if ($env:PATH -ne $originalPath) {
             throw "deactivate did not restore PATH"
           }
 
           if (Test-Path Env:VIRTUAL_ENV) {
             throw "deactivate did not remove VIRTUAL_ENV"
+          }
+
+          if (Test-Path Env:VIRTUAL_ENV_PROMPT) {
+            throw "deactivate did not remove VIRTUAL_ENV_PROMPT"
           }
 
       - name: "Create relocatable virtual environment"
@@ -501,8 +603,14 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
+          $originalPath = $env:PATH
+          $originalDirectory = (Get-Location).Path
 
           . .\relocated\Scripts\activate.ps1
+
+          if ((Get-Location).Path -ne $originalDirectory) {
+            throw "activation changed the working directory"
+          }
 
           if ($env:VIRTUAL_ENV -ne (Resolve-Path .\relocated).Path) {
             throw "VIRTUAL_ENV does not identify the relocated environment"
@@ -514,6 +622,22 @@ jobs:
           }
 
           deactivate
+
+          if ((Get-Location).Path -ne $originalDirectory) {
+            throw "deactivation changed the working directory"
+          }
+
+          if ($env:PATH -ne $originalPath) {
+            throw "deactivate did not restore PATH"
+          }
+
+          if (Test-Path Env:VIRTUAL_ENV) {
+            throw "deactivate did not remove VIRTUAL_ENV"
+          }
+
+          if (Test-Path Env:VIRTUAL_ENV_PROMPT) {
+            throw "deactivate did not remove VIRTUAL_ENV_PROMPT"
+          }
 
   activation-batch:
     name: "Windows batch activation"
@@ -534,11 +658,13 @@ jobs:
           $activationTest = @'
           @echo off
           set "ORIGINAL_PATH=%PATH%"
+          set "ORIGINAL_DIRECTORY=%CD%"
 
           call "%~1\Scripts\activate.bat"
           if errorlevel 1 exit /b 1
 
-          if /I not "%VIRTUAL_ENV%"=="%CD%\%~1" exit /b 1
+          if /I not "%CD%"=="%ORIGINAL_DIRECTORY%" exit /b 1
+          if /I not "%VIRTUAL_ENV%"=="%ORIGINAL_DIRECTORY%\%~1" exit /b 1
 
           python -c "import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ['VIRTUAL_ENV'])"
           if errorlevel 1 exit /b 1
@@ -546,8 +672,10 @@ jobs:
           call "%~1\Scripts\deactivate.bat"
           if errorlevel 1 exit /b 1
 
+          if /I not "%CD%"=="%ORIGINAL_DIRECTORY%" exit /b 1
           if not "%PATH%"=="%ORIGINAL_PATH%" exit /b 1
           if defined VIRTUAL_ENV exit /b 1
+          if defined VIRTUAL_ENV_PROMPT exit /b 1
           '@
 
           Set-Content -Path activation-test.cmd -Value $activationTest -Encoding ascii

--- a/.github/workflows/test-shell-activation.yml
+++ b/.github/workflows/test-shell-activation.yml
@@ -138,7 +138,8 @@ jobs:
           ACTIVATION_STDERR="activation-${ACTIVATION_SHELL}-${ACTIVATION_ENVIRONMENT}-${ACTIVATION_OSTYPE}.stderr"
           export ACTIVATION_STDERR
 
-          "${activation_command[@]}" <<'ACTIVATION'
+          activation_status=0
+          "${activation_command[@]}" <<'ACTIVATION' || activation_status=$?
           set -eu
 
           original_path=$PATH
@@ -153,12 +154,10 @@ jobs:
           fi
 
           if ! . "./$ACTIVATION_DIRECTORY/bin/activate" 2>"$ACTIVATION_STDERR"; then
-            cat "$ACTIVATION_STDERR" >&2
             exit 1
           fi
 
           if [ -s "$ACTIVATION_STDERR" ]; then
-            cat "$ACTIVATION_STDERR" >&2
             exit 1
           fi
 
@@ -173,6 +172,17 @@ jobs:
           test "$SCRIPT_PATH" = original-script-path
           test -z "${VIRTUAL_ENV-}"
           ACTIVATION
+
+          if [ "$activation_status" -ne 0 ]; then
+            printf 'Activation failed for %s (%s, OSTYPE %s) with exit code %s\n' \
+              "$ACTIVATION_SHELL" "$ACTIVATION_ENVIRONMENT" "$ACTIVATION_OSTYPE" "$activation_status" >&2
+
+            if [ -s "$ACTIVATION_STDERR" ]; then
+              cat "$ACTIVATION_STDERR" >&2
+            fi
+
+            exit "$activation_status"
+          fi
 
   activation-alpine:
     name: "Alpine BusyBox activation (OSTYPE ${{ matrix.ostype }})"

--- a/.github/workflows/test-shell-activation.yml
+++ b/.github/workflows/test-shell-activation.yml
@@ -305,9 +305,13 @@ jobs:
           or exit 1
 
   activation-nushell:
-    name: "Nushell activation"
+    name: "Nushell activation (${{ matrix.environment }})"
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [standard, relocatable]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -334,12 +338,14 @@ jobs:
         run: chmod +x ./uv
 
       - name: "Create virtual environment"
+        if: matrix.environment == 'standard'
         run: ./uv venv
 
       - name: "Activate and deactivate virtual environment"
+        if: matrix.environment == 'standard'
         shell: nu {0}
         run: |
-          overlay use .venv/bin/activate.nu
+          overlay use ${{ github.workspace }}/.venv/bin/activate.nu
 
           if ($env.VIRTUAL_ENV | path expand) != (".venv" | path expand) {
               error make { msg: "VIRTUAL_ENV does not identify the activated environment" }
@@ -354,14 +360,16 @@ jobs:
           }
 
       - name: "Create relocatable virtual environment"
+        if: matrix.environment == 'relocatable'
         run: |
           ./uv venv --relocatable .relocatable
           mv .relocatable relocated
 
       - name: "Activate relocated virtual environment"
+        if: matrix.environment == 'relocatable'
         shell: nu {0}
         run: |
-          overlay use relocated/bin/activate.nu
+          overlay use ${{ github.workspace }}/relocated/bin/activate.nu
 
           if ($env.VIRTUAL_ENV | path expand) != ("relocated" | path expand) {
               error make { msg: "VIRTUAL_ENV does not identify the relocated environment" }

--- a/.github/workflows/test-shell-activation.yml
+++ b/.github/workflows/test-shell-activation.yml
@@ -37,11 +37,13 @@ jobs:
             command: dash
             environment: standard
             ostype: absent
-          - name: dash (relocatable)
-            package: dash
-            command: dash
-            environment: relocatable
-            ostype: present
+          # Dash does not expose the path of a sourced activation script, so
+          # relocatable activation is not currently supported.
+          # - name: dash (relocatable)
+          #   package: dash
+          #   command: dash
+          #   environment: relocatable
+          #   ostype: present
           - name: zsh
             package: zsh
             command: zsh
@@ -67,11 +69,13 @@ jobs:
             command: yash
             environment: standard
             ostype: present
-          - name: yash (relocatable)
-            package: yash
-            command: yash
-            environment: relocatable
-            ostype: present
+          # Yash does not expose the path of a sourced activation script, so
+          # relocatable activation is not currently supported.
+          # - name: yash (relocatable)
+          #   package: yash
+          #   command: yash
+          #   environment: relocatable
+          #   ostype: present
           - name: busybox
             package: busybox
             command: busybox
@@ -82,11 +86,13 @@ jobs:
             command: busybox
             environment: standard
             ostype: absent
-          - name: busybox (relocatable)
-            package: busybox
-            command: busybox
-            environment: relocatable
-            ostype: present
+          # BusyBox ash does not expose the path of a sourced activation script,
+          # so relocatable activation is not currently supported.
+          # - name: busybox (relocatable)
+          #   package: busybox
+          #   command: busybox
+          #   environment: relocatable
+          #   ostype: present
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/test-shell-activation.yml
+++ b/.github/workflows/test-shell-activation.yml
@@ -1,0 +1,552 @@
+on:
+  workflow_call:
+    inputs:
+      sha:
+        description: "The commit SHA to use for artifact names"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  activation-posix:
+    name: "POSIX activation (${{ matrix.name }})"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: bash
+            package: bash
+            command: bash
+            environment: standard
+            ostype: present
+          - name: bash (relocatable)
+            package: bash
+            command: bash
+            environment: relocatable
+            ostype: present
+          - name: dash
+            package: dash
+            command: dash
+            environment: standard
+            ostype: present
+          - name: dash (OSTYPE unset)
+            package: dash
+            command: dash
+            environment: standard
+            ostype: absent
+          - name: dash (relocatable)
+            package: dash
+            command: dash
+            environment: relocatable
+            ostype: present
+          - name: zsh
+            package: zsh
+            command: zsh
+            environment: standard
+            ostype: present
+          - name: zsh (relocatable)
+            package: zsh
+            command: zsh
+            environment: relocatable
+            ostype: present
+          - name: ksh
+            package: ksh
+            command: ksh
+            environment: standard
+            ostype: present
+          - name: ksh (relocatable)
+            package: ksh
+            command: ksh
+            environment: relocatable
+            ostype: present
+          - name: yash
+            package: yash
+            command: yash
+            environment: standard
+            ostype: present
+          - name: yash (relocatable)
+            package: yash
+            command: yash
+            environment: relocatable
+            ostype: present
+          - name: busybox
+            package: busybox
+            command: busybox
+            environment: standard
+            ostype: present
+          - name: busybox (OSTYPE unset)
+            package: busybox
+            command: busybox
+            environment: standard
+            ostype: absent
+          - name: busybox (relocatable)
+            package: busybox
+            command: busybox
+            environment: relocatable
+            ostype: present
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Install shell"
+        env:
+          SHELL_PACKAGE: ${{ matrix.package }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes "$SHELL_PACKAGE"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-linux-libc-${{ inputs.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Create virtual environment"
+        run: ./uv venv
+
+      - name: "Create relocatable virtual environment"
+        if: matrix.environment == 'relocatable'
+        run: |
+          ./uv venv --relocatable .relocatable
+          mv .relocatable relocated
+
+      - name: "Activate and deactivate virtual environment"
+        env:
+          ACTIVATION_ENVIRONMENT: ${{ matrix.environment }}
+          ACTIVATION_OSTYPE: ${{ matrix.ostype }}
+          ACTIVATION_SHELL: ${{ matrix.command }}
+        run: |
+          if [ "$ACTIVATION_SHELL" = busybox ]; then
+            activation_command=(busybox sh)
+          else
+            activation_command=("$ACTIVATION_SHELL")
+          fi
+
+          if [ "$ACTIVATION_ENVIRONMENT" = relocatable ]; then
+            ACTIVATION_DIRECTORY=relocated
+          else
+            ACTIVATION_DIRECTORY=.venv
+          fi
+          export ACTIVATION_DIRECTORY
+
+          ACTIVATION_STDERR="activation-${ACTIVATION_SHELL}-${ACTIVATION_ENVIRONMENT}-${ACTIVATION_OSTYPE}.stderr"
+          export ACTIVATION_STDERR
+
+          "${activation_command[@]}" <<'ACTIVATION'
+          set -eu
+
+          original_path=$PATH
+          SCRIPT_PATH=original-script-path
+          export SCRIPT_PATH
+
+          if [ "$ACTIVATION_OSTYPE" = absent ]; then
+            unset OSTYPE
+          else
+            OSTYPE=${OSTYPE-linux-gnu}
+            export OSTYPE
+          fi
+
+          if ! . "./$ACTIVATION_DIRECTORY/bin/activate" 2>"$ACTIVATION_STDERR"; then
+            cat "$ACTIVATION_STDERR" >&2
+            exit 1
+          fi
+
+          if [ -s "$ACTIVATION_STDERR" ]; then
+            cat "$ACTIVATION_STDERR" >&2
+            exit 1
+          fi
+
+          test "$VIRTUAL_ENV" = "$PWD/$ACTIVATION_DIRECTORY"
+          test "$SCRIPT_PATH" = original-script-path
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+
+          deactivate
+
+          test "$PATH" = "$original_path"
+          test "$SCRIPT_PATH" = original-script-path
+          test -z "${VIRTUAL_ENV-}"
+          ACTIVATION
+
+  activation-alpine:
+    name: "Alpine BusyBox activation (OSTYPE ${{ matrix.ostype }})"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    container: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    strategy:
+      fail-fast: false
+      matrix:
+        ostype: [present, absent]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-linux-musl-${{ inputs.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Create virtual environment"
+        run: ./uv venv
+
+      - name: "Activate and deactivate virtual environment"
+        shell: sh {0}
+        env:
+          ACTIVATION_OSTYPE: ${{ matrix.ostype }}
+        run: |
+          set -eu
+
+          original_path=$PATH
+          if [ "$ACTIVATION_OSTYPE" = absent ]; then
+            unset OSTYPE
+          else
+            OSTYPE=${OSTYPE-linux-gnu}
+            export OSTYPE
+          fi
+
+          activation_stderr="activation-alpine-${ACTIVATION_OSTYPE}.stderr"
+
+          if ! . ./.venv/bin/activate 2>"$activation_stderr"; then
+            cat "$activation_stderr" >&2
+            exit 1
+          fi
+
+          if [ -s "$activation_stderr" ]; then
+            cat "$activation_stderr" >&2
+            exit 1
+          fi
+
+          test "$VIRTUAL_ENV" = "$PWD/.venv"
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+
+          deactivate
+
+          test "$PATH" = "$original_path"
+          test -z "${VIRTUAL_ENV-}"
+
+  activation-fish:
+    name: "Fish activation"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Install Fish"
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes fish
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-linux-libc-${{ inputs.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Create virtual environment"
+        run: ./uv venv
+
+      - name: "Activate and deactivate virtual environment"
+        shell: fish {0}
+        run: |
+          set original_path $PATH
+
+          source ./.venv/bin/activate.fish
+          or exit 1
+
+          test "$VIRTUAL_ENV" = "$PWD/.venv"
+          or exit 1
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+          or exit 1
+
+          deactivate
+          or exit 1
+
+          test (string join : $PATH) = (string join : $original_path)
+          or exit 1
+
+          if set -q VIRTUAL_ENV
+              exit 1
+          end
+
+      - name: "Create relocatable virtual environment"
+        run: |
+          ./uv venv --relocatable .relocatable
+          mv .relocatable relocated
+
+      - name: "Activate relocated virtual environment"
+        shell: fish {0}
+        run: |
+          source ./relocated/bin/activate.fish
+          or exit 1
+
+          test "$VIRTUAL_ENV" = "$PWD/relocated"
+          or exit 1
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+          or exit 1
+
+          deactivate
+          or exit 1
+
+  activation-nushell:
+    name: "Nushell activation"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Install Nushell"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          nu_latest=$(gh release list --repo nushell/nushell --limit 1 --exclude-pre-releases --exclude-drafts --json tagName --jq '.[0].tagName')
+          nu_tag=${nu_latest%%[[:space:]]*}
+
+          gh release download "$nu_tag" --repo nushell/nushell --pattern "nu-${nu_tag}-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xf "nu-${nu_tag}-x86_64-unknown-linux-gnu.tar.gz"
+          chmod +x "./nu-${nu_tag}-x86_64-unknown-linux-gnu/nu"
+          echo "${GITHUB_WORKSPACE}/nu-${nu_tag}-x86_64-unknown-linux-gnu" >> "$GITHUB_PATH"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-linux-libc-${{ inputs.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Create virtual environment"
+        run: ./uv venv
+
+      - name: "Activate and deactivate virtual environment"
+        shell: nu {0}
+        run: |
+          overlay use .venv/bin/activate.nu
+
+          if ($env.VIRTUAL_ENV | path expand) != (".venv" | path expand) {
+              error make { msg: "VIRTUAL_ENV does not identify the activated environment" }
+          }
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+
+          deactivate
+
+          if "VIRTUAL_ENV" in $env {
+              error make { msg: "deactivate did not remove VIRTUAL_ENV" }
+          }
+
+      - name: "Create relocatable virtual environment"
+        run: |
+          ./uv venv --relocatable .relocatable
+          mv .relocatable relocated
+
+      - name: "Activate relocated virtual environment"
+        shell: nu {0}
+        run: |
+          overlay use relocated/bin/activate.nu
+
+          if ($env.VIRTUAL_ENV | path expand) != ("relocated" | path expand) {
+              error make { msg: "VIRTUAL_ENV does not identify the relocated environment" }
+          }
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+
+          deactivate
+
+  activation-cshell:
+    name: "C shell activation"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Install tcsh"
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes tcsh
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-linux-libc-${{ inputs.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Create virtual environment"
+        run: ./uv venv
+
+      - name: "Activate and deactivate virtual environment"
+        shell: tcsh {0}
+        run: |
+          set original_path = "$PATH"
+
+          source ./.venv/bin/activate.csh
+
+          if ("$VIRTUAL_ENV" != "$cwd/.venv") exit 1
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+          if ($status != 0) exit 1
+
+          deactivate
+
+          if ("$PATH" != "$original_path") exit 1
+          if ($?VIRTUAL_ENV) exit 1
+
+      - name: "Verify relocatable environments omit the C shell activator"
+        run: |
+          ./uv venv --relocatable .relocatable
+          test ! -e .relocatable/bin/activate.csh
+
+  activation-powershell:
+    name: "PowerShell activation"
+    timeout-minutes: 10
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-windows-x86_64-${{ inputs.sha }}
+
+      - name: "Create virtual environment"
+        shell: pwsh
+        run: ./uv.exe venv
+
+      - name: "Activate and deactivate virtual environment"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $originalPath = $env:PATH
+
+          . .\.venv\Scripts\activate.ps1
+
+          if ($env:VIRTUAL_ENV -ne (Resolve-Path .\.venv).Path) {
+            throw "VIRTUAL_ENV does not identify the activated environment"
+          }
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+          if ($LASTEXITCODE -ne 0) {
+            throw "Python did not resolve to the activated environment"
+          }
+
+          deactivate
+
+          if ($env:PATH -ne $originalPath) {
+            throw "deactivate did not restore PATH"
+          }
+
+          if (Test-Path Env:VIRTUAL_ENV) {
+            throw "deactivate did not remove VIRTUAL_ENV"
+          }
+
+      - name: "Create relocatable virtual environment"
+        shell: pwsh
+        run: |
+          ./uv.exe venv --relocatable .relocatable
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to create relocatable virtual environment"
+          }
+
+          Move-Item .relocatable relocated
+
+      - name: "Activate relocated virtual environment"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          . .\relocated\Scripts\activate.ps1
+
+          if ($env:VIRTUAL_ENV -ne (Resolve-Path .\relocated).Path) {
+            throw "VIRTUAL_ENV does not identify the relocated environment"
+          }
+
+          python -c 'import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ["VIRTUAL_ENV"])'
+          if ($LASTEXITCODE -ne 0) {
+            throw "Python did not resolve to the relocated environment"
+          }
+
+          deactivate
+
+  activation-batch:
+    name: "Windows batch activation"
+    timeout-minutes: 10
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-windows-x86_64-${{ inputs.sha }}
+
+      - name: "Create virtual environment"
+        shell: cmd
+        run: .\uv.exe venv
+
+      - name: "Activate and deactivate virtual environment"
+        shell: cmd
+        run: |
+          @set "ORIGINAL_PATH=%PATH%"
+
+          @call .venv\Scripts\activate.bat
+          @if errorlevel 1 exit /b 1
+
+          @if /I not "%VIRTUAL_ENV%"=="%CD%\.venv" exit /b 1
+
+          @python -c "import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ['VIRTUAL_ENV'])"
+          @if errorlevel 1 exit /b 1
+
+          @call .venv\Scripts\deactivate.bat
+          @if errorlevel 1 exit /b 1
+
+          @if not "%PATH%"=="%ORIGINAL_PATH%" exit /b 1
+          @if defined VIRTUAL_ENV exit /b 1
+
+      - name: "Create relocatable virtual environment"
+        shell: cmd
+        run: |
+          @.\uv.exe venv --relocatable .relocatable
+          @if errorlevel 1 exit /b 1
+
+          @move .relocatable relocated
+          @if errorlevel 1 exit /b 1
+
+      - name: "Activate relocated virtual environment"
+        shell: cmd
+        run: |
+          @call relocated\Scripts\activate.bat
+          @if errorlevel 1 exit /b 1
+
+          @if /I not "%VIRTUAL_ENV%"=="%CD%\relocated" exit /b 1
+
+          @python -c "import os, sys; assert os.path.realpath(sys.prefix) == os.path.realpath(os.environ['VIRTUAL_ENV'])"
+          @if errorlevel 1 exit /b 1
+
+          @call relocated\Scripts\deactivate.bat
+          @if errorlevel 1 exit /b 1

--- a/crates/uv-virtualenv/README.md
+++ b/crates/uv-virtualenv/README.md
@@ -35,9 +35,70 @@ placeholders names used in [this crate's source][crate-placeholders].
 ### Relocatable virtual environments
 
 This crate uses some additional tweaks in the activation scripts to ensure the virtual environment
-is relocatable. Thus, the patch in [astral-sh/uv#5640] shall be retained.
+is relocatable. Retain the following shell-specific behavior when updating upstream templates:
 
+- The POSIX activator determines the script path separately for Bash, Zsh, and KornShell
+  ([astral-sh/uv#5640]). It also restores any pre-existing `SCRIPT_PATH` after activation instead of
+  leaking its temporary value into the caller ([astral-sh/uv#12672]).
+- Fish determines the relocated environment from `status -f` ([astral-sh/uv#5515]) without changing
+  the caller's working directory or relying on Bash-style command substitution
+  ([astral-sh/uv#19856]).
+- Windows batch determines the relocated environment from `%~dp0..` and resolves it to an absolute
+  path ([astral-sh/uv#5515]).
+- Nushell determines the relocated environment from `path self` ([astral-sh/uv#17036]). Because
+  `path self` can only be evaluated at parse time, the activator must declare `virtual_env` with
+  `const`, not `let` ([astral-sh/uv#20743]).
+- C shell cannot determine the path of a sourced script. Do not generate `activate.csh` for
+  relocatable environments ([astral-sh/uv#17759]).
+
+Dash, BusyBox ash, and Yash also do not expose the path of a sourced POSIX script. Relocatable
+activation is not currently supported for these shells ([astral-sh/uv#20743]).
+
+[astral-sh/uv#5515]: https://github.com/astral-sh/uv/pull/5515
 [astral-sh/uv#5640]: https://github.com/astral-sh/uv/pull/5640
+[astral-sh/uv#12672]: https://github.com/astral-sh/uv/pull/12672
+[astral-sh/uv#17036]: https://github.com/astral-sh/uv/pull/17036
+[astral-sh/uv#17759]: https://github.com/astral-sh/uv/pull/17759
+[astral-sh/uv#19856]: https://github.com/astral-sh/uv/pull/19856
+[astral-sh/uv#20743]: https://github.com/astral-sh/uv/pull/20743
+
+### POSIX shell compatibility
+
+Preserve the quoted `eval` around Zsh- and KornShell-specific parameter expansions. Yash parses
+these expansions even in branches it does not execute, so removing `eval` prevents it from sourcing
+the POSIX activator ([astral-sh/uv#20743]).
+
+Use `${OSTYPE-}` when checking for Cygwin or MSYS. `OSTYPE` is not defined by POSIX and can be unset
+in Dash and BusyBox ash. Referencing `$OSTYPE` directly causes activation to fail under `set -u`
+([astral-sh/uv#20743]).
+
+Keep `VIRTUAL_ENV_PROMPT` as the unformatted environment name and add parentheses only when
+constructing `PS1` ([astral-sh/uv#13501]).
+
+[astral-sh/uv#13501]: https://github.com/astral-sh/uv/pull/13501
+
+### Fish on Windows
+
+Preserve the `cygpath -u` conversion of `VIRTUAL_ENV` when Fish is running under Cygwin, MSYS, or
+MinGW. Otherwise, Windows and POSIX paths are mixed in `PATH` and activation breaks
+([astral-sh/uv#19703]).
+
+[astral-sh/uv#19703]: https://github.com/astral-sh/uv/pull/19703
+
+### Windows batch encoding
+
+Preserve the temporary switch to the UTF-8 code page in `activate.bat` and restore the previous code
+page after activation. Without it, environment paths containing non-ASCII characters can be
+corrupted ([astral-sh/uv#11831]).
+
+[astral-sh/uv#11831]: https://github.com/astral-sh/uv/pull/11831
+
+### Shell activation tests
+
+After updating activators, run the
+[shell activation workflow](../../.github/workflows/test-shell-activation.yml). It covers standard
+and relocatable activation, deactivation, preservation of existing shell state, unset `OSTYPE`, and
+the shells and platforms for which activation is supported.
 
 ### TCL/TK library locations
 

--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -81,6 +81,8 @@ deactivate () {
 deactivate nondestructive
 
 VIRTUAL_ENV='{{ VIRTUAL_ENV_DIR }}'
+# Preserve this condition's grouping and command substitution for POSIX shell compatibility.
+# shellcheck disable=SC2091,SC2235
 if ([ "${OSTYPE-}" = "cygwin" ] || [ "${OSTYPE-}" = "msys" ]) && $(command -v cygpath &> /dev/null) ; then
     VIRTUAL_ENV=$(cygpath -u "$VIRTUAL_ENV")
 fi
@@ -100,6 +102,8 @@ _OLD_VIRTUAL_PATH="$PATH"
 PATH="$VIRTUAL_ENV/{{ BIN_NAME }}:$PATH"
 export PATH
 
+# The prompt template is rendered when the virtual environment is created.
+# shellcheck disable=SC2050,SC2268
 if [ "x{{ VIRTUAL_PROMPT }}" != x ] ; then
     VIRTUAL_ENV_PROMPT="{{ VIRTUAL_PROMPT }}"
 else

--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -27,6 +27,8 @@ if ! [ -z "${SCRIPT_PATH+_}" ] ; then
 fi
 
 # Get script path (only used if environment is relocatable).
+# Use eval to hide shell-specific expansions from other shells' parsers.
+# Yash rejects Zsh and KornShell expansions even in branches it does not execute.
 if [ -n "${BASH_VERSION:+x}" ] ; then
     SCRIPT_PATH="${BASH_SOURCE[0]}"
     if [ "$SCRIPT_PATH" = "$0" ]; then
@@ -35,9 +37,9 @@ if [ -n "${BASH_VERSION:+x}" ] ; then
         exit 33
     fi
 elif [ -n "${ZSH_VERSION:+x}" ] ; then
-    SCRIPT_PATH="${(%):-%x}"
+    eval 'SCRIPT_PATH="${(%):-%x}"'
 elif [ -n "${KSH_VERSION:+x}" ] ; then
-    SCRIPT_PATH="${.sh.file}"
+    eval 'SCRIPT_PATH="${.sh.file}"'
 fi
 
 deactivate () {

--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -79,7 +79,7 @@ deactivate () {
 deactivate nondestructive
 
 VIRTUAL_ENV='{{ VIRTUAL_ENV_DIR }}'
-if ([ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]) && $(command -v cygpath &> /dev/null) ; then
+if ([ "${OSTYPE-}" = "cygwin" ] || [ "${OSTYPE-}" = "msys" ]) && $(command -v cygpath &> /dev/null) ; then
     VIRTUAL_ENV=$(cygpath -u "$VIRTUAL_ENV")
 fi
 export VIRTUAL_ENV

--- a/crates/uv-virtualenv/src/activator/activate.nu
+++ b/crates/uv-virtualenv/src/activator/activate.nu
@@ -69,7 +69,8 @@ export-env {
         }
     }
 
-    let virtual_env = {{ VIRTUAL_ENV_DIR }}
+    # `path self` must be evaluated at parse time for relocatable environments.
+    const virtual_env = {{ VIRTUAL_ENV_DIR }}
     let bin = '{{ BIN_NAME }}'
     let path_name = if (has-env 'Path') { 'Path' } else { 'PATH' }
     let venv_path = ([$virtual_env $bin] | path join)

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1743,7 +1743,7 @@ fn verify_pyvenv_cfg_relocatable() {
     let activate_nu = scripts.child("activate.nu");
     activate_nu.assert(predicates::path::is_file());
     activate_nu.assert(predicates::str::contains(
-        r"let virtual_env = (path self | path dirname | path dirname)",
+        r"const virtual_env = (path self | path dirname | path dirname)",
     ));
 
     // csh cannot determine its own script location, so activate.csh should not


### PR DESCRIPTION
- Implements a test matrix for virtualenv activation scripts across supported shells
- Enables ShellCheck for activate script
- Resolve failures when OSTYPE is not set
- Fix activation under yash
- Fix relocatable nushell activation script

Closes #15294 
Closes #19631 
Fixes #7480 
Fixes #10498 
Fixes #10487 