### PR TITLE
Avoid update-shell file update race between uv shutdown and file IO

### DIFF
--- a/crates/uv/src/commands/update_shell.rs
+++ b/crates/uv/src/commands/update_shell.rs
@@ -98,14 +98,16 @@ pub(super) async fn update_shell(
                 }
 
                 // Append the command to the file.
-                fs_err::tokio::OpenOptions::new()
+                let mut configuration_file = fs_err::tokio::OpenOptions::new()
                     .create(true)
                     .truncate(true)
                     .write(true)
                     .open(&file)
-                    .await?
+                    .await?;
+                configuration_file
                     .write_all(format!("{contents}\n# uv\n{command}\n").as_bytes())
                     .await?;
+                configuration_file.flush().await?;
 
                 writeln!(
                     printer.stderr(),
@@ -121,14 +123,16 @@ pub(super) async fn update_shell(
                 }
 
                 // Append the command to the file.
-                fs_err::tokio::OpenOptions::new()
+                let mut configuration_file = fs_err::tokio::OpenOptions::new()
                     .create(true)
                     .truncate(true)
                     .write(true)
                     .open(&file)
-                    .await?
+                    .await?;
+                configuration_file
                     .write_all(format!("# uv\n{command}\n").as_bytes())
                     .await?;
+                configuration_file.flush().await?;
 
                 writeln!(
                     printer.stderr(),


### PR DESCRIPTION
## Summary

We drop the file handles we're writing to without flushing them, this isn't normally a big issue, but we also shutdown the tokio runtime eagerly in `main`. This means we end up racing the file writes and can end up not writing the files.

I think in some scenarios this could wipe-out your `.bashrc` etc... It's kind of odd that it only managed to happen in our tests.

Hopefully this addresses astral-sh/uv-dev#460

## Test Plan

This should hopefully fix the flakiness. There's no good way to test against a race here.