### PR TITLE
Validate mutable root requirements across lock environments

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2595,9 +2595,6 @@ impl Lock {
                     if marker.is_false() {
                         continue;
                     }
-                    if !marker.evaluate(markers, &[]) {
-                        continue;
-                    }
 
                     activated_extras
                         .entry(package.id.clone())

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -24,7 +24,7 @@ use uv_configuration::{
     ExtrasSpecificationWithDefaults, InstallTarget, Override, Overrides, PackageOverride,
     ScopedOverrideSourceError,
 };
-use uv_distribution::{DistributionDatabase, FlatRequiresDist, RequiresDist};
+use uv_distribution::{ArchiveMetadata, DistributionDatabase, FlatRequiresDist, RequiresDist};
 use uv_distribution_filename::{
     BuildTag, DistExtension, ExtensionError, SourceDistExtension, WheelFilename,
 };
@@ -74,6 +74,7 @@ use crate::universal_marker::{ConflictMarker, UniversalMarker};
 use crate::{
     ExcludeNewer, ExcludeNewerOverride, ExcludeNewerPackage, ExcludeNewerSpan, ExcludeNewerValue,
     InMemoryIndex, MetadataResponse, PrereleaseMode, ResolutionMode, ResolverOutput,
+    UpgradePackages,
 };
 
 pub(crate) mod export;
@@ -2738,37 +2739,9 @@ impl Lock {
                     };
 
                     let metadata = {
-                        let id = dist.distribution_id();
-                        let archive = if let Some(archive) = index
-                            .distributions()
-                            .get(&id)
-                            .as_deref()
-                            .and_then(|response| {
-                                if let MetadataResponse::Found(archive, ..) = response {
-                                    Some(archive)
-                                } else {
-                                    None
-                                }
-                            }) {
-                            // If the metadata is already in the index, return it.
-                            archive.clone()
-                        } else {
-                            // Run the PEP 517 build process to extract metadata from the source distribution.
-                            let archive = database
-                                .get_or_build_wheel_metadata(&dist, hash_policy)
-                                .await
-                                .map_err(|err| LockErrorKind::Resolution {
-                                    id: package.id.clone(),
-                                    err,
-                                })?;
-
-                            // Insert the metadata into the index.
-                            index
-                                .distributions()
-                                .done(id, Arc::new(MetadataResponse::Found(archive.clone())));
-
-                            archive
-                        };
+                        let archive =
+                            Self::archive_metadata(package, &dist, hash_policy, index, database)
+                                .await?;
 
                         if validate_archive_hash
                             && !HashPolicy::All(hashes.as_slice())
@@ -3007,6 +2980,93 @@ impl Lock {
         }
 
         Ok(SatisfiesResult::Satisfied)
+    }
+
+    /// Validate every mutable archive except packages explicitly selected for upgrade.
+    ///
+    /// An authorized hash change must not short-circuit validation of unrelated locked archives.
+    pub async fn satisfies_unmodified_archive_hashes<Context: BuildContext>(
+        &self,
+        root: &Path,
+        tags: &Tags,
+        markers: &MarkerEnvironment,
+        build_options: &BuildOptions,
+        upgrades: &UpgradePackages,
+        index: &InMemoryIndex,
+        database: &DistributionDatabase<'_, Context>,
+    ) -> Result<SatisfiesResult<'_>, LockError> {
+        for package in &self.packages {
+            if !matches!(&package.id.source, Source::Path(..) | Source::Direct(..))
+                || upgrades.contains(&package.id.name)
+                || matches!(&package.id.source, Source::Direct(..))
+                    && database.client().unmanaged.connectivity().is_offline()
+            {
+                continue;
+            }
+
+            let HashedDist { dist, hashes } =
+                package.to_dist(root, TagPolicy::Preferred(tags), build_options, markers)?;
+            if hashes.is_empty() {
+                continue;
+            }
+
+            let archive = Self::archive_metadata(
+                package,
+                &dist,
+                HashPolicy::Generate(HashGeneration::Url),
+                index,
+                database,
+            )
+            .await?;
+            if !HashPolicy::All(hashes.as_slice()).matches(archive.hashes.as_slice()) {
+                return Ok(SatisfiesResult::MismatchedPackageHashes(
+                    &package.id.name,
+                    package.id.version.as_ref(),
+                    hashes,
+                    archive.hashes,
+                ));
+            }
+        }
+
+        Ok(SatisfiesResult::Satisfied)
+    }
+
+    /// Fetch archive metadata once and share it with later lock validation.
+    async fn archive_metadata<Context: BuildContext>(
+        package: &Package,
+        dist: &Dist,
+        hash_policy: HashPolicy<'_>,
+        index: &InMemoryIndex,
+        database: &DistributionDatabase<'_, Context>,
+    ) -> Result<ArchiveMetadata, LockError> {
+        let id = dist.distribution_id();
+        if let Some(archive) = index
+            .distributions()
+            .get(&id)
+            .as_deref()
+            .and_then(|response| {
+                if let MetadataResponse::Found(archive, ..) = response {
+                    Some(archive)
+                } else {
+                    None
+                }
+            })
+        {
+            return Ok(archive.clone());
+        }
+
+        let archive = database
+            .get_or_build_wheel_metadata(dist, hash_policy)
+            .await
+            .map_err(|err| LockErrorKind::Resolution {
+                id: package.id.clone(),
+                err,
+            })?;
+        index
+            .distributions()
+            .done(id, Arc::new(MetadataResponse::Found(archive.clone())));
+
+        Ok(archive)
     }
 
     async fn source_tree_requires_dist<Context: BuildContext>(

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2578,7 +2578,7 @@ impl Lock {
 
             for requirement in root_requirements {
                 for package in by_name.get(&requirement.name).into_iter().flatten() {
-                    if !package.id.source.is_local() {
+                    if package.id.source.is_immutable() {
                         continue;
                     }
 
@@ -2728,9 +2728,10 @@ impl Lock {
                         build_options,
                         markers,
                     )?;
-                    let validate_local_hash =
-                        matches!(&package.id.source, Source::Path(..)) && !hashes.is_empty();
-                    let hash_policy = if validate_local_hash {
+                    let validate_archive_hash =
+                        matches!(&package.id.source, Source::Path(..) | Source::Direct(..))
+                            && !hashes.is_empty();
+                    let hash_policy = if validate_archive_hash {
                         HashPolicy::Generate(HashGeneration::Url)
                     } else {
                         hasher.get(&dist)
@@ -2769,7 +2770,7 @@ impl Lock {
                             archive
                         };
 
-                        if validate_local_hash
+                        if validate_archive_hash
                             && !HashPolicy::All(hashes.as_slice())
                                 .matches(archive.hashes.as_slice())
                         {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -30,11 +30,11 @@ use uv_distribution_filename::{
 };
 use uv_distribution_types::{
     BuiltDist, DependencyMetadata, DirectUrlBuiltDist, DirectUrlSourceDist, DirectorySourceDist,
-    Dist, FileLocation, GitDirectorySourceDist, GitPathBuiltDist, GitPathSourceDist, Identifier,
-    IndexLocations, IndexMetadata, IndexUrl, Name, PYPI_URL, PathBuiltDist, PathSourceDist,
-    RegistryBuiltDist, RegistryBuiltWheel, RegistrySourceDist, RemoteSource, Requirement,
-    RequirementSource, RequiresPython, ResolvedDist, SimplifiedMarkerTree, StaticMetadata,
-    ToUrlError, UrlString,
+    Dist, FileLocation, GitDirectorySourceDist, GitPathBuiltDist, GitPathSourceDist,
+    HashGeneration, HashPolicy, Identifier, IndexLocations, IndexMetadata, IndexUrl, Name,
+    PYPI_URL, PathBuiltDist, PathSourceDist, RegistryBuiltDist, RegistryBuiltWheel,
+    RegistrySourceDist, RemoteSource, Requirement, RequirementSource, RequiresPython, ResolvedDist,
+    SimplifiedMarkerTree, StaticMetadata, ToUrlError, UrlString,
 };
 use uv_fs::{
     PortablePath, PortablePathBuf, Simplified, normalize_path, relative_to, try_relative_to_if,
@@ -2578,7 +2578,7 @@ impl Lock {
 
             for requirement in root_requirements {
                 for package in by_name.get(&requirement.name).into_iter().flatten() {
-                    if !package.id.source.is_source_tree() {
+                    if !package.id.source.is_local() {
                         continue;
                     }
 
@@ -2722,49 +2722,66 @@ impl Lock {
                 if !statically_satisfied {
                     // For a non-dynamic package without usable static metadata, fetch the metadata
                     // from the distribution database.
-                    let HashedDist { dist, .. } = package.to_dist(
+                    let HashedDist { dist, hashes } = package.to_dist(
                         root,
                         TagPolicy::Preferred(tags),
                         build_options,
                         markers,
                     )?;
+                    let validate_local_hash =
+                        matches!(&package.id.source, Source::Path(..)) && !hashes.is_empty();
+                    let hash_policy = if validate_local_hash {
+                        HashPolicy::Generate(HashGeneration::Url)
+                    } else {
+                        hasher.get(&dist)
+                    };
 
                     let metadata = {
                         let id = dist.distribution_id();
-                        if let Some(archive) =
-                            index
-                                .distributions()
-                                .get(&id)
-                                .as_deref()
-                                .and_then(|response| {
-                                    if let MetadataResponse::Found(archive, ..) = response {
-                                        Some(archive)
-                                    } else {
-                                        None
-                                    }
-                                })
-                        {
+                        let archive = if let Some(archive) = index
+                            .distributions()
+                            .get(&id)
+                            .as_deref()
+                            .and_then(|response| {
+                                if let MetadataResponse::Found(archive, ..) = response {
+                                    Some(archive)
+                                } else {
+                                    None
+                                }
+                            }) {
                             // If the metadata is already in the index, return it.
-                            archive.metadata.clone()
+                            archive.clone()
                         } else {
                             // Run the PEP 517 build process to extract metadata from the source distribution.
                             let archive = database
-                                .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
+                                .get_or_build_wheel_metadata(&dist, hash_policy)
                                 .await
                                 .map_err(|err| LockErrorKind::Resolution {
                                     id: package.id.clone(),
                                     err,
                                 })?;
 
-                            let metadata = archive.metadata.clone();
-
                             // Insert the metadata into the index.
                             index
                                 .distributions()
-                                .done(id, Arc::new(MetadataResponse::Found(archive)));
+                                .done(id, Arc::new(MetadataResponse::Found(archive.clone())));
 
-                            metadata
+                            archive
+                        };
+
+                        if validate_local_hash
+                            && !HashPolicy::All(hashes.as_slice())
+                                .matches(archive.hashes.as_slice())
+                        {
+                            return Ok(SatisfiesResult::MismatchedPackageHashes(
+                                &package.id.name,
+                                package.id.version.as_ref(),
+                                hashes,
+                                archive.hashes,
+                            ));
                         }
+
+                        archive.metadata
                     };
 
                     // If this is a local package, validate that it hasn't become dynamic (in which
@@ -3169,6 +3186,13 @@ pub enum SatisfiesResult<'lock> {
         Option<&'lock Version>,
         Vec<Dependency>,
         &'lock [Dependency],
+    ),
+    /// A local archive's current contents no longer match the locked hashes.
+    MismatchedPackageHashes(
+        &'lock PackageName,
+        Option<&'lock Version>,
+        HashDigests,
+        HashDigests,
     ),
     /// A package in the lockfile contains different `provides-extra` metadata than expected.
     MismatchedPackageProvidesExtra(

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -1540,6 +1540,20 @@ impl ValidatedLock {
                 }
                 Ok(Self::Preferable(lock))
             }
+            SatisfiesResult::MismatchedPackageHashes(name, version, expected, actual) => {
+                if let Some(version) = version {
+                    debug!(
+                        "Resolving despite existing lockfile due to mismatched hashes for: `{name}=={version}`\n  Requested: {:?}\n  Existing: {:?}",
+                        actual, expected
+                    );
+                } else {
+                    debug!(
+                        "Resolving despite existing lockfile due to mismatched hashes for: `{name}`\n  Requested: {:?}\n  Existing: {:?}",
+                        actual, expected
+                    );
+                }
+                Ok(Self::Preferable(lock))
+            }
             SatisfiesResult::MismatchedPackageDependencyGroups(name, version, expected, actual) => {
                 if let Some(version) = version {
                     debug!(

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -34,7 +34,7 @@ use uv_python::{
 use uv_requirements::{ExtrasResolver, LockedRequirements, read_lock_requirements};
 use uv_resolver::{
     FlatIndex, InMemoryIndex, Lock, Options, OptionsBuilder, Package, PythonRequirement,
-    ResolverEnvironment, ResolverManifest, SatisfiesResult, UniversalMarker,
+    ResolverEnvironment, ResolverManifest, SatisfiesResult, UniversalMarker, UpgradePackages,
 };
 use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
@@ -1353,23 +1353,8 @@ impl ValidatedLock {
             return Ok(Self::Preferable(lock));
         }
 
-        // If the user specified `--upgrade-package` or `--upgrade-group`, then at best we can
-        // prefer some of the existing versions.
-        if !(upgrade.is_none() || upgrade.is_all()) {
-            debug!(
-                "Resolving despite existing lockfile due to `--upgrade-package` or `--upgrade-group`"
-            );
-            return Ok(Self::Preferable(lock));
-        }
-
         if !lock.satisfies_hash_algorithms(install_path, index_locations)? {
             debug!("Resolving despite existing lockfile due to mismatched hash algorithm");
-            return Ok(Self::Preferable(lock));
-        }
-
-        // If the user specified `--refresh`, then we have to re-resolve.
-        if matches!(refresh, Some(Refresh::All(..) | Refresh::Packages(..))) {
-            debug!("Resolving despite existing lockfile due to `--refresh`");
             return Ok(Self::Preferable(lock));
         }
 
@@ -1412,6 +1397,21 @@ impl ValidatedLock {
             .await?
         {
             SatisfiesResult::Satisfied => {
+                // Validate locked archive hashes before a scoped upgrade can trigger a fresh
+                // resolution, which could otherwise silently replace an unrelated locked hash.
+                if !(upgrade.is_none() || upgrade.is_all()) {
+                    debug!(
+                        "Resolving despite existing lockfile due to `--upgrade-package` or `--upgrade-group`"
+                    );
+                    return Ok(Self::Preferable(lock));
+                }
+
+                // If the user specified `--refresh`, then we have to re-resolve.
+                if matches!(refresh, Some(Refresh::All(..) | Refresh::Packages(..))) {
+                    debug!("Resolving despite existing lockfile due to `--refresh`");
+                    return Ok(Self::Preferable(lock));
+                }
+
                 debug!("Existing `uv.lock` satisfies workspace requirements");
                 Ok(Self::Satisfies(lock))
             }
@@ -1576,7 +1576,9 @@ impl ValidatedLock {
                         actual, expected
                     );
                 }
-                if hash_mismatch_policy == HashMismatchPolicy::Update {
+                if hash_mismatch_policy == HashMismatchPolicy::Update
+                    || UpgradePackages::for_workspace(&lock, upgrade).contains(name)
+                {
                     Ok(Self::Preferable(lock))
                 } else {
                     Ok(Self::Satisfies(lock))

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -219,6 +219,7 @@ pub(crate) async fn lock(
             preview,
         )
         .with_refresh(&refresh)
+        .with_hash_updates()
         .with_lockfile_contents_check(
             matches!(&refresh, Refresh::All(..))
                 && preview.is_enabled(PreviewFeature::LockfileFormatCheck),
@@ -297,9 +298,19 @@ pub(crate) enum LockMode<'env> {
     Frozen(MissingLockfileSource),
 }
 
+/// Whether an existing archive hash can be replaced during lock validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HashMismatchPolicy {
+    /// Preserve locked hashes so installation can enforce them.
+    Preserve,
+    /// Allow an explicit lock operation to update stale archive hashes.
+    Update,
+}
+
 /// A lock operation.
 pub(crate) struct LockOperation<'env> {
     mode: LockMode<'env>,
+    hash_mismatch_policy: HashMismatchPolicy,
     constraints: Vec<NameRequirementSpecification>,
     refresh: Option<&'env Refresh>,
     check_lockfile_contents: bool,
@@ -330,6 +341,7 @@ impl<'env> LockOperation<'env> {
     ) -> Self {
         Self {
             mode,
+            hash_mismatch_policy: HashMismatchPolicy::Preserve,
             constraints: vec![],
             refresh: None,
             check_lockfile_contents: false,
@@ -359,6 +371,13 @@ impl<'env> LockOperation<'env> {
     #[must_use]
     pub(crate) fn with_refresh(mut self, refresh: &'env Refresh) -> Self {
         self.refresh = Some(refresh);
+        self
+    }
+
+    /// Allow an explicit lock operation to update mismatched archive hashes.
+    #[must_use]
+    fn with_hash_updates(mut self) -> Self {
+        self.hash_mismatch_policy = HashMismatchPolicy::Update;
         self
     }
 
@@ -427,6 +446,7 @@ impl<'env> LockOperation<'env> {
                     check_lockfile_contents,
                     self.constraints,
                     self.refresh,
+                    self.hash_mismatch_policy,
                     self.settings,
                     self.client_builder,
                     self.state,
@@ -480,6 +500,7 @@ impl<'env> LockOperation<'env> {
                     check_lockfile_contents,
                     self.constraints,
                     self.refresh,
+                    self.hash_mismatch_policy,
                     self.settings,
                     self.client_builder,
                     self.state,
@@ -513,6 +534,7 @@ async fn do_lock(
     check_lockfile_contents: Option<String>,
     external: Vec<NameRequirementSpecification>,
     refresh: Option<&Refresh>,
+    hash_mismatch_policy: HashMismatchPolicy,
     settings: &ResolverSettings,
     client_builder: &BaseClientBuilder<'_>,
     state: &UniversalState,
@@ -938,6 +960,7 @@ async fn do_lock(
             index_locations,
             upgrade,
             refresh,
+            hash_mismatch_policy,
             &options,
             &hasher,
             state.index(),
@@ -1173,6 +1196,7 @@ impl ValidatedLock {
         index_locations: &IndexLocations,
         upgrade: &Upgrade,
         refresh: Option<&Refresh>,
+        hash_mismatch_policy: HashMismatchPolicy,
         options: &Options,
         hasher: &HashStrategy,
         index: &InMemoryIndex,
@@ -1552,7 +1576,11 @@ impl ValidatedLock {
                         actual, expected
                     );
                 }
-                Ok(Self::Preferable(lock))
+                if hash_mismatch_policy == HashMismatchPolicy::Update {
+                    Ok(Self::Preferable(lock))
+                } else {
+                    Ok(Self::Satisfies(lock))
+                }
             }
             SatisfiesResult::MismatchedPackageDependencyGroups(name, version, expected, actual) => {
                 if let Some(version) = version {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -1371,6 +1371,28 @@ impl ValidatedLock {
             Some(index_locations)
         };
 
+        if hash_mismatch_policy == HashMismatchPolicy::Preserve
+            && !(upgrade.is_none() || upgrade.is_all())
+        {
+            let upgrades = UpgradePackages::for_workspace(&lock, upgrade);
+            if !matches!(
+                lock.satisfies_unmodified_archive_hashes(
+                    install_path,
+                    interpreter.tags()?,
+                    interpreter.markers(),
+                    &options.build_options,
+                    &upgrades,
+                    index,
+                    database,
+                )
+                .await?,
+                SatisfiesResult::Satisfied
+            ) {
+                debug!("Preserving unrelated locked archive hashes during a scoped upgrade");
+                return Ok(Self::Satisfies(lock));
+            }
+        }
+
         // Determine whether the lockfile satisfies the workspace requirements.
         match lock
             .satisfies(

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -52,6 +52,7 @@ use uv_warnings::warn_user_once;
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip;
+use crate::commands::project::lock::HashMismatchPolicy;
 
 /// An error raised when a tool package provides no executables.
 #[derive(Debug, Error)]
@@ -539,6 +540,7 @@ impl ToolLock {
             index_locations,
             upgrade,
             Some(refresh),
+            HashMismatchPolicy::Preserve,
             &options,
             &hasher,
             state.index(),

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -2,6 +2,12 @@ use anyhow::Result;
 #[cfg(feature = "test-universal")]
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
+#[cfg(feature = "test-universal")]
+use async_zip::base::write::ZipFileWriter;
+#[cfg(feature = "test-universal")]
+use async_zip::{Compression, ZipEntryBuilder};
+#[cfg(feature = "test-universal")]
+use futures::executor::block_on;
 use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
 #[cfg(feature = "test-universal")]
@@ -31518,6 +31524,118 @@ fn lock_script_conditional_path_dependency_change() -> Result<()> {
         requires-python = ">=3.12"
         dependencies = ["ok==2.0.0"]
         "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+/// Local wheel requirements must participate in script lock freshness checks.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_script_local_wheel_dependency_change() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("script.py").write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["child"]
+        #
+        # [tool.uv.sources]
+        # child = { path = "child-1.0.0-py3-none-any.whl" }
+        # ///
+
+        print("hello")
+        "#})?;
+
+    let wheel = context.temp_dir.child("child-1.0.0-py3-none-any.whl");
+    let write_wheel = |dependency: &str, payload: &str| -> Result<()> {
+        let mut archive = ZipFileWriter::new(Vec::new());
+        for (path, contents) in [
+            ("child/__init__.py", payload.to_string()),
+            (
+                "child-1.0.0.dist-info/METADATA",
+                format!(
+                    "Metadata-Version: 2.4\nName: child\nVersion: 1.0.0\nRequires-Dist: ok=={dependency}\n"
+                ),
+            ),
+            (
+                "child-1.0.0.dist-info/WHEEL",
+                "Wheel-Version: 1.0\nGenerator: uv-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+                    .to_string(),
+            ),
+            ("child-1.0.0.dist-info/RECORD", String::new()),
+        ] {
+            let entry = ZipEntryBuilder::new(path.into(), Compression::Stored);
+            block_on(archive.write_entry_whole(entry, contents.as_bytes()))?;
+        }
+        fs_err::write(wheel.path(), block_on(archive.close())?)?;
+        Ok(())
+    };
+    write_wheel("1.0.0", "before")?;
+
+    let links = context.workspace_root.join("test/links");
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    write_wheel("1.0.0", "after")?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    write_wheel("2.0.0", "after")?;
 
     uv_snapshot!(context.filters(), context.lock()
         .arg("--script")

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -31657,6 +31657,150 @@ fn lock_script_local_wheel_dependency_change() -> Result<()> {
     Ok(())
 }
 
+/// Direct URL requirements must validate mutable remote archives when a network is available.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_script_direct_url_dependency_change() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = MockServer::start().await;
+    let wheel_path = "/child-1.0.0-py3-none-any.whl";
+
+    let wheel = |dependency: &str, payload: &str| -> Result<Vec<u8>> {
+        let mut archive = ZipFileWriter::new(Vec::new());
+        for (path, contents) in [
+            ("child/__init__.py", payload.to_string()),
+            (
+                "child-1.0.0.dist-info/METADATA",
+                format!(
+                    "Metadata-Version: 2.4\nName: child\nVersion: 1.0.0\nRequires-Dist: ok=={dependency}\n"
+                ),
+            ),
+            (
+                "child-1.0.0.dist-info/WHEEL",
+                "Wheel-Version: 1.0\nGenerator: uv-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+                    .to_string(),
+            ),
+            ("child-1.0.0.dist-info/RECORD", String::new()),
+        ] {
+            let entry = ZipEntryBuilder::new(path.into(), Compression::Stored);
+            block_on(archive.write_entry_whole(entry, contents.as_bytes()))?;
+        }
+        Ok(block_on(archive.close())?)
+    };
+
+    Mock::given(method("GET"))
+        .and(path(wheel_path))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(wheel("1.0.0", "before")?))
+        .mount(&server)
+        .await;
+
+    context
+        .temp_dir
+        .child("script.py")
+        .write_str(&formatdoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["child"]
+        #
+        # [tool.uv.sources]
+        # child = {{ url = "{}{wheel_path}" }}
+        # ///
+
+        print("hello")
+        "#,
+            server.uri()
+        })?;
+
+    let links = context.workspace_root.join("test/links");
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    // Preserve the existing offline behavior when the direct URL cannot be refreshed.
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    server.reset().await;
+    Mock::given(method("GET"))
+        .and(path(wheel_path))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(wheel("1.0.0", "after")?))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    server.reset().await;
+    Mock::given(method("GET"))
+        .and(path(wheel_path))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(wheel("2.0.0", "after")?))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
 /// `uv lock --script` should add a PEP 723 tag, if it doesn't exist already.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -20118,6 +20118,88 @@ fn lock_non_project_conditional() -> Result<()> {
     Ok(())
 }
 
+/// Validate conditional root dependencies across every platform covered by the lock.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_non_project_conditional_path_dependency_change() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let platform = if cfg!(windows) { "linux" } else { "win32" };
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [tool.uv.workspace]
+        members = []
+
+        [dependency-groups]
+        dev = ["child; sys_platform == '{platform}'"]
+
+        [tool.uv.sources]
+        child = {{ path = "child" }}
+        "#})?;
+
+    let child = context.temp_dir.child("child");
+    child.create_dir_all()?;
+    let pyproject_toml = child.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok==1.0.0"]
+        "#})?;
+
+    let links = context.workspace_root.join("test/links");
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
+    Resolved 2 packages in [TIME]
+    ");
+
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok==2.0.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
 /// Lock a non-project workspace root with `dependency-groups`.
 #[cfg(feature = "test-universal")]
 #[test]
@@ -31371,6 +31453,88 @@ fn lock_script_editable_path_dependency_change() -> Result<()> {
         "#
         );
     });
+
+    Ok(())
+}
+
+/// Validate script dependencies for Python versions other than the current interpreter.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_script_conditional_path_dependency_change() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("script.py").write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["child; python_full_version >= '3.13'"]
+        #
+        # [tool.uv.sources]
+        # child = { path = "child" }
+        # ///
+
+        print("hello")
+        "#})?;
+
+    let child = context.temp_dir.child("child");
+    child.create_dir_all()?;
+    let pyproject_toml = child.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok==1.0.0"]
+        "#})?;
+
+    let links = context.workspace_root.join("test/links");
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok==2.0.0"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -31654,6 +31654,35 @@ fn lock_script_local_wheel_dependency_change() -> Result<()> {
     hint: To update the lockfile, run `uv lock`.
     ");
 
+    // An explicit lock operation is authorized to replace the stale archive hash.
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Updated ok v1.0.0 -> v2.0.0
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
     Ok(())
 }
 

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -11062,6 +11062,86 @@ fn path_hash_mismatch() -> Result<()> {
     Ok(())
 }
 
+/// Upgrading one package must not replace the locked hash of an unrelated local archive.
+#[test]
+fn scoped_upgrade_preserves_unrelated_archive_hash() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let links = context.workspace_root.join("test/links");
+    let wheel = context
+        .temp_dir
+        .child("simple_launcher-0.1.0-py3-none-any.whl");
+    fs_err::copy(links.join("simple_launcher-0.1.0-py3-none-any.whl"), &wheel)?;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["simple-launcher", "ok==1.0.0"]
+
+        [tool.uv.sources]
+        simple-launcher = {{ path = "{}" }}
+        "#,
+        wheel.path().portable_display()
+        })?;
+
+    context
+        .sync()
+        .arg("--offline")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links)
+        .assert()
+        .success();
+
+    let mut archive = fs_err::read(&wheel)?;
+    let comment_length_offset = archive.len() - 2;
+    archive[comment_length_offset..].copy_from_slice(&8u16.to_le_bytes());
+    archive.extend_from_slice(b"tampered");
+    fs_err::write(&wheel, archive)?;
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--upgrade-package")
+        .arg("ok")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+      × Failed to read `simple-launcher @ file://[TEMP_DIR]/simple_launcher-0.1.0-py3-none-any.whl`
+      ╰─▶ Hash mismatch for `simple-launcher @ file://[TEMP_DIR]/simple_launcher-0.1.0-py3-none-any.whl`
+
+          Expected:
+            sha256:5327e0bb67cdb46800999de6dcf034bf0a5335702883494af0d8b7f6ca48cee4
+
+          Computed:
+            sha256:b6b1e19063b10118c0181105fe9cd5b25dccb0f7c761cee3b319566d5d306d66
+
+    hint: `simple-launcher` (v0.1.0) was included because `project` (v0.1.0) depends on `simple-launcher`
+    ");
+
+    // Explicitly selecting the changed package permits refreshing its archive hash.
+    context
+        .sync()
+        .arg("--upgrade-package")
+        .arg("simple-launcher")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(&links)
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 #[test]
 fn find_links_relative_in_config_works_from_subdir() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -11071,6 +11071,8 @@ fn scoped_upgrade_preserves_unrelated_archive_hash() -> Result<()> {
         .temp_dir
         .child("simple_launcher-0.1.0-py3-none-any.whl");
     fs_err::copy(links.join("simple_launcher-0.1.0-py3-none-any.whl"), &wheel)?;
+    let ok_wheel = context.temp_dir.child("ok-1.0.0-py3-none-any.whl");
+    fs_err::copy(links.join("ok-1.0.0-py3-none-any.whl"), &ok_wheel)?;
 
     context
         .temp_dir
@@ -11084,8 +11086,10 @@ fn scoped_upgrade_preserves_unrelated_archive_hash() -> Result<()> {
 
         [tool.uv.sources]
         simple-launcher = {{ path = "{}" }}
+        ok = {{ path = "{}" }}
         "#,
-        wheel.path().portable_display()
+        wheel.path().portable_display(),
+        ok_wheel.path().portable_display(),
         })?;
 
     context
@@ -11097,11 +11101,14 @@ fn scoped_upgrade_preserves_unrelated_archive_hash() -> Result<()> {
         .assert()
         .success();
 
-    let mut archive = fs_err::read(&wheel)?;
-    let comment_length_offset = archive.len() - 2;
-    archive[comment_length_offset..].copy_from_slice(&8u16.to_le_bytes());
-    archive.extend_from_slice(b"tampered");
-    fs_err::write(&wheel, archive)?;
+    let original_ok = fs_err::read(&ok_wheel)?;
+    for archive_path in [&wheel, &ok_wheel] {
+        let mut archive = fs_err::read(archive_path)?;
+        let comment_length_offset = archive.len() - 2;
+        archive[comment_length_offset..].copy_from_slice(&8u16.to_le_bytes());
+        archive.extend_from_slice(b"tampered");
+        fs_err::write(archive_path, archive)?;
+    }
 
     uv_snapshot!(context.filters(), context.sync()
         .arg("--upgrade-package")
@@ -11127,6 +11134,7 @@ fn scoped_upgrade_preserves_unrelated_archive_hash() -> Result<()> {
     ");
 
     // Explicitly selecting the changed package permits refreshing its archive hash.
+    fs_err::write(&ok_wheel, original_ok)?;
     context
         .sync()
         .arg("--upgrade-package")


### PR DESCRIPTION
## Summary

Root requirements from PEP 723 scripts and non-project workspace dependency groups were validated only when their markers matched the running interpreter, while local archives and direct URLs were omitted entirely. As a result, `uv lock --locked` could silently accept changed dependencies on another platform or Python version, or replaced local and remote archives.

Traverse every satisfiable mutable root requirement across the universal lock environment, including path-based wheels, source archives, and direct URLs. Recompute and compare recorded archive hashes during metadata validation, preserving offline direct-URL behavior. Share cached archive metadata across validation passes, and preflight every unrelated mutable archive before scoped upgrades; only explicit lock operations and explicitly selected packages may replace existing hashes.

Cover non-host platforms, future Python versions, unchanged local and remote wheels, modified archive payloads, changed wheel dependencies, offline direct URLs, explicit lock refresh, installation hash enforcement, and simultaneous tampering with upgraded and unrelated archives.