### PR TITLE
Avoid flattened wheel-source deserialization

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -6196,8 +6196,9 @@ impl Wheel {
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct WheelWire {
-    #[serde(flatten)]
-    url: WheelWireSource,
+    url: Option<UrlString>,
+    path: Option<Box<Path>>,
+    filename: Option<WheelFilename>,
     /// A hash of the built distribution.
     ///
     /// This is only present for wheels that come from registries and direct
@@ -6248,7 +6249,17 @@ impl TryFrom<WheelWire> for Wheel {
     type Error = String;
 
     fn try_from(wire: WheelWire) -> Result<Self, String> {
-        let filename = match &wire.url {
+        let source = if let Some(url) = wire.url {
+            WheelWireSource::Url { url }
+        } else if let Some(path) = wire.path {
+            WheelWireSource::Path { path }
+        } else if let Some(filename) = wire.filename {
+            WheelWireSource::Filename { filename }
+        } else {
+            return Err("wheel has no URL, path, or filename".to_string());
+        };
+
+        let filename = match &source {
             WheelWireSource::Url { url } => {
                 let filename = url.filename().map_err(|err| err.to_string())?;
                 filename.parse::<WheelFilename>().map_err(|err| {
@@ -6270,7 +6281,7 @@ impl TryFrom<WheelWire> for Wheel {
         };
 
         Ok(Self {
-            url: wire.url,
+            url: source,
             hash: wire.hash,
             size: wire.size,
             upload_time: wire.upload_time,
@@ -8312,6 +8323,21 @@ source = { editable = "path/to/a" }
 "#;
         let result = toml::from_str::<Lock>(data);
         insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn wheel_sources_deserialize() {
+        for source in [
+            r#"url = "https://example.com/dependency-1.0.0-py3-none-any.whl""#,
+            r#"path = "dependency-1.0.0-py3-none-any.whl""#,
+            r#"filename = "dependency-1.0.0-py3-none-any.whl""#,
+        ] {
+            let wheel: Wheel = toml::from_str(source).expect("valid wheel source");
+            assert_eq!(
+                wheel.filename.to_string(),
+                "dependency-1.0.0-py3-none-any.whl"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wheel sources in `uv.lock` are deserialized through `#[serde(flatten)]`, which requires Serde to buffer the enclosing map even though a wheel has only three mutually exclusive source forms: URL, local path, or filename.

Deserialize those three fields directly, then construct the existing wheel-source enum after parsing. Preserve filename extraction and validation behavior, and cover all three source representations with a focused wheel-deserialization regression.

## Benchmarks

30 Criterion samples per run, four runs per revision, pinned to one x86-64 core. Times are the median estimates across runs; the baseline is the unchanged `main` revision, and the same temporary allocator-matched harness was used for both revisions.

| Input | Main | Optimized | Result |
| --- | ---: | ---: | ---: |
| packse, 0.13 MB | 0.633 ms | 0.583 ms | 1.09× faster (8.0%) |
| jupyterlab, 0.72 MB | 3.534 ms | 3.279 ms | 1.08× faster (7.2%) |
| transformers, 2.09 MB | 20.846 ms | 20.301 ms | 1.03× faster (2.6%) |
| Three ecosystem lockfiles, total | 25.013 ms | 24.163 ms | 1.04× faster (3.4%) |