### PR TITLE
Keep paths passed via `--index` to `uv add` as paths when modifying `pyproject.toml`

### DIFF
--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -12,7 +12,7 @@ use toml_edit::{
 
 use uv_cache_key::CanonicalUrl;
 use uv_distribution_types::{Index, IndexFormat, IndexUrl};
-use uv_fs::{PortablePath, is_same_file_allow_missing};
+use uv_fs::{PortablePath, is_same_file_allow_missing, try_relative_to_if};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Version, VersionParseError, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{MarkerTree, Requirement, VersionOrUrl};
@@ -530,17 +530,24 @@ impl PyProjectTomlMut {
             table.insert("name", Value::String(formatted).into());
         }
 
+        let url = if let IndexUrl::Path(url) = &index.url
+            && let Ok(path) = url.to_file_path()
+            && let Ok(path) = try_relative_to_if(path, root_dir, !url.was_given_absolute())
+        {
+            PortablePath::from(&path).to_string()
+        } else {
+            index.url.without_credentials().to_string()
+        };
         let existing_url = table.get("url").and_then(|item| item.as_str());
 
         // Update the stored URL independently of whether the index location changed.
-        let url_needs_update =
-            existing_url.is_none_or(|url| url != index.url.without_credentials().as_str());
-        let index_location_changed =
-            existing_url.is_none_or(|url| !index_locations_equal(url, &index.url, root_dir));
+        let url_needs_update = existing_url.is_none_or(|existing| existing != url);
+        let index_location_changed = existing_url
+            .is_none_or(|existing| !index_locations_equal(existing, &index.url, root_dir));
 
         // If necessary, update the URL.
         if url_needs_update {
-            let mut formatted = Formatted::new(index.url.without_credentials().to_string());
+            let mut formatted = Formatted::new(url);
             if let Some(value) = table.get("url").and_then(Item::as_value) {
                 if let Some(prefix) = value.decor().prefix() {
                     formatted.decor_mut().set_prefix(prefix.clone());
@@ -2539,14 +2546,13 @@ format = "flat"
         let new_index = Index::from_str(r"index=C:\links")?;
         doc.add_index(&new_index, &std::env::current_dir()?)?;
 
-        let expected_url = new_index.url.without_credentials();
         let index = doc.doc["tool"]["uv"]["index"]
             .as_array_of_tables()
             .and_then(|indexes| indexes.get(0))
             .expect("index table");
         assert_eq!(
             index.get("url").and_then(|item| item.as_str()),
-            Some(expected_url.as_str())
+            Some("C:/links")
         );
         assert_eq!(
             index.get("format").and_then(|item| item.as_str()),

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -10765,11 +10765,61 @@ fn add_index_with_existing_relative_path_index() -> Result<()> {
 
         [[tool.uv.index]]
         name = "local"
-        url = "file://[TEMP_DIR]/project/test-index"
+        url = "[TEMP_DIR]/project/test-index"
         format = "flat"
 
         [tool.uv.sources]
         iniconfig = { index = "local" }
+        "#);
+    });
+
+    Ok(())
+}
+
+#[test]
+fn add_index_with_relative_path_for_project() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let project = context.temp_dir.child("project");
+    project.create_dir_all()?;
+    let pyproject_toml = project.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let packages = project.child("test-index");
+    packages.create_dir_all()?;
+    packages.child("placeholder").touch()?;
+
+    uv_snapshot!(context.filters(), context.add().arg("iniconfig").arg("--frozen").arg("--project").arg(project.path()).arg("--index").arg("local=./project/test-index"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    ");
+
+    let pyproject_toml = fs_err::read_to_string(project.join("pyproject.toml"))?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig",
+        ]
+
+        [tool.uv.sources]
+        iniconfig = { index = "local" }
+
+        [[tool.uv.index]]
+        name = "local"
+        url = "test-index"
         "#);
     });
 
@@ -10822,7 +10872,7 @@ fn add_index_with_existing_relative_path_in_script() -> Result<()> {
         #
         # [[tool.uv.index]]
         # name = "local"
-        # url = "file://[TEMP_DIR]/links"
+        # url = "links"
         # format = "flat"
         #
         # [tool.uv.sources]


### PR DESCRIPTION
## Summary

Previously doing `uv add --index ./path` would edit the `pyproject.toml` to insert `file://.../path` but this seemed wrong. This change will produce different `pyproject.toml` contents when using this feature but the result shouldn't break things and should fix some odd cases.

## Test Plan

There are a couple of existing test change as we were solidifying the "incorrect" transformation. There's a new test specifically to ensure re-relativisation works.