### PR TITLE
Make relocatable launchers compatible with BusyBox realpath

### DIFF
--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -125,7 +125,7 @@ fn format_shebang(executable: impl AsRef<Path>, os_name: &str, relocatable: bool
         // (note: the Windows trampoline binaries natively support relative paths to executable)
         if shebang_length > 127 || executable.contains(' ') || relocatable {
             let prefix = if relocatable {
-                r#""$(dirname -- "$(realpath -- "$0")")"/"#
+                r#""$(dirname -- "$(realpath "$0")")"/"#
             } else {
                 ""
             };
@@ -1415,7 +1415,7 @@ mod test {
         let os_name = "posix";
         assert_eq!(
             format_shebang(executable, os_name, true),
-            "#!/bin/sh\n'''exec' \"$(dirname -- \"$(realpath -- \"$0\")\")\"/'python3' \"$0\" \"$@\"\n' '''"
+            "#!/bin/sh\n'''exec' \"$(dirname -- \"$(realpath \"$0\")\")\"/'python3' \"$0\" \"$@\"\n' '''"
         );
 
         // Except on Windows...

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -104,6 +104,8 @@ fn copy_and_hash(reader: &mut impl Read, writer: &mut impl Write) -> io::Result<
     ))
 }
 
+const RELOCATABLE_REALPATH: &str = r#"if _uv_realpath_probe=$(realpath -- / 2>/dev/null) && [ "$_uv_realpath_probe" = / ]; then realpath -- "$0"; else realpath "$0"; fi"#;
+
 /// Format the shebang for a given Python executable.
 ///
 /// Like pip, if a shebang is non-simple (too long or contains spaces), we use `/bin/sh` as the
@@ -125,9 +127,9 @@ fn format_shebang(executable: impl AsRef<Path>, os_name: &str, relocatable: bool
         // (note: the Windows trampoline binaries natively support relative paths to executable)
         if shebang_length > 127 || executable.contains(' ') || relocatable {
             let prefix = if relocatable {
-                r#""$(dirname -- "$(realpath "$0")")"/"#
+                format!(r#""$(dirname -- "$({RELOCATABLE_REALPATH})")"/"#)
             } else {
-                ""
+                String::new()
             };
             let executable = format!(
                 "{}'{}'",
@@ -1221,14 +1223,17 @@ impl RenameOrCopy {
 mod test {
     use std::io::{Cursor, ErrorKind};
     use std::path::Path;
+    #[cfg(unix)]
+    use std::process::Command;
 
     use anyhow::Result;
     use assert_fs::prelude::*;
     use indoc::{formatdoc, indoc};
 
     use super::{
-        Error, RecordEntry, Script, WheelFile, format_shebang, get_script_executable,
-        parse_email_message_file, parse_scripts, read_record, write_installer_metadata,
+        Error, RELOCATABLE_REALPATH, RecordEntry, Script, WheelFile, format_shebang,
+        get_script_executable, parse_email_message_file, parse_scripts, read_record,
+        write_installer_metadata,
     };
 
     #[test]
@@ -1392,6 +1397,117 @@ mod test {
         );
     }
 
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs_err::write(path, contents).unwrap();
+        let mut permissions = fs_err::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs_err::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relocatable_realpath_uses_delimiter_when_supported() {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let bin = temp_dir.child("bin");
+        bin.create_dir_all().unwrap();
+        let log = temp_dir.child("realpath.log");
+        let realpath = bin.child("realpath");
+        write_executable(
+            realpath.path(),
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$UV_REALPATH_LOG"
+if [ "$1" != "--" ]; then
+    echo "missing --" >&2
+    exit 64
+fi
+shift
+for path do
+    case "$path" in
+        /*) printf '%s\n' "$path" ;;
+        *) printf '%s/%s\n' "$PWD" "$path" ;;
+    esac
+done
+"#,
+        );
+        temp_dir.child("-foo").touch().unwrap();
+
+        let output = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(RELOCATABLE_REALPATH)
+            .arg("-foo")
+            .current_dir(temp_dir.path())
+            .env("PATH", bin.path())
+            .env("UV_REALPATH_LOG", log.path())
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert!(output.stderr.is_empty());
+        let expected = fs_err::canonicalize(temp_dir.child("-foo").path()).unwrap();
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            format!("{}\n", expected.display())
+        );
+        assert_eq!(
+            fs_err::read_to_string(log.path()).unwrap(),
+            "-- /\n-- -foo\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relocatable_realpath_falls_back_for_busybox() {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let bin = temp_dir.child("bin");
+        bin.create_dir_all().unwrap();
+        let log = temp_dir.child("realpath.log");
+        let realpath = bin.child("realpath");
+        write_executable(
+            realpath.path(),
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$UV_REALPATH_LOG"
+status=0
+for path do
+    if [ ! -e "$path" ]; then
+        printf 'realpath: %s: No such file or directory\n' "$path" >&2
+        status=1
+        continue
+    fi
+    case "$path" in
+        /*) printf '%s\n' "$path" ;;
+        *) printf '%s/%s\n' "$PWD" "$path" ;;
+    esac
+done
+exit "$status"
+"#,
+        );
+        temp_dir.child("-foo").touch().unwrap();
+        // A status-only probe would misclassify BusyBox if this path happened to exist.
+        temp_dir.child("--").touch().unwrap();
+
+        let output = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(RELOCATABLE_REALPATH)
+            .arg("-foo")
+            .current_dir(temp_dir.path())
+            .env("PATH", bin.path())
+            .env("UV_REALPATH_LOG", log.path())
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert!(output.stderr.is_empty());
+        let expected = fs_err::canonicalize(temp_dir.child("-foo").path()).unwrap();
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            format!("{}\n", expected.display())
+        );
+        assert_eq!(fs_err::read_to_string(log.path()).unwrap(), "-- /\n-foo\n");
+    }
+
     #[test]
     fn test_shebang() {
         // By default, use a simple shebang.
@@ -1415,7 +1531,7 @@ mod test {
         let os_name = "posix";
         assert_eq!(
             format_shebang(executable, os_name, true),
-            "#!/bin/sh\n'''exec' \"$(dirname -- \"$(realpath \"$0\")\")\"/'python3' \"$0\" \"$@\"\n' '''"
+            "#!/bin/sh\n'''exec' \"$(dirname -- \"$(if _uv_realpath_probe=$(realpath -- / 2>/dev/null) && [ \"$_uv_realpath_probe\" = / ]; then realpath -- \"$0\"; else realpath \"$0\"; fi)\")\"/'python3' \"$0\" \"$@\"\n' '''"
         );
 
         // Except on Windows...

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -1230,10 +1230,11 @@ mod test {
     use assert_fs::prelude::*;
     use indoc::{formatdoc, indoc};
 
+    #[cfg(unix)]
+    use super::RELOCATABLE_REALPATH;
     use super::{
-        Error, RELOCATABLE_REALPATH, RecordEntry, Script, WheelFile, format_shebang,
-        get_script_executable, parse_email_message_file, parse_scripts, read_record,
-        write_installer_metadata,
+        Error, RecordEntry, Script, WheelFile, format_shebang, get_script_executable,
+        parse_email_message_file, parse_scripts, read_record, write_installer_metadata,
     };
 
     #[test]

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -482,13 +482,13 @@ pub(crate) fn create(
                 path: location.clone(),
             })?;
         let virtual_env_dir = match (relocatable, name.to_owned()) {
-            (true, "activate") => {
-                Cow::Borrowed(r#"'"$(dirname -- "$(dirname -- "$(realpath "$SCRIPT_PATH")")")"'"#)
-            }
+            (true, "activate") => Cow::Borrowed(
+                r#"'"$(dirname -- "$(dirname -- "$(if _uv_realpath_probe=$(realpath -- / 2>/dev/null) && [ "$_uv_realpath_probe" = / ]; then realpath -- "$SCRIPT_PATH"; else realpath "$SCRIPT_PATH"; fi)")")"'"#,
+            ),
             (true, "activate.bat") => Cow::Borrowed(r"%~dp0.."),
-            (true, "activate.fish") => {
-                Cow::Borrowed(r"'(dirname -- (dirname -- (realpath (status -f))))'")
-            }
+            (true, "activate.fish") => Cow::Borrowed(
+                r#"'(dirname -- (dirname -- (if set -l _uv_realpath_probe (realpath -- / 2>/dev/null); and test (count $_uv_realpath_probe) -eq 1; and test "$_uv_realpath_probe[1]" = /; realpath -- (status -f); else; realpath (status -f); end)))'"#,
+            ),
             (true, "activate.nu") => Cow::Borrowed(r"(path self | path dirname | path dirname)"),
             (false, "activate.nu") => Cow::Owned(format!(
                 "'{}'",

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -482,12 +482,12 @@ pub(crate) fn create(
                 path: location.clone(),
             })?;
         let virtual_env_dir = match (relocatable, name.to_owned()) {
-            (true, "activate") => Cow::Borrowed(
-                r#"'"$(dirname -- "$(dirname -- "$(realpath -- "$SCRIPT_PATH")")")"'"#,
-            ),
+            (true, "activate") => {
+                Cow::Borrowed(r#"'"$(dirname -- "$(dirname -- "$(realpath "$SCRIPT_PATH")")")"'"#)
+            }
             (true, "activate.bat") => Cow::Borrowed(r"%~dp0.."),
             (true, "activate.fish") => {
-                Cow::Borrowed(r"'(dirname -- (dirname -- (realpath -- (status -f))))'")
+                Cow::Borrowed(r"'(dirname -- (dirname -- (realpath (status -f))))'")
             }
             (true, "activate.nu") => Cow::Borrowed(r"(path self | path dirname | path dirname)"),
             (false, "activate.nu") => Cow::Owned(format!(

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -2030,13 +2030,13 @@ enum CopyEntrypointError {
 
 #[cfg(unix)]
 const RELOCATABLE_SHEBANG: &str = r#"#!/bin/sh
-'''exec' "$(dirname -- "$(realpath "$0")")"/'python' "$0" "$@"
+'''exec' "$(dirname -- "$(if _uv_realpath_probe=$(realpath -- / 2>/dev/null) && [ "$_uv_realpath_probe" = / ]; then realpath -- "$0"; else realpath "$0"; fi)")"/'python' "$0" "$@"
 ' '''
 "#;
 
 #[cfg(unix)]
 const RELOCATABLE_PYTHON3_SHEBANG: &str = r#"#!/bin/sh
-'''exec' "$(dirname -- "$(realpath "$0")")"/'python3' "$0" "$@"
+'''exec' "$(dirname -- "$(if _uv_realpath_probe=$(realpath -- / 2>/dev/null) && [ "$_uv_realpath_probe" = / ]; then realpath -- "$0"; else realpath "$0"; fi)")"/'python3' "$0" "$@"
 ' '''
 "#;
 
@@ -2107,7 +2107,7 @@ fn copy_entrypoint(
     }
 
     let Some(contents) = contents
-        // Check for corrected relocatable shebangs.
+        // Check for current relocatable shebangs.
         .strip_prefix(RELOCATABLE_SHEBANG)
         .or_else(|| contents.strip_prefix(RELOCATABLE_PYTHON3_SHEBANG))
         // Keep recognizing launchers generated before BusyBox compatibility was fixed.

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -2017,6 +2017,30 @@ enum CopyEntrypointError {
     Trampoline(#[from] uv_trampoline_builder::Error),
 }
 
+#[cfg(unix)]
+const RELOCATABLE_SHEBANG: &str = r#"#!/bin/sh
+'''exec' "$(dirname -- "$(realpath "$0")")"/'python' "$0" "$@"
+' '''
+"#;
+
+#[cfg(unix)]
+const RELOCATABLE_PYTHON3_SHEBANG: &str = r#"#!/bin/sh
+'''exec' "$(dirname -- "$(realpath "$0")")"/'python3' "$0" "$@"
+' '''
+"#;
+
+#[cfg(unix)]
+const LEGACY_RELOCATABLE_SHEBANG: &str = r#"#!/bin/sh
+'''exec' "$(dirname -- "$(realpath -- "$0")")"/'python' "$0" "$@"
+' '''
+"#;
+
+#[cfg(unix)]
+const LEGACY_RELOCATABLE_PYTHON3_SHEBANG: &str = r#"#!/bin/sh
+'''exec' "$(dirname -- "$(realpath -- "$0")")"/'python3' "$0" "$@"
+' '''
+"#;
+
 /// Create a copy of the entrypoint at `source` at `target`, if it has a Python shebang, replacing
 /// the previous Python executable with a new one.
 ///
@@ -2072,13 +2096,12 @@ fn copy_entrypoint(
     }
 
     let Some(contents) = contents
-        // Check for a relative path or relocatable shebang
-        .strip_prefix(
-            r#"#!/bin/sh
-'''exec' "$(dirname -- "$(realpath -- "$0")")"/'python' "$0" "$@"
-' '''
-"#,
-        )
+        // Check for corrected relocatable shebangs.
+        .strip_prefix(RELOCATABLE_SHEBANG)
+        .or_else(|| contents.strip_prefix(RELOCATABLE_PYTHON3_SHEBANG))
+        // Keep recognizing launchers generated before BusyBox compatibility was fixed.
+        .or_else(|| contents.strip_prefix(LEGACY_RELOCATABLE_SHEBANG))
+        .or_else(|| contents.strip_prefix(LEGACY_RELOCATABLE_PYTHON3_SHEBANG))
         // Or, an absolute path shebang
         .or_else(|| contents.strip_prefix(&format!("#!{}\n", previous_executable.display())))
         // If the previous executable ends with `python3`, check for a shebang with `python` too
@@ -2161,5 +2184,56 @@ impl uv_errors::Hint for RecursionLimitError {
             "uv run".green(),
             "--script".green(),
         ))
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+
+    use super::{
+        LEGACY_RELOCATABLE_PYTHON3_SHEBANG, LEGACY_RELOCATABLE_SHEBANG,
+        RELOCATABLE_PYTHON3_SHEBANG, RELOCATABLE_SHEBANG, copy_entrypoint,
+    };
+
+    fn assert_relocatable_shebang_is_copied(shebang: &str) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source = temp_dir.path().join("source-entrypoint");
+        let target = temp_dir.path().join("target-entrypoint");
+        fs_err::write(&source, format!("{shebang}print('probe')\n")).unwrap();
+
+        let mut permissions = fs_err::metadata(&source).unwrap().permissions();
+        permissions.set_mode(0o751);
+        fs_err::set_permissions(&source, permissions).unwrap();
+
+        copy_entrypoint(
+            &source,
+            &target,
+            Path::new("/old/environment/bin/python3"),
+            Path::new("/new/environment/bin/python"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs_err::read_to_string(&target).unwrap(),
+            "#!/new/environment/bin/python\nprint('probe')\n"
+        );
+        assert_eq!(
+            fs_err::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o751
+        );
+    }
+
+    #[test]
+    fn copy_entrypoint_accepts_current_and_legacy_relocatable_shebangs() {
+        for shebang in [
+            RELOCATABLE_SHEBANG,
+            RELOCATABLE_PYTHON3_SHEBANG,
+            LEGACY_RELOCATABLE_SHEBANG,
+            LEGACY_RELOCATABLE_PYTHON3_SHEBANG,
+        ] {
+            assert_relocatable_shebang_is_copied(shebang);
+        }
     }
 }

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1699,7 +1699,7 @@ fn verify_pyvenv_cfg_relocatable() {
     let activate_sh = scripts.child("activate");
     activate_sh.assert(predicates::path::is_file());
     activate_sh.assert(predicates::str::contains(
-        r#"VIRTUAL_ENV=''"$(dirname -- "$(dirname -- "$(realpath -- "$SCRIPT_PATH")")")"''"#,
+        r#"VIRTUAL_ENV=''"$(dirname -- "$(dirname -- "$(realpath "$SCRIPT_PATH")")")"''"#,
     ));
 
     let activate_bat = scripts.child("activate.bat");
@@ -1711,7 +1711,7 @@ fn verify_pyvenv_cfg_relocatable() {
     let activate_fish = scripts.child("activate.fish");
     activate_fish.assert(predicates::path::is_file());
     activate_fish.assert(predicates::str::contains(
-        r"set -gx VIRTUAL_ENV ''(dirname -- (dirname -- (realpath -- (status -f))))''",
+        r"set -gx VIRTUAL_ENV ''(dirname -- (dirname -- (realpath (status -f))))''",
     ));
     activate_fish.assert(predicates::str::contains(
         "if string match -qr 'CYGWIN|MSYS|MINGW' (uname); and command -s cygpath >/dev/null",

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1699,7 +1699,7 @@ fn verify_pyvenv_cfg_relocatable() {
     let activate_sh = scripts.child("activate");
     activate_sh.assert(predicates::path::is_file());
     activate_sh.assert(predicates::str::contains(
-        r#"VIRTUAL_ENV=''"$(dirname -- "$(dirname -- "$(realpath "$SCRIPT_PATH")")")"''"#,
+        r#"VIRTUAL_ENV=''"$(dirname -- "$(dirname -- "$(if _uv_realpath_probe=$(realpath -- / 2>/dev/null) && [ "$_uv_realpath_probe" = / ]; then realpath -- "$SCRIPT_PATH"; else realpath "$SCRIPT_PATH"; fi)")")"''"#,
     ));
 
     let activate_bat = scripts.child("activate.bat");
@@ -1711,7 +1711,7 @@ fn verify_pyvenv_cfg_relocatable() {
     let activate_fish = scripts.child("activate.fish");
     activate_fish.assert(predicates::path::is_file());
     activate_fish.assert(predicates::str::contains(
-        r"set -gx VIRTUAL_ENV ''(dirname -- (dirname -- (realpath (status -f))))''",
+        r#"set -gx VIRTUAL_ENV ''(dirname -- (dirname -- (if set -l _uv_realpath_probe (realpath -- / 2>/dev/null); and test (count $_uv_realpath_probe) -eq 1; and test "$_uv_realpath_probe[1]" = /; realpath -- (status -f); else; realpath (status -f); end)))''"#,
     ));
     activate_fish.assert(predicates::str::contains(
         "if string match -qr 'CYGWIN|MSYS|MINGW' (uname); and command -s cygpath >/dev/null",


### PR DESCRIPTION
Closes #16209

## Summary

BusyBox `realpath` treats `--` as a pathname, so uv-generated relocatable launchers can still run on Alpine while printing:

```text
realpath: --: No such file or directory
```

This keeps the `--` delimiter on implementations that support it. Generated launchers and activation scripts check the runtime `realpath` implementation and use the compatibility form only when `--` is not supported.

The check happens at execution time because a relocatable environment can be created on one system and used on another. Quoting, `dirname --`, and `realpath`-based symlink resolution remain unchanged.

`uv run` also reads these generated launchers, so the patch recognizes the current `python` and `python3` forms as well as launchers generated by older uv versions.

## Test Plan

* Added deterministic coverage for `realpath` implementations that support `--` and BusyBox-style implementations that do not.
* Covered a bare leading-hyphen operand and the case where a file named `--` exists.
* Updated the wheel and relocatable-venv expectations.
* Added coverage for the current and legacy `python` and `python3` launcher forms.
* Ran formatting and focused `uv-install-wheel`, `uv-virtualenv`, and `uv` tests on macOS, and verified the resolver behavior with GNU and BusyBox `realpath`.