### PR TITLE
docs: fix --python-pin flag typo in uv init example (should be --pin-python)

### DIFF
--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -344,5 +344,5 @@ cases uv will still configure a build system but will not create the expected fi
 When `--bare` is used, additional features can still be used opt-in:
 
 ```console
-$ uv init example-bare --bare --description "Hello world" --author-from git --vcs git --python-pin
+$ uv init example-bare --bare --description "Hello world" --author-from git --vcs git --pin-python
 ```


### PR DESCRIPTION
The `--bare` opt-in example in `docs/concepts/projects/init.md` passes `--python-pin`:

```
uv init example-bare --bare --description "Hello world" --author-from git --vcs git --python-pin
```

But `--python-pin` is not a valid flag. The argument is `--pin-python` (`pin_python` in `crates/uv-cli/src/lib.rs`, with its `--no-pin-python` counterpart); `--python-pin` appears nowhere in the CLI definition, so `clap` rejects it with `unexpected argument --python-pin found`.

In context, every other flag on that line re-enables a feature `--bare` disables (`--description`, `--author-from`, `--vcs`); the flag that re-enables the pinned `.python-version` file is `--pin-python`. This corrects the transposed token.

Docs-only, no functional change.
