### PR TITLE
Honor PATHEXT when checking script suffixes

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -15,7 +15,7 @@ use flate2::write::GzEncoder;
 use futures::executor::block_on;
 use futures::io::AllowStdIo;
 use sha2::{Digest, Sha256};
-use tokio_util::compat::FuturesAsyncWriteCompatExt;
+use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -15,7 +15,7 @@ use flate2::write::GzEncoder;
 use futures::executor::block_on;
 use futures::io::AllowStdIo;
 use sha2::{Digest, Sha256};
-use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
+use tokio_util::compat::FuturesAsyncWriteCompatExt;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -15,19 +15,34 @@ pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
     })
 });
 
-/// The list of valid executable extensions, on Windows.
+/// The list of valid executable extensions on Windows.
+///
+/// This always includes `.exe`, even if not explicitly included.
 #[cfg(windows)]
 pub static PATHEXT: LazyLock<Vec<Cow<'static, str>>> = LazyLock::new(|| {
-    if let Ok(pathext) = std::env::var("PATHEXT") {
-        pathext.split(';').map(|e| Cow::Owned(e.into())).collect()
+    let mut extensions: Vec<_> = if let Ok(pathext) = std::env::var("PATHEXT") {
+        pathext
+            .split(';')
+            .filter(|extension| !extension.is_empty())
+            .map(|extension| Cow::Owned(extension.to_ascii_lowercase()))
+            .collect()
     } else {
         [
-            ".COM", ".EXE", ".BAT", ".CMD", ".VBS", ".VBE", ".JS", ".JSE", ".WSF", ".WSH", ".MSC",
+            ".com", ".exe", ".bat", ".cmd", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".msc",
         ]
         .into_iter()
         .map(Cow::Borrowed)
         .collect()
+    };
+
+    if !extensions
+        .iter()
+        .any(|extension| extension.as_ref() == ".exe")
+    {
+        extensions.push(Cow::Borrowed(".exe"));
     }
+
+    extensions
 });
 
 pub trait Simplified {

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -19,7 +19,7 @@ pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
 #[cfg(windows)]
 pub static PATHEXT: LazyLock<Vec<Cow<'static, str>>> = LazyLock::new(|| {
     if let Ok(pathext) = std::env::var("PATHEXT") {
-        pathext.split(";").collect()
+        pathext.split(";").map(|e| e.into()).collect()
     } else {
         [
             ".COM", ".EXE", ".BAT", ".CMD", ".VBS", ".VBE", ".JS", ".JSE", ".WSF", ".WSH", ".MSC",

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -19,7 +19,7 @@ pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
 #[cfg(windows)]
 pub static PATHEXT: LazyLock<Vec<Cow<'static, str>>> = LazyLock::new(|| {
     if let Ok(pathext) = std::env::var("PATHEXT") {
-        pathext.split(";").map(|e| e.into()).collect()
+        pathext.split(";").map(|e| Cow::Owned(e.into())).collect()
     } else {
         [
             ".COM", ".EXE", ".BAT", ".CMD", ".VBS", ".VBE", ".JS", ".JSE", ".WSF", ".WSH", ".MSC",

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -19,7 +19,7 @@ pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
 #[cfg(windows)]
 pub static PATHEXT: LazyLock<Vec<Cow<'static, str>>> = LazyLock::new(|| {
     if let Ok(pathext) = std::env::var("PATHEXT") {
-        pathext.split(";").map(|e| Cow::Owned(e.into())).collect()
+        pathext.split(';').map(|e| Cow::Owned(e.into())).collect()
     } else {
         [
             ".COM", ".EXE", ".BAT", ".CMD", ".VBS", ".VBE", ".JS", ".JSE", ".WSF", ".WSH", ".MSC",

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -15,6 +15,21 @@ pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
     })
 });
 
+/// The list of valid executable extensions, on Windows.
+#[cfg(windows)]
+pub static PATHEXT: LazyLock<Vec<Cow<'static, str>>> = LazyLock::new(|| {
+    if let Ok(pathext) = std::env::var("PATHEXT") {
+        pathext.split(";").collect()
+    } else {
+        [
+            ".COM", ".EXE", ".BAT", ".CMD", ".VBS", ".VBE", ".JS", ".JSE", ".WSF", ".WSH", ".MSC",
+        ]
+        .into_iter()
+        .map(Cow::Borrowed)
+        .collect()
+    }
+});
+
 pub trait Simplified {
     /// Simplify a [`Path`].
     ///

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -15,35 +15,23 @@ pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
     })
 });
 
-/// The list of valid executable extensions on Windows.
+/// A common list of valid executable suffixes on Windows.
 ///
-/// This always includes `.exe`, even if not explicitly included.
+/// This is similar to the default value of `PATHEXT` but not derived from it.
 #[cfg(windows)]
-pub static PATHEXT: LazyLock<Vec<Cow<'static, str>>> = LazyLock::new(|| {
-    let mut extensions: Vec<_> = if let Ok(pathext) = std::env::var("PATHEXT") {
-        pathext
-            .split(';')
-            .filter(|extension| !extension.is_empty())
-            .map(|extension| Cow::Owned(extension.to_ascii_lowercase()))
-            .collect()
-    } else {
-        [
-            ".com", ".exe", ".bat", ".cmd", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".msc",
-        ]
-        .into_iter()
-        .map(Cow::Borrowed)
-        .collect()
-    };
+pub static EXE_SUFFIXES: &[&str] = &[
+    // Default on Windows 10+
+    // learn.microsoft.com/en-us/windows-server/administration/windows-commands/start
+    ".com", ".exe", ".bat", ".cmd", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".msc",
+    // Honored by PowerShell, but not in the default `PATHEXT`.
+    ".ps1",
+];
 
-    if !extensions
-        .iter()
-        .any(|extension| extension.as_ref() == ".exe")
-    {
-        extensions.push(Cow::Borrowed(".exe"));
-    }
-
-    extensions
-});
+/// Like [`EXE_SUFFIXES`], but without leading dots.
+#[cfg(windows)]
+pub static EXE_EXTENSIONS: &[&str] = &[
+    "com", "exe", "bat", "cmd", "vbs", "vbe", "js", "jse", "wsf", "wsh", "msc", "ps1",
+];
 
 pub trait Simplified {
     /// Simplify a [`Path`].

--- a/crates/uv-fs/src/which.rs
+++ b/crates/uv-fs/src/which.rs
@@ -1,26 +1,5 @@
 use std::path::Path;
 
-#[cfg(windows)]
-#[allow(unsafe_code)] // We need to do an FFI call through the windows-* crates.
-fn get_binary_type(path: &Path) -> windows::core::Result<u32> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows::Win32::Storage::FileSystem::GetBinaryTypeW;
-    use windows::core::PCWSTR;
-
-    // References:
-    // https://github.com/denoland/deno/blob/01a6379505712be34ebf2cdc874fa7f54a6e9408/runtime/permissions/which.rs#L131-L154
-    // https://github.com/conradkleinespel/rooster/blob/afa78dc9918535752c4af59d2f812197ad754e5a/src/quale.rs#L51-L77
-    let mut binary_type = 0u32;
-    let name = path
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<u16>>();
-    // SAFETY: winapi call
-    unsafe { GetBinaryTypeW(PCWSTR(name.as_ptr()), &raw mut binary_type)? };
-    Ok(binary_type)
-}
-
 /// Check whether a path in PATH is a valid executable.
 ///
 /// Derived from `which`'s `Checker`.
@@ -34,14 +13,19 @@ pub fn is_executable(path: &Path) -> bool {
 
     #[cfg(target_os = "windows")]
     {
+        // Extension check first, since it's cheaper than metadata access.
+        // Extensionless files fall through.
+        if let Some(ext) = path.extension().and_then(|ext| ext.to_str())
+            && !crate::EXE_EXTENSIONS.contains(&ext)
+        {
+            return false;
+        }
+
         let Ok(file_type) = fs_err::symlink_metadata(path).map(|metadata| metadata.file_type())
         else {
             return false;
         };
         if !file_type.is_file() && !file_type.is_symlink() {
-            return false;
-        }
-        if path.extension().is_none() && get_binary_type(path).is_err() {
             return false;
         }
     }

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -245,7 +245,7 @@ fn validate_data_script_destination(target: &Path, scripts: &Path) -> Result<(),
         windows => {
             uv_fs::PATHEXT
                 .iter()
-                .find_map(|ext| normalized_name.strip_suffix(ext))
+                .find_map(|extension| normalized_name.strip_suffix(extension.as_ref()))
                 .unwrap_or(&normalized_name)
         },
         // On all other platforms, strip `.exe` if present.

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -237,9 +237,27 @@ fn validate_data_script_destination(target: &Path, scripts: &Path) -> Result<(),
     };
 
     let normalized_name = name.to_ascii_lowercase();
-    let normalized_name = normalized_name
-        .strip_suffix(".exe")
-        .unwrap_or(&normalized_name);
+
+    let normalized_name = cfg_select! {
+        // On Windows, check (and strip) any prefix matching `%PATHEXT%`.
+        // This ensures that we reject e.g. `python.bat`, which Windows
+        // would otherwise execute as `python`.
+        windows => {
+            uv_fs::PATHEXT
+                .iter()
+                .find(|ext| normalized_name.strip_suffix(ext))
+                .unwrap_or(&normalized_name)
+        },
+        // On all other platforms, strip `.exe` if present.
+        // We could probably remove this since non-Windows doesn't
+        // have the equivalent of `%PATHEXT%`.
+        _ => {
+            normalized_name
+                .strip_suffix(".exe")
+                .unwrap_or(&normalized_name)
+        }
+    };
+
     if let Some(reserved) = reserved_script_name(normalized_name) {
         return Err(Error::ReservedScriptName {
             reserved: reserved.to_string(),

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -245,7 +245,7 @@ fn validate_data_script_destination(target: &Path, scripts: &Path) -> Result<(),
         windows => {
             uv_fs::PATHEXT
                 .iter()
-                .find(|ext| normalized_name.strip_suffix(ext))
+                .find_map(|ext| normalized_name.strip_suffix(ext))
                 .unwrap_or(&normalized_name)
         },
         // On all other platforms, strip `.exe` if present.

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -239,18 +239,20 @@ fn validate_data_script_destination(target: &Path, scripts: &Path) -> Result<(),
     let normalized_name = name.to_ascii_lowercase();
 
     let normalized_name = cfg_select! {
-        // On Windows, check (and strip) any prefix matching `%PATHEXT%`.
-        // This ensures that we reject e.g. `python.bat`, which Windows
+        // On Windows, check (and strip) any prefix matching a common extension
+        // suffix. This ensures that we reject e.g. `python.bat`, which Windows
         // would otherwise execute as `python`.
+        // NOTE: This is a heuristic, since whether or not a suffix
+        // implies executable intent is a properly of a given shell on Windows,
+        // not the system itself.
         windows => {
-            uv_fs::PATHEXT
+            uv_fs::EXE_SUFFIXES
                 .iter()
-                .find_map(|extension| normalized_name.strip_suffix(extension.as_ref()))
+                .find_map(|extension| normalized_name.strip_suffix(extension))
                 .unwrap_or(&normalized_name)
         },
         // On all other platforms, strip `.exe` if present.
-        // We could probably remove this since non-Windows doesn't
-        // have the equivalent of `%PATHEXT%`.
+        // We could probably remove this.
         _ => {
             normalized_name
                 .strip_suffix(".exe")

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13183,10 +13183,23 @@ fn reject_reserved_wheel_data_script_name() -> Result<()> {
         "python"
     };
     let scripts = if cfg!(windows) { "Scripts" } else { "bin" };
+    let executables = [
+        "python",
+        "python.py",
+        "Python.exe",
+        "python.EXE",
+        "Python.PY",
+    ]
+    .into_iter()
+    .chain(
+        cfg!(windows)
+            .then_some(["python.bat", "Python.CMD", "python.CuStOm"])
+            .into_iter()
+            .flatten(),
+    );
 
     allow_duplicates! {
-        for data_path in ["python", "python.py", "Python.exe", "python.EXE", "Python.PY"]
-            .into_iter()
+        for data_path in executables
             .flat_map(|executable| {
                 [
                     format!("foo-0.1.0.data/scripts/{executable}"),
@@ -13195,7 +13208,7 @@ fn reject_reserved_wheel_data_script_name() -> Result<()> {
             })
         {
             let context = uv_test::test_context!("3.12").with_filter((
-                r"got: `(?:Python\.(?:exe|PY)|python(?:\.EXE|\.py)?)`",
+                r"got: `(?i:python(?:\.[a-z]+)?)`",
                 "got: `python`",
             ));
             let wheel = context.temp_dir.join("foo-0.1.0-py3-none-any.whl");
@@ -13227,7 +13240,12 @@ fn reject_reserved_wheel_data_script_name() -> Result<()> {
             }
             fs_err::write(&wheel, block_on(writer.close())?)?;
 
-            uv_snapshot!(context.filters(), context.pip_install().arg(&wheel), @"
+            let mut command = context.pip_install();
+            command.arg(&wheel);
+            #[cfg(windows)]
+            command.env("PATHEXT", ".BAT;.CMD;.CUSTOM");
+
+            uv_snapshot!(context.filters(), command, @"
         exit_code: 2 (failure)
         ----- stderr -----
         Resolved 1 package in [TIME]

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13242,8 +13242,6 @@ fn reject_reserved_wheel_data_script_name() -> Result<()> {
 
             let mut command = context.pip_install();
             command.arg(&wheel);
-            #[cfg(windows)]
-            command.env("PATHEXT", ".BAT;.CMD;.CUSTOM");
 
             uv_snapshot!(context.filters(), command, @"
         exit_code: 2 (failure)


### PR DESCRIPTION
## Summary

TL;DR: when validating entrypoint and script names, we need to check everything in `%PATHEXT%`, not just `.exe`, since `python.bat`, etc. can also shadow the user's invocation of `python`.

See https://github.com/astral-sh/uv/pull/20749#discussion_r3667481180 for context.

## Test Plan

Needs tests.