### PR TITLE
Give a specific error when a PEP 723 closing tag has trailing whitespace

### DIFF
--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -561,15 +561,16 @@ impl ScriptTag {
         // ```
         //
         // The latter `///` is the closing pragma
-        let Some(index) = toml.iter().rev().position(|line| *line == "///") else {
-            // A closing tag with trailing whitespace (e.g. `# /// `) is a common mistake; flag it
-            // specifically instead of the generic "no closing tag" error.
-            if toml.iter().any(|line| line.trim_end() == "///") {
-                return Err(Pep723Error::UnclosedBlockTrailingWhitespace);
-            }
+        let Some(index) = toml.iter().rev().position(|line| line.trim_end() == "///") else {
             return Err(Pep723Error::UnclosedBlock);
         };
         let index = toml.len() - index;
+
+        // PEP 723 requires the closing tag to be exactly `# ///`. A terminator with trailing
+        // whitespace (`# /// `) is a common mistake, so flag it specifically.
+        if toml[index - 1] != "///" {
+            return Err(Pep723Error::UnclosedBlockTrailingWhitespace);
+        }
 
         // Discard any lines after the closing `# ///`.
         //

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -440,9 +440,9 @@ pub enum Pep723Error {
     )]
     UnclosedBlock,
     #[error(
-        "An opening tag (`# /// script`) was found, but the closing tag (`# ///`) has trailing whitespace. Remove the trailing whitespace so the line is exactly `# ///`."
+        "An opening tag (`# /// script`) was found, but the closing tag (`# ///`) has trailing content. Remove the trailing content so the line is exactly `# ///`."
     )]
-    UnclosedBlockTrailingWhitespace,
+    UnclosedBlockTrailingContent,
     #[error("The script contains multiple PEP 723 metadata blocks")]
     DuplicateBlock,
     #[error("The PEP 723 metadata block is missing from the script.")]
@@ -566,14 +566,15 @@ impl ScriptTag {
         // `index` is the position just past the terminator, matching the truncation below.
         let index = match toml
             .iter()
-            .copied()
             .enumerate()
             .rev()
-            .find(|(_, line)| line.trim_end() == "///")
+            .find(|(_, line)| line.starts_with("///"))
         {
+            // No matching terminator.
             None => return Err(Pep723Error::UnclosedBlock),
-            Some((_, line)) if line != "///" => {
-                return Err(Pep723Error::UnclosedBlockTrailingWhitespace);
+            // We have a matching terminator, but there's whitespace or other content trailing it.
+            Some((_, line)) if *line != "///" => {
+                return Err(Pep723Error::UnclosedBlockTrailingContent);
             }
             Some((index, _)) => index + 1,
         };
@@ -761,7 +762,7 @@ mod tests {
 
         assert!(matches!(
             ScriptTag::parse(contents.as_bytes()),
-            Err(Pep723Error::UnclosedBlockTrailingWhitespace)
+            Err(Pep723Error::UnclosedBlockTrailingContent)
         ));
     }
 
@@ -951,7 +952,7 @@ mod tests {
             # dependencies = ["requests"]
             # ///
 
-            
+
             # /// other
             # /// script
             # ///

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -561,16 +561,22 @@ impl ScriptTag {
         // ```
         //
         // The latter `///` is the closing pragma
-        let Some(index) = toml.iter().rev().position(|line| line.trim_end() == "///") else {
-            return Err(Pep723Error::UnclosedBlock);
+        // Match on the trimmed candidate so a terminator with trailing whitespace (`# /// `),
+        // which PEP 723 does not allow, gets a specific error instead of the generic one.
+        // `index` is the position just past the terminator, matching the truncation below.
+        let index = match toml
+            .iter()
+            .copied()
+            .enumerate()
+            .rev()
+            .find(|(_, line)| line.trim_end() == "///")
+        {
+            None => return Err(Pep723Error::UnclosedBlock),
+            Some((_, line)) if line != "///" => {
+                return Err(Pep723Error::UnclosedBlockTrailingWhitespace);
+            }
+            Some((index, _)) => index + 1,
         };
-        let index = toml.len() - index;
-
-        // PEP 723 requires the closing tag to be exactly `# ///`. A terminator with trailing
-        // whitespace (`# /// `) is a common mistake, so flag it specifically.
-        if toml[index - 1] != "///" {
-            return Err(Pep723Error::UnclosedBlockTrailingWhitespace);
-        }
 
         // Discard any lines after the closing `# ///`.
         //

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -560,23 +560,28 @@ impl ScriptTag {
         // # ///
         // ```
         //
-        // The latter `///` is the closing pragma
-        // Match on the trimmed candidate so a terminator with trailing whitespace (`# /// `),
-        // which PEP 723 does not allow, gets a specific error instead of the generic one.
-        // `index` is the position just past the terminator, matching the truncation below.
-        let index = match toml
-            .iter()
-            .enumerate()
-            .rev()
-            .find(|(_, line)| line.starts_with("///"))
-        {
-            // No matching terminator.
-            None => return Err(Pep723Error::UnclosedBlock),
-            // We have a matching terminator, but there's whitespace or other content trailing it.
-            Some((_, line)) if *line != "///" => {
-                return Err(Pep723Error::UnclosedBlockTrailingContent);
+        // The latter `///` is the closing pragma. Track malformed terminators while searching, but
+        // continue looking for an exact terminator so trailing comments cannot invalidate it.
+        let mut has_trailing_content = false;
+        let mut closing_index = None;
+
+        for (index, line) in toml.iter().enumerate().rev() {
+            if *line == "///" {
+                closing_index = Some(index + 1);
+                break;
             }
-            Some((index, _)) => index + 1,
+
+            if line.starts_with("///") {
+                has_trailing_content = true;
+            }
+        }
+
+        let Some(index) = closing_index else {
+            return Err(if has_trailing_content {
+                Pep723Error::UnclosedBlockTrailingContent
+            } else {
+                Pep723Error::UnclosedBlock
+            });
         };
 
         // Discard any lines after the closing `# ///`.
@@ -767,6 +772,50 @@ mod tests {
     }
 
     #[test]
+    fn closing_tag_trailing_content() {
+        let contents = indoc::indoc! {r"
+            # /// script
+            # requires-python = '>=3.11'
+            # /// unexpected
+        "};
+
+        assert!(matches!(
+            ScriptTag::parse(contents.as_bytes()),
+            Err(Pep723Error::UnclosedBlockTrailingContent)
+        ));
+    }
+
+    #[test]
+    fn closing_tag_followed_by_prefixed_comment() {
+        let contents = indoc::indoc! {r#"
+            # /// script
+            # dependencies = []
+            # ///
+            # /// documentation
+            print("Hello, world!")
+        "#};
+
+        let actual = ScriptTag::parse(contents.as_bytes()).unwrap().unwrap();
+
+        assert_eq!(actual.metadata, "dependencies = []\n");
+        assert_eq!(
+            actual.postlude,
+            "# /// documentation\nprint(\"Hello, world!\")\n"
+        );
+    }
+
+    #[test]
+    fn closing_tag_followed_by_trailing_whitespace_comment() {
+        let contents =
+            "# /// script\n# dependencies = []\n# ///\n# /// \nprint(\"Hello, world!\")\n";
+
+        let actual = ScriptTag::parse(contents.as_bytes()).unwrap().unwrap();
+
+        assert_eq!(actual.metadata, "dependencies = []\n");
+        assert_eq!(actual.postlude, "# /// \nprint(\"Hello, world!\")\n");
+    }
+
+    #[test]
     fn leading_content() {
         let contents = indoc::indoc! {r"
         pass # /// script
@@ -943,6 +992,22 @@ mod tests {
         "#};
 
         assert!(ScriptTag::parse(contents.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn adjacent_unclosed_second_script_block_is_not_duplicate() {
+        let contents = indoc::indoc! {r#"
+            # /// script
+            # dependencies = []
+            # ///
+            # /// script
+            print("Hello, world!")
+        "#};
+
+        let actual = ScriptTag::parse(contents.as_bytes()).unwrap().unwrap();
+
+        assert_eq!(actual.metadata, "dependencies = []\n");
+        assert_eq!(actual.postlude, "# /// script\nprint(\"Hello, world!\")\n");
     }
 
     #[test]

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -439,6 +439,10 @@ pub enum Pep723Error {
         "An opening tag (`# /// script`) was found without a closing tag (`# ///`). Ensure that every line between the opening and closing tags (including empty lines) starts with a leading `#`."
     )]
     UnclosedBlock,
+    #[error(
+        "An opening tag (`# /// script`) was found, but the closing tag (`# ///`) has trailing whitespace. Remove the trailing whitespace so the line is exactly `# ///`."
+    )]
+    UnclosedBlockTrailingWhitespace,
     #[error("The script contains multiple PEP 723 metadata blocks")]
     DuplicateBlock,
     #[error("The PEP 723 metadata block is missing from the script.")]
@@ -558,6 +562,11 @@ impl ScriptTag {
         //
         // The latter `///` is the closing pragma
         let Some(index) = toml.iter().rev().position(|line| *line == "///") else {
+            // A closing tag with trailing whitespace (e.g. `# /// `) is a common mistake; flag it
+            // specifically instead of the generic "no closing tag" error.
+            if toml.iter().any(|line| line.trim_end() == "///") {
+                return Err(Pep723Error::UnclosedBlockTrailingWhitespace);
+            }
             return Err(Pep723Error::UnclosedBlock);
         };
         let index = toml.len() - index;
@@ -735,6 +744,17 @@ mod tests {
         assert!(matches!(
             ScriptTag::parse(contents.as_bytes()),
             Err(Pep723Error::UnclosedBlock)
+        ));
+    }
+
+    #[test]
+    fn closing_tag_trailing_whitespace() {
+        // Explicit string (not `indoc`) so the closing tag's trailing space is preserved.
+        let contents = "# /// script\n# requires-python = '>=3.11'\n# /// \n";
+
+        assert!(matches!(
+            ScriptTag::parse(contents.as_bytes()),
+            Err(Pep723Error::UnclosedBlockTrailingWhitespace)
         ));
     }
 


### PR DESCRIPTION
## Summary

Closes #10918.

When a PEP 723 block is closed with `# ///` that has trailing whitespace (e.g. `# /// `), uv can't find the closing tag and returns the generic "opening tag without a closing tag" error, which doesn't point at the real cause.

Per the discussion on the issue, we still want to reject trailing whitespace to stay consistent with the PEP 723 reference implementation, so this only adds a specific error message for that case rather than changing parsing behaviour. If no exact `# ///` closing tag is found, I check whether a line trims to `///` and, if so, return a dedicated error telling the user to remove the trailing whitespace.

## Test Plan

Added a `uv-scripts` unit test (`closing_tag_trailing_whitespace`) next to the existing unclosed-block tests.

- `cargo test -p uv-scripts` (20 passed)
- `cargo clippy -p uv-scripts --all-targets` (clean)
- `cargo fmt -p uv-scripts -- --check` (clean)
