### PR TITLE
Stage Windows self-updates before replacing uv.exe

### DIFF
--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -10,6 +10,8 @@ use axoupdater::{
 };
 use owo_colors::OwoColorize;
 use serde::Deserialize;
+#[cfg(windows)]
+use serde_json::Value;
 use tempfile::TempDir;
 use thiserror::Error;
 use tokio::process::Command;
@@ -353,11 +355,12 @@ async fn run_official_updater(
         official_installer_urls_with_mirror(target_version, custom_astral_mirror.as_deref())?;
     let temp_dir = TempDir::new()?;
     let installer_path = temp_dir.path().join(installer_filename());
-    #[cfg(not(windows))]
     let install_prefix = PathBuf::from(updater.install_prefix_root()?.as_str());
     // If we can't determine the previous PATH behavior, abort rather than potentially changing the
     // user's shell configuration unexpectedly.
-    let modify_path = load_receipt_modify_path("uv")
+    let receipt_path = find_receipt_path("uv")?
+        .context("Failed to locate the standalone install receipt for `uv`")?;
+    let modify_path = load_receipt_modify_path(&receipt_path)
         .context("Failed to determine whether the existing standalone install modified PATH")?;
 
     #[cfg(windows)]
@@ -392,7 +395,13 @@ async fn run_official_updater(
     .await?;
 
     #[cfg(windows)]
-    replace_from_temporary_install(temporary_install_dir.path())?;
+    replace_from_temporary_install(
+        temporary_install_dir.path(),
+        temporary_config_dir.path(),
+        &receipt_path,
+        &install_prefix,
+        modify_path,
+    )?;
 
     let direction = if current_version > target_version {
         "Downgraded"
@@ -527,7 +536,13 @@ fn installer_download_github_token<'a>(
 }
 
 #[cfg(windows)]
-fn replace_from_temporary_install(temporary_install_dir: &Path) -> Result<()> {
+fn replace_from_temporary_install(
+    temporary_install_dir: &Path,
+    temporary_config_dir: &Path,
+    receipt_path: &Path,
+    install_prefix: &Path,
+    modify_path: bool,
+) -> Result<()> {
     let current_executable = std::env::current_exe()?;
     let current_file_name = current_executable.file_name().ok_or_else(|| {
         std::io::Error::new(
@@ -550,8 +565,57 @@ fn replace_from_temporary_install(temporary_install_dir: &Path) -> Result<()> {
         fs_err::copy(entry.path(), install_dir.join(entry.file_name()))?;
     }
 
+    update_standalone_install_receipt(
+        temporary_config_dir,
+        receipt_path,
+        install_prefix,
+        modify_path,
+    )?;
+
     self_replace::self_replace(temporary_install_dir.join(current_file_name))
         .context("Failed to replace the current executable")?;
+    Ok(())
+}
+
+/// Promote the receipt written by a staged Windows installation to its original location.
+///
+/// The installer records the staging directory as its install prefix and disables PATH
+/// modification, so those fields must retain the original installation's values.
+#[cfg(windows)]
+fn update_standalone_install_receipt(
+    temporary_config_dir: &Path,
+    receipt_path: &Path,
+    install_prefix: &Path,
+    modify_path: bool,
+) -> Result<()> {
+    let temporary_receipt_path = temporary_config_dir.join("uv").join("uv-receipt.json");
+    let receipt = fs_err::read(&temporary_receipt_path).with_context(|| {
+        format!(
+            "Failed to read staged install receipt at `{}`",
+            temporary_receipt_path.display()
+        )
+    })?;
+    let mut receipt: Value = serde_json::from_slice(&receipt).with_context(|| {
+        format!(
+            "Failed to parse staged install receipt at `{}`",
+            temporary_receipt_path.display()
+        )
+    })?;
+    let receipt = receipt
+        .as_object_mut()
+        .context("Staged install receipt must be a JSON object")?;
+    receipt.insert(
+        "install_prefix".to_string(),
+        serde_json::to_value(install_prefix)?,
+    );
+    receipt.insert("modify_path".to_string(), Value::Bool(modify_path));
+
+    fs_err::write(receipt_path, serde_json::to_vec(&receipt)?).with_context(|| {
+        format!(
+            "Failed to write updated install receipt at `{}`",
+            receipt_path.display()
+        )
+    })?;
     Ok(())
 }
 
@@ -614,13 +678,9 @@ async fn execute_official_installer(
 /// Read whether the existing standalone install opted out of PATH modification.
 ///
 /// Older receipts that lack this field default to `true` for modifying PATH.
-fn load_receipt_modify_path(app_name: &str) -> Result<bool> {
-    let Some(receipt_path) = find_receipt_path(app_name)? else {
-        anyhow::bail!("Failed to locate the standalone install receipt for `{app_name}`");
-    };
-
+fn load_receipt_modify_path(receipt_path: &Path) -> Result<bool> {
     // Axoupdater does not expose `modify_path`, so we re-read the already-validated receipt.
-    let receipt = fs_err::read(&receipt_path).with_context(|| {
+    let receipt = fs_err::read(receipt_path).with_context(|| {
         format!(
             "Failed to read install receipt at `{}`",
             receipt_path.display()
@@ -1148,6 +1208,58 @@ mod tests {
         let receipt: StandaloneInstallReceipt = serde_json::from_str("{\"modify_path\":false}\n")
             .expect("receipt with explicit modify_path should parse");
         assert!(!receipt.modify_path);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_update_standalone_install_receipt_preserves_install_details() -> Result<()> {
+        let temporary_config_dir = TempDir::new()?;
+        let temporary_receipt_path = temporary_config_dir
+            .path()
+            .join("uv")
+            .join("uv-receipt.json");
+        fs_err::create_dir_all(
+            temporary_receipt_path
+                .parent()
+                .context("Staged receipt path must have a parent directory")?,
+        )?;
+        fs_err::write(
+            &temporary_receipt_path,
+            serde_json::to_vec(&serde_json::json!({
+                "binaries": ["uv", "uvx", "uvw"],
+                "binary_aliases": {"uv": ["uv.exe"]},
+                "install_prefix": temporary_config_dir.path(),
+                "modify_path": false,
+                "version": "0.12.1",
+            }))?,
+        )?;
+
+        let receipt_dir = TempDir::new()?;
+        let receipt_path = receipt_dir.path().join("uv-receipt.json");
+        let install_prefix = receipt_dir.path().join("bin");
+        fs_err::write(&receipt_path, "{\"version\":\"0.12.0\"}")?;
+
+        update_standalone_install_receipt(
+            temporary_config_dir.path(),
+            &receipt_path,
+            &install_prefix,
+            true,
+        )?;
+
+        let receipt: Value = serde_json::from_slice(&fs_err::read(&receipt_path)?)?;
+        assert_eq!(
+            receipt["install_prefix"],
+            Value::String(install_prefix.display().to_string())
+        );
+        assert_eq!(receipt["modify_path"], Value::Bool(true));
+        assert_eq!(receipt["binaries"], serde_json::json!(["uv", "uvx", "uvw"]));
+        assert_eq!(
+            receipt["binary_aliases"],
+            serde_json::json!({"uv": ["uv.exe"]})
+        );
+        assert_eq!(receipt["version"], Value::String("0.12.1".to_string()));
+
+        Ok(())
     }
 
     #[cfg(unix)]

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -345,16 +345,33 @@ async fn run_official_updater(
     client_builder: BaseClientBuilder<'_>,
     github_token: Option<&str>,
 ) -> Result<ExitStatus> {
+    #[cfg(windows)]
+    let _ = updater;
+
     let custom_astral_mirror = astral_mirror_url_from_env();
     let installer_urls =
         official_installer_urls_with_mirror(target_version, custom_astral_mirror.as_deref())?;
     let temp_dir = TempDir::new()?;
     let installer_path = temp_dir.path().join(installer_filename());
+    #[cfg(not(windows))]
     let install_prefix = PathBuf::from(updater.install_prefix_root()?.as_str());
     // If we can't determine the previous PATH behavior, abort rather than potentially changing the
     // user's shell configuration unexpectedly.
     let modify_path = load_receipt_modify_path("uv")
         .context("Failed to determine whether the existing standalone install modified PATH")?;
+
+    #[cfg(windows)]
+    let temporary_install_dir = TempDir::new()?;
+    #[cfg(windows)]
+    let temporary_config_dir = TempDir::new()?;
+    #[cfg(windows)]
+    let installer_install_prefix = temporary_install_dir.path();
+    #[cfg(not(windows))]
+    let installer_install_prefix = install_prefix.as_path();
+    #[cfg(windows)]
+    let installer_config_path = Some(temporary_config_dir.path());
+    #[cfg(not(windows))]
+    let installer_config_path = None;
 
     download_installer_from_urls(
         &installer_urls,
@@ -366,12 +383,16 @@ async fn run_official_updater(
 
     execute_official_installer(
         &installer_path,
-        &install_prefix,
-        modify_path,
+        installer_install_prefix,
+        if cfg!(windows) { false } else { modify_path },
         target_version,
         custom_astral_mirror.as_deref(),
+        installer_config_path,
     )
     .await?;
+
+    #[cfg(windows)]
+    replace_from_temporary_install(temporary_install_dir.path())?;
 
     let direction = if current_version > target_version {
         "Downgraded"
@@ -505,6 +526,35 @@ fn installer_download_github_token<'a>(
     }
 }
 
+#[cfg(windows)]
+fn replace_from_temporary_install(temporary_install_dir: &Path) -> Result<()> {
+    let current_executable = std::env::current_exe()?;
+    let current_file_name = current_executable.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Current executable has no file name",
+        )
+    })?;
+    let install_dir = current_executable.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Current executable has no parent directory",
+        )
+    })?;
+
+    for entry in fs_err::read_dir(temporary_install_dir)? {
+        let entry = entry?;
+        if entry.file_name() == current_file_name {
+            continue;
+        }
+        fs_err::copy(entry.path(), install_dir.join(entry.file_name()))?;
+    }
+
+    self_replace::self_replace(temporary_install_dir.join(current_file_name))
+        .context("Failed to replace the current executable")?;
+    Ok(())
+}
+
 /// Execute the standalone installer while preserving the existing install location and PATH
 /// behavior.
 ///
@@ -517,6 +567,7 @@ async fn execute_official_installer(
     modify_path: bool,
     target_version: &Pep440Version,
     astral_mirror_url: Option<&str>,
+    installer_config_path: Option<&Path>,
 ) -> Result<(), AxoupdateError> {
     let mut command = if cfg!(windows) {
         let mut command = Command::new("powershell");
@@ -526,21 +577,14 @@ async fn execute_official_installer(
     } else {
         Command::new(installer_path)
     };
-
-    let to_restore = if cfg!(windows) {
-        let old_path = std::env::current_exe()?;
-        let mut previous_path = old_path.as_os_str().to_os_string();
-        previous_path.push(".previous.exe");
-        let previous_path = PathBuf::from(previous_path);
-        fs_err::rename(&old_path, &previous_path)?;
-        Some((previous_path, old_path))
-    } else {
-        None
-    };
+    command.kill_on_drop(true);
 
     command.env_remove(EnvVars::PS_MODULE_PATH);
     command.env("CARGO_DIST_FORCE_INSTALL_DIR", install_prefix);
     command.env(EnvVars::UV_INSTALL_DIR, install_prefix);
+    if let Some(installer_config_path) = installer_config_path {
+        command.env("XDG_CONFIG_HOME", installer_config_path);
+    }
     // When a custom Astral mirror is configured, point the installer at the mirrored
     // uv release directory so it downloads the archive from the mirror too.
     if let Some(download_url) = installer_download_url(target_version, astral_mirror_url) {
@@ -551,20 +595,7 @@ async fn execute_official_installer(
         command.env(format!("{app_name_env_var}_NO_MODIFY_PATH"), "1");
     }
 
-    let result = command.output().await;
-    let failed = !result.as_ref().is_ok_and(|output| output.status.success());
-
-    if let Some((previous_path, old_path)) = to_restore.as_ref() {
-        if failed {
-            fs_err::rename(previous_path, old_path)?;
-        } else {
-            #[cfg(windows)]
-            self_replace::self_delete_at(previous_path)
-                .map_err(|_| AxoupdateError::CleanupFailed {})?;
-        }
-    }
-
-    let output = result?;
+    let output = command.output().await?;
     if output.status.success() {
         return Ok(());
     }
@@ -1165,6 +1196,7 @@ mod tests {
             true,
             &Pep440Version::new([1, 2, 3]),
             None,
+            None,
         )
         .await
         .expect_err("failing installer should return an error");
@@ -1208,6 +1240,7 @@ mod tests {
             false,
             &Pep440Version::new([1, 2, 3]),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1248,6 +1281,7 @@ mod tests {
             true,
             &Pep440Version::new([1, 2, 3]),
             Some("https://nexus.example.com/repository/releases.astral.sh/"),
+            None,
         )
         .await
         .unwrap();
@@ -1284,6 +1318,7 @@ mod tests {
             true,
             &Pep440Version::new([1, 2, 3]),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1291,6 +1326,59 @@ mod tests {
         assert_eq!(
             fs_err::read_to_string(&output_path).unwrap(),
             "UV_NO_MODIFY_PATH=\n"
+        );
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn test_interrupted_official_installer_preserves_original_executable() {
+        let temp_dir = TempDir::new().unwrap();
+        let installer_path = temp_dir.path().join("installer.ps1");
+        let install_prefix = temp_dir.path().join("install-prefix");
+        let original_path = temp_dir.path().join("uv.exe");
+        let started_path = temp_dir.path().join("installer-started");
+        let finish_path = temp_dir.path().join("finish-installer");
+
+        fs_err::write(&original_path, "old uv").unwrap();
+        fs_err::write(
+            &installer_path,
+            format!(
+                "New-Item -ItemType File -Force -Path '{}' | Out-Null\nwhile (-not (Test-Path -LiteralPath '{}')) {{ Start-Sleep -Milliseconds 10 }}\n",
+                started_path.display(),
+                finish_path.display(),
+            ),
+        )
+        .unwrap();
+
+        let task_installer_path = installer_path.clone();
+        let task_install_prefix = install_prefix.clone();
+        let task = tokio::spawn(async move {
+            execute_official_installer(
+                &task_installer_path,
+                &task_install_prefix,
+                true,
+                &Pep440Version::new([1, 2, 3]),
+                None,
+                None,
+            )
+            .await
+        });
+
+        for _ in 0..100 {
+            if started_path.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(started_path.exists(), "installer should have started");
+
+        task.abort();
+        drop(task);
+        fs_err::write(&finish_path, "finish").unwrap();
+
+        assert!(
+            original_path.exists(),
+            "the original executable should remain available after interruption"
         );
     }
 }


### PR DESCRIPTION
﻿﻿### Summary

Fix Windows self-updates so an interrupted or failed installation does not leave `uv` unusable.

Instead of renaming the current `uv.exe` before running the installer, the updater now stages the new release in a temporary directory. The existing executable remains in place until installation completes successfully, after which `uv` replaces itself using the Windows-safe self-replacement mechanism.

Addresses #12142.

### Changes

* Install the new release into a temporary directory before replacing the running executable.
* Keep the existing `uv.exe` in place while the external installer runs.
* Replace `uv.exe` from the staged copy only after installation succeeds.
* Copy companion binaries from the temporary installation into the existing executable directory.
* Run the temporary installer with:

  * an isolated configuration directory;
  * PATH modification disabled.
* Preserve the existing install receipt and shell configuration.
* Configure the updater child process to terminate when the parent task is interrupted.
* Remove the previous flow that renamed `uv.exe` to `.previous.exe` before installation.

The old flow could leave the canonical executable missing when an update was interrupted. With this change, failed or interrupted installations leave the existing `uv.exe` available.

### Testing

Added a Windows regression test that:

1. Starts a self-update installer.
2. Interrupts it after installation begins.
3. Verifies that the original executable is still present.

The regression test failed against the previous implementation and passes with this change.

Validation completed locally:

```text
cargo test -p uv --lib --features self-update -- --nocapture
# 43 passed

cargo fmt --all --check

cargo clippy -p uv --all-targets --all-features --locked -- -D warnings
```

Not run locally:

* Full workspace and integration test suite.
* A self-update using the real release installer.

These are best covered by CI.
