### PR TITLE
Document breaking changes and stabilizations for uv 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,7 @@ requires = ["uv_build>=0.11.32,<0.13"]
 ### Breaking changes
 
 - **Define build systems by default with `uv init`**
-  ([#19197](https://github.com/astral-sh/uv/pull/19197),
-  [#20773](https://github.com/astral-sh/uv/pull/20773))
+  ([#19197](https://github.com/astral-sh/uv/pull/19197))
 
   Projects created with `uv init` now declare a build system and are packaged by default. This was
   the default project layout all the way back in v0.3, but we found that the use of the `hatchling`
@@ -37,10 +36,10 @@ requires = ["uv_build>=0.11.32,<0.13"]
   `pyproject.toml` without a build system. The project could declare dependencies but was not itself
   installed into its virtual environment.
 
-  Now, both `uv init example` and `uv init --app example` define a `[build-system]` using
-  `uv_build`, place application source code in `src/example`, and include a `[project.scripts]`
-  entry named `example`. Defining a build system allows the project to be imported from tests or
-  other code, installed as a dependency, and run as a command:
+  Now, `uv init example` defines a `[build-system]` using `uv_build`, places application source
+  code in `src/example`, and includes a `[project.scripts]` entry named `example`. Defining a
+  build system allows the project to be imported from tests or other code, installed as a
+  dependency, and run as a command:
 
   ```console
   $ uv init example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,9 +109,9 @@ requires = ["uv_build>=0.11.32,<0.13"]
   entire dependency graph.
 
   The default mode is now `if-necessary`. uv tries stable candidates first and falls back to
-  pre-releases when no stable candidate satisfies the active constraints, including constraints
-  discovered transitively. This matches modern pip's pre-release handling, but can select different
-  versions than previous uv releases when both stable and pre-release candidates are available.
+  pre-releases when no stable candidate satisfies the active constraints. Like pip, uv now supports
+  pre-release requirements discovered transitively, but can select different versions than previous
+  uv releases when both stable and pre-release candidates are available.
 
   You can opt out of automatic pre-release selection with `--prerelease disallow`. Alternatively,
   `--prerelease allow` considers pre-releases without first preferring stable releases, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,9 +91,14 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
 
   You can opt out of automatic pre-release selection with `--prerelease disallow`. Alternatively,
   `--prerelease allow` considers pre-releases without first preferring stable releases, while
-  `--prerelease explicit` only allows them for direct requirements that mention a pre-release. If you
-  explicitly configured `if-necessary-or-explicit`, replace it with `if-necessary`; the old name
-  remains available as a deprecated alias.
+  `--prerelease explicit` only allows them for direct requirements that mention a pre-release.
+
+  The old `if-necessary-or-explicit` mode distinguished between explicitly requested pre-releases
+  and packages with no stable releases. That distinction is unnecessary now that `if-necessary`
+  handles both cases, including transitive requirements. The old name remains available as an alias
+  but emits a deprecation warning and will be removed in a future release. Replace
+  `--prerelease if-necessary-or-explicit` with `--prerelease if-necessary`, and update any
+  corresponding `prerelease` configuration values.
 
 - **Respect `--require-hashes` directives in `requirements.txt`**
   ([#19336](https://github.com/astral-sh/uv/pull/19336))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ build-backend = "uv_build"
   The old `if-necessary-or-explicit` mode distinguished between explicitly requested pre-releases
   and packages with no stable releases. That distinction is unnecessary now that `if-necessary`
   handles both cases, including transitive requirements. The old name remains available as an alias
-  but emits a deprecation warning and will be removed in a future release. Replace
+  but is deprecated and will be removed in a future release. Replace
   `--prerelease if-necessary-or-explicit` with `--prerelease if-necessary`, and update any
   corresponding `prerelease` configuration values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,7 @@ requires = ["uv_build>=0.11.32,<0.13"]
   distributions remain supported for backwards compatibility.
 
   Wheels and other ZIP archives can no longer contain entries compressed with bzip2, LZMA, or XZ.
-  Entries must use the stored, DEFLATE, or zstd compression methods. zstd remains supported for
-  wheels and other archives; `.tar.zst` is not accepted specifically as a source distribution
-  because PEP 625 requires `.tar.gz`.
+  Entries must use the stored, DEFLATE, or zstd compression methods.
 
   Removing support for uncommon compression methods reduces uv's compression dependencies and the
   attack surface exposed when processing untrusted packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## 0.12.0
 
+Released on 2026-07-28.
+
 Since we released uv [0.11.0](https://github.com/astral-sh/uv/releases/tag/0.11.0) in March, we've
 accumulated changes that improve correctness, safety, and compatibility with specifications, but
 could break some workflows. This release contains those changes; many have been marked as breaking
@@ -406,6 +408,14 @@ requires = ["uv_build>=0.11.32,<0.13"]
   running with the existing limit.
 
   This stabilizes the `adjust-ulimit` preview feature.
+
+### Preview features
+
+- Allow `uv upgrade` to target multiple packages, upgrade all production dependencies, and exclude selected dependencies ([#20338](https://github.com/astral-sh/uv/pull/20338))
+
+### Bug fixes
+
+- Include extras activated by dependency groups when evaluating conflicts ([#20237](https://github.com/astral-sh/uv/pull/20237))
 
 ## 0.11.33
 
@@ -1484,4 +1494,3 @@ See [changelogs/0.2.x](./changelogs/0.2.x.md)
 See [changelogs/0.1.x](./changelogs/0.1.x.md)
 
 <!-- prettier-ignore-end -->
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,8 +225,8 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
   preview feature was enabled. Now, even a TOML 1.0 input is normalized and the source distribution
   gains an additional `pyproject.toml.orig` file.
 
-  You cannot opt out of this behavior. If you compare source distributions byte-for-byte or depend
-  on their exact file list, update those expectations.
+  You cannot opt out of this behavior. If a tool needs the original contents or formatting, read
+  `pyproject.toml.orig` from the source distribution instead.
 
 - **Classify Conda environments named `base` and `root` by their paths**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,8 @@ build-backend = "uv_build"
   Hello from example!
   ```
 
-  Existing projects are unaffected. Use `uv init --no-package example` to create the previous flat
-  layout without a build system.
+  Existing projects are unaffected. Use `uv init --no-package example` to create the previous
+  unpackaged layout without a build system.
 
   See the
   [project creation documentation](https://docs.astral.sh/uv/concepts/projects/init/#applications)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,13 @@ build-backend = "uv_build"
   [project creation documentation](https://docs.astral.sh/uv/concepts/projects/init/#applications)
   for more details.
 
+- **TOML 1.0-compatible source distributions**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  `uv_build` now writes a TOML 1.0-compatible `pyproject.toml` when building source distributions,
+  allowing older Python build frontends to consume projects that use newer TOML syntax. The
+  original project file remains available in the archive as `pyproject.toml.orig`.
+
 - **Script-relative project and workspace discovery**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
@@ -386,13 +393,6 @@ build-backend = "uv_build"
   uv now determines whether a Conda environment is the base environment from its location instead
   of treating `base` and `root` as reserved names. Child environments with either name can be
   discovered and used normally.
-
-- **TOML 1.0-compatible source distributions**
-  ([#20225](https://github.com/astral-sh/uv/pull/20225))
-
-  `uv_build` now writes a TOML 1.0-compatible `pyproject.toml` when building source distributions,
-  allowing older Python build frontends to consume projects that use newer TOML syntax. The
-  original project file remains available in the archive as `pyproject.toml.orig`.
 
 - **Automatic open-file limit adjustment on Unix**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,25 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
   wheels with a supported ZIP compression method. If an existing `uv.lock` references an
   unsupported source distribution, update the dependency and regenerate the lockfile.
 
+- **Reject wheel files that could replace the Python interpreter**
+  ([#20748](https://github.com/astral-sh/uv/pull/20748),
+  [#20749](https://github.com/astral-sh/uv/pull/20749))
+
+  uv already rejected wheel entry points named `python`, but case variants such as `Python` were
+  still accepted. On case-insensitive filesystems, including common macOS and Windows setups,
+  these entry points could overwrite the virtual environment's interpreter.
+
+  Wheels could also place interpreter files in their `.data/scripts` directory or in paths such as
+  `.data/data/bin/python`, bypassing the entry-point check and replacing the interpreter during
+  installation.
+
+  uv now rejects case-insensitive variants of reserved interpreter names and wheel data files that
+  would be installed over an interpreter. This includes names such as `Python`, `python.py`, and
+  `Python.exe`, along with other reserved interpreter names and their versioned variants.
+
+  You cannot opt out of these checks. Rename conflicting entry points or wheel data files and
+  rebuild the affected wheel.
+
 - **Prefer stable releases before falling back to pre-releases**
   ([#19993](https://github.com/astral-sh/uv/pull/19993))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ a `src` layout and the uv build backend; the previous flat layout remains availa
 `uv init --no-package` or `uv init --app`.
 
 This release also stabilizes preview behavior for project discovery, virtual environment safety,
-publishing, Conda environments, and source distributions.
+publishing, Conda environments, source distributions, and Unix resource limits.
 
 The [`uv_build` build backend](https://docs.astral.sh/uv/concepts/build-backend/) follows uv's
 breaking-release versioning policy. If your `[build-system]` table includes an upper bound such as
@@ -299,6 +299,74 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
   though annotations were disabled. That footer is now omitted.
 
   You can recover the footer by removing `--no-annotate`.
+
+### Stabilizations
+
+- **Packaged projects created by `uv init`**
+  ([#19197](https://github.com/astral-sh/uv/pull/19197))
+
+  `uv init` now creates an importable, distributable project with a `src` layout, the `uv_build`
+  backend, and a command-line entry point by default. Existing projects are unaffected, and
+  `uv init --no-package` or `uv init --app` retains the previous flat application layout.
+
+  See the
+  [project creation documentation](https://docs.astral.sh/uv/concepts/projects/init/#packaged-applications)
+  for more details.
+
+- **Script-relative project and workspace discovery**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  `uv run path/to/project/script.py` now discovers the target project or workspace from the
+  script's directory. This allows scripts to use their own project's dependencies even when they
+  are invoked from another directory. An explicit `--project` still takes precedence.
+
+- **Safer virtual environment clearing**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  `uv venv --clear` now protects directories that are not virtual environments from accidental
+  deletion. Existing virtual environments can still be replaced normally; use `--force` when
+  clearing another directory is intentional.
+
+- **Validation of `--project` paths**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  Project commands now validate `--project` before proceeding, providing an immediate error when
+  the selected path does not exist or is not a directory. Paths to a `pyproject.toml` file remain
+  supported and select the containing project.
+
+- **Project paths for `uv init`**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  `uv init` now rejects `--project`, which is intended to select an existing project. Use a
+  positional path to create a project in another directory, or `--directory` to change the working
+  directory before initialization.
+
+- **Normalized distribution filenames in `uv publish`**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  `uv publish` now skips wheels and source distributions whose package names or versions are not
+  normalized, preventing invalid artifacts from being uploaded to package indexes.
+
+- **Conda environments named `base` and `root`**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  uv now determines whether a Conda environment is the base environment from its location instead
+  of treating `base` and `root` as reserved names. Child environments with either name can be
+  discovered and used normally.
+
+- **TOML 1.0-compatible source distributions**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  `uv_build` now writes a TOML 1.0-compatible `pyproject.toml` when building source distributions,
+  allowing older Python build frontends to consume projects that use newer TOML syntax. The
+  original project file remains available in the archive as `pyproject.toml.orig`.
+
+- **Automatic open-file limit adjustment on Unix**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  On Linux and macOS, uv now raises the soft open-file limit at startup toward the hard limit,
+  capped at 1,048,576 descriptors. The higher limit is inherited by subprocesses and helps prevent
+  open-file exhaustion during large dependency installations and builds.
 
 ## 0.11.33
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 ## 0.12.0
 
 Since we released uv [0.11.0](https://github.com/astral-sh/uv/releases/tag/0.11.0) in March, we've
-accumulated changes that improve correctness, safety, and compatibility, but could break some
-workflows. This release contains those changes; many have been marked as breaking out of an
-abundance of caution. We expect most users to be able to upgrade without making changes.
+accumulated changes that improve correctness, safety, and compatibility with specifications, but
+could break some workflows. This release contains those changes; many have been marked as breaking
+out of an abundance of caution. We expect most users to be able to upgrade without making changes.
 
 Projects created with `uv init` are now packaged by default. When uv's project interface stabilized
 in 0.3, `uv init` created packaged projects using Hatchling. In 0.4, the default was changed to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 Since we released uv [0.11.0](https://github.com/astral-sh/uv/releases/tag/0.11.0) in March, we've
 accumulated changes that improve correctness, safety, and compatibility with specifications, but
 could break some workflows. This release contains those changes; many have been marked as breaking
-out of an abundance of caution. We expect most users to be able to upgrade without making changes.
+out of an abundance of caution.
+
+**We expect most users to be able to upgrade without making changes.**
 
 Projects created with `uv init` now declare a build system and are packaged by default. This was
 the default project layout all the way back in v0.3, but we found that the use of the `hatchling`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ build-backend = "uv_build"
   versions than previous uv releases when both stable and pre-release candidates are available.
 
   You can opt out of automatic pre-release selection with `--prerelease disallow`. Alternatively,
-  `--prerelease allow` considers pre-releases without first preferring stable releases, while
+  `--prerelease allow` considers pre-releases without first preferring stable releases, and
   `--prerelease explicit` only allows them for direct requirements that mention a pre-release.
 
   The old `if-necessary-or-explicit` mode distinguished between explicitly requested pre-releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,9 +125,7 @@ build-backend = "uv_build"
   The old `if-necessary-or-explicit` mode distinguished between explicitly requested pre-releases
   and packages with no stable releases. That distinction is unnecessary now that `if-necessary`
   handles both cases, including transitive requirements. The old name remains available as an alias
-  but is deprecated and will be removed in a future release. Replace
-  `--prerelease if-necessary-or-explicit` with `--prerelease if-necessary`, and update any
-  corresponding `prerelease` configuration values.
+  but is deprecated and will be removed in a future release.
 
 - **Respect `--require-hashes` directives in `requirements.txt`**
   ([#19336](https://github.com/astral-sh/uv/pull/19336))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,8 @@ requires = ["uv_build>=0.11.32,<0.13"]
 
   Previously, `uv pip install --require-hashes` and `uv pip sync --require-hashes` accepted
   requirements whose only available digest used MD5. MD5 is not collision-resistant, so relying on
-  it undermined explicitly integrity-enforced installations and differed from pip's behavior.
+  it undermined installations that explicitly require hash verification and differed from pip's
+  behavior.
 
   Hash-checking mode now requires at least one secure digest for every requirement. For example,
   the following requirement is rejected unless a secure hash, such as SHA-256, is also supplied:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,11 @@ accumulated changes that improve correctness, safety, and compatibility with spe
 could break some workflows. This release contains those changes; many have been marked as breaking
 out of an abundance of caution. We expect most users to be able to upgrade without making changes.
 
-Projects created with `uv init` are now packaged by default. When uv's project interface stabilized
-in 0.3, `uv init` created packaged projects using Hatchling. In 0.4, the default was changed to a
-flat, unpackaged application because requiring a build backend confused users whose projects did
-not need to be distributed. Since then, uv has introduced its own build backend, `uv_build`, which
-integrates with uv and provides a simpler packaging experience. New projects now use a `src` layout
-and `uv_build`, making their code importable, testable, and distributable. The previous flat layout
-remains available with `uv init --no-package` or `uv init --app`.
+Projects created with `uv init` now declare a build system and are packaged by default. This was
+the default project layout all the way back in v0.3, but we found that the use of the `hatchling`
+build system was confusing to newcomers and consequently dropped use of a build system by default
+in v0.4. Since then, we've created our own build system (`uv_build`) with tight integration with
+uv and are excited to restore the default to a best-practice project layout.
 
 This release also stabilizes preview behavior for project discovery, virtual environment safety,
 publishing, Conda environments, source distributions, and Unix resource limits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ accumulated changes that improve correctness, safety, and compatibility, but cou
 workflows. This release contains those changes; many have been marked as breaking out of an
 abundance of caution. We expect most users to be able to upgrade without making changes.
 
-The most visible change is to `uv init`, which now creates a packaged project by default. When uv's
-project interface stabilized in 0.3, the default application layout was kept intentionally simple:
-a flat `main.py` file and no build system. This allowed projects to declare dependencies and
-participate in workspaces without requiring packaging, but became limiting when users wanted to
-import their own code, write tests, define commands, or distribute a project. New projects now use
-a `src` layout and the uv build backend; the previous flat layout remains available with
-`uv init --no-package` or `uv init --app`.
+Projects created with `uv init` are now packaged by default. When uv's project interface stabilized
+in 0.3, the default application layout was kept intentionally simple: a flat `main.py` file and no
+build system. This allowed projects to declare dependencies and participate in workspaces without
+requiring packaging, but became limiting when users wanted to import their own code, write tests,
+define commands, or distribute a project. New projects now use a `src` layout and the uv build
+backend; the previous flat layout remains available with `uv init --no-package` or
+`uv init --app`.
 
 This release also stabilizes preview behavior for project discovery, virtual environment safety,
 publishing, Conda environments, source distributions, and Unix resource limits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,243 @@
 
 ## 0.12.0
 
-Released on 2026-07-28.
+Since we released uv [0.11.0](https://github.com/astral-sh/uv/releases/tag/0.11.0) in March, we've
+accumulated changes that improve correctness, safety, and compatibility, but could break some
+workflows. This release contains those changes; many have been marked as breaking out of an
+abundance of caution. We expect most users to be able to upgrade without making changes.
 
-### Security
+This release also stabilizes preview behavior for project discovery, virtual environment safety,
+publishing, Conda environments, and source distributions.
 
-- Prevent wheel data files from overwriting virtual-environment interpreters ([#20749](https://github.com/astral-sh/uv/pull/20749))
-- Prevent case-variant reserved wheel entry points from overwriting interpreters on case-insensitive filesystems ([#20748](https://github.com/astral-sh/uv/pull/20748))
+The [`uv_build` build backend](https://docs.astral.sh/uv/concepts/build-backend/) now rewrites
+`pyproject.toml` in source distributions, as described below. If you have an upper bound in your
+`[build-system]` table, you should update it, e.g., from `<0.12` to `<0.13`.
 
 ### Breaking changes
 
-- Reject requirements that provide only MD5 hashes in hash-checking mode ([#20758](https://github.com/astral-sh/uv/pull/20758))
+- **Reject unsupported source distribution and wheel archive formats**
+  ([#18927](https://github.com/astral-sh/uv/pull/18927))
 
-### Preview features
+  [PEP 625](https://peps.python.org/pep-0625/) requires source distributions to use `.tar.gz`
+  archives. Previously, uv also accepted legacy formats such as `.tar.bz2`, `.tar.xz`, and
+  `.tar.zst`. Those formats are now rejected, including when referenced by an existing lockfile.
+  Legacy `.zip` source distributions remain supported for backwards compatibility.
 
-- Allow `uv upgrade` to target multiple packages, upgrade all production dependencies, and exclude selected dependencies ([#20338](https://github.com/astral-sh/uv/pull/20338))
+  Wheels and other ZIP archives can no longer contain entries compressed with bzip2, LZMA, or XZ.
+  Entries must use the stored, DEFLATE, or zstd compression methods.
 
-### Bug fixes
+  You cannot opt out of this behavior. Rebuild source distributions as `.tar.gz` archives and
+  wheels with a supported ZIP compression method. If an existing `uv.lock` references an
+  unsupported source distribution, update the dependency and regenerate the lockfile.
 
-- Include extras activated by dependency groups when evaluating conflicts ([#20237](https://github.com/astral-sh/uv/pull/20237))
+- **Prefer stable releases before falling back to pre-releases**
+  ([#19993](https://github.com/astral-sh/uv/pull/19993))
+
+  uv previously allowed pre-releases by default when a direct dependency explicitly requested one
+  or a package only published pre-releases. A pre-release requested by a transitive dependency,
+  e.g., `example>=2.0.0b1`, could cause resolution to fail even when that pre-release satisfied
+  every requirement.
+
+  uv now prefers stable candidates and considers pre-releases when no stable candidate satisfies
+  the active constraints. This allows transitive pre-release requirements, but can change which
+  versions are selected when both stable and pre-release candidates are available.
+
+  You can opt out of automatic pre-release selection with `--prerelease disallow`. Alternatively,
+  `--prerelease allow` considers pre-releases without first preferring stable releases. If you
+  explicitly configured `if-necessary-or-explicit`, replace it with `if-necessary`; the old name
+  remains available as a deprecated alias.
+
+- **Respect `--require-hashes` directives in `requirements.txt`**
+  ([#19336](https://github.com/astral-sh/uv/pull/19336))
+
+  Previously, `uv pip install` and `uv pip sync` warned about `--require-hashes` inside a
+  `requirements.txt` file but still installed dependencies without checking their hashes. Now, the
+  directive enables hash-checking mode, just as if `--require-hashes` had been passed on the command
+  line.
+
+  For example, this requirements file is no longer accepted because the requirement is neither
+  pinned nor hashed:
+
+  ```text
+  --require-hashes
+  anyio
+  ```
+
+  You cannot opt out while the directive is present. Pin every requirement with `==` and provide
+  its hash, or remove `--require-hashes` if hash checking is not intended.
+
+- **Require package entries in `pylock.toml` files**
+  ([#20402](https://github.com/astral-sh/uv/pull/20402))
+
+  The [`pylock.toml` specification](https://packaging.python.org/en/latest/specifications/pylock-toml/#packages)
+  requires a `packages` array. Previously, uv interpreted a missing array as an empty lockfile;
+  passing such a file to `uv pip sync` could therefore uninstall an environment instead of
+  rejecting the invalid input.
+
+  uv now rejects `pylock.toml` files without `packages`. You cannot opt out of this behavior.
+  Regenerate the lockfile, or use `packages = []` if it intentionally contains no packages.
+
+- **Support pip-compatible `--cert` handling in `uv pip`**
+  ([#20418](https://github.com/astral-sh/uv/pull/20418))
+
+  The `uv pip` interface now accepts `--cert <path>`, e.g.:
+
+  ```console
+  $ uv pip install --cert ./company-ca.pem example
+  ```
+
+  As in pip, the provided PEM bundle replaces all other certificate sources for that invocation,
+  including system certificates and `SSL_CERT_FILE` or `SSL_CERT_DIR`. This change has no effect
+  unless you pass `--cert`. If a connection fails after adding the option, ensure the bundle
+  contains every required certificate authority.
+
+  `--cert` is only supported by `uv pip` commands; other uv commands continue to use their existing
+  certificate configuration.
+
+- **Discover projects relative to the script passed to `uv run`**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  Previously, `uv run project/script.py` discovered its project from the current directory, even
+  when the script belonged to another project. uv now starts project and workspace discovery from
+  the script's directory instead.
+
+  For example, running `uv run other-project/script.py` now uses `other-project` and its
+  dependencies. This fixes scripts that previously failed because their own dependencies were not
+  installed, but can select a different environment than before.
+
+  You can opt out of script-relative discovery by selecting a project explicitly, e.g.,
+  `uv run --project . other-project/script.py`.
+
+- **Require `--force` before clearing a directory that is not a virtual environment**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  `uv venv --clear` previously removed any existing target directory, even if it was not a virtual
+  environment. uv emitted a warning but still deleted the directory and its contents. Now, uv
+  refuses to clear directories that do not contain a virtual environment.
+
+  You can opt out of this safety check by explicitly passing `--force`, e.g.,
+  `uv venv --clear --force ./not-a-virtualenv`.
+
+- **Reject `--project` when initializing a project**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  `--project` selects an existing project, so it is not meaningful when initializing a new one.
+  Previously, `uv init --project example` warned and initialized `example` anyway; if a positional
+  path was also provided, `--project` was ignored.
+
+  This usage is now an error. Use `uv init example` to initialize a project at the requested path,
+  or `uv init --directory example` to change the working directory first.
+
+- **Require `--project` paths to exist and refer to directories**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  uv previously warned when `--project` referred to a missing directory or a file other than
+  `pyproject.toml`, but then attempted to continue. This could produce confusing errors later or run
+  against an unintended project.
+
+  Now, `uv run --project missing python` fails immediately instead of continuing. You cannot opt
+  out of this behavior. Create the directory first or select an existing project. Passing
+  `--project path/to/pyproject.toml` remains supported and selects the file's parent directory.
+
+- **Skip distributions with non-normalized filenames when publishing**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  Distribution filenames must use normalized package names and versions. For example, a wheel for
+  version `1.01.0` should be named `example-1.1.0-py3-none-any.whl`, not
+  `example-1.01.0-py3-none-any.whl`.
+
+  Previously, `uv publish` warned about non-normalized filenames but still attempted to upload
+  them. It now skips the affected wheels and source distributions instead.
+
+  You cannot opt out of this behavior. Rebuild distributions with normalized filenames before
+  publishing.
+
+- **Rewrite `pyproject.toml` files in source distributions for TOML 1.0 compatibility**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  Python's `tomllib` only supports TOML 1.0 through Python 3.14, so source distributions using
+  TOML 1.1 syntax can fail when built by older frontends. `uv_build` now always rewrites the
+  distributed `pyproject.toml` as TOML 1.0 and includes the original as `pyproject.toml.orig`.
+
+  Previously, the rewrite occurred only when TOML 1.1 syntax was detected or the corresponding
+  preview feature was enabled. Now, even a TOML 1.0 input is normalized and the source distribution
+  gains an additional `pyproject.toml.orig` file.
+
+  You cannot opt out of this behavior. If you compare source distributions byte-for-byte or depend
+  on their exact file list, update those expectations.
+
+- **Classify Conda environments named `base` and `root` by their paths**
+  ([#20225](https://github.com/astral-sh/uv/pull/20225))
+
+  Conda environments named `base` or `root` were previously assumed to be the base Conda
+  environment, even when they were ordinary child environments. uv now determines whether these
+  environments are base environments from their paths, as it already does for other names.
+
+  A child environment at a path such as `/envs/base` can therefore be discovered as a virtual
+  environment instead of being ignored. You can opt out of automatic interpreter selection by
+  requesting an interpreter explicitly with `--python /path/to/python`.
+
+- **Reinstall matching installed Python patch versions instead of upgrading implicitly**
+  ([#20659](https://github.com/astral-sh/uv/pull/20659))
+
+  Before Python upgrades were supported, `uv python install 3.12 --reinstall` doubled as a way to
+  install the latest Python 3.12 patch release. Now that `--upgrade` is available, `--reinstall`
+  reinstalls the matching patch releases that are already present.
+
+  For example, if Python 3.12.6 and 3.12.7 are installed, `uv python install 3.12 --reinstall`
+  reinstalls both versions instead of installing the latest available 3.12 release.
+
+  You can recover the previous upgrade behavior with `uv python install 3.12 --upgrade`. Combine
+  `--upgrade --reinstall` to reinstall only the latest patch.
+
+- **Require `--upgrade-group` to name an existing dependency group**
+  ([#18957](https://github.com/astral-sh/uv/pull/18957))
+
+  Previously, `uv lock --upgrade-group docs` silently succeeded even if no `docs` dependency group
+  existed. uv now validates the requested group against the project, its workspace members, and
+  workspace-level dependency groups.
+
+  You cannot opt out of this behavior. Correct the group name or add it to `[dependency-groups]`.
+  Legacy `tool.uv.dev-dependencies` still satisfies `--upgrade-group dev`, and `--frozen` continues
+  to ignore upgrade requests.
+
+- **Preserve absolute paths provided to `uv add`**
+  ([#18402](https://github.com/astral-sh/uv/pull/18402))
+
+  `uv add` previously converted every local dependency into a project-relative path, even when the
+  original request used an absolute path or a literal `file://` URL. It now preserves the form of
+  the request in `pyproject.toml` and `uv.lock`:
+
+  ```console
+  $ uv add ../library             # remains relative
+  $ uv add /projects/library      # remains absolute
+  ```
+
+  Absolute paths make a project less portable. You can opt out of absolute-path recording by
+  providing a relative path instead. URLs containing expanded variables retain their existing
+  relative-path behavior.
+
+- **Remove older PyPy distributions that are only available as bzip2 archives**
+  ([#20423](https://github.com/astral-sh/uv/pull/20423))
+
+  Older PyPy patch releases that are only distributed as `.tar.bz2` archives are no longer
+  available through `uv python install`. This follows the removal of bzip2 archive support
+  described above.
+
+  The latest PyPy release for each supported Python minor version is available as a gzip-compressed
+  archive and remains supported. For example, `uv python list 3.10 --all-versions` still includes
+  the latest PyPy 3.10 release, but older bzip2-only patch releases are omitted.
+
+  You cannot opt out of this behavior. Request a newer PyPy patch release instead.
+
+- **Omit excluded-package comments when annotations are disabled**
+  ([#20085](https://github.com/astral-sh/uv/pull/20085))
+
+  `uv pip compile --no-annotate` suppresses comments describing the generated requirements file.
+  Previously, a footer listing packages excluded with `--unsafe-package` was still included, even
+  though annotations were disabled. That footer is now omitted.
+
+  You can recover the footer by removing `--no-annotate`.
 
 ## 0.11.33
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,24 @@ build-backend = "uv_build"
   You cannot opt out of these checks. Regenerate malformed lockfiles, rename invalid filenames, and
   either correct or remove an incorrect optional `size` value.
 
+- **Honor explicit certificate overrides even when no certificates can be loaded**
+  ([#20741](https://github.com/astral-sh/uv/pull/20741),
+  [#20767](https://github.com/astral-sh/uv/pull/20767))
+
+  Previously, uv ignored `SSL_CERT_FILE` or `SSL_CERT_DIR` values that pointed to missing or
+  inaccessible paths, empty files or directories, or sources without valid certificates. Instead,
+  it fell back to its default trust roots, potentially allowing HTTPS connections that the
+  configured override was intended to reject.
+
+  Now, any non-empty `SSL_CERT_FILE` or `SSL_CERT_DIR` value replaces uv's default certificate
+  roots, even when no valid certificates can be loaded. In that case, HTTPS requests fail because
+  no certificates are trusted. This applies to package downloads and remote scripts, including
+  GitHub Gists.
+
+  To restore connectivity, fix the configured certificate file or directory, or unset the
+  variable to use the default trust store. Empty environment-variable values continue to be
+  ignored.
+
 - **Support pip-compatible `--cert` handling in `uv pip`**
   ([#20418](https://github.com/astral-sh/uv/pull/20418))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,6 @@ build system was confusing to newcomers and consequently dropped use of a build 
 in v0.4. Since then, we've created our own build system (`uv_build`) with tight integration with
 uv and are excited to restore the default to a best-practice project layout.
 
-This release also stabilizes preview behavior for project discovery, virtual environment safety,
-publishing, Conda environments, source distributions, and Unix resource limits.
-
 The [`uv_build` build backend](https://docs.astral.sh/uv/concepts/build-backend/) follows uv's
 breaking-release versioning policy. If your `[build-system]` table includes an upper bound such as
 `uv_build>=0.11.32,<0.12`, it will continue selecting an older build backend after upgrading uv.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,7 +256,7 @@ requires = ["uv_build>=0.11.32,<0.13"]
 
   This stabilizes the `init-project-flag` preview feature.
 
-- **Require `--project` paths to exist and refer to directories**
+- **Reject missing or invalid `--project` paths**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
   uv previously warned when `--project` referred to a missing directory or a file other than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,20 @@ requires = ["uv_build>=0.11.32,<0.13"]
 
   This stabilizes the `special-conda-env-names` preview feature.
 
+- **Reject broken `.venv` symlinks during environment discovery**
+  ([#20433](https://github.com/astral-sh/uv/pull/20433))
+
+  Previously, uv could ignore a broken `.venv` symlink and continue searching parent directories
+  for another virtual environment. As a result, commands such as `uv pip install` could
+  unexpectedly modify an unrelated ancestor environment.
+
+  uv now stops at a broken `.venv` symlink and reports its exact path. Errors encountered while
+  reading virtual environment metadata, including permission failures, are also reported
+  immediately instead of being ignored.
+
+  You cannot opt out of this behavior. Repair or remove the broken `.venv` symlink and correct
+  any permissions that prevent uv from inspecting the environment.
+
 - **Reinstall matching installed Python patch versions instead of upgrading implicitly**
   ([#20659](https://github.com/astral-sh/uv/pull/20659))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ workflows. This release contains those changes; many have been marked as breakin
 abundance of caution. We expect most users to be able to upgrade without making changes.
 
 Projects created with `uv init` are now packaged by default. When uv's project interface stabilized
-in 0.3, the default application layout was kept intentionally simple: a flat `main.py` file and no
-build system. This allowed projects to declare dependencies and participate in workspaces without
-requiring packaging, but became limiting when users wanted to import their own code, write tests,
-define commands, or distribute a project. New projects now use a `src` layout and the uv build
-backend; the previous flat layout remains available with `uv init --no-package` or
-`uv init --app`.
+in 0.3, `uv init` created packaged projects using Hatchling. In 0.4, the default was changed to a
+flat, unpackaged application because requiring a build backend confused users whose projects did
+not need to be distributed. Since then, uv has introduced its own build backend, `uv_build`, which
+integrates with uv and provides a simpler packaging experience. New projects now use a `src` layout
+and `uv_build`, making their code importable, testable, and distributable. The previous flat layout
+remains available with `uv init --no-package` or `uv init --app`.
 
 This release also stabilizes preview behavior for project discovery, virtual environment safety,
 publishing, Conda environments, source distributions, and Unix resource limits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ a `src` layout and the uv build backend; the previous flat layout remains availa
 This release also stabilizes preview behavior for project discovery, virtual environment safety,
 publishing, Conda environments, and source distributions.
 
-The [`uv_build` build backend](https://docs.astral.sh/uv/concepts/build-backend/) now rewrites
-`pyproject.toml` in source distributions, as described below. If you have an upper bound in your
-`[build-system]` table, you should update it, e.g., from `<0.12` to `<0.13`.
+The [`uv_build` build backend](https://docs.astral.sh/uv/concepts/build-backend/) follows uv's
+breaking-release versioning policy. If your `[build-system]` table includes an upper bound such as
+`uv_build>=0.11.32,<0.12`, it will continue selecting an older build backend after upgrading uv.
+Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend also changes how
+`pyproject.toml` is included in source distributions, as described below.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,9 +365,10 @@ build-backend = "uv_build"
 - **Automatic open-file limit adjustment on Unix**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
-  On Linux and macOS, uv now raises the soft open-file limit at startup toward the hard limit,
-  capped at 1,048,576 descriptors. The higher limit is inherited by subprocesses and helps prevent
-  open-file exhaustion during large dependency installations and builds.
+  On Linux and macOS, uv now attempts to raise the soft open-file limit at startup toward the hard
+  limit, capped at 1,048,576 descriptors. The higher limit is inherited by subprocesses and helps
+  prevent open-file exhaustion during large dependency installations and builds. If the limit
+  cannot be raised, uv continues running with the existing limit.
 
   This stabilizes the `adjust-ulimit` preview feature.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,21 +20,8 @@ uv and are excited to restore the default to a best-practice project layout.
 
 There are no breaking changes to the configuration of the
 [uv build backend](https://docs.astral.sh/uv/concepts/build-backend/). If your `[build-system]`
-table includes an upper bound on `uv_build`, update it to allow `uv_build` 0.12:
-
-```toml
-[build-system]
-requires = ["uv_build>=0.11.32,<0.12"]
-build-backend = "uv_build"
-```
-
-becomes:
-
-```toml
-[build-system]
-requires = ["uv_build>=0.11.32,<0.13"]
-build-backend = "uv_build"
-```
+table includes an upper bound on `uv_build`, update it from `<0.12` to `<0.13` to allow
+`uv_build` 0.12.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ build-backend = "uv_build"
   The default mode is now `if-necessary`. uv tries stable candidates first and falls back to
   pre-releases when no stable candidate satisfies the active constraints, including constraints
   discovered transitively. This matches modern pip's pre-release handling, but can select different
-  versions than previous uv releases when stable and pre-release candidates are both available.
+  versions than previous uv releases when both stable and pre-release candidates are available.
 
   You can opt out of automatic pre-release selection with `--prerelease disallow`. Alternatively,
   `--prerelease allow` considers pre-releases without first preferring stable releases, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,26 @@ requires = ["uv_build>=0.11.32,<0.13"]
   You cannot opt out of this behavior. Correct the group name or add it to `[dependency-groups]`.
   Legacy `tool.uv.dev-dependencies` still satisfies `--upgrade-group dev`.
 
+- **Resolve relative indexes and find-links against `--directory`**
+  ([#20740](https://github.com/astral-sh/uv/pull/20740))
+
+  The `--directory` option changes the directory in which uv operates. Previously, relative index
+  and find-links paths supplied on the command line were still resolved against the original
+  working directory.
+
+  uv now resolves `--index`, `--default-index`, `--index-url`, `--extra-index-url`, and
+  `--find-links` relative to the directory selected by `--directory`. For example:
+
+  ```console
+  $ uv add --directory project --index ./packages example
+  ```
+
+  This now uses `project/packages` instead of `./packages` in the original working directory.
+  Absolute paths and indexes loaded from configuration files are unaffected.
+
+  To preserve the previous target, pass an absolute path or adjust the relative path, e.g.,
+  `--index ../packages`.
+
 - **Preserve absolute paths provided to `uv add`**
   ([#18402](https://github.com/astral-sh/uv/pull/18402))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,10 +102,11 @@ build-backend = "uv_build"
 - **Prefer stable releases before falling back to pre-releases**
   ([#19993](https://github.com/astral-sh/uv/pull/19993))
 
-  Pre-releases are difficult to resolve because requirements are discovered incrementally. uv
-  previously required each package's pre-release eligibility to be known before resolution began:
-  the default `if-necessary-or-explicit` mode allowed them for direct requirements that explicitly
-  requested a pre-release, or for packages that only published pre-releases.
+  Pre-releases are difficult to model during resolution because requirements are discovered
+  incrementally. uv previously required each package's pre-release eligibility to be known before
+  resolution began: the default `if-necessary-or-explicit` mode allowed them for direct
+  requirements that explicitly requested a pre-release, or for packages that only published
+  pre-releases.
 
   This meant that a pre-release requirement discovered in a dependency's metadata, e.g.,
   `example>=2.0.0b1`, could fail to resolve even when a compatible pre-release existed. Users had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,8 +260,7 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
   workspace-level dependency groups.
 
   You cannot opt out of this behavior. Correct the group name or add it to `[dependency-groups]`.
-  Legacy `tool.uv.dev-dependencies` still satisfies `--upgrade-group dev`, and `--frozen` continues
-  to ignore upgrade requests.
+  Legacy `tool.uv.dev-dependencies` still satisfies `--upgrade-group dev`.
 
 - **Preserve absolute paths provided to `uv add`**
   ([#18402](https://github.com/astral-sh/uv/pull/18402))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,12 +55,17 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
   ([#18927](https://github.com/astral-sh/uv/pull/18927))
 
   [PEP 625](https://peps.python.org/pep-0625/) requires source distributions to use `.tar.gz`
-  archives. Previously, uv also accepted legacy formats such as `.tar.bz2`, `.tar.xz`, and
-  `.tar.zst`. Those formats are now rejected, including when referenced by an existing lockfile.
-  Legacy `.zip` source distributions remain supported for backwards compatibility.
+  archives. Previously, uv also accepted legacy formats such as `.tar.bz2` and `.tar.xz`. Those
+  formats are now rejected, including when referenced by an existing lockfile. Legacy `.zip` source
+  distributions remain supported for backwards compatibility.
 
   Wheels and other ZIP archives can no longer contain entries compressed with bzip2, LZMA, or XZ.
-  Entries must use the stored, DEFLATE, or zstd compression methods.
+  Entries must use the stored, DEFLATE, or zstd compression methods. zstd remains supported for
+  wheels and other archives; `.tar.zst` is not accepted specifically as a source distribution
+  because PEP 625 requires `.tar.gz`.
+
+  Removing support for uncommon compression methods reduces uv's compression dependencies and the
+  attack surface exposed when processing untrusted packages.
 
   You cannot opt out of this behavior. Rebuild source distributions as `.tar.gz` archives and
   wheels with a supported ZIP compression method. If an existing `uv.lock` references an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,9 +71,9 @@ requires = ["uv_build>=0.11.32,<0.13"]
   Removing support for uncommon compression methods reduces uv's compression dependencies and the
   attack surface exposed when processing untrusted packages.
 
-  You cannot opt out of this behavior. Rebuild source distributions as `.tar.gz` archives and
-  wheels with a supported ZIP compression method. If an existing `uv.lock` references an
-  unsupported source distribution, update the dependency and regenerate the lockfile.
+  You cannot opt out of this behavior. If you depend on a legacy source distribution that uses an
+  unsupported format, we recommend rebuilding it as a `.tar.gz` archive and regenerating any
+  lockfile containing references to the legacy archive.
 
 - **Reject wheel files that could replace the Python interpreter**
   ([#20748](https://github.com/astral-sh/uv/pull/20748),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,16 +119,25 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
   You cannot opt out while the directive is present. Pin every requirement with `==` and provide
   its hash, or remove `--require-hashes` if hash checking is not intended.
 
-- **Require package entries in `pylock.toml` files**
-  ([#20402](https://github.com/astral-sh/uv/pull/20402))
+- **Reject invalid `pylock.toml` files and artifacts**
+  ([#20402](https://github.com/astral-sh/uv/pull/20402),
+  [#20440](https://github.com/astral-sh/uv/pull/20440),
+  [#20443](https://github.com/astral-sh/uv/pull/20443))
 
-  The [`pylock.toml` specification](https://packaging.python.org/en/latest/specifications/pylock-toml/#packages)
-  requires a `packages` array. Previously, uv interpreted a missing array as an empty lockfile;
-  passing such a file to `uv pip sync` could therefore uninstall an environment instead of
-  rejecting the invalid input.
+  uv now validates additional requirements from the
+  [`pylock.toml` specification](https://packaging.python.org/en/latest/specifications/pylock-toml/):
 
-  uv now rejects `pylock.toml` files without `packages`. You cannot opt out of this behavior.
-  Regenerate the lockfile, or use `packages = []` if it intentionally contains no packages.
+  - The `packages` array must be present. Previously, uv interpreted a missing array as an empty
+    lockfile, so `uv pip sync` could uninstall an environment instead of rejecting malformed
+    input. An explicitly empty `packages = []` array remains valid.
+  - Lockfile filenames must be `pylock.toml` or a single-name variant such as `pylock.dev.toml`.
+    Names such as `pylock..toml` and `pylock.foo.bar.toml` are rejected.
+  - If a wheel, source distribution, or other artifact declares a `size`, the downloaded or cached
+    artifact must match. Previously, an incorrect size was accepted when the hash was correct.
+    Sizes reported by package indexes remain advisory.
+
+  You cannot opt out of these checks. Regenerate malformed lockfiles, rename invalid filenames, and
+  either correct or remove an incorrect optional `size` value.
 
 - **Support pip-compatible `--cert` handling in `uv pip`**
   ([#20418](https://github.com/astral-sh/uv/pull/20418))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ out of an abundance of caution.
 There are no breaking changes to the configuration of the
 [uv build backend](https://docs.astral.sh/uv/concepts/build-backend/). If your `[build-system]`
 table includes an upper bound on `uv_build`, update it from `<0.12` to `<0.13` to allow
-`uv_build` 0.12.
+`uv_build` 0.12:
+
+```toml
+requires = ["uv_build>=0.11.32,<0.13"]
+```
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,6 @@ out of an abundance of caution.
 
 **We expect most users to be able to upgrade without making changes.**
 
-Projects created with `uv init` now declare a build system and are packaged by default. This was
-the default project layout all the way back in v0.3, but we found that the use of the `hatchling`
-build system was confusing to newcomers and consequently dropped use of a build system by default
-in v0.4. Since then, we've created our own build system (`uv_build`) with tight integration with
-uv and are excited to restore the default to a best-practice project layout.
-
 There are no breaking changes to the configuration of the
 [uv build backend](https://docs.astral.sh/uv/concepts/build-backend/). If your `[build-system]`
 table includes an upper bound on `uv_build`, update it from `<0.12` to `<0.13` to allow
@@ -27,6 +21,12 @@ table includes an upper bound on `uv_build`, update it from `<0.12` to `<0.13` t
 
 - **Define build systems by default with `uv init`**
   ([#19197](https://github.com/astral-sh/uv/pull/19197))
+
+  Projects created with `uv init` now declare a build system and are packaged by default. This was
+  the default project layout all the way back in v0.3, but we found that the use of the `hatchling`
+  build system was confusing to newcomers and consequently dropped use of a build system by default
+  in v0.4. Since then, we've created our own build system (`uv_build`) with tight integration with
+  uv and are excited to restore the default to a best-practice project layout.
 
   Previously, `uv init example` created an unpackaged layout containing `main.py` and a
   `pyproject.toml` without a build system. The project could declare dependencies but was not itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,11 +97,10 @@ requires = ["uv_build>=0.11.32,<0.13"]
 - **Prefer stable releases before falling back to pre-releases**
   ([#19993](https://github.com/astral-sh/uv/pull/19993))
 
-  Pre-releases are difficult to model during resolution because requirements are discovered
-  incrementally. uv previously required each package's pre-release eligibility to be known before
-  resolution began: the default `if-necessary-or-explicit` mode allowed them for direct
-  requirements that explicitly requested a pre-release, or for packages that only published
-  pre-releases.
+  A dependency can introduce a pre-release requirement after resolution starts. uv previously
+  required each package's pre-release eligibility to be known before resolution began: the default
+  `if-necessary-or-explicit` mode allowed them for direct requirements that explicitly requested a
+  pre-release, or for packages that only published pre-releases.
 
   This meant that a pre-release requirement discovered in a dependency's metadata, e.g.,
   `example>=2.0.0b1`, would fail to resolve even when a compatible pre-release existed. To resolve
@@ -146,8 +145,7 @@ requires = ["uv_build>=0.11.32,<0.13"]
 
   Previously, `uv pip install --require-hashes` and `uv pip sync --require-hashes` accepted
   requirements whose only available digest used MD5. MD5 is not collision-resistant, so relying on
-  it undermined installations that explicitly require hash verification and differed from pip's
-  behavior.
+  it undermined installations that require hash verification and differed from pip's behavior.
 
   Hash-checking mode now requires at least one secure digest for every requirement. For example,
   the following requirement is rejected unless a secure hash, such as SHA-256, is also supplied:
@@ -196,9 +194,8 @@ requires = ["uv_build>=0.11.32,<0.13"]
   no certificates are trusted. This applies to package downloads and remote scripts, including
   GitHub Gists.
 
-  To restore connectivity, fix the configured certificate file or directory, or unset the
-  variable to use the default trust store. Empty environment-variable values continue to be
-  ignored.
+  Fix or unset the certificate override. Unsetting it restores the default trust store; empty
+  environment-variable values continue to be ignored.
 
 - **Support pip-compatible `--cert` handling in `uv pip`**
   ([#20418](https://github.com/astral-sh/uv/pull/20418))
@@ -211,8 +208,7 @@ requires = ["uv_build>=0.11.32,<0.13"]
 
   As in pip, the provided PEM bundle replaces all other certificate sources for that invocation,
   including system certificates and `SSL_CERT_FILE` or `SSL_CERT_DIR`. This change has no effect
-  unless you pass `--cert`. If a connection fails after adding the option, ensure the bundle
-  contains every required certificate authority.
+  unless you pass `--cert`. Include the necessary certificate authorities in the bundle.
 
   `--cert` is only supported by `uv pip` commands; other uv commands continue to use their existing
   certificate configuration.
@@ -289,12 +285,11 @@ requires = ["uv_build>=0.11.32,<0.13"]
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
   Conda environments named `base` or `root` were previously assumed to be the base Conda
-  environment, even when they were ordinary child environments. uv now determines whether these
-  environments are base environments from their paths, as it already does for other names.
+  environment, even when they were ordinary child environments. uv now recognizes child Conda
+  environments named `base` or `root` based on their paths, as it already does for other names.
 
-  A child environment at a path such as `/envs/base` can therefore be discovered as a virtual
-  environment instead of being ignored. You can opt out of automatic interpreter selection by
-  requesting an interpreter explicitly with `--python /path/to/python`.
+  You can opt out of automatic interpreter selection by requesting an interpreter explicitly with
+  `--python /path/to/python`.
 
   This stabilizes the `special-conda-env-names` preview feature.
 
@@ -367,16 +362,14 @@ requires = ["uv_build>=0.11.32,<0.13"]
   $ uv add /projects/library      # remains absolute
   ```
 
-  Absolute paths make a project less portable. You can opt out of absolute-path recording by
-  providing a relative path instead. URLs containing expanded variables retain their existing
-  relative-path behavior.
+  Absolute paths make a project less portable. Use a relative path to avoid recording an absolute
+  path. URLs containing expanded variables retain their existing relative-path behavior.
 
 - **Remove older PyPy distributions that are only available as bzip2 archives**
   ([#20423](https://github.com/astral-sh/uv/pull/20423))
 
   Older PyPy patch releases that are only distributed as `.tar.bz2` archives are no longer
-  available through `uv python install`. This follows the removal of bzip2 archive support
-  described above.
+  available through `uv python install`. These releases require unsupported bzip2 archives.
 
   The latest PyPy release for each supported Python minor version is available as a gzip-compressed
   archive and remains supported. For example, `uv python list 3.10 --all-versions` still includes
@@ -408,9 +401,9 @@ requires = ["uv_build>=0.11.32,<0.13"]
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
   On Linux and macOS, uv now attempts to raise the soft open-file limit at startup toward the hard
-  limit, capped at 1,048,576 descriptors. The higher limit is inherited by subprocesses and helps
-  prevent open-file exhaustion during large dependency installations and builds. If the limit
-  cannot be raised, uv continues running with the existing limit.
+  limit, capped at 1,048,576 descriptors. The new limit also applies to subprocesses and reduces
+  failures caused by running out of file descriptors. If the limit cannot be raised, uv continues
+  running with the existing limit.
 
   This stabilizes the `adjust-ulimit` preview feature.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,16 +36,17 @@ build-backend = "uv_build"
 
 ### Breaking changes
 
-- **Create packaged projects by default with `uv init`**
+- **Define build systems by default with `uv init`**
   ([#19197](https://github.com/astral-sh/uv/pull/19197))
 
-  Previously, `uv init example` created an unpackaged application containing `main.py` and a
+  Previously, `uv init example` created an unpackaged layout containing `main.py` and a
   `pyproject.toml` without a build system. The project could declare dependencies but was not itself
   installed into its virtual environment.
 
-  Now, `uv init example` creates a packaged application with source code in `src/example`, a
-  `[build-system]` using `uv_build`, and a `[project.scripts]` entry named `example`. The project
-  can be imported from tests or other code, installed as a dependency, and run as a command:
+  Now, `uv init example` defines a `[build-system]` using `uv_build`, places application source
+  code in `src/example`, and includes a `[project.scripts]` entry named `example`. Defining a
+  build system allows the project to be imported from tests or other code, installed as a
+  dependency, and run as a command:
 
   ```console
   $ uv init example
@@ -55,8 +56,8 @@ build-backend = "uv_build"
   ```
 
   Existing projects are unaffected. You can opt out of the new layout with
-  `uv init --no-package example` or `uv init --app example`, which create the previous flat
-  application layout.
+  `uv init --no-package example` or `uv init --app example`, which create the previous flat layout
+  without a build system.
 
 - **Reject unsupported source distribution and wheel archive formats**
   ([#18927](https://github.com/astral-sh/uv/pull/18927))
@@ -334,12 +335,12 @@ build-backend = "uv_build"
 
 ### Stabilizations
 
-- **Packaged projects created by `uv init`**
+- **Build systems for projects created by `uv init`**
   ([#19197](https://github.com/astral-sh/uv/pull/19197))
 
-  `uv init` now creates an importable, distributable project with a `src` layout, the `uv_build`
-  backend, and a command-line entry point by default. Existing projects are unaffected, and
-  `uv init --no-package` or `uv init --app` retains the previous flat application layout.
+  `uv init` now defines a build system using `uv_build`, places application source code in a `src`
+  directory, and includes a command-line entry point by default. Existing projects are unaffected,
+  and `uv init --no-package` or `uv init --app` retains a flat layout without a build system.
 
   See the
   [project creation documentation](https://docs.astral.sh/uv/concepts/projects/init/#packaged-applications)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ requires = ["uv_build>=0.11.32,<0.13"]
 ### Breaking changes
 
 - **Define build systems by default with `uv init`**
-  ([#19197](https://github.com/astral-sh/uv/pull/19197))
+  ([#19197](https://github.com/astral-sh/uv/pull/19197),
+  [#20773](https://github.com/astral-sh/uv/pull/20773))
 
   Projects created with `uv init` now declare a build system and are packaged by default. This was
   the default project layout all the way back in v0.3, but we found that the use of the `hatchling`
@@ -36,10 +37,10 @@ requires = ["uv_build>=0.11.32,<0.13"]
   `pyproject.toml` without a build system. The project could declare dependencies but was not itself
   installed into its virtual environment.
 
-  Now, `uv init example` defines a `[build-system]` using `uv_build`, places application source
-  code in `src/example`, and includes a `[project.scripts]` entry named `example`. Defining a
-  build system allows the project to be imported from tests or other code, installed as a
-  dependency, and run as a command:
+  Now, both `uv init example` and `uv init --app example` define a `[build-system]` using
+  `uv_build`, place application source code in `src/example`, and include a `[project.scripts]`
+  entry named `example`. Defining a build system allows the project to be imported from tests or
+  other code, installed as a dependency, and run as a command:
 
   ```console
   $ uv init example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ build-backend = "uv_build"
   Existing projects are unaffected. Use `uv init --no-package example` to create the previous flat
   layout without a build system.
 
+  See the
+  [project creation documentation](https://docs.astral.sh/uv/concepts/projects/init/#applications)
+  for more details.
+
+  This stabilizes the `packaged-init` preview feature.
+
 - **Reject unsupported source distribution and wheel archive formats**
   ([#18927](https://github.com/astral-sh/uv/pull/18927))
 
@@ -217,6 +223,8 @@ build-backend = "uv_build"
   You can opt out of script-relative discovery by selecting a project explicitly, e.g.,
   `uv run --project . other-project/script.py`.
 
+  This stabilizes the `target-workspace-discovery` preview feature.
+
 - **Require `--force` before clearing a directory that is not a virtual environment**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
@@ -226,6 +234,8 @@ build-backend = "uv_build"
 
   You can opt out of this safety check by explicitly passing `--force`, e.g.,
   `uv venv --clear --force ./not-a-virtualenv`.
+
+  This stabilizes the `venv-safe-clear` preview feature.
 
 - **Reject `--project` when initializing a project**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
@@ -237,6 +247,8 @@ build-backend = "uv_build"
   This usage is now an error. Use `uv init example` to initialize a project at the requested path,
   or `uv init --directory example` to change the working directory first.
 
+  This stabilizes the `init-project-flag` preview feature.
+
 - **Require `--project` paths to exist and refer to directories**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
@@ -247,6 +259,8 @@ build-backend = "uv_build"
   Now, `uv run --project missing python` fails immediately instead of continuing. You cannot opt
   out of this behavior. Create the directory first or select an existing project. Passing
   `--project path/to/pyproject.toml` remains supported and selects the file's parent directory.
+
+  This stabilizes the `project-directory-must-exist` preview feature.
 
 - **Skip distributions with non-normalized filenames when publishing**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
@@ -261,6 +275,8 @@ build-backend = "uv_build"
   You cannot opt out of this behavior. Rebuild distributions with normalized filenames before
   publishing.
 
+  This stabilizes the `publish-require-normalized` preview feature.
+
 - **Classify Conda environments named `base` and `root` by their paths**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
@@ -271,6 +287,8 @@ build-backend = "uv_build"
   A child environment at a path such as `/envs/base` can therefore be discovered as a virtual
   environment instead of being ignored. You can opt out of automatic interpreter selection by
   requesting an interpreter explicitly with `--python /path/to/python`.
+
+  This stabilizes the `special-conda-env-names` preview feature.
 
 - **Reinstall matching installed Python patch versions instead of upgrading implicitly**
   ([#20659](https://github.com/astral-sh/uv/pull/20659))
@@ -335,17 +353,6 @@ build-backend = "uv_build"
 
 ### Stabilizations
 
-- **Build systems for projects created by `uv init`**
-  ([#19197](https://github.com/astral-sh/uv/pull/19197))
-
-  `uv init` now defines a build system using `uv_build`, places application source code in a `src`
-  directory, and includes a command-line entry point by default. Existing projects are unaffected.
-  Use `uv init --no-package` to create a flat layout without a build system.
-
-  See the
-  [project creation documentation](https://docs.astral.sh/uv/concepts/projects/init/#applications)
-  for more details.
-
 - **TOML 1.0-compatible source distributions**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
 
@@ -353,46 +360,7 @@ build-backend = "uv_build"
   allowing older Python build frontends to consume projects that use newer TOML syntax. The
   original project file remains available in the archive as `pyproject.toml.orig`.
 
-- **Script-relative project and workspace discovery**
-  ([#20225](https://github.com/astral-sh/uv/pull/20225))
-
-  `uv run path/to/project/script.py` now discovers the target project or workspace from the
-  script's directory. This allows scripts to use their own project's dependencies even when they
-  are invoked from another directory. An explicit `--project` still takes precedence.
-
-- **Safer virtual environment clearing**
-  ([#20225](https://github.com/astral-sh/uv/pull/20225))
-
-  `uv venv --clear` now protects directories that are not virtual environments from accidental
-  deletion. Existing virtual environments can still be replaced normally; use `--force` when
-  clearing another directory is intentional.
-
-- **Validation of `--project` paths**
-  ([#20225](https://github.com/astral-sh/uv/pull/20225))
-
-  Project commands now validate `--project` before proceeding, providing an immediate error when
-  the selected path does not exist or is not a directory. Paths to a `pyproject.toml` file remain
-  supported and select the containing project.
-
-- **Project paths for `uv init`**
-  ([#20225](https://github.com/astral-sh/uv/pull/20225))
-
-  `uv init` now rejects `--project`, which is intended to select an existing project. Use a
-  positional path to create a project in another directory, or `--directory` to change the working
-  directory before initialization.
-
-- **Normalized distribution filenames in `uv publish`**
-  ([#20225](https://github.com/astral-sh/uv/pull/20225))
-
-  `uv publish` now skips wheels and source distributions whose package names or versions are not
-  normalized, preventing invalid artifacts from being uploaded to package indexes.
-
-- **Conda environments named `base` and `root`**
-  ([#20225](https://github.com/astral-sh/uv/pull/20225))
-
-  uv now determines whether a Conda environment is the base environment from its location instead
-  of treating `base` and `root` as reserved names. Child environments with either name can be
-  discovered and used normally.
+  This stabilizes the `toml-backwards-compatibility` preview feature.
 
 - **Automatic open-file limit adjustment on Unix**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))
@@ -400,6 +368,8 @@ build-backend = "uv_build"
   On Linux and macOS, uv now raises the soft open-file limit at startup toward the hard limit,
   capped at 1,048,576 descriptors. The higher limit is inherited by subprocesses and helps prevent
   open-file exhaustion during large dependency installations and builds.
+
+  This stabilizes the `adjust-ulimit` preview feature.
 
 ## 0.11.33
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,17 +74,24 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
 - **Prefer stable releases before falling back to pre-releases**
   ([#19993](https://github.com/astral-sh/uv/pull/19993))
 
-  uv previously allowed pre-releases by default when a direct dependency explicitly requested one
-  or a package only published pre-releases. A pre-release requested by a transitive dependency,
-  e.g., `example>=2.0.0b1`, could cause resolution to fail even when that pre-release satisfied
-  every requirement.
+  Pre-releases are difficult to resolve because requirements are discovered incrementally. uv
+  previously required each package's pre-release eligibility to be known before resolution began:
+  the default `if-necessary-or-explicit` mode allowed them for direct requirements that explicitly
+  requested a pre-release, or for packages that only published pre-releases.
 
-  uv now prefers stable candidates and considers pre-releases when no stable candidate satisfies
-  the active constraints. This allows transitive pre-release requirements, but can change which
-  versions are selected when both stable and pre-release candidates are available.
+  This meant that a pre-release requirement discovered in a dependency's metadata, e.g.,
+  `example>=2.0.0b1`, could fail to resolve even when a compatible pre-release existed. Users had
+  to add that dependency as a direct requirement or allow pre-releases across their entire
+  dependency graph.
+
+  The default mode is now `if-necessary`. uv tries stable candidates first and falls back to
+  pre-releases when no stable candidate satisfies the active constraints, including constraints
+  discovered transitively. This matches modern pip's pre-release handling, but can select different
+  versions than previous uv releases when stable and pre-release candidates are both available.
 
   You can opt out of automatic pre-release selection with `--prerelease disallow`. Alternatively,
-  `--prerelease allow` considers pre-releases without first preferring stable releases. If you
+  `--prerelease allow` considers pre-releases without first preferring stable releases, while
+  `--prerelease explicit` only allows them for direct requirements that mention a pre-release. If you
   explicitly configured `if-necessary-or-explicit`, replace it with `if-necessary`; the old name
   remains available as a deprecated alias.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,8 @@ build-backend = "uv_build"
   Hello from example!
   ```
 
-  Existing projects are unaffected. You can opt out of the new layout with
-  `uv init --no-package example` or `uv init --app example`, which create the previous flat layout
-  without a build system.
+  Existing projects are unaffected. Use `uv init --no-package example` to create the previous flat
+  layout without a build system.
 
 - **Reject unsupported source distribution and wheel archive formats**
   ([#18927](https://github.com/astral-sh/uv/pull/18927))
@@ -339,11 +338,11 @@ build-backend = "uv_build"
   ([#19197](https://github.com/astral-sh/uv/pull/19197))
 
   `uv init` now defines a build system using `uv_build`, places application source code in a `src`
-  directory, and includes a command-line entry point by default. Existing projects are unaffected,
-  and `uv init --no-package` or `uv init --app` retains a flat layout without a build system.
+  directory, and includes a command-line entry point by default. Existing projects are unaffected.
+  Use `uv init --no-package` to create a flat layout without a build system.
 
   See the
-  [project creation documentation](https://docs.astral.sh/uv/concepts/projects/init/#packaged-applications)
+  [project creation documentation](https://docs.astral.sh/uv/concepts/projects/init/#applications)
   for more details.
 
 - **Script-relative project and workspace discovery**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,26 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
   You cannot opt out while the directive is present. Pin every requirement with `==` and provide
   its hash, or remove `--require-hashes` if hash checking is not intended.
 
+- **Reject MD5-only hashes in hash-checking mode**
+  ([#20758](https://github.com/astral-sh/uv/pull/20758))
+
+  Previously, `uv pip install --require-hashes` and `uv pip sync --require-hashes` accepted
+  requirements whose only available digest used MD5. MD5 is not collision-resistant, so relying on
+  it undermined explicitly integrity-enforced installations and differed from pip's behavior.
+
+  Hash-checking mode now requires at least one secure digest for every requirement. For example,
+  the following requirement is rejected unless a secure hash, such as SHA-256, is also supplied:
+
+  ```text
+  anyio==4.0.0 --hash=md5:420d85e19168705cdf0223621b18831a
+  ```
+
+  A secure hash can be supplied directly on the requirement or in a matching constraints file.
+  Ordinary hash verification without `--require-hashes` continues to support MD5.
+
+  You cannot opt out while hash checking is required. Regenerate affected hashes with SHA-256 or
+  another supported secure hash.
+
 - **Reject invalid `pylock.toml` files and artifacts**
   ([#20402](https://github.com/astral-sh/uv/pull/20402),
   [#20440](https://github.com/astral-sh/uv/pull/20440),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,9 +109,9 @@ build-backend = "uv_build"
   pre-releases.
 
   This meant that a pre-release requirement discovered in a dependency's metadata, e.g.,
-  `example>=2.0.0b1`, could fail to resolve even when a compatible pre-release existed. Users had
-  to add that dependency as a direct requirement or allow pre-releases across their entire
-  dependency graph.
+  `example>=2.0.0b1`, would fail to resolve even when a compatible pre-release existed. To resolve
+  it, you had to add that dependency as a direct requirement or allow pre-releases across your
+  entire dependency graph.
 
   The default mode is now `if-necessary`. uv tries stable candidates first and falls back to
   pre-releases when no stable candidate satisfies the active constraints, including constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,23 @@ build system was confusing to newcomers and consequently dropped use of a build 
 in v0.4. Since then, we've created our own build system (`uv_build`) with tight integration with
 uv and are excited to restore the default to a best-practice project layout.
 
-The [`uv_build` build backend](https://docs.astral.sh/uv/concepts/build-backend/) follows uv's
-breaking-release versioning policy. If your `[build-system]` table includes an upper bound such as
-`uv_build>=0.11.32,<0.12`, it will continue selecting an older build backend after upgrading uv.
-Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend also changes how
-`pyproject.toml` is included in source distributions, as described below.
+There are no breaking changes to the configuration of the
+[uv build backend](https://docs.astral.sh/uv/concepts/build-backend/). If your `[build-system]`
+table includes an upper bound on `uv_build`, update it to allow `uv_build` 0.12:
+
+```toml
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+```
+
+becomes:
+
+```toml
+[build-system]
+requires = ["uv_build>=0.11.32,<0.13"]
+build-backend = "uv_build"
+```
 
 ### Breaking changes
 
@@ -247,20 +259,6 @@ Update that upper bound to `<0.13` to use `uv_build` 0.12. The build backend als
 
   You cannot opt out of this behavior. Rebuild distributions with normalized filenames before
   publishing.
-
-- **Rewrite `pyproject.toml` files in source distributions for TOML 1.0 compatibility**
-  ([#20225](https://github.com/astral-sh/uv/pull/20225))
-
-  Python's `tomllib` only supports TOML 1.0 through Python 3.14, so source distributions using
-  TOML 1.1 syntax can fail when built by older frontends. `uv_build` now always rewrites the
-  distributed `pyproject.toml` as TOML 1.0 and includes the original as `pyproject.toml.orig`.
-
-  Previously, the rewrite occurred only when TOML 1.1 syntax was detected or the corresponding
-  preview feature was enabled. Now, even a TOML 1.0 input is normalized and the source distribution
-  gains an additional `pyproject.toml.orig` file.
-
-  You cannot opt out of this behavior. If a tool needs the original contents or formatting, read
-  `pyproject.toml.orig` from the source distribution instead.
 
 - **Classify Conda environments named `base` and `root` by their paths**
   ([#20225](https://github.com/astral-sh/uv/pull/20225))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ accumulated changes that improve correctness, safety, and compatibility, but cou
 workflows. This release contains those changes; many have been marked as breaking out of an
 abundance of caution. We expect most users to be able to upgrade without making changes.
 
+The most visible change is to `uv init`, which now creates a packaged project by default. When uv's
+project interface stabilized in 0.3, the default application layout was kept intentionally simple:
+a flat `main.py` file and no build system. This allowed projects to declare dependencies and
+participate in workspaces without requiring packaging, but became limiting when users wanted to
+import their own code, write tests, define commands, or distribute a project. New projects now use
+a `src` layout and the uv build backend; the previous flat layout remains available with
+`uv init --no-package` or `uv init --app`.
+
 This release also stabilizes preview behavior for project discovery, virtual environment safety,
 publishing, Conda environments, and source distributions.
 
@@ -18,6 +26,28 @@ The [`uv_build` build backend](https://docs.astral.sh/uv/concepts/build-backend/
 `[build-system]` table, you should update it, e.g., from `<0.12` to `<0.13`.
 
 ### Breaking changes
+
+- **Create packaged projects by default with `uv init`**
+  ([#19197](https://github.com/astral-sh/uv/pull/19197))
+
+  Previously, `uv init example` created an unpackaged application containing `main.py` and a
+  `pyproject.toml` without a build system. The project could declare dependencies but was not itself
+  installed into its virtual environment.
+
+  Now, `uv init example` creates a packaged application with source code in `src/example`, a
+  `[build-system]` using `uv_build`, and a `[project.scripts]` entry named `example`. The project
+  can be imported from tests or other code, installed as a dependency, and run as a command:
+
+  ```console
+  $ uv init example
+  $ cd example
+  $ uv run example
+  Hello from example!
+  ```
+
+  Existing projects are unaffected. You can opt out of the new layout with
+  `uv init --no-package example` or `uv init --app example`, which create the previous flat
+  application layout.
 
 - **Reject unsupported source distribution and wheel archive formats**
   ([#18927](https://github.com/astral-sh/uv/pull/18927))


### PR DESCRIPTION
Document the compatibility changes planned for uv 0.12, including archive and lockfile validation, pre-release resolution, certificate handling, Python installation, and preview feature stabilizations. Each entry explains the affected workflows and provides migration guidance.