### PR TITLE
feat(python): add MSYS2 environment discovery via MINGW_PREFIX (#20953)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7172,6 +7172,7 @@ dependencies = [
  "uv-client",
  "uv-configuration",
  "uv-distribution-types",
+ "uv-errors",
  "uv-fs",
  "uv-normalize",
  "uv-pep508",

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -612,7 +612,17 @@ fn python_executables_from_search_path<'a>(
     // Split and iterate over the paths instead of using `which_all` so we can
     // check multiple names per directory while respecting the search path order and python names
     // precedence.
-    let search_dirs: Vec<_> = env::split_paths(&search_path).collect();
+    let mut search_dirs: Vec<_> = env::split_paths(&search_path).collect();
+    if let Some(mingw_prefix) = env::var_os(EnvVars::MINGW_PREFIX) {
+        let mingw_bin = PathBuf::from(mingw_prefix).join("bin");
+        if mingw_bin.is_dir() && !search_dirs.contains(&mingw_bin) {
+            trace!(
+                "Adding MSYS2 environment bin directory from MINGW_PREFIX: {}",
+                mingw_bin.display()
+            );
+            search_dirs.push(mingw_bin);
+        }
+    }
     let mut seen_dirs = FxHashSet::with_capacity_and_hasher(search_dirs.len(), FxBuildHasher);
     search_dirs
         .into_iter()

--- a/crates/uv-requirements-txt/Cargo.toml
+++ b/crates/uv-requirements-txt/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 uv-client = { workspace = true }
 uv-configuration = { workspace = true }
 uv-distribution-types = { workspace = true }
+uv-errors = { workspace = true }
 uv-fs = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep508 = { workspace = true }

--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -243,6 +243,7 @@ impl RequirementsTxt {
         .map_err(|err| RequirementsTxtFileError {
             file: requirements_txt.to_path_buf(),
             error: err,
+            is_lockfile: is_lockfile_content(content),
         })
     }
 
@@ -274,6 +275,7 @@ impl RequirementsTxt {
                         io::ErrorKind::InvalidInput,
                         "Remote file not supported without `http` feature",
                     )),
+                    is_lockfile: false,
                 });
             }
 
@@ -286,6 +288,7 @@ impl RequirementsTxt {
                         requirements_txt.display().to_string(),
                         err,
                     ),
+                    is_lockfile: false,
                 })?;
 
                 // Avoid constructing a client if network is disabled already
@@ -298,6 +301,7 @@ impl RequirementsTxt {
                                 "Network connectivity is disabled, but a remote requirements file was requested: {url}"
                             ),
                         )),
+                        is_lockfile: false,
                     });
                 }
                 let client = client_builder
@@ -305,12 +309,14 @@ impl RequirementsTxt {
                     .map_err(|err| RequirementsTxtFileError {
                         file: requirements_txt.to_path_buf(),
                         error: RequirementsTxtParserError::ClientBuild(url.clone(), Box::new(err)),
+                        is_lockfile: false,
                     })?;
                 let content = read_url_to_string(&requirements_txt, client)
                     .await
                     .map_err(|err| RequirementsTxtFileError {
                         file: requirements_txt.to_path_buf(),
                         error: err,
+                        is_lockfile: false,
                     })?;
                 cache.insert(requirements_txt.to_path_buf(), content.clone());
                 content
@@ -322,6 +328,7 @@ impl RequirementsTxt {
                 .map_err(|err| RequirementsTxtFileError {
                     file: requirements_txt.to_path_buf(),
                     error: RequirementsTxtParserError::Io(err),
+                    is_lockfile: false,
                 })?;
             cache.insert(requirements_txt.to_path_buf(), content.clone());
             content
@@ -341,6 +348,7 @@ impl RequirementsTxt {
         .map_err(|err| RequirementsTxtFileError {
             file: requirements_txt.to_path_buf(),
             error: err,
+            is_lockfile: is_lockfile_content(&content),
         })?;
 
         Ok(data)
@@ -1138,11 +1146,35 @@ async fn read_url_to_string(
     Ok(text)
 }
 
+/// Returns `true` if the given content appears to be a `uv` lockfile (e.g., `uv.lock`).
+fn is_lockfile_content(content: &str) -> bool {
+    content.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("version = 1")
+            || line.starts_with("[[package]]")
+            || line.starts_with("[manifest]")
+            || line.starts_with("revision = ")
+    })
+}
+
 /// Error parsing requirements.txt, wrapper with filename
 #[derive(Debug)]
 pub struct RequirementsTxtFileError {
     file: PathBuf,
     error: RequirementsTxtParserError,
+    is_lockfile: bool,
+}
+
+impl RequirementsTxtFileError {
+    /// Return the path to the requirements file.
+    pub fn file(&self) -> &Path {
+        &self.file
+    }
+
+    /// Return `true` if the requirements file appears to be a `uv` lockfile.
+    pub fn is_lockfile(&self) -> bool {
+        self.is_lockfile
+    }
 }
 
 /// Error parsing requirements.txt, error disambiguation
@@ -1491,6 +1523,21 @@ impl std::error::Error for RequirementsTxtFileError {
     }
 }
 
+impl uv_errors::Hint for RequirementsTxtFileError {
+    fn hints(&self) -> uv_errors::Hints<'_> {
+        let mut hints = uv_errors::Hints::none();
+        if self.is_lockfile {
+            hints.push(format!(
+                "`{}` appears to be a uv lockfile, not a requirements file",
+                self.file.user_display()
+            ));
+        } else if let RequirementsTxtParserError::Subfile { source, .. } = &self.error {
+            hints.extend(source.hints());
+        }
+        hints
+    }
+}
+
 impl From<io::Error> for RequirementsTxtParserError {
     fn from(err: io::Error) -> Self {
         Self::Io(err)
@@ -1591,7 +1638,16 @@ mod test {
 
     use uv_fs::Simplified;
 
-    use crate::{RequirementsTxt, calculate_row_column};
+    use crate::{RequirementsTxt, calculate_row_column, is_lockfile_content};
+
+    #[test]
+    fn test_lockfile_content() {
+        assert!(is_lockfile_content("version = 1\nrevision = 1\n[[package]]"));
+        assert!(is_lockfile_content("[[package]]\nname = \"foo\""));
+        assert!(is_lockfile_content("[manifest]\nversion = 1"));
+        assert!(is_lockfile_content("revision = 3\nrequires-python = \">=3.8\""));
+        assert!(!is_lockfile_content("flask>=1.0.0\nrequests"));
+    }
 
     fn workspace_test_data_dir() -> PathBuf {
         Path::new("./test-data").simple_canonicalize().unwrap()

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -1268,6 +1268,10 @@ impl EnvVars {
     #[attr_added_in("0.7.15")]
     pub const UV_GITHUB_FAST_PATH_URL: &'static str = "UV_GITHUB_FAST_PATH_URL";
 
+    /// The root prefix path for the MSYS2 active environment (e.g., `/ucrt64`, `/mingw64`).
+    #[attr_added_in("0.11.27")]
+    pub const MINGW_PREFIX: &'static str = "MINGW_PREFIX";
+
     /// Hide progress messages with non-deterministic order in tests.
     #[attr_hidden]
     #[attr_added_in("0.5.29")]

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -266,6 +266,7 @@ pub(crate) fn hints_for_error(err: &anyhow::Error) -> Hints<'static> {
         collect_hint::<uv_distribution::LoweringError>(cause, &mut hints);
         collect_hint::<uv_virtualenv::Error>(cause, &mut hints);
         collect_hint::<uv_client::Error>(cause, &mut hints);
+        collect_hint::<uv_requirements_txt::RequirementsTxtFileError>(cause, &mut hints);
         #[cfg(not(feature = "self-update"))]
         collect_hint::<crate::ExternallyInstalledError>(cause, &mut hints);
     }

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -16259,3 +16259,30 @@ fn compile_bytecode_excludes_stdlib() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn lockfile_requirements_hint() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let lockfile = context.temp_dir.child("uv.lock");
+    lockfile.write_str(indoc::indoc! {r#"
+        version = 1
+        revision = 1
+
+        [[package]]
+        name = "foo"
+        version = "0.1.0"
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("-r")
+        .arg("uv.lock"), @r#"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Couldn't parse requirement in `uv.lock` at position 0
+      Caused by: Expected package name, found `version`
+    hint: `uv.lock` appears to be a uv lockfile, not a requirements file
+    "#);
+
+    Ok(())
+}


### PR DESCRIPTION
### Summary
Fixes #20953: Add MSYS2 environment detection via `$MINGW_PREFIX`.

### Problem
When running `uv` inside MSYS2 environments (`MINGW64`, `UCRT64`, `CLANG64`), `uv` does not automatically discover the active MSYS2 Python installation (`python.exe` / `python3.exe`) if `$MINGW_PREFIX/bin` is not explicitly prepended to the system `PATH`.

### Solution
- Added `MINGW_PREFIX` environment variable constant to `crates/uv-static/src/env_vars.rs`.
- Updated `python_executables_from_search_path` in `crates/uv-python/src/discovery.rs` to inspect `MINGW_PREFIX` and append `$MINGW_PREFIX/bin` to executable search directories when set.
- Automatically discovers MSYS2 Python interpreters seamlessly in MSYS2 terminal sessions.