### PR TITLE
Add IndexOptions to clean up `settings.rs` (a bit)

### DIFF
--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -6,9 +6,11 @@ use anyhow::bail;
 
 use uv_cache::Refresh;
 use uv_configuration::{BuildIsolation, Reinstall, Upgrade};
-use uv_distribution_types::{ConfigSettings, Index, PackageConfigSettings, Requirement};
+use uv_distribution_types::{ConfigSettings, PackageConfigSettings, Requirement};
 use uv_resolver::{ExcludeNewerPackage, PrereleaseMode};
-use uv_settings::{Combine, EnvFlag, PipOptions, ResolverInstallerOptions, ResolverOptions};
+use uv_settings::{
+    Combine, EnvFlag, IndexOptions, PipOptions, ResolverInstallerOptions, ResolverOptions,
+};
 use uv_warnings::owo_colors::OwoColorize;
 
 use crate::{
@@ -231,27 +233,6 @@ impl TryFrom<RefreshArgs> for Refresh {
             refresh_package,
         ))
     }
-}
-
-/// Extract the `--index` and `--default-index` values from [`IndexArgs`].
-fn indexes_from_args(
-    default_index: Option<&Maybe<Index>>,
-    index: Option<&[Vec<Maybe<Index>>]>,
-) -> Option<Vec<Index>> {
-    let default_index = default_index
-        .cloned()
-        .and_then(Maybe::into_option)
-        .map(|default_index| vec![default_index]);
-    let index = index.map(|index| {
-        index
-            .iter()
-            .flatten()
-            .cloned()
-            .filter_map(Maybe::into_option)
-            .collect()
-    });
-
-    default_index.combine(index)
 }
 
 impl TryFrom<ResolverArgs> for PipOptions {
@@ -542,39 +523,48 @@ impl TryFrom<FetchArgs> for PipOptions {
     }
 }
 
-impl TryFrom<IndexArgs> for PipOptions {
-    type Error = anyhow::Error;
-
-    fn try_from(args: IndexArgs) -> anyhow::Result<Self> {
-        let IndexArgs {
+impl IndexArgs {
+    /// Resolve the index arguments shared by pip, resolver, and installer settings.
+    fn resolve(self) -> IndexOptions {
+        let Self {
             default_index,
             index,
             index_url,
             extra_index_url,
             no_index,
             find_links,
-        } = args;
+        } = self;
 
-        Self {
-            index: indexes_from_args(default_index.as_ref(), index.as_deref()),
+        let default_index = default_index
+            .and_then(Maybe::into_option)
+            .map(|index| vec![index]);
+        let index = index.map(|indexes| {
+            indexes
+                .into_iter()
+                .flatten()
+                .filter_map(Maybe::into_option)
+                .collect()
+        });
+
+        IndexOptions {
+            index: default_index.combine(index),
             index_url: index_url.and_then(Maybe::into_option),
-            extra_index_url: extra_index_url.map(|extra_index_urls| {
-                extra_index_urls
-                    .into_iter()
-                    .filter_map(Maybe::into_option)
-                    .collect()
-            }),
-            no_index: if no_index { Some(true) } else { None },
-            find_links: find_links.map(|find_links| {
-                find_links
-                    .into_iter()
-                    .filter_map(Maybe::into_option)
-                    .collect()
-            }),
-            ..Self::default()
+            extra_index_url: extra_index_url
+                .map(|indexes| indexes.into_iter().filter_map(Maybe::into_option).collect()),
+            no_index: no_index.then_some(true),
+            find_links: find_links
+                .map(|links| links.into_iter().filter_map(Maybe::into_option).collect()),
         }
-        .relative_to(&env::current_dir()?)
-        .map_err(Into::into)
+    }
+}
+
+impl TryFrom<IndexArgs> for PipOptions {
+    type Error = anyhow::Error;
+
+    fn try_from(args: IndexArgs) -> anyhow::Result<Self> {
+        Ok(Self::from(
+            args.resolve().relative_to(&env::current_dir()?)?,
+        ))
     }
 }
 
@@ -634,28 +624,7 @@ pub fn resolver_options(
     } = build_args;
 
     ResolverOptions {
-        index: indexes_from_args(
-            index_args.default_index.as_ref(),
-            index_args.index.as_deref(),
-        ),
-        index_url: index_args.index_url.and_then(Maybe::into_option),
-        extra_index_url: index_args.extra_index_url.map(|extra_index_url| {
-            extra_index_url
-                .into_iter()
-                .filter_map(Maybe::into_option)
-                .collect()
-        }),
-        no_index: if index_args.no_index {
-            Some(true)
-        } else {
-            None
-        },
-        find_links: index_args.find_links.map(|find_links| {
-            find_links
-                .into_iter()
-                .filter_map(Maybe::into_option)
-                .collect()
-        }),
+        indexes: index_args.resolve(),
         upgrade: Upgrade::from_args(
             flag(upgrade, no_upgrade, "no-upgrade")?,
             upgrade_package.into_iter().map(Requirement::from).collect(),
@@ -778,28 +747,7 @@ pub fn resolver_installer_options(
     } = build_args;
 
     ResolverInstallerOptions {
-        index: indexes_from_args(
-            index_args.default_index.as_ref(),
-            index_args.index.as_deref(),
-        ),
-        index_url: index_args.index_url.and_then(Maybe::into_option),
-        extra_index_url: index_args.extra_index_url.map(|extra_index_url| {
-            extra_index_url
-                .into_iter()
-                .filter_map(Maybe::into_option)
-                .collect()
-        }),
-        no_index: if index_args.no_index {
-            Some(true)
-        } else {
-            None
-        },
-        find_links: index_args.find_links.map(|find_links| {
-            find_links
-                .into_iter()
-                .filter_map(Maybe::into_option)
-                .collect()
-        }),
+        indexes: index_args.resolve(),
         upgrade: Upgrade::from_args(
             flag(upgrade, no_upgrade, "upgrade")?,
             upgrade_package.into_iter().map(Requirement::from).collect(),

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -10,7 +10,7 @@ use uv_configuration::{
     ProxyUrl, Reinstall, RequiredVersion, TargetTriple, TrustedHost, TrustedPublishing, Upgrade,
 };
 use uv_distribution_types::{
-    ConfigSettings, ExtraBuildVariables, Index, IndexUrl, IndexUrlError, Origin,
+    ConfigSettings, ExtraBuildVariables, Index, IndexLocations, IndexUrl, IndexUrlError, Origin,
     PackageConfigSettings, PipExtraIndex, PipFindLinks, PipIndex, StaticMetadata,
 };
 use uv_install_wheel::LinkMode;
@@ -577,14 +577,79 @@ pub struct InstallerOptions {
     no_sources_package: Option<Vec<PackageName>>,
 }
 
-/// Settings relevant to all resolver operations.
+/// Settings shared by all operations that use package indexes.
 #[derive(Debug, Clone, Default, CombineOptions)]
-pub struct ResolverOptions {
+pub struct IndexOptions {
     pub index: Option<Vec<Index>>,
     pub index_url: Option<PipIndex>,
     pub extra_index_url: Option<Vec<PipExtraIndex>>,
     pub no_index: Option<bool>,
     pub find_links: Option<Vec<PipFindLinks>>,
+}
+
+impl IndexOptions {
+    /// Resolve the [`IndexOptions`] relative to the given root directory.
+    pub fn relative_to(mut self, root_dir: &Path) -> Result<Self, IndexUrlError> {
+        rebase_indexes(
+            root_dir,
+            &mut self.index,
+            &mut self.index_url,
+            &mut self.extra_index_url,
+            &mut self.find_links,
+        )?;
+
+        Ok(self)
+    }
+}
+
+impl From<IndexOptions> for IndexLocations {
+    fn from(value: IndexOptions) -> Self {
+        let IndexOptions {
+            index,
+            index_url,
+            extra_index_url,
+            no_index,
+            find_links,
+        } = value;
+
+        Self::new(
+            index
+                .into_iter()
+                .flatten()
+                .chain(extra_index_url.into_iter().flatten().map(Index::from))
+                .chain(index_url.into_iter().map(Index::from))
+                .collect(),
+            find_links.into_iter().flatten().map(Index::from).collect(),
+            no_index.unwrap_or_default(),
+        )
+    }
+}
+
+impl From<IndexOptions> for PipOptions {
+    fn from(value: IndexOptions) -> Self {
+        let IndexOptions {
+            index,
+            index_url,
+            extra_index_url,
+            no_index,
+            find_links,
+        } = value;
+
+        Self {
+            index,
+            index_url,
+            extra_index_url,
+            no_index,
+            find_links,
+            ..Self::default()
+        }
+    }
+}
+
+/// Settings relevant to all resolver operations.
+#[derive(Debug, Clone, Default, CombineOptions)]
+pub struct ResolverOptions {
+    pub indexes: IndexOptions,
     pub index_strategy: Option<IndexStrategy>,
     pub keyring_provider: Option<KeyringProviderType>,
     pub resolution: Option<ResolutionMode>,
@@ -612,14 +677,7 @@ pub struct ResolverOptions {
 impl ResolverOptions {
     /// Resolve the [`ResolverOptions`] relative to the given root directory.
     pub fn relative_to(mut self, root_dir: &Path) -> Result<Self, IndexUrlError> {
-        rebase_indexes(
-            root_dir,
-            &mut self.index,
-            &mut self.index_url,
-            &mut self.extra_index_url,
-            &mut self.find_links,
-        )?;
-
+        self.indexes = self.indexes.relative_to(root_dir)?;
         Ok(self)
     }
 }
@@ -628,11 +686,7 @@ impl ResolverOptions {
 /// union of [`InstallerOptions`] and [`ResolverOptions`].
 #[derive(Debug, Clone, Default, CombineOptions)]
 pub struct ResolverInstallerOptions {
-    pub index: Option<Vec<Index>>,
-    pub index_url: Option<PipIndex>,
-    pub extra_index_url: Option<Vec<PipExtraIndex>>,
-    pub no_index: Option<bool>,
-    pub find_links: Option<Vec<PipFindLinks>>,
+    pub indexes: IndexOptions,
     pub index_strategy: Option<IndexStrategy>,
     pub keyring_provider: Option<KeyringProviderType>,
     pub resolution: Option<ResolutionMode>,
@@ -662,14 +716,7 @@ pub struct ResolverInstallerOptions {
 impl ResolverInstallerOptions {
     /// Resolve the [`ResolverInstallerOptions`] relative to the given root directory.
     pub fn relative_to(mut self, root_dir: &Path) -> Result<Self, IndexUrlError> {
-        rebase_indexes(
-            root_dir,
-            &mut self.index,
-            &mut self.index_url,
-            &mut self.extra_index_url,
-            &mut self.find_links,
-        )?;
-
+        self.indexes = self.indexes.relative_to(root_dir)?;
         Ok(self)
     }
 }
@@ -711,11 +758,13 @@ impl From<ResolverInstallerSchema> for ResolverInstallerOptions {
             no_binary_package,
         } = value;
         Self {
-            index,
-            index_url,
-            extra_index_url,
-            no_index,
-            find_links,
+            indexes: IndexOptions {
+                index,
+                index_url,
+                extra_index_url,
+                no_index,
+                find_links,
+            },
             index_strategy,
             keyring_provider,
             resolution,
@@ -2127,7 +2176,7 @@ pub struct PipOptions {
 
 impl PipOptions {
     /// Resolve the [`PipOptions`] relative to the given root directory.
-    pub fn relative_to(mut self, root_dir: &Path) -> Result<Self, IndexUrlError> {
+    fn relative_to(mut self, root_dir: &Path) -> Result<Self, IndexUrlError> {
         rebase_indexes(
             root_dir,
             &mut self.index,
@@ -2143,11 +2192,13 @@ impl PipOptions {
 impl From<ResolverInstallerSchema> for ResolverOptions {
     fn from(value: ResolverInstallerSchema) -> Self {
         Self {
-            index: value.index,
-            index_url: value.index_url,
-            extra_index_url: value.extra_index_url,
-            no_index: value.no_index,
-            find_links: value.find_links,
+            indexes: IndexOptions {
+                index: value.index,
+                index_url: value.index_url,
+                extra_index_url: value.extra_index_url,
+                no_index: value.no_index,
+                find_links: value.find_links,
+            },
             index_strategy: value.index_strategy,
             keyring_provider: value.keyring_provider,
             resolution: value.resolution,
@@ -2295,16 +2346,16 @@ pub struct ToolOptionsWire {
 impl From<ResolverInstallerOptions> for ToolOptions {
     fn from(value: ResolverInstallerOptions) -> Self {
         Self {
-            index: value.index.map(|indexes| {
+            index: value.indexes.index.map(|indexes| {
                 indexes
                     .into_iter()
                     .map(Index::with_promoted_auth_policy)
                     .collect()
             }),
-            index_url: value.index_url,
-            extra_index_url: value.extra_index_url,
-            no_index: value.no_index,
-            find_links: value.find_links,
+            index_url: value.indexes.index_url,
+            extra_index_url: value.indexes.extra_index_url,
+            no_index: value.indexes.no_index,
+            find_links: value.indexes.find_links,
             index_strategy: value.index_strategy,
             keyring_provider: value.keyring_provider,
             resolution: value.resolution,
@@ -2433,11 +2484,13 @@ impl From<ToolOptions> for ToolOptionsWire {
 impl From<ToolOptions> for ResolverInstallerOptions {
     fn from(value: ToolOptions) -> Self {
         Self {
-            index: value.index,
-            index_url: value.index_url,
-            extra_index_url: value.extra_index_url,
-            no_index: value.no_index,
-            find_links: value.find_links,
+            indexes: IndexOptions {
+                index: value.index,
+                index_url: value.index_url,
+                extra_index_url: value.extra_index_url,
+                no_index: value.no_index,
+                find_links: value.find_links,
+            },
             index_strategy: value.index_strategy,
             keyring_provider: value.keyring_provider,
             resolution: value.resolution,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -57,8 +57,8 @@ use uv_resolver::{
     ForkStrategy, PrereleaseMode, ResolutionMode,
 };
 use uv_settings::{
-    Combine, EnvironmentOptions, FilesystemOptions, MalwareCheckSettings, Options, PipOptions,
-    PreviewFeaturesOption, PreviewOption, PublishOptions, PythonInstallMirrors,
+    Combine, EnvironmentOptions, FilesystemOptions, IndexOptions, MalwareCheckSettings, Options,
+    PipOptions, PreviewFeaturesOption, PreviewOption, PublishOptions, PythonInstallMirrors,
     ResolverInstallerOptions, ResolverInstallerSchema, ResolverOptions,
 };
 use uv_static::EnvVars;
@@ -1261,7 +1261,10 @@ impl ToolListSettings {
             .map(|options| options.top_level)
             .unwrap_or_default();
         let filesystem = ResolverInstallerOptions {
-            index: top_level.index,
+            indexes: IndexOptions {
+                index: top_level.index,
+                ..IndexOptions::default()
+            },
             exclude_newer: top_level.exclude_newer,
             exclude_newer_package: top_level.exclude_newer_package,
             ..ResolverInstallerOptions::default()
@@ -2388,7 +2391,7 @@ impl AddSettings {
         );
         let refresh = Refresh::try_from(refresh)?;
         let options = resolver_installer_options(installer, build)?;
-        let indexes = options.index.clone().unwrap_or_default();
+        let indexes = options.indexes.index.clone().unwrap_or_default();
 
         Ok(Self {
             lock_check: resolve_lock_check(locked),
@@ -4362,24 +4365,8 @@ impl ResolverSettings {
 
 impl From<ResolverOptions> for ResolverSettings {
     fn from(value: ResolverOptions) -> Self {
-        let index_locations = IndexLocations::new(
-            value
-                .index
-                .into_iter()
-                .flatten()
-                .chain(value.extra_index_url.into_iter().flatten().map(Index::from))
-                .chain(value.index_url.into_iter().map(Index::from))
-                .collect(),
-            value
-                .find_links
-                .into_iter()
-                .flatten()
-                .map(Index::from)
-                .collect(),
-            value.no_index.unwrap_or_default(),
-        );
         Self {
-            index_locations,
+            index_locations: value.indexes.into(),
             resolution: value.resolution.unwrap_or_default(),
             prerelease: warn_if_deprecated_prerelease_mode(value.prerelease.unwrap_or_default()),
             fork_strategy: value.fork_strategy.unwrap_or_default(),
@@ -4477,22 +4464,7 @@ fn resolver_installer_options_with_environment(
 
 impl From<ResolverInstallerOptions> for ResolverInstallerSettings {
     fn from(value: ResolverInstallerOptions) -> Self {
-        let index_locations = IndexLocations::new(
-            value
-                .index
-                .into_iter()
-                .flatten()
-                .chain(value.extra_index_url.into_iter().flatten().map(Index::from))
-                .chain(value.index_url.into_iter().map(Index::from))
-                .collect(),
-            value
-                .find_links
-                .into_iter()
-                .flatten()
-                .map(Index::from)
-                .collect(),
-            value.no_index.unwrap_or_default(),
-        );
+        let index_locations = value.indexes.into();
         Self {
             resolver: ResolverSettings {
                 build_options: BuildOptions::new(

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -907,11 +907,13 @@ fn tool_install_baseline() {
             ),
         ),
         options: ResolverInstallerOptions {
-            index: None,
-            index_url: None,
-            extra_index_url: None,
-            no_index: None,
-            find_links: None,
+            indexes: IndexOptions {
+                index: None,
+                index_url: None,
+                extra_index_url: None,
+                no_index: None,
+                find_links: None,
+            },
             index_strategy: None,
             keyring_provider: None,
             resolution: None,
@@ -1961,7 +1963,7 @@ fn resolve_tool() -> anyhow::Result<()> {
         .arg("requirements.in")
         .env(EnvVars::XDG_CONFIG_HOME, xdg.path()), @"
     ...
-             find_links: None,
+             },
              index_strategy: None,
              keyring_provider: None,
     -        resolution: None,


### PR DESCRIPTION
## Summary

We had `IndexArgs` and `IndexLocations`, this adds `IndexOptions`, it lets us avoid needing to carry around a set of inherently related fields directly in some structs.

IndexLocations is the "resolved" version of what is now in `IndexOptions` and adding this type lets us do this resolution in one place.

## Test Plan

Existing coverage.