### PR TITLE
Verify mold release checksums before installation

### DIFF
--- a/scripts/install-mold.sh
+++ b/scripts/install-mold.sh
@@ -9,7 +9,38 @@ set -euo pipefail
 MOLD_VERSION="${MOLD_VERSION:-2.40.4}"
 
 arch="$(uname -m)"
+
+# Release assets are mutable, so new versions require reviewed SHA-256 digests.
+case "${MOLD_VERSION}:${arch}" in
+    2.40.4:aarch64)
+        checksum="c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37"
+        ;;
+    2.40.4:x86_64)
+        checksum="4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1"
+        ;;
+    *)
+        echo "No trusted mold checksum for version ${MOLD_VERSION} (${arch})" >&2
+        exit 1
+        ;;
+esac
+
 url="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${arch}-linux.tar.gz"
+
+echo "Installing mold ${MOLD_VERSION} (${arch})..."
+
+archive="$(mktemp)"
+trap 'rm -f "$archive"' EXIT
+
+wget -O "$archive" \
+    --timeout=10 \
+    --tries=5 \
+    --waitretry=3 \
+    --retry-connrefused \
+    --retry-on-http-error=429,500,502,503,504 \
+    --progress=dot:mega \
+    "$url"
+
+printf '%s  %s\n' "$checksum" "$archive" | sha256sum -c -
 
 if [ "$(whoami)" = root ]; then
     SUDO=""
@@ -17,17 +48,7 @@ else
     SUDO="sudo"
 fi
 
-echo "Installing mold ${MOLD_VERSION} (${arch})..."
-
-wget -O- \
-    --timeout=10 \
-    --tries=5 \
-    --waitretry=3 \
-    --retry-connrefused \
-    --retry-on-http-error=429,500,502,503,504 \
-    --progress=dot:mega \
-    "$url" \
-    | $SUDO tar -C /usr/local --strip-components=1 --no-overwrite-dir -xzf -
+$SUDO tar -C /usr/local --strip-components=1 --no-overwrite-dir -xzf "$archive"
 
 # Make mold the default linker
 current_ld="$(realpath /usr/bin/ld)"


### PR DESCRIPTION
## Summary

`scripts/install-mold.sh` downloaded mold from a mutable GitHub release and piped the archive directly into `sudo tar`. A replaced release asset could install an attacker-controlled linker before CI builds binaries that later run with cloud and publishing credentials.

Pin reviewed SHA-256 digests for the two architectures used in CI (`aarch64` and `x86_64`), download the archive to a temporary file, and verify it before extraction or privileged execution. Unsupported architectures, unreviewed versions, missing verification, and checksum mismatches now fail closed. Updating mold requires reviewing and updating the pinned digests.

## Test plan (on top of CI)

- Downloaded the `aarch64` and `x86_64` release archives and verified their SHA-256 digests against the pinned values.
- Confirmed valid archives are verified before privileged extraction on both supported CI architectures.
- Reproduced privileged extraction of attacker-controlled bytes with the previous installer and verified the updated installer rejects them before invoking `sudo` or `tar`.
- Confirmed unsupported architectures and unreviewed versions fail before downloading, and missing verification or checksum mismatches fail before privileged execution.
- Ran ShellCheck and `bash -n` against the updated installer.
