### PR TITLE
Support continued version specifiers in requirements files

### DIFF
--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -965,7 +965,7 @@ fn parse_requirement_and_hashes(
     let start = s.cursor();
     // Termination: s.eat() eventually becomes None
     let (end, has_hashes) = loop {
-        let end = s.cursor();
+        let mut end = s.cursor();
 
         //  We look for the end of the line ...
         if s.eat_if('\n') {
@@ -992,6 +992,7 @@ fn parse_requirement_and_hashes(
         if s.eat().is_none() {
             break (end, false);
         }
+        end = s.cursor();
     };
 
     let requirement = &content[start..end];
@@ -1016,7 +1017,18 @@ fn parse_requirement_and_hashes(
         }
     }
 
-    let requirement = RequirementsTxtRequirement::parse(requirement, working_dir, editable)
+    let requirement = if requirement.contains('\\') {
+        Cow::Owned(
+            requirement
+                .replace("\\\r\n", "")
+                .replace("\\\n", "")
+                .replace("\\\r", ""),
+        )
+    } else {
+        Cow::Borrowed(requirement)
+    };
+
+    let requirement = RequirementsTxtRequirement::parse(&requirement, working_dir, editable)
         .map(|requirement| {
             if let Some(source) = source {
                 requirement.with_origin(RequirementOrigin::File(source.to_path_buf()))
@@ -1630,6 +1642,21 @@ mod test {
         }, {
             insta::assert_debug_snapshot!(snapshot, actual);
         });
+    }
+
+    #[tokio::test]
+    async fn escaped_line_continuation_before_version_specifier() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let requirements_txt = temp_dir.path().join("requirements.txt");
+        fs::write(&requirements_txt, "anyio \\\n     >1.0.0\n")?;
+
+        let requirements = RequirementsTxt::parse(&requirements_txt, temp_dir.path()).await?;
+
+        assert_eq!(
+            requirements.requirements[0].requirement.to_string(),
+            "anyio>1.0.0"
+        );
+        Ok(())
     }
 
     #[test_case(Path::new("basic.txt"))]


### PR DESCRIPTION
## Summary
- preserve requirement text after escaped line continuations
- remove escaped physical line breaks before PEP 508 parsing
- add a regression test for a continued version specifier

## Root cause
The requirements parser used the cursor before each consumed character as the final requirement boundary. After consuming a backslash continuation, the following version specifier was omitted from the slice; after extending the boundary, the literal backslash/newline still needed normalization before PEP 508 parsing.

## Validation
- Reproduced on macOS Apple Silicon with uv 0.11.30: the reported input failed.
- pip accepted the same input.
- `cargo fmt --all -- --check`
- `cargo test -p uv-requirements-txt` (54 passed)
- `cargo clippy -p uv-requirements-txt --all-targets --all-features --locked -- -D warnings`
- `cargo build --bin uv`
- built binary accepts the reproducer with `uv pip install --system --dry-run -r requirements.txt` and reports `Would make no changes`.

Closes #20744
