### PR TITLE
docs: show how to exclude multiple packages from pip freeze

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2528,8 +2528,8 @@ pub struct PipFreezeArgs {
     pub exclude_editable: bool,
 
     /// Exclude the specified package(s) from the output.
-///
-/// May be provided multiple times, e.g., `uv pip freeze --exclude pip --exclude setuptools`.
+    ///
+    /// May be provided multiple times, e.g., `uv pip freeze --exclude pip --exclude setuptools`.
     #[arg(long)]
     pub r#exclude: Vec<PackageName>,
 
@@ -2601,8 +2601,8 @@ pub struct PipListArgs {
     pub exclude_editable: bool,
 
     /// Exclude the specified package(s) from the output.
-///
-/// May be provided multiple times, e.g., `uv pip freeze --exclude pip --exclude setuptools`.
+    ///
+    /// May be provided multiple times, e.g., `uv pip freeze --exclude pip --exclude setuptools`.
     #[arg(long, value_hint = ValueHint::Other)]
     pub r#exclude: Vec<PackageName>,
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2528,6 +2528,8 @@ pub struct PipFreezeArgs {
     pub exclude_editable: bool,
 
     /// Exclude the specified package(s) from the output.
+///
+/// May be provided multiple times, e.g., `uv pip freeze --exclude pip --exclude setuptools`.
     #[arg(long)]
     pub r#exclude: Vec<PackageName>,
 
@@ -2599,6 +2601,8 @@ pub struct PipListArgs {
     pub exclude_editable: bool,
 
     /// Exclude the specified package(s) from the output.
+///
+/// May be provided multiple times, e.g., `uv pip freeze --exclude pip --exclude setuptools`.
     #[arg(long, value_hint = ValueHint::Other)]
     pub r#exclude: Vec<PackageName>,
 


### PR DESCRIPTION
Fixes #18429

The `--exclude` option already accepts repeated values, but the generated help only describes the option in the singular. This adds a concrete command example so users can see how to omit multiple packages from `uv pip freeze`.