### PR TITLE
CD: GitHub Actions workflow, publish all releases

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -366,10 +366,9 @@ First, add a release workflow to your project:
 name: "Publish release to PyPI"
 
 on:
-  push:
-    tags:
-      # Publish on any tag starting with a `v`, e.g., v0.1.0
-      - v*
+  release:
+    types:
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

The previous trigger published all tags starting with a `v`, which includes `very-bad-idea` and excludes `1.0.0`. The new trigger publishes all releases made through GitHub. Note that some projects do not include a `v` in their tags, but some projects also don't publish releases, only tags.

## Test Plan

I've been using this workflow for years. Documentation can be found here: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release