### PR TITLE
Reuse source distribution file metadata

### DIFF
--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -470,7 +470,7 @@ impl<W: Write + Unpin + Send> DirectoryWriter for TarGzWriter<W> {
         #[cfg(unix)]
         let executable_bit = {
             use std::os::unix::fs::PermissionsExt;
-            file.metadata()?.permissions().mode() & 0o111 != 0
+            metadata.permissions().mode() & 0o111 != 0
         };
         // Windows has no executable bit
         #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

When building source distributions on Unix, we already retrieve each file's metadata to populate its tar header, but separately query the same metadata to read its executable bits.

Reuse the existing metadata for the executable-bit check, eliminating one filesystem metadata lookup per included file without changing archive permissions.
