### PR TITLE
docs: clarify workspace roots without projects

### DIFF
--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -48,10 +48,9 @@ contain a `pyproject.toml` file. However, workspace members can be _either_
 [applications](./init.md#applications) or [libraries](./init.md#libraries); both are supported in
 the workspace context.
 
-A workspace always has a root directory. If the root contains a `[project]` table, the root package is
-automatically a workspace member. In the above example, `albatross`
-is the workspace root, and the workspace members include all projects under the `packages`
-directory, except `seeds`.
+A workspace always has a root directory. If the root contains a `[project]` table, the root package
+is automatically a workspace member. In the above example, `albatross` is the workspace root, and
+the workspace members include all projects under the `packages` directory, except `seeds`.
 
 A workspace root does not need to be a project itself. For example, the root `pyproject.toml` can
 contain only the workspace configuration:

--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -48,9 +48,16 @@ contain a `pyproject.toml` file. However, workspace members can be _either_
 [applications](./init.md#applications) or [libraries](./init.md#libraries); both are supported in
 the workspace context.
 
-Every workspace needs a root, which is _also_ a workspace member. In the above example, `albatross`
+A workspace always has a root directory. If the root contains a ``[project]`` table, the root package is automatically a workspace member. In the above example, `albatross`
 is the workspace root, and the workspace members include all projects under the `packages`
 directory, except `seeds`.
+
+A workspace root does not need to be a project itself. For example, the root ``pyproject.toml`` can contain only the workspace configuration:
+
+```toml
+[tool.uv.workspace]
+members = ["packages/*"]
+```
 
 By default, `uv run` and `uv sync` operates on the workspace root. For example, in the above
 example, `uv run` and `uv run --package albatross` would be equivalent, while

--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -48,11 +48,13 @@ contain a `pyproject.toml` file. However, workspace members can be _either_
 [applications](./init.md#applications) or [libraries](./init.md#libraries); both are supported in
 the workspace context.
 
-A workspace always has a root directory. If the root contains a ``[project]`` table, the root package is automatically a workspace member. In the above example, `albatross`
+A workspace always has a root directory. If the root contains a `[project]` table, the root package is
+automatically a workspace member. In the above example, `albatross`
 is the workspace root, and the workspace members include all projects under the `packages`
 directory, except `seeds`.
 
-A workspace root does not need to be a project itself. For example, the root ``pyproject.toml`` can contain only the workspace configuration:
+A workspace root does not need to be a project itself. For example, the root `pyproject.toml` can
+contain only the workspace configuration:
 
 ```toml
 [tool.uv.workspace]


### PR DESCRIPTION
Fixes #20421.

Clarify that a workspace root may omit a `[project]` table, explain when the root package is a workspace member, and add a minimal virtual workspace example.