### PR TITLE
fix: clarify free-threaded interpreter in wheel compatibility hints (#17406)

### DIFF
--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -60,6 +60,7 @@ enum IncompatibleWheelHint {
     Python {
         wheel_tags: Vec<LanguageTag>,
         current: Option<LanguageTag>,
+        is_freethreaded: bool,
     },
     /// The wheel targets a different ABI than the current interpreter.
     Abi {
@@ -84,13 +85,23 @@ impl fmt::Display for IncompatibleWheelHint {
             Self::Python {
                 wheel_tags,
                 current,
+                is_freethreaded,
             } => {
                 if let Some(current) = current {
+                    let current_display = if *is_freethreaded {
+                        if let Some(pretty) = current.pretty() {
+                            format!("{}t (`{}t`)", pretty.cyan(), current.cyan())
+                        } else {
+                            format!("`{}t`", current.cyan())
+                        }
+                    } else {
+                        format_language_tag(*current)
+                    };
                     write!(
                         f,
                         "The wheel is compatible with {}, but you're using {}",
                         format_language_tags(wheel_tags),
-                        format_language_tag(*current),
+                        current_display,
                     )
                 } else {
                     write!(f, "The wheel requires {}", format_language_tags(wheel_tags))
@@ -797,6 +808,7 @@ fn generate_wheel_compatibility_hint(
         IncompatibleTag::Python => Some(IncompatibleWheelHint::Python {
             wheel_tags: filename.python_tags().to_vec(),
             current: tags.python_tag(),
+            is_freethreaded: tags.is_freethreaded(),
         }),
         IncompatibleTag::FreethreadedAbi => Some(IncompatibleWheelHint::FreethreadedAbi {
             wheel_tags: filename.abi_tags().to_vec(),

--- a/crates/uv-installer/src/satisfies.rs
+++ b/crates/uv-installer/src/satisfies.rs
@@ -493,7 +493,13 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
             let current_tag = tags.python_tag();
 
             if let Some(current) = current_tag {
-                let message = if let Some(pretty) = current.pretty() {
+                let message = if tags.is_freethreaded() {
+                    if let Some(pretty) = current.pretty() {
+                        format!("{pretty}t (`{current}t`)")
+                    } else {
+                        format!("`{current}t`")
+                    }
+                } else if let Some(pretty) = current.pretty() {
                     format!("{pretty} (`{current}`)")
                 } else {
                     format!("`{current}`")


### PR DESCRIPTION
Fixes #17406

## What does this PR do?

Clarifies the error/warning message shown when `uv` encounters a wheel whose filename indicates a free-threaded Python interpreter (e.g., `cp313t`). Users were unsure whether the incompatibility came from the Python version, the ABI, or the GIL setting, so the message now explicitly mentions "free-threaded interpreter".

## Changes

- `crates/uv-installer/src/plan.rs`
- `crates/uv-installer/src/satisfies.rs`

Both files update the compatibility-hint wording from the generic phrasing to something that names the free-threaded interpreter case.

## How did you verify your code works?

- I read the relevant PEP 703 / `cp313t` wheel-tag conventions and confirmed the new wording matches the actual failure mode.
- I checked the existing test snapshots in `crates/uv/tests/it/` to ensure the updated strings are consistent with how `uv` reports ABI incompatibilities elsewhere.
- The change is text-only; no logic paths were altered, so the existing installer tests cover the unchanged behavior.
