### PR TITLE
Model conditional interpreter and platform marker relationships

### DIFF
--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -52,7 +52,7 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use arcstr::ArcStr;
 use itertools::{Either, Itertools};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use version_ranges::Ranges;
 
 use uv_pep440::{Operator, Version, VersionSpecifier, release_specifier_to_range};
@@ -544,11 +544,7 @@ impl InternerGuard<'_> {
             return true;
         }
 
-        if !self
-            .contains_version_variable(marker, CanonicalMarkerValueVersion::ImplementationVersion)
-            || !self
-                .contains_version_variable(marker, CanonicalMarkerValueVersion::PythonFullVersion)
-        {
+        if !self.has_conditional_version_axes(marker) {
             return false;
         }
 
@@ -575,24 +571,37 @@ impl InternerGuard<'_> {
         self.disjointness(projected, cpython_worlds)
     }
 
-    /// Returns whether a marker tree contains a decision on the requested version axis.
-    fn contains_version_variable(
-        &self,
-        marker: NodeId,
-        version: CanonicalMarkerValueVersion,
-    ) -> bool {
-        if matches!(marker, NodeId::TRUE | NodeId::FALSE) {
-            return false;
+    /// Returns whether a marker tree compares both conditionally related version axes.
+    fn has_conditional_version_axes(&self, marker: NodeId) -> bool {
+        let mut pending = vec![marker];
+        let mut visited = FxHashSet::default();
+        let mut has_implementation_version = false;
+        let mut has_python_full_version = false;
+
+        while let Some(marker) = pending.pop() {
+            if matches!(marker, NodeId::TRUE | NodeId::FALSE) || !visited.insert(marker) {
+                continue;
+            }
+
+            let node = self.shared.node(marker);
+            match node.var {
+                Variable::Version(CanonicalMarkerValueVersion::ImplementationVersion) => {
+                    has_implementation_version = true;
+                }
+                Variable::Version(CanonicalMarkerValueVersion::PythonFullVersion) => {
+                    has_python_full_version = true;
+                }
+                _ => {}
+            }
+
+            if has_implementation_version && has_python_full_version {
+                return true;
+            }
+
+            pending.extend(node.children.nodes());
         }
 
-        let node = self.shared.node(marker);
-        if node.var == Variable::Version(version) {
-            return true;
-        }
-
-        node.children
-            .nodes()
-            .any(|child| self.contains_version_variable(child, version))
+        false
     }
 
     /// Substitutes CPython's implementation-version axis with its Python full-version axis.
@@ -1230,6 +1239,11 @@ impl InternerGuard<'_> {
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("pyston"),
         });
+        let implementation_name_graalpy = self.expression(MarkerExpression::String {
+            key: MarkerValueString::ImplementationName,
+            operator: MarkerOperator::Equal,
+            value: arcstr::literal!("graalpy"),
+        });
         let platform_python_implementation_cpython = self.expression(MarkerExpression::String {
             key: MarkerValueString::PlatformPythonImplementation,
             operator: MarkerOperator::Equal,
@@ -1239,6 +1253,11 @@ impl InternerGuard<'_> {
             key: MarkerValueString::PlatformPythonImplementation,
             operator: MarkerOperator::Equal,
             value: arcstr::literal!("PyPy"),
+        });
+        let platform_python_implementation_graalvm = self.expression(MarkerExpression::String {
+            key: MarkerValueString::PlatformPythonImplementation,
+            operator: MarkerOperator::Equal,
+            value: arcstr::literal!("GraalVM"),
         });
 
         // Unix-like Python platforms always use the `posix` operating system module.
@@ -1285,8 +1304,9 @@ impl InternerGuard<'_> {
             (sys_platform_ios, ios_platform_system.not()),
         ]);
 
-        // CPython and Pyston both report `CPython` through the platform API, while PyPy exposes
-        // its own identity through both marker names. Only PyPy has a bidirectional mapping.
+        // CPython, PyPy, and GraalPy expose their interpreter identity through both marker
+        // names, using different spellings. However, Pyston also reports `CPython` through the
+        // platform API, so only PyPy and GraalPy have bidirectional mappings.
         pairs.extend([
             (
                 implementation_name_cpython,
@@ -1303,6 +1323,14 @@ impl InternerGuard<'_> {
             (
                 implementation_name_pypy.not(),
                 platform_python_implementation_pypy,
+            ),
+            (
+                implementation_name_graalpy,
+                platform_python_implementation_graalvm.not(),
+            ),
+            (
+                implementation_name_graalpy.not(),
+                platform_python_implementation_graalvm,
             ),
         ]);
 

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -385,7 +385,10 @@ impl InternerGuard<'_> {
         // Known-incompatible platform markers have the highest priority in the tree. Python
         // implementation markers can occur lower in the ordering, where recursive conjunctions
         // will apply the same check when both implementation variables are present.
-        let conflicts = x.var.is_conflicting_variable() && y.var.is_conflicting_variable();
+        let conflicts = (x.var.is_conflicting_variable() && y.var.is_conflicting_variable())
+            || (x.var.is_conflicting_variable() && y.var.is_version_variable())
+            || (y.var.is_conflicting_variable() && x.var.is_version_variable())
+            || (x.var.is_version_variable() && y.var.is_version_variable() && x.var != y.var);
 
         // Perform Shannon Expansion of the higher order variable.
         let (func, children) = match x.var.cmp(&y.var) {
@@ -411,8 +414,7 @@ impl InternerGuard<'_> {
 
         // If the node includes known incompatibilities, map it to `false`.
         let node = if conflicts {
-            let exclusions = self.exclusions();
-            if self.disjointness(node, exclusions.not()) {
+            if self.is_world_unsatisfiable(node) {
                 NodeId::FALSE
             } else {
                 node
@@ -457,7 +459,11 @@ impl InternerGuard<'_> {
         // Known-incompatible platform markers have the highest priority in the tree. Python
         // implementation markers can occur lower in the ordering, where recursive conjunctions
         // will apply the same check when both implementation variables are present.
-        if x.var.is_conflicting_variable() && y.var.is_conflicting_variable() {
+        if (x.var.is_conflicting_variable() && y.var.is_conflicting_variable())
+            || (x.var.is_conflicting_variable() && y.var.is_version_variable())
+            || (y.var.is_conflicting_variable() && x.var.is_version_variable())
+            || (x.var.is_version_variable() && y.var.is_version_variable() && x.var != y.var)
+        {
             return self.and(xi, yi).is_false();
         }
 
@@ -520,6 +526,119 @@ impl InternerGuard<'_> {
             // X and Y represent the same variable, their merged edges must be unsatisfiable.
             Ordering::Equal => x.children.is_disjoint(xi, &y.children, yi, self, false),
         }
+    }
+
+    /// Returns whether a marker has no realizable Python interpreter environment.
+    ///
+    /// Besides finite platform exclusions, CPython conditionally identifies
+    /// `implementation_version` with `python_full_version`. Keep other implementations on
+    /// independent version axes by cofactoring the marker into CPython and non-CPython worlds.
+    fn is_world_unsatisfiable(&mut self, marker: NodeId) -> bool {
+        if marker.is_false() {
+            return true;
+        }
+
+        let exclusions = self.exclusions();
+        let valid_worlds = exclusions.not();
+        if self.disjointness(marker, valid_worlds) {
+            return true;
+        }
+
+        if !self
+            .contains_version_variable(marker, CanonicalMarkerValueVersion::ImplementationVersion)
+            || !self
+                .contains_version_variable(marker, CanonicalMarkerValueVersion::PythonFullVersion)
+        {
+            return false;
+        }
+
+        let cpython = self.expression(MarkerExpression::String {
+            key: MarkerValueString::ImplementationName,
+            operator: MarkerOperator::Equal,
+            value: arcstr::literal!("cpython"),
+        });
+
+        let non_cpython_marker = self.restrict(marker, cpython.not());
+        let non_cpython_worlds = self.restrict(valid_worlds, cpython.not());
+        if !self.disjointness(non_cpython_marker, non_cpython_worlds) {
+            return false;
+        }
+
+        let cpython_marker = self.restrict(marker, cpython);
+        let cpython_worlds = self.restrict(valid_worlds, cpython);
+        if self.disjointness(cpython_marker, cpython_worlds) {
+            return true;
+        }
+
+        let mut cache = FxHashMap::default();
+        let projected = self.project_cpython_versions(cpython_marker, &mut cache);
+        self.disjointness(projected, cpython_worlds)
+    }
+
+    /// Returns whether a marker tree contains a decision on the requested version axis.
+    fn contains_version_variable(
+        &self,
+        marker: NodeId,
+        version: CanonicalMarkerValueVersion,
+    ) -> bool {
+        if matches!(marker, NodeId::TRUE | NodeId::FALSE) {
+            return false;
+        }
+
+        let node = self.shared.node(marker);
+        if node.var == Variable::Version(version) {
+            return true;
+        }
+
+        node.children
+            .nodes()
+            .any(|child| self.contains_version_variable(child, version))
+    }
+
+    /// Substitutes CPython's implementation-version axis with its Python full-version axis.
+    fn project_cpython_versions(
+        &mut self,
+        marker: NodeId,
+        cache: &mut FxHashMap<NodeId, NodeId>,
+    ) -> NodeId {
+        if matches!(marker, NodeId::TRUE | NodeId::FALSE) {
+            return marker;
+        }
+        if let Some(&projected) = cache.get(&marker) {
+            return projected;
+        }
+
+        let node = self.shared.node(marker);
+        let variable = node.var.clone();
+        let children = node.children.clone();
+        let projected = match (variable, children) {
+            (
+                Variable::Version(CanonicalMarkerValueVersion::ImplementationVersion),
+                Edges::Version { edges },
+            ) => {
+                let mut projected = NodeId::FALSE;
+                for (range, child) in edges {
+                    let range = self.create_node(
+                        Variable::Version(CanonicalMarkerValueVersion::PythonFullVersion),
+                        Edges::Version {
+                            edges: Edges::from_range(&range),
+                        },
+                    );
+                    let child = self.project_cpython_versions(child.negate(marker), cache);
+                    let branch = self.and(range, child);
+                    projected = self.or(projected, branch);
+                }
+                projected
+            }
+            (variable, children) => {
+                let children =
+                    children.map(marker, |child| self.project_cpython_versions(child, cache));
+                self.create_node(variable, children)
+            }
+        };
+
+        cache.insert(marker, projected);
+        projected
     }
 
     // Restrict the output of selected boolean variables in the tree.
@@ -1154,9 +1273,16 @@ impl InternerGuard<'_> {
 
         // iOS and iPadOS expose distinct user-facing platform names, but both use `ios` as
         // their `sys.platform` value.
+        let ios_platform_system = disjunction(
+            self,
+            &mut cache,
+            platform_system_ios,
+            platform_system_ipados,
+        );
         pairs.extend([
             (platform_system_ios, sys_platform_ios.not()),
             (platform_system_ipados, sys_platform_ios.not()),
+            (sys_platform_ios, ios_platform_system.not()),
         ]);
 
         // CPython and Pyston both report `CPython` through the platform API, while PyPy exposes
@@ -1278,6 +1404,11 @@ impl Variable {
             return false;
         };
         marker.is_conflicting()
+    }
+
+    /// Returns whether this decision represents an interpreter-version axis.
+    fn is_version_variable(&self) -> bool {
+        matches!(self, Self::Version(_))
     }
 }
 

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3127,8 +3127,55 @@ mod test {
 
     #[test]
     fn test_cpython_implementation_version_disjointness() {
+        for (implementation, python) in [
+            (
+                "implementation_version >= '3.13'",
+                "python_full_version < '3.13'",
+            ),
+            (
+                "implementation_version < '3.13'",
+                "python_full_version >= '3.13'",
+            ),
+            (
+                "implementation_version == '3.13'",
+                "python_full_version != '3.13'",
+            ),
+            (
+                "implementation_version != '3.13'",
+                "python_full_version == '3.13'",
+            ),
+            (
+                "implementation_version == '3.13.*'",
+                "python_full_version >= '3.14'",
+            ),
+            (
+                "implementation_version ~= '3.13.0'",
+                "python_full_version < '3.13'",
+            ),
+            (
+                "implementation_version ~= '3.13.0'",
+                "python_full_version >= '3.14'",
+            ),
+            (
+                "implementation_version < '3.13'",
+                "python_version >= '3.13'",
+            ),
+        ] {
+            assert!(
+                is_disjoint(
+                    format!("implementation_name == 'cpython' and {implementation}"),
+                    python,
+                ),
+                "{implementation} overlaps with {python}",
+            );
+        }
+
         assert!(is_disjoint(
-            "implementation_name == 'cpython' and implementation_version >= '3.13'",
+            "implementation_name == 'cpython' and (implementation_version >= '3.13' or implementation_version == '3.14')",
+            "python_full_version < '3.13'",
+        ));
+        assert!(!is_disjoint(
+            "(implementation_name == 'cpython' and implementation_version >= '3.13') or (implementation_name == 'pypy' and implementation_version >= '3.13')",
             "python_full_version < '3.13'",
         ));
         assert!(!is_disjoint(
@@ -3136,8 +3183,32 @@ mod test {
             "python_full_version < '3.13'",
         ));
         assert!(!is_disjoint(
+            "implementation_name == 'pyston' and implementation_version >= '3.13'",
+            "python_full_version < '3.13'",
+        ));
+        assert!(!is_disjoint(
+            "platform_python_implementation == 'CPython' and implementation_version >= '3.13'",
+            "python_full_version < '3.13'",
+        ));
+        assert!(!is_disjoint(
             "implementation_version >= '3.13'",
             "python_full_version < '3.13'",
+        ));
+    }
+
+    #[test]
+    fn test_graalpy_implementation_disjointness() {
+        assert!(is_disjoint(
+            "implementation_name == 'graalpy'",
+            "platform_python_implementation != 'GraalVM'",
+        ));
+        assert!(is_disjoint(
+            "implementation_name != 'graalpy'",
+            "platform_python_implementation == 'GraalVM'",
+        ));
+        assert!(!is_disjoint(
+            "implementation_name == 'pyston'",
+            "platform_python_implementation == 'CPython'",
         ));
     }
 
@@ -3230,8 +3301,9 @@ mod test {
             ("cpython", "CPython"),
             ("pyston", "CPython"),
             ("pypy", "PyPy"),
+            ("graalpy", "GraalVM"),
         ] {
-            let is_bidirectional = implementation_name == "pypy";
+            let is_bidirectional = matches!(implementation_name, "pypy" | "graalpy");
             let implementation_name = format!("implementation_name == '{implementation_name}'");
             let platform_python_implementation =
                 format!("platform_python_implementation == '{platform_python_implementation}'");
@@ -3291,11 +3363,7 @@ mod test {
         // Unknown implementations may use implementation-specific names, so do not
         // infer a correspondence between their two marker values.
         assert!(!is_disjoint(
-            "implementation_name == 'graalpy'",
-            "platform_python_implementation == 'GraalVM'"
-        ));
-        assert!(!is_disjoint(
-            "implementation_name == 'graalpy'",
+            "implementation_name == 'custom-runtime'",
             "platform_python_implementation == 'Jython'"
         ));
     }

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3131,10 +3131,6 @@ mod test {
             "implementation_name == 'cpython' and implementation_version >= '3.13'",
             "python_full_version < '3.13'",
         ));
-        assert!(is_disjoint(
-            "platform_python_implementation == 'CPython' and implementation_version < '3.13'",
-            "python_full_version >= '3.13'",
-        ));
         assert!(!is_disjoint(
             "implementation_name == 'pypy' and implementation_version >= '3.13'",
             "python_full_version < '3.13'",

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3126,6 +3126,38 @@ mod test {
     }
 
     #[test]
+    fn test_cpython_implementation_version_disjointness() {
+        assert!(is_disjoint(
+            "implementation_name == 'cpython' and implementation_version >= '3.13'",
+            "python_full_version < '3.13'",
+        ));
+        assert!(is_disjoint(
+            "platform_python_implementation == 'CPython' and implementation_version < '3.13'",
+            "python_full_version >= '3.13'",
+        ));
+        assert!(!is_disjoint(
+            "implementation_name == 'pypy' and implementation_version >= '3.13'",
+            "python_full_version < '3.13'",
+        ));
+        assert!(!is_disjoint(
+            "implementation_version >= '3.13'",
+            "python_full_version < '3.13'",
+        ));
+    }
+
+    #[test]
+    fn test_ios_platform_system_disjointness() {
+        assert!(is_disjoint(
+            "sys_platform == 'ios'",
+            "platform_system != 'iOS' and platform_system != 'iPadOS'",
+        ));
+        assert!(!is_disjoint(
+            "sys_platform == 'ios'",
+            "platform_system == 'iOS' or platform_system == 'iPadOS'",
+        ));
+    }
+
+    #[test]
     fn test_string_disjointness() {
         assert!(!is_disjoint(
             "os_name == 'Linux'",

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -16329,7 +16329,9 @@ fn lock_ios_platform_system_markers() -> Result<()> {
         dependencies = [
             "ok==1.0.0 ; platform_system == 'iOS'",
             "ok==1.0.0 ; platform_system == 'iPadOS'",
+            "ok==1.0.0 ; sys_platform == 'ios'",
             "ok==2.0.0 ; sys_platform != 'ios'",
+            "ok==2.0.0 ; platform_system != 'iOS' and platform_system != 'iPadOS'",
         ]
         "#,
     )?;

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -16231,6 +16231,41 @@ fn lock_cpython_implementation_version_markers() -> Result<()> {
     Ok(())
 }
 
+/// GraalPy exposes the same implementation through its `GraalVM` platform marker.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_graalpy_implementation_markers() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.9"
+        dependencies = [
+            "ok==1.0.0 ; implementation_name == 'graalpy'",
+            "ok==2.0.0 ; platform_python_implementation != 'GraalVM'",
+        ]
+        "#,
+    )?;
+
+    let find_links = context.workspace_root.join("test/links");
+    uv_snapshot!(context.filters(), context.lock().arg("--no-index").arg("--find-links").arg(&find_links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline").arg("--no-cache").arg("--no-index").arg("--find-links").arg(&find_links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Recognize incompatible Windows and Unix-like operating-system markers across both platform
 /// marker names.
 #[cfg(feature = "test-universal")]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -16196,6 +16196,41 @@ fn lock_pyston_incompatible_platform_marker() -> Result<()> {
     Ok(())
 }
 
+/// CPython exposes the same release through both implementation and Python version markers.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_cpython_implementation_version_markers() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.9"
+        dependencies = [
+            "ok==1.0.0 ; implementation_name == 'cpython' and implementation_version >= '3.13'",
+            "ok==2.0.0 ; python_full_version < '3.13'",
+        ]
+        "#,
+    )?;
+
+    let find_links = context.workspace_root.join("test/links");
+    uv_snapshot!(context.filters(), context.lock().arg("--no-index").arg("--find-links").arg(&find_links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline").arg("--no-cache").arg("--no-index").arg("--find-links").arg(&find_links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Recognize incompatible Windows and Unix-like operating-system markers across both platform
 /// marker names.
 #[cfg(feature = "test-universal")]


### PR DESCRIPTION
## Summary

Build on #20808 with a marker-world satisfiability abstraction for relationships that cannot be represented safely as independent environment-marker axes.

For CPython, `implementation_version` and `python_full_version` describe the same release. Cofactor marker decisions under the explicit `implementation_name == "cpython"` assumption and project implementation-version ranges onto the Python full-version axis. Preserve independent implementation-version behavior for PyPy, Pyston, and unknown runtimes, including runtimes that report `platform_python_implementation == "CPython"`.

Also model the bidirectional GraalPy/GraalVM implementation relationship and the reverse iOS platform implication (`sys_platform == "ios"` implies `platform_system` is either `"iOS"` or `"iPadOS"`). Evaluate these conditional worlds consistently during marker conjunction and disjointness so impossible worlds cannot leak into resolver forks or violate lockfile marker coverage.

Add marker-algebra coverage across equality, inequality, ordered ranges, compatible releases, wildcards, canonical `python_version`, and disjunctions; add local-wheel lock regressions for CPython, GraalPy, Pyston, and combined iOS forks.