### PR TITLE
Respect scoped dependencies when validating metadata-free locks

### DIFF
--- a/crates/uv-configuration/src/excludes.rs
+++ b/crates/uv-configuration/src/excludes.rs
@@ -104,6 +104,11 @@ impl Excludes {
         self.global.contains(name)
     }
 
+    /// Return whether any exclusions are scoped to the given package.
+    pub fn has_scoped_package(&self, package: &PackageName) -> bool {
+        self.scoped.contains_key(package)
+    }
+
     /// Check if a dependency is excluded from a specific package version.
     pub fn contains_for(
         &self,

--- a/crates/uv-configuration/src/overrides.rs
+++ b/crates/uv-configuration/src/overrides.rs
@@ -226,6 +226,11 @@ impl Overrides {
             .flat_map(|scoped| scoped.overrides.values().flatten())
     }
 
+    /// Return whether any overrides are scoped to the given package.
+    pub fn has_scoped_package(&self, package: &PackageName) -> bool {
+        self.scoped.contains_key(package)
+    }
+
     /// Return whether a package has overrides for an exact version.
     pub(crate) fn has_exact_scope(&self, package: &PackageName, version: &Version) -> bool {
         self.scoped.get(package).is_some_and(|entries| {

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -367,12 +367,6 @@ impl FlatRequiresDist {
             return Self(requirements);
         }
 
-        // Memoize the top level extras, in the same order as `requirements`
-        let top_level_extras: Vec<_> = requirements
-            .iter()
-            .map(|req| req.marker.top_level_extra_name())
-            .collect();
-
         // Transitively process all extras that are recursively included.
         let mut flattened = requirements.to_vec();
         let mut seen = FxHashSet::<(ExtraName, MarkerTree)>::default();
@@ -386,21 +380,27 @@ impl FlatRequiresDist {
                 continue;
             }
 
-            // Find the requirements for the extra.
-            for (requirement, top_level_extra) in requirements.iter().zip(top_level_extras.iter()) {
-                if top_level_extra.as_deref() != Some(&extra) {
+            // Find the optional portion of each requirement for this extra. A requirement can
+            // also apply in production, as in `sys_platform == 'win32' or extra == 'base'`.
+            for requirement in &requirements {
+                let production_marker = requirement.marker.simplify_not_extras_with(|_| true);
+                let extra_marker = requirement
+                    .marker
+                    .simplify_extras(slice::from_ref(&extra))
+                    .simplify_not_extras_with(|candidate| candidate != &extra)
+                    .and(production_marker.negate());
+                if extra_marker.is_false() {
                     continue;
                 }
                 let requirement = {
-                    let mut marker = marker;
-                    marker = marker.and(requirement.marker);
+                    let marker = marker.and(extra_marker);
                     Requirement {
                         name: requirement.name.clone(),
                         extras: requirement.extras.clone(),
                         groups: requirement.groups.clone(),
                         source: requirement.source.clone(),
                         origin: requirement.origin.clone(),
-                        marker: marker.simplify_extras(slice::from_ref(&extra)),
+                        marker,
                     }
                 };
                 if requirement.name == *name {
@@ -869,6 +869,28 @@ mod test {
         let actual = FlatRequiresDist::from_requirements(requirements.into(), &name);
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_flat_requires_dist_with_production_and_extra_marker() -> anyhow::Result<()> {
+        let name = PackageName::from_str("pkg")?;
+        let requirements = [
+            Requirement::from_str("ok; sys_platform == 'win32' or extra == 'base'")?.into(),
+            Requirement::from_str("pkg[base]; extra == 'feature'")?.into(),
+        ];
+
+        let expected = FlatRequiresDist(
+            [
+                Requirement::from_str("ok; sys_platform == 'win32' or extra == 'base'")?.into(),
+                Requirement::from_str("ok; sys_platform != 'win32' and extra == 'feature'")?.into(),
+            ]
+            .into(),
+        );
+
+        let actual = FlatRequiresDist::from_requirements(requirements.into(), &name);
+
+        assert_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -51,8 +51,8 @@ use uv_platform_tags::{
 };
 use uv_preview::PreviewFeature;
 use uv_pypi_types::{
-    ConflictItem, ConflictKindRef, Conflicts, HashAlgorithm, HashDigest, HashDigests, Hashes,
-    ParsedArchiveUrl, ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml,
+    ConflictItem, ConflictKindRef, ConflictSet, Conflicts, HashAlgorithm, HashDigest, HashDigests,
+    Hashes, ParsedArchiveUrl, ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml,
 };
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_small_str::SmallString;
@@ -862,6 +862,28 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         Some(marker)
     }
 
+    /// Preserve project selections while removing extra and group selections from activation.
+    fn extra_activation_marker(&self, activation: UniversalMarker) -> UniversalMarker {
+        let mut marker = UniversalMarker::from_combined(activation.pep508());
+        for project in self
+            .lock
+            .conflicts
+            .iter()
+            .flat_map(ConflictSet::iter)
+            .filter(|item| matches!(item.kind().as_ref(), ConflictKindRef::Project))
+        {
+            let mut without_project = activation;
+            without_project.assume_not_conflict_item(project);
+            if without_project.is_false() {
+                marker.and(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflict_item(project),
+                ));
+            }
+        }
+        marker
+    }
+
     /// Restore the resolver node's conflict context, if it is reachable.
     fn context_parent_marker(&self, context: DependencyContext<'_>) -> UniversalMarker {
         let mut parent_marker = self.package_marker;
@@ -869,7 +891,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         if let DependencyContext::Extra(extra) = context
             && let Some(marker) = self.activated_extras.get(extra)
         {
-            parent_marker.and(UniversalMarker::from_combined(marker.pep508()));
+            parent_marker.and(self.extra_activation_marker(*marker));
         }
 
         if self.lock.conflicts.is_empty() {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -404,6 +404,50 @@ enum DependencyContext<'a> {
     Group(&'a GroupName),
 }
 
+/// The distinct reachability and simplification contexts of a resolved dependency node.
+#[derive(Clone, Copy, Debug)]
+struct DependencyActivation {
+    /// The complete activation context, including selected extras, groups, and conflict forks.
+    marker: UniversalMarker,
+    /// The parent context used to build dependency edges.
+    parent_marker: UniversalMarker,
+    /// The parent context whose PEP 508 predicates may be removed from dependency edges.
+    simplification_parent_marker: UniversalMarker,
+}
+
+/// The full package reachability and per-extra reachability observed during lock validation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ActivatedPackage {
+    marker: UniversalMarker,
+    extras: BTreeMap<ExtraName, UniversalMarker>,
+    /// Contexts in which a refreshed declaration explicitly authorizes this resolved source.
+    source_marker: UniversalMarker,
+    /// Contexts in which a source-agnostic declaration relies on this non-registry source.
+    source_authority_required: UniversalMarker,
+}
+
+impl Default for ActivatedPackage {
+    fn default() -> Self {
+        Self {
+            marker: UniversalMarker::FALSE,
+            extras: BTreeMap::default(),
+            source_marker: UniversalMarker::FALSE,
+            source_authority_required: UniversalMarker::FALSE,
+        }
+    }
+}
+
+impl DependencyActivation {
+    /// Use an existing resolver node's marker for each activation context.
+    fn from_resolver_node(marker: UniversalMarker) -> Self {
+        Self {
+            marker,
+            parent_marker: marker,
+            simplification_parent_marker: marker,
+        }
+    }
+}
+
 impl DependencyContext<'_> {
     /// Return the conflict item selected by this extra or dependency-group node, if any.
     fn selected_conflict(
@@ -456,22 +500,19 @@ impl DependencyContext<'_> {
 struct LockedDependencyBuilder<'a> {
     requires_python: &'a RequiresPython,
     environment: SimplifiedMarkerTree,
-    parent_marker: UniversalMarker,
-    simplification_parent_marker: UniversalMarker,
+    activation: DependencyActivation,
 }
 
 impl<'a> LockedDependencyBuilder<'a> {
     fn new(
         requires_python: &'a RequiresPython,
         environment: SimplifiedMarkerTree,
-        parent_marker: UniversalMarker,
-        simplification_parent_marker: UniversalMarker,
+        activation: DependencyActivation,
     ) -> Self {
         Self {
             requires_python,
             environment,
-            parent_marker,
-            simplification_parent_marker,
+            activation,
         }
     }
 
@@ -483,7 +524,7 @@ impl<'a> LockedDependencyBuilder<'a> {
         dependencies: &mut Vec<Dependency>,
         expected: &ExpectedPackageDependencies<'_>,
         context: DependencyContext<'_>,
-        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>>,
+        activated_packages: &mut FxHashMap<PackageId, ActivatedPackage>,
     ) -> Result<bool, LockError> {
         let empty_requirements = BTreeSet::new();
         let requirements = match context {
@@ -509,10 +550,134 @@ impl<'a> LockedDependencyBuilder<'a> {
                     .simplify_not_extras_with(|candidate| candidate != extra)
                     .and(production_marker.negate()),
             };
-            let mut required_marker = UniversalMarker::from_combined(requirement_marker);
-            required_marker.and(self.parent_marker);
+            let mut base_marker = UniversalMarker::from_combined(requirement_marker);
+            base_marker.and(self.activation.parent_marker);
             if let Some(conflict_marker) =
-                expected.requirement_conflict_marker(context, requirement)
+                expected.requirement_conflict_marker(context, requirement, false)
+            {
+                base_marker.and(conflict_marker);
+            }
+
+            // A package's production selection can conflict with one of its own requested
+            // extras. The resolver keeps the base package in either selection, but places
+            // non-conflicting extras only in the production branch.
+            let project_conflicts_with_extra = |extra: &ExtraName| {
+                expected.lock.conflicts.iter().any(|conflicts| {
+                    conflicts.contains(&requirement.name, ConflictKindRef::Project)
+                        && conflicts.contains(&requirement.name, extra)
+                })
+            };
+            let project_conflict_marker = (expected
+                .lock
+                .conflicts
+                .contains(&requirement.name, ConflictKindRef::Project)
+                && requirement.extras.iter().any(|extra| {
+                    project_conflicts_with_extra(extra)
+                        || expected
+                            .lock
+                            .conflicts
+                            .iter()
+                            .filter(|conflicts| conflicts.contains(&requirement.name, extra))
+                            .flat_map(ConflictSet::iter)
+                            .any(|alternative| {
+                                expected.lock.conflicts.iter().any(|conflicts| {
+                                    conflicts.contains(&requirement.name, ConflictKindRef::Project)
+                                        && conflicts.iter().any(|conflict| conflict == alternative)
+                                })
+                            })
+                }))
+            .then(|| {
+                UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflict_item(&ConflictItem::from(
+                        requirement.name.clone(),
+                    )),
+                )
+            });
+            let project_implies_extra = |extra: &ExtraName, project_marker: UniversalMarker| {
+                let mut alternatives = expected.conflicting_alternatives(&ConflictItem::from((
+                    requirement.name.clone(),
+                    extra.clone(),
+                )));
+                alternatives.and(project_marker);
+                alternatives.and(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflicts(&expected.lock.conflicts),
+                ));
+                marker_is_unreachable(self.requires_python, alternatives.combined())
+            };
+            // Serialized graph edges omit empty or inactive conflict alternatives, but explicitly
+            // requested selections still activate the target and must refresh its metadata.
+            let mut requested_base_marker = base_marker;
+            if project_conflict_marker.is_some() {
+                for alternative in expected
+                    .lock
+                    .conflicts
+                    .iter()
+                    .filter(|conflicts| {
+                        conflicts.contains(&requirement.name, ConflictKindRef::Project)
+                    })
+                    .flat_map(ConflictSet::iter)
+                {
+                    let ConflictKindRef::Extra(extra) = alternative.kind().as_ref() else {
+                        continue;
+                    };
+                    if alternative.package() != &requirement.name
+                        || expected
+                            .packages_for_name(&requirement.name)
+                            .iter()
+                            .any(|package| package.optional_dependencies.contains_key(extra))
+                        || context
+                            .dependencies(expected.package)
+                            .iter()
+                            .any(|dependency| {
+                                dependency.package_id.name == requirement.name
+                                    && dependency.extra.contains(extra)
+                            })
+                        || activated_packages.iter().any(|(package_id, activation)| {
+                            package_id.name == requirement.name
+                                && activation.extras.contains_key(extra)
+                        })
+                    {
+                        continue;
+                    }
+                    base_marker.and(UniversalMarker::new(
+                        MarkerTree::TRUE,
+                        ConflictMarker::from_conflict_item(alternative).negate(),
+                    ));
+                    if !requirement.extras.contains(extra) {
+                        requested_base_marker.and(UniversalMarker::new(
+                            MarkerTree::TRUE,
+                            ConflictMarker::from_conflict_item(alternative).negate(),
+                        ));
+                    }
+                }
+            }
+            if let Some(project_conflict_marker) = project_conflict_marker
+                && !matches!(context, DependencyContext::Production)
+            {
+                let mut package_conflict_marker = project_conflict_marker;
+                for extra in requirement
+                    .extras
+                    .iter()
+                    .filter(|extra| project_conflicts_with_extra(extra))
+                {
+                    package_conflict_marker.or(UniversalMarker::new(
+                        MarkerTree::TRUE,
+                        ConflictMarker::from_conflict_item(&ConflictItem::from((
+                            requirement.name.clone(),
+                            extra.clone(),
+                        ))),
+                    ));
+                }
+                base_marker.and(package_conflict_marker);
+                requested_base_marker.and(package_conflict_marker);
+            }
+
+            let mut required_marker = base_marker;
+            if project_conflict_marker.is_none()
+                && let Some(conflict_marker) =
+                    expected.requirement_conflict_marker(context, requirement, true)
             {
                 required_marker.and(conflict_marker);
             }
@@ -527,7 +692,6 @@ impl<'a> LockedDependencyBuilder<'a> {
                 // constraints must still be satisfied by the locked parent package.
                 if !ExpectedPackageDependencies::package_satisfies_requirement(
                     expected.package,
-                    expected.package,
                     requirement,
                     expected.workspace_root,
                 )? {
@@ -539,9 +703,14 @@ impl<'a> LockedDependencyBuilder<'a> {
             let required_marker = required_marker.combined();
 
             let mut covered_marker = MarkerTree::FALSE;
-            for dependency in expected.packages_for_name(&requirement.name) {
+            let candidates = expected.packages_for_name(&requirement.name);
+            let has_source_forks = candidates.first().is_some_and(|first| {
+                candidates
+                    .iter()
+                    .any(|dependency| dependency.id.source != first.id.source)
+            });
+            for dependency in candidates {
                 if !ExpectedPackageDependencies::package_satisfies_requirement(
-                    expected.package,
                     dependency,
                     requirement,
                     expected.workspace_root,
@@ -550,6 +719,29 @@ impl<'a> LockedDependencyBuilder<'a> {
                 }
 
                 let mut marker = UniversalMarker::from_combined(required_marker);
+                let mut base_edge_marker = base_marker;
+                let mut requested_edge_marker = requested_base_marker;
+                if matches!(
+                    requirement.source,
+                    RequirementSource::Registry { index: None, .. }
+                ) && !matches!(dependency.id.source, Source::Registry(_))
+                    && let Some(activation) = activated_packages.get(&dependency.id)
+                    && !activation.source_marker.is_false()
+                {
+                    marker.and(activation.source_marker);
+                    base_edge_marker.and(activation.source_marker);
+                    requested_edge_marker.and(activation.source_marker);
+                } else if has_source_forks
+                    && matches!(
+                        requirement.source,
+                        RequirementSource::Registry { index: None, .. }
+                    )
+                    && let Some(activation) = activated_packages.get(&dependency.id)
+                {
+                    marker.and(activation.marker);
+                    base_edge_marker.and(activation.marker);
+                    requested_edge_marker.and(activation.marker);
+                }
                 if !dependency.fork_markers.is_empty() {
                     let dependency_marker = dependency
                         .fork_markers
@@ -558,44 +750,149 @@ impl<'a> LockedDependencyBuilder<'a> {
                             marker.or(fork_marker.combined())
                         });
                     marker.and(UniversalMarker::from_combined(dependency_marker));
+                    base_edge_marker.and(UniversalMarker::from_combined(dependency_marker));
+                    requested_edge_marker.and(UniversalMarker::from_combined(dependency_marker));
                 }
                 if marker.is_false() {
                     continue;
                 }
                 covered_marker = covered_marker.or(marker.combined());
 
-                let activated = activated_extras.entry(dependency.id.clone()).or_default();
-                let activation_marker = marker;
-                for extra in &requirement.extras {
-                    activated
-                        .entry(extra.clone())
-                        .and_modify(|existing| existing.or(activation_marker))
-                        .or_insert(activation_marker);
+                let mut activation_marker = base_edge_marker;
+                activation_marker.and(self.activation.marker);
+                let activated = activated_packages.entry(dependency.id.clone()).or_default();
+                activated.marker.or(activation_marker);
+                if matches!(
+                    requirement.source,
+                    RequirementSource::Registry { index: None, .. }
+                ) {
+                    if !matches!(dependency.id.source, Source::Registry(_)) {
+                        activated.source_authority_required.or(activation_marker);
+                    }
+                } else {
+                    activated.source_marker.or(activation_marker);
                 }
-
+                for extra in &requirement.extras {
+                    let mut extra_activation_marker =
+                        if dependency.optional_dependencies.contains_key(extra) {
+                            base_edge_marker
+                        } else {
+                            requested_edge_marker
+                        };
+                    if expected.lock.conflicts.contains(&requirement.name, extra)
+                        && project_conflict_marker.is_none_or(|project_conflict_marker| {
+                            !project_implies_extra(extra, project_conflict_marker)
+                        })
+                    {
+                        extra_activation_marker.and(UniversalMarker::new(
+                            MarkerTree::TRUE,
+                            ConflictMarker::from_conflict_item(&ConflictItem::from((
+                                requirement.name.clone(),
+                                extra.clone(),
+                            ))),
+                        ));
+                    }
+                    if let Some(project_conflict_marker) = project_conflict_marker
+                        && !project_conflicts_with_extra(extra)
+                    {
+                        extra_activation_marker.and(project_conflict_marker);
+                    }
+                    extra_activation_marker.and(self.activation.marker);
+                    activated.marker.or(extra_activation_marker);
+                    if matches!(
+                        requirement.source,
+                        RequirementSource::Registry { index: None, .. }
+                    ) {
+                        if !matches!(dependency.id.source, Source::Registry(_)) {
+                            activated
+                                .source_authority_required
+                                .or(extra_activation_marker);
+                        }
+                    } else {
+                        activated.source_marker.or(extra_activation_marker);
+                    }
+                    activated
+                        .extras
+                        .entry(extra.clone())
+                        .and_modify(|existing| existing.or(extra_activation_marker))
+                        .or_insert(extra_activation_marker);
+                }
                 let extras = requirement
                     .extras
                     .iter()
-                    .filter(|extra| dependency.optional_dependencies.contains_key(*extra))
+                    .filter(|extra| {
+                        dependency.optional_dependencies.contains_key(*extra)
+                            || context
+                                .dependencies(expected.package)
+                                .iter()
+                                .any(|existing| {
+                                    existing.package_id == dependency.id
+                                        && existing.extra.contains(*extra)
+                                })
+                    })
                     .cloned()
                     .collect::<BTreeSet<_>>();
 
-                // Requesting an extra also selects its base distribution. Usually both edges
-                // merge, but another declaration can widen the base beyond the extra's marker.
+                // Requesting an extra also selects its base distribution. Each requested extra
+                // has its own conflict context, and equal contexts merge below.
                 if !extras.is_empty() {
                     edges
                         .entry((dependency.id.clone(), BTreeSet::new()))
+                        .and_modify(|existing| existing.or(base_edge_marker))
+                        .or_insert(base_edge_marker);
+                }
+                if extras.is_empty() {
+                    edges
+                        .entry((dependency.id.clone(), extras))
                         .and_modify(|existing| existing.or(marker))
                         .or_insert(marker);
+                } else {
+                    for extra in extras {
+                        let mut extra_marker = base_edge_marker;
+                        if expected.lock.conflicts.contains(&requirement.name, &extra)
+                            && project_conflict_marker.is_none_or(|project_conflict_marker| {
+                                !project_implies_extra(&extra, project_conflict_marker)
+                            })
+                        {
+                            extra_marker.and(UniversalMarker::new(
+                                MarkerTree::TRUE,
+                                ConflictMarker::from_conflict_item(&ConflictItem::from((
+                                    requirement.name.clone(),
+                                    extra.clone(),
+                                ))),
+                            ));
+                        }
+                        if let Some(project_conflict_marker) = project_conflict_marker
+                            && !project_conflicts_with_extra(&extra)
+                        {
+                            extra_marker.and(project_conflict_marker);
+                        }
+                        edges
+                            .entry((dependency.id.clone(), BTreeSet::from([extra])))
+                            .and_modify(|existing| existing.or(extra_marker))
+                            .or_insert(extra_marker);
+                    }
                 }
-                edges
-                    .entry((dependency.id.clone(), extras))
-                    .and_modify(|existing| existing.or(marker))
-                    .or_insert(marker);
             }
 
             // Check that we cover at least the required marker.
-            if !covered_marker.negate().is_disjoint(required_marker) {
+            let mut coverage_marker = UniversalMarker::from_combined(required_marker);
+            coverage_marker.and(self.activation.marker);
+            if !expected.lock.conflicts.is_empty() {
+                coverage_marker.and(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflicts(&expected.lock.conflicts),
+                ));
+            }
+            let covered_marker = SimplifiedMarkerTree::new(self.requires_python, covered_marker)
+                .as_simplified_marker_tree()
+                .restrict(self.requires_python.to_marker_tree());
+            let coverage_marker =
+                SimplifiedMarkerTree::new(self.requires_python, coverage_marker.combined())
+                    .as_simplified_marker_tree()
+                    .restrict(self.requires_python.to_marker_tree());
+            let uncovered_marker = coverage_marker.and(covered_marker.negate());
+            if !marker_is_unreachable(self.requires_python, uncovered_marker) {
                 complete = false;
             }
         }
@@ -616,7 +913,7 @@ impl<'a> LockedDependencyBuilder<'a> {
         let simplified_marker = simplify_dependency_marker(
             self.requires_python,
             self.environment,
-            self.simplification_parent_marker,
+            self.activation.simplification_parent_marker,
             marker,
         );
         let dependency =
@@ -663,8 +960,8 @@ struct ExpectedPackageDependencies<'lock> {
     declarations: BTreeSet<Requirement>,
     provides_extra: &'lock [ExtraName],
     dependency_groups: BTreeMap<GroupName, BTreeSet<Requirement>>,
-    /// The marker environments and conflict contexts in which each requested extra is active.
-    activated_extras: BTreeMap<ExtraName, UniversalMarker>,
+    /// The marker environments and conflict contexts in which the package and its extras run.
+    activated_package: ActivatedPackage,
     /// The environment under which this package can be selected.
     package_marker: UniversalMarker,
     /// The package environment before platform-specific source forks are applied.
@@ -685,7 +982,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         package_requires_python: Option<&VersionSpecifiers>,
         package_version: Option<&Version>,
         package: &'lock Package,
-        activated_extras: BTreeMap<ExtraName, UniversalMarker>,
+        activated_package: ActivatedPackage,
         workspace_root: &'lock Path,
     ) -> Self {
         let package_context = package_version.map(|version| (&package.id.name, version));
@@ -737,7 +1034,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             declarations,
             provides_extra,
             dependency_groups,
-            activated_extras,
+            activated_package,
             package_marker,
             unforked_package_marker,
             lock_marker,
@@ -758,20 +1055,20 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
 
     /// Check the resolved source and version once for both generation and existing-edge lookup.
     fn package_satisfies_requirement(
-        parent_package: &Package,
         package: &Package,
         requirement: &Requirement,
         workspace_root: &Path,
     ) -> Result<bool, LockError> {
+        // Ordinary registry requirements can reuse a globally selected direct URL or local
+        // source, but only when a refreshed declaration still authorizes that exact source.
         let source_matches = package
             .id
             .source
             .satisfies_requirement_source(&requirement.source, workspace_root)?
-            || package.id == parent_package.id
-                && matches!(
-                    requirement.source,
-                    RequirementSource::Registry { index: None, .. }
-                );
+            || matches!(
+                requirement.source,
+                RequirementSource::Registry { index: None, .. }
+            );
         let version_matches = requirement
             .source
             .version_specifiers()
@@ -784,22 +1081,19 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
 
     /// Include locked-only contexts too, so stale extra and group sections cannot be retained.
     fn contexts(&self) -> impl Iterator<Item = DependencyContext<'_>> + '_ {
-        let is_workspace_package = self.lock.members().contains(&self.package.id.name)
-            || self.lock.members().is_empty()
-                && self
-                    .lock
-                    .root()
-                    .is_some_and(|root| root.id == self.package.id);
         let extras = self
             .provides_extra
             .iter()
-            .filter(|extra| is_workspace_package || self.activated_extras.contains_key(*extra))
+            .filter(|extra| {
+                self.is_workspace_package() || self.activated_package.extras.contains_key(*extra)
+            })
             .chain(self.package.optional_dependencies.keys())
+            .chain(self.activated_package.extras.keys())
             .collect::<BTreeSet<_>>();
         let groups = self
             .dependency_groups
             .keys()
-            .filter(|_| is_workspace_package)
+            .filter(|_| self.is_workspace_package())
             .chain(self.package.dependency_groups.keys())
             .collect::<BTreeSet<_>>();
 
@@ -808,11 +1102,22 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             .chain(groups.into_iter().map(DependencyContext::Group))
     }
 
+    /// Workspace packages and their extras can be selected independently of incoming edges.
+    fn is_workspace_package(&self) -> bool {
+        self.lock.members().contains(&self.package.id.name)
+            || self.lock.members().is_empty()
+                && self
+                    .lock
+                    .root()
+                    .is_some_and(|root| root.id == self.package.id)
+    }
+
     /// Preserve selected, source, requested-extra, and workspace-project conflicts on resolved edges.
     fn requirement_conflict_marker(
         &self,
         context: DependencyContext<'_>,
         requirement: &Requirement,
+        include_requested_extras: bool,
     ) -> Option<UniversalMarker> {
         if self.lock.conflicts.is_empty() {
             return None;
@@ -825,13 +1130,16 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         let requested_conflicts = requirement
             .extras
             .iter()
-            .filter(|extra| self.lock.conflicts.contains(&requirement.name, *extra))
+            .filter(|extra| {
+                include_requested_extras && self.lock.conflicts.contains(&requirement.name, *extra)
+            })
             .map(|extra| ConflictItem::from((requirement.name.clone(), extra.clone())));
-        let requested_project = self
-            .lock
-            .conflicts
-            .contains(&requirement.name, ConflictKindRef::Project)
-            .then(|| ConflictItem::from(requirement.name.clone()));
+        let requested_project = (requirement.extras.is_empty()
+            && self
+                .lock
+                .conflicts
+                .contains(&requirement.name, ConflictKindRef::Project))
+        .then(|| ConflictItem::from(requirement.name.clone()));
         let selected = context.selected_conflict(&self.package.id.name, &self.lock.conflicts);
         let mut conflicts = source_conflict
             .cloned()
@@ -889,7 +1197,8 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         let mut parent_marker = self.package_marker;
         // An extra is reachable only where at least one incoming edge activates it.
         if let DependencyContext::Extra(extra) = context
-            && let Some(marker) = self.activated_extras.get(extra)
+            && !self.is_workspace_package()
+            && let Some(marker) = self.activated_package.extras.get(extra)
         {
             parent_marker.and(self.extra_activation_marker(*marker));
         }
@@ -904,12 +1213,21 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             .contains(&self.package.id.name, ConflictKindRef::Project);
         let project = ConflictItem::from(self.package.id.name.clone());
         let selected = context.selected_conflict(&self.package.id.name, &self.lock.conflicts);
+        let selected_conflicts_with_project = selected.as_ref().is_some_and(|selected| {
+            self.lock.conflicts.iter().any(|conflicts| {
+                conflicts.contains(&self.package.id.name, ConflictKindRef::Project)
+                    && conflicts.iter().any(|conflict| conflict == selected)
+            })
+        });
 
         let mut world = UniversalMarker::new(
             MarkerTree::TRUE,
             ConflictMarker::from_conflicts(&self.lock.conflicts),
         );
-        if project_conflicts && !matches!(context, DependencyContext::Group(_)) {
+        if project_conflicts
+            && !matches!(context, DependencyContext::Group(_))
+            && !selected_conflicts_with_project
+        {
             world.assume_conflict_item(&project);
         }
         if let Some(selected) = &selected {
@@ -937,66 +1255,270 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                 }
             }
             parent_marker.and(activation);
+        } else if project_conflicts
+            && matches!(context, DependencyContext::Extra(_))
+            && !selected_conflicts_with_project
+        {
+            parent_marker.and(UniversalMarker::new(
+                MarkerTree::TRUE,
+                ConflictMarker::from_conflict_item(&project),
+            ));
         }
         parent_marker
     }
 
-    /// Choose the resolver-node context used to simplify a regenerated dependency edge.
-    fn simplification_parent_marker(
-        &self,
-        context: DependencyContext<'_>,
-        parent_marker: UniversalMarker,
-    ) -> UniversalMarker {
-        if self.lock.conflicts.is_empty() {
-            return parent_marker;
+    /// Reconstruct the full reachability and edge-simplification contexts of a dependency node.
+    fn activation(&self, context: DependencyContext<'_>) -> DependencyActivation {
+        let parent_marker = self.context_parent_marker(context);
+        let mut marker = parent_marker;
+        if !self.activated_package.marker.is_false() {
+            marker.and(self.activated_package.marker);
+        }
+        if let DependencyContext::Extra(extra) = context
+            && !self.is_workspace_package()
+            && let Some(activation) = self.activated_package.extras.get(extra)
+        {
+            marker.and(*activation);
+        }
+        if let Some(selected) =
+            context.selected_conflict(&self.package.id.name, &self.lock.conflicts)
+        {
+            marker.and(UniversalMarker::new(
+                MarkerTree::TRUE,
+                ConflictMarker::from_conflict_item(&selected),
+            ));
         }
 
-        let DependencyContext::Extra(extra) = context else {
-            return self.unforked_package_marker;
-        };
-        let Some(activation) = self.activated_extras.get(extra) else {
-            return self.unforked_package_marker;
-        };
-        if !activation.has_conflict_marker() || !self.package.fork_markers.is_empty() {
-            return self.unforked_package_marker;
-        }
-
-        let activation_marker =
-            SimplifiedMarkerTree::new(&self.lock.requires_python, activation.pep508())
-                .as_simplified_marker_tree();
-        let selects_resolution_fork = self.lock.fork_markers.iter().any(|fork_marker| {
-            let fork_marker =
-                SimplifiedMarkerTree::new(&self.lock.requires_python, fork_marker.pep508())
-                    .as_simplified_marker_tree();
-            !fork_marker.is_true() && activation_marker.is_disjoint(fork_marker.negate())
-        });
-        if selects_resolution_fork {
-            self.unforked_package_marker
-        } else {
+        let simplification_parent_marker = if self.lock.conflicts.is_empty() {
             parent_marker
+        } else if let DependencyContext::Extra(extra) = context
+            && !self.is_workspace_package()
+            && let Some(activation) = self.activated_package.extras.get(extra)
+            && activation.has_conflict_marker()
+            && self.package.fork_markers.is_empty()
+        {
+            let mut selected_forks = UniversalMarker::FALSE;
+            for fork_marker in &self.lock.fork_markers {
+                let mut reachable_fork = *activation;
+                reachable_fork.and(*fork_marker);
+                reachable_fork.and(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflicts(&self.lock.conflicts),
+                ));
+                if !reachable_fork.is_false() {
+                    selected_forks.or(*fork_marker);
+                }
+            }
+            let selected_environment =
+                SimplifiedMarkerTree::new(&self.lock.requires_python, selected_forks.pep508())
+                    .as_simplified_marker_tree();
+            let package_environment = SimplifiedMarkerTree::new(
+                &self.lock.requires_python,
+                self.unforked_package_marker.pep508(),
+            )
+            .as_simplified_marker_tree();
+            if selected_environment != package_environment {
+                self.unforked_package_marker
+            } else {
+                parent_marker
+            }
+        } else {
+            self.unforked_package_marker
+        };
+
+        DependencyActivation {
+            marker,
+            parent_marker,
+            simplification_parent_marker,
         }
     }
 
-    /// Return dependency identities and complete markers, including encoded conflict predicates.
+    /// Return selections that cannot coexist with a required conflict item.
+    fn conflicting_alternatives(&self, required: &ConflictItem) -> UniversalMarker {
+        let mut alternatives = UniversalMarker::FALSE;
+        for conflicts in self.lock.conflicts.iter() {
+            if !conflicts.iter().any(|conflict| conflict == required) {
+                continue;
+            }
+            for conflict in conflicts.iter().filter(|conflict| *conflict != required) {
+                alternatives.or(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflict_item(conflict),
+                ));
+            }
+        }
+        alternatives
+    }
+
+    /// Return the worlds in which an incoming extra edge has an observable selection.
+    fn selected_extra_payload_marker(
+        &self,
+        package_id: &PackageId,
+        extras: &BTreeSet<ExtraName>,
+        activation: DependencyActivation,
+        environment: MarkerTree,
+    ) -> MarkerTree {
+        if extras.is_empty() {
+            return MarkerTree::TRUE;
+        }
+
+        let package = self.lock.find_by_id(package_id);
+        let candidates = self.packages_for_name(&package.id.name);
+        if candidates
+            .iter()
+            .any(|candidate| candidate.id.source != package.id.source)
+        {
+            return MarkerTree::TRUE;
+        }
+
+        let conflicts = UniversalMarker::new(
+            MarkerTree::TRUE,
+            ConflictMarker::from_conflicts(&self.lock.conflicts),
+        );
+        let mut payload_marker = MarkerTree::FALSE;
+        for extra in extras {
+            if !self.lock.conflicts.contains(&package.id.name, extra) {
+                return MarkerTree::TRUE;
+            }
+            let Some(dependencies) = package.optional_dependencies.get(extra) else {
+                return MarkerTree::TRUE;
+            };
+
+            let selected = ConflictItem::from((package.id.name.clone(), extra.clone()));
+            for fork_marker in &self.lock.fork_markers {
+                let mut fork = *fork_marker;
+                fork.and(activation.marker);
+                fork.and(UniversalMarker::from_combined(environment));
+                fork.and(conflicts);
+                if marker_is_unreachable(&self.lock.requires_python, fork.combined()) {
+                    continue;
+                }
+
+                fork.assume_not_conflict_item(&selected);
+                if marker_is_unreachable(&self.lock.requires_python, fork.combined()) {
+                    return MarkerTree::TRUE;
+                }
+            }
+
+            for dependency in dependencies {
+                payload_marker = payload_marker.or(dependency.complexified_marker.combined());
+            }
+        }
+        payload_marker
+    }
+
+    /// Compare dependency edges in their reachable PEP 508 environment and conflict world.
     fn comparable_dependencies(
         &self,
         dependencies: &[Dependency],
-    ) -> Vec<(PackageId, BTreeSet<ExtraName>, SimplifiedMarkerTree)> {
+        context: DependencyContext<'_>,
+        activation: DependencyActivation,
+    ) -> Vec<(
+        PackageId,
+        BTreeSet<ExtraName>,
+        MarkerTree,
+        MarkerTree,
+        MarkerTree,
+    )> {
         let conflicts = ConflictMarker::from_conflicts(&self.lock.conflicts);
-        let mut comparable = dependencies
-            .iter()
-            .map(|dependency| {
-                let mut marker = dependency.complexified_marker;
-                marker.imbibe(conflicts);
-                (
-                    dependency.package_id.clone(),
-                    dependency.extra.clone(),
-                    SimplifiedMarkerTree::new(&self.lock.requires_python, marker.combined()),
-                )
-            })
-            .collect::<Vec<_>>();
-        comparable.sort();
+        let mut comparable: BTreeMap<
+            (PackageId, BTreeSet<ExtraName>),
+            (MarkerTree, MarkerTree, MarkerTree),
+        > = BTreeMap::new();
+        for dependency in dependencies {
+            let mut forbidden_conflict = UniversalMarker::FALSE;
+            if matches!(context, DependencyContext::Production)
+                && self
+                    .lock
+                    .conflicts
+                    .contains(&self.package.id.name, ConflictKindRef::Project)
+            {
+                forbidden_conflict.or(self
+                    .conflicting_alternatives(&ConflictItem::from(self.package.id.name.clone())));
+            }
+            let source_variants = self.packages_for_name(&dependency.package_id.name);
+            let has_source_forks = source_variants.first().is_some_and(|first| {
+                source_variants
+                    .iter()
+                    .any(|package| package.id.source != first.id.source)
+            });
+            if let Some(selected) =
+                context.selected_conflict(&self.package.id.name, &self.lock.conflicts)
+                && (!dependency.extra.is_empty() || has_source_forks)
+            {
+                forbidden_conflict.or(self.conflicting_alternatives(&selected));
+            }
+            for extra in &dependency.extra {
+                if self
+                    .lock
+                    .conflicts
+                    .contains(&dependency.package_id.name, extra)
+                {
+                    forbidden_conflict.or(self.conflicting_alternatives(&ConflictItem::from((
+                        dependency.package_id.name.clone(),
+                        extra.clone(),
+                    ))));
+                }
+            }
+            let mut marker = dependency.complexified_marker;
+            marker.and(activation.marker);
+            let target = self.lock.find_by_id(&dependency.package_id);
+            for alternative in self
+                .lock
+                .conflicts
+                .iter()
+                .filter(|conflicts| {
+                    conflicts.contains(&dependency.package_id.name, ConflictKindRef::Project)
+                })
+                .flat_map(ConflictSet::iter)
+            {
+                let ConflictKindRef::Extra(extra) = alternative.kind().as_ref() else {
+                    continue;
+                };
+                if alternative.package() != &dependency.package_id.name
+                    || target.optional_dependencies.contains_key(extra)
+                    || dependencies.iter().any(|existing| {
+                        existing.package_id.name == dependency.package_id.name
+                            && existing.extra.contains(extra)
+                    })
+                {
+                    continue;
+                }
+                marker.and(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflict_item(alternative).negate(),
+                ));
+            }
+            marker.and(UniversalMarker::from_combined(
+                self.lock.requires_python.to_marker_tree(),
+            ));
+            if !self.lock.conflicts.is_empty() {
+                marker.and(UniversalMarker::new(MarkerTree::TRUE, conflicts));
+            }
+            if marker_is_unreachable(&self.lock.requires_python, marker.combined()) {
+                continue;
+            }
+            let key = (dependency.package_id.clone(), dependency.extra.clone());
+            let marker = marker.combined();
+            let forbidden_conflict = forbidden_conflict.combined();
+            let raw_conflict =
+                UniversalMarker::new(MarkerTree::TRUE, dependency.complexified_marker.conflict())
+                    .combined();
+            comparable
+                .entry(key)
+                .and_modify(|(existing, forbidden, raw)| {
+                    *existing = existing.or(marker);
+                    *forbidden = forbidden.or(forbidden_conflict);
+                    *raw = raw.or(raw_conflict);
+                })
+                .or_insert((marker, forbidden_conflict, raw_conflict));
+        }
         comparable
+            .into_iter()
+            .map(|((package, extras), (marker, forbidden, raw))| {
+                (package, extras, marker, forbidden, raw)
+            })
+            .collect()
     }
 }
 
@@ -2110,7 +2632,7 @@ impl Lock {
         package_requires_python: Option<&VersionSpecifiers>,
         package_version: Option<&Version>,
         package: &'lock Package,
-        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>>,
+        activated_packages: &mut FxHashMap<PackageId, ActivatedPackage>,
         remotes: &mut Option<BTreeSet<UrlString>>,
         locals: &mut Option<BTreeSet<Box<Path>>>,
         root: &Path,
@@ -2227,7 +2749,7 @@ impl Lock {
 
         if allow_missing_package_metadata {
             let declarations = flattened.as_ref().unwrap_or(&expected_requirements);
-            let package_activated_extras = activated_extras
+            let package_activation = activated_packages
                 .get(&package.id)
                 .cloned()
                 .unwrap_or_default();
@@ -2241,12 +2763,12 @@ impl Lock {
                 package_requires_python,
                 package_version,
                 package,
-                package_activated_extras,
+                package_activation,
                 root,
             );
             match self.satisfied_no_metadata(
                 package,
-                activated_extras,
+                activated_packages,
                 missing_metadata,
                 &expected,
             )? {
@@ -2270,7 +2792,7 @@ impl Lock {
     fn satisfied_no_metadata<'lock>(
         &self,
         package: &'lock Package,
-        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>>,
+        activated_packages: &mut FxHashMap<PackageId, ActivatedPackage>,
         missing_metadata: bool,
         expected: &ExpectedPackageDependencies,
     ) -> Result<SatisfiesResult<'lock>, LockError> {
@@ -2292,29 +2814,90 @@ impl Lock {
                 continue;
             }
 
-            // A false parent marker omits dependencies in unreachable conflict contexts.
-            let parent_marker = expected.context_parent_marker(context);
-            let simplification_parent_marker =
-                expected.simplification_parent_marker(context, parent_marker);
+            // Locked optional sections on dependencies are meaningful only after an incoming
+            // edge requests the extra. Cycles can expose the section before that edge is visited;
+            // the package is revisited once its extra activation becomes available.
+            if let DependencyContext::Extra(extra) = context
+                && !expected.is_workspace_package()
+                && !expected.activated_package.extras.contains_key(extra)
+            {
+                continue;
+            }
 
+            // Keep full activation distinct from the parent contexts used to generate edges.
+            let activation = expected.activation(context);
             let mut generated = Vec::new();
             let builder = LockedDependencyBuilder::new(
                 &self.requires_python,
                 expected.lock_marker,
-                parent_marker,
-                simplification_parent_marker,
+                activation,
             );
             let complete =
-                builder.add_requirements(&mut generated, expected, context, activated_extras)?;
+                builder.add_requirements(&mut generated, expected, context, activated_packages)?;
             generated.sort();
             if !missing_metadata {
                 continue;
             }
             let actual = context.dependencies(package);
-            if !complete
-                || expected.comparable_dependencies(&generated)
-                    != expected.comparable_dependencies(actual)
-            {
+            let generated_comparable =
+                expected.comparable_dependencies(&generated, context, activation);
+            let actual_comparable = expected.comparable_dependencies(actual, context, activation);
+            let equivalent = generated_comparable.len() == actual_comparable.len()
+                && generated_comparable.iter().zip(&actual_comparable).all(
+                    |(
+                        (
+                            generated_package,
+                            generated_extras,
+                            generated_marker,
+                            generated_forbidden_conflict,
+                            _,
+                        ),
+                        (actual_package, actual_extras, actual_marker, _, actual_conflict),
+                    )| {
+                        if generated_package != actual_package || generated_extras != actual_extras
+                        {
+                            return false;
+                        }
+
+                        let payload_marker = expected.selected_extra_payload_marker(
+                            generated_package,
+                            generated_extras,
+                            activation,
+                            generated_marker.or(*actual_marker).without_extras(),
+                        );
+                        marker_is_unreachable(
+                            &self.requires_python,
+                            generated_marker
+                                .without_extras()
+                                .and(actual_marker.without_extras().negate()),
+                        ) && marker_is_unreachable(
+                            &self.requires_python,
+                            actual_marker
+                                .without_extras()
+                                .and(generated_marker.without_extras().negate()),
+                        ) && marker_is_unreachable(
+                            &self.requires_python,
+                            generated_marker
+                                .and(actual_marker.negate())
+                                .and(payload_marker),
+                        ) && marker_is_unreachable(
+                            &self.requires_python,
+                            actual_marker
+                                .and(generated_marker.negate())
+                                .and(payload_marker),
+                        ) && marker_is_unreachable(
+                            &self.requires_python,
+                            actual_conflict.and(*generated_forbidden_conflict).and(
+                                UniversalMarker::new(
+                                    MarkerTree::TRUE,
+                                    ConflictMarker::from_conflicts(&self.conflicts),
+                                )
+                                .combined(),
+                            ),
+                        )
+                    },
+                );
+            if !complete || !equivalent {
                 return Ok(SatisfiesResult::MismatchedPackageDependencies(
                     &package.id.name,
                     package.id.version.as_ref(),
@@ -2351,6 +2934,48 @@ impl Lock {
         }
     }
 
+    /// Record explicit current requirements that authorize a locked non-registry source.
+    fn record_source_authority(
+        &self,
+        requirement: &Requirement,
+        activated_packages: &mut FxHashMap<PackageId, ActivatedPackage>,
+        root: &Path,
+    ) -> Result<(), LockError> {
+        if matches!(
+            requirement.source,
+            RequirementSource::Registry { index: None, .. }
+        ) {
+            return Ok(());
+        }
+        for package in self
+            .packages
+            .iter()
+            .filter(|package| package.id.name == requirement.name)
+        {
+            if !ExpectedPackageDependencies::package_satisfies_requirement(
+                package,
+                requirement,
+                root,
+            )? {
+                continue;
+            }
+            let mut marker = UniversalMarker::from_combined(requirement.marker);
+            if !package.fork_markers.is_empty() {
+                let fork_marker = package
+                    .fork_markers
+                    .iter()
+                    .fold(MarkerTree::FALSE, |marker, fork| marker.or(fork.combined()));
+                marker.and(UniversalMarker::from_combined(fork_marker));
+            }
+            activated_packages
+                .entry(package.id.clone())
+                .or_default()
+                .source_marker
+                .or(marker);
+        }
+        Ok(())
+    }
+
     /// Check whether the lock matches the project structure, requirements and configuration.
     #[instrument(skip_all)]
     pub async fn satisfies<Context: BuildContext>(
@@ -2379,10 +3004,8 @@ impl Lock {
             allow_missing_package_metadata && self.supports_missing_package_metadata();
         let mut queue: VecDeque<&Package> = VecDeque::new();
         let mut seen = FxHashSet::default();
-        let mut activated_extras: FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>> =
-            FxHashMap::default();
-        let mut validated_extras: FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>> =
-            FxHashMap::default();
+        let mut activated_packages: FxHashMap<PackageId, ActivatedPackage> = FxHashMap::default();
+        let mut validated_packages: FxHashMap<PackageId, ActivatedPackage> = FxHashMap::default();
 
         // Validate that the lockfile was generated with the same root members.
         {
@@ -2646,9 +3269,19 @@ impl Lock {
                 return Ok(SatisfiesResult::MissingRoot(root_name.clone()));
             };
 
+            let activation = UniversalMarker::from_combined(self.fork_markers_union());
+            let activated = activated_packages.entry(root.id.clone()).or_default();
+            activated.marker.or(activation);
+            activated.source_marker.or(activation);
             if seen.insert(&root.id) {
                 queue.push_back(root);
             }
+        }
+
+        // Direct-source constraints select their distribution globally even when every
+        // dependency edge uses a source-agnostic registry requirement.
+        for constraint in constraints {
+            self.record_source_authority(constraint, &mut activated_packages, root)?;
         }
 
         // Add requirements attached directly to the target root (e.g., PEP 723 requirements or
@@ -2659,6 +3292,9 @@ impl Lock {
             .collect::<Vec<_>>();
 
         for requirement in &root_requirements {
+            if self.root().is_none() {
+                self.record_source_authority(requirement, &mut activated_packages, root)?;
+            }
             if let RequirementSource::Registry {
                 index: Some(index), ..
             } = &requirement.source
@@ -2706,14 +3342,27 @@ impl Lock {
                         continue;
                     }
 
-                    let activated = activated_extras.entry(package.id.clone()).or_default();
+                    let activation_marker = UniversalMarker::from_combined(marker);
+                    let activated = activated_packages.entry(package.id.clone()).or_default();
+                    activated.marker.or(activation_marker);
+                    if matches!(
+                        requirement.source,
+                        RequirementSource::Registry { index: None, .. }
+                    ) {
+                        if !matches!(package.id.source, Source::Registry(_)) {
+                            activated.source_authority_required.or(activation_marker);
+                        }
+                    } else {
+                        activated.source_marker.or(activation_marker);
+                    }
                     for extra in &requirement.extras {
                         activated
+                            .extras
                             .entry(extra.clone())
                             .and_modify(|existing| {
-                                existing.or(UniversalMarker::from_combined(marker));
+                                existing.or(activation_marker);
                             })
-                            .or_insert_with(|| UniversalMarker::from_combined(marker));
+                            .or_insert(activation_marker);
                     }
 
                     if seen.insert(&package.id) {
@@ -2819,7 +3468,7 @@ impl Lock {
                             requires_python.as_ref(),
                             Some(version),
                             package,
-                            &mut activated_extras,
+                            &mut activated_packages,
                             &mut remotes,
                             &mut locals,
                             root,
@@ -2918,7 +3567,7 @@ impl Lock {
                         metadata.requires_python.as_ref(),
                         Some(&metadata.version),
                         package,
-                        &mut activated_extras,
+                        &mut activated_packages,
                         &mut remotes,
                         &mut locals,
                         root,
@@ -2981,7 +3630,7 @@ impl Lock {
                         requires_python.as_ref(),
                         None,
                         package,
-                        &mut activated_extras,
+                        &mut activated_packages,
                         &mut remotes,
                         &mut locals,
                         root,
@@ -3079,7 +3728,7 @@ impl Lock {
                         metadata.requires_python.as_ref(),
                         Some(&metadata.version),
                         package,
-                        &mut activated_extras,
+                        &mut activated_packages,
                         &mut remotes,
                         &mut locals,
                         root,
@@ -3093,24 +3742,46 @@ impl Lock {
                 return Ok(SatisfiesResult::MissingVersion(&package.id.name));
             }
 
-            // Revisit an already-validated dependency if another parent activated more extras.
-            // Empty extras have no locked edges, so their activation is otherwise order-dependent.
-            validated_extras.insert(
+            // Revisit a dependency when another parent expands its package or extra reachability.
+            validated_packages.insert(
                 package.id.clone(),
-                activated_extras
+                activated_packages
                     .get(&package.id)
                     .cloned()
                     .unwrap_or_default(),
             );
             for dependency in package.all_dependencies() {
-                let needs_extra_validation = validated_extras
+                let needs_activation_validation = validated_packages
                     .get(&dependency.package_id)
-                    .zip(activated_extras.get(&dependency.package_id))
+                    .zip(activated_packages.get(&dependency.package_id))
                     .is_some_and(|(validated, activated)| validated != activated);
-                if seen.insert(&dependency.package_id) || needs_extra_validation {
+                if seen.insert(&dependency.package_id) || needs_activation_validation {
                     let dependency_package = self.find_by_id(&dependency.package_id);
                     queue.push_back(dependency_package);
                 }
+            }
+        }
+
+        for (package_id, activation) in activated_packages {
+            let unauthorized = activation
+                .source_authority_required
+                .combined()
+                .and(activation.source_marker.combined().negate())
+                .and(
+                    UniversalMarker::new(
+                        MarkerTree::TRUE,
+                        ConflictMarker::from_conflicts(&self.conflicts),
+                    )
+                    .combined(),
+                );
+            if !marker_is_unreachable(&self.requires_python, unauthorized) {
+                let package = self.find_by_id(&package_id);
+                return Ok(SatisfiesResult::MismatchedPackageDependencies(
+                    &package.id.name,
+                    package.id.version.as_ref(),
+                    Vec::new(),
+                    &package.dependencies,
+                ));
             }
         }
 
@@ -3744,8 +4415,7 @@ impl Package {
         let builder = LockedDependencyBuilder::new(
             requires_python,
             environment,
-            parent_marker,
-            parent_marker,
+            DependencyActivation::from_resolver_node(parent_marker),
         );
         for edge in resolution.graph.edges(node_index) {
             let ResolutionGraphNode::Dist(distribution) = &resolution.graph[edge.target()] else {
@@ -7501,6 +8171,33 @@ fn fork_markers_union(
         environment = environment.or(fork_marker.pep508());
     }
     environment
+}
+
+/// Return whether a marker has no satisfiable branch in the supported Python environment.
+fn marker_is_unreachable(requires_python: &RequiresPython, marker: MarkerTree) -> bool {
+    let marker = requires_python.simplify_markers(marker);
+    if marker.is_false() {
+        return true;
+    }
+    if marker.is_true() {
+        return false;
+    }
+    let environment = requires_python.simplify_markers(marker.without_extras());
+    if environment.is_false() {
+        return true;
+    }
+    if environment.is_true() {
+        return false;
+    }
+
+    environment.to_dnf().into_iter().all(|conjunction| {
+        let marker = conjunction
+            .into_iter()
+            .fold(MarkerTree::TRUE, |marker, expression| {
+                marker.and(MarkerTree::expression(expression))
+            });
+        requires_python.simplify_markers(marker).is_false()
+    })
 }
 
 /// Simplify an edge marker using the PEP 508 conditions that must already hold to reach its parent

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -449,6 +449,19 @@ impl DependencyActivation {
 }
 
 impl DependencyContext<'_> {
+    /// Specialize a declaration to this production, extra, or dependency-group context.
+    fn requirement_marker(self, requirement: &Requirement) -> MarkerTree {
+        let production = requirement.marker.simplify_not_extras_with(|_| true);
+        match self {
+            Self::Production | Self::Group(_) => production,
+            Self::Extra(extra) => requirement
+                .marker
+                .simplify_extras(slice::from_ref(extra))
+                .simplify_not_extras_with(|candidate| candidate != extra)
+                .and(production.negate()),
+        }
+    }
+
     /// Return the conflict item selected by this extra or dependency-group node, if any.
     fn selected_conflict(
         self,
@@ -541,15 +554,26 @@ impl<'a> LockedDependencyBuilder<'a> {
         for requirement in requirements {
             // Specialize the declaration to its production, extra, or dependency-group context.
             // This handles cases such as `sys_platform == "darwin" or extra == "foo"`.
-            let production_marker = requirement.marker.simplify_not_extras_with(|_| true);
-            let requirement_marker = match context {
-                DependencyContext::Production | DependencyContext::Group(_) => production_marker,
-                DependencyContext::Extra(extra) => requirement
-                    .marker
-                    .simplify_extras(slice::from_ref(extra))
-                    .simplify_not_extras_with(|candidate| candidate != extra)
-                    .and(production_marker.negate()),
-            };
+            let mut requirement_marker = context.requirement_marker(requirement);
+            if let DependencyContext::Extra(selected) = context
+                && !requirement.extras.contains(selected)
+                && requirement.extras.iter().any(|extra| {
+                    expected.lock.conflicts.iter().any(|conflicts| {
+                        conflicts.contains(&requirement.name, selected)
+                            && conflicts.contains(&requirement.name, extra)
+                    })
+                })
+            {
+                let selected_marker = requirements
+                    .iter()
+                    .filter(|candidate| {
+                        candidate.name == requirement.name && candidate.extras.contains(selected)
+                    })
+                    .fold(MarkerTree::FALSE, |marker, candidate| {
+                        marker.or(context.requirement_marker(candidate))
+                    });
+                requirement_marker = requirement_marker.and(selected_marker.negate());
+            }
             let mut base_marker = UniversalMarker::from_combined(requirement_marker);
             base_marker.and(self.activation.parent_marker);
             if let Some(conflict_marker) =
@@ -567,6 +591,13 @@ impl<'a> LockedDependencyBuilder<'a> {
                         && conflicts.contains(&requirement.name, extra)
                 })
             };
+            let root_extra_project_conflict = matches!(context, DependencyContext::Extra(_))
+                && expected
+                    .lock
+                    .root()
+                    .is_some_and(|root| root.id == expected.package.id)
+                && expected.lock.members().contains(&requirement.name)
+                && requirement.extras.iter().any(&project_conflicts_with_extra);
             let project_conflict_marker = (expected
                 .lock
                 .conflicts
@@ -593,6 +624,39 @@ impl<'a> LockedDependencyBuilder<'a> {
                         requirement.name.clone(),
                     )),
                 )
+            });
+            let parent_has_selected_conflict = matches!(context, DependencyContext::Group(_))
+                || matches!(context, DependencyContext::Extra(_))
+                    && context
+                        .selected_conflict(&expected.package.id.name, &expected.lock.conflicts)
+                        .is_some();
+            let selected_context_has_project_compatible_alternative = parent_has_selected_conflict
+                && requirement.extras.iter().any(|extra| {
+                    expected
+                        .lock
+                        .conflicts
+                        .iter()
+                        .filter(|conflicts| conflicts.contains(&requirement.name, extra))
+                        .flat_map(ConflictSet::iter)
+                        .any(|alternative| {
+                            let ConflictKindRef::Extra(alternative_extra) =
+                                alternative.kind().as_ref()
+                            else {
+                                return false;
+                            };
+                            alternative.package() == &requirement.name
+                                && alternative_extra != extra
+                                && !project_conflicts_with_extra(alternative_extra)
+                                && expected
+                                    .packages_for_name(&requirement.name)
+                                    .iter()
+                                    .any(|package| package.has_extra_payload(alternative_extra))
+                        })
+                });
+            let project_conflict_marker = project_conflict_marker.filter(|_| {
+                !parent_has_selected_conflict
+                    || requirement.extras.iter().any(&project_conflicts_with_extra)
+                        && !selected_context_has_project_compatible_alternative
             });
             let project_implies_extra = |extra: &ExtraName| {
                 let selected = ConflictItem::from((requirement.name.clone(), extra.clone()));
@@ -632,7 +696,7 @@ impl<'a> LockedDependencyBuilder<'a> {
                         || expected
                             .packages_for_name(&requirement.name)
                             .iter()
-                            .any(|package| package.optional_dependencies.contains_key(extra))
+                            .any(|package| package.has_extra_payload(extra))
                         || context
                             .dependencies(expected.package)
                             .iter()
@@ -662,19 +726,50 @@ impl<'a> LockedDependencyBuilder<'a> {
             if let Some(project_conflict_marker) = project_conflict_marker
                 && !matches!(context, DependencyContext::Production)
             {
-                let mut package_conflict_marker = project_conflict_marker;
-                for extra in requirement
-                    .extras
-                    .iter()
-                    .filter(|extra| project_conflicts_with_extra(extra))
-                {
-                    package_conflict_marker.or(UniversalMarker::new(
-                        MarkerTree::TRUE,
-                        ConflictMarker::from_conflict_item(&ConflictItem::from((
-                            requirement.name.clone(),
-                            extra.clone(),
-                        ))),
-                    ));
+                let root_extra_has_external_conflict = root_extra_project_conflict
+                    && requirement.extras.iter().any(|extra| {
+                        expected
+                            .lock
+                            .conflicts
+                            .iter()
+                            .filter(|conflicts| conflicts.contains(&requirement.name, extra))
+                            .flat_map(ConflictSet::iter)
+                            .any(|alternative| alternative.package() != &requirement.name)
+                    });
+                let mut package_conflict_marker = if root_extra_has_external_conflict {
+                    UniversalMarker::TRUE
+                } else {
+                    project_conflict_marker
+                };
+                if root_extra_has_external_conflict {
+                    for extra in requirement
+                        .extras
+                        .iter()
+                        .filter(|extra| project_conflicts_with_extra(extra))
+                    {
+                        package_conflict_marker.and(UniversalMarker::new(
+                            MarkerTree::TRUE,
+                            ConflictMarker::from_conflict_item(&ConflictItem::from((
+                                requirement.name.clone(),
+                                extra.clone(),
+                            )))
+                            .negate(),
+                        ));
+                    }
+                } else if !root_extra_project_conflict {
+                    for extra in requirement
+                        .extras
+                        .iter()
+                        .filter(|extra| project_conflicts_with_extra(extra))
+                    {
+                        package_conflict_marker.or(UniversalMarker::new(
+                            MarkerTree::TRUE,
+                            ConflictMarker::from_conflict_item(&ConflictItem::from((
+                                requirement.name.clone(),
+                                extra.clone(),
+                            ))),
+                        ));
+                    }
                 }
                 base_marker.and(package_conflict_marker);
                 requested_base_marker.and(package_conflict_marker);
@@ -779,12 +874,11 @@ impl<'a> LockedDependencyBuilder<'a> {
                     activated.source_marker.or(activation_marker);
                 }
                 for extra in &requirement.extras {
-                    let mut extra_activation_marker =
-                        if dependency.optional_dependencies.contains_key(extra) {
-                            base_edge_marker
-                        } else {
-                            requested_edge_marker
-                        };
+                    let mut extra_activation_marker = if dependency.has_extra_payload(extra) {
+                        base_edge_marker
+                    } else {
+                        requested_edge_marker
+                    };
                     if expected.lock.conflicts.contains(&requirement.name, extra)
                         && project_conflict_marker.is_none_or(|_| !project_implies_extra(extra))
                     {
@@ -825,27 +919,141 @@ impl<'a> LockedDependencyBuilder<'a> {
                     .extras
                     .iter()
                     .filter(|extra| {
-                        dependency.optional_dependencies.contains_key(*extra)
-                            || context
-                                .dependencies(expected.package)
-                                .iter()
-                                .any(|existing| {
-                                    existing.package_id == dependency.id
-                                        && existing.extra.contains(*extra)
-                                })
+                        (!root_extra_project_conflict || !project_conflicts_with_extra(extra))
+                            && (dependency.has_extra_payload(extra)
+                                || context
+                                    .dependencies(expected.package)
+                                    .iter()
+                                    .any(|existing| {
+                                        existing.package_id == dependency.id
+                                            && existing.extra.contains(*extra)
+                                    }))
                     })
                     .cloned()
                     .collect::<BTreeSet<_>>();
 
                 // Requesting an extra also selects its base distribution. Each requested extra
                 // has its own conflict context, and equal contexts merge below.
-                if !extras.is_empty() {
+                let mut standalone_base_edge_marker = base_edge_marker;
+                if has_source_forks
+                    && matches!(context, DependencyContext::Extra(_))
+                    && !requirement.extras.is_empty()
+                {
+                    let mut competing_activations = activated.extras.clone();
+                    for (parent_extra, parent_activation) in &expected.activated_package.extras {
+                        for candidate in requirements
+                            .iter()
+                            .filter(|candidate| candidate.name == dependency.id.name)
+                        {
+                            let mut marker = UniversalMarker::from_combined(
+                                DependencyContext::Extra(parent_extra)
+                                    .requirement_marker(candidate),
+                            );
+                            marker.and(*parent_activation);
+                            if marker_is_unreachable(self.requires_python, marker.combined()) {
+                                continue;
+                            }
+                            for alternative in &candidate.extras {
+                                competing_activations
+                                    .entry(alternative.clone())
+                                    .and_modify(|activation| activation.or(marker))
+                                    .or_insert(marker);
+                            }
+                        }
+                    }
+                    for extra in &requirement.extras {
+                        let selected =
+                            ConflictItem::from((dependency.id.name.clone(), extra.clone()));
+                        for (alternative, activation) in &competing_activations {
+                            let externally_selected_alternative =
+                                expected.activated_package.extras.iter().any(
+                                    |(parent_extra, parent_activation)| {
+                                        requirements.iter().any(|candidate| {
+                                            if candidate.name != dependency.id.name
+                                                || !candidate.extras.contains(alternative)
+                                            {
+                                                return false;
+                                            }
+                                            let mut marker = UniversalMarker::from_combined(
+                                                DependencyContext::Extra(parent_extra)
+                                                    .requirement_marker(candidate),
+                                            );
+                                            marker.and(*parent_activation);
+                                            !marker_is_unreachable(
+                                                self.requires_python,
+                                                marker.combined(),
+                                            )
+                                        })
+                                    },
+                                );
+                            if alternative == extra
+                                || matches!(context, DependencyContext::Extra(parent_extra)
+                                    if expected
+                                        .activated_package
+                                        .extras
+                                        .contains_key(parent_extra)
+                                        && !externally_selected_alternative)
+                                || !dependency.optional_dependencies.contains_key(alternative)
+                                    && !externally_selected_alternative
+                                || !expected.lock.conflicts.iter().any(|conflicts| {
+                                    conflicts.contains(&dependency.id.name, extra)
+                                        && conflicts.contains(&dependency.id.name, alternative)
+                                })
+                            {
+                                continue;
+                            }
+                            let mut competing = expected.project_activation_marker(*activation);
+                            competing.and(self.activation.marker);
+                            if !expected.lock.conflicts.is_empty() {
+                                competing.and(UniversalMarker::new(
+                                    MarkerTree::TRUE,
+                                    ConflictMarker::from_relevant_conflicts(
+                                        &expected.lock.conflicts,
+                                        [competing],
+                                    ),
+                                ));
+                            }
+                            if marker_is_unreachable(self.requires_python, competing.combined()) {
+                                continue;
+                            }
+                            let mut compatible = UniversalMarker::from_combined(
+                                competing.combined().without_extras().negate(),
+                            );
+                            compatible.or(UniversalMarker::new(
+                                MarkerTree::TRUE,
+                                ConflictMarker::from_conflict_item(&selected),
+                            ));
+                            standalone_base_edge_marker.and(compatible);
+                        }
+                    }
+                }
+                if !extras.is_empty()
+                    && !self.base_covered_by_requested_extras(
+                        expected,
+                        context,
+                        &dependency.id,
+                        &extras,
+                        standalone_base_edge_marker,
+                    )
+                {
                     edges
                         .entry((dependency.id.clone(), BTreeSet::new()))
-                        .and_modify(|existing| existing.or(base_edge_marker))
-                        .or_insert(base_edge_marker);
+                        .and_modify(|existing| existing.or(standalone_base_edge_marker))
+                        .or_insert(standalone_base_edge_marker);
                 }
                 if extras.is_empty() {
+                    if !requirement.extras.is_empty()
+                        && (has_source_forks
+                            || self.has_unselected_base_edge(
+                                expected,
+                                context,
+                                &dependency.id,
+                                requirement,
+                                base_edge_marker,
+                            ))
+                    {
+                        marker.or(standalone_base_edge_marker);
+                    }
                     edges
                         .entry((dependency.id.clone(), extras))
                         .and_modify(|existing| existing.or(marker))
@@ -913,6 +1121,111 @@ impl<'a> LockedDependencyBuilder<'a> {
             self.add(dependencies, package_id, extras, marker);
         }
         Ok(complete)
+    }
+
+    /// Return whether locked extra edges already activate their dependency's entire base marker.
+    ///
+    /// Following an extra edge selects its base package too. Resolver serialization may therefore
+    /// omit a separate base edge when the selected extra covers the full required environment.
+    fn base_covered_by_requested_extras(
+        &self,
+        expected: &ExpectedPackageDependencies<'_>,
+        context: DependencyContext<'_>,
+        package_id: &PackageId,
+        extras: &BTreeSet<ExtraName>,
+        base_marker: UniversalMarker,
+    ) -> bool {
+        if !matches!(context, DependencyContext::Extra(_)) {
+            return false;
+        }
+        if expected
+            .lock
+            .root()
+            .is_some_and(|root| root.id == expected.package.id)
+            && (expected
+                .lock
+                .conflicts
+                .contains(&package_id.name, ConflictKindRef::Project)
+                || expected.has_local_conflicting_extra(&package_id.name, extras))
+        {
+            return false;
+        }
+
+        let existing = context.dependencies(expected.package);
+        if existing
+            .iter()
+            .any(|dependency| dependency.package_id == *package_id && dependency.extra.is_empty())
+        {
+            return false;
+        }
+
+        let mut covered = UniversalMarker::FALSE;
+        for dependency in existing.iter().filter(|dependency| {
+            dependency.package_id == *package_id
+                && dependency.extra.iter().any(|extra| extras.contains(extra))
+        }) {
+            let mut marker = dependency.complexified_marker;
+            for extra in &dependency.extra {
+                if expected.lock.conflicts.contains(&package_id.name, extra) {
+                    marker.assume_conflict_item(&ConflictItem::from((
+                        package_id.name.clone(),
+                        extra.clone(),
+                    )));
+                }
+            }
+            covered.or(marker);
+        }
+        if covered.is_false() {
+            return false;
+        }
+
+        let mut uncovered = base_marker;
+        uncovered.and(self.activation.marker);
+        uncovered.and(UniversalMarker::from_combined(covered.combined().negate()));
+        if !expected.lock.conflicts.is_empty() {
+            uncovered.and(UniversalMarker::new(
+                MarkerTree::TRUE,
+                ConflictMarker::from_relevant_conflicts(&expected.lock.conflicts, [uncovered]),
+            ));
+        }
+        marker_is_unreachable(self.requires_python, uncovered.combined())
+    }
+
+    /// Return whether a source-forked target retains a base edge outside its requested extras.
+    fn has_unselected_base_edge(
+        &self,
+        expected: &ExpectedPackageDependencies<'_>,
+        context: DependencyContext<'_>,
+        package_id: &PackageId,
+        requirement: &Requirement,
+        base_marker: UniversalMarker,
+    ) -> bool {
+        context
+            .dependencies(expected.package)
+            .iter()
+            .filter(|dependency| {
+                dependency.package_id == *package_id && dependency.extra.is_empty()
+            })
+            .any(|dependency| {
+                let mut marker = dependency.complexified_marker;
+                marker.and(base_marker);
+                marker.and(self.activation.marker);
+                for extra in &requirement.extras {
+                    if expected.lock.conflicts.contains(&package_id.name, extra) {
+                        marker.assume_not_conflict_item(&ConflictItem::from((
+                            package_id.name.clone(),
+                            extra.clone(),
+                        )));
+                    }
+                }
+                if !expected.lock.conflicts.is_empty() {
+                    marker.and(UniversalMarker::new(
+                        MarkerTree::TRUE,
+                        ConflictMarker::from_relevant_conflicts(&expected.lock.conflicts, [marker]),
+                    ));
+                }
+                !marker_is_unreachable(self.requires_python, marker.combined())
+            })
     }
 
     fn add(
@@ -1139,6 +1452,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             RequirementSource::Registry { conflict, .. } => conflict.as_ref(),
             _ => None,
         };
+        let selected = context.selected_conflict(&self.package.id.name, &self.lock.conflicts);
         let requested_conflicts = requirement
             .extras
             .iter()
@@ -1152,7 +1466,6 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                 .conflicts
                 .contains(&requirement.name, ConflictKindRef::Project))
         .then(|| ConflictItem::from(requirement.name.clone()));
-        let selected = context.selected_conflict(&self.package.id.name, &self.lock.conflicts);
         let mut conflicts = source_conflict
             .cloned()
             .into_iter()
@@ -1198,6 +1511,39 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                 marker.and(UniversalMarker::new(
                     MarkerTree::TRUE,
                     ConflictMarker::from_conflict_item(project),
+                ));
+            }
+        }
+        marker
+    }
+
+    /// Remove extra selections while retaining both required and excluded project branches.
+    fn project_activation_marker(&self, activation: UniversalMarker) -> UniversalMarker {
+        let mut marker = self.extra_activation_marker(activation);
+        for project in self
+            .lock
+            .conflicts
+            .iter()
+            .flat_map(ConflictSet::iter)
+            .filter(|item| matches!(item.kind().as_ref(), ConflictKindRef::Project))
+        {
+            let mut included = activation;
+            let project_marker = UniversalMarker::new(
+                MarkerTree::TRUE,
+                ConflictMarker::from_conflict_item(project),
+            );
+            included.and(project_marker);
+            included.and(UniversalMarker::new(
+                MarkerTree::TRUE,
+                ConflictMarker::from_relevant_conflicts(
+                    &self.lock.conflicts,
+                    [activation, project_marker],
+                ),
+            ));
+            if marker_is_unreachable(&self.lock.requires_python, included.combined()) {
+                marker.and(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflict_item(project).negate(),
                 ));
             }
         }
@@ -1344,6 +1690,23 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         alternatives
     }
 
+    /// Return whether a selected extra conflicts with another selection on its own package.
+    fn has_local_conflicting_extra(
+        &self,
+        package: &PackageName,
+        extras: &BTreeSet<ExtraName>,
+    ) -> bool {
+        extras.iter().any(|extra| {
+            let selected = ConflictItem::from((package.clone(), extra.clone()));
+            self.lock.conflicts.iter().any(|conflicts| {
+                conflicts.contains(package, extra)
+                    && conflicts.iter().any(|alternative| {
+                        alternative.package() == package && alternative != &selected
+                    })
+            })
+        })
+    }
+
     /// Return the worlds in which an incoming extra edge has an observable selection.
     fn selected_extra_payload_marker(
         &self,
@@ -1367,7 +1730,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
 
         if extras.iter().any(|extra| {
             !self.lock.conflicts.contains(&package.id.name, extra)
-                || !package.optional_dependencies.contains_key(extra)
+                || !package.has_extra_payload(extra)
         }) {
             return MarkerTree::TRUE;
         }
@@ -1477,7 +1840,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                     continue;
                 };
                 if alternative.package() != &dependency.package_id.name
-                    || target.optional_dependencies.contains_key(extra)
+                    || target.has_extra_payload(extra)
                     || dependencies.iter().any(|existing| {
                         existing.package_id.name == dependency.package_id.name
                             && existing.extra.contains(extra)
@@ -1495,6 +1858,49 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             ));
             if !conflicts.is_true() {
                 marker.and(UniversalMarker::new(MarkerTree::TRUE, conflicts));
+            }
+            if matches!(context, DependencyContext::Extra(_))
+                && (self
+                    .lock
+                    .root()
+                    .is_none_or(|root| root.id != self.package.id)
+                    || !self.has_local_conflicting_extra(
+                        &dependency.package_id.name,
+                        &dependency.extra,
+                    ))
+            {
+                for extra in &dependency.extra {
+                    if self
+                        .lock
+                        .conflicts
+                        .contains(&dependency.package_id.name, extra)
+                    {
+                        marker.assume_conflict_item(&ConflictItem::from((
+                            dependency.package_id.name.clone(),
+                            extra.clone(),
+                        )));
+                    }
+                }
+            }
+            if matches!(context, DependencyContext::Group(_)) {
+                let selected = dependencies
+                    .iter()
+                    .filter(|existing| existing.package_id == dependency.package_id)
+                    .flat_map(|existing| existing.extra.iter())
+                    .filter(|extra| {
+                        self.lock
+                            .conflicts
+                            .contains(&dependency.package_id.name, *extra)
+                    })
+                    .collect::<BTreeSet<_>>();
+                if selected.len() == 1
+                    && let Some(extra) = selected.iter().next()
+                {
+                    marker.assume_conflict_item(&ConflictItem::from((
+                        dependency.package_id.name.clone(),
+                        (*extra).clone(),
+                    )));
+                }
             }
             if marker_is_unreachable(&self.lock.requires_python, marker.combined()) {
                 continue;
@@ -1888,6 +2294,15 @@ impl Lock {
     pub fn without_package_metadata(mut self) -> Self {
         self.revision = METADATA_FREE_REVISION;
         for package in &mut self.packages {
+            for extra in &package.metadata.provides_extra {
+                package
+                    .optional_dependencies
+                    .entry(extra.clone())
+                    .or_default();
+            }
+            for group in package.metadata.dependency_groups.keys() {
+                package.dependency_groups.entry(group.clone()).or_default();
+            }
             package.metadata = PackageMetadata::default();
         }
         self
@@ -2797,6 +3212,51 @@ impl Lock {
         missing_metadata: bool,
         expected: &ExpectedPackageDependencies,
     ) -> Result<SatisfiesResult<'lock>, LockError> {
+        if missing_metadata && expected.is_workspace_package() {
+            let expected_extras = expected
+                .provides_extra
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let actual_extras = package
+                .optional_dependencies
+                .keys()
+                .collect::<BTreeSet<_>>();
+            if expected_extras.iter().collect::<BTreeSet<_>>() != actual_extras {
+                return Ok(SatisfiesResult::MismatchedPackageProvidesExtra(
+                    &package.id.name,
+                    package.id.version.as_ref(),
+                    expected_extras,
+                    actual_extras,
+                ));
+            }
+
+            let expected_groups = expected.dependency_groups.keys().collect::<BTreeSet<_>>();
+            let actual_groups = package.dependency_groups.keys().collect::<BTreeSet<_>>();
+            if expected_groups != actual_groups {
+                let actual = package
+                    .dependency_groups
+                    .keys()
+                    .map(|group| {
+                        (
+                            group.clone(),
+                            expected
+                                .dependency_groups
+                                .get(group)
+                                .cloned()
+                                .unwrap_or_default(),
+                        )
+                    })
+                    .collect();
+                return Ok(SatisfiesResult::MismatchedPackageDependencyGroups(
+                    &package.id.name,
+                    package.id.version.as_ref(),
+                    expected.dependency_groups.clone(),
+                    actual,
+                ));
+            }
+        }
+
         // Use the same dependency builder as lockfile construction, including extra
         // activation for packages whose metadata does not need to be regenerated.
         for context in expected.contexts() {
@@ -2898,7 +3358,9 @@ impl Lock {
                                 .and(payload_marker),
                         ) && (generated_forbidden_conflict.is_false() || {
                             let mut forbidden = UniversalMarker::from_combined(
-                                actual_conflict.and(*generated_forbidden_conflict),
+                                actual_conflict
+                                    .and(*generated_forbidden_conflict)
+                                    .and(activation.marker.combined()),
                             );
                             forbidden.and(UniversalMarker::new(
                                 MarkerTree::TRUE,
@@ -5097,6 +5559,13 @@ impl Package {
     /// Returns the extras the package provides, if any.
     pub fn provides_extras(&self) -> &[ExtraName] {
         &self.metadata.provides_extra
+    }
+
+    /// Return whether a declared extra has any resolved dependency edges.
+    fn has_extra_payload(&self, extra: &ExtraName) -> bool {
+        self.optional_dependencies
+            .get(extra)
+            .is_some_and(|dependencies| !dependencies.is_empty())
     }
 
     /// Returns the dependency groups the package provides, if any.

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -483,7 +483,7 @@ impl<'a> LockedDependencyBuilder<'a> {
         dependencies: &mut Vec<Dependency>,
         expected: &ExpectedPackageDependencies<'_>,
         context: DependencyContext<'_>,
-        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>>,
+        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>>,
     ) -> Result<bool, LockError> {
         let empty_requirements = BTreeSet::new();
         let requirements = match context {
@@ -565,11 +565,11 @@ impl<'a> LockedDependencyBuilder<'a> {
                 covered_marker = covered_marker.or(marker.combined());
 
                 let activated = activated_extras.entry(dependency.id.clone()).or_default();
-                let activation_marker = marker.pep508();
+                let activation_marker = marker;
                 for extra in &requirement.extras {
                     activated
                         .entry(extra.clone())
-                        .and_modify(|existing| *existing = existing.or(activation_marker))
+                        .and_modify(|existing| existing.or(activation_marker))
                         .or_insert(activation_marker);
                 }
 
@@ -663,8 +663,8 @@ struct ExpectedPackageDependencies<'lock> {
     declarations: BTreeSet<Requirement>,
     provides_extra: &'lock [ExtraName],
     dependency_groups: BTreeMap<GroupName, BTreeSet<Requirement>>,
-    /// The marker environments in which each requested extra is active.
-    activated_extras: BTreeMap<ExtraName, MarkerTree>,
+    /// The marker environments and conflict contexts in which each requested extra is active.
+    activated_extras: BTreeMap<ExtraName, UniversalMarker>,
     /// The environment under which this package can be selected.
     package_marker: UniversalMarker,
     /// The package environment before platform-specific source forks are applied.
@@ -685,7 +685,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         package_requires_python: Option<&VersionSpecifiers>,
         package_version: Option<&Version>,
         package: &'lock Package,
-        activated_extras: BTreeMap<ExtraName, MarkerTree>,
+        activated_extras: BTreeMap<ExtraName, UniversalMarker>,
         workspace_root: &'lock Path,
     ) -> Self {
         let package_context = package_version.map(|version| (&package.id.name, version));
@@ -869,7 +869,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         if let DependencyContext::Extra(extra) = context
             && let Some(marker) = self.activated_extras.get(extra)
         {
-            parent_marker.and(UniversalMarker::from_combined(*marker));
+            parent_marker.and(UniversalMarker::from_combined(marker.pep508()));
         }
 
         if self.lock.conflicts.is_empty() {
@@ -2052,7 +2052,7 @@ impl Lock {
         package_requires_python: Option<&VersionSpecifiers>,
         package_version: Option<&Version>,
         package: &'lock Package,
-        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>>,
+        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>>,
         remotes: &mut Option<BTreeSet<UrlString>>,
         locals: &mut Option<BTreeSet<Box<Path>>>,
         root: &Path,
@@ -2212,7 +2212,7 @@ impl Lock {
     fn satisfied_no_metadata<'lock>(
         &self,
         package: &'lock Package,
-        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>>,
+        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>>,
         missing_metadata: bool,
         expected: &ExpectedPackageDependencies,
     ) -> Result<SatisfiesResult<'lock>, LockError> {
@@ -2238,7 +2238,16 @@ impl Lock {
             let parent_marker = expected.context_parent_marker(context);
             // Conflict resolution retains source-fork predicates on child edges, even when the
             // parent package is reachable only within that fork.
-            let simplification_parent_marker = if self.conflicts.is_empty() {
+            let selected_extra = if let DependencyContext::Extra(extra) = context {
+                expected
+                    .activated_extras
+                    .get(extra)
+                    .is_some_and(|marker| marker.has_conflict_marker())
+                    && package.fork_markers.is_empty()
+            } else {
+                false
+            };
+            let simplification_parent_marker = if self.conflicts.is_empty() || selected_extra {
                 parent_marker
             } else {
                 expected.unforked_package_marker
@@ -2326,9 +2335,9 @@ impl Lock {
             allow_missing_package_metadata && self.supports_missing_package_metadata();
         let mut queue: VecDeque<&Package> = VecDeque::new();
         let mut seen = FxHashSet::default();
-        let mut activated_extras: FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>> =
+        let mut activated_extras: FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>> =
             FxHashMap::default();
-        let mut validated_extras: FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>> =
+        let mut validated_extras: FxHashMap<PackageId, BTreeMap<ExtraName, UniversalMarker>> =
             FxHashMap::default();
 
         // Validate that the lockfile was generated with the same root members.
@@ -2657,8 +2666,10 @@ impl Lock {
                     for extra in &requirement.extras {
                         activated
                             .entry(extra.clone())
-                            .and_modify(|existing| *existing = existing.or(marker))
-                            .or_insert(marker);
+                            .and_modify(|existing| {
+                                existing.or(UniversalMarker::from_combined(marker));
+                            })
+                            .or_insert_with(|| UniversalMarker::from_combined(marker));
                     }
 
                     if seen.insert(&package.id) {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -796,7 +796,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             .chain(groups.into_iter().map(DependencyContext::Group))
     }
 
-    /// Preserve source, requested-extra, and workspace-project conflicts on resolved edges.
+    /// Preserve selected, source, requested-extra, and workspace-project conflicts on resolved edges.
     fn requirement_conflict_marker(
         &self,
         context: DependencyContext<'_>,
@@ -820,14 +820,18 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             .conflicts
             .contains(&requirement.name, ConflictKindRef::Project)
             .then(|| ConflictItem::from(requirement.name.clone()));
+        let selected = context.selected_conflict(&self.package.id.name, &self.lock.conflicts);
         let mut conflicts = source_conflict
             .cloned()
             .into_iter()
             .chain(requested_conflicts)
             .chain(requested_project)
             .peekable();
-        conflicts.peek()?;
-        let selected = context.selected_conflict(&self.package.id.name, &self.lock.conflicts);
+        // A selected parent conflict is retained on requested-extra edges, but ordinary
+        // dependencies omit the redundant parent marker.
+        if conflicts.peek().is_none() && (selected.is_none() || requirement.extras.is_empty()) {
+            return None;
+        }
         let mut marker = UniversalMarker::TRUE;
         for conflict in conflicts.chain(selected) {
             marker.and(UniversalMarker::new(

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1309,15 +1309,20 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         package: &'lock Package,
         activated_package: ActivatedPackage,
         workspace_root: &'lock Path,
+        declarations_preprocessed: bool,
     ) -> Self {
         let package_context = package_version.map(|version| (&package.id.name, version));
-        let declarations = overrides
-            .apply_for_package(package_context, declarations)
-            .filter(|requirement| {
-                !excludes.contains_for_package(package_context, &requirement.name)
-            })
-            .map(Cow::into_owned)
-            .collect::<BTreeSet<_>>();
+        let declarations = if declarations_preprocessed {
+            declarations.clone()
+        } else {
+            overrides
+                .apply_for_package(package_context, declarations)
+                .filter(|requirement| {
+                    !excludes.contains_for_package(package_context, &requirement.name)
+                })
+                .map(Cow::into_owned)
+                .collect::<BTreeSet<_>>()
+        };
         let dependency_groups = dependency_groups
             .iter()
             .map(|(group, requirements)| {
@@ -2293,6 +2298,7 @@ impl Lock {
     #[must_use]
     pub fn without_package_metadata(mut self) -> Self {
         self.revision = METADATA_FREE_REVISION;
+        let root = self.root().map(|package| package.id.clone());
         for package in &mut self.packages {
             for extra in &package.metadata.provides_extra {
                 package
@@ -2300,8 +2306,12 @@ impl Lock {
                     .entry(extra.clone())
                     .or_default();
             }
-            for group in package.metadata.dependency_groups.keys() {
-                package.dependency_groups.entry(group.clone()).or_default();
+            if self.manifest.members.contains(&package.id.name)
+                || root.as_ref().is_some_and(|id| id == &package.id)
+            {
+                for group in package.metadata.dependency_groups.keys() {
+                    package.dependency_groups.entry(group.clone()).or_default();
+                }
             }
             package.metadata = PackageMetadata::default();
         }
@@ -3181,6 +3191,7 @@ impl Lock {
                 package,
                 package_activation,
                 root,
+                missing_metadata,
             );
             match self.satisfied_no_metadata(
                 package,
@@ -3313,6 +3324,13 @@ impl Lock {
                 expected.comparable_dependencies(&generated, context, activation, conflicts);
             let actual_comparable =
                 expected.comparable_dependencies(actual, context, activation, conflicts);
+            // Production edges must retain their project selection even in a conflicting group
+            // world, rather than hiding a missing project marker behind the current activation.
+            let forbidden_environment = if matches!(context, DependencyContext::Production) {
+                activation.marker.pep508()
+            } else {
+                activation.marker.combined()
+            };
             let equivalent = generated_comparable.len() == actual_comparable.len()
                 && generated_comparable.iter().zip(&actual_comparable).all(
                     |(
@@ -3360,7 +3378,7 @@ impl Lock {
                             let mut forbidden = UniversalMarker::from_combined(
                                 actual_conflict
                                     .and(*generated_forbidden_conflict)
-                                    .and(activation.marker.combined()),
+                                    .and(forbidden_environment),
                             );
                             forbidden.and(UniversalMarker::new(
                                 MarkerTree::TRUE,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -483,7 +483,7 @@ impl<'a> LockedDependencyBuilder<'a> {
         dependencies: &mut Vec<Dependency>,
         expected: &ExpectedPackageDependencies<'_>,
         context: DependencyContext<'_>,
-        activated_extras: &mut FxHashMap<PackageId, BTreeSet<ExtraName>>,
+        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>>,
     ) -> Result<bool, LockError> {
         let empty_requirements = BTreeSet::new();
         let requirements = match context {
@@ -564,10 +564,14 @@ impl<'a> LockedDependencyBuilder<'a> {
                 }
                 covered_marker = covered_marker.or(marker.combined());
 
-                activated_extras
-                    .entry(dependency.id.clone())
-                    .or_default()
-                    .extend(requirement.extras.iter().cloned());
+                let activated = activated_extras.entry(dependency.id.clone()).or_default();
+                let activation_marker = marker.pep508();
+                for extra in &requirement.extras {
+                    activated
+                        .entry(extra.clone())
+                        .and_modify(|existing| *existing = existing.or(activation_marker))
+                        .or_insert(activation_marker);
+                }
 
                 let extras = requirement
                     .extras
@@ -659,7 +663,8 @@ struct ExpectedPackageDependencies<'lock> {
     declarations: BTreeSet<Requirement>,
     provides_extra: &'lock [ExtraName],
     dependency_groups: BTreeMap<GroupName, BTreeSet<Requirement>>,
-    activated_extras: BTreeSet<ExtraName>,
+    /// The marker environments in which each requested extra is active.
+    activated_extras: BTreeMap<ExtraName, MarkerTree>,
     /// The environment under which this package can be selected.
     package_marker: UniversalMarker,
     /// The package environment before platform-specific source forks are applied.
@@ -680,7 +685,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         package_requires_python: Option<&VersionSpecifiers>,
         package_version: Option<&Version>,
         package: &'lock Package,
-        activated_extras: BTreeSet<ExtraName>,
+        activated_extras: BTreeMap<ExtraName, MarkerTree>,
         workspace_root: &'lock Path,
     ) -> Self {
         let package_context = package_version.map(|version| (&package.id.name, version));
@@ -788,7 +793,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         let extras = self
             .provides_extra
             .iter()
-            .filter(|extra| is_workspace_package || self.activated_extras.contains(*extra))
+            .filter(|extra| is_workspace_package || self.activated_extras.contains_key(*extra))
             .chain(self.package.optional_dependencies.keys())
             .collect::<BTreeSet<_>>();
         let groups = self
@@ -860,7 +865,14 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
     /// Restore the resolver node's conflict context, if it is reachable.
     fn context_parent_marker(&self, context: DependencyContext<'_>) -> UniversalMarker {
         if self.lock.conflicts.is_empty() {
-            return self.package_marker;
+            let mut parent_marker = self.package_marker;
+            // An extra is reachable only where at least one incoming edge activates it.
+            if let DependencyContext::Extra(extra) = context
+                && let Some(marker) = self.activated_extras.get(extra)
+            {
+                parent_marker.and(UniversalMarker::from_combined(*marker));
+            }
+            return parent_marker;
         }
 
         let project_conflicts = self
@@ -2040,7 +2052,7 @@ impl Lock {
         package_requires_python: Option<&VersionSpecifiers>,
         package_version: Option<&Version>,
         package: &'lock Package,
-        activated_extras: &mut FxHashMap<PackageId, BTreeSet<ExtraName>>,
+        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>>,
         remotes: &mut Option<BTreeSet<UrlString>>,
         locals: &mut Option<BTreeSet<Box<Path>>>,
         root: &Path,
@@ -2200,7 +2212,7 @@ impl Lock {
     fn satisfied_no_metadata<'lock>(
         &self,
         package: &'lock Package,
-        activated_extras: &mut FxHashMap<PackageId, BTreeSet<ExtraName>>,
+        activated_extras: &mut FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>>,
         missing_metadata: bool,
         expected: &ExpectedPackageDependencies,
     ) -> Result<SatisfiesResult<'lock>, LockError> {
@@ -2314,8 +2326,10 @@ impl Lock {
             allow_missing_package_metadata && self.supports_missing_package_metadata();
         let mut queue: VecDeque<&Package> = VecDeque::new();
         let mut seen = FxHashSet::default();
-        let mut activated_extras: FxHashMap<PackageId, BTreeSet<ExtraName>> = FxHashMap::default();
-        let mut validated_extras: FxHashMap<PackageId, BTreeSet<ExtraName>> = FxHashMap::default();
+        let mut activated_extras: FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>> =
+            FxHashMap::default();
+        let mut validated_extras: FxHashMap<PackageId, BTreeMap<ExtraName, MarkerTree>> =
+            FxHashMap::default();
 
         // Validate that the lockfile was generated with the same root members.
         {
@@ -2639,10 +2653,13 @@ impl Lock {
                         continue;
                     }
 
-                    activated_extras
-                        .entry(package.id.clone())
-                        .or_default()
-                        .extend(requirement.extras.iter().cloned());
+                    let activated = activated_extras.entry(package.id.clone()).or_default();
+                    for extra in &requirement.extras {
+                        activated
+                            .entry(extra.clone())
+                            .and_modify(|existing| *existing = existing.or(marker))
+                            .or_insert(marker);
+                    }
 
                     if seen.insert(&package.id) {
                         queue.push_back(package);
@@ -3034,7 +3051,7 @@ impl Lock {
                 let needs_extra_validation = validated_extras
                     .get(&dependency.package_id)
                     .zip(activated_extras.get(&dependency.package_id))
-                    .is_some_and(|(validated, activated)| !activated.is_subset(validated));
+                    .is_some_and(|(validated, activated)| validated != activated);
                 if seen.insert(&dependency.package_id) || needs_extra_validation {
                     let dependency_package = self.find_by_id(&dependency.package_id);
                     queue.push_back(dependency_package);

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -457,6 +457,7 @@ struct LockedDependencyBuilder<'a> {
     requires_python: &'a RequiresPython,
     environment: SimplifiedMarkerTree,
     parent_marker: UniversalMarker,
+    simplification_parent_marker: UniversalMarker,
 }
 
 impl<'a> LockedDependencyBuilder<'a> {
@@ -464,11 +465,13 @@ impl<'a> LockedDependencyBuilder<'a> {
         requires_python: &'a RequiresPython,
         environment: SimplifiedMarkerTree,
         parent_marker: UniversalMarker,
+        simplification_parent_marker: UniversalMarker,
     ) -> Self {
         Self {
             requires_python,
             environment,
             parent_marker,
+            simplification_parent_marker,
         }
     }
 
@@ -609,7 +612,7 @@ impl<'a> LockedDependencyBuilder<'a> {
         let simplified_marker = simplify_dependency_marker(
             self.requires_python,
             self.environment,
-            self.parent_marker,
+            self.simplification_parent_marker,
             marker,
         );
         let dependency =
@@ -659,6 +662,8 @@ struct ExpectedPackageDependencies<'lock> {
     activated_extras: BTreeSet<ExtraName>,
     /// The environment under which this package can be selected.
     package_marker: UniversalMarker,
+    /// The package environment before platform-specific source forks are applied.
+    unforked_package_marker: UniversalMarker,
     /// The environment of the resolution.
     lock_marker: SimplifiedMarkerTree,
     workspace_root: &'lock Path,
@@ -702,7 +707,13 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
 
         // The locked edges already encode conflicts. Expanding independent conflict sets here
         // would create an exponential marker product for ordinary production requirements.
-        let mut package_marker = UniversalMarker::from_combined(lock.fork_markers_union());
+        let mut unforked_package_marker = UniversalMarker::from_combined(lock.fork_markers_union());
+        if let Some(requires_python) = package_requires_python {
+            unforked_package_marker.and(UniversalMarker::from_combined(
+                RequiresPython::from_specifiers(requires_python.clone()).to_marker_tree(),
+            ));
+        }
+        let mut package_marker = unforked_package_marker;
         if !package.fork_markers.is_empty() {
             let fork_marker = package
                 .fork_markers
@@ -711,11 +722,6 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                     fork_marker.or(marker.combined())
                 });
             package_marker.and(UniversalMarker::from_combined(fork_marker));
-        }
-        if let Some(requires_python) = package_requires_python {
-            package_marker.and(UniversalMarker::from_combined(
-                RequiresPython::from_specifiers(requires_python.clone()).to_marker_tree(),
-            ));
         }
         let lock_marker =
             SimplifiedMarkerTree::new(&lock.requires_python, lock.fork_markers_union());
@@ -728,6 +734,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             dependency_groups,
             activated_extras,
             package_marker,
+            unforked_package_marker,
             lock_marker,
             workspace_root,
         }
@@ -827,9 +834,17 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             .chain(requested_conflicts)
             .chain(requested_project)
             .peekable();
-        // A selected parent conflict is retained on requested-extra edges, but ordinary
-        // dependencies omit the redundant parent marker.
-        if conflicts.peek().is_none() && (selected.is_none() || requirement.extras.is_empty()) {
+        // A selected parent conflict is retained on requested-extra and source-forked edges,
+        // but ordinary dependencies omit the redundant parent marker.
+        let source_variants = self.packages_for_name(&requirement.name);
+        let has_source_forks = source_variants.first().is_some_and(|first| {
+            source_variants
+                .iter()
+                .any(|package| package.id.source != first.id.source)
+        });
+        if conflicts.peek().is_none()
+            && (selected.is_none() || requirement.extras.is_empty() && !has_source_forks)
+        {
             return None;
         }
         let mut marker = UniversalMarker::TRUE;
@@ -2209,12 +2224,20 @@ impl Lock {
 
             // A false parent marker omits dependencies in unreachable conflict contexts.
             let parent_marker = expected.context_parent_marker(context);
+            // Conflict resolution retains source-fork predicates on child edges, even when the
+            // parent package is reachable only within that fork.
+            let simplification_parent_marker = if self.conflicts.is_empty() {
+                parent_marker
+            } else {
+                expected.unforked_package_marker
+            };
 
             let mut generated = Vec::new();
             let builder = LockedDependencyBuilder::new(
                 &self.requires_python,
                 expected.lock_marker,
                 parent_marker,
+                simplification_parent_marker,
             );
             let complete =
                 builder.add_requirements(&mut generated, expected, context, activated_extras)?;
@@ -3646,7 +3669,12 @@ impl Package {
         root: &Path,
     ) -> Result<(), LockError> {
         let parent_marker = *resolution.graph[node_index].marker();
-        let builder = LockedDependencyBuilder::new(requires_python, environment, parent_marker);
+        let builder = LockedDependencyBuilder::new(
+            requires_python,
+            environment,
+            parent_marker,
+            parent_marker,
+        );
         for edge in resolution.graph.edges(node_index) {
             let ResolutionGraphNode::Dist(distribution) = &resolution.graph[edge.target()] else {
                 continue;

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2041,8 +2041,21 @@ impl Lock {
 
         // Special-case: if the version is dynamic, compare the flattened requirements.
         let flattened = if package.is_dynamic() || missing_metadata {
+            let requirements = if missing_metadata {
+                let package_context = package_version.map(|version| (&package.id.name, version));
+                // The resolver excludes recursive self-requirements before flattening extras.
+                requires_dist
+                    .iter()
+                    .filter(|requirement| {
+                        !excludes.contains_for_package(package_context, &requirement.name)
+                    })
+                    .cloned()
+                    .collect()
+            } else {
+                requires_dist.clone()
+            };
             Some(
-                FlatRequiresDist::from_requirements(requires_dist.clone(), &package.id.name)
+                FlatRequiresDist::from_requirements(requirements, &package.id.name)
                     .into_iter()
                     .map(|requirement| {
                         normalize_requirement(requirement, root, &self.requires_python)

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -878,7 +878,10 @@ impl<'a> LockedDependencyBuilder<'a> {
             // Check that we cover at least the required marker.
             let mut coverage_marker = UniversalMarker::from_combined(required_marker);
             coverage_marker.and(self.activation.marker);
-            if !expected.lock.conflicts.is_empty() {
+            if !expected.lock.conflicts.is_empty()
+                && (coverage_marker.has_conflict_marker()
+                    || UniversalMarker::from_combined(covered_marker).has_conflict_marker())
+            {
                 coverage_marker.and(UniversalMarker::new(
                     MarkerTree::TRUE,
                     ConflictMarker::from_conflicts(&expected.lock.conflicts),
@@ -1220,24 +1223,6 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             })
         });
 
-        let mut world = UniversalMarker::new(
-            MarkerTree::TRUE,
-            ConflictMarker::from_conflicts(&self.lock.conflicts),
-        );
-        if project_conflicts
-            && !matches!(context, DependencyContext::Group(_))
-            && !selected_conflicts_with_project
-        {
-            world.assume_conflict_item(&project);
-        }
-        if let Some(selected) = &selected {
-            world.assume_conflict_item(selected);
-        }
-        // https://github.com/astral-sh/uv/issues/20694
-        if world.is_false() {
-            return UniversalMarker::FALSE;
-        }
-
         if project_conflicts && matches!(context, DependencyContext::Production) {
             let mut activation = UniversalMarker::new(
                 MarkerTree::TRUE,
@@ -1413,6 +1398,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         dependencies: &[Dependency],
         context: DependencyContext<'_>,
         activation: DependencyActivation,
+        apply_conflicts: bool,
     ) -> Vec<(
         PackageId,
         BTreeSet<ExtraName>,
@@ -1420,7 +1406,12 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         MarkerTree,
         MarkerTree,
     )> {
-        let conflicts = ConflictMarker::from_conflicts(&self.lock.conflicts);
+        if dependencies.is_empty() {
+            return Vec::new();
+        }
+
+        let conflicts = (!self.lock.conflicts.is_empty() && apply_conflicts)
+            .then(|| ConflictMarker::from_conflicts(&self.lock.conflicts));
         let mut comparable: BTreeMap<
             (PackageId, BTreeSet<ExtraName>),
             (MarkerTree, MarkerTree, MarkerTree),
@@ -1492,7 +1483,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             marker.and(UniversalMarker::from_combined(
                 self.lock.requires_python.to_marker_tree(),
             ));
-            if !self.lock.conflicts.is_empty() {
+            if let Some(conflicts) = conflicts {
                 marker.and(UniversalMarker::new(MarkerTree::TRUE, conflicts));
             }
             if marker_is_unreachable(&self.lock.requires_python, marker.combined()) {
@@ -2839,9 +2830,15 @@ impl Lock {
                 continue;
             }
             let actual = context.dependencies(package);
+            let apply_conflicts = activation.marker.has_conflict_marker()
+                || generated
+                    .iter()
+                    .chain(actual)
+                    .any(|dependency| dependency.complexified_marker.has_conflict_marker());
             let generated_comparable =
-                expected.comparable_dependencies(&generated, context, activation);
-            let actual_comparable = expected.comparable_dependencies(actual, context, activation);
+                expected.comparable_dependencies(&generated, context, activation, apply_conflicts);
+            let actual_comparable =
+                expected.comparable_dependencies(actual, context, activation, apply_conflicts);
             let equivalent = generated_comparable.len() == actual_comparable.len()
                 && generated_comparable.iter().zip(&actual_comparable).all(
                     |(
@@ -2885,16 +2882,19 @@ impl Lock {
                             actual_marker
                                 .and(generated_marker.negate())
                                 .and(payload_marker),
-                        ) && marker_is_unreachable(
-                            &self.requires_python,
-                            actual_conflict.and(*generated_forbidden_conflict).and(
-                                UniversalMarker::new(
-                                    MarkerTree::TRUE,
-                                    ConflictMarker::from_conflicts(&self.conflicts),
-                                )
-                                .combined(),
-                            ),
-                        )
+                        ) && (generated_forbidden_conflict.is_false() || {
+                            let forbidden = actual_conflict.and(*generated_forbidden_conflict);
+                            marker_is_unreachable(
+                                &self.requires_python,
+                                forbidden.and(
+                                    UniversalMarker::new(
+                                        MarkerTree::TRUE,
+                                        ConflictMarker::from_conflicts(&self.conflicts),
+                                    )
+                                    .combined(),
+                                ),
+                            )
+                        })
                     },
                 );
             if !complete || !equivalent {
@@ -3763,17 +3763,22 @@ impl Lock {
         }
 
         for (package_id, activation) in activated_packages {
-            let unauthorized = activation
+            let mut unauthorized = activation
                 .source_authority_required
                 .combined()
-                .and(activation.source_marker.combined().negate())
-                .and(
+                .and(activation.source_marker.combined().negate());
+            if unauthorized.is_false() {
+                continue;
+            }
+            if !self.conflicts.is_empty() {
+                unauthorized = unauthorized.and(
                     UniversalMarker::new(
                         MarkerTree::TRUE,
                         ConflictMarker::from_conflicts(&self.conflicts),
                     )
                     .combined(),
                 );
+            }
             if !marker_is_unreachable(&self.requires_python, unauthorized) {
                 let package = self.find_by_id(&package_id);
                 return Ok(SatisfiesResult::MismatchedPackageDependencies(

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3478,13 +3478,36 @@ impl Lock {
                                         .and(*generated_forbidden_conflict)
                                         .and(forbidden_environment),
                                 );
-                                forbidden.and(UniversalMarker::new(
-                                    MarkerTree::TRUE,
-                                    ConflictMarker::from_relevant_conflicts(
-                                        &self.conflicts,
-                                        [forbidden],
-                                    ),
-                                ));
+                                // Production edges must retain the selected project marker.
+                                // In other contexts, compare only worlds the actual edge adds;
+                                // canonical edges may also contain impossible conflict products.
+                                if matches!(context, DependencyContext::Production)
+                                    && actual_conflict.is_true()
+                                {
+                                    forbidden.and(UniversalMarker::new(
+                                        MarkerTree::TRUE,
+                                        ConflictMarker::from_relevant_conflicts(
+                                            &self.conflicts,
+                                            [forbidden],
+                                        ),
+                                    ));
+                                } else {
+                                    forbidden.and(UniversalMarker::from_combined(
+                                        actual_marker.and(generated_marker.negate()),
+                                    ));
+                                    forbidden.and(UniversalMarker::new(
+                                        MarkerTree::TRUE,
+                                        ConflictMarker::from_relevant_conflicts(
+                                            &self.conflicts,
+                                            [
+                                                forbidden,
+                                                activation.marker,
+                                                UniversalMarker::from_combined(*generated_marker),
+                                                UniversalMarker::from_combined(*actual_marker),
+                                            ],
+                                        ),
+                                    ));
+                                }
                                 marker_is_unreachable(&self.requires_python, forbidden.combined())
                             })
                     },

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2043,13 +2043,14 @@ impl Lock {
         let flattened = if package.is_dynamic() || missing_metadata {
             let requirements = if missing_metadata {
                 let package_context = package_version.map(|version| (&package.id.name, version));
-                // The resolver excludes recursive self-requirements before flattening extras.
-                requires_dist
-                    .iter()
+                // The resolver applies overrides and exclusions before flattening recursive
+                // self-requirements.
+                overrides
+                    .apply_for_package(package_context, requires_dist.iter())
                     .filter(|requirement| {
                         !excludes.contains_for_package(package_context, &requirement.name)
                     })
-                    .cloned()
+                    .map(Cow::into_owned)
                     .collect()
             } else {
                 requires_dist.clone()

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -837,6 +837,7 @@ impl<'a> LockedDependencyBuilder<'a> {
                         requirement.source,
                         RequirementSource::Registry { index: None, .. }
                     )
+                    && !matches!(dependency.id.source, Source::Registry(_))
                     && let Some(activation) = activated_packages.get(&dependency.id)
                 {
                     marker.and(activation.marker);
@@ -1688,6 +1689,9 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                         ))),
                     ));
                 }
+            }
+            if !self.is_workspace_package() {
+                activation.or(self.activated_package.marker);
             }
             parent_marker.and(activation);
         } else if project_conflicts
@@ -3484,6 +3488,20 @@ impl Lock {
                                 if matches!(context, DependencyContext::Production)
                                     && actual_conflict.is_true()
                                 {
+                                    let actual_raw_marker = actual
+                                        .iter()
+                                        .filter(|dependency| {
+                                            &dependency.package_id == actual_package
+                                                && &dependency.extra == actual_extras
+                                        })
+                                        .fold(MarkerTree::FALSE, |marker, dependency| {
+                                            marker.or(dependency.complexified_marker.combined())
+                                        });
+                                    forbidden
+                                        .and(UniversalMarker::from_combined(actual_raw_marker));
+                                    forbidden.and(UniversalMarker::from_combined(
+                                        generated_marker.negate(),
+                                    ));
                                     forbidden.and(UniversalMarker::new(
                                         MarkerTree::TRUE,
                                         ConflictMarker::from_relevant_conflicts(

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -871,6 +871,16 @@ impl<'a> LockedDependencyBuilder<'a> {
                             selected.or(existing.complexified_marker);
                             selected
                         });
+                    for extra in requirement
+                        .extras
+                        .iter()
+                        .filter(|extra| !dependency.has_extra_payload(extra))
+                    {
+                        selected.assume_not_conflict_item(&ConflictItem::from((
+                            dependency.id.name.clone(),
+                            extra.clone(),
+                        )));
+                    }
                     if selected.is_false() {
                         continue;
                     }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -855,6 +855,36 @@ impl<'a> LockedDependencyBuilder<'a> {
                     base_edge_marker.and(UniversalMarker::from_combined(dependency_marker));
                     requested_edge_marker.and(UniversalMarker::from_combined(dependency_marker));
                 }
+                if matches!(dependency.id.source, Source::Registry(_))
+                    && candidates.iter().any(|candidate| {
+                        candidate.id != dependency.id && candidate.id.source == dependency.id.source
+                    })
+                {
+                    // Package-level forks lose impossible conflict combinations when projected
+                    // into PEP 508 environments. Resolved edges retain the per-context selection
+                    // between otherwise compatible versions from the same registry.
+                    let mut selected = context
+                        .dependencies(expected.package)
+                        .iter()
+                        .filter(|existing| existing.package_id == dependency.id)
+                        .fold(UniversalMarker::FALSE, |mut selected, existing| {
+                            selected.or(existing.complexified_marker);
+                            selected
+                        });
+                    if selected.is_false() {
+                        continue;
+                    }
+                    selected.and(UniversalMarker::new(
+                        MarkerTree::TRUE,
+                        ConflictMarker::from_relevant_conflicts(
+                            &expected.lock.conflicts,
+                            [selected],
+                        ),
+                    ));
+                    marker.and(selected);
+                    base_edge_marker.and(selected);
+                    requested_edge_marker.and(selected);
+                }
                 if marker.is_false() {
                     continue;
                 }
@@ -1103,6 +1133,47 @@ impl<'a> LockedDependencyBuilder<'a> {
             // Check that we cover at least the required marker.
             let mut coverage_marker = UniversalMarker::from_combined(required_marker);
             coverage_marker.and(self.activation.marker);
+            if matches!(context, DependencyContext::Group(_))
+                && requirement
+                    .extras
+                    .iter()
+                    .all(|extra| !project_conflicts_with_extra(extra))
+            {
+                let mut selected_marker = MarkerTree::FALSE;
+                let mut selected_world = UniversalMarker::FALSE;
+                for candidate in requirements
+                    .iter()
+                    .filter(|candidate| candidate.name == requirement.name)
+                {
+                    for extra in candidate
+                        .extras
+                        .iter()
+                        .filter(|extra| project_conflicts_with_extra(extra))
+                    {
+                        let marker = context.requirement_marker(candidate);
+                        selected_marker = selected_marker.or(marker);
+                        let mut world = UniversalMarker::new(
+                            MarkerTree::TRUE,
+                            ConflictMarker::from_conflict_item(&ConflictItem::from(
+                                requirement.name.clone(),
+                            )),
+                        );
+                        world.or(UniversalMarker::new(
+                            MarkerTree::TRUE,
+                            ConflictMarker::from_conflict_item(&ConflictItem::from((
+                                requirement.name.clone(),
+                                extra.clone(),
+                            ))),
+                        ));
+                        world.and(UniversalMarker::from_combined(marker));
+                        selected_world.or(world);
+                    }
+                }
+                if !selected_world.is_false() {
+                    selected_world.or(UniversalMarker::from_combined(selected_marker.negate()));
+                    coverage_marker.and(selected_world);
+                }
+            }
             if !expected.lock.conflicts.is_empty()
                 && (coverage_marker.has_conflict_marker()
                     || UniversalMarker::from_combined(covered_marker).has_conflict_marker())

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -941,6 +941,42 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         parent_marker
     }
 
+    /// Choose the resolver-node context used to simplify a regenerated dependency edge.
+    fn simplification_parent_marker(
+        &self,
+        context: DependencyContext<'_>,
+        parent_marker: UniversalMarker,
+    ) -> UniversalMarker {
+        if self.lock.conflicts.is_empty() {
+            return parent_marker;
+        }
+
+        let DependencyContext::Extra(extra) = context else {
+            return self.unforked_package_marker;
+        };
+        let Some(activation) = self.activated_extras.get(extra) else {
+            return self.unforked_package_marker;
+        };
+        if !activation.has_conflict_marker() || !self.package.fork_markers.is_empty() {
+            return self.unforked_package_marker;
+        }
+
+        let activation_marker =
+            SimplifiedMarkerTree::new(&self.lock.requires_python, activation.pep508())
+                .as_simplified_marker_tree();
+        let selects_resolution_fork = self.lock.fork_markers.iter().any(|fork_marker| {
+            let fork_marker =
+                SimplifiedMarkerTree::new(&self.lock.requires_python, fork_marker.pep508())
+                    .as_simplified_marker_tree();
+            !fork_marker.is_true() && activation_marker.is_disjoint(fork_marker.negate())
+        });
+        if selects_resolution_fork {
+            self.unforked_package_marker
+        } else {
+            parent_marker
+        }
+    }
+
     /// Return dependency identities and complete markers, including encoded conflict predicates.
     fn comparable_dependencies(
         &self,
@@ -2258,22 +2294,8 @@ impl Lock {
 
             // A false parent marker omits dependencies in unreachable conflict contexts.
             let parent_marker = expected.context_parent_marker(context);
-            // Conflict resolution retains source-fork predicates on child edges, even when the
-            // parent package is reachable only within that fork.
-            let selected_extra = if let DependencyContext::Extra(extra) = context {
-                expected
-                    .activated_extras
-                    .get(extra)
-                    .is_some_and(|marker| marker.has_conflict_marker())
-                    && package.fork_markers.is_empty()
-            } else {
-                false
-            };
-            let simplification_parent_marker = if self.conflicts.is_empty() || selected_extra {
-                parent_marker
-            } else {
-                expected.unforked_package_marker
-            };
+            let simplification_parent_marker =
+                expected.simplification_parent_marker(context, parent_marker);
 
             let mut generated = Vec::new();
             let builder = LockedDependencyBuilder::new(

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -673,15 +673,12 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         overrides: &Overrides,
         excludes: &Excludes,
         package_requires_python: Option<&VersionSpecifiers>,
+        package_version: Option<&Version>,
         package: &'lock Package,
         activated_extras: BTreeSet<ExtraName>,
         workspace_root: &'lock Path,
     ) -> Self {
-        let package_context = package
-            .id
-            .version
-            .as_ref()
-            .map(|version| (&package.id.name, version));
+        let package_context = package_version.map(|version| (&package.id.name, version));
         let declarations = overrides
             .apply_for_package(package_context, declarations)
             .filter(|requirement| {
@@ -2022,6 +2019,7 @@ impl Lock {
         overrides: &Overrides,
         excludes: &Excludes,
         package_requires_python: Option<&VersionSpecifiers>,
+        package_version: Option<&Version>,
         package: &'lock Package,
         activated_extras: &mut FxHashMap<PackageId, BTreeSet<ExtraName>>,
         remotes: &mut Option<BTreeSet<UrlString>>,
@@ -2138,6 +2136,7 @@ impl Lock {
                 overrides,
                 excludes,
                 package_requires_python,
+                package_version,
                 package,
                 package_activated_extras,
                 root,
@@ -2705,6 +2704,7 @@ impl Lock {
                             &dependency_overrides,
                             &dependency_excludes,
                             requires_python.as_ref(),
+                            Some(version),
                             package,
                             &mut activated_extras,
                             &mut remotes,
@@ -2803,6 +2803,7 @@ impl Lock {
                         &dependency_overrides,
                         &dependency_excludes,
                         metadata.requires_python.as_ref(),
+                        Some(&metadata.version),
                         package,
                         &mut activated_extras,
                         &mut remotes,
@@ -2824,8 +2825,15 @@ impl Lock {
                 // even if the version is dynamic, we can still extract the requirements without
                 // performing a build, unlike in the database where we typically construct a "complete"
                 // metadata object.
-                let metadata =
-                    Self::source_tree_requires_dist(source_tree, root, package, database).await?;
+                let metadata = if dependency_overrides.has_scoped_package(&package.id.name)
+                    || dependency_excludes.has_scoped_package(&package.id.name)
+                {
+                    // Package-scoped rules depend on the actual dynamic version, which is only
+                    // available from the built distribution metadata.
+                    None
+                } else {
+                    Self::source_tree_requires_dist(source_tree, root, package, database).await?
+                };
 
                 let satisfied = metadata.is_some_and(|SourceTreeRequiresDist {
                     requires_python,
@@ -2858,6 +2866,7 @@ impl Lock {
                         &dependency_overrides,
                         &dependency_excludes,
                         requires_python.as_ref(),
+                        None,
                         package,
                         &mut activated_extras,
                         &mut remotes,
@@ -2955,6 +2964,7 @@ impl Lock {
                         &dependency_overrides,
                         &dependency_excludes,
                         metadata.requires_python.as_ref(),
+                        Some(&metadata.version),
                         package,
                         &mut activated_extras,
                         &mut remotes,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1027,6 +1027,19 @@ impl<'a> LockedDependencyBuilder<'a> {
                         }
                     }
                 }
+                if has_source_forks
+                    && !self.source_is_covered(
+                        expected,
+                        context,
+                        requirement,
+                        requirements,
+                        &dependency.id,
+                        standalone_base_edge_marker,
+                    )
+                {
+                    complete = false;
+                }
+
                 if !extras.is_empty()
                     && !self.base_covered_by_requested_extras(
                         expected,
@@ -1121,6 +1134,83 @@ impl<'a> LockedDependencyBuilder<'a> {
             self.add(dependencies, package_id, extras, marker);
         }
         Ok(complete)
+    }
+
+    /// Return whether the locked edges cover every source-specific declaration world.
+    fn source_is_covered(
+        &self,
+        expected: &ExpectedPackageDependencies<'_>,
+        context: DependencyContext<'_>,
+        requirement: &Requirement,
+        requirements: &BTreeSet<Requirement>,
+        package_id: &PackageId,
+        base_marker: UniversalMarker,
+    ) -> bool {
+        let actual_marker = context
+            .dependencies(expected.package)
+            .iter()
+            .filter(|edge| edge.package_id == *package_id)
+            .fold(UniversalMarker::FALSE, |mut marker, edge| {
+                marker.or(edge.complexified_marker);
+                marker
+            });
+        let mut required_marker = base_marker;
+        for extra in &requirement.extras {
+            let selected = ConflictItem::from((package_id.name.clone(), extra.clone()));
+            let mut competing_marker = MarkerTree::FALSE;
+            for conflicts in expected
+                .lock
+                .conflicts
+                .iter()
+                .filter(|conflicts| conflicts.iter().any(|conflict| conflict == &selected))
+            {
+                for alternative in conflicts.iter().filter(|item| *item != &selected) {
+                    if alternative.package() == &expected.package.id.name {
+                        competing_marker = MarkerTree::TRUE;
+                        continue;
+                    }
+                    let ConflictKindRef::Extra(alternative_extra) = alternative.kind().as_ref()
+                    else {
+                        continue;
+                    };
+                    if alternative.package() != &package_id.name {
+                        continue;
+                    }
+                    for parent_extra in expected.provides_extra {
+                        for candidate in requirements.iter().filter(|candidate| {
+                            candidate.name == package_id.name
+                                && candidate.extras.contains(alternative_extra)
+                        }) {
+                            competing_marker = competing_marker
+                                .or(DependencyContext::Extra(parent_extra)
+                                    .requirement_marker(candidate));
+                        }
+                    }
+                }
+            }
+            if !competing_marker.is_false() {
+                let mut compatible = UniversalMarker::from_combined(competing_marker.negate());
+                compatible.or(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_conflict_item(&selected),
+                ));
+                required_marker.and(compatible);
+            }
+        }
+        required_marker.and(self.activation.marker);
+        required_marker.and(UniversalMarker::from_combined(
+            actual_marker.combined().negate(),
+        ));
+        if !expected.lock.conflicts.is_empty() {
+            required_marker.and(UniversalMarker::new(
+                MarkerTree::TRUE,
+                ConflictMarker::from_relevant_conflicts(
+                    &expected.lock.conflicts,
+                    [required_marker],
+                ),
+            ));
+        }
+        marker_is_unreachable(self.requires_python, required_marker.combined())
     }
 
     /// Return whether locked extra edges already activate their dependency's entire base marker.
@@ -3348,6 +3438,12 @@ impl Lock {
                             return false;
                         }
 
+                        let candidates = expected.packages_for_name(&generated_package.name);
+                        let has_source_forks = candidates.first().is_some_and(|first| {
+                            candidates
+                                .iter()
+                                .any(|candidate| candidate.id.source != first.id.source)
+                        });
                         let payload_marker = expected.selected_extra_payload_marker(
                             generated_package,
                             generated_extras,
@@ -3364,31 +3460,33 @@ impl Lock {
                             actual_marker
                                 .without_extras()
                                 .and(generated_marker.without_extras().negate()),
-                        ) && marker_is_unreachable(
-                            &self.requires_python,
-                            generated_marker
-                                .and(actual_marker.negate())
-                                .and(payload_marker),
-                        ) && marker_is_unreachable(
-                            &self.requires_python,
-                            actual_marker
-                                .and(generated_marker.negate())
-                                .and(payload_marker),
-                        ) && (generated_forbidden_conflict.is_false() || {
-                            let mut forbidden = UniversalMarker::from_combined(
-                                actual_conflict
-                                    .and(*generated_forbidden_conflict)
-                                    .and(forbidden_environment),
-                            );
-                            forbidden.and(UniversalMarker::new(
-                                MarkerTree::TRUE,
-                                ConflictMarker::from_relevant_conflicts(
-                                    &self.conflicts,
-                                    [forbidden],
-                                ),
-                            ));
-                            marker_is_unreachable(&self.requires_python, forbidden.combined())
-                        })
+                        ) && (has_source_forks
+                            || marker_is_unreachable(
+                                &self.requires_python,
+                                generated_marker
+                                    .and(actual_marker.negate())
+                                    .and(payload_marker),
+                            ) && marker_is_unreachable(
+                                &self.requires_python,
+                                actual_marker
+                                    .and(generated_marker.negate())
+                                    .and(payload_marker),
+                            ))
+                            && (generated_forbidden_conflict.is_false() || {
+                                let mut forbidden = UniversalMarker::from_combined(
+                                    actual_conflict
+                                        .and(*generated_forbidden_conflict)
+                                        .and(forbidden_environment),
+                                );
+                                forbidden.and(UniversalMarker::new(
+                                    MarkerTree::TRUE,
+                                    ConflictMarker::from_relevant_conflicts(
+                                        &self.conflicts,
+                                        [forbidden],
+                                    ),
+                                ));
+                                marker_is_unreachable(&self.requires_python, forbidden.combined())
+                            })
                     },
                 );
             if !complete || !equivalent {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -864,14 +864,15 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
 
     /// Restore the resolver node's conflict context, if it is reachable.
     fn context_parent_marker(&self, context: DependencyContext<'_>) -> UniversalMarker {
+        let mut parent_marker = self.package_marker;
+        // An extra is reachable only where at least one incoming edge activates it.
+        if let DependencyContext::Extra(extra) = context
+            && let Some(marker) = self.activated_extras.get(extra)
+        {
+            parent_marker.and(UniversalMarker::from_combined(*marker));
+        }
+
         if self.lock.conflicts.is_empty() {
-            let mut parent_marker = self.package_marker;
-            // An extra is reachable only where at least one incoming edge activates it.
-            if let DependencyContext::Extra(extra) = context
-                && let Some(marker) = self.activated_extras.get(extra)
-            {
-                parent_marker.and(UniversalMarker::from_combined(*marker));
-            }
             return parent_marker;
         }
 
@@ -897,7 +898,6 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             return UniversalMarker::FALSE;
         }
 
-        let mut parent_marker = self.package_marker;
         if project_conflicts && matches!(context, DependencyContext::Production) {
             let mut activation = UniversalMarker::new(
                 MarkerTree::TRUE,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -594,17 +594,23 @@ impl<'a> LockedDependencyBuilder<'a> {
                     )),
                 )
             });
-            let project_implies_extra = |extra: &ExtraName, project_marker: UniversalMarker| {
-                let mut alternatives = expected.conflicting_alternatives(&ConflictItem::from((
-                    requirement.name.clone(),
-                    extra.clone(),
-                )));
-                alternatives.and(project_marker);
-                alternatives.and(UniversalMarker::new(
-                    MarkerTree::TRUE,
-                    ConflictMarker::from_conflicts(&expected.lock.conflicts),
-                ));
-                marker_is_unreachable(self.requires_python, alternatives.combined())
+            let project_implies_extra = |extra: &ExtraName| {
+                let selected = ConflictItem::from((requirement.name.clone(), extra.clone()));
+                let project = ConflictItem::from(requirement.name.clone());
+                expected
+                    .lock
+                    .conflicts
+                    .iter()
+                    .filter(|conflicts| conflicts.contains(&requirement.name, extra))
+                    .flat_map(ConflictSet::iter)
+                    .filter(|alternative| *alternative != &selected)
+                    .all(|alternative| {
+                        alternative != &project
+                            && expected.lock.conflicts.iter().any(|conflicts| {
+                                conflicts.contains(&requirement.name, ConflictKindRef::Project)
+                                    && conflicts.iter().any(|conflict| conflict == alternative)
+                            })
+                    })
             };
             // Serialized graph edges omit empty or inactive conflict alternatives, but explicitly
             // requested selections still activate the target and must refresh its metadata.
@@ -780,9 +786,7 @@ impl<'a> LockedDependencyBuilder<'a> {
                             requested_edge_marker
                         };
                     if expected.lock.conflicts.contains(&requirement.name, extra)
-                        && project_conflict_marker.is_none_or(|project_conflict_marker| {
-                            !project_implies_extra(extra, project_conflict_marker)
-                        })
+                        && project_conflict_marker.is_none_or(|_| !project_implies_extra(extra))
                     {
                         extra_activation_marker.and(UniversalMarker::new(
                             MarkerTree::TRUE,
@@ -850,9 +854,8 @@ impl<'a> LockedDependencyBuilder<'a> {
                     for extra in extras {
                         let mut extra_marker = base_edge_marker;
                         if expected.lock.conflicts.contains(&requirement.name, &extra)
-                            && project_conflict_marker.is_none_or(|project_conflict_marker| {
-                                !project_implies_extra(&extra, project_conflict_marker)
-                            })
+                            && project_conflict_marker
+                                .is_none_or(|_| !project_implies_extra(&extra))
                         {
                             extra_marker.and(UniversalMarker::new(
                                 MarkerTree::TRUE,
@@ -884,7 +887,13 @@ impl<'a> LockedDependencyBuilder<'a> {
             {
                 coverage_marker.and(UniversalMarker::new(
                     MarkerTree::TRUE,
-                    ConflictMarker::from_conflicts(&expected.lock.conflicts),
+                    ConflictMarker::from_relevant_conflicts(
+                        &expected.lock.conflicts,
+                        [
+                            coverage_marker,
+                            UniversalMarker::from_combined(covered_marker),
+                        ],
+                    ),
                 ));
             }
             let covered_marker = SimplifiedMarkerTree::new(self.requires_python, covered_marker)
@@ -1288,7 +1297,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                 reachable_fork.and(*fork_marker);
                 reachable_fork.and(UniversalMarker::new(
                     MarkerTree::TRUE,
-                    ConflictMarker::from_conflicts(&self.lock.conflicts),
+                    ConflictMarker::from_relevant_conflicts(&self.lock.conflicts, [reachable_fork]),
                 ));
                 if !reachable_fork.is_false() {
                     selected_forks.or(*fork_marker);
@@ -1356,15 +1365,15 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             return MarkerTree::TRUE;
         }
 
-        let conflicts = UniversalMarker::new(
-            MarkerTree::TRUE,
-            ConflictMarker::from_conflicts(&self.lock.conflicts),
-        );
+        if extras.iter().any(|extra| {
+            !self.lock.conflicts.contains(&package.id.name, extra)
+                || !package.optional_dependencies.contains_key(extra)
+        }) {
+            return MarkerTree::TRUE;
+        }
+
         let mut payload_marker = MarkerTree::FALSE;
         for extra in extras {
-            if !self.lock.conflicts.contains(&package.id.name, extra) {
-                return MarkerTree::TRUE;
-            }
             let Some(dependencies) = package.optional_dependencies.get(extra) else {
                 return MarkerTree::TRUE;
             };
@@ -1374,7 +1383,10 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
                 let mut fork = *fork_marker;
                 fork.and(activation.marker);
                 fork.and(UniversalMarker::from_combined(environment));
-                fork.and(conflicts);
+                fork.and(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_relevant_conflicts(&self.lock.conflicts, [fork]),
+                ));
                 if marker_is_unreachable(&self.lock.requires_python, fork.combined()) {
                     continue;
                 }
@@ -1398,7 +1410,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         dependencies: &[Dependency],
         context: DependencyContext<'_>,
         activation: DependencyActivation,
-        apply_conflicts: bool,
+        conflicts: ConflictMarker,
     ) -> Vec<(
         PackageId,
         BTreeSet<ExtraName>,
@@ -1410,8 +1422,6 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             return Vec::new();
         }
 
-        let conflicts = (!self.lock.conflicts.is_empty() && apply_conflicts)
-            .then(|| ConflictMarker::from_conflicts(&self.lock.conflicts));
         let mut comparable: BTreeMap<
             (PackageId, BTreeSet<ExtraName>),
             (MarkerTree, MarkerTree, MarkerTree),
@@ -1483,7 +1493,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             marker.and(UniversalMarker::from_combined(
                 self.lock.requires_python.to_marker_tree(),
             ));
-            if let Some(conflicts) = conflicts {
+            if !conflicts.is_true() {
                 marker.and(UniversalMarker::new(MarkerTree::TRUE, conflicts));
             }
             if marker_is_unreachable(&self.lock.requires_python, marker.combined()) {
@@ -2830,15 +2840,19 @@ impl Lock {
                 continue;
             }
             let actual = context.dependencies(package);
-            let apply_conflicts = activation.marker.has_conflict_marker()
-                || generated
-                    .iter()
-                    .chain(actual)
-                    .any(|dependency| dependency.complexified_marker.has_conflict_marker());
+            let conflicts = ConflictMarker::from_relevant_conflicts(
+                &self.conflicts,
+                std::iter::once(activation.marker).chain(
+                    generated
+                        .iter()
+                        .chain(actual)
+                        .map(|dependency| dependency.complexified_marker),
+                ),
+            );
             let generated_comparable =
-                expected.comparable_dependencies(&generated, context, activation, apply_conflicts);
+                expected.comparable_dependencies(&generated, context, activation, conflicts);
             let actual_comparable =
-                expected.comparable_dependencies(actual, context, activation, apply_conflicts);
+                expected.comparable_dependencies(actual, context, activation, conflicts);
             let equivalent = generated_comparable.len() == actual_comparable.len()
                 && generated_comparable.iter().zip(&actual_comparable).all(
                     |(
@@ -2883,17 +2897,17 @@ impl Lock {
                                 .and(generated_marker.negate())
                                 .and(payload_marker),
                         ) && (generated_forbidden_conflict.is_false() || {
-                            let forbidden = actual_conflict.and(*generated_forbidden_conflict);
-                            marker_is_unreachable(
-                                &self.requires_python,
-                                forbidden.and(
-                                    UniversalMarker::new(
-                                        MarkerTree::TRUE,
-                                        ConflictMarker::from_conflicts(&self.conflicts),
-                                    )
-                                    .combined(),
+                            let mut forbidden = UniversalMarker::from_combined(
+                                actual_conflict.and(*generated_forbidden_conflict),
+                            );
+                            forbidden.and(UniversalMarker::new(
+                                MarkerTree::TRUE,
+                                ConflictMarker::from_relevant_conflicts(
+                                    &self.conflicts,
+                                    [forbidden],
                                 ),
-                            )
+                            ));
+                            marker_is_unreachable(&self.requires_python, forbidden.combined())
                         })
                     },
                 );
@@ -3763,23 +3777,22 @@ impl Lock {
         }
 
         for (package_id, activation) in activated_packages {
-            let mut unauthorized = activation
-                .source_authority_required
-                .combined()
-                .and(activation.source_marker.combined().negate());
+            let mut unauthorized = UniversalMarker::from_combined(
+                activation
+                    .source_authority_required
+                    .combined()
+                    .and(activation.source_marker.combined().negate()),
+            );
             if unauthorized.is_false() {
                 continue;
             }
             if !self.conflicts.is_empty() {
-                unauthorized = unauthorized.and(
-                    UniversalMarker::new(
-                        MarkerTree::TRUE,
-                        ConflictMarker::from_conflicts(&self.conflicts),
-                    )
-                    .combined(),
-                );
+                unauthorized.and(UniversalMarker::new(
+                    MarkerTree::TRUE,
+                    ConflictMarker::from_relevant_conflicts(&self.conflicts, [unauthorized]),
+                ));
             }
-            if !marker_is_unreachable(&self.requires_python, unauthorized) {
+            if !marker_is_unreachable(&self.requires_python, unauthorized.combined()) {
                 let package = self.find_by_id(&package_id);
                 return Ok(SatisfiesResult::MismatchedPackageDependencies(
                     &package.id.name,

--- a/crates/uv-resolver/src/lock/serialize.rs
+++ b/crates/uv-resolver/src/lock/serialize.rs
@@ -128,6 +128,7 @@ fn write_lock(writer: &mut LockWriter, lock: &Lock) -> Result<(), WriteError> {
             &lock.requires_python,
             simplified_environment,
             &dist_count_by_name,
+            lock.supports_missing_package_metadata(),
         )?;
     }
 
@@ -264,6 +265,7 @@ fn write_package(
     requires_python: &RequiresPython,
     simplified_environment: MarkerTree,
     dist_count_by_name: &FxHashMap<PackageName, u64>,
+    preserve_empty_contexts: bool,
 ) -> Result<(), WriteError> {
     writer.array_of_tables(&["package"])?;
     write_package_id(writer, &package.id, None, PackageIdLocation::Table)?;
@@ -302,45 +304,65 @@ fn write_package(
         writer.key_multiline_array("wheels", &package.wheels, write_wheel_inline)?;
     }
 
-    if package
-        .optional_dependencies
-        .values()
-        .any(|dependencies| !dependencies.is_empty())
+    if !package.optional_dependencies.is_empty()
+        && (preserve_empty_contexts
+            || package
+                .optional_dependencies
+                .values()
+                .any(|dependencies| !dependencies.is_empty()))
     {
         writer.table(&["package", "optional-dependencies"])?;
         for (extra, dependencies) in &package.optional_dependencies {
             if dependencies.is_empty() {
-                continue;
+                if preserve_empty_contexts {
+                    writer.key_start(extra.as_ref())?;
+                    writer.raw("[]\n");
+                }
+            } else {
+                writer.key_multiline_array(
+                    extra.as_ref(),
+                    dependencies,
+                    |writer, dependency| {
+                        write_dependency_inline(
+                            writer,
+                            dependency,
+                            simplified_environment,
+                            dist_count_by_name,
+                        )
+                    },
+                )?;
             }
-            writer.key_multiline_array(extra.as_ref(), dependencies, |writer, dependency| {
-                write_dependency_inline(
-                    writer,
-                    dependency,
-                    simplified_environment,
-                    dist_count_by_name,
-                )
-            })?;
         }
     }
 
-    if package
-        .dependency_groups
-        .values()
-        .any(|dependencies| !dependencies.is_empty())
+    if !package.dependency_groups.is_empty()
+        && (preserve_empty_contexts
+            || package
+                .dependency_groups
+                .values()
+                .any(|dependencies| !dependencies.is_empty()))
     {
         writer.table(&["package", "dev-dependencies"])?;
         for (group, dependencies) in &package.dependency_groups {
             if dependencies.is_empty() {
-                continue;
+                if preserve_empty_contexts {
+                    writer.key_start(group.as_ref())?;
+                    writer.raw("[]\n");
+                }
+            } else {
+                writer.key_multiline_array(
+                    group.as_ref(),
+                    dependencies,
+                    |writer, dependency| {
+                        write_dependency_inline(
+                            writer,
+                            dependency,
+                            simplified_environment,
+                            dist_count_by_name,
+                        )
+                    },
+                )?;
             }
-            writer.key_multiline_array(group.as_ref(), dependencies, |writer, dependency| {
-                write_dependency_inline(
-                    writer,
-                    dependency,
-                    simplified_environment,
-                    dist_count_by_name,
-                )
-            })?;
         }
     }
 

--- a/crates/uv-resolver/src/universal_marker.rs
+++ b/crates/uv-resolver/src/universal_marker.rs
@@ -458,6 +458,39 @@ impl ConflictMarker {
         marker
     }
 
+    /// Construct only conflict constraints observable in the provided markers.
+    ///
+    /// A pair involving an unreferenced item cannot affect these markers: that item can always be
+    /// disabled. Callers comparing multiple markers must provide every marker involved so both
+    /// sides are evaluated in the same projected conflict world.
+    pub(crate) fn from_relevant_conflicts(
+        conflicts: &Conflicts,
+        markers: impl IntoIterator<Item = UniversalMarker>,
+    ) -> Self {
+        let mut referenced = BTreeSet::new();
+        for marker in markers {
+            marker.marker.visit_extras(|_, extra| {
+                referenced.insert(extra.clone());
+            });
+        }
+
+        let mut marker = Self::TRUE;
+        for set in conflicts.iter() {
+            for (first, second) in set.iter().tuple_combinations() {
+                if !referenced.contains(&encode_conflict_item(first))
+                    || !referenced.contains(&encode_conflict_item(second))
+                {
+                    continue;
+                }
+                let pair = Self::from_conflict_item(first)
+                    .negate()
+                    .or(Self::from_conflict_item(second).negate());
+                marker = marker.and(pair);
+            }
+        }
+        marker
+    }
+
     /// Create a conflict marker that is true only when the given extra or
     /// group (for a specific package) is activated.
     pub(crate) fn from_conflict_item(item: &ConflictItem) -> Self {
@@ -1068,6 +1101,23 @@ mod tests {
         marker.imbibe(ConflictMarker::TRUE);
 
         assert_eq!(marker, expected);
+    }
+
+    #[test]
+    fn relevant_conflicts() {
+        let conflicts = create_conflicts([create_set(["foo", "bar"]), create_set(["fox", "ant"])]);
+        let pep508 =
+            MarkerTree::from_str("sys_platform == 'darwin'").expect("valid marker expression");
+        let foo = create_extra_marker("foo");
+        let fox = create_extra_marker("fox");
+        let ant = create_extra_marker("ant");
+        let generated = UniversalMarker::new(pep508, foo);
+        let actual = UniversalMarker::new(pep508, foo.or(fox.and(ant)));
+
+        assert_eq!(
+            ConflictMarker::from_relevant_conflicts(&conflicts, [generated, actual]),
+            fox.negate().or(ant.negate()),
+        );
     }
 
     #[test]

--- a/crates/uv/src/commands/project/install_target.rs
+++ b/crates/uv/src/commands/project/install_target.rs
@@ -13,7 +13,6 @@ use uv_configuration::{
 use uv_distribution_types::{Index, Resolution};
 use uv_normalize::{DEV_DEPENDENCIES, ExtraName, PackageName};
 use uv_platform_tags::Tags;
-use uv_preview::PreviewFeature;
 use uv_pypi_types::{
     DependencyGroupSpecifier, LenientRequirement, ResolverMarkerEnvironment, VerbatimParsedUrl,
 };
@@ -345,8 +344,7 @@ impl<'lock> InstallTarget<'lock> {
                     return Ok(());
                 }
 
-                let metadata_free_lock = lock.supports_missing_package_metadata()
-                    && uv_preview::is_enabled(PreviewFeature::LockWithoutMetadata);
+                let metadata_free_lock = lock.supports_missing_package_metadata();
                 let roots = self.roots().collect::<FxHashSet<_>>();
                 // Collect all known extras from the member packages.
                 let known_extras = lock
@@ -426,8 +424,7 @@ impl<'lock> InstallTarget<'lock> {
             }
             | Self::Workspace { lock, workspace }
             | Self::NonProjectWorkspace { lock, workspace } => {
-                let metadata_free_lock = lock.supports_missing_package_metadata()
-                    && uv_preview::is_enabled(PreviewFeature::LockWithoutMetadata);
+                let metadata_free_lock = lock.supports_missing_package_metadata();
                 let roots = self.roots().collect::<FxHashSet<_>>();
                 let member_groups = lock
                     .packages()

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -17822,12 +17822,875 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
         version = "0.1.0"
         source = {{ virtual = "." }}
         dependencies = [{{ name = "dep", extra = ["ordinary"], marker = "sys_platform == 'linux'" }}]
+
+        [package.optional-dependencies]
+        {extra_declarations}
         "#})?;
 
     uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("package-conflicts,lock-without-metadata").arg("--locked").arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// A workspace extra edge already selects its target's base distribution.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_workspace_extra_activates_base() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [tool.uv]
+        conflicts = [[
+            { package = "child", extra = "one" },
+            { package = "child", extra = "two" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider", "child", "leaf-one", "leaf-two"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        child = { workspace = true }
+        leaf-one = { workspace = true }
+        leaf-two = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child[one]"]
+        "#})?;
+    context
+        .temp_dir
+        .child("child/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["leaf-one"]
+        two = ["leaf-two"]
+        "#})?;
+    for name in ["leaf-one", "leaf-two"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    let mut lock = context.read("uv.lock").parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(provider) = packages
+        .iter_mut()
+        .find(|package| package["name"].as_str() == Some("provider"))
+    else {
+        anyhow::bail!("lockfile did not contain the provider");
+    };
+    let Some(dependencies) = provider["optional-dependencies"]["one"].as_array_mut() else {
+        anyhow::bail!("provider did not contain the selected child edge");
+    };
+    dependencies.remove(0);
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Conflicting target extras requested together retain the resolver's selected alternative.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_workspace_extra_conflicting_target_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [tool.uv]
+        conflicts = [[
+            { package = "child", extra = "one" },
+            { package = "child", extra = "two" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider", "child"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        child = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child[one]", "child[two] ; sys_platform != 'win32'"]
+        "#})?;
+    context
+        .temp_dir
+        .child("child/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["ok==1.0.0 ; platform_machine == 'aarch64'"]
+        two = ["ok==2.0.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links"))
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links"))
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    let mut lock = context.read("uv.lock").parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(provider) = packages
+        .iter_mut()
+        .find(|package| package["name"].as_str() == Some("provider"))
+    else {
+        anyhow::bail!("lockfile did not contain the provider");
+    };
+    let Some(dependencies) = provider["optional-dependencies"]["one"].as_array_mut() else {
+        anyhow::bail!("provider did not contain its selected child extra");
+    };
+    dependencies.clear();
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links")), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// A workspace member extra can cover the base of a project-conflicting target.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_workspace_extra_project_conflicting_target() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [tool.uv]
+        conflicts = [[
+            { package = "child" },
+            { package = "child", extra = "one" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider", "child", "leaf"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        child = { workspace = true }
+        leaf = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child[one] ; sys_platform == 'win32'"]
+        "#})?;
+    context
+        .temp_dir
+        .child("child/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["leaf"]
+        "#})?;
+    context
+        .temp_dir
+        .child("leaf/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "leaf"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Group-selected project conflicts must retain every compatible target production branch.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_group_project_conflicting_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [dependency-groups]
+        left = [{ include-group = "left-inner" }]
+        left-inner = ["provider[one] ; sys_platform == 'win32'"]
+        right = [{ include-group = "right-inner" }]
+        right-inner = ["provider[two] ; platform_machine == 'aarch64'"]
+
+        [tool.uv]
+        conflicts = [
+            [{ group = "left" }, { group = "right" }],
+            [{ package = "provider", extra = "one" }, { package = "provider", extra = "two" }],
+            [{ package = "provider" }, { package = "provider", extra = "one" }],
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["leaf-one ; sys_platform != 'win32'"]
+        two = ["leaf-two ; platform_machine == 'aarch64'"]
+
+        [tool.uv.sources]
+        leaf-one = { path = "../leaf-one" }
+        leaf-two = { path = "../leaf-two" }
+        "#})?;
+    for name in ["leaf-one", "leaf-two"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// A source scoped to the active root extra does not need to repeat that extra on its edge.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_root_extra_scoped_sources() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child"]
+        two = ["child[extra]"]
+
+        [tool.uv]
+        conflicts = [[{ extra = "one" }, { extra = "two" }]]
+
+        [tool.uv.sources]
+        child = [
+            { path = "child-one", extra = "one" },
+            { path = "child-two", extra = "two" },
+        ]
+        "#})?;
+    context
+        .temp_dir
+        .child("child-one/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#})?;
+    context
+        .temp_dir
+        .child("child-two/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "2.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        extra = ["leaf ; python_full_version >= '3.13'"]
+
+        [tool.uv.sources]
+        leaf = { path = "../leaf" }
+        "#})?;
+    context
+        .temp_dir
+        .child("leaf/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "leaf"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Root extras do not select a workspace extra that conflicts with its own project node.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_root_extra_project_conflicting_workspace_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["provider[one]"]
+
+        [tool.uv]
+        conflicts = [[
+            { package = "provider" },
+            { package = "provider", extra = "one" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider", "leaf"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        leaf = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["leaf"]
+        "#})?;
+    context
+        .temp_dir
+        .child("leaf/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "leaf"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Nested conflicting extras must preserve platform-specific source identity in every fork.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_nested_conflicting_forked_sources() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [tool.uv]
+        conflicts = [[
+            { package = "child", extra = "one" },
+            { package = "child", extra = "two" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        child = [
+            { path = "child-win", marker = "sys_platform == 'win32'" },
+            { path = "child-other", marker = "sys_platform != 'win32'" },
+        ]
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child[one] ; python_full_version < '3.13'"]
+        two = ["child[two]"]
+        "#})?;
+    for (directory, version) in [("child-win", "1.0.0"), ("child-other", "2.0.0")] {
+        context
+            .temp_dir
+            .child(format!("{directory}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "child"
+            version = "{version}"
+            requires-python = ">=3.12"
+
+            [project.optional-dependencies]
+            one = ["leaf-one ; python_full_version < '3.13'"]
+            two = ["leaf-two ; python_full_version < '3.13'"]
+
+            [tool.uv.sources]
+            leaf-one = {{ path = "../leaf-one" }}
+            leaf-two = {{ path = "../leaf-two" }}
+            "#})?;
+    }
+    for name in ["leaf-one", "leaf-two"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 6 packages in [TIME]
+    ");
+
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child[one] ; python_full_version < '3.13'"]
+        two = ["child[two] ; python_full_version >= '3.13'"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    Removed leaf-two v1.0.0
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    let mut lock = context.read("uv.lock").parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(provider) = packages
+        .iter_mut()
+        .find(|package| package["name"].as_str() == Some("provider"))
+    else {
+        anyhow::bail!("lockfile did not contain the provider");
+    };
+    let Some(dependencies) = provider["optional-dependencies"]["two"].as_array_mut() else {
+        anyhow::bail!("provider did not contain its second extra");
+    };
+    let Some(index) = dependencies.iter().position(|dependency| {
+        dependency.as_inline_table().is_some_and(|dependency| {
+            dependency.get("name").and_then(toml_edit::Value::as_str) == Some("child")
+                && dependency.get("version").and_then(toml_edit::Value::as_str) == Some("1.0.0")
+                && dependency.get("extra").is_none()
+        })
+    }) else {
+        anyhow::bail!("provider did not contain the Windows child source edge");
+    };
+    dependencies.remove(index);
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Empty declared target extras still participate in source-specific conflict selections.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_forked_source_declared_empty_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["provider[one]"]
+
+        [tool.uv]
+        conflicts = [[
+            { package = "child", extra = "one" },
+            { package = "child", extra = "two" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        child = [
+            { path = "child-win", marker = "sys_platform == 'win32'" },
+            { path = "child-other", marker = "sys_platform != 'win32'" },
+        ]
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child[one]"]
+        two = ["child[two] ; python_full_version >= '3.13'"]
+        "#})?;
+    context
+        .temp_dir
+        .child("child-win/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = []
+        two = []
+        "#})?;
+    context
+        .temp_dir
+        .child("child-other/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "2.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["leaf ; python_full_version >= '3.13'"]
+        two = []
+
+        [tool.uv.sources]
+        leaf = { path = "../leaf" }
+        "#})?;
+    context
+        .temp_dir
+        .child("leaf/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "leaf"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
     ");
 
     Ok(())
@@ -18114,6 +18977,147 @@ fn lock_metadata_free_frozen_empty_extra() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     Checked in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Metadata-free workspace members must retain declared selections without resolved edges.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_frozen_empty_workspace_selections() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [tool.uv.workspace]
+        members = ["provider"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = []
+
+        [dependency-groups]
+        one = []
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--package")
+        .arg("provider")
+        .arg("--extra")
+        .arg("one")
+        .arg("--offline")
+        .arg("--no-header"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    -e ./provider
+    ");
+
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--package")
+        .arg("provider")
+        .arg("--group")
+        .arg("one")
+        .arg("--offline")
+        .arg("--no-header"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    -e ./provider
+    ");
+
+    let original_lock = context.read("uv.lock");
+    let mut lock = original_lock.parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(provider) = packages
+        .iter_mut()
+        .find(|package| package["name"].as_str() == Some("provider"))
+    else {
+        anyhow::bail!("lockfile did not contain the provider");
+    };
+    provider["optional-dependencies"]
+        .as_table_mut()
+        .and_then(|extras| extras.remove("one"));
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&original_lock)?;
+    let mut lock = original_lock.parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(provider) = packages
+        .iter_mut()
+        .find(|package| package["name"].as_str() == Some("provider"))
+    else {
+        anyhow::bail!("lockfile did not contain the provider");
+    };
+    provider["dev-dependencies"]
+        .as_table_mut()
+        .and_then(|groups| groups.remove("one"));
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18614,6 +18614,114 @@ fn lock_metadata_free_nested_conflicting_forked_sources() -> Result<()> {
     Ok(())
 }
 
+/// Externally selected parent extras can narrow a requested source's competing conflict worlds.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_forked_source_with_parent_extra_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [tool.uv]
+        conflicts = [
+            [
+                { package = "child", extra = "one" },
+                { package = "child", extra = "two" },
+            ],
+            [
+                { package = "provider", extra = "one" },
+                { package = "child", extra = "two" },
+            ],
+        ]
+
+        [tool.uv.workspace]
+        members = ["provider"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        child = [
+            { path = "child-win", marker = "sys_platform == 'win32'" },
+            { path = "child-other", marker = "sys_platform != 'win32'" },
+        ]
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child[one] ; sys_platform != 'win32'"]
+        two = ["child[two] ; python_full_version >= '3.13'"]
+        "#})?;
+    for (directory, version, first_marker) in [
+        ("child-win", "1.0.0", ""),
+        ("child-other", "2.0.0", " ; sys_platform == 'win32'"),
+    ] {
+        context
+            .temp_dir
+            .child(format!("{directory}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "child"
+            version = "{version}"
+            requires-python = ">=3.12"
+
+            [project.optional-dependencies]
+            one = ["leaf-one{first_marker}"]
+            two = ["leaf-two ; sys_platform != 'win32'"]
+
+            [tool.uv.sources]
+            leaf-one = {{ path = "../leaf-one" }}
+            leaf-two = {{ path = "../leaf-two" }}
+            "#})?;
+    }
+    for name in ["leaf-one", "leaf-two"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 6 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Empty declared target extras still participate in source-specific conflict selections.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -17715,16 +17715,16 @@ fn lock_writes_without_package_metadata() -> Result<()> {
     Ok(())
 }
 
-/// Validate a metadata-free lock without expanding independent conflict sets.
+/// Validate a platform-markered dependency without expanding independent conflict sets.
 #[cfg(feature = "test-universal")]
 #[test]
 fn lock_metadata_free_many_conflicts() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let extra_declarations = (1..=12)
+    let extra_declarations = (1..=24)
         .map(|conflict_number| format!("a{conflict_number} = []\nb{conflict_number} = []"))
         .collect::<Vec<_>>()
         .join("\n");
-    let project_conflicts = (1..=12)
+    let project_conflicts = (1..=24)
         .map(|conflict_number| {
             format!(
                 "  [{{ extra = \"a{conflict_number}\" }}, {{ extra = \"b{conflict_number}\" }}],"
@@ -17732,7 +17732,7 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
         })
         .collect::<Vec<_>>()
         .join("\n");
-    let lock_conflicts = (1..=12)
+    let lock_conflicts = (1..=24)
         .map(|conflict_number| {
             format!(
                 "[{{ package = \"project\", extra = \"a{conflict_number}\" }}, {{ package = \"project\", extra = \"b{conflict_number}\" }}]"
@@ -17749,7 +17749,7 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = ["dep"]
+        dependencies = ["dep ; sys_platform == 'linux'"]
 
         [project.optional-dependencies]
         {extra_declarations}
@@ -17799,7 +17799,7 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = {{ virtual = "." }}
-        dependencies = [{{ name = "dep" }}]
+        dependencies = [{{ name = "dep", marker = "sys_platform == 'linux'" }}]
         "#})?;
 
     uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("package-conflicts,lock-without-metadata").arg("--locked").arg("--offline"), @"

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18642,7 +18642,7 @@ fn lock_regenerates_dynamic_version_scoped_override() -> Result<()> {
     ");
 
     // The dynamically selected version can change which scoped override applies.
-    backend.write_str(&backend_contents.replace("1.0.0", "2.0.0"))?;
+    backend.write_str(&backend_contents.replace("1.0.0", "2.0.0.post1"))?;
     uv_snapshot!(context.filters(), context.lock()
         .arg("--preview-features")
         .arg("lock-without-metadata")
@@ -18746,7 +18746,7 @@ fn lock_regenerates_dynamic_version_scoped_exclusion() -> Result<()> {
     ");
 
     // A scoped exclusion stops applying when the dynamic version no longer matches.
-    backend.write_str(&backend_contents.replace("1.0.0", "2.0.0"))?;
+    backend.write_str(&backend_contents.replace("1.0.0", "2.0.0.post1"))?;
     uv_snapshot!(context.filters(), context.lock()
         .arg("--preview-features")
         .arg("lock-without-metadata")
@@ -18800,6 +18800,69 @@ fn lock_regenerates_scoped_excluded_recursive_extra() -> Result<()> {
         [project.optional-dependencies]
         base = ["anyio"]
         feature = ["provider[base]"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Scoped overrides must apply before recursive extras are expanded for metadata-free locks.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_scoped_overridden_recursive_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    let provider = context.temp_dir.child("provider");
+    provider.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        base = ["anyio"]
+        feature = ["provider[base]"]
+        "#})?;
+    let provider_url = Url::from_directory_path(provider.path())
+        .map_err(|()| anyhow::anyhow!("failed to convert provider directory to a file URL"))?;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==4.4.0", "provider[feature] @ {provider_url}"]
+
+        [tool.uv]
+        override-dependencies = [
+            {{ package = {{ name = "provider", version = "1.0.0" }}, dependencies = ["provider==1.0.0"] }},
+        ]
         "#})?;
 
     uv_snapshot!(context.filters(), context.lock()

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -33,6 +33,28 @@ fn lock_without_package_metadata(lock: &str) -> Result<toml_edit::DocumentMut> {
         anyhow::bail!("lockfile did not contain a package array");
     };
     for package in packages.iter_mut() {
+        let extras = package
+            .get("metadata")
+            .and_then(|metadata| metadata.get("provides-extras"))
+            .and_then(toml_edit::Item::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(toml_edit::Value::as_str)
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        if !extras.is_empty() {
+            let optional_dependencies = package
+                .entry("optional-dependencies")
+                .or_insert(toml_edit::table());
+            let Some(optional_dependencies) = optional_dependencies.as_table_like_mut() else {
+                anyhow::bail!("package optional dependencies were not a table");
+            };
+            for extra in extras {
+                optional_dependencies
+                    .entry(&extra)
+                    .or_insert(toml_edit::value(toml_edit::Array::new()));
+            }
+        }
         package.remove("metadata");
     }
     lock["revision"] = toml_edit::value(4);
@@ -17673,6 +17695,12 @@ fn lock_writes_without_package_metadata() -> Result<()> {
     name = "project"
     version = "0.1.0"
     source = { virtual = "." }
+
+    [package.optional-dependencies]
+    feature = []
+
+    [package.dev-dependencies]
+    dev = []
     "#);
 
     uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--check").arg("--offline"), @"
@@ -18691,6 +18719,136 @@ fn lock_metadata_free_forked_source_declared_empty_extra() -> Result<()> {
     ----- stderr -----
     DEBUG Existing `uv.lock` satisfies workspace requirements
     Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Dependency groups on non-workspace source trees cannot be selected independently.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_ignores_non_workspace_self_referential_groups() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[one]"]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["provider[two]"]
+        two = []
+
+        [dependency-groups]
+        nested = ["provider[one]"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 2 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Preserve self-extra activation when overrides are applied before recursive flattening.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_recursive_extra_preserves_override_markers() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[one]"]
+
+        [tool.uv]
+        override-dependencies = ["ok==2.0.0"]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        ok = { path = "ok" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["provider[two] ; platform_machine == 'aarch64'"]
+        two = ["ok==1.0.0"]
+        "#})?;
+    context
+        .temp_dir
+        .child("ok/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "ok"
+        version = "2.0.0"
+        requires-python = ">=3.12"
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 3 packages in [TIME]
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18561,6 +18561,241 @@ fn lock_metadata_free_group_source_fork_project_conflict_production() -> Result<
     Ok(())
 }
 
+/// Included groups preserve the selected project's valid source-conflict worlds.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_nested_group_scoped_project_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [dependency-groups]
+        dev = ["ok[first] ; sys_platform == 'win32'"]
+        nested = [{ include-group = "dev" }, "ok[third] ; sys_platform == 'win32'"]
+
+        [tool.uv]
+        conflicts = [[
+            { package = "ok" },
+            { package = "ok", extra = "first" },
+        ]]
+
+        [tool.uv.sources]
+        ok = [{ path = "ok-local", group = "dev", marker = "sys_platform == 'win32'" }]
+        "#})?;
+    context
+        .temp_dir
+        .child("ok-local/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "ok"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        first = ["leaf"]
+        third = []
+
+        [tool.uv.sources]
+        leaf = { path = "../leaf" }
+        "#})?;
+    context
+        .temp_dir
+        .child("leaf/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "leaf"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 3 packages in [TIME]
+    ");
+
+    insta::allow_duplicates! {
+        for group in ["dev", "nested"] {
+            uv_snapshot!(context.filters(), context.sync()
+                .arg("--preview-features")
+                .arg("package-conflicts")
+                .arg("--frozen")
+                .arg("--only-group")
+                .arg(group)
+                .arg("--python-platform")
+                .arg("windows")
+                .arg("--dry-run"), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Would use project environment at: .venv
+            Would download 2 packages
+            Would install 2 packages
+             + leaf @ file://[TEMP_DIR]/leaf
+             + ok @ file://[TEMP_DIR]/ok-local
+            ");
+        }
+    }
+
+    Ok(())
+}
+
+/// Registry version selection follows conflict-normalized included-group contexts.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_nested_group_conditional_registry_constraint() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+    let scenario = toml::from_str::<Scenario>(indoc! {r#"
+        name = "nested-group-conditional-registry-constraint"
+
+        [root]
+        requires = []
+
+        [expected]
+        satisfiable = true
+
+        [packages.ok.versions."1.0.0".extras]
+        first = []
+        second = []
+        third = []
+
+        [packages.ok.versions."2.0.0".extras]
+        first = []
+        second = []
+        third = []
+    "#})?;
+    let server = PackseServer::from_scenario(&scenario);
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [dependency-groups]
+        dev = ["ok[first]>=1,<3 ; python_full_version < '3.13' or sys_platform != 'win32'"]
+        nested = [
+            { include-group = "dev" },
+            "ok[third]>=1,<3 ; python_full_version < '3.13' or sys_platform != 'win32'",
+        ]
+
+        [tool.uv]
+        conflicts = [[
+            { package = "ok", extra = "first" },
+            { package = "ok", extra = "second" },
+        ]]
+        constraint-dependencies = ["ok==1.0.0 ; sys_platform == 'win32'"]
+
+        [tool.uv.dependency-groups]
+        dev = { requires-python = ">=3.13" }
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--only-group")
+        .arg("nested")
+        .arg("--python-platform")
+        .arg("windows")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Checked in [TIME]
+    Would make no changes
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--only-group")
+        .arg("nested")
+        .arg("--python-platform")
+        .arg("x86_64-unknown-linux-gnu")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 1 package
+    Would install 1 package
+     + ok==2.0.0
+    ");
+
+    let pyproject = context
+        .read("pyproject.toml")
+        .replace("ok==1.0.0", "ok==2.0.0");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject)?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
 /// Registry fallback must not inherit activation from a source scoped to another group.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -17947,6 +17947,114 @@ fn lock_metadata_free_conflicting_direct_dependencies() -> Result<()> {
     Ok(())
 }
 
+/// Conflicting extras must retain the platform forks of their requested source variants.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_conflicting_forked_source_extras() -> Result<()> {
+    lock_metadata_free_conflicting_forked_sources(true)
+}
+
+/// Platform-specific source edges retain their selected conflict without requested extras.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_conflicting_forked_source_dependencies() -> Result<()> {
+    lock_metadata_free_conflicting_forked_sources(false)
+}
+
+/// Validate source forks in conflicting contexts, both with and without target extras.
+#[cfg(feature = "test-universal")]
+fn lock_metadata_free_conflicting_forked_sources(requested_extra: bool) -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    let first = if requested_extra {
+        "provider[one]"
+    } else {
+        "provider"
+    };
+    let second = if requested_extra {
+        "provider[two]"
+    } else {
+        "provider"
+    };
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        a = ["{first}"]
+        b = ["{second}"]
+
+        [tool.uv]
+        conflicts = [[{{ extra = "a" }}, {{ extra = "b" }}]]
+
+        [tool.uv.sources]
+        provider = [
+            {{ path = "provider-win", marker = "sys_platform == 'win32'" }},
+            {{ path = "provider-other", marker = "sys_platform != 'win32'" }},
+        ]
+        "#})?;
+
+    for (directory, version, dependency_version) in [
+        ("provider-win", "1.0.0", "4.3.0"),
+        ("provider-other", "2.0.0", "4.4.0"),
+    ] {
+        let dependencies = if requested_extra {
+            indoc! {r#"
+
+                [project.optional-dependencies]
+                one = ["anyio==4.3.0"]
+                two = ["anyio==4.4.0"]
+                "#}
+            .to_string()
+        } else {
+            format!("dependencies = [\"anyio=={dependency_version}\"]")
+        };
+        context
+            .temp_dir
+            .child(directory)
+            .child("pyproject.toml")
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "provider"
+            version = "{version}"
+            requires-python = ">=3.12"
+            {dependencies}
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 7 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 7 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// An empty extra remains selectable when its lockfile omits package metadata.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18764,6 +18764,72 @@ fn lock_regenerates_dynamic_version_scoped_exclusion() -> Result<()> {
     Ok(())
 }
 
+/// Excluded recursive extras must not be expanded when regenerating metadata-free dependencies.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_scoped_excluded_recursive_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==4.4.0", "provider[feature]"]
+
+        [tool.uv]
+        exclude-dependencies = [
+            { package = { name = "provider", version = "1.0.0" }, dependencies = ["provider"] },
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        base = ["anyio"]
+        feature = ["provider[base]"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Requested target extras must cover the same marker environments as their declarations.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -17715,7 +17715,7 @@ fn lock_writes_without_package_metadata() -> Result<()> {
     Ok(())
 }
 
-/// Validate a platform-markered dependency without expanding independent conflict sets.
+/// Validate an unrelated requested extra without expanding independent conflict sets.
 #[cfg(feature = "test-universal")]
 #[test]
 fn lock_metadata_free_many_conflicts() -> Result<()> {
@@ -17749,7 +17749,7 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = ["dep ; sys_platform == 'linux'"]
+        dependencies = ["dep[ordinary] ; sys_platform == 'linux'"]
 
         [project.optional-dependencies]
         {extra_declarations}
@@ -17760,7 +17760,7 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
         ]
 
         [tool.uv.workspace]
-        members = ["dep"]
+        members = ["dep", "leaf"]
 
         [tool.uv.sources]
         dep = {{ workspace = true }}
@@ -17770,6 +17770,20 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
     dependency.child("pyproject.toml").write_str(indoc! {r#"
         [project]
         name = "dep"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        ordinary = ["leaf"]
+
+        [tool.uv.sources]
+        leaf = { workspace = true }
+        "#})?;
+    let leaf = context.temp_dir.child("leaf");
+    leaf.create_dir_all()?;
+    leaf.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "leaf"
         version = "1.0.0"
         requires-python = ">=3.12"
         "#})?;
@@ -17788,24 +17802,32 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
         exclude-newer = "2024-03-25T00:00:00Z"
 
         [manifest]
-        members = ["dep", "project"]
+        members = ["dep", "leaf", "project"]
 
         [[package]]
         name = "dep"
         version = "1.0.0"
         source = {{ editable = "dep" }}
 
+        [package.optional-dependencies]
+        ordinary = [{{ name = "leaf" }}]
+
+        [[package]]
+        name = "leaf"
+        version = "1.0.0"
+        source = {{ editable = "leaf" }}
+
         [[package]]
         name = "project"
         version = "0.1.0"
         source = {{ virtual = "." }}
-        dependencies = [{{ name = "dep", marker = "sys_platform == 'linux'" }}]
+        dependencies = [{{ name = "dep", extra = ["ordinary"], marker = "sys_platform == 'linux'" }}]
         "#})?;
 
     uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("package-conflicts,lock-without-metadata").arg("--locked").arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Resolved 2 packages in [TIME]
+    Resolved 3 packages in [TIME]
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18723,6 +18723,70 @@ fn lock_regenerates_marker_specific_local_extra() -> Result<()> {
     Ok(())
 }
 
+/// Target extras can activate incompatible leaf versions in disjoint marker environments.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_marker_scoped_dependency_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "provider[one] ; python_full_version >= '3.13'",
+            "provider[two] ; python_full_version < '3.13'",
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        two = ["anyio==4.4.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 6 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Preserve scoped overrides and platform forks for workspace-member dependencies.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18854,6 +18854,72 @@ fn lock_regenerates_marker_scoped_dependency_extra_with_unrelated_conflicts() ->
     Ok(())
 }
 
+/// A selected conflicting extra can simplify the marker of its dependency's own extra.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_marker_scoped_dependency_extra_with_selected_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        selected = ["provider[one] ; sys_platform == 'win32'"]
+        alternative = []
+
+        [tool.uv]
+        conflicts = [[{ extra = "selected" }, { extra = "alternative" }]]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Preserve scoped overrides and platform forks for workspace-member dependencies.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18086,8 +18086,6 @@ fn lock_metadata_free_frozen_empty_extra() -> Result<()> {
         .write_str(&lock.to_string())?;
 
     uv_snapshot!(context.filters(), context.sync()
-        .arg("--preview-features")
-        .arg("lock-without-metadata")
         .arg("--frozen")
         .arg("--extra")
         .arg("empty"), @"
@@ -18546,8 +18544,6 @@ fn lock_metadata_free_frozen_filtered_dependency_selections() -> Result<()> {
         .write_str(&lock.to_string())?;
 
     uv_snapshot!(context.filters(), context.sync()
-        .arg("--preview-features")
-        .arg("lock-without-metadata")
         .arg("--frozen")
         .arg("--extra")
         .arg("empty")
@@ -18956,6 +18952,1027 @@ fn lock_regenerates_python_forked_dependency_extra_with_selected_conflict() -> R
 
         [project.optional-dependencies]
         one = ["anyio==4.3.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Conflicting extras cannot inherit another selection's disjoint resolution fork.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_disjoint_python_forked_dependency_extras_with_selected_conflicts() -> Result<()>
+{
+    lock_regenerates_disjoint_python_forked_dependencies(
+        "project.optional-dependencies",
+        "extra",
+        false,
+    )
+}
+
+/// Conflicting groups cannot inherit another selection's disjoint resolution fork.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_disjoint_python_forked_dependency_groups_with_selected_conflicts() -> Result<()>
+{
+    lock_regenerates_disjoint_python_forked_dependencies("dependency-groups", "group", false)
+}
+
+/// Explicit supported environments must not obscure the selected extra's Python fork.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_python_forked_dependency_extras_in_supported_environments() -> Result<()> {
+    lock_regenerates_disjoint_python_forked_dependencies(
+        "project.optional-dependencies",
+        "extra",
+        true,
+    )
+}
+
+/// Exercise conflicting activation across extras, groups, and supported environments.
+#[cfg(feature = "test-universal")]
+fn lock_regenerates_disjoint_python_forked_dependencies(
+    dependency_section: &str,
+    conflict_kind: &str,
+    explicit_environments: bool,
+) -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    let environments = if explicit_environments {
+        "environments = [\"sys_platform == 'linux'\", \"sys_platform == 'darwin'\"]\n"
+    } else {
+        ""
+    };
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [{dependency_section}]
+        high = ["provider[one] ; python_full_version >= '3.13'"]
+        low = ["provider[two] ; python_full_version < '3.13'"]
+
+        [tool.uv]
+        {environments}conflicts = [[{{ {conflict_kind} = "high" }}, {{ {conflict_kind} = "low" }}]]
+
+        [tool.uv.sources]
+        provider = {{ path = "provider" }}
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        two = ["anyio==4.4.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 6 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// One dependency extra can be activated by different conflicting resolution branches.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_dependency_extra_from_multiple_conflicting_python_forks() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        high-one = ["provider[one] ; python_full_version >= '3.13'"]
+        low-one = ["provider[one] ; python_full_version < '3.13'"]
+        low-two = ["provider[two] ; python_full_version < '3.13'"]
+
+        [tool.uv]
+        conflicts = [[
+            { extra = "high-one" },
+            { extra = "low-one" },
+            { extra = "low-two" },
+        ]]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        two = ["anyio==4.4.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 6 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// A workspace member's extras remain independently selectable from incoming project edges.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_independently_selected_workspace_member_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        left = ["alpha[one]"]
+        right = ["zeta[two] ; python_full_version >= '3.13'"]
+
+        [tool.uv]
+        conflicts = [
+            [{ extra = "left" }, { extra = "right" }],
+            [{ package = "alpha", extra = "one" }, { package = "zeta", extra = "two" }],
+        ]
+
+        [tool.uv.workspace]
+        members = ["alpha", "zeta"]
+
+        [tool.uv.sources]
+        alpha = { workspace = true }
+        zeta = { workspace = true }
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("alpha/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "alpha"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["provider[one] ; python_full_version < '3.13'"]
+        "#})?;
+    context
+        .temp_dir
+        .child("zeta/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "zeta"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        two = ["provider[two] ; python_full_version < '3.13'"]
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        two = ["anyio==4.4.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 8 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 8 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Resolver-minimized conflict markers may span overlapping sets while excluding alternatives.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_overlapping_conflicting_dependency_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        left = ["provider[one]"]
+        middle = ["provider[three]"]
+        right = ["provider[two]"]
+
+        [tool.uv]
+        conflicts = [
+            [{ extra = "left" }, { extra = "right" }],
+            [{ extra = "right" }, { extra = "middle" }],
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        two = ["anyio==4.4.0"]
+        three = ["anyio==4.3.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 6 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// An unpinned transitive requirement can reuse a globally selected local package source.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_source_agnostic_transitive_dependency() -> Result<()> {
+    lock_regenerates_authorized_transitive_dependency(false)
+}
+
+/// Direct-source constraints also authorize a transitive source-agnostic requirement.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_source_constrained_transitive_dependency() -> Result<()> {
+    lock_regenerates_authorized_transitive_dependency(true)
+}
+
+/// Exercise both direct requirements and direct-source constraints as source authority.
+#[cfg(feature = "test-universal")]
+fn lock_regenerates_authorized_transitive_dependency(constrained: bool) -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let dependencies = if constrained {
+        "\"bridge\""
+    } else {
+        "\"bridge\", \"provider\""
+    };
+    let constraints = if constrained {
+        "[tool.uv]\nconstraint-dependencies = [\"provider\"]\n\n"
+    } else {
+        ""
+    };
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [{dependencies}]
+
+        {constraints}[tool.uv.sources]
+        bridge = {{ path = "bridge" }}
+        provider = {{ path = "provider" }}
+        "#})?;
+    context
+        .temp_dir
+        .child("bridge/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "bridge"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider"]
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--offline")
+        .arg("--no-index"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 3 packages in [TIME]
+    ");
+
+    if !constrained {
+        let pyproject = context.read("pyproject.toml");
+        context
+            .temp_dir
+            .child("pyproject.toml")
+            .write_str(&pyproject.replace("provider = { path = \"provider\" }\n", ""))?;
+
+        uv_snapshot!(context.filters(), context.lock()
+            .arg("--preview-features")
+            .arg("lock-without-metadata")
+            .arg("--locked")
+            .arg("--offline")
+            .arg("--no-cache")
+            .arg("--no-index"), @"
+        exit_code: 1 (failure)
+        ----- stderr -----
+          × No solution found when resolving dependencies:
+          ╰─▶ Because provider was not found in the provided package locations and your project depends on provider, we can conclude that your project's requirements are unsatisfiable.
+
+        hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
+        ");
+    }
+
+    Ok(())
+}
+
+/// A conflicting selected extra also scopes the production dependencies of its target.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_python_forked_production_dependency_with_selected_extra() -> Result<()> {
+    lock_regenerates_python_forked_production_dependency("project.optional-dependencies", "extra")
+}
+
+/// A conflicting selected group also scopes the production dependencies of its target.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_python_forked_production_dependency_with_selected_group() -> Result<()> {
+    lock_regenerates_python_forked_production_dependency("dependency-groups", "group")
+}
+
+/// Exercise full package activation when an extra or group selects a local dependency.
+#[cfg(feature = "test-universal")]
+fn lock_regenerates_python_forked_production_dependency(
+    dependency_section: &str,
+    conflict_kind: &str,
+) -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [{dependency_section}]
+        selected = ["provider ; python_full_version >= '3.13'"]
+        alternative = []
+
+        [tool.uv]
+        conflicts = [[{{ {conflict_kind} = "selected" }}, {{ {conflict_kind} = "alternative" }}]]
+
+        [tool.uv.sources]
+        provider = {{ path = "provider" }}
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==4.3.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Requesting a conflicting target extra still requires the target's unselected base package.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_conflicting_dependency_extra_and_base_package() -> Result<()> {
+    lock_regenerates_conflicting_dependency_extra_and_base(false, false)
+}
+
+/// A target package's production selection may itself conflict with a requested extra.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_project_conflicting_dependency_extra_and_base_package() -> Result<()> {
+    lock_regenerates_conflicting_dependency_extra_and_base(true, false)
+}
+
+/// An unrequested alternative must not leak into a target package's production conflict branch.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_project_conflicting_dependency_extra_with_unrequested_alternative() -> Result<()>
+{
+    lock_regenerates_conflicting_dependency_extra_and_base(true, true)
+}
+
+/// Requested conflict alternatives can have payloads that are inactive in the current fork.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_project_conflicting_marker_inactive_dependency_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[one,three,four] ; python_full_version < '3.13'"]
+
+        [tool.uv]
+        conflicts = [
+            [{ package = "provider" }, { package = "provider", extra = "one" }],
+            [{ package = "provider", extra = "one" }, { package = "provider", extra = "three" }],
+            [{ package = "provider", extra = "three" }, { package = "provider", extra = "four" }],
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["leaf-one ; python_full_version >= '3.13'"]
+        three = ["leaf-three ; python_full_version >= '3.13'"]
+        four = ["leaf-four ; python_full_version >= '3.13'"]
+
+        [tool.uv.sources]
+        leaf-one = { path = "../leaf-one" }
+        leaf-three = { path = "../leaf-three" }
+        leaf-four = { path = "../leaf-four" }
+        "#})?;
+    for name in ["leaf-one", "leaf-three", "leaf-four"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    let provider = context.read("provider/pyproject.toml");
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(&provider.replace(
+            "four = [\"leaf-four ; python_full_version >= '3.13'\"]",
+            "four = [\"leaf-four ; python_full_version < '3.13'\"]",
+        ))?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Contradictory platform markers must be removed from both generated and locked edges.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_project_conflicting_incompatible_platform_dependency_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[one,two] ; platform_system == 'Linux'"]
+
+        [tool.uv]
+        conflicts = [[{ package = "provider" }, { package = "provider", extra = "one" }]]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["leaf-one ; os_name == 'nt'"]
+        two = ["leaf-two ; os_name == 'nt'"]
+
+        [tool.uv.sources]
+        leaf-one = { path = "../leaf-one" }
+        leaf-two = { path = "../leaf-two" }
+        "#})?;
+    for name in ["leaf-one", "leaf-two"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 4 packages in [TIME]
+    ");
+
+    let provider = context.read("provider/pyproject.toml");
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(&provider.replace(
+            "two = [\"leaf-two ; os_name == 'nt'\"]",
+            "two = [\"leaf-two ; os_name == 'posix'\"]",
+        ))?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Exercise requested-extra conflicts against another extra and against package production.
+#[cfg(feature = "test-universal")]
+fn lock_regenerates_conflicting_dependency_extra_and_base(
+    project_conflict: bool,
+    unrequested_alternative: bool,
+) -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    let preview_features = if project_conflict {
+        "package-conflicts,lock-without-metadata"
+    } else {
+        "lock-without-metadata"
+    };
+    let alternative = if project_conflict {
+        "{ package = \"provider\" }"
+    } else {
+        "{ package = \"provider\", extra = \"two\" }"
+    };
+    let requested_extras = if project_conflict && !unrequested_alternative {
+        "one,three"
+    } else {
+        "one"
+    };
+    let additional_conflict = if unrequested_alternative {
+        ", [{ package = \"provider\" }, { package = \"provider\", extra = \"two\" }]"
+    } else {
+        ""
+    };
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[{requested_extras}]"]
+
+        [tool.uv]
+        conflicts = [[
+            {{ package = "provider", extra = "one" }},
+            {alternative},
+        ]{additional_conflict}]
+
+        [tool.uv.sources]
+        provider = {{ path = "provider" }}
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        two = []
+        three = ["anyio==4.3.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg(preview_features)
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg(preview_features)
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    let original_lock = context.read("uv.lock");
+    let original_provider = context.read("provider/pyproject.toml");
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(&original_provider.replace(
+            "one = [\"anyio==4.3.0\"]",
+            "one = [\"anyio==4.3.0 ; python_full_version >= '3.13'\"]",
+        ))?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg(preview_features)
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(&original_provider)?;
+
+    let mut lock = original_lock.parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(project) = packages
+        .iter_mut()
+        .find(|package| package["name"].as_str() == Some("project"))
+    else {
+        anyhow::bail!("lockfile did not contain the project");
+    };
+    let Some(dependencies) = project["dependencies"].as_array_mut() else {
+        anyhow::bail!("project did not contain a dependency array");
+    };
+    let Some(base_index) = dependencies.iter().position(|dependency| {
+        dependency
+            .as_inline_table()
+            .is_some_and(|dependency| dependency.get("extra").is_none())
+    }) else {
+        anyhow::bail!("project did not contain the requested package's base edge");
+    };
+    dependencies.remove(base_index);
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg(preview_features)
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    let mut lock = original_lock.parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(provider) = packages
+        .iter_mut()
+        .find(|package| package["name"].as_str() == Some("provider"))
+    else {
+        anyhow::bail!("lockfile did not contain the requested package");
+    };
+    provider.remove("optional-dependencies");
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg(preview_features)
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Requested extras with different conflict predicates must remain independently activated.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_independently_conflicting_dependency_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[one,three,five]"]
+
+        [tool.uv]
+        conflicts = [
+            [{ package = "provider", extra = "one" }, { package = "provider", extra = "two" }],
+            [{ package = "provider", extra = "three" }, { package = "provider", extra = "four" }],
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        two = []
+        three = ["anyio==4.3.0"]
+        four = []
+        five = ["anyio==4.3.0"]
         "#})?;
 
     uv_snapshot!(context.filters(), context.lock()

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18555,6 +18555,215 @@ fn lock_regenerates_scoped_workspace_overrides() -> Result<()> {
     Ok(())
 }
 
+/// Scoped overrides must use the resolved version even when a dynamic package omits it in the lock.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_dynamic_version_scoped_override() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider"]
+
+        [tool.uv]
+        override-dependencies = [
+            { package = { name = "provider" }, dependencies = ["anyio==4.3.0"] },
+            { package = { name = "provider", version = "1.0.0" }, dependencies = ["anyio==4.4.0"] },
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==4.3.0"]
+        dynamic = ["version"]
+
+        [tool.uv]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "backend.py" }]
+
+        [build-system]
+        requires = []
+        backend-path = ["."]
+        build-backend = "backend"
+        "#})?;
+    let backend = context.temp_dir.child("provider/backend.py");
+    let backend_contents = indoc! {r#"
+        import pathlib
+
+        def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+            dist_info = pathlib.Path(metadata_directory, "provider-1.0.0.dist-info")
+            dist_info.mkdir()
+            dist_info.joinpath("METADATA").write_text(
+                "Metadata-Version: 2.1\n"
+                "Name: provider\n"
+                "Version: 1.0.0\n"
+                "Requires-Python: >=3.12\n"
+                "Requires-Dist: anyio==4.3.0\n"
+            )
+            return dist_info.name
+        "#};
+    backend.write_str(backend_contents)?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    // The dynamically selected version can change which scoped override applies.
+    backend.write_str(&backend_contents.replace("1.0.0", "2.0.0"))?;
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Scoped exclusions must use the resolved version even when a dynamic package omits it in the lock.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_dynamic_version_scoped_exclusion() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider"]
+
+        [tool.uv]
+        exclude-dependencies = [
+            { package = { name = "provider", version = "1.0.0" }, dependencies = ["anyio"] },
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==4.3.0"]
+        dynamic = ["version"]
+
+        [tool.uv]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "backend.py" }]
+
+        [build-system]
+        requires = []
+        backend-path = ["."]
+        build-backend = "backend"
+        "#})?;
+    let backend = context.temp_dir.child("provider/backend.py");
+    let backend_contents = indoc! {r#"
+        import pathlib
+
+        def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+            dist_info = pathlib.Path(metadata_directory, "provider-1.0.0.dist-info")
+            dist_info.mkdir()
+            dist_info.joinpath("METADATA").write_text(
+                "Metadata-Version: 2.1\n"
+                "Name: provider\n"
+                "Version: 1.0.0\n"
+                "Requires-Python: >=3.12\n"
+                "Requires-Dist: anyio==4.3.0\n"
+            )
+            return dist_info.name
+        "#};
+    backend.write_str(backend_contents)?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 2 packages in [TIME]
+    ");
+
+    // A scoped exclusion stops applying when the dynamic version no longer matches.
+    backend.write_str(&backend_contents.replace("1.0.0", "2.0.0"))?;
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
 /// Requested target extras must cover the same marker environments as their declarations.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18,7 +18,7 @@ use uv_fs::Simplified;
 #[cfg(feature = "test-universal")]
 use uv_static::EnvVars;
 #[cfg(feature = "test-universal")]
-use uv_test::packse::PackseServer;
+use uv_test::packse::{PackseServer, scenario::Scenario};
 use uv_test::uv_snapshot;
 #[cfg(all(feature = "test-universal", feature = "test-git"))]
 use uv_test::{READ_ONLY_GITHUB_TOKEN, decode_token};
@@ -18395,6 +18395,313 @@ fn lock_metadata_free_root_extra_and_group_project_conflict() -> Result<()> {
      + leaf-one @ file://[TEMP_DIR]/leaf-one
      + leaf-two @ file://[TEMP_DIR]/leaf-two
      + provider @ file://[TEMP_DIR]/provider
+    ");
+
+    Ok(())
+}
+
+/// Production dependencies remain active in ordinary group-selected project-conflict worlds.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_group_source_fork_project_conflict_production() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        left = ["provider[first]>=1,<3 ; python_full_version < '3.13'"]
+
+        [dependency-groups]
+        dev = ["provider[second]>=1,<3 ; python_full_version >= '3.13'"]
+
+        [tool.uv]
+        conflicts = [[{ package = "provider" }, { package = "provider", extra = "first" }]]
+
+        [tool.uv.sources]
+        provider = [
+            { path = "provider-a", marker = "sys_platform == 'win32'" },
+            { path = "provider-b", marker = "sys_platform != 'win32'" },
+        ]
+
+        [tool.uv.dependency-groups]
+        dev = { requires-python = ">=3.13" }
+        "#})?;
+    for (directory, version) in [("provider-a", "1.0.0"), ("provider-b", "2.0.0")] {
+        context
+            .temp_dir
+            .child(format!("{directory}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "provider"
+            version = "{version}"
+            requires-python = ">=3.12"
+            dependencies = ["leaf-three ; python_full_version >= '3.13'"]
+
+            [project.optional-dependencies]
+            first = ["child[alpha] ; python_full_version < '3.13'"]
+            second = ["child[beta] ; python_full_version >= '3.13'"]
+
+            [tool.uv.sources]
+            child = [
+                {{ path = "../child-a", marker = "platform_machine == 'aarch64'" }},
+                {{ path = "../child-b", marker = "platform_machine != 'aarch64'" }},
+            ]
+            leaf-three = {{ path = "../leaf-three" }}
+            "#})?;
+    }
+    for (directory, version) in [("child-a", "1.0.0"), ("child-b", "2.0.0")] {
+        context
+            .temp_dir
+            .child(format!("{directory}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "child"
+            version = "{version}"
+            requires-python = ">=3.12"
+
+            [project.optional-dependencies]
+            alpha = []
+            beta = ["leaf-two ; python_full_version >= '3.13'"]
+
+            [tool.uv.sources]
+            leaf-two = {{ path = "../leaf-two" }}
+            "#})?;
+    }
+    for name in ["leaf-three", "leaf-two"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 7 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 7 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--only-group")
+        .arg("dev")
+        .arg("--python-platform")
+        .arg("x86_64-unknown-linux-gnu")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 4 packages
+    Would install 4 packages
+     + child @ file://[TEMP_DIR]/child-b
+     + leaf-three @ file://[TEMP_DIR]/leaf-three
+     + leaf-two @ file://[TEMP_DIR]/leaf-two
+     + provider @ file://[TEMP_DIR]/provider-b
+    ");
+
+    let mut lock = context.read("uv.lock").parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(provider) = packages.iter_mut().find(|package| {
+        package["name"].as_str() == Some("provider") && package["version"].as_str() == Some("2.0.0")
+    }) else {
+        anyhow::bail!("lockfile did not contain the group-selected provider");
+    };
+    let Some(dependencies) = provider["dependencies"].as_array_mut() else {
+        anyhow::bail!("provider did not contain its production dependency");
+    };
+    dependencies.clear();
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 7 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Registry fallback must not inherit activation from a source scoped to another group.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_group_scoped_source_registry_fallback() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let scenario = toml::from_str::<Scenario>(indoc! {r#"
+        name = "group-scoped-source-registry-fallback"
+
+        [root]
+        requires = []
+
+        [expected]
+        satisfiable = true
+
+        [packages.ok.versions."2.0.0".extras]
+        first = []
+        second = []
+        third = []
+    "#})?;
+    let server = PackseServer::from_scenario(&scenario);
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [dependency-groups]
+        dev = ["ok[first]>=1,<3 ; python_full_version < '3.13' or sys_platform != 'win32'"]
+        other = ["ok[second]>=1,<3"]
+        nested = [
+            { include-group = "dev" },
+            "ok[third]>=1,<3 ; python_full_version < '3.13' or sys_platform != 'win32'",
+        ]
+
+        [tool.uv]
+        conflicts = [[
+            { package = "ok", extra = "first" },
+            { package = "ok", extra = "second" },
+        ]]
+
+        [tool.uv.sources]
+        ok = [{ path = "ok-local", group = "dev", marker = "sys_platform == 'win32'" }]
+        "#})?;
+    context
+        .temp_dir
+        .child("ok-local/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "ok"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        first = []
+        second = []
+        third = []
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--only-group")
+        .arg("dev")
+        .arg("--python-platform")
+        .arg("windows")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 1 package
+    Would install 1 package
+     + ok @ file://[TEMP_DIR]/ok-local
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--only-group")
+        .arg("other")
+        .arg("--python-platform")
+        .arg("x86_64-unknown-linux-gnu")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 1 package
+    Would install 1 package
+     + ok==2.0.0
+    ");
+
+    let pyproject = context.read("pyproject.toml").replace(
+        "ok = [{ path = \"ok-local\", group = \"dev\", marker = \"sys_platform == 'win32'\" }]",
+        "",
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject)?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18787,6 +18787,73 @@ fn lock_regenerates_marker_scoped_dependency_extras() -> Result<()> {
     Ok(())
 }
 
+/// Unrelated conflicts must not erase the marker that activates a dependency's extra.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_marker_scoped_dependency_extra_with_unrelated_conflicts() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[one] ; python_full_version >= '3.13'"]
+
+        [project.optional-dependencies]
+        unrelated-one = []
+        unrelated-two = []
+
+        [tool.uv]
+        conflicts = [[{ extra = "unrelated-one" }, { extra = "unrelated-two" }]]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Preserve scoped overrides and platform forks for workspace-member dependencies.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -17811,6 +17811,142 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
     Ok(())
 }
 
+/// Preserve the selected extra's conflict marker when it requests another package's extra.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_conflicting_transitive_extras() -> Result<()> {
+    lock_metadata_free_conflicting_transitive_dependencies("project.optional-dependencies", "extra")
+}
+
+/// Preserve the selected group's conflict marker when it requests another package's extra.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_conflicting_transitive_groups() -> Result<()> {
+    lock_metadata_free_conflicting_transitive_dependencies("dependency-groups", "group")
+}
+
+/// Exercise parent-selected conflict markers in both extra and dependency-group contexts.
+#[cfg(feature = "test-universal")]
+fn lock_metadata_free_conflicting_transitive_dependencies(
+    dependency_section: &str,
+    conflict_kind: &str,
+) -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [{dependency_section}]
+        a = ["provider[one]"]
+        b = ["provider[two]"]
+
+        [tool.uv]
+        conflicts = [[{{ {conflict_kind} = "a" }}, {{ {conflict_kind} = "b" }}]]
+
+        [tool.uv.sources]
+        provider = {{ path = "provider" }}
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        two = ["anyio==4.4.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 6 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Ordinary conflicting dependencies do not retain their parent selection marker on the edge.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_conflicting_direct_dependencies() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["anyio==4.3.0"]
+
+        [dependency-groups]
+        dev = ["anyio==4.4.0"]
+
+        [tool.uv]
+        conflicts = [[{ extra = "feature" }, { group = "dev" }]]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// An empty extra remains selectable when its lockfile omits package metadata.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19029,6 +19029,68 @@ fn lock_regenerates_scoped_overridden_recursive_extra() -> Result<()> {
     Ok(())
 }
 
+/// Recursively selected extras inherit only the optional branch of mixed production markers.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_recursive_extra_production_marker() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[feature]"]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio ; sys_platform == 'win32' or extra == 'base'"]
+
+        [project.optional-dependencies]
+        base = []
+        feature = ["provider[base]"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Requested target extras must cover the same marker environments as their declarations.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18920,6 +18920,72 @@ fn lock_regenerates_marker_scoped_dependency_extra_with_selected_conflict() -> R
     Ok(())
 }
 
+/// Resolution-level Python forks remain visible below a selected conflicting extra.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_python_forked_dependency_extra_with_selected_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        selected = ["provider[one] ; python_full_version >= '3.13'"]
+        alternative = []
+
+        [tool.uv]
+        conflicts = [[{ extra = "selected" }, { extra = "alternative" }]]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// A project conflict remains active through a dependency's requested extra.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18274,6 +18274,132 @@ fn lock_metadata_free_group_project_conflicting_extras() -> Result<()> {
     Ok(())
 }
 
+/// Conflicting extras and groups retain their platform and Python activation contexts.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_root_extra_and_group_project_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["provider[one] ; sys_platform == 'win32'"]
+
+        [dependency-groups]
+        dev = ["provider[two] ; sys_platform == 'win32'"]
+
+        [tool.uv]
+        conflicts = [
+            [{ extra = "feature" }, { group = "dev" }],
+            [{ package = "provider" }, { package = "provider", extra = "one" }],
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+
+        [tool.uv.dependency-groups]
+        dev = { requires-python = ">=3.13" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["leaf-two ; sys_platform == 'win32'"]
+
+        [project.optional-dependencies]
+        one = ["provider[bridge] ; sys_platform == 'win32'"]
+        two = ["leaf-two ; sys_platform == 'win32'"]
+        bridge = ["leaf-one ; sys_platform == 'win32'"]
+
+        [tool.uv.sources]
+        leaf-one = { path = "../leaf-one" }
+        leaf-two = { path = "../leaf-two" }
+        "#})?;
+    for name in ["leaf-one", "leaf-two"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--only-group")
+        .arg("dev")
+        .arg("--python-platform")
+        .arg("windows")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 2 packages
+    Would install 2 packages
+     + leaf-two @ file://[TEMP_DIR]/leaf-two
+     + provider @ file://[TEMP_DIR]/provider
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--no-default-groups")
+        .arg("--extra")
+        .arg("feature")
+        .arg("--python-platform")
+        .arg("windows")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 3 packages
+    Would install 3 packages
+     + leaf-one @ file://[TEMP_DIR]/leaf-one
+     + leaf-two @ file://[TEMP_DIR]/leaf-two
+     + provider @ file://[TEMP_DIR]/provider
+    ");
+
+    Ok(())
+}
+
 /// A source scoped to the active root extra does not need to repeat that extra on its edge.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18920,6 +18920,72 @@ fn lock_regenerates_marker_scoped_dependency_extra_with_selected_conflict() -> R
     Ok(())
 }
 
+/// A project conflict remains active through a dependency's requested extra.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_regenerates_dependency_extra_with_project_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[one]"]
+
+        [dependency-groups]
+        alternative = []
+
+        [tool.uv]
+        conflicts = [[{ package = "project" }, { group = "alternative" }]]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["anyio==4.3.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url())
+        .env("RUST_LOG", "uv::commands::project::lock=debug"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    DEBUG Existing `uv.lock` satisfies workspace requirements
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Preserve scoped overrides and platform forks for workspace-member dependencies.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18697,6 +18697,7 @@ fn lock_metadata_free_nested_group_conditional_registry_constraint() -> Result<(
 
         [dependency-groups]
         dev = ["ok[first]>=1,<3 ; python_full_version < '3.13' or sys_platform != 'win32'"]
+        other = ["ok[second]>=1,<3 ; sys_platform == 'win32'"]
         nested = [
             { include-group = "dev" },
             "ok[third]>=1,<3 ; python_full_version < '3.13' or sys_platform != 'win32'",
@@ -18770,6 +18771,94 @@ fn lock_metadata_free_nested_group_conditional_registry_constraint() -> Result<(
     Would install 1 package
      + ok==2.0.0
     ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--only-group")
+        .arg("other")
+        .arg("--python-platform")
+        .arg("windows")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 1 package
+    Would install 1 package
+     + ok==1.0.0
+    ");
+
+    let original_lock = context.read("uv.lock");
+    let mut lock = original_lock.parse::<toml_edit::DocumentMut>()?;
+    let Some(packages) = lock["package"].as_array_of_tables_mut() else {
+        anyhow::bail!("lockfile did not contain a package array");
+    };
+    let Some(project) = packages
+        .iter_mut()
+        .find(|package| package["name"].as_str() == Some("project"))
+    else {
+        anyhow::bail!("lockfile did not contain the project");
+    };
+    let Some(dependencies) = project["dev-dependencies"]["other"].as_array_mut() else {
+        anyhow::bail!("project did not contain its other dependency group");
+    };
+    let Some(dependency) = dependencies.iter_mut().find(|dependency| {
+        dependency
+            .as_inline_table()
+            .and_then(|dependency| dependency.get("marker"))
+            .and_then(toml_edit::Value::as_str)
+            .is_some_and(|marker| marker.starts_with("sys_platform == 'win32' or"))
+    }) else {
+        anyhow::bail!("other dependency group did not contain its base edge");
+    };
+    let Some(dependency) = dependency.as_inline_table_mut() else {
+        anyhow::bail!("other dependency group did not contain an inline edge");
+    };
+    let Some(marker) = dependency.get("marker").and_then(toml_edit::Value::as_str) else {
+        anyhow::bail!("other dependency edge did not contain a marker");
+    };
+    let marker = format!("python_full_version < '3.13' and ({marker})");
+    dependency.insert("marker", toml_edit::Value::from(marker));
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&lock.to_string())?;
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--frozen")
+        .arg("--only-group")
+        .arg("other")
+        .arg("--python-platform")
+        .arg("windows")
+        .arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Checked in [TIME]
+    Would make no changes
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&original_lock)?;
 
     let pyproject = context
         .read("pyproject.toml")


### PR DESCRIPTION
## Summary

Metadata-free lock validation must reconstruct dependencies using the same package-scoped override and exclusion semantics as the resolver.

Dynamic source trees intentionally omit their version from uv.lock, so use the freshly built distribution version for scoped rules and bypass static metadata only when relevant scoped rules are present. This accepts unchanged locks and invalidates stale locks when a dynamic version changes which rule applies.

Apply package-scoped overrides and exclusions before flattening recursive extras, matching resolver order. Otherwise an overridden or excluded self-reference can reactivate an extra, invent a dependency edge, and cause an unchanged metadata-free lock to fail offline.

Add deterministic offline integration coverage for version-specific overrides, versionless fallback precedence, scoped exclusions, dynamic-version changes, and overridden or excluded recursive extras.