### PR TITLE
Preserve requested extras across overlapping package conflicts

### DIFF
--- a/crates/uv-resolver/src/resolver/environment.rs
+++ b/crates/uv-resolver/src/resolver/environment.rs
@@ -221,6 +221,18 @@ impl ResolverEnvironment {
         }
     }
 
+    /// Returns whether a conflict item can still be explicitly included in this environment.
+    ///
+    /// Project exclusions implicitly disable their extras, but a later conflict fork can
+    /// explicitly select one of those extras. Only an exclusion of the item itself rules out
+    /// that possibility.
+    pub(crate) fn may_include_group(&self, group: ConflictItemRef<'_>) -> bool {
+        match self.kind {
+            Kind::Specific { .. } => true,
+            Kind::Universal { ref exclude, .. } => !exclude.contains(&group),
+        }
+    }
+
     /// Returns the bounding Python versions that can satisfy this
     /// resolver environment's marker, if it's constrained.
     pub(crate) fn requires_python(&self) -> Option<RequiresPythonRange> {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -4170,15 +4170,16 @@ impl Forks {
                 // "excluded" variant).
                 let non_excluded: Vec<_> = set
                     .iter()
-                    .filter(|item| fork.env.included_by_group(item.as_ref()))
+                    .filter(|item| fork.env.may_include_group(item.as_ref()))
                     .collect();
                 if non_excluded.len() < 2 {
                     // Check if any non-excluded item still has a live conflict in another set —
                     // i.e., another set where this item AND at least one other non-excluded item
                     // both appear. If so, we still need to fork to create the "excluded" variant
-                    // for that item.
-                    let dominated = non_excluded.iter().all(|item| {
-                        !conflicts.iter().any(|other_set| {
+                    // for that item. An extra implicitly excluded by its project also requires
+                    // its own fork so it can be explicitly included.
+                    let has_live_conflict = |item: &ConflictItem| {
+                        conflicts.iter().any(|other_set| {
                             !std::ptr::eq(set, other_set)
                                 && other_set.contains(item.package(), item.kind().as_ref())
                                 && other_set
@@ -4188,9 +4189,34 @@ impl Forks {
                                             || other_item.kind() != item.kind()
                                     })
                                     .any(|other_item| {
-                                        fork.env.included_by_group(other_item.as_ref())
+                                        fork.env.may_include_group(other_item.as_ref())
                                     })
                         })
+                    };
+                    if let [item] = non_excluded.as_slice()
+                        && !fork.env.included_by_group(item.as_ref())
+                        && !has_live_conflict(item)
+                    {
+                        // A project exclusion is overridden only by an explicit extra
+                        // inclusion. Without another live conflict, include that extra in this
+                        // fork directly instead of producing exponentially many subsets.
+                        let selected_extra = fork.conflicts.iter().any(|candidate| {
+                            candidate.package() == item.package()
+                                && matches!(candidate.kind().as_ref(), ConflictKindRef::Extra(_))
+                                && fork.env.included_by_group(candidate.as_ref())
+                        });
+                        if !selected_extra
+                            && let Some(excluded) = fork.clone().filter([Err((**item).clone())])
+                        {
+                            new.push(excluded);
+                        }
+                        if let Some(included) = fork.filter([Ok((**item).clone())]) {
+                            new.push(included);
+                        }
+                        continue;
+                    }
+                    let dominated = non_excluded.iter().all(|item| {
+                        fork.env.included_by_group(item.as_ref()) && !has_live_conflict(item)
                     });
                     if dominated {
                         // When dependencies are added to forks, we check `included_by_marker` but
@@ -4199,7 +4225,7 @@ impl Forks {
                         // the fork to clean up dependencies gated on already-excluded extras.
                         let rules: Vec<_> = set
                             .iter()
-                            .filter(|item| !fork.env.included_by_group(item.as_ref()))
+                            .filter(|item| !fork.env.may_include_group(item.as_ref()))
                             .cloned()
                             .map(Err)
                             .collect();
@@ -4235,6 +4261,11 @@ impl Forks {
                 }
             }
             forks = new;
+        }
+        // Project exclusions temporarily leave their extras available so later conflict sets
+        // can explicitly include them. Apply inherited exclusions once all forks are settled.
+        for fork in &mut forks {
+            fork.prune_excluded_dependencies(false);
         }
         Self {
             forks,
@@ -4337,11 +4368,23 @@ impl Fork {
         rules: impl IntoIterator<Item = Result<ConflictItem, ConflictItem>>,
     ) -> Option<Self> {
         self.env = self.env.filter_by_group(rules)?;
+        self.prune_excluded_dependencies(true);
+        Some(self)
+    }
+
+    /// Remove unavailable dependencies, optionally retaining extras a later fork can select.
+    fn prune_excluded_dependencies(&mut self, preserve_selectable_extras: bool) {
         self.dependencies.retain(|dep| {
             let Some(conflicting_item) = dep.conflicting_item() else {
                 return true;
             };
             if self.env.included_by_group(conflicting_item) {
+                return true;
+            }
+            if preserve_selectable_extras
+                && matches!(conflicting_item.kind(), ConflictKindRef::Extra(_))
+                && self.env.may_include_group(conflicting_item)
+            {
                 return true;
             }
             match conflicting_item.kind() {
@@ -4358,7 +4401,6 @@ impl Fork {
             self.conflicts.remove(&conflicting_item);
             false
         });
-        Some(self)
     }
 
     /// Compare forks, preferring forks with g `requires-python` requirements.

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -3332,6 +3332,140 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
     Ok(())
 }
 
+/// Overlapping project conflicts must preserve every explicitly requested extra fork.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_conflicting_project_preserves_requested_extra_forks() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["provider[one,two]"]
+
+        [tool.uv]
+        conflicts = [
+            [{ package = "provider" }, { package = "provider", extra = "one" }],
+            [{ package = "provider" }, { package = "provider", extra = "two" }],
+            [{ package = "provider", extra = "one" }, { package = "provider", extra = "two" }],
+        ]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["leaf-one"]
+        two = ["leaf-two"]
+
+        [tool.uv.sources]
+        leaf-one = { path = "../leaf-one" }
+        leaf-two = { path = "../leaf-two" }
+        "#})?;
+    for name in ["leaf-one", "leaf-two"] {
+        context
+            .temp_dir
+            .child(format!("{name}/pyproject.toml"))
+            .write_str(&formatdoc! {r#"
+            [project]
+            name = "{name}"
+            version = "1.0.0"
+            requires-python = ">=3.12"
+            "#})?;
+    }
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        conflicts = [[
+            { package = "provider", extra = "one" },
+            { package = "provider" },
+        ], [
+            { package = "provider", extra = "two" },
+            { package = "provider" },
+        ], [
+            { package = "provider", extra = "one" },
+            { package = "provider", extra = "two" },
+        ]]
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "leaf-one"
+        version = "1.0.0"
+        source = { directory = "leaf-one" }
+
+        [[package]]
+        name = "leaf-two"
+        version = "1.0.0"
+        source = { directory = "leaf-two" }
+
+        [[package]]
+        name = "project"
+        version = "1.0.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "provider" },
+            { name = "provider", extra = ["one"], marker = "extra == 'extra-8-provider-one' or (extra == 'extra-8-provider-two' and extra == 'project-8-provider')" },
+            { name = "provider", extra = ["two"], marker = "extra == 'extra-8-provider-two' or (extra == 'extra-8-provider-one' and extra == 'project-8-provider')" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "provider", extras = ["one", "two"], directory = "provider" }]
+
+        [[package]]
+        name = "provider"
+        version = "1.0.0"
+        source = { directory = "provider" }
+
+        [package.optional-dependencies]
+        one = [
+            { name = "leaf-one" },
+        ]
+        two = [
+            { name = "leaf-two" },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "leaf-one", marker = "extra == 'one'", directory = "leaf-one" },
+            { name = "leaf-two", marker = "extra == 'two'", directory = "leaf-two" },
+        ]
+        provides-extras = ["one", "two"]
+        "#
+        );
+    });
+
+    Ok(())
+}
+
 /// This tests a "basic" case for specifying a group that conflicts with the
 /// project itself.
 #[cfg(feature = "test-universal")]


### PR DESCRIPTION
## Summary

Overlapping conflicts between a package and its own extras could cause us to silently discard an explicitly requested extra and its transitive dependencies:

```toml
[project]
dependencies = ["provider[one,two]"]

[tool.uv]
conflicts = [
    [{ package = "provider" }, { package = "provider", extra = "one" }],
    [{ package = "provider" }, { package = "provider", extra = "two" }],
    [{ package = "provider", extra = "one" }, { package = "provider", extra = "two" }],
]
```

A package-level exclusion implicitly suppresses its extras, but a later conflict fork can explicitly reactivate one of them. Distinguish those inherited exclusions from explicit exclusions while constructing forks, defer inherited pruning until all conflict sets have been considered, and preserve the existing dominated-fork optimization by selecting compatible extras without enumerating every subset.

The resulting lock retains both requested optional-dependency sections, their transitive packages, and the base-package-only fork.