### PR TITLE
Cross-link to the resolution docs from sync docs

### DIFF
--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -1,6 +1,6 @@
 # Locking and syncing
 
-Locking is the process of resolving your project's dependencies into a
+Locking is the process of [resolving](../resolution.md) your project's dependencies into a
 [lockfile](./layout.md#the-lockfile). Syncing is the process of installing a subset of packages from
 the lockfile into the [project environment](./layout.md#the-project-environment).
 


### PR DESCRIPTION
## Summary

This is meant to be a pared down version of #18363. The idea is to not reintroduce "universal lockfiles" as a concept in the project-level docs (since they're largely an implementation detail), but to cross-link to the resolution docs so a user _can_ discover them if they desire.

Closes #18029.

## Test Plan

NFC.