### PR TITLE
Diagnose dangling shebang interpreters in `uv run` / `uv tool run`

### DIFF
--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -246,6 +246,7 @@ pub(crate) fn hints_for_error(err: &anyhow::Error) -> Hints<'static> {
         collect_hint::<uv_resolver::LockError>(cause, &mut hints);
         collect_hint::<pip::operations::Error>(cause, &mut hints);
         collect_hint::<ToolRunScriptError>(cause, &mut hints);
+        collect_hint::<crate::commands::spawn::SpawnNotFoundError>(cause, &mut hints);
         collect_hint::<RecursionLimitError>(cause, &mut hints);
         collect_hint::<DependencyNotFoundError>(cause, &mut hints);
         collect_hint::<ExtrasWithoutSourceError>(cause, &mut hints);

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -97,6 +97,7 @@ mod python;
 pub(crate) mod reporters;
 #[cfg(feature = "self-update")]
 mod self_update;
+pub(crate) mod spawn;
 mod tool;
 mod update_shell;
 mod venv;

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -77,7 +77,7 @@ use crate::commands::project::{
     update_environment, validate_project_requires_python,
 };
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::{ExitStatus, diagnostics, project, read_env_files};
+use crate::commands::{ExitStatus, diagnostics, project, read_env_files, spawn};
 use crate::printer::Printer;
 use crate::settings::{
     FrozenSource, GlobalSettings, LockCheck, LockCheckSource, ResolverInstallerSettings,
@@ -1266,21 +1266,22 @@ pub(crate) async fn run(
     let mut process = command.as_command(interpreter);
     process.envs(env_file_environment);
 
+    let ephemeral_scripts = ephemeral_env.as_ref().map(PythonEnvironment::scripts);
+    let requirements_scripts = requirements_env.as_ref().map(PythonEnvironment::scripts);
+    let base_scripts = base_interpreter.scripts();
+    // On Windows, non-virtual Python distributions put `python.exe` in the top-level directory,
+    // rather than in the `Scripts` subdirectory.
+    let base_scripts_windows_extra = cfg!(windows)
+        .then(|| base_interpreter.sys_executable().parent())
+        .flatten();
+
     // Construct the `PATH` environment variable.
     let new_path = std::env::join_paths(
-        ephemeral_env
-            .as_ref()
-            .map(PythonEnvironment::scripts)
+        ephemeral_scripts
             .into_iter()
-            .chain(requirements_env.as_ref().map(PythonEnvironment::scripts))
-            .chain(std::iter::once(base_interpreter.scripts()))
-            .chain(
-                // On Windows, non-virtual Python distributions put `python.exe` in the top-level
-                // directory, rather than in the `Scripts` subdirectory.
-                cfg!(windows)
-                    .then(|| base_interpreter.sys_executable().parent())
-                    .flatten(),
-            )
+            .chain(requirements_scripts)
+            .chain(std::iter::once(base_scripts))
+            .chain(base_scripts_windows_extra)
             .dedup()
             .map(PathBuf::from)
             .chain(
@@ -1290,7 +1291,26 @@ pub(crate) async fn run(
                     .flat_map(std::env::split_paths),
             ),
     )?;
-    process.env(EnvVars::PATH, new_path);
+    process.env(EnvVars::PATH, &new_path);
+
+    // The subset of the directories above that belong to a virtual environment, as opposed to
+    // the ambient `PATH` or a non-virtualenv (e.g. system or Homebrew) Python's own `bin` — used
+    // to scope the dangling-shebang diagnostic in `spawn_error` to environments `uv venv` can
+    // actually recreate. `base_scripts` only qualifies when `base_interpreter` is a virtualenv;
+    // a same-named script in a non-virtualenv interpreter's `bin` isn't `uv venv`'s to fix.
+    let managed_scripts_dirs: Vec<PathBuf> = ephemeral_scripts
+        .into_iter()
+        .chain(requirements_scripts)
+        .chain(base_interpreter.is_virtualenv().then_some(base_scripts))
+        .chain(
+            base_interpreter
+                .is_virtualenv()
+                .then_some(base_scripts_windows_extra)
+                .flatten(),
+        )
+        .dedup()
+        .map(PathBuf::from)
+        .collect();
 
     // Increment recursion depth counter.
     process.env(
@@ -1305,10 +1325,19 @@ pub(crate) async fn run(
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
-    // TODO(zanieb): Throw a nicer error message if the command is not found
-    let handle = process
-        .spawn()
-        .with_context(|| format!("Failed to spawn: `{}`", command.display_executable()))?;
+    let program = process.as_std().get_program().to_os_string();
+    let handle = process.spawn().map_err(|err| {
+        spawn::spawn_error(
+            &command.display_executable(),
+            &program,
+            Some(new_path.as_os_str()),
+            &managed_scripts_dirs,
+            Some(
+                "The virtual environment may have been moved or deleted; recreate it with `uv venv`.",
+            ),
+            err,
+        )
+    })?;
 
     run_to_completion(handle).await
 }

--- a/crates/uv/src/commands/spawn.rs
+++ b/crates/uv/src/commands/spawn.rs
@@ -1,0 +1,195 @@
+use std::env::current_dir;
+use std::ffi::OsStr;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::str::from_utf8;
+
+use owo_colors::OwoColorize;
+
+use uv_errors::{Hint, Hints};
+
+/// The maximum number of bytes read from a resolved executable when looking for a shebang line.
+///
+/// uv only ever emits a *direct* shebang (`#!<path>`, no `/bin/sh` wrapper) when the interpreter
+/// path is under 127 bytes (see `uv-install-wheel::wheel::format_shebang`), so this is generous
+/// headroom while still bounding memory use against arbitrary (e.g. large binary) files.
+const SHEBANG_PROBE_LEN: usize = 4096;
+
+/// Raised when spawning a resolved command fails because the executable — or the interpreter
+/// named in its shebang — cannot be found.
+#[derive(Debug, thiserror::Error)]
+#[error("Failed to spawn: `{executable}`")]
+pub(crate) struct SpawnNotFoundError {
+    executable: String,
+    #[source]
+    source: io::Error,
+    /// The interpreter path named in the executable's shebang, if it no longer exists.
+    missing_interpreter: Option<PathBuf>,
+    /// A caller-specific suggestion for how to repair the environment, if any.
+    recreate_hint: Option<&'static str>,
+}
+
+impl Hint for SpawnNotFoundError {
+    fn hints(&self) -> Hints<'_> {
+        let Some(interpreter) = &self.missing_interpreter else {
+            return Hints::none();
+        };
+        let suffix = self
+            .recreate_hint
+            .unwrap_or("The environment may have been moved, deleted, or gone stale.");
+        Hints::from(format!(
+            "`{}` uses a Python interpreter at `{}`, which no longer exists. {suffix}",
+            self.executable.cyan(),
+            interpreter.display().cyan(),
+        ))
+    }
+}
+
+/// Wrap a `spawn()` failure as an error, attaching a hint if `program` resolves — within one of
+/// `managed_dirs` — to a script whose shebang names a Python interpreter that no longer exists.
+///
+/// `display_executable` is the user-facing name for the error message (unchanged from before this
+/// diagnostic existed). `program` is the exact argument passed to
+/// [`std::process::Command::new`], and `path` is the `PATH` the child process was given — both are
+/// needed to replicate the OS's own executable resolution when looking for a shebang to inspect.
+/// `managed_dirs` restricts the diagnostic to scripts uv itself installed (e.g. a venv's
+/// `bin`/`Scripts` directory): a same-named executable found elsewhere on `PATH` is not uv's to
+/// diagnose, and guessing at unrelated scripts' interpreters would just be a second wrong message.
+/// `recreate_hint`, if given, is appended verbatim to suggest how to repair the environment.
+pub(crate) fn spawn_error(
+    display_executable: &str,
+    program: &OsStr,
+    path: Option<&OsStr>,
+    managed_dirs: &[PathBuf],
+    recreate_hint: Option<&'static str>,
+    source: io::Error,
+) -> anyhow::Error {
+    let missing_interpreter = (source.kind() == io::ErrorKind::NotFound)
+        .then(|| resolve_missing_interpreter(program, path, managed_dirs))
+        .flatten();
+
+    SpawnNotFoundError {
+        executable: display_executable.to_string(),
+        source,
+        missing_interpreter,
+        recreate_hint,
+    }
+    .into()
+}
+
+/// Resolve `program` against `path` and, if it lives under `managed_dirs` and is a script with a
+/// dangling direct shebang, return the shebang's interpreter path.
+fn resolve_missing_interpreter(
+    program: &OsStr,
+    path: Option<&OsStr>,
+    managed_dirs: &[PathBuf],
+) -> Option<PathBuf> {
+    let cwd = current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let resolved = which::which_in(program, path, cwd).ok()?;
+    if !managed_dirs.iter().any(|dir| resolved.starts_with(dir)) {
+        return None;
+    }
+    dangling_shebang_interpreter(&resolved)
+}
+
+/// If `script` begins with a direct (non-`/bin/sh`-wrapped) shebang line whose interpreter no
+/// longer exists on disk, return that interpreter's path.
+///
+/// uv only emits a direct shebang (`#!<path>`) when the interpreter path is short and
+/// space-free; longer or relocatable paths get a `/bin/sh` wrapper instead (see
+/// `uv-install-wheel::wheel::format_shebang`). The wrapper form spawns successfully and reports
+/// its own, already-clear shell error, so it's out of scope here — and since `/bin/sh` itself
+/// always exists, the existence check below already excludes it without special-casing.
+fn dangling_shebang_interpreter(script: &Path) -> Option<PathBuf> {
+    let mut file = fs_err::File::open(script).ok()?;
+    let mut buf = vec![0u8; SHEBANG_PROBE_LEN];
+    let n = file.read(&mut buf).ok()?;
+    buf.truncate(n);
+
+    let first_line = buf.split(|&b| b == b'\n').next().unwrap_or_default();
+    let first_line = from_utf8(first_line).ok()?;
+    let shebang = first_line.strip_prefix("#!")?.trim();
+    // A shebang may carry a single interpreter argument (e.g. `#!/venv/bin/python3 -s`, as
+    // installed by some build backends); only the leading token is a path.
+    let interpreter = shebang.split_whitespace().next()?;
+
+    let interpreter_path = PathBuf::from(interpreter);
+    if interpreter_path.is_absolute() && !interpreter_path.exists() {
+        Some(interpreter_path)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::dangling_shebang_interpreter;
+
+    #[test]
+    fn dangling_shebang_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("entry");
+        fs_err::write(&script, "#!/definitely/does/not/exist/python3\n").unwrap();
+
+        assert_eq!(
+            dangling_shebang_interpreter(&script),
+            Some(PathBuf::from("/definitely/does/not/exist/python3"))
+        );
+    }
+
+    #[test]
+    fn dangling_shebang_with_argument_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("entry");
+        fs_err::write(&script, "#!/definitely/does/not/exist/python3 -s\n").unwrap();
+
+        assert_eq!(
+            dangling_shebang_interpreter(&script),
+            Some(PathBuf::from("/definitely/does/not/exist/python3"))
+        );
+    }
+
+    #[test]
+    fn existing_interpreter_is_not_flagged() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("entry");
+        // Any file that exists is a valid stand-in interpreter for this check.
+        fs_err::write(&script, format!("#!{}\n", script.display())).unwrap();
+
+        assert_eq!(dangling_shebang_interpreter(&script), None);
+    }
+
+    #[test]
+    fn sh_wrapper_form_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("entry");
+        fs_err::write(
+            &script,
+            "#!/bin/sh\n'''exec' '/definitely/missing/python3' \"$0\" \"$@\"\n' '''\n",
+        )
+        .unwrap();
+
+        assert_eq!(dangling_shebang_interpreter(&script), None);
+    }
+
+    #[test]
+    fn relative_interpreter_is_not_flagged() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("entry");
+        fs_err::write(&script, "#!python3\n").unwrap();
+
+        assert_eq!(dangling_shebang_interpreter(&script), None);
+    }
+
+    #[test]
+    fn non_script_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("entry");
+        fs_err::write(&script, [0xffu8, 0xfe, 0x00, 0x01]).unwrap();
+
+        assert_eq!(dangling_shebang_interpreter(&script), None);
+    }
+}

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -55,7 +55,7 @@ use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::tool::common::{ToolPython, matching_packages, refine_interpreter};
 use crate::commands::tool::{Target, ToolRequest};
 use crate::commands::{
-    UvError, diagnostics, project::environment::CachedEnvironment, read_env_files,
+    UvError, diagnostics, project::environment::CachedEnvironment, read_env_files, spawn,
 };
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
@@ -353,9 +353,14 @@ pub(crate) async fn run(
     process.args(args);
     process.envs(env_file_environment);
 
+    // The directory uv itself installs this tool's entry points into, as opposed to the ambient
+    // `PATH` appended below — used to scope the dangling-shebang diagnostic in `spawn_error` to
+    // scripts uv actually manages.
+    let managed_scripts_dirs = [environment.scripts().to_path_buf()];
+
     // Construct the `PATH` environment variable.
     let new_path = std::env::join_paths(
-        std::iter::once(environment.scripts().to_path_buf()).chain(
+        managed_scripts_dirs.iter().cloned().chain(
             std::env::var_os(EnvVars::PATH)
                 .as_ref()
                 .iter()
@@ -363,7 +368,7 @@ pub(crate) async fn run(
         ),
     )
     .context("Failed to build new PATH variable")?;
-    process.env(EnvVars::PATH, new_path);
+    process.env(EnvVars::PATH, &new_path);
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
@@ -374,6 +379,7 @@ pub(crate) async fn run(
         args.iter().map(|arg| arg.to_string_lossy()).join(" ")
     );
 
+    let program = process.as_std().get_program().to_os_string();
     let handle = match process.spawn() {
         Ok(handle) => Ok(handle),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -390,7 +396,16 @@ pub(crate) async fn run(
         }
         Err(err) => Err(err),
     }
-    .with_context(|| format!("Failed to spawn: `{executable}`"))?;
+    .map_err(|err| {
+        spawn::spawn_error(
+            executable,
+            &program,
+            Some(new_path.as_os_str()),
+            &managed_scripts_dirs,
+            None,
+            err,
+        )
+    })?;
 
     run_to_completion(handle).await
 }

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -4046,6 +4046,69 @@ fn run_script_without_build_system() -> Result<()> {
     Ok(())
 }
 
+/// A dangling shebang — as left behind when a venv directory is moved or deleted after an
+/// entry point script was installed — should produce a hint naming the missing interpreter
+/// instead of the bare, misleading OS error.
+///
+/// See: <https://github.com/astral-sh/uv/issues/13992>
+#[test]
+#[cfg(target_family = "unix")]
+fn run_reports_dangling_shebang_interpreter() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let context = uv_test::test_context!("3.12");
+
+    // Write the entry point by hand with a short, synthetic interpreter path rather than
+    // installing a real package: `format_shebang` only emits this direct `#!<path>` form when
+    // the path is under 127 bytes, and `TestContext` temp dirs can exceed that, silently
+    // switching to the unrelated `/bin/sh` wrapper form.
+    let bin_dir = ChildPath::new(uv_test::venv_bin_path(&context.venv));
+    let entrypoint = bin_dir.child("broken-entry");
+    entrypoint.write_str("#!/definitely/does/not/exist/python3\nprint('unreachable')\n")?;
+    fs_err::set_permissions(entrypoint.path(), PermissionsExt::from_mode(0o755))?;
+
+    uv_snapshot!(context.filters(), context.run().arg("--no-project").arg("broken-entry"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Failed to spawn: `broken-entry`
+      Caused by: No such file or directory (os error 2)
+
+    hint: `broken-entry` uses a Python interpreter at `/definitely/does/not/exist/python3`, which no longer exists. The virtual environment may have been moved or deleted; recreate it with `uv venv`.
+    ");
+
+    Ok(())
+}
+
+/// A same-named executable with a dangling shebang found on the ambient `PATH` — outside any
+/// directory uv itself manages (e.g. the venv's `bin`) — must not be diagnosed: uv did not
+/// install it, so it has no basis for guessing that the interpreter it names is even Python, or
+/// that `uv venv` is the fix. It should surface the original, unannotated OS error.
+///
+/// See: <https://github.com/astral-sh/uv/issues/13992>
+#[test]
+#[cfg(target_family = "unix")]
+fn run_does_not_diagnose_dangling_shebang_outside_managed_dirs() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let context = uv_test::test_context!("3.12");
+
+    // `context.bin_dir` is prepended to the ambient `PATH` uv inherits (see
+    // `TestContext::add_shared_env`), but it is not one of uv's own managed script
+    // directories, so a dangling shebang there should be left undiagnosed.
+    let entrypoint = context.bin_dir.child("unmanaged-entry");
+    entrypoint.write_str("#!/definitely/does/not/exist/python3\nprint('unreachable')\n")?;
+    fs_err::set_permissions(entrypoint.path(), PermissionsExt::from_mode(0o755))?;
+
+    uv_snapshot!(context.filters(), context.run().arg("--no-project").arg("unmanaged-entry"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Failed to spawn: `unmanaged-entry`
+      Caused by: No such file or directory (os error 2)
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn run_script_module_conflict() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -520,6 +520,50 @@ fn tool_run_from_install() {
     ");
 }
 
+/// A dangling shebang in an installed tool's entry point — as left behind if the tool's Python
+/// interpreter is removed — should produce a hint naming the missing interpreter instead of the
+/// bare, misleading OS error.
+///
+/// See: <https://github.com/astral-sh/uv/issues/13992>
+#[test]
+#[cfg(unix)]
+fn tool_run_reports_dangling_shebang_interpreter() {
+    let context = uv_test::test_context!("3.12").with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .tool_install()
+        .arg("black==24.1.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    // Corrupt the installed tool environment's entry point with a dangling shebang, simulating
+    // e.g. the underlying Python installation being removed out from under it.
+    let entrypoint = venv_bin_path(tool_dir.join("black")).join("black");
+    fs_err::write(
+        &entrypoint,
+        "#!/definitely/does/not/exist/python3\nprint('unreachable')\n",
+    )
+    .unwrap();
+    set_permissions(&entrypoint, PermissionsExt::from_mode(0o755)).unwrap();
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("black")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Failed to spawn: `black`
+      Caused by: No such file or directory (os error 2)
+
+    hint: `black` uses a Python interpreter at `/definitely/does/not/exist/python3`, which no longer exists. The environment may have been moved, deleted, or gone stale.
+    ");
+}
+
 #[test]
 fn tool_run_from_install_constraints() {
     let context = uv_test::test_context!("3.12").with_filtered_counts();


### PR DESCRIPTION
## Summary

Fixes #13992.

When a venv (or `uv tool install`ed environment) is moved, renamed, or
deleted after an entry-point script was installed, that script's shebang
dangles — `format_shebang` bakes an absolute interpreter path into every
direct (non-`/bin/sh`-wrapped) shebang it writes. Running the entry point
afterward makes `execve()` fail with `ENOENT`, which Rust maps to
`io::ErrorKind::NotFound` — indistinguishable from "command not found".
uv's existing error interpolates the *executable name* (which exists),
not the actually-missing interpreter:

```
$ uv venv && uv pip install cowsay
$ mv .venv-project ../renamed && cd ../renamed
$ uv run --no-project cowsay -t hi
error: Failed to spawn: `cowsay`
  Caused by: No such file or directory (os error 2)
```

Every reporter in #13196 concluded uv or the package was broken; the
actual fix (`uv venv`) is undiscoverable from that message.

## Fix

On `spawn()` returning `ErrorKind::NotFound`:
1. Resolve the executable against the exact `PATH` the child process was
   given (`crates/uv/src/commands/spawn.rs`, new).
2. If it resolves to a script under a directory uv itself manages — a
   venv's `scripts()` for `uv run`, restricted to `is_virtualenv()` so a
   system/Homebrew Python's `bin` is never second-guessed; a tool's
   `environment.scripts()` for `uv tool run` — read its first line. If
   it's a direct shebang (`#!<path>`, optionally with one interpreter
   argument) whose interpreter no longer exists, attach a hint naming it:

```
error: Failed to spawn: `cowsay`
  Caused by: No such file or directory (os error 2)

hint: `cowsay` uses a Python interpreter at `/private/tmp/r1/.venv/bin/python3`, which no longer exists. The virtual environment may have been moved or deleted; recreate it with `uv venv`.
```

If the executable doesn't resolve on `PATH` at all, or resolves outside
a uv-managed directory, or its shebang interpreter still exists, the
message is byte-for-byte unchanged — this is purely additive diagnostic
information on an already-failing path.

The relocatable `/bin/sh`-wrapped shebang form (emitted when the
interpreter path is >127 bytes or contains a space) is out of scope: it
spawns successfully and the shell reports its own, already-clear error
naming the missing interpreter directly.

## Test plan

- [x] `cargo test -p uv --lib commands::spawn` — 6 unit tests on the
      shebang parser (dangling/existing/relative/`/bin/sh`-wrapper/
      argument-bearing/non-UTF8 forms)
- [x] `cargo test -p uv --test project -- run::` — 115 passed, including
      two new tests (`run_reports_dangling_shebang_interpreter`,
      `run_does_not_diagnose_dangling_shebang_outside_managed_dirs`) and
      the pre-existing `run_script_without_build_system` regression
      check for the genuine command-not-found case, unmodified
- [x] `cargo test -p uv --test tool -- tool_run::` — 57 passed, including
      a new end-to-end test (`tool_run_reports_dangling_shebang_interpreter`)
      installing a real tool and corrupting its shebang
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] Manually reproduced the original report's exact repro (moved venv
      dir) against this branch; hint fires correctly and the negative
      case (genuinely missing command) is unaffected

## Related

[#17233](https://github.com/astral-sh/uv/pull/17233) is an existing WIP
draft toward the same issue (created and last updated 2025-12-24, no
activity since); @zanieb had given a go-ahead on the issue itself. This
PR is an independent implementation — happy to close in favor of that
one, or coordinate, whichever maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rBXmpNhFG5JEU4mr2g3Ry