### PR TITLE
Remove dangling environments for malformed tool receipts

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,7 +133,18 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
+            // If the receipt is missing or malformed, the tool is not installed properly; fall
+            // through to removing the dangling environment.
+            let receipt = match installed_tools.get_tool_receipt(&name) {
+                Ok(receipt) => receipt,
+                Err(err @ uv_tool::Error::ReceiptRead(..)) => {
+                    debug!("Failed to read receipt for `{name}`: {err}");
+                    None
+                }
+                Err(err) => return Err(err.into()),
+            };
+
+            let Some(receipt) = receipt else {
                 // If the tool is not installed properly, attempt to remove the environment anyway.
                 match installed_tools.remove_environment(&name) {
                     Ok(()) => {

--- a/crates/uv/tests/tool/tool_uninstall.rs
+++ b/crates/uv/tests/tool/tool_uninstall.rs
@@ -140,6 +140,41 @@ fn tool_uninstall_missing_receipt() {
 }
 
 #[test]
+fn tool_uninstall_malformed_receipt() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black`
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    fs_err::write(tool_dir.join("black").join("uv-receipt.toml"), "invalid").unwrap();
+
+    uv_snapshot!(context.filters(), context.tool_uninstall().arg("black")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed dangling environment for `black`
+    ");
+
+    // After uninstalling the tool, it shouldn't be listed.
+    uv_snapshot!(context.filters(), context.tool_list()
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    No tools installed
+    ");
+}
+
+#[test]
 fn tool_uninstall_multiple_names_with_missing_receipt() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");


### PR DESCRIPTION
## Summary

`uv tool list` prints a hint telling the user to run `uv tool uninstall <name>` to remove a malformed tool, but that command failed with a TOML parse error, so the hint was un-actionable.

`do_uninstall` handles receipts asymmetrically. The uninstall-all path iterates `tools()`, which returns a per-tool `Result`, and its fallback removes the dangling environment for both missing and unparseable receipts. The named path used `get_tool_receipt`, which maps only `Io(NotFound)` to `Ok(None)` and propagates everything else, so a `ReceiptRead` error aborted before the same fallback could run.

This treats an unparseable receipt like a missing one in the named path, matching the uninstall-all behavior and the dangling-receipt handling added in #19623. The leniency is scoped to the call site rather than `get_tool_receipt` itself, since `upgrade`, `install`, and `run` should still fail loudly on a corrupt receipt rather than silently treat the tool as absent.

One consequence worth flagging: entrypoints are not removed, because their paths live in the receipt that cannot be parsed. That matches the existing missing-receipt and `--all` behavior.

Note that @koriyoshi2041 proposed the same fix in #19686 back in June, and got there first. That PR now conflicts with `main`, and the test file it modifies has since moved from `crates/uv/tests/it/` to `crates/uv/tests/tool/`. This is written against the current tree, but I am happy for theirs to land instead if they would like to rebase it. :)

Refs https://github.com/astral-sh/uv/issues/19630.

## Test Plan

Added `tool_uninstall_malformed_receipt` to `crates/uv/tests/tool/tool_uninstall.rs`, next to the existing `tool_uninstall_missing_receipt` and structured the same way. Verified it fails without the source change (exit code 2, `TOML parse error at line 1, column 8`) and passes with it.

`cargo test --package uv --test tool -- tool_uninstall tool_list` passes 24 tests. `cargo clippy -p uv -p uv-tool --all-targets` reports no warnings, and `cargo fmt --check` is clean now.
