### PR TITLE
Honor direct sources from remote and local archives

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -778,20 +778,17 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             }
         }
 
-        // Git packages can select any non-registry source, including external URLs, local files,
-        // source trees, and other directories or archives in the same repository. Since their
-        // metadata is immutable and isn't refreshed, the locked edge is the only available
-        // declaration of that source when another package requests it without qualification.
+        // Immutable packages retain their original metadata, so their exact locked edges can
+        // provide missing source declarations when another package requests a dependency without
+        // qualification.
         if !source_matches
             && matches!(
                 requirement.source,
                 RequirementSource::Registry { index: None, .. }
             )
         {
-            // The locked package identity includes the complete source, including a Git
-            // repository, precise commit, and LFS configuration.
             source_matches = self.lock.packages.iter().any(|provider| {
-                matches!(provider.id.source, Source::Git(..))
+                provider.id.source.is_immutable()
                     && provider
                         .all_dependencies()
                         .any(|dependency| dependency.package_id == package.id)
@@ -2511,6 +2508,47 @@ impl Lock {
                 )?);
             }
 
+            // Direct-URL metadata cannot be refreshed while offline. Reuse its exact locked
+            // dependency edges as source declarations, just as later validation preserves the
+            // package's locked metadata instead of downloading its archive.
+            if database.client().unmanaged.connectivity().is_offline() {
+                for provider in &self.packages {
+                    if !matches!(provider.id.source, Source::Direct(..)) {
+                        continue;
+                    }
+
+                    for dependency in provider.all_dependencies() {
+                        if matches!(dependency.package_id.source, Source::Registry(..)) {
+                            continue;
+                        }
+
+                        let package = self.find_by_id(&dependency.package_id);
+                        let HashedDist { dist, .. } = package.to_dist(
+                            root,
+                            TagPolicy::Preferred(tags),
+                            build_options,
+                            markers,
+                        )?;
+                        let dist = ResolvedDist::Installable {
+                            dist: Arc::new(dist),
+                            version: package.id.version.clone(),
+                        };
+                        source_requirements.insert(normalize_requirement(
+                            Requirement {
+                                name: package.id.name.clone(),
+                                extras: Box::new([]),
+                                groups: Box::new([]),
+                                source: RequirementSource::from(&dist),
+                                marker: MarkerTree::TRUE,
+                                origin: None,
+                            },
+                            root,
+                            &self.requires_python,
+                        )?);
+                    }
+                }
+            }
+
             let mut add_source_requirements =
                 |package: &Package, requirements: Vec<Requirement>| -> Result<(), LockError> {
                     let package_context = package
@@ -2560,11 +2598,10 @@ impl Lock {
                     continue;
                 }
 
-                let Some(source_tree) = package.id.source.as_source_tree() else {
-                    continue;
-                };
-                if let Some(SourceTreeRequiresDist { metadata, .. }) =
-                    Self::source_tree_requires_dist(source_tree, root, package, database).await?
+                if let Some(source_tree) = package.id.source.as_source_tree()
+                    && let Some(SourceTreeRequiresDist { metadata, .. }) =
+                        Self::source_tree_requires_dist(source_tree, root, package, database)
+                            .await?
                 {
                     let direct_requirements = metadata
                         .requires_dist
@@ -2578,6 +2615,13 @@ impl Lock {
                         )
                         .collect();
                     add_source_requirements(package, direct_requirements)?;
+                    continue;
+                }
+
+                if package.id.source.is_immutable()
+                    || matches!(package.id.source, Source::Direct(..))
+                        && database.client().unmanaged.connectivity().is_offline()
+                {
                     continue;
                 }
 

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19795,6 +19795,20 @@ async fn lock_metadata_free_shared_archive_direct_sources() -> Result<()> {
                 .arg("--preview-features")
                 .arg("lock-without-metadata")
                 .arg("--locked")
+                .arg("--no-cache")
+                .arg("--index-url")
+                .arg(index.index_url())
+                .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            DEBUG Existing `uv.lock` satisfies workspace requirements
+            Resolved 4 packages in [TIME]
+            ");
+
+            uv_snapshot!(context.filters(), context.lock()
+                .arg("--preview-features")
+                .arg("lock-without-metadata")
+                .arg("--locked")
                 .arg("--offline")
                 .arg("--no-cache")
                 .arg("--index-url")

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -2,12 +2,18 @@
 use std::{path::Path, process::Command};
 
 use anyhow::Result;
-#[cfg(all(feature = "test-universal", feature = "test-git"))]
-use anyhow::anyhow;
+#[cfg(feature = "test-universal")]
+use anyhow::{Error, anyhow};
 #[cfg(feature = "test-universal")]
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
+#[cfg(feature = "test-universal")]
+use async_zip::base::write::ZipFileWriter;
+#[cfg(feature = "test-universal")]
+use async_zip::{Compression, ZipEntryBuilder};
 use indoc::{formatdoc, indoc};
+#[cfg(feature = "test-universal")]
+use insta::allow_duplicates;
 use insta::assert_snapshot;
 #[cfg(feature = "test-universal")]
 use serde_json::json;
@@ -19713,6 +19719,94 @@ fn lock_metadata_free_shared_git_external_direct_source() -> Result<()> {
     ----- stderr -----
     Resolved 6 packages in [TIME]
     ");
+
+    Ok(())
+}
+
+/// Remote and local wheel archives can select a direct source for an unqualified dependency.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_metadata_free_shared_archive_direct_sources() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let index = PackseServer::new("extras/lock-without-metadata.toml");
+    let provider = MockServer::start().await;
+
+    let metadata = formatdoc! {"
+        Metadata-Version: 2.1
+        Name: provider
+        Version: 1.0.0
+        Requires-Python: >=3.12
+        Requires-Dist: httpx @ {}
+    ", index.file_url("httpx-1.0.0-py3-none-any.whl")};
+    let mut wheel = ZipFileWriter::new(Vec::new());
+    for (path, contents) in [
+        ("provider-1.0.0.dist-info/METADATA", metadata.as_str()),
+        (
+            "provider-1.0.0.dist-info/WHEEL",
+            "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+        ),
+        ("provider-1.0.0.dist-info/RECORD", ""),
+    ] {
+        let entry = ZipEntryBuilder::new(path.into(), Compression::Stored);
+        wheel.write_entry_whole(entry, contents.as_bytes()).await?;
+    }
+    let wheel = wheel.close().await?;
+    let local_wheel = context.temp_dir.child("provider-1.0.0-py3-none-any.whl");
+    local_wheel.write_binary(&wheel)?;
+
+    Mock::given(method("GET"))
+        .and(path("/provider-1.0.0-py3-none-any.whl"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(wheel))
+        .mount(&provider)
+        .await;
+
+    let local_wheel_url = Url::from_file_path(local_wheel.path())
+        .map_err(|()| anyhow!("failed to convert provider wheel path to file URL"))?;
+    allow_duplicates! {
+        for provider_url in [
+            format!("{}/provider-1.0.0-py3-none-any.whl", provider.uri()),
+            local_wheel_url.to_string(),
+        ] {
+            context
+                .temp_dir
+                .child("pyproject.toml")
+                .write_str(&formatdoc! {r#"
+                [project]
+                name = "project"
+                version = "0.1.0"
+                requires-python = ">=3.12"
+                dependencies = [
+                    "httpx[http2]",
+                    "provider @ {provider_url}",
+                ]
+                "#})?;
+
+            uv_snapshot!(context.filters(), context.lock()
+                .arg("--preview-features")
+                .arg("lock-without-metadata")
+                .arg("--index-url")
+                .arg(index.index_url()), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Resolved 4 packages in [TIME]
+            ");
+
+            uv_snapshot!(context.filters(), context.lock()
+                .arg("--preview-features")
+                .arg("lock-without-metadata")
+                .arg("--locked")
+                .arg("--offline")
+                .arg("--no-cache")
+                .arg("--index-url")
+                .arg(index.index_url()), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Resolved 4 packages in [TIME]
+            ");
+        }
+
+        Ok::<(), Error>(())
+    }?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Metadata-free lock validation can reject an unchanged lock when an HTTP-served or local wheel supplies the direct source for another otherwise unqualified dependency.

Reuse exact locked dependency edges from remote archives while offline, and refresh local archive metadata before reconstructing first-party dependencies. Treat immutable registry and Git providers consistently when matching locked sources.

Exercise both remote and file-backed wheels with offline, uncached integration coverage.