### PR TITLE
name the rejected version and restore the index hint

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1227,6 +1227,60 @@ fn merge_unavailable_versions(
     }))
 }
 
+/// Combine two unavailabilities of one package that are the causes of the same derivation.
+///
+/// A derivation whose two causes both say that a package cannot be used concludes their union. If
+/// they say it for the same reason, they are one statement about a larger set and the derivation
+/// collapses into it, as [`merge_unavailable_versions`] does for a cause nested one level deeper.
+/// Otherwise the two statements stay separate and only the conclusion is widened to cover them
+/// both.
+///
+/// Two unavailabilities are siblings rather than nested when their version sets are contiguous.
+fn merge_unavailable_siblings(derived: &ErrorDerived) -> Option<ErrorTree> {
+    let DerivationTree::External(External::Custom(package, versions, reason)) = &*derived.cause1
+    else {
+        return None;
+    };
+    let DerivationTree::External(External::Custom(other_package, other_versions, other_reason)) =
+        &*derived.cause2
+    else {
+        return None;
+    };
+    if package != other_package {
+        return None;
+    }
+
+    // Only rewrite a derivation that concludes about this package alone.
+    let mut terms = derived.terms.iter();
+    let Some((term_package, Term::Positive(term_versions))) = terms.next() else {
+        return None;
+    };
+    if terms.next().is_some() || term_package != package {
+        return None;
+    }
+
+    let versions = versions.union(other_versions);
+    if reason == other_reason {
+        return Some(DerivationTree::External(External::Custom(
+            package.clone(),
+            versions,
+            reason.clone(),
+        )));
+    }
+    if versions.subset_of(term_versions) {
+        return None;
+    }
+    Some(DerivationTree::Derived(Derived {
+        terms: Map::from_iter([(
+            package.clone(),
+            Term::Positive(term_versions.union(&versions)),
+        )]),
+        shared_id: derived.shared_id,
+        cause1: derived.cause1.clone(),
+        cause2: derived.cause2.clone(),
+    }))
+}
+
 /// Given a [`DerivationTree`], collapse incompatibilities for versions of a package that are
 /// unavailable for the same reason to avoid repeating the same message for every unavailable
 /// version.
@@ -1235,17 +1289,27 @@ fn collapse_unavailable_versions(tree: ErrorTree) -> ErrorTree {
         tree,
         DerivationTree::External,
         |metadata, cause1, cause2| {
-            if let DerivationTree::External(External::Custom(package, versions, reason)) = &cause1
+            let tree = if let DerivationTree::External(External::Custom(package, versions, reason)) =
+                &cause1
                 && let Some(tree) = merge_unavailable_versions(package, versions, reason, &cause2)
             {
-                return tree;
-            }
-            if let DerivationTree::External(External::Custom(package, versions, reason)) = &cause2
+                tree
+            } else if let DerivationTree::External(External::Custom(package, versions, reason)) =
+                &cause2
                 && let Some(tree) = merge_unavailable_versions(package, versions, reason, &cause1)
             {
-                return tree;
+                tree
+            } else {
+                derived_tree(metadata, cause1, cause2)
+            };
+
+            // Merging a cause can also leave two unavailabilities of one package side by side.
+            if let DerivationTree::Derived(derived) = &tree
+                && let Some(merged) = merge_unavailable_siblings(derived)
+            {
+                return merged;
             }
-            derived_tree(metadata, cause1, cause2)
+            tree
         },
     )
 }
@@ -1595,6 +1659,7 @@ fn simplify_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resolver::UnavailableVersion;
 
     fn deep_derivation_tree() -> ErrorTree {
         let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
@@ -1611,6 +1676,81 @@ mod tests {
         }
 
         tree
+    }
+
+    fn pubgrub_package(name: &str) -> PubGrubPackage {
+        PubGrubPackage::from(PubGrubPackageInner::Package {
+            name: package_name(name),
+            extra: None,
+            group: None,
+            marker: uv_pep508::MarkerTree::TRUE,
+        })
+    }
+
+    fn package_name(name: &str) -> PackageName {
+        name.parse().expect("valid package name")
+    }
+
+    fn version(version: &str) -> Version {
+        version.parse().expect("valid version")
+    }
+
+    fn unavailable(package: &PubGrubPackage, versions: Range<Version>) -> ErrorTree {
+        ErrorTree::External(External::Custom(
+            package.clone(),
+            versions,
+            UnavailableReason::Version(UnavailableVersion::InvalidMetadata),
+        ))
+    }
+
+    /// Two rejections of the same package for the same reason read as one statement.
+    #[test]
+    fn collapses_sibling_unavailable_versions() {
+        let package = pubgrub_package("numpy");
+        let cause1 = unavailable(&package, Range::singleton(version("1.0")));
+        let cause2 = unavailable(
+            &package,
+            Range::from_range_bounds(version("2.0")..=version("3.0")),
+        );
+        let terms = pubgrub::Map::from_iter([(
+            package.clone(),
+            Term::Positive(Range::from_range_bounds(version("2.0")..=version("3.0"))),
+        )]);
+        let tree = ErrorTree::Derived(Derived {
+            terms,
+            shared_id: None,
+            cause1: Arc::new(cause1),
+            cause2: Arc::new(cause2),
+        });
+
+        let collapsed = collapse_unavailable_versions(tree);
+        let ErrorTree::External(External::Custom(_, versions, _)) = collapsed else {
+            panic!("expected a custom incompatibility");
+        };
+        assert_eq!(versions.to_string(), "==1.0 | >=2.0, <=3.0");
+    }
+
+    /// A derivation that concludes about more than the unavailable package is left alone.
+    #[test]
+    fn keeps_sibling_unavailable_versions_concluding_about_another_package() {
+        let package = pubgrub_package("numpy");
+        let cause1 = unavailable(&package, Range::singleton(version("1.0")));
+        let cause2 = unavailable(&package, Range::singleton(version("3.0")));
+        let terms = pubgrub::Map::from_iter([
+            (package.clone(), Term::Positive(Range::full())),
+            (pubgrub_package("scipy"), Term::Positive(Range::full())),
+        ]);
+        let tree = ErrorTree::Derived(Derived {
+            terms,
+            shared_id: None,
+            cause1: Arc::new(cause1),
+            cause2: Arc::new(cause2),
+        });
+
+        assert!(matches!(
+            collapse_unavailable_versions(tree),
+            ErrorTree::Derived(_)
+        ));
     }
 
     #[test]

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -572,33 +572,66 @@ impl NoSolutionError {
 
     /// Shrinks widened version sets in the derivation tree back onto the known versions.
     ///
-    /// The resolver widens the version set on the depending side of a dependency
-    /// incompatibility to the largest interval containing the same known versions
-    /// ([`Ranges::widen_versions`]), keeping version sets small during resolution. The widened
-    /// bounds are misleading in error messages, e.g., `a>1.5.2,<2.0.0` when `a 1.5.3` is the only
-    /// version in that interval. Shrink the depending side and positive terms back: a set
-    /// containing all known versions of a package becomes the full range ("all versions of a");
-    /// otherwise, bounded ends are narrowed to inclusive bounds on the known versions they
-    /// contain while unbounded ends are preserved. Dependency requests (the depended-on side and
-    /// negative terms) are shown as requested.
+    /// The resolver widens version sets to the largest interval containing the same known
+    /// versions ([`Ranges::widen_versions`]), both on the depending side of a dependency
+    /// incompatibility and for a version that cannot be used, keeping version sets small during
+    /// resolution. The widened bounds are misleading in error messages, e.g., `a>1.5.2,<2.0.0`
+    /// when `a 1.5.3` is the only version in that interval. Shrink the depending side, the
+    /// unavailable set, and positive terms back: a set containing all known versions of a package
+    /// becomes the full range ("all versions of a"); otherwise, bounded ends are narrowed to
+    /// inclusive bounds on the known versions they contain while unbounded ends are preserved,
+    /// except on an unavailable set, which never claims a version outside the listing. Dependency
+    /// requests (the depended-on side and negative terms) are shown as requested.
     pub(crate) fn narrow_widened_sets(
         derivation_tree: ErrorTree,
         known_versions: &FxHashMap<PackageName, Arc<[Version]>>,
     ) -> ErrorTree {
-        let narrow = |package: &PubGrubPackage, set: Range<Version>| -> Range<Version> {
-            let Some(versions) = package
-                .name_no_root()
-                .and_then(|name| known_versions.get(name))
-                .filter(|versions| !versions.is_empty())
-            else {
-                return set;
-            };
+        /// Narrow a version set onto a non-empty list of known versions.
+        fn narrow_to_known(set: &Range<Version>, versions: &[Version]) -> Range<Version> {
             if versions.iter().all(|version| set.contains(version)) {
                 Range::full()
             } else {
                 set.narrow_versions(versions)
             }
+        }
+
+        // The known versions of a package, with the lowest and the highest. An empty list carries
+        // no information, so it is treated as absent.
+        let listed = |package: &PubGrubPackage| -> Option<(&[Version], &Version, &Version)> {
+            let versions = package
+                .name_no_root()
+                .and_then(|name| known_versions.get(name))?;
+            Some((versions, versions.first()?, versions.last()?))
         };
+
+        let narrow = |package: &PubGrubPackage, set: Range<Version>| -> Range<Version> {
+            let Some((versions, _, _)) = listed(package) else {
+                return set;
+            };
+            narrow_to_known(&set, versions)
+        };
+
+        // A single version's unavailability says nothing about versions outside the listing, so
+        // an unbounded end of its widened set must not be reported as a claim about them.
+        let narrow_unavailable =
+            |package: &PubGrubPackage, set: Range<Version>| -> Range<Version> {
+                let Some((versions, lowest, highest)) = listed(package) else {
+                    return set;
+                };
+                let narrowed = narrow_to_known(&set, versions);
+                // A claim about every known version is reported as such, not as its bounds.
+                if narrowed == Range::full() {
+                    return narrowed;
+                }
+                let envelope = Range::from_range_bounds(lowest.clone()..=highest.clone());
+                let clamped = narrowed.intersection(&envelope);
+                // A rejected version outside the listing has no envelope to report it in.
+                if clamped == Range::empty() {
+                    narrowed
+                } else {
+                    clamped
+                }
+            };
 
         map_derivation_tree(
             derivation_tree,
@@ -608,6 +641,13 @@ impl NoSolutionError {
                     DerivationTree::External(External::FromDependencyOf(
                         package1, versions1, package2, versions2,
                     ))
+                }
+                External::Custom(package, versions, reason) => {
+                    let versions = match &reason {
+                        UnavailableReason::Version(_) => narrow_unavailable(&package, versions),
+                        UnavailableReason::Package(_) => narrow(&package, versions),
+                    };
+                    DerivationTree::External(External::Custom(package, versions, reason))
                 }
                 external => DerivationTree::External(external),
             },
@@ -1695,12 +1735,78 @@ mod tests {
         version.parse().expect("valid version")
     }
 
+    fn known_versions(name: &str, versions: &[&str]) -> FxHashMap<PackageName, Arc<[Version]>> {
+        let versions: Arc<[Version]> = versions.iter().copied().map(version).collect();
+        FxHashMap::from_iter([(package_name(name), versions)])
+    }
+
     fn unavailable(package: &PubGrubPackage, versions: Range<Version>) -> ErrorTree {
         ErrorTree::External(External::Custom(
             package.clone(),
             versions,
             UnavailableReason::Version(UnavailableVersion::InvalidMetadata),
         ))
+    }
+
+    fn narrow_unavailable(
+        package: &PubGrubPackage,
+        versions: Range<Version>,
+        known_versions: &FxHashMap<PackageName, Arc<[Version]>>,
+    ) -> Range<Version> {
+        let narrowed =
+            NoSolutionError::narrow_widened_sets(unavailable(package, versions), known_versions);
+        let ErrorTree::External(External::Custom(_, versions, _)) = narrowed else {
+            panic!("expected a custom incompatibility");
+        };
+        versions
+    }
+
+    /// A widened unavailable set is narrowed back onto the known versions.
+    #[test]
+    fn narrows_widened_unavailable_versions() {
+        let package = pubgrub_package("numpy");
+        let known_versions = known_versions("numpy", &["1.0", "2.0", "3.0"]);
+
+        // A gap-widened rejection reports the single version it excludes.
+        let widened = Range::singleton(version("2.0")).widen_versions(&[
+            version("1.0"),
+            version("2.0"),
+            version("3.0"),
+        ]);
+        assert_eq!(widened.to_string(), ">1.0, <3.0");
+        assert_eq!(
+            narrow_unavailable(&package, widened, &known_versions),
+            Range::singleton(version("2.0"))
+        );
+
+        // At the top of a listing the widened set is unbounded, but the rejection says nothing
+        // about versions that are not published yet.
+        let widened = Range::from_range_bounds(version("2.0")..);
+        assert_eq!(
+            narrow_unavailable(&package, widened, &known_versions),
+            Range::from_range_bounds(version("2.0")..=version("3.0"))
+        );
+
+        // Merged rejections covering every known version report as the full range.
+        let merged = Range::from_range_bounds(version("0")..);
+        assert_eq!(
+            narrow_unavailable(&package, merged, &known_versions),
+            Range::full()
+        );
+
+        // A rejected version outside the known versions has no envelope to report it in.
+        let widened = Range::from_range_bounds(version("4.0")..version("5.0"));
+        assert_eq!(
+            narrow_unavailable(&package, widened.clone(), &known_versions),
+            widened
+        );
+
+        // A package without a known version list is reported as recorded.
+        let widened = Range::from_range_bounds(version("1.0")..version("3.0"));
+        assert_eq!(
+            narrow_unavailable(&pubgrub_package("scipy"), widened.clone(), &known_versions),
+            widened
+        );
     }
 
     /// Two rejections of the same package for the same reason read as one statement.

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -764,7 +764,8 @@ impl NoSolutionError {
             &self.env,
         );
 
-        // This needs to be applied _after_ simplification of the ranges
+        // These need to be applied _after_ simplification of the ranges
+        tree = restate_available_versions(tree, &self.included_versions);
         tree = collapse_redundant_no_versions(tree);
 
         loop {
@@ -954,6 +955,201 @@ fn display_tree_inner(
                 }
             }
         }
+    }
+}
+
+/// Given a [`DerivationTree`], restate the availability of a package where a derivation reaches
+/// past the versions its causes rule out.
+///
+/// A derivation rules out the union of what its causes rule out, but the reported version sets are
+/// simplified onto the versions that exist, which drops the versions that do not. The derivation
+/// then reaches past its causes over a range that holds nothing, and the report has to say so, as it
+/// does for the ranges the resolver itself finds empty. The version sets are left as they are; only
+/// the statement that carries them is added, and only when every version it adds is one that the
+/// package does not have.
+fn restate_available_versions(
+    tree: ErrorTree,
+    included_versions: &FxHashMap<PackageName, BTreeSet<Version>>,
+) -> ErrorTree {
+    map_derivation_tree(
+        tree,
+        DerivationTree::External,
+        |metadata, cause1, cause2| {
+            let restated = unlisted_versions(&metadata.terms, &cause1, &cause2, included_versions)
+                .map(|(package, unlisted)| {
+                    // Carry the range on the cause it follows, so that the causes still meet.
+                    let first = reported_versions(&package, &cause1);
+                    let second = reported_versions(&package, &cause2);
+                    (package, starts_lower(&first, &second), unlisted)
+                });
+            let Some((package, first_carries, unlisted)) = restated else {
+                return derived_tree(metadata, cause1, cause2);
+            };
+
+            let carry = |cause: ErrorTree| {
+                let carried = reported_versions(&package, &cause).union(&unlisted);
+                DerivationTree::Derived(Derived {
+                    terms: Map::from_iter([(package.clone(), Term::Positive(carried))]),
+                    shared_id: None,
+                    cause1: Arc::new(cause),
+                    cause2: Arc::new(DerivationTree::External(External::NoVersions(
+                        package.clone(),
+                        unlisted.clone(),
+                    ))),
+                })
+            };
+            if first_carries {
+                derived_tree(metadata, carry(cause1), cause2)
+            } else {
+                derived_tree(metadata, cause1, carry(cause2))
+            }
+        },
+    )
+}
+
+/// The versions a derivation rules out without either cause mentioning them, when they are versions
+/// the package does not have.
+///
+/// A derivation reaches past its causes in two places: the conclusion it draws about a package, and
+/// the requirement it resolves for a package it drops from its terms.
+fn unlisted_versions(
+    terms: &ErrorTerms,
+    cause1: &ErrorTree,
+    cause2: &ErrorTree,
+    included_versions: &FxHashMap<PackageName, BTreeSet<Version>>,
+) -> Option<(PubGrubPackage, Range<Version>)> {
+    // What the causes establish about the package carries its conclusion, but only what they rule
+    // out can carry a requirement: a dependency of the package is not a statement that it cannot be
+    // used.
+    let concluded = concluded_package(terms).map(|(package, concluded)| {
+        let reported =
+            reported_versions(package, cause1).union(&reported_versions(package, cause2));
+        (package, concluded.clone(), reported)
+    });
+    let resolved = cause_packages(cause1)
+        .into_iter()
+        .chain(cause_packages(cause2))
+        .filter(|package| !terms.contains_key(*package))
+        .map(|package| {
+            let required =
+                required_versions(package, cause1).union(&required_versions(package, cause2));
+            let ruled_out =
+                ruled_out_versions(package, cause1).union(&ruled_out_versions(package, cause2));
+            (package, required, ruled_out)
+        });
+
+    for (package, covered, reported) in concluded.into_iter().chain(resolved) {
+        // A requirement that no cause rules out any of is unavailable outright rather than across a
+        // range, which [`collapse_redundant_depends_on_no_versions`] reports without the listing.
+        if reported.is_empty() {
+            continue;
+        }
+        let unlisted = covered.intersection(&reported.complement());
+        if unlisted.is_empty() {
+            continue;
+        }
+        // Only a version the package does not have can go unmentioned; anything else is a
+        // derivation its causes really do not support.
+        let Some(versions) = package
+            .name_no_root()
+            .and_then(|name| included_versions.get(name))
+        else {
+            continue;
+        };
+        if versions.iter().any(|version| unlisted.contains(version)) {
+            continue;
+        }
+        return Some((package.clone(), unlisted));
+    }
+    None
+}
+
+/// Whether the first version set starts below the second, treating an empty set as starting above
+/// every other.
+fn starts_lower(first: &Range<Version>, second: &Range<Version>) -> bool {
+    let lowest = |versions: &Range<Version>| {
+        versions.bounding_range().map(|(lower, _)| match lower {
+            Bound::Unbounded => None,
+            Bound::Included(version) | Bound::Excluded(version) => Some(version.clone()),
+        })
+    };
+    match (lowest(first), lowest(second)) {
+        // An unbounded start sorts below every version.
+        (Some(first), Some(second)) => first <= second,
+        (Some(_), None) => true,
+        (None, _) => false,
+    }
+}
+
+/// The package a derivation concludes about, when it concludes about one alone.
+fn concluded_package(terms: &ErrorTerms) -> Option<(&PubGrubPackage, &Range<Version>)> {
+    let mut terms = terms.iter();
+    let (package, Term::Positive(versions)) = terms.next()? else {
+        return None;
+    };
+    terms.next().is_none().then_some((package, versions))
+}
+
+/// The packages a cause states something about.
+fn cause_packages(cause: &ErrorTree) -> Vec<&PubGrubPackage> {
+    match cause {
+        DerivationTree::Derived(derived) => derived.terms.keys().collect(),
+        DerivationTree::External(
+            External::Custom(package, ..)
+            | External::NoVersions(package, ..)
+            | External::NotRoot(package, ..),
+        ) => vec![package],
+        DerivationTree::External(External::FromDependencyOf(package, _, dependency, _)) => {
+            vec![package, dependency]
+        }
+    }
+}
+
+/// The versions of `package` that a cause requires to remain usable.
+fn required_versions(package: &PubGrubPackage, cause: &ErrorTree) -> Range<Version> {
+    match cause {
+        DerivationTree::Derived(derived) => match derived.terms.get(package) {
+            Some(Term::Negative(versions)) => versions.clone(),
+            _ => Range::empty(),
+        },
+        DerivationTree::External(External::FromDependencyOf(_, _, required, versions))
+            if required == package =>
+        {
+            versions.clone()
+        }
+        DerivationTree::External(_) => Range::empty(),
+    }
+}
+
+/// The versions of `package` that a cause states cannot be used.
+fn ruled_out_versions(package: &PubGrubPackage, cause: &ErrorTree) -> Range<Version> {
+    match cause {
+        DerivationTree::Derived(derived) => match concluded_package(&derived.terms) {
+            Some((concluded, versions)) if concluded == package => versions.clone(),
+            _ => Range::empty(),
+        },
+        DerivationTree::External(External::Custom(ruled_out, versions, _))
+            if ruled_out == package =>
+        {
+            versions.clone()
+        }
+        DerivationTree::External(_) => Range::empty(),
+    }
+}
+
+/// The versions of `package` that a cause is reported as establishing something about.
+fn reported_versions(package: &PubGrubPackage, cause: &ErrorTree) -> Range<Version> {
+    match cause {
+        DerivationTree::Derived(derived) => match derived.terms.get(package) {
+            Some(Term::Positive(versions)) => versions.clone(),
+            _ => Range::empty(),
+        },
+        DerivationTree::External(
+            External::Custom(reported, versions, _)
+            | External::NoVersions(reported, versions)
+            | External::FromDependencyOf(reported, versions, ..),
+        ) if reported == package => versions.clone(),
+        DerivationTree::External(_) => Range::empty(),
     }
 }
 

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -637,7 +637,13 @@ impl NoSolutionError {
             derivation_tree,
             |external| match external {
                 External::FromDependencyOf(package1, versions1, package2, versions2) => {
-                    let versions1 = narrow(&package1, versions1);
+                    // A rejected version is recorded as a dependency on Python, so the widened
+                    // side is an exclusion and stops at the listing like any other.
+                    let versions1 = if matches!(&*package2, PubGrubPackageInner::Python(_)) {
+                        narrow_unavailable(&package1, versions1)
+                    } else {
+                        narrow(&package1, versions1)
+                    };
                     DerivationTree::External(External::FromDependencyOf(
                         package1, versions1, package2, versions2,
                     ))
@@ -975,30 +981,53 @@ fn restate_available_versions(
         tree,
         DerivationTree::External,
         |metadata, cause1, cause2| {
-            let restated = unlisted_versions(&metadata.terms, &cause1, &cause2, included_versions)
-                .map(|(package, unlisted)| {
-                    // Carry the range on the cause it follows, so that the causes still meet.
-                    let first = reported_versions(&package, &cause1);
-                    let second = reported_versions(&package, &cause2);
-                    (package, starts_lower(&first, &second), unlisted)
-                });
-            let Some((package, first_carries, unlisted)) = restated else {
+            let Some((package, unlisted)) =
+                unlisted_versions(&metadata.terms, &cause1, &cause2, included_versions)
+            else {
                 return derived_tree(metadata, cause1, cause2);
             };
 
+            let statement = || {
+                DerivationTree::External(External::NoVersions(package.clone(), unlisted.clone()))
+            };
             let carry = |cause: ErrorTree| {
-                let carried = reported_versions(&package, &cause).union(&unlisted);
+                let carried = ruled_out_versions(&package, &cause).union(&unlisted);
                 DerivationTree::Derived(Derived {
                     terms: Map::from_iter([(package.clone(), Term::Positive(carried))]),
                     shared_id: None,
                     cause1: Arc::new(cause),
-                    cause2: Arc::new(DerivationTree::External(External::NoVersions(
-                        package.clone(),
-                        unlisted.clone(),
-                    ))),
+                    cause2: Arc::new(statement()),
                 })
             };
-            if first_carries {
+
+            // The statement carries a step that rules the package out, so it goes on the cause that
+            // does the ruling out.  Where neither does, the step reaches past its causes on its own
+            // and the statement carries the step itself.
+            let first = ruled_out_versions(&package, &cause1);
+            let second = ruled_out_versions(&package, &cause2);
+            if first.is_empty() && second.is_empty() {
+                let concluded = metadata
+                    .terms
+                    .get(&package)
+                    .cloned()
+                    .unwrap_or_else(|| Term::Positive(unlisted.clone()));
+                let mut inner = metadata;
+                let shared_id = inner.shared_id.take();
+                inner.terms = Map::from_iter([(
+                    package.clone(),
+                    Term::Positive(
+                        reported_versions(&package, &cause1)
+                            .union(&reported_versions(&package, &cause2)),
+                    ),
+                )]);
+                return DerivationTree::Derived(Derived {
+                    terms: Map::from_iter([(package.clone(), concluded)]),
+                    shared_id,
+                    cause1: Arc::new(derived_tree(inner, cause1, cause2)),
+                    cause2: Arc::new(statement()),
+                });
+            }
+            if starts_lower(&first, &second) {
                 derived_tree(metadata, carry(cause1), cause2)
             } else {
                 derived_tree(metadata, cause1, carry(cause2))

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -791,6 +791,7 @@ impl PubGrubReportFormatter<'_> {
                         Self::index_hints(
                             name,
                             set,
+                            self.included_versions.get(name),
                             selector,
                             index_locations,
                             index_capabilities,
@@ -857,6 +858,7 @@ impl PubGrubReportFormatter<'_> {
                         Self::index_hints(
                             name,
                             set,
+                            self.included_versions.get(name),
                             selector,
                             index_locations,
                             index_capabilities,
@@ -1194,6 +1196,7 @@ impl PubGrubReportFormatter<'_> {
     fn index_hints(
         name: &PackageName,
         set: &Range<Version>,
+        listed: Option<&BTreeSet<Version>>,
         selector: &CandidateSelector,
         index_locations: &IndexLocations,
         index_capabilities: &IndexCapabilities,
@@ -1288,13 +1291,11 @@ impl PubGrubReportFormatter<'_> {
         // Add hints due to the package being available on an index, but not at the correct version,
         // with subsequent indexes that were _not_ queried.
         if matches!(selector.index_strategy(), IndexStrategy::FirstIndex) {
-            // Do not include the hint if the set is "all versions". This is an unusual but valid
-            // case in which a package returns a 200 response, but without any versions or
-            // distributions for the package.
-            if !set
-                .iter()
-                .all(|range| matches!(range, (Bound::Unbounded, Bound::Unbounded)))
-            {
+            // Do not include the hint when the index listed no version at all. This is an
+            // unusual but valid case in which a package returns a 200 response, but without any
+            // versions or distributions for the package.  A package that listed versions and had
+            // none of them work is the case the hint exists for, and its set covers them all.
+            if listed.is_some_and(|listed| !listed.is_empty()) {
                 if let Some(found_index) = available_indexes.get(name).and_then(BTreeSet::first) {
                     // Determine whether the index is the last-available index. If not, then some
                     // indexes were not queried, and could contain a compatible version.

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -760,6 +760,8 @@ impl PubGrubReportFormatter<'_> {
             }
         }
 
+        let requested_ranges = requested_ranges(derivation_tree);
+
         let mut pending = vec![(derivation_tree, inherited_exclude_newer_ranges.clone())];
         while let Some((derivation_tree, inherited_exclude_newer_ranges)) = pending.pop() {
             match derivation_tree {
@@ -774,7 +776,15 @@ impl PubGrubReportFormatter<'_> {
                     if let Some(name) = package.name_no_root() {
                         // Check for no versions due to pre-release options.
                         if !fork_urls.contains_key(name) {
-                            self.prerelease_hint(name, set, selector, env, options, output_hints);
+                            self.prerelease_hint(
+                                name,
+                                set,
+                                requested_ranges.get(name).map(Vec::as_slice),
+                                selector,
+                                env,
+                                options,
+                                output_hints,
+                            );
                         }
 
                         // Check for no versions due to no `--find-links` flat index.
@@ -832,7 +842,15 @@ impl PubGrubReportFormatter<'_> {
                     if let Some(name) = package.name_no_root() {
                         // Check for no versions due to pre-release options.
                         if !fork_urls.contains_key(name) {
-                            self.prerelease_hint(name, set, selector, env, options, output_hints);
+                            self.prerelease_hint(
+                                name,
+                                set,
+                                requested_ranges.get(name).map(Vec::as_slice),
+                                selector,
+                                env,
+                                options,
+                                output_hints,
+                            );
                         }
 
                         // Check for no versions due to no `--find-links` flat index.
@@ -1315,10 +1333,17 @@ impl PubGrubReportFormatter<'_> {
         }
     }
 
+    /// Generate a [`PubGrubHint`] for a package whose pre-releases were not considered.
+    ///
+    /// A pre-release marker is only visible in `requested`, the ranges the package was requested
+    /// with. The bounds of the derived `set` land on whichever versions the registry lists next,
+    /// pre-release or not, since the resolver widens version sets across the gaps between the
+    /// known versions of a package.
     fn prerelease_hint(
         &self,
         name: &PackageName,
         set: &Range<Version>,
+        requested: Option<&[&Range<Version>]>,
         selector: &CandidateSelector,
         env: &ResolverEnvironment,
         options: &Options,
@@ -1328,48 +1353,25 @@ impl PubGrubReportFormatter<'_> {
             return;
         }
 
-        let any_prerelease = set.iter().any(|(start, end)| {
-            // Ignore, e.g., `>=2.4.dev0,<2.5.dev0`, which is the desugared form of `==2.4.*`.
-            if PrefixMatch::from_range(start, end).is_some() {
-                return false;
-            }
+        let prerelease_request = requested
+            .unwrap_or_default()
+            .iter()
+            .copied()
+            .find(|range| requests_prerelease(range));
 
-            let is_pre1 = match start {
-                Bound::Included(version) => version.any_prerelease(),
-                Bound::Excluded(version) => version.any_prerelease(),
-                Bound::Unbounded => false,
-            };
-            if is_pre1 {
-                return true;
-            }
-
-            let is_pre2 = match end {
-                Bound::Included(version) => version.any_prerelease(),
-                Bound::Excluded(version) => {
-                    version.any_prerelease() && !is_compatible_release_upper_bound(version)
-                }
-                Bound::Unbounded => false,
-            };
-            if is_pre2 {
-                return true;
-            }
-
-            false
-        });
-
-        if any_prerelease {
+        if let Some(range) = prerelease_request {
             // A pre-release marker appeared in the version requirements.
             match options.flexibility {
                 Flexibility::Configurable => {
                     hints.insert(PubGrubHint::PrereleaseRequested {
                         name: name.clone(),
-                        range: set.clone(),
+                        range: range.clone(),
                     });
                 }
                 Flexibility::Fixed => {
                     hints.insert(PubGrubHint::BuildPrereleaseRequested {
                         name: name.clone(),
-                        range: set.clone(),
+                        range: range.clone(),
                     });
                 }
             }
@@ -1397,6 +1399,62 @@ impl PubGrubReportFormatter<'_> {
             }
         }
     }
+}
+
+/// Collect the version ranges each package was requested with anywhere in the derivation tree.
+///
+/// The depended-on side of a dependency incompatibility is the range as written in the
+/// requirement, unlike the sets the resolver derives from it.
+fn requested_ranges(derivation_tree: &ErrorTree) -> FxHashMap<&PackageName, Vec<&Range<Version>>> {
+    let mut requested: FxHashMap<&PackageName, Vec<&Range<Version>>> = FxHashMap::default();
+    let mut pending = vec![derivation_tree];
+    while let Some(derivation_tree) = pending.pop() {
+        match derivation_tree {
+            DerivationTree::External(External::FromDependencyOf(_, _, dependency, versions)) => {
+                if let Some(name) = dependency.name_no_root() {
+                    requested.entry(name).or_default().push(versions);
+                }
+            }
+            DerivationTree::External(_) => {}
+            DerivationTree::Derived(derived) => {
+                pending.push(&derived.cause1);
+                pending.push(&derived.cause2);
+            }
+        }
+    }
+    requested
+}
+
+/// Return `true` if a requested range includes a pre-release version explicitly.
+fn requests_prerelease(range: &Range<Version>) -> bool {
+    range.iter().any(|(start, end)| {
+        // Ignore, e.g., `>=2.4.dev0,<2.5.dev0`, which is the desugared form of `==2.4.*`.
+        if PrefixMatch::from_range(start, end).is_some() {
+            return false;
+        }
+
+        let is_pre1 = match start {
+            Bound::Included(version) => version.any_prerelease(),
+            Bound::Excluded(version) => version.any_prerelease(),
+            Bound::Unbounded => false,
+        };
+        if is_pre1 {
+            return true;
+        }
+
+        let is_pre2 = match end {
+            Bound::Included(version) => version.any_prerelease(),
+            Bound::Excluded(version) => {
+                version.any_prerelease() && !is_compatible_release_upper_bound(version)
+            }
+            Bound::Unbounded => false,
+        };
+        if is_pre2 {
+            return true;
+        }
+
+        false
+    })
 }
 
 /// Return `true` for the excluded `.dev0` upper bounds used to desugar compatible releases.
@@ -1939,16 +1997,19 @@ impl std::fmt::Display for PubGrubHint {
                 package_set,
                 package_requires_python,
             } => {
+                let package = PubGrubPackage::base(name.clone());
+                let package_range = PackageRange::compatibility(&package, package_set, None);
+                let supports = if package_range.plural() {
+                    "support"
+                } else {
+                    "supports"
+                };
                 write!(
                     f,
-                    "The `requires-python` value ({}) includes Python versions that are not supported by your dependencies (e.g., {} only supports {}). Consider using a more restrictive `requires-python` value (like {}).",
+                    "The `requires-python` value ({}) includes Python versions that are not supported by your dependencies (e.g., {} only {} {}). Consider using a more restrictive `requires-python` value (like {}).",
                     requires_python.cyan(),
-                    PackageRange::compatibility(
-                        &PubGrubPackage::base(name.clone()),
-                        package_set,
-                        None,
-                    )
-                    .cyan(),
+                    package_range.cyan(),
+                    supports,
                     package_requires_python.cyan(),
                     package_requires_python.cyan(),
                 )
@@ -1960,16 +2021,19 @@ impl std::fmt::Display for PubGrubHint {
                 package_set,
                 package_requires_python,
             } => {
+                let package = PubGrubPackage::base(name.clone());
+                let package_range = PackageRange::compatibility(&package, package_set, None);
+                let supports = if package_range.plural() {
+                    "support"
+                } else {
+                    "supports"
+                };
                 write!(
                     f,
-                    "The `--python-version` value ({}) includes Python versions that are not supported by your dependencies (e.g., {} only supports {}). Consider using a higher `--python-version` value.",
+                    "The `--python-version` value ({}) includes Python versions that are not supported by your dependencies (e.g., {} only {} {}). Consider using a higher `--python-version` value.",
                     requires_python.cyan(),
-                    PackageRange::compatibility(
-                        &PubGrubPackage::base(name.clone()),
-                        package_set,
-                        None,
-                    )
-                    .cyan(),
+                    package_range.cyan(),
+                    supports,
                     package_requires_python.cyan(),
                 )
             }
@@ -1980,15 +2044,18 @@ impl std::fmt::Display for PubGrubHint {
                 package_set,
                 package_requires_python,
             } => {
+                let package = PubGrubPackage::base(name.clone());
+                let package_range = PackageRange::compatibility(&package, package_set, None);
+                let supports = if package_range.plural() {
+                    "support"
+                } else {
+                    "supports"
+                };
                 write!(
                     f,
-                    "The Python interpreter uses a Python version that is not supported by your dependencies (e.g., {} only supports {}). Consider passing a `--python-version` value to raise the minimum supported version.",
-                    PackageRange::compatibility(
-                        &PubGrubPackage::base(name.clone()),
-                        package_set,
-                        None,
-                    )
-                    .cyan(),
+                    "The Python interpreter uses a Python version that is not supported by your dependencies (e.g., {} only {} {}). Consider passing a `--python-version` value to raise the minimum supported version.",
+                    package_range.cyan(),
+                    supports,
                     package_requires_python.cyan(),
                 )
             }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -13,7 +13,7 @@ use either::Either;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use papaya::{HashMap, ResizeMode};
-use pubgrub::{Id, IncompId, Incompatibility, Kind, Ranges, State};
+use pubgrub::{Id, IncompId, Incompatibility, Kind, Ranges, State, Term};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
@@ -592,7 +592,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             continue 'FORK;
                         }
                         ResolverVersion::Unavailable(version, reason) => {
-                            state.add_unavailable_version(version, reason);
+                            state.add_unavailable_version(
+                                version,
+                                reason,
+                                &self.index,
+                                &self.installed_packages,
+                            );
                             continue;
                         }
                     };
@@ -651,11 +656,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     ForkedDependencies::Unavailable(reason) => {
                         // Then here, if we get a reason that we consider unrecoverable, we should
                         // show the derivation chain.
+                        let versions = state.widen_version_to_gap(
+                            &version,
+                            &self.index,
+                            &self.installed_packages,
+                        );
                         state
                             .pubgrub
-                            .add_incompatibility(Incompatibility::custom_version(
+                            .add_incompatibility(Incompatibility::custom_term(
                                 next_id,
-                                version.clone(),
+                                Term::Positive(versions),
                                 UnavailableReason::Version(reason),
                             ));
                     }
@@ -785,11 +795,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             }
                         }
 
+                        let versions = state.widen_version_to_gap(
+                            &version,
+                            &self.index,
+                            &self.installed_packages,
+                        );
                         state
                             .pubgrub
-                            .add_incompatibility(Incompatibility::custom_version(
+                            .add_incompatibility(Incompatibility::custom_term(
                                 next_id,
-                                version.clone(),
+                                Term::Positive(versions),
                                 UnavailableReason::Version(UnavailableVersion::RequiresPython(
                                     requires_python,
                                 )),
@@ -1168,14 +1183,13 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         Ok(())
     }
 
-    /// Returns the sorted, deduplicated candidate universe used to widen dependency ranges.
+    /// Returns the sorted, deduplicated candidate universe used to widen version sets.
     ///
-    /// Every selectable version must be present: omitting one could extend a dependency
-    /// incompatibility across it, while including an unselectable version only prevents a
-    /// possible simplification. The result is therefore conservative, including yanked and
-    /// otherwise unavailable versions from every index plus installed versions missing from the
-    /// indexes. Versions past the exclude-newer cutoff are omitted because resolution treats them
-    /// as nonexistent.
+    /// Every selectable version must be present: omitting one could extend an incompatibility
+    /// across it, while including an unselectable version only prevents a possible simplification.
+    /// The result is therefore conservative, including yanked and otherwise unavailable versions
+    /// from every index plus installed versions missing from the indexes. Versions past the
+    /// exclude-newer cutoff are omitted because resolution treats them as nonexistent.
     ///
     /// Non-blocking: Returns `None` if the version map hasn't been fetched yet, or if the
     /// package is not a registry package.
@@ -3331,24 +3345,7 @@ impl ForkState {
 
         // Widen across gaps so rejected adjacent versions merge into contiguous ranges rather
         // than leaving one hole per version.
-        let versions = Range::singleton(for_version.clone());
-        let versions = if let Some(known_versions) =
-            ResolverState::<InstalledPackages>::known_versions(
-                index,
-                installed_packages,
-                &self.fork_urls,
-                &self.fork_indexes,
-                &mut self.known_versions,
-                &self.pubgrub.package_store[self.next],
-            )
-            .filter(|versions| !versions.is_empty())
-        {
-            versions.widen_versions(known_versions)
-        } else {
-            // A decided version is always selectable and thus in the list, but an empty list
-            // would unsoundly widen to the full range.
-            versions
-        };
+        let versions = self.widen_version_to_gap(for_version, index, installed_packages);
         let conflict = self.pubgrub.add_package_version_dependencies(
             self.next,
             for_version.clone(),
@@ -3369,6 +3366,26 @@ impl ForkState {
         if let Some(incompatibility) = conflict {
             self.record_conflict(for_package, Some(for_version), incompatibility);
         }
+    }
+
+    /// Widens a version of the current package to the gap around it in the known versions.
+    fn widen_version_to_gap<InstalledPackages: InstalledPackagesProvider>(
+        &mut self,
+        version: &Version,
+        index: &InMemoryIndex,
+        installed_packages: &InstalledPackages,
+    ) -> Range<Version> {
+        widen_to_gap(
+            version,
+            ResolverState::<InstalledPackages>::known_versions(
+                index,
+                installed_packages,
+                &self.fork_urls,
+                &self.fork_indexes,
+                &mut self.known_versions,
+                &self.pubgrub.package_store[self.next],
+            ),
+        )
     }
 
     fn record_conflict(
@@ -3429,7 +3446,22 @@ impl ForkState {
         }
     }
 
-    fn add_unavailable_version(&mut self, version: Version, reason: UnavailableVersion) {
+    /// Records that a version cannot be used.
+    ///
+    /// The rejected version is widened to the gap around it, so that a run of rejected versions
+    /// excludes one contiguous range. The gap holds no known version but the rejected one, and
+    /// none at all when that version is itself unknown: `--exclude-newer` drops a version whose
+    /// files carry no upload time from [`ResolverState::known_versions`], but every one of its
+    /// distributions is incompatible, so it cannot be selected either.
+    fn add_unavailable_version<InstalledPackages: InstalledPackagesProvider>(
+        &mut self,
+        version: Version,
+        reason: UnavailableVersion,
+        index: &InMemoryIndex,
+        installed_packages: &InstalledPackages,
+    ) {
+        let versions = self.widen_version_to_gap(&version, index, installed_packages);
+
         // Incompatible requires-python versions are special in that we track
         // them as incompatible dependencies instead of marking the package version
         // as unavailable directly.
@@ -3448,7 +3480,7 @@ impl ForkState {
             self.pubgrub
                 .add_incompatibility(Incompatibility::from_dependency(
                     *package,
-                    Range::singleton(version.clone()),
+                    versions,
                     (
                         python,
                         Range::from_versions(release_specifiers_to_ranges(requires_python)),
@@ -3460,9 +3492,9 @@ impl ForkState {
             return;
         }
         self.pubgrub
-            .add_incompatibility(Incompatibility::custom_version(
+            .add_incompatibility(Incompatibility::custom_term(
                 self.next,
-                version.clone(),
+                Term::Positive(versions),
                 UnavailableReason::Version(reason),
             ));
     }
@@ -3756,6 +3788,24 @@ impl ForkState {
             pins: self.pins,
             env: self.env,
         }
+    }
+}
+
+/// Widens a single version to the largest interval that contains no other known version
+/// ([`Ranges::widen_versions`]).
+///
+/// The interval adds only versions the registry does not list, which can never be selected, so an
+/// incompatibility recorded for it holds for the same selectable versions.
+///
+/// Returns the singleton range when the known versions are unavailable, as for a URL or workspace
+/// package, and for an empty list, which would otherwise widen to the full range.
+fn widen_to_gap(version: &Version, known_versions: Option<&[Version]>) -> Range<Version> {
+    let versions = Range::singleton(version.clone());
+    match known_versions {
+        Some(known_versions) if !known_versions.is_empty() => {
+            versions.widen_versions(known_versions)
+        }
+        _ => versions,
     }
 }
 
@@ -4530,4 +4580,54 @@ struct ConflictTracker {
     ///
     /// Distilled from `culprit` for fast checking in the hot loop.
     deprioritize: Vec<Id<PubGrubPackage>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn versions(versions: &[&str]) -> Vec<Version> {
+        versions
+            .iter()
+            .map(|version| version.parse().expect("valid version"))
+            .collect()
+    }
+
+    #[test]
+    fn widens_a_version_to_its_gap() {
+        let known_versions = versions(&["1.0", "2.0", "3.0"]);
+        let version: Version = "2.0".parse().expect("valid version");
+
+        // A version between two others widens to the open interval between them.
+        assert_eq!(
+            widen_to_gap(&version, Some(&known_versions)).to_string(),
+            ">1.0, <3.0"
+        );
+
+        // At the ends of the listing the interval is unbounded.
+        let version: Version = "1.0".parse().expect("valid version");
+        assert_eq!(
+            widen_to_gap(&version, Some(&known_versions)).to_string(),
+            "<2.0"
+        );
+        let version: Version = "3.0".parse().expect("valid version");
+        assert_eq!(
+            widen_to_gap(&version, Some(&known_versions)).to_string(),
+            ">2.0"
+        );
+    }
+
+    #[test]
+    fn widens_a_version_without_known_versions_to_itself() {
+        let version: Version = "2.0".parse().expect("valid version");
+
+        // A URL or workspace package has no registry version map to widen against.
+        assert_eq!(
+            widen_to_gap(&version, None),
+            Range::singleton(version.clone())
+        );
+
+        // An empty list would otherwise widen to the full range.
+        assert_eq!(widen_to_gap(&version, Some(&[])), Range::singleton(version));
+    }
 }

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -5807,18 +5807,10 @@ fn lock_requires_python() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: python_full_version >= '3.7' and python_full_version < '3.7.9'):
-      ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.7.9 and pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4, we can conclude that pygls>=1.1.0,<=1.2.1 cannot be used.
-          And because only the following versions of pygls are available:
-              pygls<=1.1.0
-              pygls==1.1.1
-              pygls==1.1.2
-              pygls==1.2.0
-              pygls==1.2.1
-              pygls==1.3.0
-          we can conclude that pygls>=1.1.0,<1.3.0 cannot be used. (1)
+      ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.7.9 and pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4, we can conclude that pygls>=1.1.0,<=1.2.1 cannot be used. (1)
 
-          Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls==1.3.0 depends on Python>=3.8, we can conclude that pygls==1.3.0 cannot be used.
-          And because we know from (1) that pygls>=1.1.0,<1.3.0 cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
+          Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls>=1.3.0 depends on Python>=3.8, we can conclude that pygls>=1.3.0 cannot be used.
+          And because we know from (1) that pygls>=1.1.0,<=1.2.1 cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
           And because your project depends on pygls>=1.1.0, we can conclude that your project's requirements are unsatisfiable.
 
     hint: While the active Python version is 3.12, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.
@@ -36664,8 +36656,8 @@ fn lock_required_environment_cycle_reports_resolution_error() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: platform_machine == 'arm64'):
-      ╰─▶ Because a==1.0.0 has no `platform_machine == 'arm64'`-compatible wheels and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because pkg-a depends on a and your workspace requires pkg-a, we can conclude that your workspace's requirements are unsatisfiable.
+      ╰─▶ Because all versions of a have no `platform_machine == 'arm64'`-compatible wheels and pkg-a depends on a, we can conclude that pkg-a's requirements are unsatisfiable.
+          And because your workspace requires pkg-a, we can conclude that your workspace's requirements are unsatisfiable.
     "
     );
 
@@ -36705,25 +36697,8 @@ fn lock_supported_environment_wheel_only_package_requires_compatible_wheels() ->
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: sys_platform == 'linux'):
-      ╰─▶ Because only the following versions of pywin32 are available:
-              pywin32==222
-              pywin32==223
-              pywin32==224
-              pywin32==225
-              pywin32==226
-              pywin32==227
-              pywin32==228
-              pywin32==300
-              pywin32==301
-              pywin32==302
-              pywin32==303
-              pywin32==304
-              pywin32==305
-              pywin32==306
-              pywin32==307
-              pywin32==308
-          and pywin32<=305 has no wheels with a matching Python version tag (e.g., `cp312`), we can conclude that pywin32<=305 cannot be used.
-          And because pywin32>=306 has no Linux-compatible wheels and your project depends on pywin32, we can conclude that your project's requirements are unsatisfiable.
+      ╰─▶ Because pywin32<=305 has no wheels with a matching Python version tag (e.g., `cp312`) and pywin32>=306 has no Linux-compatible wheels, we can conclude that all versions of pywin32 cannot be used.
+          And because your project depends on pywin32, we can conclude that your project's requirements are unsatisfiable.
 
     hint: Wheels are available for `pywin32` (v305) with the following Python ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`, `cp310`, `cp311`
     ");

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -5807,10 +5807,14 @@ fn lock_requires_python() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: python_full_version >= '3.7' and python_full_version < '3.7.9'):
-      ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.7.9 and pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4, we can conclude that pygls>=1.1.0,<=1.2.1 cannot be used. (1)
+      ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.7.9 and pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4, we can conclude that pygls>=1.1.0,<=1.2.1 cannot be used.
+          And because only the following versions of pygls are available:
+              pygls<=1.2.1
+              pygls>=1.3.0
+          we can conclude that pygls>=1.1.0,<1.3.0 cannot be used. (1)
 
           Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls>=1.3.0 depends on Python>=3.8, we can conclude that pygls>=1.3.0 cannot be used.
-          And because we know from (1) that pygls>=1.1.0,<=1.2.1 cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
+          And because we know from (1) that pygls>=1.1.0,<1.3.0 cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
           And because your project depends on pygls>=1.1.0, we can conclude that your project's requirements are unsatisfiable.
 
     hint: While the active Python version is 3.12, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.
@@ -36697,8 +36701,11 @@ fn lock_supported_environment_wheel_only_package_requires_compatible_wheels() ->
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: sys_platform == 'linux'):
-      ╰─▶ Because pywin32<=305 has no wheels with a matching Python version tag (e.g., `cp312`) and pywin32>=306 has no Linux-compatible wheels, we can conclude that all versions of pywin32 cannot be used.
-          And because your project depends on pywin32, we can conclude that your project's requirements are unsatisfiable.
+      ╰─▶ Because pywin32<=305 has no wheels with a matching Python version tag (e.g., `cp312`) and only the following versions of pywin32 are available:
+              pywin32<=305
+              pywin32>=306
+          we can conclude that pywin32<306 cannot be used.
+          And because pywin32>=306 has no Linux-compatible wheels and your project depends on pywin32, we can conclude that your project's requirements are unsatisfiable.
 
     hint: Wheels are available for `pywin32` (v305) with the following Python ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`, `cp310`, `cp311`
     ");

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -5813,7 +5813,8 @@ fn lock_requires_python() -> Result<()> {
               pygls>=1.3.0
           we can conclude that pygls>=1.1.0,<1.3.0 cannot be used. (1)
 
-          Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls>=1.3.0 depends on Python>=3.8, we can conclude that pygls>=1.3.0 cannot be used.
+          Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls==1.3.0 depends on Python>=3.8, we can conclude that pygls==1.3.0 cannot be used.
+          And because only pygls<=1.3.0 is available, we can conclude that pygls>=1.3.0 cannot be used.
           And because we know from (1) that pygls>=1.1.0,<1.3.0 cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
           And because your project depends on pygls>=1.1.0, we can conclude that your project's requirements are unsatisfiable.
 

--- a/crates/uv/tests/pip/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip/pip_compile_scenarios.rs
@@ -366,10 +366,10 @@ fn compatible_python_incompatible_override() -> Result<()> {
     ----- stderr -----
     warning: The requested Python version 3.9 is not available; 3.11.[X] will be used to build dependencies instead.
       × No solution found when resolving dependencies:
-      ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.10 and a==1.0.0 depends on Python>=3.10, we can conclude that a==1.0.0 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.10 and all versions of a depend on Python>=3.10, we can conclude that all versions of a cannot be used.
           And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
 
-    hint: The `--python-version` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., a==1.0.0 only supports >=3.10). Consider using a higher `--python-version` value.
+    hint: The `--python-version` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., all versions of a only support >=3.10). Consider using a higher `--python-version` value.
     "
     );
 
@@ -644,10 +644,10 @@ fn python_patch_override_no_patch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.9.4 and a==1.0.0 depends on Python>=3.9.4, we can conclude that a==1.0.0 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.9.4 and all versions of a depend on Python>=3.9.4, we can conclude that all versions of a cannot be used.
           And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
 
-    hint: The `--python-version` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., a==1.0.0 only supports >=3.9.4). Consider using a higher `--python-version` value.
+    hint: The `--python-version` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., all versions of a only support >=3.9.4). Consider using a higher `--python-version` value.
     "
     );
 

--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -4110,18 +4110,13 @@ fn python_greater_than_current_excluded() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==2.0.0 depends on Python>=3.10, we can conclude that a==2.0.0 cannot be used.
-          And because only the following versions of a are available:
-              a<=2.0.0
-              a==3.0.0
-              a==4.0.0
-          we can conclude that a>=2.0.0,<3.0.0 cannot be used. (1)
+      ╰─▶ Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==2.0.0 depends on Python>=3.10, we can conclude that a==2.0.0 cannot be used. (1)
 
           Because the current Python version (3.9.[X]) does not satisfy Python>=3.11 and a==3.0.0 depends on Python>=3.11, we can conclude that a==3.0.0 cannot be used.
-          And because we know from (1) that a>=2.0.0,<3.0.0 cannot be used, we can conclude that a>=2.0.0,<4.0.0 cannot be used. (2)
+          And because we know from (1) that a==2.0.0 cannot be used, we can conclude that a>=2.0.0,<=3.0.0 cannot be used. (2)
 
-          Because the current Python version (3.9.[X]) does not satisfy Python>=3.12 and a==4.0.0 depends on Python>=3.12, we can conclude that a==4.0.0 cannot be used.
-          And because we know from (2) that a>=2.0.0,<4.0.0 cannot be used, we can conclude that a>=2.0.0 cannot be used.
+          Because the current Python version (3.9.[X]) does not satisfy Python>=3.12 and a>=4.0.0 depends on Python>=3.12, we can conclude that a>=4.0.0 cannot be used.
+          And because we know from (2) that a>=2.0.0,<=3.0.0 cannot be used, we can conclude that a>=2.0.0 cannot be used.
           And because you require a>=2.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
@@ -4205,7 +4200,7 @@ fn python_greater_than_current_patch() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because the current Python version (3.13) does not satisfy Python>=3.13.2 and a==1.0.0 depends on Python>=3.13.2, we can conclude that a==1.0.0 cannot be used.
+      ╰─▶ Because the current Python version (3.13) does not satisfy Python>=3.13.2 and all versions of a depend on Python>=3.13.2, we can conclude that all versions of a cannot be used.
           And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
@@ -4236,7 +4231,7 @@ fn python_greater_than_current() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==1.0.0 depends on Python>=3.10, we can conclude that a==1.0.0 cannot be used.
+      ╰─▶ Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and all versions of a depend on Python>=3.10, we can conclude that all versions of a cannot be used.
           And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
@@ -4299,7 +4294,7 @@ fn python_version_does_not_exist() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because the current Python version (3.12.[X]) does not satisfy Python>=3.30 and a==1.0.0 depends on Python>=3.30, we can conclude that a==1.0.0 cannot be used.
+      ╰─▶ Because the current Python version (3.12.[X]) does not satisfy Python>=3.30 and all versions of a depend on Python>=3.30, we can conclude that all versions of a cannot be used.
           And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
@@ -4555,8 +4550,7 @@ fn no_sdist_no_wheels_with_matching_abi() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only a==1.0.0 is available and a==1.0.0 has no wheels with a matching Python ABI tag (e.g., `cp312`), we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of a have no wheels with a matching Python ABI tag (e.g., `cp312`) and you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: You require CPython 3.12 (`cp312`), but we only found wheels for `a` (v1.0.0) with the following Python ABI tag: `graalpy240_310_native`
     ");
@@ -4588,8 +4582,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only a==1.0.0 is available and a==1.0.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`), we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of a have no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are available for `a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
     ");
@@ -4621,8 +4614,7 @@ fn no_sdist_no_wheels_with_matching_python() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only a==1.0.0 is available and a==1.0.0 has no wheels with a matching Python implementation tag (e.g., `cp312`), we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of a have no wheels with a matching Python implementation tag (e.g., `cp312`) and you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: You require CPython 3.12 (`cp312`), but we only found wheels for `a` (v1.0.0) with the following Python implementation tag: `graalpy310`
     ");
@@ -4655,8 +4647,7 @@ fn no_wheels_no_build() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only a==1.0.0 is available and a==1.0.0 has no usable wheels, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of a have no usable wheels and you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are required for `a` because building from source is disabled for `a` (i.e., with `--no-build-package a`)
     ");
@@ -4747,8 +4738,7 @@ fn only_wheels_no_binary() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only a==1.0.0 is available and a==1.0.0 has no source distribution, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of a have no source distribution and you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: A source distribution is required for `a` because using pre-built wheels is disabled for `a` (i.e., with `--no-binary-package a`)
     ");
@@ -4838,11 +4828,7 @@ fn package_only_yanked_in_range() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only the following versions of a are available:
-              a<=0.1.0
-              a==1.0.0
-          and a==1.0.0 was yanked, we can conclude that a>0.1.0 cannot be used.
-          And because you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because a==1.0.0 was yanked and you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Since there are other versions of `a` available, yanked versions should not be selected without explicit opt-in.
@@ -4872,8 +4858,7 @@ fn package_only_yanked() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only a==1.0.0 is available and a==1.0.0 was yanked, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of a were yanked and you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Yanked versions should not be installed, even if they are the only one available.
@@ -5020,11 +5005,8 @@ fn transitive_package_only_yanked_in_range() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only the following versions of b are available:
-              b<=0.1
-              b==1.0.0
-          and b==1.0.0 was yanked, we can conclude that b>0.1 cannot be used.
-          And because all versions of a depend on b>0.1 and you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because b==1.0.0 was yanked and all versions of a depend on b>0.1, we can conclude that all versions of a cannot be used.
+          And because you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Yanked versions should not be installed, even if they are the only valid version in a range.
@@ -5058,8 +5040,8 @@ fn transitive_package_only_yanked() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only b==1.0.0 is available and b==1.0.0 was yanked, we can conclude that all versions of b cannot be used.
-          And because all versions of a depend on b and you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of b were yanked and all versions of a depend on b, we can conclude that all versions of a cannot be used.
+          And because you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Yanked versions should not be installed, even if they are the only one available.

--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -4110,13 +4110,21 @@ fn python_greater_than_current_excluded() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==2.0.0 depends on Python>=3.10, we can conclude that a==2.0.0 cannot be used. (1)
+      ╰─▶ Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==2.0.0 depends on Python>=3.10, we can conclude that a==2.0.0 cannot be used.
+          And because only the following versions of a are available:
+              a<=2.0.0
+              a>=3.0.0
+          we can conclude that a>=2.0.0,<3.0.0 cannot be used. (1)
 
           Because the current Python version (3.9.[X]) does not satisfy Python>=3.11 and a==3.0.0 depends on Python>=3.11, we can conclude that a==3.0.0 cannot be used.
-          And because we know from (1) that a==2.0.0 cannot be used, we can conclude that a>=2.0.0,<=3.0.0 cannot be used. (2)
+          And because we know from (1) that a>=2.0.0,<3.0.0 cannot be used, we can conclude that a>=2.0.0,<=3.0.0 cannot be used.
+          And because only the following versions of a are available:
+              a<=3.0.0
+              a>=4.0.0
+          we can conclude that a>=2.0.0,<4.0.0 cannot be used. (2)
 
           Because the current Python version (3.9.[X]) does not satisfy Python>=3.12 and a>=4.0.0 depends on Python>=3.12, we can conclude that a>=4.0.0 cannot be used.
-          And because we know from (2) that a>=2.0.0,<=3.0.0 cannot be used, we can conclude that a>=2.0.0 cannot be used.
+          And because we know from (2) that a>=2.0.0,<4.0.0 cannot be used, we can conclude that a>=2.0.0 cannot be used.
           And because you require a>=2.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
@@ -4828,7 +4836,11 @@ fn package_only_yanked_in_range() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because a==1.0.0 was yanked and you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because a==1.0.0 was yanked and only the following versions of a are available:
+              a<=0.1.0
+              a==1.0.0
+          we can conclude that a>0.1.0 cannot be used.
+          And because you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Since there are other versions of `a` available, yanked versions should not be selected without explicit opt-in.
@@ -5005,8 +5017,11 @@ fn transitive_package_only_yanked_in_range() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because b==1.0.0 was yanked and all versions of a depend on b>0.1, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because b==1.0.0 was yanked and only the following versions of b are available:
+              b<=0.1
+              b==1.0.0
+          we can conclude that b>0.1 cannot be used.
+          And because all versions of a depend on b>0.1 and you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Yanked versions should not be installed, even if they are the only valid version in a range.

--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -4123,7 +4123,8 @@ fn python_greater_than_current_excluded() {
               a>=4.0.0
           we can conclude that a>=2.0.0,<4.0.0 cannot be used. (2)
 
-          Because the current Python version (3.9.[X]) does not satisfy Python>=3.12 and a>=4.0.0 depends on Python>=3.12, we can conclude that a>=4.0.0 cannot be used.
+          Because the current Python version (3.9.[X]) does not satisfy Python>=3.12 and a==4.0.0 depends on Python>=3.12, we can conclude that a==4.0.0 cannot be used.
+          And because only a<=4.0.0 is available, we can conclude that a>=4.0.0 cannot be used.
           And because we know from (2) that a>=2.0.0,<4.0.0 cannot be used, we can conclude that a>=2.0.0 cannot be used.
           And because you require a>=2.0.0, we can conclude that your requirements are unsatisfiable.
     ");

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -3978,12 +3978,7 @@ fn compile_yanked_version_indirect() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only the following versions of attrs are available:
-              attrs<=20.3.0
-              attrs==21.1.0
-              attrs>=21.2.0
-          and attrs==21.1.0 was yanked (reason: Installable but not importable on Python 3.4), we can conclude that attrs>20.3.0,<21.2.0 cannot be used.
-          And because you require attrs>20.3.0,<21.2.0, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because attrs==21.1.0 was yanked (reason: Installable but not importable on Python 3.4) and you require attrs>20.3.0,<21.2.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -14155,8 +14150,7 @@ fn no_binary_only_binary() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only source-distribution>=0.0.1 is available and source-distribution==0.0.1 has no usable wheels, we can conclude that source-distribution<=0.0.1 cannot be used.
-          And because you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because source-distribution==0.0.1 has no usable wheels and you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are required for `source-distribution` because building from source is disabled for all packages (i.e., with `--no-build`)
     "
@@ -14729,8 +14723,7 @@ fn universal_required_environment() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: platform_machine == 'arm64'):
-      ╰─▶ Because only a==1.0.0 is available and a==1.0.0 has no `platform_machine == 'arm64'`-compatible wheels, we can conclude that all versions of a cannot be used.
-          And because project depends on a, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of a have no `platform_machine == 'arm64'`-compatible wheels and project depends on a, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -15357,25 +15350,8 @@ fn invalid_platform() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only the following versions of open3d are available:
-              open3d==0.8.0.0
-              open3d==0.9.0.0
-              open3d==0.10.0.0
-              open3d==0.10.0.1
-              open3d==0.11.0
-              open3d==0.11.1
-              open3d==0.11.2
-              open3d==0.12.0
-              open3d==0.13.0
-              open3d==0.14.1
-              open3d==0.15.1
-              open3d==0.15.2
-              open3d==0.16.0
-              open3d==0.16.1
-              open3d==0.17.0
-              open3d==0.18.0
-          and open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`), we can conclude that open3d<=0.15.2 cannot be used.
-          And because open3d>=0.16.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require open3d, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`) and open3d>=0.16.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`), we can conclude that all versions of open3d cannot be used.
+          And because you require open3d, we can conclude that your requirements are unsatisfiable.
 
     hint: You require CPython 3.10 (`cp310`), but we only found wheels for `open3d` (v0.15.2) with the following Python ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`
     hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `win_amd64`

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -3978,7 +3978,12 @@ fn compile_yanked_version_indirect() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because attrs==21.1.0 was yanked (reason: Installable but not importable on Python 3.4) and you require attrs>20.3.0,<21.2.0, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because attrs==21.1.0 was yanked (reason: Installable but not importable on Python 3.4) and only the following versions of attrs are available:
+              attrs<=20.3.0
+              attrs==21.1.0
+              attrs>=21.2.0
+          we can conclude that attrs>20.3.0,<21.2.0 cannot be used.
+          And because you require attrs>20.3.0,<21.2.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -14150,7 +14155,8 @@ fn no_binary_only_binary() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because source-distribution==0.0.1 has no usable wheels and you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because source-distribution==0.0.1 has no usable wheels and only source-distribution>=0.0.1 is available, we can conclude that source-distribution<=0.0.1 cannot be used.
+          And because you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are required for `source-distribution` because building from source is disabled for all packages (i.e., with `--no-build`)
     "
@@ -15350,8 +15356,11 @@ fn invalid_platform() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`) and open3d>=0.16.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`), we can conclude that all versions of open3d cannot be used.
-          And because you require open3d, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`) and only the following versions of open3d are available:
+              open3d<=0.15.2
+              open3d>=0.16.0
+          we can conclude that open3d<0.16.0 cannot be used.
+          And because open3d>=0.16.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require open3d, we can conclude that your requirements are unsatisfiable.
 
     hint: You require CPython 3.10 (`cp310`), but we only found wheels for `open3d` (v0.15.2) with the following Python ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`
     hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `win_amd64`

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -13449,8 +13449,7 @@ async fn add_auth_policy_never_with_url_credentials_ignored() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only anyio==4.3.0 is available and anyio==4.3.0 could not be fetched from the network (`401 Unauthorized`), we can conclude that all versions of anyio cannot be used.
-          And because your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      ╰─▶ Because all versions of anyio could not be fetched from the network (`401 Unauthorized`) and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: Metadata for `anyio` (v4.3.0) could not be fetched; the server returned: `401 Unauthorized`
     hint: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -995,10 +995,11 @@ fn group_requires_python_useful_defaults() -> Result<()> {
     Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
     Creating virtual environment at: .venv
       × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
-      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx>=7.2.6 depends on Python>=3.9, we can conclude that sphinx>=7.2.6 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
+          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
           And because pharaohs-tomp:dev depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:dev, we can conclude that your project's requirements are unsatisfiable.
 
-    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx>=7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
+    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
 
     // Running `uv sync` should always fail, as now sphinx is involved
@@ -1006,10 +1007,11 @@ fn group_requires_python_useful_defaults() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
-      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx>=7.2.6 depends on Python>=3.9, we can conclude that sphinx>=7.2.6 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
+          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
           And because pharaohs-tomp:dev depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:dev, we can conclude that your project's requirements are unsatisfiable.
 
-    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx>=7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
+    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
 
     // Adding group requires python should fix it
@@ -1125,10 +1127,11 @@ fn group_requires_python_useful_non_defaults() -> Result<()> {
     Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
     Creating virtual environment at: .venv
       × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
-      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx>=7.2.6 depends on Python>=3.9, we can conclude that sphinx>=7.2.6 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
+          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
           And because pharaohs-tomp:mygroup depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:mygroup, we can conclude that your project's requirements are unsatisfiable.
 
-    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx>=7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
+    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
 
     // Running `uv sync --group mygroup` should definitely fail, as now sphinx is involved
@@ -1137,10 +1140,11 @@ fn group_requires_python_useful_non_defaults() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
-      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx>=7.2.6 depends on Python>=3.9, we can conclude that sphinx>=7.2.6 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
+          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
           And because pharaohs-tomp:mygroup depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:mygroup, we can conclude that your project's requirements are unsatisfiable.
 
-    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx>=7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
+    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
 
     // Adding group requires python should fix it
@@ -14913,6 +14917,8 @@ async fn sync_non_pep625_sdist() -> Result<()> {
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because all versions of basic-package have a non-PEP 625-compliant source distribution filename and your project depends on basic-package, we can conclude that your project's requirements are unsatisfiable.
+
+    hint: `basic-package` was found on http://[LOCALHOST]/simple, but not at the requested version (all versions of basic-package). A compatible version may be available on a subsequent index (e.g., https://pypi.org/simple). By default, uv will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `--index-strategy unsafe-best-match` to consider all versions from all indexes, regardless of the order in which they were defined.
     ");
 
     Ok(())

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -995,11 +995,10 @@ fn group_requires_python_useful_defaults() -> Result<()> {
     Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
     Creating virtual environment at: .venv
       × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
-      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
-          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx>=7.2.6 depends on Python>=3.9, we can conclude that sphinx>=7.2.6 cannot be used.
           And because pharaohs-tomp:dev depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:dev, we can conclude that your project's requirements are unsatisfiable.
 
-    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
+    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx>=7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
 
     // Running `uv sync` should always fail, as now sphinx is involved
@@ -1007,11 +1006,10 @@ fn group_requires_python_useful_defaults() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
-      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
-          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx>=7.2.6 depends on Python>=3.9, we can conclude that sphinx>=7.2.6 cannot be used.
           And because pharaohs-tomp:dev depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:dev, we can conclude that your project's requirements are unsatisfiable.
 
-    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
+    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx>=7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
 
     // Adding group requires python should fix it
@@ -1127,11 +1125,10 @@ fn group_requires_python_useful_non_defaults() -> Result<()> {
     Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
     Creating virtual environment at: .venv
       × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
-      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
-          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx>=7.2.6 depends on Python>=3.9, we can conclude that sphinx>=7.2.6 cannot be used.
           And because pharaohs-tomp:mygroup depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:mygroup, we can conclude that your project's requirements are unsatisfiable.
 
-    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
+    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx>=7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
 
     // Running `uv sync --group mygroup` should definitely fail, as now sphinx is involved
@@ -1140,11 +1137,10 @@ fn group_requires_python_useful_non_defaults() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
-      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
-          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
+      ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx>=7.2.6 depends on Python>=3.9, we can conclude that sphinx>=7.2.6 cannot be used.
           And because pharaohs-tomp:mygroup depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:mygroup, we can conclude that your project's requirements are unsatisfiable.
 
-    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
+    hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx>=7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
 
     // Adding group requires python should fix it
@@ -14916,13 +14912,7 @@ async fn sync_non_pep625_sdist() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only basic-package==0.1.0 is available and basic-package==0.1.0 has a non-PEP 625-compliant source distribution filename, we can conclude that all versions of basic-package cannot be used.
-          And because your project depends on basic-package, we can conclude that your project's requirements are unsatisfiable.
-
-    hint: `basic-package` was found on http://[LOCALHOST]/simple, but not at the requested version (all of:
-        basic-package<0.1.0
-        basic-package>0.1.0
-    ). A compatible version may be available on a subsequent index (e.g., https://pypi.org/simple). By default, uv will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `--index-strategy unsafe-best-match` to consider all versions from all indexes, regardless of the order in which they were defined.
+      ╰─▶ Because all versions of basic-package have a non-PEP 625-compliant source distribution filename and your project depends on basic-package, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -5780,8 +5780,7 @@ fn tool_install_find_links() {
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving tool dependencies:
-      ╰─▶ Because only basic-app==0.1 is available and basic-app==0.1 needs to be downloaded from a registry, we can conclude that all versions of basic-app cannot be used.
-          And because you require basic-app, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because all versions of basic-app need to be downloaded from a registry and you require basic-app, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     ");


### PR DESCRIPTION
Stacked on #20809, only the last commit is new. It closes the two things #20809's body lists as not fixed, plus a bug in #20809's own rule that the first of them exposes.

A rejected version is recorded as a dependency on Python, so its widened range never reached the clamp #20809 applies to other rejections, and the message named a window instead of the version: `sphinx>=7.2.6 depends on Python>=3.9` where main says `sphinx==7.2.6`. It leaked into the `requires-python` hint too. Clamping that side restores the version and the availability statement closes the step:

```
Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
```

That exposed the second thing. #20809 put the availability statement on whichever cause started lower, which can be a dependency statement rather than an exclusion, and the step it then forms does not follow: "because a==7.2.6 depends on Python>=3.9 and only a<=7.2.6 is available" does not give "a>=7.2.6 cannot be used" without the Python fact. The statement now goes on a cause that rules the package out, or on the step itself when neither cause does.

Third, the `UncheckedIndex` hint was suppressed whenever the set was all versions. After widening that also covers "the index listed versions and none of them worked", which is the case the hint exists for. It now checks whether the index listed anything, and `sync_non_pep625_sdist` gets its hint back.

Naming the version rather than the window matters more than it looks. `sphinx>=7.2.6` reads as a range of real releases, and for something like `a (5.2.1, 5.4)` most readers will take both endpoints as implicated when the claim is about one release.
