### PR TITLE
Search a workspace member's own indexes during resolution

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -561,6 +561,18 @@ async fn do_lock(
     let dependency_groups = target.dependency_groups()?;
     let source_trees = vec![];
 
+    // A workspace member's own `tool.uv.index` entries are otherwise only consulted when
+    // looking up a named index for a `tool.uv.sources` pin, or when extracting credentials;
+    // they're never treated as indexes to actually search during resolution, since the
+    // resolver only sees the indexes defined at the workspace root plus the CLI. Extend the
+    // resolved locations with every member's own indexes so `uv add --index` inside a member
+    // isn't a silent no-op.
+    let index_locations =
+        index_locations
+            .clone()
+            .combine(target.indexes().cloned().collect(), Vec::new(), false);
+    let index_locations = &index_locations;
+
     // If necessary, lower the overrides and constraints.
     let requirements = target
         .lower(

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -10973,13 +10973,17 @@ async fn lock_index_workspace_member() -> Result<()> {
         proxy_uri = proxy.uri()
     ))?;
 
-    // Locking without the necessary credentials should fail.
+    // Locking without the necessary credentials should fail. The member's own index is now
+    // consulted (that's the fix), so the failure comes from a 401 against it rather than the
+    // index being silently skipped.
     uv_snapshot!(context.filters(), context.lock(), @"
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because iniconfig was not found in the package registry and child depends on iniconfig>=2, we can conclude that child's requirements are unsatisfiable.
           And because your workspace requires child, we can conclude that your workspace's requirements are unsatisfiable.
+
+    hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
     ");
 
     uv_snapshot!(context.filters(), context.lock()

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -11057,6 +11057,72 @@ async fn lock_index_workspace_member() -> Result<()> {
     Ok(())
 }
 
+/// Lock a workspace in which a member defines an extra index that isn't referenced by name from
+/// `tool.uv.sources`. The index still needs to be searched during resolution, not just kept around
+/// for named lookups and credential extraction.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_index_workspace_member_without_source_pin() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    // The root defines an unreachable default index, so the lock can only succeed if the
+    // member's own index is actually searched.
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child"]
+
+        [tool.uv.workspace]
+        members = ["child"]
+
+        [tool.uv.sources]
+        child = { workspace = true }
+
+        [[tool.uv.index]]
+        url = "https://index.invalid/simple"
+        default = true
+        "#,
+    )?;
+
+    let child = context.temp_dir.child("child");
+    fs_err::create_dir_all(&child)?;
+
+    let pyproject_toml = child.child("pyproject.toml");
+    pyproject_toml.write_str(&format!(
+        r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig>=2"]
+
+        [[tool.uv.index]]
+        name = "my-index"
+        url = "{proxy_uri}/basic-auth/simple"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+        "#,
+        proxy_uri = proxy.uri()
+    ))?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .env(EnvVars::UV_INDEX_MY_INDEX_USERNAME, "public")
+        .env(EnvVars::UV_INDEX_MY_INDEX_PASSWORD, "heron"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Ensure that development dependencies are omitted for non-workspace members. Below, `bar` depends
 /// on `foo`, but `bar/uv.lock` should omit `anyio`, but should include `typing-extensions`.
 #[cfg(feature = "test-universal")]


### PR DESCRIPTION
## Summary

Closes #20678.

`uv add --index` inside a workspace member writes the index into that member's own `pyproject.toml`. But the resolver's actual index locations only ever come from the workspace root's `[[tool.uv.index]]` entries plus the CLI (`Workspace::indexes()` is documented as "the index table from the workspace pyproject.toml", root only). The member's index stays readable for two narrower things, a named `tool.uv.sources` lookup and credential extraction, but it never gets added to the set of indexes actually searched for candidates. Outside the one case the issue calls out (a single named index gets pinned via `tool.uv.sources`, so it happens to work through that narrower path), the member's index is a silent no-op.

Fix extends the resolved `IndexLocations` in `do_lock` with every workspace member's own indexes, reusing `LockTarget::indexes()`, which already walks root plus all members correctly for the credentials-only case. Covers both `uv lock` and `uv sync`, since sync goes through the same `do_lock` via `LockOperation`.

## Test Plan

Read through `Workspace::indexes()` and its three call sites first to find the actual root cause, then confirmed it empirically before writing any fix: in a `python:3.12-slim` container, installed the published `uv` 0.12.1, set an unreachable index as the workspace root's default and a real one only in a member's `pyproject.toml`, ran `uv lock`, and watched it request only the bogus root index and never touch the member's.

Added `lock_index_workspace_member_without_source_pin` next to the existing `lock_index_workspace_member` test, same `pypi_proxy` setup but without the `tool.uv.sources` pin, so it exercises the "just search this index" path instead of the named-lookup path. Confirmed it fails without the fix (same symptom as the manual repro above) and passes with it, by stashing just the source change and rerunning.

`cargo check`, `cargo fmt`, and `cargo clippy --tests -D warnings` all clean.
