### PR TITLE
Fork incompatible dependencies across project contexts

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2092,7 +2092,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 .map(|mut dependencies| {
                     // Production, optional, and group requirements are separate PubGrub
                     // packages. Split now when another context can require an incompatible
-                    // version; otherwise, those requirements never become sibling dependencies.
+                    // version or source; otherwise, those requirements never become siblings.
                     for dependency in &dependencies {
                         if dependency.package.marker().is_true() {
                             continue;
@@ -2112,12 +2112,27 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                     .flat_map(|requirements| requirements.iter()),
                             )
                             .filter(|requirement| requirement.name == *dependency_name)
-                            .filter_map(|requirement| requirement.source.version_specifiers())
-                            .any(|specifier| {
-                                dependency
-                                    .version
-                                    .intersection(&Range::from(specifier.clone()))
-                                    == Range::empty()
+                            .any(|requirement| {
+                                let incompatible_version = requirement
+                                    .source
+                                    .version_specifiers()
+                                    .is_some_and(|specifier| {
+                                        dependency
+                                            .version
+                                            .intersection(&Range::from(specifier.clone()))
+                                            == Range::empty()
+                                    });
+
+                                let incompatible_source = match (
+                                    dependency.source.verbatim_url(),
+                                    requirement.source.to_verbatim_parsed_url(),
+                                ) {
+                                    (Some(current), Some(candidate)) => current != &candidate,
+                                    (Some(_), None) | (None, Some(_)) => true,
+                                    (None, None) => false,
+                                };
+
+                                incompatible_version || incompatible_source
                             });
 
                         if has_conflicting_context {
@@ -3956,7 +3971,7 @@ enum Dependencies {
     /// These conflicts are resolved via `Dependencies::fork`.
     Available {
         dependencies: Vec<PubGrubDependency>,
-        /// Dependencies with incompatible versions in another extra or group context.
+        /// Dependencies with incompatible versions or sources in another extra or group context.
         cross_context_forks: BTreeSet<PackageName>,
     },
     /// Package metadata has a `Requires-Python` specifier that is incompatible with the target.
@@ -3974,7 +3989,7 @@ impl Dependencies {
     /// groups of dependencies.
     ///
     /// A fork occurs when sibling dependencies, or dependencies from different
-    /// extras or groups of the same distribution, require incompatible versions
+    /// extras or groups of the same distribution, require incompatible versions or sources
     /// behind distinct marker expressions.
     fn fork(
         self,

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1916,8 +1916,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         );
         if env.marker_environment().is_some() {
             result.map(|deps| match deps {
-                Dependencies::Available(deps) | Dependencies::Unforkable(deps) => {
-                    ForkedDependencies::Unforked(deps)
+                Dependencies::Available { dependencies, .. }
+                | Dependencies::Unforkable(dependencies) => {
+                    ForkedDependencies::Unforked(dependencies)
                 }
                 Dependencies::RequiresPython(requires_python) => {
                     ForkedDependencies::RequiresPython(requires_python)
@@ -1942,6 +1943,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         python_requirement: &PythonRequirement,
         pubgrub: &State<UvDependencyProvider>,
     ) -> Result<Dependencies, ResolveError> {
+        let mut cross_context_forks = BTreeSet::new();
         let dependencies = match &**package {
             PubGrubPackageInner::Root(_) => {
                 let no_dev_deps = BTreeMap::default();
@@ -2088,6 +2090,41 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     Some(package),
                 )
                 .map(|mut dependencies| {
+                    // Production, optional, and group requirements are separate PubGrub
+                    // packages. Split now when another context can require an incompatible
+                    // version; otherwise, those requirements never become sibling dependencies.
+                    for dependency in &dependencies {
+                        if dependency.package.marker().is_true() {
+                            continue;
+                        }
+
+                        let Some(dependency_name) = dependency.package.name() else {
+                            continue;
+                        };
+
+                        let has_conflicting_context = metadata
+                            .requires_dist
+                            .iter()
+                            .chain(
+                                metadata
+                                    .dependency_groups
+                                    .values()
+                                    .flat_map(|requirements| requirements.iter()),
+                            )
+                            .filter(|requirement| requirement.name == *dependency_name)
+                            .filter_map(|requirement| requirement.source.version_specifiers())
+                            .any(|specifier| {
+                                dependency
+                                    .version
+                                    .intersection(&Range::from(specifier.clone()))
+                                    == Range::empty()
+                            });
+
+                        if has_conflicting_context {
+                            cross_context_forks.insert(dependency_name.clone());
+                        }
+                    }
+
                     dependencies.extend(system_dependencies);
                     dependencies
                 })
@@ -2172,7 +2209,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             }
         };
         Ok(match dependencies {
-            Ok(dependencies) => Dependencies::Available(dependencies),
+            Ok(dependencies) => Dependencies::Available {
+                dependencies,
+                cross_context_forks,
+            },
             Err(requirement) => {
                 Dependencies::Unavailable(UnavailableVersion::UnsatisfiableDependency(requirement))
             }
@@ -3914,7 +3954,11 @@ enum Dependencies {
     /// Note that in universal mode, it is possible and allowed for multiple
     /// `PubGrubPackage` values in this list to have the same package name.
     /// These conflicts are resolved via `Dependencies::fork`.
-    Available(Vec<PubGrubDependency>),
+    Available {
+        dependencies: Vec<PubGrubDependency>,
+        /// Dependencies with incompatible versions in another extra or group context.
+        cross_context_forks: BTreeSet<PackageName>,
+    },
     /// Package metadata has a `Requires-Python` specifier that is incompatible with the target.
     RequiresPython(VersionSpecifiers),
     /// Dependencies that should never result in a fork.
@@ -3929,17 +3973,20 @@ impl Dependencies {
     /// Turn this flat list of dependencies into a potential set of forked
     /// groups of dependencies.
     ///
-    /// A fork *only* occurs when there are multiple dependencies with the same
-    /// name *and* those dependency specifications have corresponding marker
-    /// expressions that are completely disjoint with one another.
+    /// A fork occurs when sibling dependencies, or dependencies from different
+    /// extras or groups of the same distribution, require incompatible versions
+    /// behind distinct marker expressions.
     fn fork(
         self,
         env: &ResolverEnvironment,
         python_requirement: &PythonRequirement,
         conflicts: &Conflicts,
     ) -> ForkedDependencies {
-        let deps = match self {
-            Self::Available(deps) => deps,
+        let (deps, cross_context_forks) = match self {
+            Self::Available {
+                dependencies,
+                cross_context_forks,
+            } => (dependencies, cross_context_forks),
             Self::Unforkable(deps) => return ForkedDependencies::Unforked(deps),
             Self::RequiresPython(requires_python) => {
                 return ForkedDependencies::RequiresPython(requires_python);
@@ -3958,7 +4005,13 @@ impl Dependencies {
         let Forks {
             mut forks,
             diverging_packages,
-        } = Forks::new(name_to_deps, env, python_requirement, conflicts);
+        } = Forks::new(
+            name_to_deps,
+            &cross_context_forks,
+            env,
+            python_requirement,
+            conflicts,
+        );
         if forks.is_empty() {
             ForkedDependencies::Unforked(vec![])
         } else if forks.len() == 1 {
@@ -4015,6 +4068,7 @@ struct Forks {
 impl Forks {
     fn new(
         name_to_deps: BTreeMap<PackageName, Vec<PubGrubDependency>>,
+        cross_context_forks: &BTreeSet<PackageName>,
         env: &ResolverEnvironment,
         python_requirement: &PythonRequirement,
         conflicts: &Conflicts,
@@ -4036,15 +4090,16 @@ impl Forks {
             // that case, we don't detect the fork ahead of time (at
             // present).
             if let [dep] = deps.as_slice() {
-                // There's one exception: if the requirement increases the minimum-supported Python
-                // version, we also fork in order to respect that minimum in the subsequent
-                // resolution.
+                // There are two exceptions: if another dependency context requires an incompatible
+                // version, or if the requirement increases the minimum-supported Python version,
+                // we fork in order to respect those boundaries in the subsequent resolution.
                 //
                 // For example, given `requires-python = ">=3.7"` and `uv ; python_version >= "3.8"`,
                 // where uv itself only supports Python 3.8 and later, we need to fork to ensure
                 // that the resolution can find a solution.
-                if marker::requires_python(dep.package.marker())
-                    .is_none_or(|bound| !python_requirement.raises(&bound))
+                if !cross_context_forks.contains(&name)
+                    && marker::requires_python(dep.package.marker())
+                        .is_none_or(|bound| !python_requirement.raises(&bound))
                 {
                     let dep = deps.pop().unwrap();
                     let marker = dep.package.marker();

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2111,6 +2111,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                     .values()
                                     .flat_map(|requirements| requirements.iter()),
                             )
+                            .chain(self.constraints.get(dependency_name).into_iter().flatten())
                             .filter(|requirement| requirement.name == *dependency_name)
                             .filter(|requirement| {
                                 !dependency.package.marker().is_disjoint(requirement.marker)
@@ -2129,6 +2130,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                     .values()
                                     .flat_map(|requirements| requirements.iter()),
                             )
+                            .chain(self.constraints.get(dependency_name).into_iter().flatten())
                             .filter(|requirement| requirement.name == *dependency_name)
                             .any(|requirement| {
                                 let incompatible_version = requirement
@@ -4157,8 +4159,9 @@ impl Forks {
                         // Unless that "same marker" is a Python requirement that is stricter than
                         // the current Python requirement. In that case, we need to fork to respect
                         // the stricter requirement.
-                        if marker::requires_python(marker)
-                            .is_none_or(|bound| !python_requirement.raises(&bound))
+                        if !cross_context_forks.contains(&name)
+                            && marker::requires_python(marker)
+                                .is_none_or(|bound| !python_requirement.raises(&bound))
                         {
                             for dep in deps {
                                 for fork in &mut forks {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2133,6 +2133,13 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             .chain(self.constraints.get(dependency_name).into_iter().flatten())
                             .filter(|requirement| requirement.name == *dependency_name)
                             .any(|requirement| {
+                                // Equal environments are handled as siblings in the current fork.
+                                if requirement.marker.without_extras()
+                                    == dependency.package.marker()
+                                {
+                                    return false;
+                                }
+
                                 let incompatible_version = requirement
                                     .source
                                     .version_specifiers()

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -25,8 +25,8 @@ use uv_distribution::{ArchiveMetadata, DistributionDatabase};
 use uv_distribution_types::{
     BuiltDist, CompatibleDist, DerivationChain, Dist, DistErrorKind, Identifier, IncompatibleDist,
     IncompatibleSource, IncompatibleWheel, IndexCapabilities, IndexLocations, IndexMetadata,
-    IndexUrl, InstalledDist, Name, PythonRequirementKind, RemoteSource, Requirement, ResolvedDist,
-    ResolvedDistRef, SourceDist, VersionOrUrlRef, implied_markers,
+    IndexUrl, InstalledDist, Name, PythonRequirementKind, RemoteSource, Requirement,
+    RequirementSource, ResolvedDist, ResolvedDistRef, SourceDist, VersionOrUrlRef, implied_markers,
 };
 use uv_git::GitResolver;
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -2102,6 +2102,24 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             continue;
                         };
 
+                        let dependency_index = metadata
+                            .requires_dist
+                            .iter()
+                            .chain(
+                                metadata
+                                    .dependency_groups
+                                    .values()
+                                    .flat_map(|requirements| requirements.iter()),
+                            )
+                            .filter(|requirement| requirement.name == *dependency_name)
+                            .filter(|requirement| {
+                                !dependency.package.marker().is_disjoint(requirement.marker)
+                            })
+                            .find_map(|requirement| match &requirement.source {
+                                RequirementSource::Registry { index, .. } => index.as_ref(),
+                                _ => None,
+                            });
+
                         let has_conflicting_context = metadata
                             .requires_dist
                             .iter()
@@ -2132,7 +2150,13 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                     (None, None) => false,
                                 };
 
-                                incompatible_version || incompatible_source
+                                let incompatible_index = matches!(
+                                    &requirement.source,
+                                    RequirementSource::Registry { index, .. }
+                                        if dependency_index != index.as_ref()
+                                );
+
+                                incompatible_version || incompatible_source || incompatible_index
                             });
 
                         if has_conflicting_context {
@@ -3971,7 +3995,7 @@ enum Dependencies {
     /// These conflicts are resolved via `Dependencies::fork`.
     Available {
         dependencies: Vec<PubGrubDependency>,
-        /// Dependencies with incompatible versions or sources in another extra or group context.
+        /// Dependencies with incompatible versions, URLs, or indexes in another extra or group.
         cross_context_forks: BTreeSet<PackageName>,
     },
     /// Package metadata has a `Requires-Python` specifier that is incompatible with the target.

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1782,6 +1782,92 @@ fn lock_project_extra() -> Result<()> {
     Ok(())
 }
 
+/// Production and optional requirements can pin different versions on disjoint platforms.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_project_extra_disjoint_platform_markers() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok==1.0.0 ; sys_platform == 'win32'"]
+
+        [project.optional-dependencies]
+        feature = ["ok==2.0.0 ; sys_platform != 'win32'"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--offline")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links")), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links")), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Production and group requirements can pin different versions on disjoint platforms.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_project_group_disjoint_platform_markers() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok==1.0.0 ; sys_platform == 'win32'"]
+
+        [dependency-groups]
+        test = ["ok==2.0.0 ; sys_platform != 'win32'"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--offline")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links")), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-index")
+        .arg("--find-links")
+        .arg(context.workspace_root.join("test/links")), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Lock a project with `uv.tool.override-dependencies`.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -2018,6 +2018,77 @@ fn lock_project_disjoint_platform_registry_urls() -> Result<()> {
     Ok(())
 }
 
+/// Different explicit indexes can be selected in disjoint optional or group contexts.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_project_disjoint_platform_indexes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel = context
+        .workspace_root
+        .join("test/links/ok-1.0.0-py3-none-any.whl");
+    let windows_index = context.temp_dir.child("windows-index");
+    let other_index = context.temp_dir.child("other-index");
+    windows_index.create_dir_all()?;
+    other_index.create_dir_all()?;
+    fs_err::copy(&wheel, windows_index.join("ok-1.0.0-py3-none-any.whl"))?;
+    fs_err::copy(&wheel, other_index.join("ok-1.0.0-py3-none-any.whl"))?;
+    let windows_url = Url::from_file_path(&windows_index)
+        .map_err(|()| anyhow::anyhow!("invalid Windows index path"))?;
+    let other_url = Url::from_file_path(&other_index)
+        .map_err(|()| anyhow::anyhow!("invalid fallback index path"))?;
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    let lockfile = context.temp_dir.child("uv.lock");
+
+    for (section, scope) in [
+        (
+            "[project.optional-dependencies]\nfeature",
+            "extra = 'feature'",
+        ),
+        ("[dependency-groups]\ntest", "group = 'test'"),
+    ] {
+        pyproject_toml.write_str(&formatdoc! {r#"
+            [project]
+            name = "project"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+            dependencies = ["ok==1.0.0 ; sys_platform == 'win32'"]
+
+            {section} = ["ok==1.0.0 ; sys_platform != 'win32'"]
+
+            [tool.uv.sources]
+            ok = [
+                {{ index = "windows", marker = "sys_platform == 'win32'" }},
+                {{ index = "other", {scope}, marker = "sys_platform != 'win32'" }},
+            ]
+
+            [[tool.uv.index]]
+            name = "windows"
+            url = "{windows_url}"
+            format = "flat"
+            explicit = true
+
+            [[tool.uv.index]]
+            name = "other"
+            url = "{other_url}"
+            format = "flat"
+            explicit = true
+            "#})?;
+        if lockfile.exists() {
+            fs_err::remove_file(&lockfile)?;
+        }
+
+        insta::allow_duplicates! {
+            uv_snapshot!(context.filters(), context.lock().arg("--offline").arg("--no-cache"), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Resolved 3 packages in [TIME]
+            ");
+        }
+    }
+
+    Ok(())
+}
+
 /// Lock a project with `uv.tool.override-dependencies`.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1868,6 +1868,156 @@ fn lock_project_group_disjoint_platform_markers() -> Result<()> {
     Ok(())
 }
 
+/// Production and optional requirements can select different direct URLs per platform.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_project_extra_disjoint_platform_urls() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let windows_wheel = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+    )
+    .map_err(|()| anyhow::anyhow!("invalid Windows wheel path"))?;
+    let other_wheel = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links/ok-2.0.0-py3-none-any.whl"),
+    )
+    .map_err(|()| anyhow::anyhow!("invalid fallback wheel path"))?;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok @ {windows_wheel} ; sys_platform == 'win32'"]
+
+        [project.optional-dependencies]
+        feature = ["ok @ {other_wheel} ; sys_platform != 'win32'"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--offline").arg("--no-index"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline").arg("--no-index"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Production and group requirements can select different direct URLs per platform.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_project_group_disjoint_platform_urls() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let windows_wheel = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+    )
+    .map_err(|()| anyhow::anyhow!("invalid Windows wheel path"))?;
+    let other_wheel = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links/ok-2.0.0-py3-none-any.whl"),
+    )
+    .map_err(|()| anyhow::anyhow!("invalid fallback wheel path"))?;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok @ {windows_wheel} ; sys_platform == 'win32'"]
+
+        [dependency-groups]
+        test = ["ok @ {other_wheel} ; sys_platform != 'win32'"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--offline").arg("--no-index"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline").arg("--no-index"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Registry and direct-URL requirements can coexist in disjoint project contexts.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_project_disjoint_platform_registry_urls() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let windows_wheel = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+    )
+    .map_err(|()| anyhow::anyhow!("invalid Windows wheel path"))?;
+    let other_wheel = Url::from_file_path(
+        context
+            .workspace_root
+            .join("test/links/ok-2.0.0-py3-none-any.whl"),
+    )
+    .map_err(|()| anyhow::anyhow!("invalid fallback wheel path"))?;
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    let lockfile = context.temp_dir.child("uv.lock");
+
+    for section in [
+        "[project.optional-dependencies]\nfeature",
+        "[dependency-groups]\ntest",
+    ] {
+        for (production, contextual) in [
+            (format!("ok @ {windows_wheel}"), "ok==2.0.0".to_string()),
+            ("ok==1.0.0".to_string(), format!("ok @ {other_wheel}")),
+        ] {
+            pyproject_toml.write_str(&formatdoc! {r#"
+                [project]
+                name = "project"
+                version = "0.1.0"
+                requires-python = ">=3.12"
+                dependencies = ["{production} ; sys_platform == 'win32'"]
+
+                {section} = ["{contextual} ; sys_platform != 'win32'"]
+                "#})?;
+            if lockfile.exists() {
+                fs_err::remove_file(&lockfile)?;
+            }
+
+            insta::allow_duplicates! {
+                uv_snapshot!(context.filters(), context.lock()
+                    .arg("--offline")
+                    .arg("--no-index")
+                    .arg("--find-links")
+                    .arg(context.workspace_root.join("test/links")), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Resolved 3 packages in [TIME]
+                ");
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Lock a project with `uv.tool.override-dependencies`.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1868,6 +1868,53 @@ fn lock_project_group_disjoint_platform_markers() -> Result<()> {
     Ok(())
 }
 
+/// Platform-specific constraints can diverge across production, optional, and group contexts.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_project_disjoint_platform_constraints() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    let lockfile = context.temp_dir.child("uv.lock");
+
+    for section in [
+        "[project.optional-dependencies]\nfeature",
+        "[dependency-groups]\ntest",
+    ] {
+        pyproject_toml.write_str(&formatdoc! {r#"
+            [project]
+            name = "project"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+            dependencies = ["ok ; sys_platform == 'win32'"]
+
+            {section} = ["ok ; sys_platform != 'win32'"]
+
+            [tool.uv]
+            constraint-dependencies = [
+                "ok==1.0.0 ; sys_platform == 'win32'",
+                "ok==2.0.0 ; sys_platform != 'win32'",
+            ]
+            "#})?;
+        if lockfile.exists() {
+            fs_err::remove_file(&lockfile)?;
+        }
+
+        insta::allow_duplicates! {
+            uv_snapshot!(context.filters(), context.lock()
+                .arg("--offline")
+                .arg("--no-index")
+                .arg("--find-links")
+                .arg(context.workspace_root.join("test/links")), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Resolved 3 packages in [TIME]
+            ");
+        }
+    }
+
+    Ok(())
+}
+
 /// Production and optional requirements can select different direct URLs per platform.
 #[cfg(feature = "test-universal")]
 #[test]


### PR DESCRIPTION
## Summary
- fork disjoint requirements shared across production dependencies, extras, and dependency groups when their versions, platform-specific global constraints, direct URLs, or explicit indexes differ
- preserve the existing single-requirement optimization unless another dependency context needs an incompatible source, version, or constraint
- cover version pins, conditional constraints, wheel URLs, registry-to-URL orientations, and distinct flat indexes with offline integration regressions