### PR TITLE
Respect configured indexes in `uv tool list --outdated`

### DIFF
--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -667,17 +667,22 @@ mod tests {
     }
 
     #[test]
-    fn configured_indexes_keep_first_named_definition() -> Result<(), Box<dyn Error>> {
+    fn named_indexes_use_first_definition() -> Result<(), Box<dyn Error>> {
         let first = Index::from_str("shared=https://first.example.com/simple")?;
         let mut shadowed = Index::from_str("shared=https://shadowed.example.com/simple")?;
         shadowed.explicit = true;
         let mut explicit = Index::from_str("explicit=https://explicit.example.com/simple")?;
         explicit.explicit = true;
+        let shadowed_implicit =
+            Index::from_str("explicit=https://shadowed-implicit.example.com/simple")?;
         let mut default = Index::from_str("default=https://default.example.com/simple")?;
         default.default = true;
 
-        let locations =
-            IndexLocations::new(vec![first, shadowed, explicit, default], vec![], false);
+        let locations = IndexLocations::new(
+            vec![first, shadowed, explicit, shadowed_implicit, default],
+            vec![],
+            false,
+        );
 
         assert_eq!(
             index_urls(locations.simple_indexes()),
@@ -715,7 +720,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_indexes_preserve_all_unnamed_indexes() -> Result<(), Box<dyn Error>> {
+    fn unnamed_indexes_are_not_deduplicated() -> Result<(), Box<dyn Error>> {
         let first = Index::from_str("https://first.example.com/simple")?;
         let repeated = Index::from_str("https://first.example.com/simple")?;
         let last = Index::from_str("https://last.example.com/simple")?;
@@ -742,7 +747,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_indexes_ignore_shadowed_default() -> Result<(), Box<dyn Error>> {
+    fn shadowed_default_falls_back_to_pypi() -> Result<(), Box<dyn Error>> {
         let first = Index::from_str("shared=https://first.example.com/simple")?;
         let mut shadowed = Index::from_str("shared=https://shadowed.example.com/simple")?;
         shadowed.default = true;

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -715,23 +715,6 @@ mod tests {
     }
 
     #[test]
-    fn configured_indexes_preserve_first_explicit_definition() -> Result<(), Box<dyn Error>> {
-        let mut explicit = Index::from_str("shared=https://explicit.example.com/simple")?;
-        explicit.explicit = true;
-        let shadowed = Index::from_str("shared=https://shadowed.example.com/simple")?;
-        let locations = IndexLocations::new(vec![explicit, shadowed], vec![], false);
-
-        assert_eq!(
-            index_urls(locations.explicit_indexes()),
-            ["https://explicit.example.com/simple"]
-        );
-        assert_eq!(index_urls(locations.implicit_indexes()), [] as [&str; 0]);
-        assert_eq!(index_urls(locations.indexes()), ["https://pypi.org/simple"]);
-
-        Ok(())
-    }
-
-    #[test]
     fn configured_indexes_preserve_all_unnamed_indexes() -> Result<(), Box<dyn Error>> {
         let first = Index::from_str("https://first.example.com/simple")?;
         let repeated = Index::from_str("https://first.example.com/simple")?;
@@ -759,29 +742,6 @@ mod tests {
     }
 
     #[test]
-    fn configured_indexes_preserve_first_default() -> Result<(), Box<dyn Error>> {
-        let mut first = Index::from_str("first=https://first.example.com/simple")?;
-        first.default = true;
-        let mut second = Index::from_str("second=https://second.example.com/simple")?;
-        second.default = true;
-        let locations = IndexLocations::new(vec![first, second], vec![], false);
-
-        assert_eq!(
-            index_urls(locations.default_index()),
-            ["https://first.example.com/simple"]
-        );
-        assert_eq!(
-            index_urls(locations.defined_indexes()),
-            [
-                "https://first.example.com/simple",
-                "https://second.example.com/simple",
-            ]
-        );
-
-        Ok(())
-    }
-
-    #[test]
     fn configured_indexes_ignore_shadowed_default() -> Result<(), Box<dyn Error>> {
         let first = Index::from_str("shared=https://first.example.com/simple")?;
         let mut shadowed = Index::from_str("shared=https://shadowed.example.com/simple")?;
@@ -797,47 +757,6 @@ mod tests {
             [
                 "https://first.example.com/simple",
                 "https://pypi.org/simple",
-            ]
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn disabled_indexes_preserve_flat_indexes() -> Result<(), Box<dyn Error>> {
-        let configured = Index::from_str("configured=https://configured.example.com/simple")?;
-        let first =
-            Index::from_find_links(IndexUrl::from_str("https://first.example.com/packages")?);
-        let second =
-            Index::from_find_links(IndexUrl::from_str("https://second.example.com/packages")?);
-        let locations = IndexLocations::new(vec![configured], vec![first, second], true);
-
-        assert!(locations.no_index());
-        assert!(locations.default_index().is_none());
-        assert_eq!(index_urls(locations.simple_indexes()), [] as [&str; 0]);
-        assert_eq!(index_urls(locations.implicit_indexes()), [] as [&str; 0]);
-        assert_eq!(index_urls(locations.explicit_indexes()), [] as [&str; 0]);
-        assert_eq!(index_urls(locations.indexes()), [] as [&str; 0]);
-        assert_eq!(index_urls(locations.defined_indexes()), [] as [&str; 0]);
-        assert_eq!(
-            index_urls(locations.flat_indexes()),
-            [
-                "https://first.example.com/packages",
-                "https://second.example.com/packages",
-            ]
-        );
-        assert_eq!(
-            index_urls(locations.allowed_indexes()),
-            [
-                "https://second.example.com/packages",
-                "https://first.example.com/packages",
-            ]
-        );
-        assert_eq!(
-            index_urls(locations.known_indexes()),
-            [
-                "https://second.example.com/packages",
-                "https://first.example.com/packages",
             ]
         );
 

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -305,6 +305,14 @@ fn is_same_index(a: &IndexUrl, b: &IndexUrl) -> bool {
 }
 
 impl<'a> IndexLocations {
+    /// Return configured indexes in definition order, keeping the first index for each name.
+    fn configured_indexes(&'a self) -> impl Iterator<Item = &'a Index> + 'a {
+        let mut seen = FxHashSet::default();
+        self.indexes
+            .iter()
+            .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
+    }
+
     /// Return the default [`Index`] entry.
     ///
     /// If `--no-index` is set, return `None`.
@@ -314,10 +322,7 @@ impl<'a> IndexLocations {
         if self.no_index {
             None
         } else {
-            let mut seen = FxHashSet::default();
-            self.indexes
-                .iter()
-                .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
+            self.configured_indexes()
                 .find(|index| index.default)
                 .or_else(|| Some(&DEFAULT_INDEX))
         }
@@ -330,11 +335,8 @@ impl<'a> IndexLocations {
         if self.no_index {
             Either::Left(std::iter::empty())
         } else {
-            let mut seen = FxHashSet::default();
             Either::Right(
-                self.indexes
-                    .iter()
-                    .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
+                self.configured_indexes()
                     .filter(|index| !index.default && !index.explicit),
             )
         }
@@ -347,13 +349,7 @@ impl<'a> IndexLocations {
         if self.no_index {
             Either::Left(std::iter::empty())
         } else {
-            let mut seen = FxHashSet::default();
-            Either::Right(
-                self.indexes
-                    .iter()
-                    .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
-                    .filter(|index| index.explicit),
-            )
+            Either::Right(self.configured_indexes().filter(|index| index.explicit))
         }
     }
 
@@ -387,12 +383,7 @@ impl<'a> IndexLocations {
         if self.no_index {
             Either::Left(std::iter::empty())
         } else {
-            let mut seen = FxHashSet::default();
-            Either::Right(
-                self.indexes
-                    .iter()
-                    .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name))),
-            )
+            Either::Right(self.configured_indexes())
         }
     }
 
@@ -477,17 +468,8 @@ impl<'a> IndexLocations {
             return Either::Left(std::iter::empty());
         }
 
-        let mut seen = FxHashSet::default();
         let (non_default, default) = self
-            .indexes
-            .iter()
-            .filter(move |index| {
-                if let Some(name) = &index.name {
-                    seen.insert(name)
-                } else {
-                    true
-                }
-            })
+            .configured_indexes()
             .partition::<Vec<_>, _>(|index| !index.default);
 
         Either::Right(non_default.into_iter().chain(default))
@@ -638,9 +620,18 @@ impl IndexCapabilities {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
+
     use super::*;
     use crate::{IndexCacheControl, IndexFormat, IndexName};
     use http::HeaderValue;
+
+    fn index_urls<'a>(indexes: impl IntoIterator<Item = &'a Index>) -> Vec<&'a str> {
+        indexes
+            .into_iter()
+            .map(|index| index.url().url().as_str())
+            .collect()
+    }
 
     #[test]
     fn test_index_url_parse_valid_paths() {
@@ -673,6 +664,184 @@ mod tests {
         assert!(is_disambiguated_path(
             "git+https://github.com/example/repo.git"
         ));
+    }
+
+    #[test]
+    fn configured_indexes_keep_first_named_definition() -> Result<(), Box<dyn Error>> {
+        let first = Index::from_str("shared=https://first.example.com/simple")?;
+        let mut shadowed = Index::from_str("shared=https://shadowed.example.com/simple")?;
+        shadowed.explicit = true;
+        let mut explicit = Index::from_str("explicit=https://explicit.example.com/simple")?;
+        explicit.explicit = true;
+        let mut default = Index::from_str("default=https://default.example.com/simple")?;
+        default.default = true;
+
+        let locations =
+            IndexLocations::new(vec![first, shadowed, explicit, default], vec![], false);
+
+        assert_eq!(
+            index_urls(locations.simple_indexes()),
+            [
+                "https://first.example.com/simple",
+                "https://explicit.example.com/simple",
+                "https://default.example.com/simple",
+            ]
+        );
+        assert_eq!(
+            index_urls(locations.implicit_indexes()),
+            ["https://first.example.com/simple"]
+        );
+        assert_eq!(
+            index_urls(locations.explicit_indexes()),
+            ["https://explicit.example.com/simple"]
+        );
+        assert_eq!(
+            index_urls(locations.indexes()),
+            [
+                "https://first.example.com/simple",
+                "https://default.example.com/simple",
+            ]
+        );
+        assert_eq!(
+            index_urls(locations.defined_indexes()),
+            [
+                "https://first.example.com/simple",
+                "https://explicit.example.com/simple",
+                "https://default.example.com/simple",
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn configured_indexes_preserve_first_explicit_definition() -> Result<(), Box<dyn Error>> {
+        let mut explicit = Index::from_str("shared=https://explicit.example.com/simple")?;
+        explicit.explicit = true;
+        let shadowed = Index::from_str("shared=https://shadowed.example.com/simple")?;
+        let locations = IndexLocations::new(vec![explicit, shadowed], vec![], false);
+
+        assert_eq!(
+            index_urls(locations.explicit_indexes()),
+            ["https://explicit.example.com/simple"]
+        );
+        assert_eq!(index_urls(locations.implicit_indexes()), [] as [&str; 0]);
+        assert_eq!(index_urls(locations.indexes()), ["https://pypi.org/simple"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn configured_indexes_preserve_all_unnamed_indexes() -> Result<(), Box<dyn Error>> {
+        let first = Index::from_str("https://first.example.com/simple")?;
+        let repeated = Index::from_str("https://first.example.com/simple")?;
+        let last = Index::from_str("https://last.example.com/simple")?;
+        let locations = IndexLocations::new(vec![first, repeated, last], vec![], false);
+        let expected = [
+            "https://first.example.com/simple",
+            "https://first.example.com/simple",
+            "https://last.example.com/simple",
+        ];
+
+        assert_eq!(index_urls(locations.simple_indexes()), expected);
+        assert_eq!(index_urls(locations.implicit_indexes()), expected);
+        assert_eq!(index_urls(locations.defined_indexes()), expected);
+        assert_eq!(
+            index_urls(locations.fetch_indexes()),
+            [
+                "https://first.example.com/simple",
+                "https://last.example.com/simple",
+                "https://pypi.org/simple",
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn configured_indexes_preserve_first_default() -> Result<(), Box<dyn Error>> {
+        let mut first = Index::from_str("first=https://first.example.com/simple")?;
+        first.default = true;
+        let mut second = Index::from_str("second=https://second.example.com/simple")?;
+        second.default = true;
+        let locations = IndexLocations::new(vec![first, second], vec![], false);
+
+        assert_eq!(
+            index_urls(locations.default_index()),
+            ["https://first.example.com/simple"]
+        );
+        assert_eq!(
+            index_urls(locations.defined_indexes()),
+            [
+                "https://first.example.com/simple",
+                "https://second.example.com/simple",
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn configured_indexes_ignore_shadowed_default() -> Result<(), Box<dyn Error>> {
+        let first = Index::from_str("shared=https://first.example.com/simple")?;
+        let mut shadowed = Index::from_str("shared=https://shadowed.example.com/simple")?;
+        shadowed.default = true;
+        let locations = IndexLocations::new(vec![first, shadowed], vec![], false);
+
+        assert_eq!(
+            index_urls(locations.default_index()),
+            ["https://pypi.org/simple"]
+        );
+        assert_eq!(
+            index_urls(locations.indexes()),
+            [
+                "https://first.example.com/simple",
+                "https://pypi.org/simple",
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn disabled_indexes_preserve_flat_indexes() -> Result<(), Box<dyn Error>> {
+        let configured = Index::from_str("configured=https://configured.example.com/simple")?;
+        let first =
+            Index::from_find_links(IndexUrl::from_str("https://first.example.com/packages")?);
+        let second =
+            Index::from_find_links(IndexUrl::from_str("https://second.example.com/packages")?);
+        let locations = IndexLocations::new(vec![configured], vec![first, second], true);
+
+        assert!(locations.no_index());
+        assert!(locations.default_index().is_none());
+        assert_eq!(index_urls(locations.simple_indexes()), [] as [&str; 0]);
+        assert_eq!(index_urls(locations.implicit_indexes()), [] as [&str; 0]);
+        assert_eq!(index_urls(locations.explicit_indexes()), [] as [&str; 0]);
+        assert_eq!(index_urls(locations.indexes()), [] as [&str; 0]);
+        assert_eq!(index_urls(locations.defined_indexes()), [] as [&str; 0]);
+        assert_eq!(
+            index_urls(locations.flat_indexes()),
+            [
+                "https://first.example.com/packages",
+                "https://second.example.com/packages",
+            ]
+        );
+        assert_eq!(
+            index_urls(locations.allowed_indexes()),
+            [
+                "https://second.example.com/packages",
+                "https://first.example.com/packages",
+            ]
+        );
+        assert_eq!(
+            index_urls(locations.known_indexes()),
+            [
+                "https://second.example.com/packages",
+                "https://first.example.com/packages",
+            ]
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1277,14 +1277,14 @@ impl ToolListSettings {
             no_python_downloads: _,
         } = args;
 
-        let filesystem = filesystem
+        let top_level = filesystem
             .map(FilesystemOptions::into_options)
             .map(|options| options.top_level)
             .unwrap_or_default();
         let filesystem = ResolverInstallerOptions {
-            index: filesystem.index,
-            exclude_newer: filesystem.exclude_newer,
-            exclude_newer_package: filesystem.exclude_newer_package,
+            index: top_level.index,
+            exclude_newer: top_level.exclude_newer,
+            exclude_newer_package: top_level.exclude_newer_package,
             ..ResolverInstallerOptions::default()
         };
 

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1279,10 +1279,12 @@ impl ToolListSettings {
 
         let filesystem = filesystem
             .map(FilesystemOptions::into_options)
+            .map(|options| options.top_level)
             .unwrap_or_default();
         let filesystem = ResolverInstallerOptions {
-            exclude_newer: filesystem.top_level.exclude_newer,
-            exclude_newer_package: filesystem.top_level.exclude_newer_package,
+            index: filesystem.index,
+            exclude_newer: filesystem.exclude_newer,
+            exclude_newer_package: filesystem.exclude_newer_package,
             ..ResolverInstallerOptions::default()
         };
 

--- a/crates/uv/tests/tool/tool_list.rs
+++ b/crates/uv/tests/tool/tool_list.rs
@@ -5,6 +5,10 @@ use fs_err as fs;
 use insta::assert_snapshot;
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
 
 #[test]
 fn tool_list() {
@@ -145,6 +149,64 @@ fn tool_list_outdated() {
     - black
     - blackd
     ");
+}
+
+#[tokio::test]
+async fn tool_list_outdated_respects_configured_index() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/simple/black/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{
+                "meta": { "api-version": "1.1" },
+                "name": "black",
+                "files": [{
+                    "filename": "black-99.0.0-py3-none-any.whl",
+                    "url": "black-99.0.0-py3-none-any.whl",
+                    "hashes": {},
+                    "upload-time": "2024-03-24T00:00:00Z"
+                }]
+            }"#,
+            "application/vnd.pypi.simple.v1+json",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    fs::write(
+        context.temp_dir.child("uv.toml"),
+        format!(
+            "[[index]]\nname = \"ordinary\"\nurl = \"{}/simple\"\ndefault = true\n",
+            server.uri()
+        ),
+    )?;
+
+    uv_snapshot!(context.filters(), context.tool_list()
+    .arg("--outdated")
+    .arg("--config-file")
+    .arg(context.temp_dir.child("uv.toml").as_os_str())
+    .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+    .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    black v24.2.0 [latest: 99.0.0]
+    - black
+    - blackd
+    ");
+
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
`uv tool list --outdated` currently discards filesystem-configured package indexes when resolving its settings. As a result, outdated-version checks can query the default index instead of the configured index.

Preserve configured indexes alongside the existing `exclude-newer` setting while retaining tool receipt precedence. Add an integration test that installs a tool before configuring a separate index, then verifies that the latest available version comes from that index.