### PR TITLE
Avoid metadata lookups during bytecode compilation

### DIFF
--- a/crates/uv-installer/src/compile.rs
+++ b/crates/uv-installer/src/compile.rs
@@ -209,23 +209,21 @@ pub async fn compile_tree(
         // Otherwise we stumble over temporary files from `compileall`.
         .filter_entry(|dir| dir.file_name() != "__pycache__");
     for entry in walker {
-        // Retrieve the entry and its metadata, with shared handling for IO errors
-        let (entry, metadata) =
-            match entry.and_then(|entry| entry.metadata().map(|metadata| (entry, metadata))) {
-                Ok((entry, metadata)) => (entry, metadata),
-                Err(err) => {
-                    if err
-                        .io_error()
-                        .is_some_and(|err| err.kind() == io::ErrorKind::NotFound)
-                    {
-                        // The directory was removed, just ignore it
-                        continue;
-                    }
-                    return Err(err.into());
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                if err
+                    .io_error()
+                    .is_some_and(|err| err.kind() == io::ErrorKind::NotFound)
+                {
+                    // The directory was removed, just ignore it
+                    continue;
                 }
-            };
+                return Err(err.into());
+            }
+        };
         // https://github.com/pypa/pip/blob/3820b0e52c7fed2b2c43ba731b718f316e6816d1/src/pip/_internal/operations/install/wheel.py#L593-L604
-        if metadata.is_file() && entry.path().extension().is_some_and(|ext| ext == "py") {
+        if entry.file_type().is_file() && entry.path().extension().is_some_and(|ext| ext == "py") {
             source_files += 1;
             if let Err(err) = sender.send(entry.path().to_owned()).await {
                 // The workers exited.


### PR DESCRIPTION
## Summary

When discovering Python files for bytecode compilation, we currently retrieve filesystem metadata for every directory entry even though we only use it to determine whether the entry is a regular file.

Use the file type already cached by `WalkDir` instead, avoiding one metadata lookup per visited entry while retaining existing handling for directories removed during traversal.