### PR TITLE
fix(requirements-txt): strip backslash line continuations before PEP 508 parsing

### DIFF
--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -988,6 +988,16 @@ fn parse_requirement_and_hashes(
     };
 
     let requirement = &content[start..end];
+    let requirement = if requirement.contains('\\') {
+        Cow::Owned(
+            requirement
+                .replace("\\\r\n", "")
+                .replace("\\\n", "")
+                .replace("\\\r", ""),
+        )
+    } else {
+        Cow::Borrowed(requirement)
+    };
 
     // If the requirement looks like a `requirements.txt` file (with a missing `-r`), raise an
     // error.


### PR DESCRIPTION
## Description
This PR resolves issue #20744 by stripping escaped line continuations (`\\n`, `\\r\n`, `\\r`) from requirement strings in `crates/uv-requirements-txt/src/lib.rs` prior to passing them to `RequirementsTxtRequirement::parse()`.

## Details
- Fixes parsing of multiline requirements with backslash continuation preceding version specifiers (e.g. `project \\n >1.0.0`).