### PR TITLE
Hashes in build constraints  disable uv build backend fast path

### DIFF
--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -24,7 +24,7 @@ use uv_distribution_filename::{
 };
 use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations,
-    PackageConfigSettings, Requirement, SourceDist,
+    PackageConfigSettings, Requirement, RequirementSource, SourceDist,
 };
 use uv_errors::{ErrorOptions, Hint, Hints, write_error_chain_with_options};
 use uv_fs::{Simplified, normalize_path, relative_to};
@@ -631,6 +631,10 @@ async fn build_package(
     // Read build constraints.
     let build_constraints =
         operations::read_constraints(build_constraints, &client_builder).await?;
+    let has_backend_build_constraint_hashes = hash_checking.is_some()
+        && build_constraints.iter().any(|constraint| {
+            constraint.requirement.name.as_str() == "uv-build" && !constraint.hashes.is_empty()
+        });
 
     // Collect the set of required hashes.
     let hasher = if let Some(hash_checking) = hash_checking {
@@ -652,9 +656,17 @@ async fn build_package(
             .map(|constraint| constraint.requirement)
             .chain(build_constraints_from_workspace.iter().cloned()),
     );
-    let has_backend_build_constraints = build_constraints
-        .requirements()
-        .any(|requirement| requirement.name.as_str() == "uv-build");
+    let has_incompatible_backend_build_constraints =
+        build_constraints.requirements().any(|requirement| {
+            requirement.name.as_str() == "uv-build"
+                && match &requirement.source {
+                    RequirementSource::Registry { specifier, .. } => {
+                        Version::from_str(uv_version::version())
+                            .is_ok_and(|version| !specifier.contains(&version))
+                    }
+                    _ => true,
+                }
+        });
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder.clone(), cache.clone())
@@ -750,9 +762,15 @@ async fn build_package(
             source.path().user_display()
         );
         BuildAction::Pep517
-    } else if has_backend_build_constraints {
+    } else if has_backend_build_constraint_hashes {
         debug!(
-            "Not using `uv_build` direct build for `{}` because `uv_build` has build constraints",
+            "Not using `uv_build` direct build for `{}` because `uv_build` has build constraint hashes",
+            source.path().user_display()
+        );
+        BuildAction::Pep517
+    } else if has_incompatible_backend_build_constraints {
+        debug!(
+            "Not using `uv_build` direct build for `{}` because `uv_build` has incompatible build constraints",
             source.path().user_display()
         );
         BuildAction::Pep517

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -656,17 +656,6 @@ async fn build_package(
             .map(|constraint| constraint.requirement)
             .chain(build_constraints_from_workspace.iter().cloned()),
     );
-    let has_incompatible_backend_build_constraints =
-        build_constraints.requirements().any(|requirement| {
-            requirement.name.as_str() == "uv-build"
-                && match &requirement.source {
-                    RequirementSource::Registry { specifier, .. } => {
-                        Version::from_str(uv_version::version())
-                            .is_ok_and(|version| !specifier.contains(&version))
-                    }
-                    _ => true,
-                }
-        });
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder.clone(), cache.clone())
@@ -765,12 +754,6 @@ async fn build_package(
     } else if has_backend_build_constraint_hashes {
         debug!(
             "Not using `uv_build` direct build for `{}` because `uv_build` has build constraint hashes",
-            source.path().user_display()
-        );
-        BuildAction::Pep517
-    } else if has_incompatible_backend_build_constraints {
-        debug!(
-            "Not using `uv_build` direct build for `{}` because `uv_build` has incompatible build constraints",
             source.path().user_display()
         );
         BuildAction::Pep517

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -652,6 +652,9 @@ async fn build_package(
             .map(|constraint| constraint.requirement)
             .chain(build_constraints_from_workspace.iter().cloned()),
     );
+    let has_backend_build_constraints = build_constraints
+        .requirements()
+        .any(|requirement| requirement.name.as_str() == "uv-build");
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder.clone(), cache.clone())
@@ -740,6 +743,18 @@ async fn build_package(
 
         BuildAction::List
     } else if force_pep517 {
+        BuildAction::Pep517
+    } else if hash_checking.is_some_and(|mode| mode.is_require()) {
+        debug!(
+            "Not using `uv_build` direct build for `{}` because hashes are required",
+            source.path().user_display()
+        );
+        BuildAction::Pep517
+    } else if has_backend_build_constraints {
+        debug!(
+            "Not using `uv_build` direct build for `{}` because `uv_build` has build constraints",
+            source.path().user_display()
+        );
         BuildAction::Pep517
     } else {
         match check_direct_build(source.path(), uv_version::version()) {

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -24,7 +24,7 @@ use uv_distribution_filename::{
 };
 use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations,
-    PackageConfigSettings, Requirement, RequirementSource, SourceDist,
+    PackageConfigSettings, Requirement, SourceDist,
 };
 use uv_errors::{ErrorOptions, Hint, Hints, write_error_chain_with_options};
 use uv_fs::{Simplified, normalize_path, relative_to};

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -612,17 +612,6 @@ async fn build_package(
             .map(|constraint| constraint.requirement)
             .chain(build_constraints_from_workspace.iter().cloned()),
     );
-    let has_incompatible_backend_build_constraints =
-        build_constraints.requirements().any(|requirement| {
-            requirement.name.as_str() == "uv-build"
-                && match &requirement.source {
-                    RequirementSource::Registry { specifier, .. } => {
-                        Version::from_str(uv_version::version())
-                            .is_ok_and(|version| !specifier.contains(&version))
-                    }
-                    _ => true,
-                }
-        });
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder.clone(), cache.clone())
@@ -721,12 +710,6 @@ async fn build_package(
     } else if has_backend_build_constraint_hashes {
         debug!(
             "Not using `uv_build` direct build for `{}` because `uv_build` has build constraint hashes",
-            source.path().user_display()
-        );
-        BuildAction::Pep517
-    } else if has_incompatible_backend_build_constraints {
-        debug!(
-            "Not using `uv_build` direct build for `{}` because `uv_build` has incompatible build constraints",
             source.path().user_display()
         );
         BuildAction::Pep517

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -24,7 +24,7 @@ use uv_distribution_filename::{
 };
 use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations,
-    PackageConfigSettings, Requirement, SourceDist,
+    PackageConfigSettings, Requirement, RequirementSource, SourceDist,
 };
 use uv_errors::{ErrorOptions, Hint, Hints, write_error_chain_with_options};
 use uv_fs::{Simplified, normalize_path, relative_to};
@@ -587,6 +587,10 @@ async fn build_package(
     // Read build constraints.
     let build_constraints =
         operations::read_constraints(build_constraints, &client_builder).await?;
+    let has_backend_build_constraint_hashes = hash_checking.is_some()
+        && build_constraints.iter().any(|constraint| {
+            constraint.requirement.name.as_str() == "uv-build" && !constraint.hashes.is_empty()
+        });
 
     // Collect the set of required hashes.
     let hasher = if let Some(hash_checking) = hash_checking {
@@ -608,9 +612,17 @@ async fn build_package(
             .map(|constraint| constraint.requirement)
             .chain(build_constraints_from_workspace.iter().cloned()),
     );
-    let has_backend_build_constraints = build_constraints
-        .requirements()
-        .any(|requirement| requirement.name.as_str() == "uv-build");
+    let has_incompatible_backend_build_constraints =
+        build_constraints.requirements().any(|requirement| {
+            requirement.name.as_str() == "uv-build"
+                && match &requirement.source {
+                    RequirementSource::Registry { specifier, .. } => {
+                        Version::from_str(uv_version::version())
+                            .is_ok_and(|version| !specifier.contains(&version))
+                    }
+                    _ => true,
+                }
+        });
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder.clone(), cache.clone())
@@ -706,9 +718,15 @@ async fn build_package(
             source.path().user_display()
         );
         BuildAction::Pep517
-    } else if has_backend_build_constraints {
+    } else if has_backend_build_constraint_hashes {
         debug!(
-            "Not using `uv_build` direct build for `{}` because `uv_build` has build constraints",
+            "Not using `uv_build` direct build for `{}` because `uv_build` has build constraint hashes",
+            source.path().user_display()
+        );
+        BuildAction::Pep517
+    } else if has_incompatible_backend_build_constraints {
+        debug!(
+            "Not using `uv_build` direct build for `{}` because `uv_build` has incompatible build constraints",
             source.path().user_display()
         );
         BuildAction::Pep517

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -608,6 +608,9 @@ async fn build_package(
             .map(|constraint| constraint.requirement)
             .chain(build_constraints_from_workspace.iter().cloned()),
     );
+    let has_backend_build_constraints = build_constraints
+        .requirements()
+        .any(|requirement| requirement.name.as_str() == "uv-build");
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder.clone(), cache.clone())
@@ -696,6 +699,18 @@ async fn build_package(
 
         BuildAction::List
     } else if force_pep517 {
+        BuildAction::Pep517
+    } else if hash_checking.is_some_and(|mode| mode.is_require()) {
+        debug!(
+            "Not using `uv_build` direct build for `{}` because hashes are required",
+            source.path().user_display()
+        );
+        BuildAction::Pep517
+    } else if has_backend_build_constraints {
+        debug!(
+            "Not using `uv_build` direct build for `{}` because `uv_build` has build constraints",
+            source.path().user_display()
+        );
         BuildAction::Pep517
     } else {
         match check_direct_build(source.path(), uv_version::version()) {

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2190,6 +2190,101 @@ fn build_fast_path_verbose() -> Result<()> {
     Ok(())
 }
 
+/// Backend constraints must be enforced even when the bundled backend version is compatible.
+#[test]
+fn build_fast_path_backend_build_constraints() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2026-08-01T00:00:00Z");
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([
+            (r"uv-build==\d+\.\d+\.\d+", "uv-build==[VERSION]"),
+            (r"sha256:[a-f0-9]{64}", "sha256:[HASH]"),
+        ])
+        .collect::<Vec<_>>();
+    let project = context.temp_dir.child("project");
+    let uv_version = uv_version::version();
+
+    project.child("pyproject.toml").write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["uv_build=={uv_version}"]
+        build-backend = "uv_build"
+    "#})?;
+    project.child("src/project/__init__.py").touch()?;
+    project.child("constraints.txt").write_str(&formatdoc! {r"
+        uv_build=={uv_version} \
+            --hash=sha256:0000000000000000000000000000000000000000000000000000000000000000
+    "})?;
+
+    uv_snapshot!(&filters, context.build().arg("--wheel").arg("--build-constraint").arg("constraints.txt").current_dir(&project), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Building wheel...
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to install requirements from `build-system.requires`
+      Caused by: Failed to download `uv-build==[VERSION]`
+      Caused by: Hash mismatch for `uv-build==[VERSION]`
+
+        Expected:
+          sha256:[HASH]
+
+        Computed:
+          sha256:[HASH]
+    ");
+
+    project
+        .child("dist/project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::missing());
+
+    Ok(())
+}
+
+/// Required hashes cannot be checked against the bundled backend.
+#[test]
+fn build_fast_path_require_hashes() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2026-08-01T00:00:00Z");
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([(r"uv-build==\d+\.\d+\.\d+", "uv-build==[VERSION]")])
+        .collect::<Vec<_>>();
+    let project = context.temp_dir.child("project");
+    let uv_version = uv_version::version();
+
+    project.child("pyproject.toml").write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["uv_build=={uv_version}"]
+        build-backend = "uv_build"
+    "#})?;
+    project.child("src/project/__init__.py").touch()?;
+
+    uv_snapshot!(&filters, context.build().arg("--wheel").arg("--require-hashes").current_dir(&project), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Building wheel...
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to resolve requirements from `build-system.requires`
+      Caused by: No solution found when resolving: `uv-build==[VERSION]`
+      Caused by: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `uv-build`
+    ");
+
+    project
+        .child("dist/project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::missing());
+
+    Ok(())
+}
+
 /// Reject path-shaped script entry point names before writing wheel metadata.
 #[test]
 fn build_unsafe_script_entry_point_name() -> Result<()> {

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2209,21 +2209,20 @@ fn build_fast_path_backend_build_constraints() -> Result<()> {
         ])
         .collect::<Vec<_>>();
     let project = context.temp_dir.child("project");
-    let uv_version = uv_version::version();
 
-    project.child("pyproject.toml").write_str(&formatdoc! {r#"
+    project.child("pyproject.toml").write_str(indoc! {r#"
         [project]
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
 
         [build-system]
-        requires = ["uv_build=={uv_version}"]
+        requires = ["uv_build>=0.5.15,<10000"]
         build-backend = "uv_build"
     "#})?;
     project.child("src/project/__init__.py").touch()?;
-    project.child("constraints.txt").write_str(&formatdoc! {r"
-        uv_build=={uv_version} \
+    project.child("constraints.txt").write_str(indoc! {r"
+        uv_build==0.12.0 \
             --hash=sha256:0000000000000000000000000000000000000000000000000000000000000000
     "})?;
 
@@ -2254,33 +2253,28 @@ fn build_fast_path_backend_build_constraints() -> Result<()> {
 #[test]
 fn build_fast_path_require_hashes() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_exclude_newer("2026-08-01T00:00:00Z");
-    let filters = context
-        .filters()
-        .into_iter()
-        .chain([(r"uv-build==\d+\.\d+\.\d+", "uv-build==[VERSION]")])
-        .collect::<Vec<_>>();
+    let filters = context.filters();
     let project = context.temp_dir.child("project");
-    let uv_version = uv_version::version();
 
-    project.child("pyproject.toml").write_str(&formatdoc! {r#"
+    project.child("pyproject.toml").write_str(indoc! {r#"
         [project]
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
 
         [build-system]
-        requires = ["uv_build=={uv_version}"]
+        requires = ["uv_build>=0.5.15,<10000"]
         build-backend = "uv_build"
     "#})?;
     project.child("src/project/__init__.py").touch()?;
 
-    uv_snapshot!(&filters, context.build().arg("--wheel").arg("--require-hashes").current_dir(&project), @"
+    uv_snapshot!(filters, context.build().arg("--wheel").arg("--require-hashes").current_dir(&project), @"
     exit_code: 2 (failure)
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/project`
       Caused by: Failed to resolve requirements from `build-system.requires`
-      Caused by: No solution found when resolving: `uv-build==[VERSION]`
+      Caused by: No solution found when resolving: `uv-build>=0.5.15, <10000`
       Caused by: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `uv-build`
     ");
 

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2139,7 +2139,8 @@ fn build_fast_path_unbounded_backend() -> Result<()> {
     Ok(())
 }
 
-/// Only mention the bundled build backend when verbose logging is enabled.
+/// Only mention the bundled build backend when verbose logging is enabled, including when the
+/// bundled version satisfies build constraints.
 #[test]
 fn build_fast_path_verbose() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2156,11 +2157,16 @@ fn build_fast_path_verbose() -> Result<()> {
         build-backend = "uv_build"
     "#})?;
     project.child("src/project/__init__.py").touch()?;
+    project
+        .child("constraints.txt")
+        .write_str(&format!("uv_build=={}", uv_version::version()))?;
 
     let output = context
         .build()
         .arg("project")
         .arg("--sdist")
+        .arg("--build-constraint")
+        .arg(project.child("constraints.txt").path())
         .arg("--verbose")
         .env_remove(EnvVars::RUST_LOG)
         .output()?;

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2234,6 +2234,101 @@ fn build_fast_path_verbose() -> Result<()> {
     Ok(())
 }
 
+/// Backend constraints must be enforced even when the bundled backend version is compatible.
+#[test]
+fn build_fast_path_backend_build_constraints() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2026-08-01T00:00:00Z");
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([
+            (r"uv-build==\d+\.\d+\.\d+", "uv-build==[VERSION]"),
+            (r"sha256:[a-f0-9]{64}", "sha256:[HASH]"),
+        ])
+        .collect::<Vec<_>>();
+    let project = context.temp_dir.child("project");
+    let uv_version = uv_version::version();
+
+    project.child("pyproject.toml").write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["uv_build=={uv_version}"]
+        build-backend = "uv_build"
+    "#})?;
+    project.child("src/project/__init__.py").touch()?;
+    project.child("constraints.txt").write_str(&formatdoc! {r"
+        uv_build=={uv_version} \
+            --hash=sha256:0000000000000000000000000000000000000000000000000000000000000000
+    "})?;
+
+    uv_snapshot!(&filters, context.build().arg("--wheel").arg("--build-constraint").arg("constraints.txt").current_dir(&project), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Building wheel...
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to install requirements from `build-system.requires`
+      Caused by: Failed to download `uv-build==[VERSION]`
+      Caused by: Hash mismatch for `uv-build==[VERSION]`
+
+        Expected:
+          sha256:[HASH]
+
+        Computed:
+          sha256:[HASH]
+    ");
+
+    project
+        .child("dist/project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::missing());
+
+    Ok(())
+}
+
+/// Required hashes cannot be checked against the bundled backend.
+#[test]
+fn build_fast_path_require_hashes() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2026-08-01T00:00:00Z");
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([(r"uv-build==\d+\.\d+\.\d+", "uv-build==[VERSION]")])
+        .collect::<Vec<_>>();
+    let project = context.temp_dir.child("project");
+    let uv_version = uv_version::version();
+
+    project.child("pyproject.toml").write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["uv_build=={uv_version}"]
+        build-backend = "uv_build"
+    "#})?;
+    project.child("src/project/__init__.py").touch()?;
+
+    uv_snapshot!(&filters, context.build().arg("--wheel").arg("--require-hashes").current_dir(&project), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Building wheel...
+    error: Failed to build `[TEMP_DIR]/project`
+      Caused by: Failed to resolve requirements from `build-system.requires`
+      Caused by: No solution found when resolving: `uv-build==[VERSION]`
+      Caused by: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `uv-build`
+    ");
+
+    project
+        .child("dist/project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::missing());
+
+    Ok(())
+}
+
 /// Reject path-shaped script entry point names before writing wheel metadata.
 #[test]
 fn build_unsafe_script_entry_point_name() -> Result<()> {

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2183,7 +2183,8 @@ fn build_fast_path() -> Result<()> {
     Ok(())
 }
 
-/// Only mention the bundled build backend when verbose logging is enabled.
+/// Only mention the bundled build backend when verbose logging is enabled, including when the
+/// bundled version satisfies build constraints.
 #[test]
 fn build_fast_path_verbose() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2200,11 +2201,16 @@ fn build_fast_path_verbose() -> Result<()> {
         build-backend = "uv_build"
     "#})?;
     project.child("src/project/__init__.py").touch()?;
+    project
+        .child("constraints.txt")
+        .write_str(&format!("uv_build=={}", uv_version::version()))?;
 
     let output = context
         .build()
         .arg("project")
         .arg("--sdist")
+        .arg("--build-constraint")
+        .arg(project.child("constraints.txt").path())
         .arg("--verbose")
         .env_remove(EnvVars::RUST_LOG)
         .output()?;


### PR DESCRIPTION
Usually, we fast-path with the uv build backend when we now the version is configuration-compatible, unless `--force-pep517` is passed. We now also disable this behavior when explicit build constraints are passed or when hashes are required. to honor the explicit user preference.