### PR TITLE
Absorb `Forks` in `ForkedDependencies`

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -940,7 +940,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         version: &'a Version,
         forks: Vec<Fork>,
         request_sink: &'a Sender<Request>,
-        diverging_packages: &'a [PackageName],
+        diverging_packages: &'a BTreeSet<PackageName>,
     ) -> impl Iterator<Item = Result<ForkState, ResolveError>> + 'a {
         debug!(
             "Splitting resolution on {}=={} over {} into {} resolution{} with separate markers",
@@ -1892,7 +1892,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
     }
 
     /// Given a candidate package and version, return its dependencies.
-    #[instrument(skip_all, fields(%package, %version))]
     fn get_dependencies_forking(
         &self,
         id: Id<PubGrubPackage>,
@@ -1904,7 +1903,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         python_requirement: &PythonRequirement,
         pubgrub: &State<UvDependencyProvider>,
     ) -> Result<ForkedDependencies, ResolveError> {
-        let result = self.get_dependencies(
+        let dependencies = self.get_dependencies(
             id,
             package,
             version,
@@ -1913,19 +1912,18 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             env,
             python_requirement,
             pubgrub,
-        );
+        )?;
         if env.marker_environment().is_some() {
-            result.map(|deps| match deps {
-                Dependencies::Available(deps) | Dependencies::Unforkable(deps) => {
-                    ForkedDependencies::Unforked(deps)
-                }
-                Dependencies::RequiresPython(requires_python) => {
-                    ForkedDependencies::RequiresPython(requires_python)
-                }
-                Dependencies::Unavailable(err) => ForkedDependencies::Unavailable(err),
-            })
+            Ok(ForkedDependencies::from_dependencies_platform_specific(
+                dependencies,
+            ))
         } else {
-            Ok(result?.fork(env, python_requirement, &self.conflicts))
+            Ok(ForkedDependencies::from_dependencies_universal(
+                dependencies,
+                env,
+                python_requirement,
+                &self.conflicts,
+            ))
         }
     }
 
@@ -3913,7 +3911,7 @@ enum Dependencies {
     ///
     /// Note that in universal mode, it is possible and allowed for multiple
     /// `PubGrubPackage` values in this list to have the same package name.
-    /// These conflicts are resolved via `Dependencies::fork`.
+    /// These conflicts are resolved via [`ForkedDependencies::from_dependencies_universal`].
     Available(Vec<PubGrubDependency>),
     /// Package metadata has a `Requires-Python` specifier that is incompatible with the target.
     RequiresPython(VersionSpecifiers),
@@ -3923,53 +3921,6 @@ enum Dependencies {
     /// same name and version, but differ according to marker expressions.
     /// But we never want this to result in a fork.
     Unforkable(Vec<PubGrubDependency>),
-}
-
-impl Dependencies {
-    /// Turn this flat list of dependencies into a potential set of forked
-    /// groups of dependencies.
-    ///
-    /// A fork *only* occurs when there are multiple dependencies with the same
-    /// name *and* those dependency specifications have corresponding marker
-    /// expressions that are completely disjoint with one another.
-    fn fork(
-        self,
-        env: &ResolverEnvironment,
-        python_requirement: &PythonRequirement,
-        conflicts: &Conflicts,
-    ) -> ForkedDependencies {
-        let deps = match self {
-            Self::Available(deps) => deps,
-            Self::Unforkable(deps) => return ForkedDependencies::Unforked(deps),
-            Self::RequiresPython(requires_python) => {
-                return ForkedDependencies::RequiresPython(requires_python);
-            }
-            Self::Unavailable(err) => return ForkedDependencies::Unavailable(err),
-        };
-        let mut name_to_deps: BTreeMap<PackageName, Vec<PubGrubDependency>> = BTreeMap::new();
-        for dep in deps {
-            let name = dep
-                .package
-                .name()
-                .expect("dependency always has a name")
-                .clone();
-            name_to_deps.entry(name).or_default().push(dep);
-        }
-        let Forks {
-            mut forks,
-            diverging_packages,
-        } = Forks::new(name_to_deps, env, python_requirement, conflicts);
-        if forks.is_empty() {
-            ForkedDependencies::Unforked(vec![])
-        } else if forks.len() == 1 {
-            ForkedDependencies::Unforked(forks.pop().unwrap().dependencies)
-        } else {
-            ForkedDependencies::Forked {
-                forks,
-                diverging_packages: diverging_packages.into_iter().collect(),
-            }
-        }
-    }
 }
 
 /// Information about the (possibly forked) dependencies for a particular
@@ -3994,31 +3945,79 @@ enum ForkedDependencies {
     Forked {
         forks: Vec<Fork>,
         /// The package(s) with different requirements for disjoint markers.
-        diverging_packages: Vec<PackageName>,
+        diverging_packages: BTreeSet<PackageName>,
     },
     /// Package metadata has a `Requires-Python` specifier that is incompatible with the target.
     RequiresPython(VersionSpecifiers),
 }
 
-/// A list of forks determined from the dependencies of a single package.
-///
-/// Any time a marker expression is seen that is not true for all possible
-/// marker environments, it is possible for it to introduce a new fork.
-#[derive(Debug, Default)]
-struct Forks {
-    /// The forks discovered among the dependencies.
-    forks: Vec<Fork>,
-    /// The package(s) that provoked at least one additional fork.
-    diverging_packages: BTreeSet<PackageName>,
-}
-
-impl Forks {
-    fn new(
-        name_to_deps: BTreeMap<PackageName, Vec<PubGrubDependency>>,
+impl ForkedDependencies {
+    /// Turn a flat list of dependencies into a potential set of forked
+    /// groups of dependencies.
+    ///
+    /// A fork *only* occurs when there are multiple dependencies with the same
+    /// name *and* those dependency specifications have corresponding marker
+    /// expressions that are completely disjoint with one another.
+    fn from_dependencies_universal(
+        dependencies: Dependencies,
         env: &ResolverEnvironment,
         python_requirement: &PythonRequirement,
         conflicts: &Conflicts,
     ) -> Self {
+        let deps = match dependencies {
+            Dependencies::Available(deps) => deps,
+            Dependencies::Unforkable(deps) => return Self::Unforked(deps),
+            Dependencies::RequiresPython(requires_python) => {
+                return Self::RequiresPython(requires_python);
+            }
+            Dependencies::Unavailable(err) => return Self::Unavailable(err),
+        };
+        let mut name_to_deps: BTreeMap<PackageName, Vec<PubGrubDependency>> = BTreeMap::new();
+        for dep in deps {
+            let name = dep
+                .package
+                .name()
+                .expect("dependency always has a name")
+                .clone();
+            name_to_deps.entry(name).or_default().push(dep);
+        }
+        let (mut forks, diverging_packages) =
+            Self::fork(name_to_deps, env, python_requirement, conflicts);
+        if forks.is_empty() {
+            Self::Unforked(vec![])
+        } else if forks.len() == 1 {
+            Self::Unforked(forks.pop().unwrap().dependencies)
+        } else {
+            Self::Forked {
+                forks,
+                diverging_packages,
+            }
+        }
+    }
+
+    /// Noop companion to [`ForkedDependencies::from_dependencies_universal`] for non-universal
+    /// resolutions with a fixed marker environment.
+    fn from_dependencies_platform_specific(dependencies: Dependencies) -> Self {
+        match dependencies {
+            Dependencies::Available(deps) | Dependencies::Unforkable(deps) => Self::Unforked(deps),
+            Dependencies::RequiresPython(requires_python) => Self::RequiresPython(requires_python),
+            Dependencies::Unavailable(err) => Self::Unavailable(err),
+        }
+    }
+
+    /// Build a list of forks determined from the dependencies of a single package.
+    ///
+    /// Any time a marker expression is seen that is not true for all possible
+    /// marker environments, it is possible for it to introduce a new fork.
+    ///
+    /// Returns the forks discovered among the dependencies and the package(s) that
+    /// provoked at least one additional fork.
+    fn fork(
+        name_to_deps: BTreeMap<PackageName, Vec<PubGrubDependency>>,
+        env: &ResolverEnvironment,
+        python_requirement: &PythonRequirement,
+        conflicts: &Conflicts,
+    ) -> (Vec<Fork>, BTreeSet<PackageName>) {
         let python_marker = python_requirement.to_marker_tree();
 
         let mut forks = vec![Fork::new(env.clone())];
@@ -4236,10 +4235,7 @@ impl Forks {
             }
             forks = new;
         }
-        Self {
-            forks,
-            diverging_packages,
-        }
+        (forks, diverging_packages)
     }
 }
 


### PR DESCRIPTION
The `Forks` type wasn't actually used, it's only callsite immediately destructured the result.