### PR TITLE
automations: update codex versions/pins and add support for auto-updates via Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,18 @@
       versioning: "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
     },
     {
+      // Codex Action publishes two-component tags instead of full SemVer tags.
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["openai/codex-action"],
+      extractVersion: "^(?<version>v?\\d+\\.\\d+)$",
+      versioning: "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)$",
+    },
+    {
+      groupName: "Codex automation dependencies",
+      matchPackageNames: ["@openai/codex", "openai/codex-action"],
+      description: "Weekly update of Codex Action and Codex CLI dependencies",
+    },
+    {
       // Disable updates of `zip-rs`; intentionally pinned for now due to ownership change
       // See: https://github.com/astral-sh/uv/issues/3642
       matchPackageNames: ["/zip/"],
@@ -165,6 +177,26 @@
       packageNameTemplate: "PyO3/maturin",
       datasourceTemplate: "github-releases",
     },
+    // Codex CLI versions passed to Codex Action.
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      matchStrings: ['codex-version:\\s*"(?<currentValue>\\d+\\.\\d+\\.\\d+)"'],
+      depNameTemplate: "@openai/codex",
+      datasourceTemplate: "npm",
+      versioningTemplate: "semver",
+    },
+    // Keep the directly downloaded Codex release and its SHA-256 in sync.
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^agents/scripts/install-codex-security\\.sh$/"],
+      matchStrings: [
+        "releases/download/rust-v(?<currentValue>\\d+\\.\\d+\\.\\d+)/codex-x86_64-unknown-linux-musl\\.tar\\.gz[\\s\\S]*?(?<currentDigest>[a-f0-9]{64})",
+      ],
+      depNameTemplate: "@openai/codex",
+      datasourceTemplate: "custom.codex-release-assets",
+      versioningTemplate: "semver",
+    },
     // Minimum supported Rust toolchain version
     {
       customType: "regex",
@@ -188,6 +220,15 @@
       datasourceTemplate: "github-releases",
     },
   ],
+  customDatasources: {
+    "codex-release-assets": {
+      // Include release history so the inherited minimum release age can apply.
+      defaultRegistryUrlTemplate: "https://api.github.com/repos/openai/codex/releases?per_page=100",
+      transformTemplates: [
+        '{"releases": [$[draft = false and prerelease = false and $exists(assets[name = "codex-x86_64-unknown-linux-musl.tar.gz"].digest)].{"version": $substringAfter(tag_name, "rust-v"), "digest": $substringAfter(assets[name = "codex-x86_64-unknown-linux-musl.tar.gz"].digest, "sha256:"), "releaseTimestamp": published_at, "isStable": true}]}',
+      ],
+    },
+  },
   vulnerabilityAlerts: {
     commitMessageSuffix: "",
     labels: ["internal", "security"],

--- a/.github/workflows/diagnose-workflow-failure.yml
+++ b/.github/workflows/diagnose-workflow-failure.yml
@@ -91,11 +91,12 @@ jobs:
 
       - name: "Diagnose workflow failure"
         id: diagnose
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: "0.146.0"
           codex-home: "agents/codex"
           effort: high
           permission-profile: "workflow-failure"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -61,11 +61,12 @@ jobs:
 
       - name: "Triage issue"
         id: triage
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: "0.146.0"
           codex-home: "agents/codex"
           effort: high
           permission-profile: "issue-triage"

--- a/.github/workflows/pull-request-labels.yml
+++ b/.github/workflows/pull-request-labels.yml
@@ -63,11 +63,12 @@ jobs:
 
       - name: "Determine pull request labels"
         id: labels
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: "0.146.0"
           working-directory: "${{ github.workspace }}/pull-request"
           codex-home: "${{ github.workspace }}/agents/codex"
           permission-profile: "pull-request-labels"

--- a/.github/workflows/pull-request-security-review.yml
+++ b/.github/workflows/pull-request-security-review.yml
@@ -74,13 +74,13 @@ jobs:
 
       - name: "Review pull request"
         id: review
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TMPDIR: ${{ runner.temp }}/codex-security
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          codex-version: "0.144.4"
+          codex-version: "0.146.0"
           codex-home: "agents/codex"
           effort: high
           permission-profile: "pull-request-review"

--- a/.github/workflows/rebase-conflicted-pull-request.yml
+++ b/.github/workflows/rebase-conflicted-pull-request.yml
@@ -89,12 +89,13 @@ jobs:
           fi
 
       - name: Rebase pull request
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           BASE_REF: ${{ inputs.base-ref }}
           TMPDIR: ${{ runner.temp }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: "0.146.0"
           model: gpt-5.6-sol
           effort: high
           codex-home: "${{ runner.temp }}/codex-home"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -70,9 +70,10 @@ jobs:
           } > "$RUNNER_TEMP/editorialize-changelog-prompt.md"
 
       - name: "Rewrite changelog"
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: "0.146.0"
           model: gpt-5.6-sol
           effort: high
           permission-profile: ":read-only"

--- a/.github/workflows/reproduce-bug.yml
+++ b/.github/workflows/reproduce-bug.yml
@@ -90,13 +90,14 @@ jobs:
 
       - name: "Reproduce issue behavior"
         id: reproduce
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TMPDIR: ${{ runner.temp }}
           UV_CACHE_DIR: ${{ runner.temp }}/uv-reproduce-cache
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: "0.146.0"
           codex-home: "agents/codex"
           effort: high
           permission-profile: "reproduce-bug"
@@ -230,7 +231,7 @@ jobs:
 
       - name: "Create integration test"
         id: create-test
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INSTA_UPDATE: "no"
@@ -238,6 +239,7 @@ jobs:
           UV_CACHE_DIR: ${{ runner.temp }}/uv-create-test-cache
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: "0.146.0"
           codex-home: "agents/codex"
           effort: high
           permission-profile: "create-bug-test"

--- a/agents/scripts/install-codex-security.sh
+++ b/agents/scripts/install-codex-security.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 mkdir -p "$RUNNER_TEMP/codex-security"
 curl --fail --location --silent --show-error \
   --output "$RUNNER_TEMP/codex.tar.gz" \
-  https://github.com/openai/codex/releases/download/rust-v0.144.4/codex-x86_64-unknown-linux-musl.tar.gz
+  https://github.com/openai/codex/releases/download/rust-v0.146.0/codex-x86_64-unknown-linux-musl.tar.gz
 printf '%s  %s\n' \
-  37c985be9d89e8c4f43b3aa0594c1213eac212d30ae2b95221f08fec807515d1 \
+  5ba3b9405543953081f661d0854d266f76e2abbe51d41349355a36de7673776a \
   "$RUNNER_TEMP/codex.tar.gz" | sha256sum --check
 tar --extract --gzip --file "$RUNNER_TEMP/codex.tar.gz" --directory "$RUNNER_TEMP"
 codex="$RUNNER_TEMP/codex-x86_64-unknown-linux-musl"


### PR DESCRIPTION
while considering actions run flakiness, i was considering what versions of these tools we had involved, and realized we didn't pin them universally.

this introduces version pinning and a renovate config to keep things up to date.