### PR TITLE
Resolve conflicting extras through package-qualified dependency edges

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2366,13 +2366,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 requirement
             })
             .filter(move |requirement| {
-                Self::is_requirement_applicable(
-                    requirement,
-                    extra,
-                    env,
-                    python_marker,
-                    python_requirement,
-                )
+                Self::is_requirement_applicable(requirement, env, python_marker, python_requirement)
             })
             .flat_map(move |requirement| {
                 iter::once(requirement.clone()).chain(self.constraints_for_requirement(
@@ -2385,34 +2379,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             })
     }
 
-    /// Whether a requirement is applicable for the Python version, the markers of this fork and the
-    /// requested extra.
+    /// Whether a requirement is applicable for the Python version and the markers of this fork.
     fn is_requirement_applicable(
         requirement: &Requirement,
-        extra: Option<&ExtraName>,
         env: &ResolverEnvironment,
         python_marker: MarkerTree,
         python_requirement: &PythonRequirement,
     ) -> bool {
         // If the requirement isn't relevant for the current platform, skip it.
-        match extra {
-            Some(source_extra) => {
-                if !requirement.evaluate_markers(env.marker_environment(), &[]) {
-                    return false;
-                }
-
-                if (requirement.extras.is_empty() || requirement.extras.contains(source_extra))
-                    && !env
-                        .included_by_group(ConflictItemRef::from((&requirement.name, source_extra)))
-                {
-                    return false;
-                }
-            }
-            None => {
-                if !requirement.evaluate_markers(env.marker_environment(), &[]) {
-                    return false;
-                }
-            }
+        if !requirement.evaluate_markers(env.marker_environment(), &[]) {
+            return false;
         }
 
         // If the requirement would not be selected with any Python version
@@ -2534,15 +2510,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     Some(source_extra) => {
                         if !constraint
                             .evaluate_markers(env.marker_environment(), slice::from_ref(source_extra))
-                        {
-                            return None;
-                        }
-                        if (requirement.extras.is_empty()
-                            || requirement.extras.contains(source_extra))
-                            && !env.included_by_group(ConflictItemRef::from((
-                                &requirement.name,
-                                source_extra,
-                            )))
                         {
                             return None;
                         }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2201,6 +2201,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             Either::Left(Either::Left(self.requirements_for_extra(
                 dev_dependencies.get(dev).into_iter().flatten(),
                 extra,
+                name,
                 None,
                 name.zip(version),
                 env,
@@ -2215,6 +2216,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             Either::Left(Either::Right(self.requirements_for_extra(
                 dependencies.iter(),
                 extra,
+                name,
                 name.zip(version),
                 name.zip(version),
                 env,
@@ -2226,6 +2228,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 .requirements_for_extra(
                     dependencies.iter(),
                     extra,
+                    name,
                     name.zip(version),
                     name.zip(version),
                     env,
@@ -2249,6 +2252,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 for requirement in self.requirements_for_extra(
                     dependencies,
                     Some(&extra),
+                    name,
                     name.zip(version),
                     name.zip(version),
                     env,
@@ -2320,6 +2324,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         &'data self,
         dependencies: impl IntoIterator<Item = &'data Requirement> + 'parameters,
         extra: Option<&'parameters ExtraName>,
+        source_package: Option<&'parameters PackageName>,
         override_package: Option<(&'parameters PackageName, &'parameters Version)>,
         exclusion_package: Option<(&'parameters PackageName, &'parameters Version)>,
         env: &'parameters ResolverEnvironment,
@@ -2369,6 +2374,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 Self::is_requirement_applicable(
                     requirement,
                     extra,
+                    source_package,
                     env,
                     python_marker,
                     python_requirement,
@@ -2378,6 +2384,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 iter::once(requirement.clone()).chain(self.constraints_for_requirement(
                     requirement,
                     extra,
+                    source_package,
                     env,
                     python_marker,
                     python_requirement,
@@ -2390,6 +2397,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
     fn is_requirement_applicable(
         requirement: &Requirement,
         extra: Option<&ExtraName>,
+        source_package: Option<&PackageName>,
         env: &ResolverEnvironment,
         python_marker: MarkerTree,
         python_requirement: &PythonRequirement,
@@ -2401,7 +2409,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     return false;
                 }
 
-                if !env.included_by_group(ConflictItemRef::from((&requirement.name, source_extra)))
+                if let Some(source_package) = source_package
+                    && !env.included_by_group(ConflictItemRef::from((source_package, source_extra)))
                 {
                     return false;
                 }
@@ -2439,6 +2448,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         &'data self,
         requirement: Cow<'data, Requirement>,
         extra: Option<&'parameters ExtraName>,
+        source_package: Option<&'parameters PackageName>,
         env: &'parameters ResolverEnvironment,
         python_marker: MarkerTree,
         python_requirement: &'parameters PythonRequirement,
@@ -2535,7 +2545,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         {
                             return None;
                         }
-                        if !env.included_by_group(ConflictItemRef::from((&requirement.name, source_extra)))
+                        if let Some(source_package) = source_package
+                            && !env.included_by_group(ConflictItemRef::from((source_package, source_extra)))
                         {
                             return None;
                         }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2201,7 +2201,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             Either::Left(Either::Left(self.requirements_for_extra(
                 dev_dependencies.get(dev).into_iter().flatten(),
                 extra,
-                name,
                 None,
                 name.zip(version),
                 env,
@@ -2216,7 +2215,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             Either::Left(Either::Right(self.requirements_for_extra(
                 dependencies.iter(),
                 extra,
-                name,
                 name.zip(version),
                 name.zip(version),
                 env,
@@ -2228,7 +2226,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 .requirements_for_extra(
                     dependencies.iter(),
                     extra,
-                    name,
                     name.zip(version),
                     name.zip(version),
                     env,
@@ -2252,7 +2249,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 for requirement in self.requirements_for_extra(
                     dependencies,
                     Some(&extra),
-                    name,
                     name.zip(version),
                     name.zip(version),
                     env,
@@ -2324,7 +2320,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         &'data self,
         dependencies: impl IntoIterator<Item = &'data Requirement> + 'parameters,
         extra: Option<&'parameters ExtraName>,
-        source_package: Option<&'parameters PackageName>,
         override_package: Option<(&'parameters PackageName, &'parameters Version)>,
         exclusion_package: Option<(&'parameters PackageName, &'parameters Version)>,
         env: &'parameters ResolverEnvironment,
@@ -2374,7 +2369,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 Self::is_requirement_applicable(
                     requirement,
                     extra,
-                    source_package,
                     env,
                     python_marker,
                     python_requirement,
@@ -2384,7 +2378,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 iter::once(requirement.clone()).chain(self.constraints_for_requirement(
                     requirement,
                     extra,
-                    source_package,
                     env,
                     python_marker,
                     python_requirement,
@@ -2397,7 +2390,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
     fn is_requirement_applicable(
         requirement: &Requirement,
         extra: Option<&ExtraName>,
-        source_package: Option<&PackageName>,
         env: &ResolverEnvironment,
         python_marker: MarkerTree,
         python_requirement: &PythonRequirement,
@@ -2409,8 +2401,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     return false;
                 }
 
-                if let Some(source_package) = source_package
-                    && !env.included_by_group(ConflictItemRef::from((source_package, source_extra)))
+                if (requirement.extras.is_empty() || requirement.extras.contains(source_extra))
+                    && !env
+                        .included_by_group(ConflictItemRef::from((&requirement.name, source_extra)))
                 {
                     return false;
                 }
@@ -2448,7 +2441,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         &'data self,
         requirement: Cow<'data, Requirement>,
         extra: Option<&'parameters ExtraName>,
-        source_package: Option<&'parameters PackageName>,
         env: &'parameters ResolverEnvironment,
         python_marker: MarkerTree,
         python_requirement: &'parameters PythonRequirement,
@@ -2545,8 +2537,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         {
                             return None;
                         }
-                        if let Some(source_package) = source_package
-                            && !env.included_by_group(ConflictItemRef::from((source_package, source_extra)))
+                        if (requirement.extras.is_empty()
+                            || requirement.extras.contains(source_extra))
+                            && !env.included_by_group(ConflictItemRef::from((
+                                &requirement.name,
+                                source_extra,
+                            )))
                         {
                             return None;
                         }

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -5163,9 +5163,11 @@ fn lock_check_refresh_workspace_conflicts() -> Result<()> {
 
         [package.optional-dependencies]
         non-prod = [
+            { name = "package-a", marker = "extra == 'extra-14-workspace-demo-non-prod' or (extra == 'extra-9-package-a-non-prod' and extra == 'extra-9-package-a-prod')" },
             { name = "package-a", extra = ["non-prod"], marker = "(extra == 'extra-14-workspace-demo-non-prod' and extra == 'extra-14-workspace-demo-prod') or (extra == 'extra-14-workspace-demo-non-prod' and extra == 'extra-9-package-a-non-prod') or (extra == 'extra-9-package-a-non-prod' and extra == 'extra-9-package-a-prod')" },
         ]
         prod = [
+            { name = "package-a", marker = "extra == 'extra-14-workspace-demo-prod' or (extra == 'extra-9-package-a-non-prod' and extra == 'extra-9-package-a-prod')" },
             { name = "package-a", extra = ["prod"], marker = "(extra == 'extra-14-workspace-demo-non-prod' and extra == 'extra-14-workspace-demo-prod') or (extra == 'extra-14-workspace-demo-prod' and extra == 'extra-9-package-a-prod') or (extra == 'extra-9-package-a-non-prod' and extra == 'extra-9-package-a-prod')" },
         ]
 

--- a/crates/uv/tests/lock_scenarios/lock_conflict.rs
+++ b/crates/uv/tests/lock_scenarios/lock_conflict.rs
@@ -186,6 +186,90 @@ fn workspace_extra_preserves_independently_requested_conflicting_extra() -> Resu
     Ok(())
 }
 
+/// A parent extra must not be mistaken for an identically named extra on a plain dependency.
+#[test]
+fn workspace_extra_preserves_plain_dependency_with_conflicting_target_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [tool.uv]
+        conflicts = [[
+            { package = "child", extra = "one" },
+            { package = "child", extra = "two" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider", "child"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        child = { workspace = true }
+        "#,
+    )?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(
+            r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child"]
+        "#,
+        )?;
+    context.temp_dir.child("child/pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = []
+        two = []
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--frozen")
+        .arg("--dry-run")
+        .arg("--package")
+        .arg("provider")
+        .arg("--extra")
+        .arg("one")
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 2 packages
+    Would install 2 packages
+     + child @ file://[TEMP_DIR]/child
+     + provider @ file://[TEMP_DIR]/provider
+    ");
+
+    Ok(())
+}
+
 /// Recursive workspace extras must retain their independently conflicting target selections.
 #[test]
 fn workspace_recursive_extra_preserves_independently_conflicting_target_extra() -> Result<()> {

--- a/crates/uv/tests/lock_scenarios/lock_conflict.rs
+++ b/crates/uv/tests/lock_scenarios/lock_conflict.rs
@@ -102,6 +102,90 @@ fn extra_conflict_discovery_respects_parent_reachability() -> Result<()> {
     Ok(())
 }
 
+/// An independently requested target extra must not be dropped due to the source extra's name.
+#[test]
+fn workspace_extra_preserves_independently_requested_conflicting_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [tool.uv]
+        conflicts = [[
+            { package = "child", extra = "one" },
+            { package = "child", extra = "two" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider", "child"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        child = { workspace = true }
+        "#,
+    )?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(
+            r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["child[two]"]
+        "#,
+        )?;
+    context.temp_dir.child("child/pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "child"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = []
+        two = []
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--frozen")
+        .arg("--dry-run")
+        .arg("--package")
+        .arg("provider")
+        .arg("--extra")
+        .arg("one")
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 2 packages
+    Would install 2 packages
+     + child @ file://[TEMP_DIR]/child
+     + provider @ file://[TEMP_DIR]/provider
+    ");
+
+    Ok(())
+}
+
 /// Workspace-member extras remain selectable outside the conflicting path that first reached them.
 #[test]
 fn workspace_extra_selection_ignores_unrelated_conflict_paths() -> Result<()> {

--- a/crates/uv/tests/lock_scenarios/lock_conflict.rs
+++ b/crates/uv/tests/lock_scenarios/lock_conflict.rs
@@ -102,6 +102,100 @@ fn extra_conflict_discovery_respects_parent_reachability() -> Result<()> {
     Ok(())
 }
 
+/// Workspace-member extras remain selectable outside the conflicting path that first reached them.
+#[test]
+fn workspace_extra_selection_ignores_unrelated_conflict_paths() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "root-project"
+        version = "1.0.0"
+        requires-python = ">=3.10"
+
+        [project.optional-dependencies]
+        left = ["alpha[one]"]
+
+        [dependency-groups]
+        right = ["zeta[two]"]
+
+        [tool.uv]
+        conflicts = [
+            [{ extra = "left" }, { group = "right" }],
+            [{ package = "alpha", extra = "one" }, { package = "zeta", extra = "two" }],
+        ]
+
+        [tool.uv.workspace]
+        members = ["alpha", "zeta"]
+
+        [tool.uv.sources]
+        alpha = { workspace = true }
+        zeta = { workspace = true }
+        leaf = { path = "leaf" }
+        "#,
+    )?;
+    context.temp_dir.child("alpha/pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "alpha"
+        version = "1.0.0"
+        requires-python = ">=3.10"
+
+        [project.optional-dependencies]
+        one = ["zeta[one]"]
+        two = ["leaf"]
+        "#,
+    )?;
+    context.temp_dir.child("zeta/pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "zeta"
+        version = "1.0.0"
+        requires-python = ">=3.10"
+
+        [project.optional-dependencies]
+        one = ["alpha[two]"]
+        two = []
+        "#,
+    )?;
+    context.temp_dir.child("leaf/pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "leaf"
+        version = "1.0.0"
+        requires-python = ">=3.10"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--package")
+        .arg("zeta")
+        .arg("--extra")
+        .arg("one")
+        .arg("--no-hashes")
+        .arg("--no-header")
+        .arg("--no-annotate"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    -e ./alpha
+    -e ./zeta
+    ./leaf
+    ");
+
+    Ok(())
+}
+
 /// This tests a "basic" case for specifying conflicting extras.
 ///
 /// Namely, we check that 1) without declaring them conflicting,

--- a/crates/uv/tests/lock_scenarios/lock_conflict.rs
+++ b/crates/uv/tests/lock_scenarios/lock_conflict.rs
@@ -186,6 +186,123 @@ fn workspace_extra_preserves_independently_requested_conflicting_extra() -> Resu
     Ok(())
 }
 
+/// Recursive workspace extras must retain their independently conflicting target selections.
+#[test]
+fn workspace_recursive_extra_preserves_independently_conflicting_target_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [dependency-groups]
+        dev = ["provider[two] ; platform_machine == 'aarch64'"]
+
+        [tool.uv]
+        conflicts = [[
+            { package = "leaf-one" },
+            { package = "leaf-one", extra = "nested" },
+        ]]
+
+        [tool.uv.workspace]
+        members = ["provider"]
+
+        [tool.uv.sources]
+        provider = { workspace = true }
+        leaf-one = { path = "leaf-one" }
+        leaf-two = { path = "leaf-two" }
+        "#,
+    )?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(
+            r#"
+        [project]
+        name = "provider"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        one = ["provider[bridge] ; python_full_version >= '3.13'"]
+        two = ["leaf-two ; platform_machine == 'aarch64'"]
+        bridge = ["leaf-one[nested] ; platform_machine == 'aarch64'"]
+
+        [dependency-groups]
+        provider-dev = ["leaf-one ; python_full_version >= '3.13'"]
+
+        [tool.uv.sources]
+        leaf-one = { path = "../leaf-one" }
+        leaf-two = { path = "../leaf-two" }
+        "#,
+        )?;
+    context
+        .temp_dir
+        .child("leaf-one/pyproject.toml")
+        .write_str(
+            r#"
+        [project]
+        name = "leaf-one"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        nested = ["leaf-two ; python_full_version >= '3.13'"]
+
+        [tool.uv.sources]
+        leaf-two = { path = "../leaf-two" }
+        "#,
+        )?;
+    context
+        .temp_dir
+        .child("leaf-two/pyproject.toml")
+        .write_str(
+            r#"
+        [project]
+        name = "leaf-two"
+        version = "1.0.0"
+        requires-python = ">=3.12"
+        "#,
+        )?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--frozen")
+        .arg("--dry-run")
+        .arg("--package")
+        .arg("provider")
+        .arg("--extra")
+        .arg("one")
+        .arg("--no-default-groups")
+        .arg("--python-platform")
+        .arg("aarch64-unknown-linux-gnu")
+        .arg("--preview-features")
+        .arg("package-conflicts")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 3 packages
+    Would install 3 packages
+     + leaf-one @ file://[TEMP_DIR]/leaf-one
+     + leaf-two @ file://[TEMP_DIR]/leaf-two
+     + provider @ file://[TEMP_DIR]/provider
+    ");
+
+    Ok(())
+}
+
 /// Workspace-member extras remain selectable outside the conflicting path that first reached them.
 #[test]
 fn workspace_extra_selection_ignores_unrelated_conflict_paths() -> Result<()> {


### PR DESCRIPTION
## Summary

Prior to this change, we evaluated conflicting extras before converting requirements into dependency edges. That check combined a dependency package with the extra selected on its parent, so `provider[one] -> child[two]` invented `child[one]`; even `provider[one] -> child` could silently omit `child`.

Remove those premature requirement and constraint filters. The existing PubGrub representation already splits each dependency into package-qualified base and extra edges, and conflict forks select those edges independently. This also preserves mandatory recursive self-extra dependencies so genuinely incompatible extras remain unsatisfiable.

Add workspace regressions covering independently requested child extras, plain dependencies, recursive selections, and frozen sync/export.
