### PR TITLE
Avoid flattened source-distribution deserialization

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -5742,33 +5742,32 @@ impl SourceDist {
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
-#[serde(untagged, rename_all = "kebab-case")]
-enum SourceDistWire {
-    Url {
-        url: UrlString,
-        #[serde(flatten)]
-        metadata: SourceDistMetadata,
-    },
-    Path {
-        path: PortablePathBuf,
-        #[serde(flatten)]
-        metadata: SourceDistMetadata,
-    },
-    Metadata {
-        #[serde(flatten)]
-        metadata: SourceDistMetadata,
-    },
+#[serde(rename_all = "kebab-case")]
+struct SourceDistWire {
+    url: Option<UrlString>,
+    path: Option<PortablePathBuf>,
+    hash: Option<Hash>,
+    size: Option<u64>,
+    #[serde(alias = "upload_time")]
+    upload_time: Option<Timestamp>,
 }
 
 impl From<SourceDistWire> for SourceDist {
     fn from(wire: SourceDistWire) -> Self {
-        match wire {
-            SourceDistWire::Url { url, metadata } => Self::Url { url, metadata },
-            SourceDistWire::Path { path, metadata } => Self::Path {
+        let metadata = SourceDistMetadata {
+            hash: wire.hash,
+            size: wire.size,
+            upload_time: wire.upload_time,
+        };
+        if let Some(url) = wire.url {
+            Self::Url { url, metadata }
+        } else if let Some(path) = wire.path {
+            Self::Path {
                 path: path.into(),
                 metadata,
-            },
-            SourceDistWire::Metadata { metadata } => Self::Metadata { metadata },
+            }
+        } else {
+            Self::Metadata { metadata }
         }
     }
 }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -5446,8 +5446,7 @@ enum GitSourceKind {
 }
 
 /// Inspired by: <https://discuss.python.org/t/lock-files-again-but-this-time-w-sdists/46593>
-#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct SourceDistMetadata {
     /// A hash of the source distribution.
     hash: Option<Hash>,
@@ -5456,7 +5455,6 @@ struct SourceDistMetadata {
     /// This is only present for source distributions that come from registries.
     size: Option<u64>,
     /// The upload time of the source distribution.
-    #[serde(alias = "upload_time")]
     upload_time: Option<Timestamp>,
 }
 

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -5464,23 +5464,60 @@ struct SourceDistMetadata {
 /// locked against was found. The location does not need to exist in the
 /// future, so this should be treated as only a hint to where to look
 /// and/or recording where the source dist file originally came from.
-#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
-#[serde(from = "SourceDistWire")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum SourceDist {
     Url {
         url: UrlString,
-        #[serde(flatten)]
         metadata: SourceDistMetadata,
     },
     Path {
         path: Box<Path>,
-        #[serde(flatten)]
         metadata: SourceDistMetadata,
     },
     Metadata {
-        #[serde(flatten)]
         metadata: SourceDistMetadata,
     },
+}
+
+impl<'de> serde::Deserialize<'de> for SourceDist {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        struct Fields {
+            url: Option<UrlString>,
+            path: Option<PortablePathBuf>,
+            hash: Option<Hash>,
+            size: Option<u64>,
+            #[serde(alias = "upload_time")]
+            upload_time: Option<Timestamp>,
+        }
+
+        let Fields {
+            url,
+            path,
+            hash,
+            size,
+            upload_time,
+        } = serde::Deserialize::deserialize(deserializer)?;
+
+        let metadata = SourceDistMetadata {
+            hash,
+            size,
+            upload_time,
+        };
+
+        Ok(match (url, path) {
+            (Some(url), _) => Self::Url { url, metadata },
+            (None, Some(path)) => Self::Path {
+                path: path.into(),
+                metadata,
+            },
+            (None, None) => Self::Metadata { metadata },
+        })
+    }
 }
 
 impl SourceDist {
@@ -5738,37 +5775,6 @@ impl SourceDist {
                 upload_time: None,
             },
         })
-    }
-}
-
-#[derive(Clone, Debug, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct SourceDistWire {
-    url: Option<UrlString>,
-    path: Option<PortablePathBuf>,
-    hash: Option<Hash>,
-    size: Option<u64>,
-    #[serde(alias = "upload_time")]
-    upload_time: Option<Timestamp>,
-}
-
-impl From<SourceDistWire> for SourceDist {
-    fn from(wire: SourceDistWire) -> Self {
-        let metadata = SourceDistMetadata {
-            hash: wire.hash,
-            size: wire.size,
-            upload_time: wire.upload_time,
-        };
-        if let Some(url) = wire.url {
-            Self::Url { url, metadata }
-        } else if let Some(path) = wire.path {
-            Self::Path {
-                path: path.into(),
-                metadata,
-            }
-        } else {
-            Self::Metadata { metadata }
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Source distributions in `uv.lock` are currently decoded through an untagged enum whose URL, local-path, and metadata-only variants each flatten their shared metadata. This makes Serde buffer and replay map fields while trying the available representations.

Deserialize source-distribution locations and metadata directly into one wire struct, then construct the existing URL, path, or metadata-only representation after parsing. Preserve hash, size, and upload-time handling, including the legacy `upload_time` alias.

## Benchmarks

Nine timing samples per lockfile, four interleaved runs per revision, pinned to one x86-64 core. Times are the median estimates across runs; the baseline is unchanged `main`, and the same production-allocator-matched harness was used for both revisions.

| Input | Main | Optimized | Result |
| --- | ---: | ---: | ---: |
| packse | 0.605 ms | 0.590 ms | 2.5% faster |
| jupyterlab | 3.446 ms | 3.342 ms | 3.0% faster |
| transformers | 19.741 ms | 19.419 ms | 1.6% faster |
| warehouse | 2.388 ms | 2.269 ms | 5.0% faster |
| Twelve ecosystem lockfiles, total | 48.307 ms | 47.231 ms | 2.2% faster |
