### PR TITLE
__main__.py file now autogenerates with uv init

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1158,11 +1158,23 @@ fn generate_package_scripts(
         fs_err::write(init_py, package_script)?;
     }
 
-    // Create `src/{name}/py.typed`, if it doesn't exist already.
     if is_lib {
+        // Create `src/{name}/py.typed`, if it doesn't exist already.
         let py_typed = pkg_dir.join("py.typed");
         if !py_typed.try_exists()? {
             fs_err::write(py_typed, "")?;
+        }
+    } else {
+        let main_py = pkg_dir.join("__main__.py");
+        if !main_py.try_exists()? {
+            fs_err::write(
+                main_py,
+                indoc::formatdoc! {r"
+                from {module_name} import main
+
+                main()
+                "},
+            )?;
         }
     }
 

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -119,6 +119,7 @@ fn init_application() -> Result<()> {
 
     let pyproject_toml = child.join("pyproject.toml");
     let init_py = child.join("src").join("foo").join("__init__.py");
+    let main_py = child.join("src").join("foo").join("__main__.py");
 
     uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app"), @"
     exit_code: 0 (success)
@@ -162,6 +163,19 @@ fn init_application() -> Result<()> {
         );
     });
 
+    let main = fs_err::read_to_string(main_py)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            main, @r#"
+        from foo import main
+
+        main()
+        "#
+        );
+    });
+
     uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("foo"), @"
     exit_code: 0 (success)
     ----- stdout -----
@@ -175,6 +189,17 @@ fn init_application() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + foo==0.1.0 (from file://[TEMP_DIR]/foo)
+    ");
+
+    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("python").arg("-m").arg("foo"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    Hello from foo!
+
+    ----- stderr -----
+    warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
+    Resolved 1 package in [TIME]
+    Checked 1 package in [TIME]
     ");
 
     Ok(())
@@ -292,6 +317,7 @@ fn init_application_package() -> Result<()> {
 
     let pyproject_toml = child.join("pyproject.toml");
     let init_py = child.join("src").join("foo").join("__init__.py");
+    let main_py = child.join("src").join("foo").join("__main__.py");
 
     uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--package"), @"
     exit_code: 0 (success)
@@ -331,6 +357,19 @@ fn init_application_package() -> Result<()> {
             init, @r#"
         def main() -> None:
             print("Hello from foo!")
+        "#
+        );
+    });
+
+    let main = fs_err::read_to_string(main_py)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            main, @r#"
+        from foo import main
+
+        main()
         "#
         );
     });
@@ -412,6 +451,11 @@ fn init_library() -> Result<()> {
             py_typed, @""
         );
     });
+
+    assert!(
+        !child.join("src").join("foo").join("__main__.py").exists(),
+        "Libraries should not include a `__main__.py`"
+    );
 
     uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("python").arg("-c").arg("import foo; print(foo.hello())"), @"
     exit_code: 0 (success)
@@ -3317,6 +3361,7 @@ fn init_app_build_backend_maturin() -> Result<()> {
 
     let pyproject_toml = child.join("pyproject.toml");
     let init_py = child.join("src").join("foo").join("__init__.py");
+    let main_py = child.join("src").join("foo").join("__main__.py");
     let pyi_file = child.join("src").join("foo").join("_core.pyi");
     let lib_core = child.join("src").join("lib.rs");
     let build_file = child.join("Cargo.toml");
@@ -3371,6 +3416,19 @@ fn init_app_build_backend_maturin() -> Result<()> {
         def main() -> None:
             print(hello_from_bin())
         "
+        );
+    });
+
+    let main = fs_err::read_to_string(main_py)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            main, @r#"
+        from foo import main
+
+        main()
+        "#
         );
     });
 
@@ -3444,6 +3502,7 @@ fn init_app_build_backend_scikit() -> Result<()> {
 
     let pyproject_toml = child.join("pyproject.toml");
     let init_py = child.join("src").join("foo").join("__init__.py");
+    let main_py = child.join("src").join("foo").join("__main__.py");
     let pyi_file = child.join("src").join("foo").join("_core.pyi");
     let lib_core = child.join("src").join("main.cpp");
     let build_file = child.join("CMakeLists.txt");
@@ -3497,6 +3556,19 @@ fn init_app_build_backend_scikit() -> Result<()> {
         def main() -> None:
             print(hello_from_bin())
         "
+        );
+    });
+
+    let main = fs_err::read_to_string(main_py)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            main, @r#"
+        from foo import main
+
+        main()
+        "#
         );
     });
 

--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -35,7 +35,8 @@ Applications are the default target for `uv init`, but can also be specified wit
 $ uv init example-app
 ```
 
-The source code lives in a `src` directory with a module directory and an `__init__.py` file:
+The source code lives in a `src` directory with a module directory containing an `__init__.py` file
+and a `__main__.py` file:
 
 ```console
 $ tree example-app
@@ -45,7 +46,8 @@ example-app/
 ├── pyproject.toml
 └── src
     └── example_app
-        └── __init__.py
+        ├── __init__.py
+        └── __main__.py
 ```
 
 A [build system](./config.md#build-systems) is defined, so the project will be installed into the
@@ -209,6 +211,7 @@ example-ext/
     ├── lib.rs
     └── example_ext
         ├── __init__.py
+        ├── __main__.py
         └── _core.pyi
 ```
 

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -36,7 +36,8 @@ uv will create the following files and directories:
 ├── README.md
 └── src
     └── hello_world
-        └── __init__.py
+        ├── __init__.py
+        └── __main__.py
 ```
 
 The `pyproject.toml` defines a `hello-world` entrypoint referring to a simple "Hello world" program
@@ -68,7 +69,8 @@ A complete listing would look like:
 ├── README.md
 ├── src
 │   └── hello_world
-│       └── __init__.py
+│       ├── __init__.py
+│       └── __main__.py
 ├── pyproject.toml
 └── uv.lock
 ```


### PR DESCRIPTION
uv init now autogenerates a __main__.py file when generating applications. Libraries are intentionally excluded because they do not contain a main function for an entry point. Docs and tests also were updated to reflect this change.

**Reference issue: https://github.com/astral-sh/uv/issues/16611**

## Summary

uv init now autogenerates a __main__.py file when generating applications when a main function is present. This is a standard Python convention, as mentioned in the Python docs (https://docs.python.org/3.14/library/__main__.html#main-py-in-python-packages), as well as by another uv maintainer in the reference issue (https://github.com/astral-sh/uv/issues/16611). It's also very common in many popular Python packages like FastAPI, Django, TQDM, etc. 

Libraries are intentionally excluded from generating a __main__.py because they do not contain a main function for an entry point. Docs and tests also were updated to reflect this change.

## Test Plan

This was manually tested, and also the tests were extended to assert the __main__.py file contents, and also to assert that running python3 -m foo prints the proper message. 