### PR TITLE
Preserve conditional direct-source authority in metadata-free locks

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -37,7 +37,7 @@ use crate::error::PythonVersion;
 use crate::hash::http_hash_algorithms;
 use crate::metadata::{ArchiveMetadata, Metadata};
 use crate::source::SourceDistributionBuilder;
-use crate::{Error, LocalWheel, Reporter, RequiresDist};
+use crate::{Error, LocalWheel, Reporter, RequiresDist, SourcedDependencyGroups};
 
 /// A cached high-level interface to convert distributions (a requirement resolved to a location)
 /// to a wheel or wheel metadata.
@@ -661,6 +661,21 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 self.client.unmanaged.credentials_cache(),
             )
             .await
+    }
+
+    /// Return the lowered dependency groups from a source tree's `pyproject.toml`.
+    pub async fn dependency_groups(&self, path: &Path) -> Result<SourcedDependencyGroups, Error> {
+        SourcedDependencyGroups::from_virtual_project(
+            &path.join("pyproject.toml"),
+            None,
+            self.build_context.locations(),
+            self.build_context.sources().clone(),
+            self.build_context.cache(),
+            self.build_context.workspace_cache(),
+            self.client.unmanaged.credentials_cache(),
+        )
+        .await
+        .map_err(Error::from)
     }
 
     /// Stream a wheel from a URL, unzipping it into the cache as it's downloaded.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -37,7 +37,7 @@ use crate::error::PythonVersion;
 use crate::hash::http_hash_algorithms;
 use crate::metadata::{ArchiveMetadata, Metadata};
 use crate::source::SourceDistributionBuilder;
-use crate::{Error, LocalWheel, Reporter, RequiresDist, SourcedDependencyGroups};
+use crate::{Error, LocalWheel, Reporter, RequiresDist};
 
 /// A cached high-level interface to convert distributions (a requirement resolved to a location)
 /// to a wheel or wheel metadata.
@@ -661,21 +661,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 self.client.unmanaged.credentials_cache(),
             )
             .await
-    }
-
-    /// Return the lowered dependency groups from a source tree's `pyproject.toml`.
-    pub async fn dependency_groups(&self, path: &Path) -> Result<SourcedDependencyGroups, Error> {
-        SourcedDependencyGroups::from_virtual_project(
-            &path.join("pyproject.toml"),
-            None,
-            self.build_context.locations(),
-            self.build_context.sources().clone(),
-            self.build_context.cache(),
-            self.build_context.workspace_cache(),
-            self.client.unmanaged.credentials_cache(),
-        )
-        .await
-        .map_err(Error::from)
     }
 
     /// Stream a wheel from a URL, unzipping it into the cache as it's downloaded.

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -44,15 +44,17 @@ use uv_git_types::{GitLfs, GitOid, GitReference, GitUrl, GitUrlParseError};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::{
-    MarkerEnvironment, MarkerTree, Scheme, VerbatimUrl, VerbatimUrlError, split_scheme,
+    MarkerEnvironment, MarkerTree, Scheme, VerbatimUrl, VerbatimUrlError, VersionOrUrl,
+    split_scheme,
 };
 use uv_platform_tags::{
     AbiTag, IncompatibleTag, LanguageTag, PlatformTag, TagCompatibility, TagPriority, Tags,
 };
 use uv_preview::PreviewFeature;
 use uv_pypi_types::{
-    ConflictItem, ConflictKindRef, Conflicts, HashAlgorithm, HashDigest, HashDigests, Hashes,
-    ParsedArchiveUrl, ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml, VerbatimParsedUrl,
+    ConflictItem, ConflictKindRef, Conflicts, DependencyGroupSpecifier, HashAlgorithm, HashDigest,
+    HashDigests, Hashes, ParsedArchiveUrl, ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml,
+    VerbatimParsedUrl,
 };
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_small_str::SmallString;
@@ -2468,13 +2470,73 @@ impl Lock {
         };
         let dependency_sources = if allow_missing_package_metadata {
             let mut source_requirements = normalized_constraints;
+            let mut add_source_requirements =
+                |package: &Package, requirements: Vec<Requirement>| -> Result<(), LockError> {
+                    let package_context = package
+                        .id
+                        .version
+                        .as_ref()
+                        .map(|version| (&package.id.name, version));
+
+                    for requirement in dependency_overrides
+                        .apply_for_package(package_context, &requirements)
+                        .filter(|requirement| {
+                            !dependency_excludes
+                                .contains_for_package(package_context, &requirement.name)
+                        })
+                    {
+                        if matches!(requirement.source, RequirementSource::Registry { .. }) {
+                            continue;
+                        }
+
+                        source_requirements.insert(normalize_requirement(
+                            requirement.into_owned(),
+                            root,
+                            &self.requires_python,
+                        )?);
+                    }
+
+                    Ok(())
+                };
+
             for member in packages.values() {
-                let has_direct_requirements = member
+                let has_direct_production_requirements = member
                     .project()
                     .dependencies
                     .iter()
                     .flatten()
                     .any(|requirement| requirement.contains('@'));
+                let has_direct_optional_requirements = member
+                    .project()
+                    .optional_dependencies
+                    .iter()
+                    .flat_map(|extras| extras.values())
+                    .flatten()
+                    .any(|requirement| requirement.contains('@'));
+                let has_direct_group_requirements = member
+                    .pyproject_toml()
+                    .dependency_groups
+                    .iter()
+                    .flatten()
+                    .flat_map(|(_, requirements)| requirements)
+                    .any(|requirement| {
+                        matches!(
+                            requirement,
+                            DependencyGroupSpecifier::Requirement(requirement)
+                                if requirement.contains('@')
+                        )
+                    });
+                let has_direct_dev_requirements = member
+                    .pyproject_toml()
+                    .tool
+                    .as_ref()
+                    .and_then(|tool| tool.uv.as_ref())
+                    .and_then(|uv| uv.dev_dependencies.as_ref())
+                    .is_some_and(|requirements| {
+                        requirements.iter().any(|requirement| {
+                            matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_)))
+                        })
+                    });
                 let has_direct_sources = member
                     .pyproject_toml()
                     .tool
@@ -2495,14 +2557,23 @@ impl Lock {
                                 )
                             })
                     });
-                if !has_direct_requirements && !has_direct_sources {
+                if !has_direct_production_requirements
+                    && !has_direct_optional_requirements
+                    && !has_direct_group_requirements
+                    && !has_direct_dev_requirements
+                    && !has_direct_sources
+                {
                     continue;
                 }
 
                 let Some(package) = self.find_by_name(&member.project().name).ok().flatten() else {
                     continue;
                 };
-                let direct_requirements = if has_direct_sources {
+                let direct_requirements = if has_direct_sources
+                    || has_direct_optional_requirements
+                    || has_direct_group_requirements
+                    || has_direct_dev_requirements
+                {
                     let path = member.root().join("pyproject.toml");
                     let pyproject_toml =
                         PyProjectToml::from_toml(&member.pyproject_toml().raw, path.user_display())
@@ -2520,7 +2591,17 @@ impl Lock {
                     else {
                         continue;
                     };
-                    metadata.requires_dist.into_vec()
+                    metadata
+                        .requires_dist
+                        .into_vec()
+                        .into_iter()
+                        .chain(
+                            metadata
+                                .dependency_groups
+                                .into_values()
+                                .flat_map(<[Requirement]>::into_vec),
+                        )
+                        .collect()
                 } else {
                     member
                         .project()
@@ -2534,29 +2615,57 @@ impl Lock {
                         .map(Requirement::from)
                         .collect()
                 };
-                let package_context = package
-                    .id
-                    .version
-                    .as_ref()
-                    .map(|version| (&package.id.name, version));
+                add_source_requirements(package, direct_requirements)?;
+            }
 
-                for requirement in dependency_overrides
-                    .apply_for_package(package_context, &direct_requirements)
-                    .filter(|requirement| {
-                        !dependency_excludes
-                            .contains_for_package(package_context, &requirement.name)
-                    })
-                {
-                    if matches!(requirement.source, RequirementSource::Registry { .. }) {
-                        continue;
-                    }
-
-                    source_requirements.insert(normalize_requirement(
-                        requirement.into_owned(),
-                        root,
-                        &self.requires_python,
-                    )?);
+            for package in &self.packages {
+                if packages.contains_key(&package.id.name) {
+                    continue;
                 }
+
+                let Some(source_tree) = package.id.source.as_source_tree() else {
+                    continue;
+                };
+                let package_root = root.join(source_tree);
+                let path = package_root.join("pyproject.toml");
+                let contents = match fs_err::tokio::read_to_string(&path).await {
+                    Ok(contents) => contents,
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                    Err(err) => {
+                        return Err(LockErrorKind::UnreadablePyprojectToml { path, err }.into());
+                    }
+                };
+                if !contents.contains('@') && !contents.contains("sources") {
+                    continue;
+                }
+
+                let pyproject_toml = PyProjectToml::from_toml(&contents, path.user_display())
+                    .map_err(|err| LockErrorKind::InvalidPyprojectToml {
+                        path: path.clone(),
+                        err,
+                    })?;
+                let Some(metadata) = database
+                    .requires_dist(&package_root, &pyproject_toml)
+                    .await
+                    .map_err(|err| LockErrorKind::Resolution {
+                        id: package.id.clone(),
+                        err,
+                    })?
+                else {
+                    continue;
+                };
+                let direct_requirements = metadata
+                    .requires_dist
+                    .into_vec()
+                    .into_iter()
+                    .chain(
+                        metadata
+                            .dependency_groups
+                            .into_values()
+                            .flat_map(<[Requirement]>::into_vec),
+                    )
+                    .collect();
+                add_source_requirements(package, direct_requirements)?;
             }
 
             Constraints::from_requirements(source_requirements.into_iter())

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2605,7 +2605,24 @@ impl Lock {
                     metadata
                 };
 
-                add_source_requirements(package, Box::into_iter(metadata.requires_dist).collect())?;
+                let mut direct_requirements = metadata.requires_dist.into_vec();
+                if contents.contains("dependency-groups") || contents.contains("dev-dependencies") {
+                    let dependency_groups = database
+                        .dependency_groups(&package_root)
+                        .await
+                        .map_err(|err| LockErrorKind::Resolution {
+                            id: package.id.clone(),
+                            err,
+                        })?;
+                    direct_requirements.extend(
+                        dependency_groups
+                            .dependency_groups
+                            .into_values()
+                            .flat_map(<[Requirement]>::into_vec),
+                    );
+                }
+
+                add_source_requirements(package, direct_requirements)?;
             }
 
             for member in packages.values() {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2521,6 +2521,93 @@ impl Lock {
                     Ok(())
                 };
 
+            for package in &self.packages {
+                if let Some(metadata) =
+                    dependency_metadata.get(&package.id.name, package.id.version.as_ref())
+                {
+                    add_source_requirements(
+                        package,
+                        Box::into_iter(metadata.requires_dist)
+                            .map(Requirement::from)
+                            .collect(),
+                    )?;
+                    continue;
+                }
+
+                if !package
+                    .all_dependencies()
+                    .any(|dependency| !matches!(dependency.package_id.source, Source::Registry(..)))
+                {
+                    continue;
+                }
+
+                let Some(source_tree) = package.id.source.as_source_tree() else {
+                    continue;
+                };
+                let package_root = root.join(source_tree);
+                let path = package_root.join("pyproject.toml");
+                let contents = match fs_err::tokio::read_to_string(&path).await {
+                    Ok(contents) => contents,
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                    Err(err) => {
+                        return Err(LockErrorKind::UnreadablePyprojectToml { path, err }.into());
+                    }
+                };
+                if !contents.contains("dynamic") {
+                    continue;
+                }
+
+                let pyproject_toml = PyProjectToml::from_toml(&contents, path.user_display())
+                    .map_err(|err| LockErrorKind::InvalidPyprojectToml {
+                        path: path.clone(),
+                        err,
+                    })?;
+                let has_dynamic_requirements = pyproject_toml
+                    .project
+                    .as_ref()
+                    .and_then(|project| project.dynamic.as_ref())
+                    .is_some_and(|fields| {
+                        fields.iter().any(|field| {
+                            matches!(field.as_str(), "dependencies" | "optional-dependencies")
+                        })
+                    });
+                if !has_dynamic_requirements {
+                    continue;
+                }
+
+                let HashedDist { dist, .. } =
+                    package.to_dist(root, TagPolicy::Preferred(tags), build_options, markers)?;
+                let id = dist.distribution_id();
+                let metadata = if let Some(archive) = index
+                    .distributions()
+                    .get(&id)
+                    .as_deref()
+                    .and_then(|response| {
+                        if let MetadataResponse::Found(archive, ..) = response {
+                            Some(archive)
+                        } else {
+                            None
+                        }
+                    }) {
+                    archive.metadata.clone()
+                } else {
+                    let archive = database
+                        .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
+                        .await
+                        .map_err(|err| LockErrorKind::Resolution {
+                            id: package.id.clone(),
+                            err,
+                        })?;
+                    let metadata = archive.metadata.clone();
+                    index
+                        .distributions()
+                        .done(id, Arc::new(MetadataResponse::Found(archive)));
+                    metadata
+                };
+
+                add_source_requirements(package, Box::into_iter(metadata.requires_dist).collect())?;
+            }
+
             for member in packages.values() {
                 let has_direct_production_requirements = member
                     .project()

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2553,22 +2553,17 @@ impl Lock {
                         return Err(LockErrorKind::UnreadablePyprojectToml { path, err }.into());
                     }
                 };
-                if !contents.contains("dynamic") {
-                    continue;
-                }
-
                 let pyproject_toml = PyProjectToml::from_toml(&contents, path.user_display())
                     .map_err(|err| LockErrorKind::InvalidPyprojectToml {
                         path: path.clone(),
                         err,
                     })?;
-                let has_dynamic_requirements = pyproject_toml
-                    .project
-                    .as_ref()
-                    .and_then(|project| project.dynamic.as_ref())
-                    .is_some_and(|fields| {
-                        fields.iter().any(|field| {
-                            matches!(field.as_str(), "dependencies" | "optional-dependencies")
+                let has_dynamic_requirements =
+                    pyproject_toml.project.as_ref().is_none_or(|project| {
+                        project.dynamic.as_ref().is_some_and(|fields| {
+                            fields.iter().any(|field| {
+                                matches!(field.as_str(), "dependencies" | "optional-dependencies")
+                            })
                         })
                     });
                 if !has_dynamic_requirements {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2544,36 +2544,13 @@ impl Lock {
                 let Some(source_tree) = package.id.source.as_source_tree() else {
                     continue;
                 };
-                let package_root = root.join(source_tree);
-                let path = package_root.join("pyproject.toml");
-                let contents = match fs_err::tokio::read_to_string(&path).await {
-                    Ok(contents) => Some(contents),
-                    Err(err) if err.kind() == io::ErrorKind::NotFound => None,
-                    Err(err) => {
-                        return Err(LockErrorKind::UnreadablePyprojectToml { path, err }.into());
-                    }
-                };
-                if let Some(contents) = contents.as_ref() {
-                    let pyproject_toml = PyProjectToml::from_toml(contents, path.user_display())
-                        .map_err(|err| LockErrorKind::InvalidPyprojectToml {
-                            path: path.clone(),
-                            err,
-                        })?;
-                    let has_dynamic_requirements =
-                        pyproject_toml.project.as_ref().is_none_or(|project| {
-                            project.dynamic.as_ref().is_some_and(|fields| {
-                                fields.iter().any(|field| {
-                                    matches!(
-                                        field.as_str(),
-                                        "dependencies" | "optional-dependencies"
-                                    )
-                                })
-                            })
-                        });
-                    if !has_dynamic_requirements {
-                        continue;
-                    }
+                if Self::source_tree_requires_dist(source_tree, root, package, database)
+                    .await?
+                    .is_some()
+                {
+                    continue;
                 }
+                let package_root = root.join(source_tree);
 
                 let HashedDist { dist, .. } =
                     package.to_dist(root, TagPolicy::Preferred(tags), build_options, markers)?;
@@ -2606,9 +2583,7 @@ impl Lock {
                 };
 
                 let mut direct_requirements = metadata.requires_dist.into_vec();
-                if contents.as_ref().is_some_and(|contents| {
-                    contents.contains("dependency-groups") || contents.contains("dev-dependencies")
-                }) {
+                if !package.resolved_dependency_groups().is_empty() {
                     let dependency_groups = database
                         .dependency_groups(&package_root)
                         .await

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2543,42 +2543,31 @@ impl Lock {
                 let Some(source_tree) = package.id.source.as_source_tree() else {
                     continue;
                 };
-                if let Some(SourceTreeRequiresDist { metadata, .. }) =
-                    Self::source_tree_requires_dist(source_tree, root, package, database).await?
-                {
-                    let direct_requirements = metadata
-                        .requires_dist
-                        .into_vec()
-                        .into_iter()
-                        .chain(
-                            metadata
-                                .dependency_groups
-                                .into_values()
-                                .flat_map(<[Requirement]>::into_vec),
+                let (requires_dist, dependency_groups) =
+                    if let Some(SourceTreeRequiresDist { metadata, .. }) =
+                        Self::source_tree_requires_dist(source_tree, root, package, database)
+                            .await?
+                    {
+                        (metadata.requires_dist, metadata.dependency_groups)
+                    } else {
+                        let metadata = Self::package_metadata(
+                            package,
+                            root,
+                            tags,
+                            markers,
+                            build_options,
+                            hasher,
+                            index,
+                            database,
                         )
-                        .collect();
-                    add_source_requirements(package, direct_requirements)?;
-                    continue;
-                }
-
-                let metadata = Self::package_metadata(
-                    package,
-                    root,
-                    tags,
-                    markers,
-                    build_options,
-                    hasher,
-                    index,
-                    database,
-                )
-                .await?;
-                let direct_requirements = metadata
-                    .requires_dist
+                        .await?;
+                        (metadata.requires_dist, metadata.dependency_groups)
+                    };
+                let direct_requirements = requires_dist
                     .into_vec()
                     .into_iter()
                     .chain(
-                        metadata
-                            .dependency_groups
+                        dependency_groups
                             .into_values()
                             .flat_map(<[Requirement]>::into_vec),
                     )

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2470,6 +2470,28 @@ impl Lock {
         };
         let dependency_sources = if allow_missing_package_metadata {
             let mut source_requirements = normalized_constraints;
+            for requirement in dependency_overrides
+                .apply_for_package(
+                    None,
+                    requirements
+                        .iter()
+                        .chain(dependency_groups.values().flatten()),
+                )
+                .filter(|requirement| {
+                    !dependency_excludes.contains_for_package(None, &requirement.name)
+                })
+            {
+                if matches!(requirement.source, RequirementSource::Registry { .. }) {
+                    continue;
+                }
+
+                source_requirements.insert(normalize_requirement(
+                    requirement.into_owned(),
+                    root,
+                    &self.requires_python,
+                )?);
+            }
+
             let mut add_source_requirements =
                 |package: &Package, requirements: Vec<Requirement>| -> Result<(), LockError> {
                     let package_context = package

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -525,7 +525,14 @@ impl<'a> LockedDependencyBuilder<'a> {
             {
                 // Self-requirements do not create graph edges, but their source and version
                 // constraints must still be satisfied by the locked parent package.
-                if !expected.package_satisfies_requirement(expected.package, requirement)? {
+                let source_marker =
+                    expected.package_satisfies_requirement(expected.package, requirement)?;
+                if source_marker.is_none_or(|source_marker| {
+                    !required_marker
+                        .combined()
+                        .and(source_marker.negate())
+                        .is_false()
+                }) {
                     complete = false;
                 }
                 continue;
@@ -535,11 +542,14 @@ impl<'a> LockedDependencyBuilder<'a> {
 
             let mut covered_marker = MarkerTree::FALSE;
             for dependency in expected.packages_for_name(&requirement.name) {
-                if !expected.package_satisfies_requirement(dependency, requirement)? {
+                let Some(source_marker) =
+                    expected.package_satisfies_requirement(dependency, requirement)?
+                else {
                     continue;
-                }
+                };
 
                 let mut marker = UniversalMarker::from_combined(required_marker);
+                marker.and(UniversalMarker::from_combined(source_marker));
                 if !dependency.fork_markers.is_empty() {
                     let dependency_marker = dependency
                         .fork_markers
@@ -649,7 +659,7 @@ struct ExpectedPackageDependencies<'lock> {
     declarations: BTreeSet<Requirement>,
     provides_extra: &'lock [ExtraName],
     dependency_groups: BTreeMap<GroupName, BTreeSet<Requirement>>,
-    constraints: &'lock Constraints,
+    source_requirements: &'lock Constraints,
     activated_extras: BTreeSet<ExtraName>,
     /// The environment under which this package can be selected.
     package_marker: UniversalMarker,
@@ -664,7 +674,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         declarations: &BTreeSet<Requirement>,
         provides_extra: &'lock [ExtraName],
         dependency_groups: &BTreeMap<GroupName, BTreeSet<Requirement>>,
-        constraints: &'lock Constraints,
+        source_requirements: &'lock Constraints,
         overrides: &Overrides,
         excludes: &Excludes,
         package_requires_python: Option<&VersionSpecifiers>,
@@ -724,7 +734,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             declarations,
             provides_extra,
             dependency_groups,
-            constraints,
+            source_requirements,
             activated_extras,
             package_marker,
             lock_marker,
@@ -748,39 +758,42 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         &self,
         package: &Package,
         requirement: &Requirement,
-    ) -> Result<bool, LockError> {
-        let mut source_matches = package
+    ) -> Result<Option<MarkerTree>, LockError> {
+        let source_matches = package
             .id
             .source
-            .satisfies_requirement_source(&requirement.source, self.workspace_root)?;
+            .satisfies_requirement_source(&requirement.source, self.workspace_root)?
+            || package.id == self.package.id
+                && matches!(
+                    requirement.source,
+                    RequirementSource::Registry { index: None, .. }
+                );
+        let mut source_marker = if source_matches {
+            MarkerTree::TRUE
+        } else {
+            MarkerTree::FALSE
+        };
 
-        // A constraint can select a direct source for an otherwise unqualified registry
-        // requirement. Sources apply globally, even across disjoint marker environments,
-        // but the locked source must still match that constraint exactly.
-        if !source_matches
+        // A direct source can be selected by both constraints and explicit requirements. Preserve
+        // the union of their markers so another requirement can widen a conditional constraint.
+        if source_marker.is_false()
             && matches!(
                 requirement.source,
                 RequirementSource::Registry { index: None, .. }
             )
-            && let Some(constraints) = self.constraints.get(&requirement.name)
+            && let Some(source_requirements) = self.source_requirements.get(&requirement.name)
         {
-            for constraint in constraints {
+            for source_requirement in source_requirements {
                 if package
                     .id
                     .source
-                    .satisfies_requirement_source(&constraint.source, self.workspace_root)?
+                    .satisfies_requirement_source(&source_requirement.source, self.workspace_root)?
                 {
-                    source_matches = true;
-                    break;
+                    source_marker = source_marker.or(source_requirement.marker);
                 }
             }
         }
 
-        source_matches |= package.id == self.package.id
-            && matches!(
-                requirement.source,
-                RequirementSource::Registry { index: None, .. }
-            );
         let version_matches = requirement
             .source
             .version_specifiers()
@@ -788,7 +801,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             // Dynamic local packages intentionally omit their version from the lockfile.
             .is_none_or(|(specifiers, version)| specifiers.contains(version));
 
-        Ok(source_matches && version_matches)
+        Ok((!source_marker.is_false() && version_matches).then_some(source_marker))
     }
 
     /// Include locked-only contexts too, so stale extra and group sections cannot be retained.
@@ -2061,7 +2074,7 @@ impl Lock {
         requires_dist: Box<[Requirement]>,
         provides_extra: &[ExtraName],
         dependency_groups: BTreeMap<GroupName, Box<[Requirement]>>,
-        constraints: &Constraints,
+        source_requirements: &Constraints,
         overrides: &Overrides,
         excludes: &Excludes,
         package_requires_python: Option<&VersionSpecifiers>,
@@ -2178,7 +2191,7 @@ impl Lock {
                 declarations,
                 provides_extra,
                 &expected_groups,
-                constraints,
+                source_requirements,
                 overrides,
                 excludes,
                 package_requires_python,
@@ -2214,7 +2227,7 @@ impl Lock {
         package: &'lock Package,
         activated_extras: &mut FxHashMap<PackageId, BTreeSet<ExtraName>>,
         missing_metadata: bool,
-        expected: &ExpectedPackageDependencies<'_>,
+        expected: &ExpectedPackageDependencies,
     ) -> Result<SatisfiesResult<'lock>, LockError> {
         // Use the same dependency builder as lockfile construction, including extra
         // activation for packages whose metadata does not need to be regenerated.
@@ -2454,11 +2467,6 @@ impl Lock {
             }
         }
 
-        let dependency_constraints = if allow_missing_package_metadata {
-            Constraints::from_requirements(normalized_constraints.into_iter())
-        } else {
-            Constraints::default()
-        };
         let dependency_overrides = if allow_missing_package_metadata {
             Overrides::from_entries(normalized_overrides.into_iter().collect())
                 .map_err(LockErrorKind::InvalidScopedOverride)?
@@ -2546,6 +2554,135 @@ impl Lock {
                 return Ok(SatisfiesResult::MismatchedStaticMetadata(expected, actual));
             }
         }
+
+        let source_requirements = if allow_missing_package_metadata {
+            let mut source_requirements = normalized_constraints.into_iter().collect::<Vec<_>>();
+            let conditional_source_names = source_requirements
+                .iter()
+                .filter(|requirement| {
+                    !matches!(requirement.source, RequirementSource::Registry { .. })
+                        && !requirement.marker.is_true()
+                })
+                .map(|requirement| requirement.name.clone())
+                .collect::<FxHashSet<_>>();
+
+            if !conditional_source_names.is_empty() {
+                let mut registry_markers = FxHashMap::<PackageName, MarkerTree>::default();
+                let mut unconditional_registries = FxHashSet::<PackageName>::default();
+
+                for requirement in requirements
+                    .iter()
+                    .chain(dependency_groups.values().flatten())
+                {
+                    if !conditional_source_names.contains(&requirement.name)
+                        || requirement.marker.top_level_extra().is_some()
+                    {
+                        continue;
+                    }
+
+                    if matches!(
+                        requirement.source,
+                        RequirementSource::Registry { index: None, .. }
+                    ) {
+                        if requirement.marker.is_true() {
+                            unconditional_registries.insert(requirement.name.clone());
+                        } else {
+                            registry_markers
+                                .entry(requirement.name.clone())
+                                .and_modify(|marker| *marker = marker.or(requirement.marker))
+                                .or_insert(requirement.marker);
+                        }
+                    } else if !matches!(requirement.source, RequirementSource::Registry { .. }) {
+                        source_requirements.push(normalize_requirement(
+                            requirement.clone(),
+                            root,
+                            &self.requires_python,
+                        )?);
+                    }
+                }
+
+                for name in packages.keys() {
+                    let Some(package) = self.find_by_name(name).ok().flatten() else {
+                        continue;
+                    };
+                    let Some(source_tree) = package.id.source.as_source_tree() else {
+                        continue;
+                    };
+                    let Some(SourceTreeRequiresDist { metadata, .. }) =
+                        Self::source_tree_requires_dist(source_tree, root, package, database)
+                            .await?
+                    else {
+                        continue;
+                    };
+
+                    let package_context = package
+                        .id
+                        .version
+                        .as_ref()
+                        .map(|version| (&package.id.name, version));
+                    for requirement in dependency_overrides.apply_for_package(
+                        package_context,
+                        metadata
+                            .requires_dist
+                            .iter()
+                            .chain(metadata.dependency_groups.values().flatten()),
+                    ) {
+                        if !conditional_source_names.contains(&requirement.name)
+                            || requirement.marker.top_level_extra().is_some()
+                            || dependency_excludes
+                                .contains_for_package(package_context, &requirement.name)
+                        {
+                            continue;
+                        }
+
+                        if matches!(
+                            requirement.source,
+                            RequirementSource::Registry { index: None, .. }
+                        ) {
+                            if requirement.marker.is_true() {
+                                unconditional_registries.insert(requirement.name.clone());
+                            } else {
+                                registry_markers
+                                    .entry(requirement.name.clone())
+                                    .and_modify(|marker| *marker = marker.or(requirement.marker))
+                                    .or_insert(requirement.marker);
+                            }
+                        } else if !matches!(requirement.source, RequirementSource::Registry { .. })
+                        {
+                            source_requirements.push(normalize_requirement(
+                                requirement.into_owned(),
+                                root,
+                                &self.requires_python,
+                            )?);
+                        }
+                    }
+                }
+
+                // Conditional direct sources can be selected globally across disjoint,
+                // marker-scoped requirements. An unconditional registry declaration, however,
+                // must retain its uncovered environments and cannot inherit that source.
+                let widened_sources = source_requirements
+                    .iter()
+                    .filter_map(|requirement| {
+                        if !conditional_source_names.contains(&requirement.name)
+                            || unconditional_registries.contains(&requirement.name)
+                            || matches!(requirement.source, RequirementSource::Registry { .. })
+                        {
+                            return None;
+                        }
+
+                        let mut widened = requirement.clone();
+                        widened.marker = *registry_markers.get(&requirement.name)?;
+                        Some(widened)
+                    })
+                    .collect::<Vec<_>>();
+                source_requirements.extend(widened_sources);
+            }
+
+            Constraints::from_requirements(source_requirements.into_iter())
+        } else {
+            Constraints::default()
+        };
 
         // Collect the set of available indexes (both `--index-url` and `--find-links` entries).
         let mut remotes = indexes.map(|locations| {
@@ -2752,7 +2889,7 @@ impl Lock {
                             metadata.requires_dist,
                             &metadata.provides_extra,
                             metadata.dependency_groups,
-                            &dependency_constraints,
+                            &source_requirements,
                             &dependency_overrides,
                             &dependency_excludes,
                             requires_python.as_ref(),
@@ -2851,7 +2988,7 @@ impl Lock {
                         metadata.requires_dist,
                         &metadata.provides_extra,
                         metadata.dependency_groups,
-                        &dependency_constraints,
+                        &source_requirements,
                         &dependency_overrides,
                         &dependency_excludes,
                         metadata.requires_python.as_ref(),
@@ -2907,7 +3044,7 @@ impl Lock {
                         metadata.requires_dist,
                         &metadata.provides_extra,
                         metadata.dependency_groups,
-                        &dependency_constraints,
+                        &source_requirements,
                         &dependency_overrides,
                         &dependency_excludes,
                         requires_python.as_ref(),
@@ -3005,7 +3142,7 @@ impl Lock {
                         metadata.requires_dist,
                         &metadata.provides_extra,
                         metadata.dependency_groups,
-                        &dependency_constraints,
+                        &source_requirements,
                         &dependency_overrides,
                         &dependency_excludes,
                         metadata.requires_python.as_ref(),

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2547,27 +2547,32 @@ impl Lock {
                 let package_root = root.join(source_tree);
                 let path = package_root.join("pyproject.toml");
                 let contents = match fs_err::tokio::read_to_string(&path).await {
-                    Ok(contents) => contents,
-                    Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                    Ok(contents) => Some(contents),
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => None,
                     Err(err) => {
                         return Err(LockErrorKind::UnreadablePyprojectToml { path, err }.into());
                     }
                 };
-                let pyproject_toml = PyProjectToml::from_toml(&contents, path.user_display())
-                    .map_err(|err| LockErrorKind::InvalidPyprojectToml {
-                        path: path.clone(),
-                        err,
-                    })?;
-                let has_dynamic_requirements =
-                    pyproject_toml.project.as_ref().is_none_or(|project| {
-                        project.dynamic.as_ref().is_some_and(|fields| {
-                            fields.iter().any(|field| {
-                                matches!(field.as_str(), "dependencies" | "optional-dependencies")
+                if let Some(contents) = contents.as_ref() {
+                    let pyproject_toml = PyProjectToml::from_toml(contents, path.user_display())
+                        .map_err(|err| LockErrorKind::InvalidPyprojectToml {
+                            path: path.clone(),
+                            err,
+                        })?;
+                    let has_dynamic_requirements =
+                        pyproject_toml.project.as_ref().is_none_or(|project| {
+                            project.dynamic.as_ref().is_some_and(|fields| {
+                                fields.iter().any(|field| {
+                                    matches!(
+                                        field.as_str(),
+                                        "dependencies" | "optional-dependencies"
+                                    )
+                                })
                             })
-                        })
-                    });
-                if !has_dynamic_requirements {
-                    continue;
+                        });
+                    if !has_dynamic_requirements {
+                        continue;
+                    }
                 }
 
                 let HashedDist { dist, .. } =
@@ -2601,7 +2606,9 @@ impl Lock {
                 };
 
                 let mut direct_requirements = metadata.requires_dist.into_vec();
-                if contents.contains("dependency-groups") || contents.contains("dev-dependencies") {
+                if contents.as_ref().is_some_and(|contents| {
+                    contents.contains("dependency-groups") || contents.contains("dev-dependencies")
+                }) {
                     let dependency_groups = database
                         .dependency_groups(&package_root)
                         .await

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -24,7 +24,9 @@ use uv_configuration::{
     ExtrasSpecificationWithDefaults, InstallTarget, Override, Overrides, PackageOverride,
     ScopedOverrideSourceError,
 };
-use uv_distribution::{DistributionDatabase, FlatRequiresDist, RequiresDist};
+use uv_distribution::{
+    DistributionDatabase, FlatRequiresDist, Metadata as DistributionMetadata, RequiresDist,
+};
 use uv_distribution_filename::{
     BuildTag, DistExtension, ExtensionError, SourceDistExtension, WheelFilename,
 };
@@ -44,23 +46,20 @@ use uv_git_types::{GitLfs, GitOid, GitReference, GitUrl, GitUrlParseError};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::{
-    MarkerEnvironment, MarkerTree, Scheme, VerbatimUrl, VerbatimUrlError, VersionOrUrl,
-    split_scheme,
+    MarkerEnvironment, MarkerTree, Scheme, VerbatimUrl, VerbatimUrlError, split_scheme,
 };
 use uv_platform_tags::{
     AbiTag, IncompatibleTag, LanguageTag, PlatformTag, TagCompatibility, TagPriority, Tags,
 };
 use uv_preview::PreviewFeature;
 use uv_pypi_types::{
-    ConflictItem, ConflictKindRef, Conflicts, DependencyGroupSpecifier, HashAlgorithm, HashDigest,
-    HashDigests, Hashes, ParsedArchiveUrl, ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml,
-    VerbatimParsedUrl,
+    ConflictItem, ConflictKindRef, Conflicts, HashAlgorithm, HashDigest, HashDigests, Hashes,
+    ParsedArchiveUrl, ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml,
 };
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_small_str::SmallString;
 use uv_types::{BuildContext, HashStrategy};
 use uv_warnings::warn_user_once;
-use uv_workspace::pyproject::{Source as WorkspaceSource, Sources as WorkspaceSources};
 use uv_workspace::{Editability, WorkspaceMember};
 
 use crate::fork_strategy::ForkStrategy;
@@ -2544,157 +2543,10 @@ impl Lock {
                 let Some(source_tree) = package.id.source.as_source_tree() else {
                     continue;
                 };
-                if Self::source_tree_requires_dist(source_tree, root, package, database)
-                    .await?
-                    .is_some()
+                if let Some(SourceTreeRequiresDist { metadata, .. }) =
+                    Self::source_tree_requires_dist(source_tree, root, package, database).await?
                 {
-                    continue;
-                }
-                let package_root = root.join(source_tree);
-
-                let HashedDist { dist, .. } =
-                    package.to_dist(root, TagPolicy::Preferred(tags), build_options, markers)?;
-                let id = dist.distribution_id();
-                let metadata = if let Some(archive) = index
-                    .distributions()
-                    .get(&id)
-                    .as_deref()
-                    .and_then(|response| {
-                        if let MetadataResponse::Found(archive, ..) = response {
-                            Some(archive)
-                        } else {
-                            None
-                        }
-                    }) {
-                    archive.metadata.clone()
-                } else {
-                    let archive = database
-                        .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
-                        .await
-                        .map_err(|err| LockErrorKind::Resolution {
-                            id: package.id.clone(),
-                            err,
-                        })?;
-                    let metadata = archive.metadata.clone();
-                    index
-                        .distributions()
-                        .done(id, Arc::new(MetadataResponse::Found(archive)));
-                    metadata
-                };
-
-                let mut direct_requirements = metadata.requires_dist.into_vec();
-                if !package.resolved_dependency_groups().is_empty() {
-                    let dependency_groups = database
-                        .dependency_groups(&package_root)
-                        .await
-                        .map_err(|err| LockErrorKind::Resolution {
-                            id: package.id.clone(),
-                            err,
-                        })?;
-                    direct_requirements.extend(
-                        dependency_groups
-                            .dependency_groups
-                            .into_values()
-                            .flat_map(<[Requirement]>::into_vec),
-                    );
-                }
-
-                add_source_requirements(package, direct_requirements)?;
-            }
-
-            for member in packages.values() {
-                let has_direct_production_requirements = member
-                    .project()
-                    .dependencies
-                    .iter()
-                    .flatten()
-                    .any(|requirement| requirement.contains('@'));
-                let has_direct_optional_requirements = member
-                    .project()
-                    .optional_dependencies
-                    .iter()
-                    .flat_map(|extras| extras.values())
-                    .flatten()
-                    .any(|requirement| requirement.contains('@'));
-                let has_direct_group_requirements = member
-                    .pyproject_toml()
-                    .dependency_groups
-                    .iter()
-                    .flatten()
-                    .flat_map(|(_, requirements)| requirements)
-                    .any(|requirement| {
-                        matches!(
-                            requirement,
-                            DependencyGroupSpecifier::Requirement(requirement)
-                                if requirement.contains('@')
-                        )
-                    });
-                let has_direct_dev_requirements = member
-                    .pyproject_toml()
-                    .tool
-                    .as_ref()
-                    .and_then(|tool| tool.uv.as_ref())
-                    .and_then(|uv| uv.dev_dependencies.as_ref())
-                    .is_some_and(|requirements| {
-                        requirements.iter().any(|requirement| {
-                            matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_)))
-                        })
-                    });
-                let has_direct_sources = member
-                    .pyproject_toml()
-                    .tool
-                    .as_ref()
-                    .and_then(|tool| tool.uv.as_ref())
-                    .and_then(|uv| uv.sources.as_ref())
-                    .is_some_and(|sources| {
-                        sources
-                            .inner()
-                            .values()
-                            .flat_map(WorkspaceSources::iter)
-                            .any(|source| {
-                                matches!(
-                                    source,
-                                    WorkspaceSource::Git { .. }
-                                        | WorkspaceSource::Url { .. }
-                                        | WorkspaceSource::Path { .. }
-                                )
-                            })
-                    });
-                if !has_direct_production_requirements
-                    && !has_direct_optional_requirements
-                    && !has_direct_group_requirements
-                    && !has_direct_dev_requirements
-                    && !has_direct_sources
-                {
-                    continue;
-                }
-
-                let Some(package) = self.find_by_name(&member.project().name).ok().flatten() else {
-                    continue;
-                };
-                let direct_requirements = if has_direct_sources
-                    || has_direct_optional_requirements
-                    || has_direct_group_requirements
-                    || has_direct_dev_requirements
-                {
-                    let path = member.root().join("pyproject.toml");
-                    let pyproject_toml =
-                        PyProjectToml::from_toml(&member.pyproject_toml().raw, path.user_display())
-                            .map_err(|err| LockErrorKind::InvalidPyprojectToml {
-                                path: path.clone(),
-                                err,
-                            })?;
-                    let Some(metadata) = database
-                        .requires_dist(member.root(), &pyproject_toml)
-                        .await
-                        .map_err(|err| LockErrorKind::Resolution {
-                            id: package.id.clone(),
-                            err,
-                        })?
-                    else {
-                        continue;
-                    };
-                    metadata
+                    let direct_requirements = metadata
                         .requires_dist
                         .into_vec()
                         .into_iter()
@@ -2704,59 +2556,22 @@ impl Lock {
                                 .into_values()
                                 .flat_map(<[Requirement]>::into_vec),
                         )
-                        .collect()
-                } else {
-                    member
-                        .project()
-                        .dependencies
-                        .iter()
-                        .flatten()
-                        .filter(|requirement| requirement.contains('@'))
-                        .filter_map(|requirement| {
-                            uv_pep508::Requirement::<VerbatimParsedUrl>::from_str(requirement).ok()
-                        })
-                        .map(Requirement::from)
-                        .collect()
-                };
-                add_source_requirements(package, direct_requirements)?;
-            }
-
-            for package in &self.packages {
-                if packages.contains_key(&package.id.name) {
+                        .collect();
+                    add_source_requirements(package, direct_requirements)?;
                     continue;
                 }
 
-                let Some(source_tree) = package.id.source.as_source_tree() else {
-                    continue;
-                };
-                let package_root = root.join(source_tree);
-                let path = package_root.join("pyproject.toml");
-                let contents = match fs_err::tokio::read_to_string(&path).await {
-                    Ok(contents) => contents,
-                    Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
-                    Err(err) => {
-                        return Err(LockErrorKind::UnreadablePyprojectToml { path, err }.into());
-                    }
-                };
-                if !contents.contains('@') && !contents.contains("sources") {
-                    continue;
-                }
-
-                let pyproject_toml = PyProjectToml::from_toml(&contents, path.user_display())
-                    .map_err(|err| LockErrorKind::InvalidPyprojectToml {
-                        path: path.clone(),
-                        err,
-                    })?;
-                let Some(metadata) = database
-                    .requires_dist(&package_root, &pyproject_toml)
-                    .await
-                    .map_err(|err| LockErrorKind::Resolution {
-                        id: package.id.clone(),
-                        err,
-                    })?
-                else {
-                    continue;
-                };
+                let metadata = Self::package_metadata(
+                    package,
+                    root,
+                    tags,
+                    markers,
+                    build_options,
+                    hasher,
+                    index,
+                    database,
+                )
+                .await?;
                 let direct_requirements = metadata
                     .requires_dist
                     .into_vec()
@@ -3081,50 +2896,17 @@ impl Lock {
                 if !statically_satisfied {
                     // For a non-dynamic package without usable static metadata, fetch the metadata
                     // from the distribution database.
-                    let HashedDist { dist, .. } = package.to_dist(
+                    let metadata = Self::package_metadata(
+                        package,
                         root,
-                        TagPolicy::Preferred(tags),
-                        build_options,
+                        tags,
                         markers,
-                    )?;
-
-                    let metadata = {
-                        let id = dist.distribution_id();
-                        if let Some(archive) =
-                            index
-                                .distributions()
-                                .get(&id)
-                                .as_deref()
-                                .and_then(|response| {
-                                    if let MetadataResponse::Found(archive, ..) = response {
-                                        Some(archive)
-                                    } else {
-                                        None
-                                    }
-                                })
-                        {
-                            // If the metadata is already in the index, return it.
-                            archive.metadata.clone()
-                        } else {
-                            // Run the PEP 517 build process to extract metadata from the source distribution.
-                            let archive = database
-                                .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
-                                .await
-                                .map_err(|err| LockErrorKind::Resolution {
-                                    id: package.id.clone(),
-                                    err,
-                                })?;
-
-                            let metadata = archive.metadata.clone();
-
-                            // Insert the metadata into the index.
-                            index
-                                .distributions()
-                                .done(id, Arc::new(MetadataResponse::Found(archive)));
-
-                            metadata
-                        }
-                    };
+                        build_options,
+                        hasher,
+                        index,
+                        database,
+                    )
+                    .await?;
 
                     // If this is a local package, validate that it hasn't become dynamic (in which
                     // case, we'd expect the version to be omitted).
@@ -3245,50 +3027,17 @@ impl Lock {
                 // exactly. For example, `hatchling` will flatten any recursive (or self-referential)
                 // extras, while `setuptools` will not.
                 if !satisfied {
-                    let HashedDist { dist, .. } = package.to_dist(
+                    let metadata = Self::package_metadata(
+                        package,
                         root,
-                        TagPolicy::Preferred(tags),
-                        build_options,
+                        tags,
                         markers,
-                    )?;
-
-                    let metadata = {
-                        let id = dist.distribution_id();
-                        if let Some(archive) =
-                            index
-                                .distributions()
-                                .get(&id)
-                                .as_deref()
-                                .and_then(|response| {
-                                    if let MetadataResponse::Found(archive, ..) = response {
-                                        Some(archive)
-                                    } else {
-                                        None
-                                    }
-                                })
-                        {
-                            // If the metadata is already in the index, return it.
-                            archive.metadata.clone()
-                        } else {
-                            // Run the PEP 517 build process to extract metadata from the source distribution.
-                            let archive = database
-                                .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
-                                .await
-                                .map_err(|err| LockErrorKind::Resolution {
-                                    id: package.id.clone(),
-                                    err,
-                                })?;
-
-                            let metadata = archive.metadata.clone();
-
-                            // Insert the metadata into the index.
-                            index
-                                .distributions()
-                                .done(id, Arc::new(MetadataResponse::Found(archive)));
-
-                            metadata
-                        }
-                    };
+                        build_options,
+                        hasher,
+                        index,
+                        database,
+                    )
+                    .await?;
 
                     // Validate that the package is still dynamic.
                     if !metadata.dynamic {
@@ -3351,6 +3100,49 @@ impl Lock {
         }
 
         Ok(SatisfiesResult::Satisfied)
+    }
+
+    /// Read the current metadata for a locked package, reusing the resolver's in-memory cache.
+    async fn package_metadata<Context: BuildContext>(
+        package: &Package,
+        root: &Path,
+        tags: &Tags,
+        markers: &MarkerEnvironment,
+        build_options: &BuildOptions,
+        hasher: &HashStrategy,
+        index: &InMemoryIndex,
+        database: &DistributionDatabase<'_, Context>,
+    ) -> Result<DistributionMetadata, LockError> {
+        let HashedDist { dist, .. } =
+            package.to_dist(root, TagPolicy::Preferred(tags), build_options, markers)?;
+        let id = dist.distribution_id();
+        if let Some(archive) = index
+            .distributions()
+            .get(&id)
+            .as_deref()
+            .and_then(|response| {
+                if let MetadataResponse::Found(archive, ..) = response {
+                    Some(archive)
+                } else {
+                    None
+                }
+            })
+        {
+            return Ok(archive.metadata.clone());
+        }
+
+        let archive = database
+            .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
+            .await
+            .map_err(|err| LockErrorKind::Resolution {
+                id: package.id.clone(),
+                err,
+            })?;
+        let metadata = archive.metadata.clone();
+        index
+            .distributions()
+            .done(id, Arc::new(MetadataResponse::Found(archive)));
+        Ok(metadata)
     }
 
     async fn source_tree_requires_dist<Context: BuildContext>(

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -52,12 +52,13 @@ use uv_platform_tags::{
 use uv_preview::PreviewFeature;
 use uv_pypi_types::{
     ConflictItem, ConflictKindRef, Conflicts, HashAlgorithm, HashDigest, HashDigests, Hashes,
-    ParsedArchiveUrl, ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml,
+    ParsedArchiveUrl, ParsedGitDirectoryUrl, ParsedGitPathUrl, PyProjectToml, VerbatimParsedUrl,
 };
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_small_str::SmallString;
 use uv_types::{BuildContext, HashStrategy};
 use uv_warnings::warn_user_once;
+use uv_workspace::pyproject::{Source as WorkspaceSource, Sources as WorkspaceSources};
 use uv_workspace::{Editability, WorkspaceMember};
 
 use crate::fork_strategy::ForkStrategy;
@@ -649,7 +650,7 @@ struct ExpectedPackageDependencies<'lock> {
     declarations: BTreeSet<Requirement>,
     provides_extra: &'lock [ExtraName],
     dependency_groups: BTreeMap<GroupName, BTreeSet<Requirement>>,
-    constraints: &'lock Constraints,
+    source_requirements: &'lock Constraints,
     activated_extras: BTreeSet<ExtraName>,
     /// The environment under which this package can be selected.
     package_marker: UniversalMarker,
@@ -664,7 +665,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
         declarations: &BTreeSet<Requirement>,
         provides_extra: &'lock [ExtraName],
         dependency_groups: &BTreeMap<GroupName, BTreeSet<Requirement>>,
-        constraints: &'lock Constraints,
+        source_requirements: &'lock Constraints,
         overrides: &Overrides,
         excludes: &Excludes,
         package_requires_python: Option<&VersionSpecifiers>,
@@ -724,7 +725,7 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             declarations,
             provides_extra,
             dependency_groups,
-            constraints,
+            source_requirements,
             activated_extras,
             package_marker,
             lock_marker,
@@ -754,21 +755,21 @@ impl<'lock> ExpectedPackageDependencies<'lock> {
             .source
             .satisfies_requirement_source(&requirement.source, self.workspace_root)?;
 
-        // A constraint can select a direct source for an otherwise unqualified registry
-        // requirement. Sources apply globally, even across disjoint marker environments,
-        // but the locked source must still match that constraint exactly.
+        // A constraint or another first-party requirement can select a direct source for an
+        // otherwise unqualified registry requirement. Source selections apply globally, even
+        // across disjoint marker environments, but the locked source must match exactly.
         if !source_matches
             && matches!(
                 requirement.source,
                 RequirementSource::Registry { index: None, .. }
             )
-            && let Some(constraints) = self.constraints.get(&requirement.name)
+            && let Some(source_requirements) = self.source_requirements.get(&requirement.name)
         {
-            for constraint in constraints {
+            for source_requirement in source_requirements {
                 if package
                     .id
                     .source
-                    .satisfies_requirement_source(&constraint.source, self.workspace_root)?
+                    .satisfies_requirement_source(&source_requirement.source, self.workspace_root)?
                 {
                     source_matches = true;
                     break;
@@ -2061,7 +2062,7 @@ impl Lock {
         requires_dist: Box<[Requirement]>,
         provides_extra: &[ExtraName],
         dependency_groups: BTreeMap<GroupName, Box<[Requirement]>>,
-        constraints: &Constraints,
+        source_requirements: &Constraints,
         overrides: &Overrides,
         excludes: &Excludes,
         package_requires_python: Option<&VersionSpecifiers>,
@@ -2178,7 +2179,7 @@ impl Lock {
                 declarations,
                 provides_extra,
                 &expected_groups,
-                constraints,
+                source_requirements,
                 overrides,
                 excludes,
                 package_requires_python,
@@ -2454,11 +2455,6 @@ impl Lock {
             }
         }
 
-        let dependency_constraints = if allow_missing_package_metadata {
-            Constraints::from_requirements(normalized_constraints.into_iter())
-        } else {
-            Constraints::default()
-        };
         let dependency_overrides = if allow_missing_package_metadata {
             Overrides::from_entries(normalized_overrides.into_iter().collect())
                 .map_err(LockErrorKind::InvalidScopedOverride)?
@@ -2469,6 +2465,103 @@ impl Lock {
             Excludes::from_entries(excludes.iter().cloned())
         } else {
             Excludes::default()
+        };
+        let dependency_sources = if allow_missing_package_metadata {
+            let mut source_requirements = normalized_constraints;
+            for member in packages.values() {
+                let has_direct_requirements = member
+                    .project()
+                    .dependencies
+                    .iter()
+                    .flatten()
+                    .any(|requirement| requirement.contains('@'));
+                let has_direct_sources = member
+                    .pyproject_toml()
+                    .tool
+                    .as_ref()
+                    .and_then(|tool| tool.uv.as_ref())
+                    .and_then(|uv| uv.sources.as_ref())
+                    .is_some_and(|sources| {
+                        sources
+                            .inner()
+                            .values()
+                            .flat_map(WorkspaceSources::iter)
+                            .any(|source| {
+                                matches!(
+                                    source,
+                                    WorkspaceSource::Git { .. }
+                                        | WorkspaceSource::Url { .. }
+                                        | WorkspaceSource::Path { .. }
+                                )
+                            })
+                    });
+                if !has_direct_requirements && !has_direct_sources {
+                    continue;
+                }
+
+                let Some(package) = self.find_by_name(&member.project().name).ok().flatten() else {
+                    continue;
+                };
+                let direct_requirements = if has_direct_sources {
+                    let path = member.root().join("pyproject.toml");
+                    let pyproject_toml =
+                        PyProjectToml::from_toml(&member.pyproject_toml().raw, path.user_display())
+                            .map_err(|err| LockErrorKind::InvalidPyprojectToml {
+                                path: path.clone(),
+                                err,
+                            })?;
+                    let Some(metadata) = database
+                        .requires_dist(member.root(), &pyproject_toml)
+                        .await
+                        .map_err(|err| LockErrorKind::Resolution {
+                            id: package.id.clone(),
+                            err,
+                        })?
+                    else {
+                        continue;
+                    };
+                    metadata.requires_dist.into_vec()
+                } else {
+                    member
+                        .project()
+                        .dependencies
+                        .iter()
+                        .flatten()
+                        .filter(|requirement| requirement.contains('@'))
+                        .filter_map(|requirement| {
+                            uv_pep508::Requirement::<VerbatimParsedUrl>::from_str(requirement).ok()
+                        })
+                        .map(Requirement::from)
+                        .collect()
+                };
+                let package_context = package
+                    .id
+                    .version
+                    .as_ref()
+                    .map(|version| (&package.id.name, version));
+
+                for requirement in dependency_overrides
+                    .apply_for_package(package_context, &direct_requirements)
+                    .filter(|requirement| {
+                        !dependency_excludes
+                            .contains_for_package(package_context, &requirement.name)
+                    })
+                {
+                    if matches!(requirement.source, RequirementSource::Registry { .. }) {
+                        continue;
+                    }
+
+                    source_requirements.insert(normalize_requirement(
+                        requirement.into_owned(),
+                        root,
+                        &self.requires_python,
+                    )?);
+                }
+            }
+
+            Constraints::from_requirements(source_requirements.into_iter())
+        } else {
+            Constraints::default()
         };
 
         // Validate that the lockfile was generated with the same build constraints.
@@ -2752,7 +2845,7 @@ impl Lock {
                             metadata.requires_dist,
                             &metadata.provides_extra,
                             metadata.dependency_groups,
-                            &dependency_constraints,
+                            &dependency_sources,
                             &dependency_overrides,
                             &dependency_excludes,
                             requires_python.as_ref(),
@@ -2851,7 +2944,7 @@ impl Lock {
                         metadata.requires_dist,
                         &metadata.provides_extra,
                         metadata.dependency_groups,
-                        &dependency_constraints,
+                        &dependency_sources,
                         &dependency_overrides,
                         &dependency_excludes,
                         metadata.requires_python.as_ref(),
@@ -2907,7 +3000,7 @@ impl Lock {
                         metadata.requires_dist,
                         &metadata.provides_extra,
                         metadata.dependency_groups,
-                        &dependency_constraints,
+                        &dependency_sources,
                         &dependency_overrides,
                         &dependency_excludes,
                         requires_python.as_ref(),
@@ -3005,7 +3098,7 @@ impl Lock {
                         metadata.requires_dist,
                         &metadata.provides_extra,
                         metadata.dependency_groups,
-                        &dependency_constraints,
+                        &dependency_sources,
                         &dependency_overrides,
                         &dependency_excludes,
                         metadata.requires_python.as_ref(),

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18816,6 +18816,72 @@ fn lock_metadata_free_disjoint_marker_direct_url_constraint() -> Result<()> {
     Ok(())
 }
 
+/// First-party direct sources can satisfy unqualified dependencies throughout the workspace.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_direct_sources() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx[http2]", "six", "member"]
+
+        [tool.uv.workspace]
+        members = ["member"]
+
+        [tool.uv.sources]
+        member = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("member/pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx @ {httpx_url}", "six"]
+
+        [tool.uv.sources]
+        six = {{ url = "{six_url}" }}
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+            six_url = server.file_url("six-1.0.0-py3-none-any.whl"),
+        })?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Requested target extras must cover the same marker environments as their declarations.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19167,6 +19167,82 @@ fn lock_metadata_free_shared_dynamic_direct_source() -> Result<()> {
     Ok(())
 }
 
+/// Backend-only source trees can select direct sources without declaring PEP 621 dynamic fields.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_backend_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx[http2]", "provider"]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/pyproject.toml")
+        .write_str(indoc! {r#"
+        [build-system]
+        requires = []
+        backend-path = ["."]
+        build-backend = "backend"
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/backend.py")
+        .write_str(&formatdoc! {r#"
+        import pathlib
+
+        def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+            dist_info = pathlib.Path(metadata_directory, "provider-1.0.0.dist-info")
+            dist_info.mkdir()
+            dist_info.joinpath("METADATA").write_text(
+                "Metadata-Version: 2.1\n"
+                "Name: provider\n"
+                "Version: 1.0.0\n"
+                "Requires-Python: >=3.12\n"
+                "Requires-Dist: httpx @ {httpx_url}\n"
+            )
+            return dist_info.name
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+        })?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Dependency groups on dynamic workspace members can select shared direct sources.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18816,6 +18816,90 @@ fn lock_metadata_free_disjoint_marker_direct_url_constraint() -> Result<()> {
     Ok(())
 }
 
+/// Conditional direct-source authority must be refreshed when an explicit source is removed.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_conditional_direct_url_constraint() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+    let httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx ; sys_platform != 'darwin'", "member"]
+
+        [tool.uv]
+        constraint-dependencies = ["httpx @ {httpx_url} ; sys_platform == 'darwin'"]
+
+        [tool.uv.workspace]
+        members = ["member"]
+
+        [tool.uv.sources]
+        member = {{ workspace = true }}
+        "#})?;
+    let member = context.temp_dir.child("member/pyproject.toml");
+    member.write_str(&formatdoc! {r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx @ {httpx_url}"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    member.write_str(indoc! {r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
 /// Requested target extras must cover the same marker environments as their declarations.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19243,6 +19243,78 @@ fn lock_metadata_free_shared_backend_direct_source() -> Result<()> {
     Ok(())
 }
 
+/// Legacy `setup.py` source trees can select direct sources without a `pyproject.toml`.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_legacy_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.10");
+    let server = PackseServer::empty();
+
+    context
+        .python_command()
+        .arg("-m")
+        .arg("ensurepip")
+        .assert()
+        .success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.10"
+        dependencies = ["setuptools", "provider"]
+
+        [tool.uv]
+        no-build-isolation-package = ["provider"]
+
+        [tool.uv.sources]
+        provider = { path = "provider" }
+        "#})?;
+    context
+        .temp_dir
+        .child("provider/setup.py")
+        .write_str(&formatdoc! {r#"
+        from setuptools import setup
+
+        setup(
+            name="provider",
+            version="1.0.0",
+            python_requires=">=3.10",
+            install_requires=["setuptools @ {setuptools_url}"],
+        )
+        "#,
+            setuptools_url = server.file_url("setuptools-69.0.2-py3-none-any.whl"),
+        })?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Dependency groups on dynamic workspace members can select shared direct sources.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19167,6 +19167,97 @@ fn lock_metadata_free_shared_dynamic_direct_source() -> Result<()> {
     Ok(())
 }
 
+/// Dependency groups on dynamic workspace members can select shared direct sources.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_dynamic_group_direct_sources() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx", "six", "member"]
+
+        [tool.uv.workspace]
+        members = ["member"]
+
+        [tool.uv.sources]
+        member = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("member/pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dynamic = ["dependencies"]
+
+        [dependency-groups]
+        dev = ["httpx @ {httpx_url}", "six"]
+
+        [tool.uv.sources]
+        six = {{ url = "{six_url}" }}
+
+        [build-system]
+        requires = []
+        backend-path = ["."]
+        build-backend = "backend"
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+            six_url = server.file_url("six-1.0.0-py3-none-any.whl"),
+        })?;
+    context
+        .temp_dir
+        .child("member/backend.py")
+        .write_str(indoc! {r#"
+        import pathlib
+
+        def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+            dist_info = pathlib.Path(metadata_directory, "member-0.1.0.dist-info")
+            dist_info.mkdir()
+            dist_info.joinpath("METADATA").write_text(
+                "Metadata-Version: 2.1\n"
+                "Name: member\n"
+                "Version: 0.1.0\n"
+                "Requires-Python: >=3.12\n"
+            )
+            return dist_info.name
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Configured static dependency metadata can select a source for another first-party dependency.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19009,6 +19009,155 @@ fn lock_metadata_free_shared_transitive_direct_source() -> Result<()> {
     Ok(())
 }
 
+/// Direct sources emitted by a dynamic workspace member apply to otherwise unqualified dependencies.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_dynamic_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx[http2]", "member"]
+
+        [tool.uv.workspace]
+        members = ["member"]
+
+        [tool.uv.sources]
+        member = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("member/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dynamic = ["dependencies"]
+
+        [build-system]
+        requires = []
+        backend-path = ["."]
+        build-backend = "backend"
+        "#})?;
+    context
+        .temp_dir
+        .child("member/backend.py")
+        .write_str(&formatdoc! {r#"
+        import pathlib
+
+        def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+            dist_info = pathlib.Path(metadata_directory, "member-0.1.0.dist-info")
+            dist_info.mkdir()
+            dist_info.joinpath("METADATA").write_text(
+                "Metadata-Version: 2.1\n"
+                "Name: member\n"
+                "Version: 0.1.0\n"
+                "Requires-Python: >=3.12\n"
+                "Requires-Dist: httpx @ {httpx_url}\n"
+            )
+            return dist_info.name
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+        })?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Configured static dependency metadata can select a source for another first-party dependency.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_static_metadata_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx[http2]", "local"]
+
+        [tool.uv.sources]
+        local = {{ path = "local" }}
+
+        [[tool.uv.dependency-metadata]]
+        name = "local"
+        version = "0.1.0"
+        requires-dist = ["httpx @ {httpx_url}"]
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+        })?;
+    context
+        .temp_dir
+        .child("local/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "local"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dynamic = ["dependencies"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Projectless workspace root groups can select direct sources for workspace-member requirements.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18899,7 +18899,6 @@ fn lock_metadata_free_shared_disjoint_marker_direct_sources() -> Result<()> {
         requires-python = ">=3.12"
         dependencies = [
             "httpx[http2] ; sys_platform == 'win32'",
-            "six ; sys_platform == 'win32'",
             "member",
         ]
 
@@ -18917,84 +18916,9 @@ fn lock_metadata_free_shared_disjoint_marker_direct_sources() -> Result<()> {
         name = "member"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = [
-            "httpx @ {httpx_url} ; sys_platform == 'darwin'",
-            "six ; sys_platform == 'darwin'",
-        ]
-
-        [tool.uv.sources]
-        six = {{ url = "{six_url}" }}
+        dependencies = ["httpx @ {httpx_url} ; sys_platform == 'darwin'"]
         "#,
             httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
-            six_url = server.file_url("six-1.0.0-py3-none-any.whl"),
-        })?;
-
-    uv_snapshot!(context.filters(), context.lock()
-        .arg("--preview-features")
-        .arg("lock-without-metadata")
-        .arg("--index-url")
-        .arg(server.index_url()), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 5 packages in [TIME]
-    ");
-
-    uv_snapshot!(context.filters(), context.lock()
-        .arg("--preview-features")
-        .arg("lock-without-metadata")
-        .arg("--locked")
-        .arg("--offline")
-        .arg("--no-cache")
-        .arg("--index-url")
-        .arg(server.index_url()), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 5 packages in [TIME]
-    ");
-
-    Ok(())
-}
-
-/// Extras and dependency groups can select direct sources for otherwise unqualified dependencies.
-#[cfg(feature = "test-universal")]
-#[test]
-fn lock_metadata_free_shared_optional_and_group_direct_sources() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let server = PackseServer::new("extras/lock-without-metadata.toml");
-
-    context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(indoc! {r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = ["httpx", "six", "member[feature]"]
-
-        [tool.uv.workspace]
-        members = ["member"]
-
-        [tool.uv.sources]
-        member = { workspace = true }
-        "#})?;
-    context
-        .temp_dir
-        .child("member/pyproject.toml")
-        .write_str(&formatdoc! {r#"
-        [project]
-        name = "member"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-
-        [project.optional-dependencies]
-        feature = ["httpx @ {httpx_url}"]
-
-        [dependency-groups]
-        dev = ["six @ {six_url}"]
-        "#,
-            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
-            six_url = server.file_url("six-1.0.0-py3-none-any.whl"),
         })?;
 
     uv_snapshot!(context.filters(), context.lock()
@@ -19238,83 +19162,6 @@ fn lock_metadata_free_shared_backend_direct_source() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    ");
-
-    Ok(())
-}
-
-/// Legacy `setup.py` source trees can select direct sources without a `pyproject.toml`.
-#[cfg(feature = "test-universal")]
-#[test]
-fn lock_metadata_free_shared_legacy_direct_source() -> Result<()> {
-    let context = uv_test::test_context!("3.10");
-    let server = PackseServer::empty();
-
-    context
-        .python_command()
-        .arg("-m")
-        .arg("ensurepip")
-        .assert()
-        .success();
-    context
-        .pip_install()
-        .arg(server.file_url("wheel-0.42.0-py3-none-any.whl"))
-        .assert()
-        .success();
-
-    context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(indoc! {r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.10"
-        dependencies = ["setuptools", "provider"]
-
-        [tool.uv]
-        no-build-isolation-package = ["provider"]
-
-        [tool.uv.sources]
-        provider = { path = "provider" }
-        "#})?;
-    context
-        .temp_dir
-        .child("provider/setup.py")
-        .write_str(&formatdoc! {r#"
-        from setuptools import setup
-
-        setup(
-            name="provider",
-            version="1.0.0",
-            python_requires=">=3.10",
-            install_requires=["setuptools @ {setuptools_url}"],
-        )
-        "#,
-            setuptools_url = server.file_url("setuptools-69.0.2-py3-none-any.whl"),
-        })?;
-
-    uv_snapshot!(context.filters(), context.lock()
-        .arg("--preview-features")
-        .arg("lock-without-metadata")
-        .arg("--index-url")
-        .arg(server.index_url()), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 3 packages in [TIME]
-    ");
-
-    uv_snapshot!(context.filters(), context.lock()
-        .arg("--preview-features")
-        .arg("lock-without-metadata")
-        .arg("--locked")
-        .arg("--offline")
-        .arg("--no-cache")
-        .arg("--index-url")
-        .arg(server.index_url()), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 3 packages in [TIME]
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18882,6 +18882,79 @@ fn lock_metadata_free_shared_direct_sources() -> Result<()> {
     Ok(())
 }
 
+/// First-party direct sources apply globally, even across disjoint platform markers.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_disjoint_marker_direct_sources() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "httpx[http2] ; sys_platform == 'win32'",
+            "six ; sys_platform == 'win32'",
+            "member",
+        ]
+
+        [tool.uv.workspace]
+        members = ["member"]
+
+        [tool.uv.sources]
+        member = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("member/pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "httpx @ {httpx_url} ; sys_platform == 'darwin'",
+            "six ; sys_platform == 'darwin'",
+        ]
+
+        [tool.uv.sources]
+        six = {{ url = "{six_url}" }}
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+            six_url = server.file_url("six-1.0.0-py3-none-any.whl"),
+        })?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Extras and dependency groups can select direct sources for otherwise unqualified dependencies.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19009,6 +19009,127 @@ fn lock_metadata_free_shared_transitive_direct_source() -> Result<()> {
     Ok(())
 }
 
+/// Projectless workspace root groups can select direct sources for workspace-member requirements.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_root_group_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [tool.uv.workspace]
+        members = ["member"]
+
+        [dependency-groups]
+        dev = ["httpx @ {httpx_url}"]
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+        })?;
+    context
+        .temp_dir
+        .child("member/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx[http2]"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// PEP 723 script requirements can select direct sources for local-package requirements.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_script_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("script.py")
+        .write_str(&formatdoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = [
+        #     "httpx @ {httpx_url}",
+        #     "local",
+        # ]
+        #
+        # [tool.uv.sources]
+        # local = {{ path = "local" }}
+        # ///
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+        })?;
+    context
+        .temp_dir
+        .child("local/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "local"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx[http2]"]
+        "#})?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--script")
+        .arg("script.py")
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Requested target extras must cover the same marker environments as their declarations.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -19256,6 +19256,11 @@ fn lock_metadata_free_shared_legacy_direct_source() -> Result<()> {
         .arg("ensurepip")
         .assert()
         .success();
+    context
+        .pip_install()
+        .arg(server.file_url("wheel-0.42.0-py3-none-any.whl"))
+        .assert()
+        .success();
 
     context
         .temp_dir

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -18882,6 +18882,133 @@ fn lock_metadata_free_shared_direct_sources() -> Result<()> {
     Ok(())
 }
 
+/// Extras and dependency groups can select direct sources for otherwise unqualified dependencies.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_optional_and_group_direct_sources() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx", "six", "member[feature]"]
+
+        [tool.uv.workspace]
+        members = ["member"]
+
+        [tool.uv.sources]
+        member = { workspace = true }
+        "#})?;
+    context
+        .temp_dir
+        .child("member/pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        feature = ["httpx @ {httpx_url}"]
+
+        [dependency-groups]
+        dev = ["six @ {six_url}"]
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+            six_url = server.file_url("six-1.0.0-py3-none-any.whl"),
+        })?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Direct sources selected by a non-workspace local dependency are shared across the resolution.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_metadata_free_shared_transitive_direct_source() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("extras/lock-without-metadata.toml");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx[http2]", "local"]
+
+        [tool.uv.sources]
+        local = { path = "local" }
+        "#})?;
+    context
+        .temp_dir
+        .child("local/pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "local"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["httpx @ {httpx_url}"]
+        "#,
+            httpx_url = server.file_url("httpx-1.0.0-py3-none-any.whl"),
+        })?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Requested target extras must cover the same marker environments as their declarations.
 #[cfg(feature = "test-universal")]
 #[test]


### PR DESCRIPTION
## Summary

Metadata-free lock validation can preserve stale direct-source authority from old workspace declarations or apply a conditional source outside its marker environment. This can either accept an outdated lock after an explicit direct requirement is removed or reject a valid lock whose registry requirement covers the remaining environments.

Refresh workspace source metadata before deriving source authority, and track the marker union of exact matching constraints and current first-party declarations when validating each locked source. Cover unchanged conditional direct-source locks and stale explicit-source removal with an offline workspace regression.
