### PR TITLE
fix ost-simple-sts.json

### DIFF
--- a/.github/ost-simple-sts.json
+++ b/.github/ost-simple-sts.json
@@ -114,7 +114,8 @@
       "reusable_workflow": "rebase-conflicted-pull-request.yml",
       "on": ["push", "workflow_dispatch"],
       "permissions": { "contents": "write", "workflows": "write" },
-      "targets": ["uv", "uv-dev"]
+      "targets": ["uv", "uv-dev"],
+      "installation": "automations"
     },
     {
       "caller": "uv-dev",


### PR DESCRIPTION
Change in #20861 introduced multi-repo sts policy for rebase-conflicted-pull-request.yml, but did not add the required "installations" key, which led to an invalid policy file and failure to fetch tokens.