### PR TITLE
Document Astral GPU indexes in the PyTorch guide

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -275,6 +275,9 @@ deepspeed = [{ requirement = "torch", match-runtime = true }]
 This will ensure that `deepspeed` is built with the same version of `torch` that is installed in the
 project environment.
 
+Pre-built `deepspeed` wheels are also available from the
+[Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
+
 Similarly, to build `flash-attn` with `torch` as an additional build dependency, include the
 following in your `pyproject.toml`:
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -305,6 +305,9 @@ flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }
     to `TRUE` can lead to an incompatible install if no compatible pre-built wheel is available
     for the target PyTorch version, GPU version, and platform.
 
+    Pre-built `flash-attn` wheels are also available from the
+    [Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
+
 Similarly, [`deep_gemm`](https://github.com/deepseek-ai/DeepGEMM) follows the same pattern:
 
 ```toml title="pyproject.toml"

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -275,8 +275,10 @@ deepspeed = [{ requirement = "torch", match-runtime = true }]
 This will ensure that `deepspeed` is built with the same version of `torch` that is installed in the
 project environment.
 
-Pre-built `deepspeed` wheels are also available from the
-[Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
+!!! tip
+
+    Pre-built `deepspeed` wheels are also available from the
+    [Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
 
 Similarly, to build `flash-attn` with `torch` as an additional build dependency, include the
 following in your `pyproject.toml`:
@@ -308,8 +310,10 @@ flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }
     to `TRUE` can lead to an incompatible install if no compatible pre-built wheel is available
     for the target PyTorch version, GPU version, and platform.
 
-Pre-built `flash-attn` wheels are also available from the
-[Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
+!!! tip
+
+    Pre-built `flash-attn` wheels are also available from the
+    [Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
 
 Similarly, [`deep_gemm`](https://github.com/deepseek-ai/DeepGEMM) follows the same pattern:
 
@@ -329,8 +333,10 @@ deep_gemm = { git = "https://github.com/deepseek-ai/DeepGEMM" }
 deep_gemm = [{ requirement = "torch", match-runtime = true }]
 ```
 
-Pre-built `deep_gemm` wheels are also available from the
-[Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
+!!! tip
+
+    Pre-built `deep_gemm` wheels are also available from the
+    [Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
 
 The use of `extra-build-dependencies` and `extra-build-variables` are tracked in the uv cache, such
 that changes to these settings will trigger a reinstall and rebuild of the affected packages. For

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -308,8 +308,8 @@ flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }
     to `TRUE` can lead to an incompatible install if no compatible pre-built wheel is available
     for the target PyTorch version, GPU version, and platform.
 
-    Pre-built `flash-attn` wheels are also available from the
-    [Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
+Pre-built `flash-attn` wheels are also available from the
+[Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
 
 Similarly, [`deep_gemm`](https://github.com/deepseek-ai/DeepGEMM) follows the same pattern:
 
@@ -328,6 +328,9 @@ deep_gemm = { git = "https://github.com/deepseek-ai/DeepGEMM" }
 [tool.uv.extra-build-dependencies]
 deep_gemm = [{ requirement = "torch", match-runtime = true }]
 ```
+
+Pre-built `deep_gemm` wheels are also available from the
+[Astral GPU indexes](../../guides/integration/pytorch.md#installing-gpu-enabled-pytorch-extensions).
 
 The use of `extra-build-dependencies` and `extra-build-variables` are tracked in the uv cache, such
 that changes to these settings will trigger a reinstall and rebuild of the affected packages. For

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -2,7 +2,7 @@
 title: Using uv with PyTorch
 description:
   A guide to using uv with PyTorch, including installing PyTorch, configuring per-platform and
-  per-accelerator builds, and more.
+  per-accelerator builds, and installing GPU-enabled PyTorch extensions.
 ---
 
 # Using uv with PyTorch
@@ -436,6 +436,46 @@ explicit = true
 
     Since GPU-accelerated builds aren't available on macOS, the above configuration will fail to install
     on macOS when the `cu130` extra is enabled.
+
+## Installing GPU-enabled PyTorch extensions
+
+Many packages in the PyTorch ecosystem include GPU-enabled extensions that are compiled for a
+specific combination of CUDA and PyTorch versions. Building these packages from source often
+requires access to the CUDA development toolkit and additional build configuration.
+
+The [Astral GPU indexes](https://wheels.astral.sh/) provide pre-built wheels for packages like
+`flash-attn`, `deepspeed`, `torch-scatter`, and `vllm`, across a range of Python, CUDA, and PyTorch
+versions.
+
+To install `flash-attn` from the index for CUDA 12.8, run:
+
+```console
+$ uv add flash-attn --index astral-cu128=https://wheels.astral.sh/simple/cu128/
+```
+
+The command adds `flash-attn` to the project dependencies, configures the Astral GPU index, and pins
+`flash-attn` to that index.
+
+As with the PyTorch indexes, set `explicit = true` to restrict the Astral GPU index to packages that
+are explicitly pinned to it:
+
+```toml title="pyproject.toml"
+[tool.uv.sources]
+flash-attn = { index = "astral-cu128" }
+
+[[tool.uv.index]]
+name = "astral-cu128"
+url = "https://wheels.astral.sh/simple/cu128/"
+explicit = true
+```
+
+Each Astral GPU index targets a specific CUDA version, and its wheels are built for specific PyTorch
+versions. For example, a wheel with a `+cu.12.8.torch.2.11` local version is built for CUDA 12.8 and
+PyTorch 2.11. Select the index and wheel that match your Python version, platform, CUDA version, and
+PyTorch installation.
+
+For the available packages, CUDA versions, and PyTorch versions, see the
+[Astral GPU indexes](https://wheels.astral.sh/).
 
 ## The `uv pip` interface
 

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -444,8 +444,8 @@ specific combination of CUDA and PyTorch versions. Building these packages from 
 requires access to the CUDA development toolkit and additional build configuration.
 
 The [Astral GPU indexes](https://wheels.astral.sh/) provide pre-built wheels for packages like
-`flash-attn`, `deepspeed`, `torch-scatter`, and `vllm`, across a range of Python, CUDA, and PyTorch
-versions.
+`flash-attn`, `deepspeed`, `deep-gemm`, `torch-scatter`, and `vllm`, across a range of Python, CUDA,
+and PyTorch versions.
 
 To install `flash-attn` from the index for CUDA 12.8, run:
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the GPU indexes, both as a section within the existing PyTorch integration guide and via mentions in the relevant package-specific sections (e.g., for DeepSpeed and FlashAttention).
