### PR TITLE
fix(installer): repair editable installs when the .pth file is missing

### DIFF
--- a/crates/uv-installer/src/satisfies.rs
+++ b/crates/uv-installer/src/satisfies.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::fs;
 
 use same_file::is_same_file;
 use tracing::{debug, trace};
@@ -14,6 +15,7 @@ use uv_distribution_types::{
     PackageConfigSettings, RequirementSource,
 };
 use uv_git_types::{GitLfs, GitOid};
+use uv_install_wheel::read_record;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_platform_tags::{AbiTag, IncompatibleTag, TagCompatibility, Tags};
@@ -30,6 +32,39 @@ pub(crate) enum RequirementSatisfaction {
 }
 
 impl RequirementSatisfaction {
+    /// Returns true if the editable install is exposed through a `.pth` file
+    /// that is still present on disk.
+    ///
+    /// Editable installs expose the source tree via a `.pth` file in
+    /// site-packages (e.g., `<name>.pth` for uv's build backend, or
+    /// `__editable__...pth` for setuptools). If the file is removed, the
+    /// distribution metadata remains intact, but the package's modules are no
+    /// longer importable, and uv would otherwise report the requirement as
+    /// already installed.
+    fn editable_pth_is_present(distribution: &InstalledDist) -> bool {
+        let Some(site_packages) = distribution.install_path().parent() else {
+            return false;
+        };
+
+        // The `.pth` files that should be present are recorded in the `RECORD`.
+        let record_path = distribution.install_path().join("RECORD");
+        let Ok(record) = fs::read_to_string(record_path) else {
+            return true;
+        };
+        let Ok(entries) = read_record(record.as_bytes()) else {
+            return true;
+        };
+
+        entries
+            .iter()
+            .filter(|entry| {
+                entry.path.ends_with(".pth")
+                    && !entry.path.contains('/')
+                    && !entry.path.contains('\\')
+            })
+            .all(|entry| site_packages.join(&entry.path).is_file())
+    }
+
     /// Returns true if a requirement is satisfied by an installed distribution.
     ///
     /// Returns an error if IO fails during a freshness check for a local path.
@@ -412,6 +447,15 @@ impl RequirementSatisfaction {
                         debug!("Failed to read cached requirement for: {distribution} ({err})");
                         return Self::CacheInvalid;
                     }
+                }
+
+                // If the installed distribution is editable, verify that the
+                // `.pth` file exposing the source tree is still present.
+                if (*requested_editable).unwrap_or(false)
+                    && !Self::editable_pth_is_present(distribution)
+                {
+                    debug!("Editable `.pth` file is missing for: {distribution}");
+                    return Self::OutOfDate;
                 }
             }
         }

--- a/crates/uv-installer/src/satisfies.rs
+++ b/crates/uv-installer/src/satisfies.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
-use std::fs;
+use std::path::Path;
 
+use fs_err as fs;
 use same_file::is_same_file;
 use tracing::{debug, trace};
 use url::Url;
@@ -58,9 +59,10 @@ impl RequirementSatisfaction {
         entries
             .iter()
             .filter(|entry| {
-                entry.path.ends_with(".pth")
+                Path::new(&entry.path)
+                    .extension()
+                    .is_some_and(|ext| ext == "pth")
                     && !entry.path.contains('/')
-                    && !entry.path.contains('\\')
             })
             .all(|entry| site_packages.join(&entry.path).is_file())
     }

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -15386,6 +15386,64 @@ fn toggle_workspace_editable() -> Result<()> {
     Ok(())
 }
 
+/// The editable install should be repaired if its `.pth` file is missing.
+///
+/// See: <https://github.com/astral-sh/uv/issues/20945>
+#[test]
+fn sync_reinstalls_editable_when_pth_missing() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+        "#,
+    )?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    uv_snapshot!(context.filters(), context.sync(), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + project==0.1.0 (from file://[TEMP_DIR]/)
+    ");
+
+    let pth = context.site_packages().join("project.pth");
+    assert!(pth.is_file());
+
+    // Remove the `.pth` file; the distribution metadata remains intact, so the
+    // editable install must be repaired on the next sync.
+    fs_err::remove_file(&pth)?;
+
+    uv_snapshot!(context.filters(), context.sync(), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ project==0.1.0 (from file://[TEMP_DIR]/)
+    ");
+
+    // The `.pth` file should be restored.
+    assert!(pth.is_file());
+
+    Ok(())
+}
+
 #[test]
 #[cfg(not(windows))]
 fn workspace_editable_conflict() -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #20945. When the `.pth` file that exposes an editable install's source tree is removed (e.g., by a cleanup), the distribution metadata remains intact, so `uv` reports the requirement as already installed and skips reinstalling. The entry point scripts then fail with `ModuleNotFoundError` even though `uv sync`/`uv run` succeed.

With this change, `RequirementSatisfaction::check` verifies that every top-level `.pth` file recorded in the installed distribution's `RECORD` is still present for editable directory requirements. If one is missing, the requirement is treated as out-of-date and the editable install is repaired on the next sync. The check is scoped to files that were actually installed (per `RECORD`), so editable installs from other build backends (e.g., setuptools `__editable__...pth`, hatchling `_<name>.pth`) are unaffected.

## Test Plan

- Added `sync_reinstalls_editable_when_pth_missing` regression test: sync a uv_build project, remove `project.pth` from site-packages, sync again, assert the package is reinstalled and the `.pth` is restored.
- Verified the test fails on `main` without the fix and passes with it.
- Existing editable-related tests pass: `toggle_workspace_editable`, `pip_install::install_editable`, `project::run_with_editable`, and the `uv-installer` unit tests.
- End-to-end: reproduced #20945 with a local build (`uv init --package` + `uv run <name>`), removed `repro_test.pth`, and confirmed `uv run` now reinstalls the editable package and the entry point runs.