### PR TITLE
Cleanup managed Python temporary directory on error

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1351,7 +1351,7 @@ impl ManagedPythonDownload {
         // Extract the top-level directory.
         let mut extracted = match uv_extract::strip_component(temp_dir.path()) {
             Ok(top_level) => top_level,
-            Err(uv_extract::Error::NonSingularArchive(_)) => temp_dir.keep(),
+            Err(uv_extract::Error::NonSingularArchive(_)) => temp_dir.path().to_path_buf(),
             Err(err) => return Err(Error::ExtractError(filename, err)),
         };
 


### PR DESCRIPTION
## Description
This PR resolves issue #20675 by replacing `temp_dir.keep()` with `temp_dir.path().to_path_buf()` in `crates/uv-python/src/downloads.rs`.

## Details
- Prevents temporary directories in `~/.local/share/uv/python/.temp/` from persisting on disk after Python installation completes or fails.