### PR TITLE
Honor Git-provided direct sources without lock metadata

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -778,40 +778,48 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             }
         }
 
-        // Git packages can depend on another directory or archive in the same repository. Since
-        // their metadata is immutable and isn't refreshed, the locked edge is the only available
-        // declaration of that source when another package requests it without qualification.
+        // Git packages can depend on an external direct URL or another directory or archive in
+        // the same repository. Since their metadata is immutable and isn't refreshed, the locked
+        // edge is the only available declaration of that source when another package requests it
+        // without qualification.
         if !source_matches
             && matches!(
                 requirement.source,
                 RequirementSource::Registry { index: None, .. }
             )
-            && let Source::Git(_, source) = &package.id.source
-            && let Some(repository) = package.as_git_ref()?
+            && matches!(&package.id.source, Source::Direct(..) | Source::Git(..))
         {
             for provider in &self.lock.packages {
                 let Source::Git(_, provider_source) = &provider.id.source else {
                     continue;
                 };
-                let Some(provider_repository) = provider.as_git_ref()? else {
-                    continue;
-                };
-                if provider_repository.sha != repository.sha
-                    || provider_repository.reference.url != repository.reference.url
-                    || provider_source.lfs != source.lfs
+
+                // Source selections apply globally, even when this edge and the unqualified
+                // requirement have disjoint markers.
+                if !provider
+                    .all_dependencies()
+                    .any(|dependency| dependency.package_id == package.id)
                 {
                     continue;
                 }
 
-                // Source selections apply globally, even when this edge and the unqualified
-                // requirement have disjoint markers.
-                if provider
-                    .all_dependencies()
-                    .any(|dependency| dependency.package_id == package.id)
-                {
-                    source_matches = true;
-                    break;
+                if let Source::Git(_, source) = &package.id.source {
+                    let Some(repository) = package.as_git_ref()? else {
+                        continue;
+                    };
+                    let Some(provider_repository) = provider.as_git_ref()? else {
+                        continue;
+                    };
+                    if provider_repository.sha != repository.sha
+                        || provider_repository.reference.url != repository.reference.url
+                        || provider_source.lfs != source.lfs
+                    {
+                        continue;
+                    }
                 }
+
+                source_matches = true;
+                break;
             }
         }
 

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -778,18 +778,14 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             }
         }
 
-        // Git packages can depend on an external direct URL or another directory or archive in
-        // the same repository. Since their metadata is immutable and isn't refreshed, the locked
-        // edge is the only available declaration of that source when another package requests it
-        // without qualification.
+        // Git packages can select any non-registry source, including external URLs, local files,
+        // source trees, and other directories or archives in the same repository. Since their
+        // metadata is immutable and isn't refreshed, the locked edge is the only available
+        // declaration of that source when another package requests it without qualification.
         if !source_matches
             && matches!(
                 requirement.source,
                 RequirementSource::Registry { index: None, .. }
-            )
-            && matches!(
-                &package.id.source,
-                Source::Direct(..) | Source::Path(..) | Source::Git(..)
             )
         {
             for provider in &self.lock.packages {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -787,7 +787,10 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                 requirement.source,
                 RequirementSource::Registry { index: None, .. }
             )
-            && matches!(&package.id.source, Source::Direct(..) | Source::Git(..))
+            && matches!(
+                &package.id.source,
+                Source::Direct(..) | Source::Path(..) | Source::Git(..)
+            )
         {
             for provider in &self.lock.packages {
                 let Source::Git(_, provider_source) = &provider.id.source else {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -788,38 +788,14 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                 RequirementSource::Registry { index: None, .. }
             )
         {
-            for provider in &self.lock.packages {
-                let Source::Git(_, provider_source) = &provider.id.source else {
-                    continue;
-                };
-
-                // Source selections apply globally, even when this edge and the unqualified
-                // requirement have disjoint markers.
-                if !provider
-                    .all_dependencies()
-                    .any(|dependency| dependency.package_id == package.id)
-                {
-                    continue;
-                }
-
-                if let Source::Git(_, source) = &package.id.source {
-                    let Some(repository) = package.as_git_ref()? else {
-                        continue;
-                    };
-                    let Some(provider_repository) = provider.as_git_ref()? else {
-                        continue;
-                    };
-                    if provider_repository.sha != repository.sha
-                        || provider_repository.reference.url != repository.reference.url
-                        || provider_source.lfs != source.lfs
-                    {
-                        continue;
-                    }
-                }
-
-                source_matches = true;
-                break;
-            }
+            // The locked package identity includes the complete source, including a Git
+            // repository, precise commit, and LFS configuration.
+            source_matches = self.lock.packages.iter().any(|provider| {
+                matches!(provider.id.source, Source::Git(..))
+                    && provider
+                        .all_dependencies()
+                        .any(|dependency| dependency.package_id == package.id)
+            });
         }
 
         source_matches |= package.id == self.package.id

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -778,6 +778,43 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             }
         }
 
+        // Git packages can depend on another directory or archive in the same repository. Since
+        // their metadata is immutable and isn't refreshed, the locked edge is the only available
+        // declaration of that source when another package requests it without qualification.
+        if !source_matches
+            && matches!(
+                requirement.source,
+                RequirementSource::Registry { index: None, .. }
+            )
+            && let Source::Git(_, source) = &package.id.source
+            && let Some(repository) = package.as_git_ref()?
+        {
+            for provider in &self.lock.packages {
+                let Source::Git(_, provider_source) = &provider.id.source else {
+                    continue;
+                };
+                let Some(provider_repository) = provider.as_git_ref()? else {
+                    continue;
+                };
+                if provider_repository.sha != repository.sha
+                    || provider_repository.reference.url != repository.reference.url
+                    || provider_source.lfs != source.lfs
+                {
+                    continue;
+                }
+
+                // Source selections apply globally, even when this edge and the unqualified
+                // requirement have disjoint markers.
+                if provider
+                    .all_dependencies()
+                    .any(|dependency| dependency.package_id == package.id)
+                {
+                    source_matches = true;
+                    break;
+                }
+            }
+        }
+
         source_matches |= package.id == self.package.id
             && matches!(
                 requirement.source,

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19573,12 +19573,24 @@ fn lock_metadata_free_shared_git_direct_source() -> Result<()> {
     Ok(())
 }
 
-/// Immutable Git packages can select external direct URLs for first-party dependencies.
+/// Immutable Git packages can select external URLs and local wheels for first-party dependencies.
 #[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
 fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
+    let context = uv_test::test_context!("3.13");
     let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    let archive = context
+        .temp_dir
+        .child("basic_package-0.1.0-py3-none-any.whl");
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/basic_package-0.1.0-py3-none-any.whl"),
+        archive.path(),
+    )?;
+    let archive_url = Url::from_file_path(archive.path())
+        .map_err(|()| anyhow!("failed to convert archive path to file URL"))?;
 
     let repository = context.temp_dir.child("repository");
     repository.create_dir_all()?;
@@ -19588,8 +19600,11 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         [project]
         name = "provider"
         version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = ["httpx @ {httpx_url} ; sys_platform == 'darwin'"]
+        requires-python = ">=3.13"
+        dependencies = [
+            "httpx @ {httpx_url} ; sys_platform == 'darwin'",
+            "basic-package @ {archive_url} ; sys_platform == 'darwin'",
+        ]
         "#,
             httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
         })?;
@@ -19630,8 +19645,12 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         [project]
         name = "project"
         version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = ["httpx ; sys_platform == 'win32'", "provider"]
+        requires-python = ">=3.13"
+        dependencies = [
+            "httpx ; sys_platform == 'win32'",
+            "basic-package ; sys_platform == 'win32'",
+            "provider",
+        ]
 
         [tool.uv.sources]
         provider = {{ git = "{repository_url}" }}
@@ -19644,8 +19663,10 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Resolved 3 packages in [TIME]
+    Resolved 4 packages in [TIME]
     ");
+
+    fs_err::remove_dir_all(repository.path())?;
 
     uv_snapshot!(context.filters(), context.lock()
         .arg("--preview-features")
@@ -19657,7 +19678,7 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Resolved 3 packages in [TIME]
+    Resolved 4 packages in [TIME]
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19573,6 +19573,96 @@ fn lock_metadata_free_shared_git_direct_source() -> Result<()> {
     Ok(())
 }
 
+/// Immutable Git packages can select external direct URLs for first-party dependencies.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
+#[test]
+fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    let repository = context.temp_dir.child("repository");
+    repository.create_dir_all()?;
+    repository
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "provider"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx @ {httpx_url} ; sys_platform == 'darwin'"]
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+        })?;
+
+    Command::new("git")
+        .arg("init")
+        .arg(repository.path())
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("-C")
+        .arg(repository.path())
+        .arg("add")
+        .arg(".")
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("-C")
+        .arg(repository.path())
+        .arg("-c")
+        .arg("user.name=Example")
+        .arg("-c")
+        .arg("user.email=example@example.com")
+        .arg("commit")
+        .arg("-m")
+        .arg("Initial commit")
+        .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
+        .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
+        .assert()
+        .success();
+
+    let repository_url = Url::from_directory_path(repository.path())
+        .map_err(|()| anyhow!("failed to convert repository path to file URL"))?;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx ; sys_platform == 'win32'", "provider"]
+
+        [tool.uv.sources]
+        provider = {{ git = "{repository_url}" }}
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Projectless workspace root groups can select direct sources for workspace-member requirements.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19573,7 +19573,7 @@ fn lock_metadata_free_shared_git_direct_source() -> Result<()> {
     Ok(())
 }
 
-/// Immutable Git packages can select external URLs and local wheels for first-party dependencies.
+/// Immutable Git packages can select external URLs, local wheels, and local source trees.
 #[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
 fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
@@ -19592,6 +19592,17 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
     let archive_url = Url::from_file_path(archive.path())
         .map_err(|()| anyhow!("failed to convert archive path to file URL"))?;
 
+    let directory = context.temp_dir.child("directory-package");
+    directory.create_dir_all()?;
+    directory.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "directory-package"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        "#})?;
+    let directory_url = Url::from_directory_path(directory.path())
+        .map_err(|()| anyhow!("failed to convert source-tree path to file URL"))?;
+
     let repository = context.temp_dir.child("repository");
     repository.create_dir_all()?;
     repository
@@ -19604,6 +19615,7 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         dependencies = [
             "httpx @ {httpx_url} ; sys_platform == 'darwin'",
             "basic-package @ {archive_url} ; sys_platform == 'darwin'",
+            "directory-package @ {directory_url} ; sys_platform == 'darwin'",
         ]
         "#,
             httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
@@ -19649,6 +19661,7 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         dependencies = [
             "httpx ; sys_platform == 'win32'",
             "basic-package ; sys_platform == 'win32'",
+            "directory-package ; sys_platform == 'win32'",
             "provider",
         ]
 
@@ -19663,7 +19676,7 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Resolved 4 packages in [TIME]
+    Resolved 5 packages in [TIME]
     ");
 
     fs_err::remove_dir_all(repository.path())?;
@@ -19678,7 +19691,7 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Resolved 4 packages in [TIME]
+    Resolved 5 packages in [TIME]
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1,4 +1,9 @@
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
+use std::process::Command;
+
 use anyhow::Result;
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
+use anyhow::anyhow;
 #[cfg(feature = "test-universal")]
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
@@ -19470,6 +19475,99 @@ fn lock_metadata_free_shared_static_metadata_direct_source() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Immutable Git packages can select repository-internal archives for first-party dependencies.
+#[cfg(all(feature = "test-universal", feature = "test-git"))]
+#[test]
+fn lock_metadata_free_shared_git_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+
+    let repository = context.temp_dir.child("repository");
+    repository.child("archives").create_dir_all()?;
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/basic_package-0.1.0-py3-none-any.whl"),
+        repository
+            .child("archives/basic_package-0.1.0-py3-none-any.whl")
+            .path(),
+    )?;
+    repository.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["basic-package ; sys_platform == 'darwin'"]
+
+        [tool.uv.sources]
+        basic-package = { path = "archives/basic_package-0.1.0-py3-none-any.whl" }
+        "#})?;
+
+    Command::new("git")
+        .arg("init")
+        .arg(repository.path())
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("-C")
+        .arg(repository.path())
+        .arg("add")
+        .arg(".")
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("-C")
+        .arg(repository.path())
+        .arg("-c")
+        .arg("user.name=Example")
+        .arg("-c")
+        .arg("user.email=example@example.com")
+        .arg("commit")
+        .arg("-m")
+        .arg("Initial commit")
+        .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
+        .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
+        .assert()
+        .success();
+
+    let repository_url = Url::from_directory_path(repository.path())
+        .map_err(|()| anyhow!("failed to convert repository path to file URL"))?;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["basic-package ; sys_platform == 'win32'", "provider"]
+
+        [tool.uv.sources]
+        provider = {{ git = "{repository_url}" }}
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1,5 +1,5 @@
 #[cfg(all(feature = "test-universal", feature = "test-git"))]
-use std::process::Command;
+use std::{path::Path, process::Command};
 
 use anyhow::Result;
 #[cfg(all(feature = "test-universal", feature = "test-git"))]
@@ -19573,12 +19573,41 @@ fn lock_metadata_free_shared_git_direct_source() -> Result<()> {
     Ok(())
 }
 
-/// Immutable Git packages can select external URLs, local wheels, and local source trees.
+/// Immutable Git packages can select external URLs, local sources, and other Git repositories.
 #[cfg(all(feature = "test-universal", feature = "test-git"))]
 #[test]
 fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
     let context = uv_test::test_context!("3.13");
     let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    let initialize_repository = |repository: &Path| {
+        Command::new("git")
+            .arg("init")
+            .arg(repository)
+            .assert()
+            .success();
+        Command::new("git")
+            .arg("-C")
+            .arg(repository)
+            .arg("add")
+            .arg(".")
+            .assert()
+            .success();
+        Command::new("git")
+            .arg("-C")
+            .arg(repository)
+            .arg("-c")
+            .arg("user.name=Example")
+            .arg("-c")
+            .arg("user.email=example@example.com")
+            .arg("commit")
+            .arg("-m")
+            .arg("Initial commit")
+            .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
+            .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
+            .assert()
+            .success();
+    };
 
     let archive = context
         .temp_dir
@@ -19603,6 +19632,20 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
     let directory_url = Url::from_directory_path(directory.path())
         .map_err(|()| anyhow!("failed to convert source-tree path to file URL"))?;
 
+    let git_repository = context.temp_dir.child("git-repository");
+    git_repository.create_dir_all()?;
+    git_repository
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "git-package"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        "#})?;
+    initialize_repository(git_repository.path());
+    let git_repository_url = Url::from_directory_path(git_repository.path())
+        .map_err(|()| anyhow!("failed to convert Git repository path to file URL"))?;
+
     let repository = context.temp_dir.child("repository");
     repository.create_dir_all()?;
     repository
@@ -19616,37 +19659,13 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
             "httpx @ {httpx_url} ; sys_platform == 'darwin'",
             "basic-package @ {archive_url} ; sys_platform == 'darwin'",
             "directory-package @ {directory_url} ; sys_platform == 'darwin'",
+            "git-package @ git+{git_repository_url} ; sys_platform == 'darwin'",
         ]
         "#,
             httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
         })?;
 
-    Command::new("git")
-        .arg("init")
-        .arg(repository.path())
-        .assert()
-        .success();
-    Command::new("git")
-        .arg("-C")
-        .arg(repository.path())
-        .arg("add")
-        .arg(".")
-        .assert()
-        .success();
-    Command::new("git")
-        .arg("-C")
-        .arg(repository.path())
-        .arg("-c")
-        .arg("user.name=Example")
-        .arg("-c")
-        .arg("user.email=example@example.com")
-        .arg("commit")
-        .arg("-m")
-        .arg("Initial commit")
-        .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
-        .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
-        .assert()
-        .success();
+    initialize_repository(repository.path());
 
     let repository_url = Url::from_directory_path(repository.path())
         .map_err(|()| anyhow!("failed to convert repository path to file URL"))?;
@@ -19662,6 +19681,7 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
             "httpx ; sys_platform == 'win32'",
             "basic-package ; sys_platform == 'win32'",
             "directory-package ; sys_platform == 'win32'",
+            "git-package ; sys_platform == 'win32'",
             "provider",
         ]
 
@@ -19676,7 +19696,7 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Resolved 5 packages in [TIME]
+    Resolved 6 packages in [TIME]
     ");
 
     fs_err::remove_dir_all(repository.path())?;
@@ -19691,7 +19711,7 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
         .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Resolved 5 packages in [TIME]
+    Resolved 6 packages in [TIME]
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

- Reuse exact dependency edges from immutable Git packages when validating metadata-free locks.
- Match the complete locked package identity, including its repository URL, commit, subdirectory or archive path, Git reference, and LFS configuration.
- Preserve globally shared sources across disjoint platform markers and distinct Git repositories.
- Cover repository-internal archives, external HTTP wheels, local wheels, local source trees, and separate Git repositories with offline, uncached integration regressions.

## Validation

- 17 focused metadata-free lock integration tests.
- Resolver Clippy with all targets and features.
- Cross-repository Git lock validates offline after its provider repository is removed.