### PR TITLE
fix(resolver): ignore trailing slashes when matching remote indexes in lockfile validation

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2022,10 +2022,13 @@ impl Lock {
             if let Source::Registry(index) = &package.id.source {
                 match index {
                     RegistrySource::Url(url) => {
-                        if remotes
-                            .as_ref()
-                            .is_some_and(|remotes| !remotes.contains(url))
-                        {
+                        if remotes.as_ref().is_some_and(|remotes| {
+                            !remotes.contains(url)
+                                && !remotes.iter().any(|r| {
+                                    r.as_str().trim_end_matches('/')
+                                        == url.as_str().trim_end_matches('/')
+                                })
+                        }) {
                             let name = &package.id.name;
                             let version = &package
                                 .id


### PR DESCRIPTION
## Description
This PR resolves issue #20635 by ignoring trailing slash differences when validating remote indexes in `crates/uv-resolver/src/lock/mod.rs`.

## Details
- Prevents `SatisfiesResult::MissingRemoteIndex` when index URLs in `pyproject.toml` and `uv.lock` differ only by a trailing slash (e.g. `https://.../pypi/simple` vs `https://.../pypi/simple/`).