### PR TITLE
Use GHA's self-repo syntax

### DIFF
--- a/.github/workflows/check-zizmor.yml
+++ b/.github/workflows/check-zizmor.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     needs: plan
     if: ${{ github.event_name == 'pull_request' && github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.full_name == github.repository && needs.plan.outputs.review-security == 'true' }}
     uses: $/.github/workflows/pull-request-security-review.yml
-    secrets: inherit # zizmor: ignore[secrets-inherit] required for the automations environment, as in release.yml
+    secrets: inherit
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ concurrency:
 
 jobs:
   plan:
-    uses: ./.github/workflows/plan.yml
+    uses: $/.github/workflows/plan.yml
 
   check-fmt:
-    uses: ./.github/workflows/check-fmt.yml
+    uses: $/.github/workflows/check-fmt.yml
 
   review:
     needs: plan
     if: ${{ github.event_name == 'pull_request' && github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.full_name == github.repository && needs.plan.outputs.review-security == 'true' }}
-    uses: ./.github/workflows/pull-request-security-review.yml
+    uses: $/.github/workflows/pull-request-security-review.yml
     secrets: inherit # zizmor: ignore[secrets-inherit] required for the automations environment, as in release.yml
     permissions:
       contents: read
@@ -32,7 +32,7 @@ jobs:
 
   check-lint:
     needs: plan
-    uses: ./.github/workflows/check-lint.yml
+    uses: $/.github/workflows/check-lint.yml
     with:
       code-changed: ${{ needs.plan.outputs.test-code }}
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
@@ -40,13 +40,13 @@ jobs:
   check-docs:
     needs: plan
     if: ${{ needs.plan.outputs.run-checks == 'true' }}
-    uses: ./.github/workflows/check-docs.yml
+    uses: $/.github/workflows/check-docs.yml
     secrets: inherit
 
   check-zizmor:
     needs: plan
     if: ${{ needs.plan.outputs.run-checks == 'true' }}
-    uses: ./.github/workflows/check-zizmor.yml
+    uses: $/.github/workflows/check-zizmor.yml
     permissions:
       contents: read
       security-events: write
@@ -54,22 +54,22 @@ jobs:
   check-publish:
     needs: plan
     if: ${{ needs.plan.outputs.test-code == 'true' }}
-    uses: ./.github/workflows/check-publish.yml
+    uses: $/.github/workflows/check-publish.yml
 
   check-release:
     needs: plan
     if: ${{ needs.plan.outputs.run-checks == 'true' }}
-    uses: ./.github/workflows/check-release.yml
+    uses: $/.github/workflows/check-release.yml
 
   check-lock:
     needs: plan
     if: ${{ needs.plan.outputs.run-checks == 'true' }}
-    uses: ./.github/workflows/check-lock.yml
+    uses: $/.github/workflows/check-lock.yml
 
   check-generated-files:
     needs: plan
     if: ${{ needs.plan.outputs.test-code == 'true' }}
-    uses: ./.github/workflows/check-generated-files.yml
+    uses: $/.github/workflows/check-generated-files.yml
     with:
       schema-changed: ${{ needs.plan.outputs.check-schema }}
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
@@ -77,7 +77,7 @@ jobs:
   test:
     needs: plan
     if: ${{ needs.plan.outputs.test-code == 'true' }}
-    uses: ./.github/workflows/test.yml
+    uses: $/.github/workflows/test.yml
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
       test-macos: ${{ needs.plan.outputs.test-macos }}
@@ -85,14 +85,14 @@ jobs:
   test-windows-trampolines:
     needs: plan
     if: ${{ needs.plan.outputs.test-windows-trampoline == 'true' }}
-    uses: ./.github/workflows/test-windows-trampolines.yml
+    uses: $/.github/workflows/test-windows-trampolines.yml
     with:
       trampoline-build: ${{ needs.plan.outputs.test-windows-trampoline-check-binary }}
 
   build-dev-binaries:
     needs: plan
     if: ${{ needs.plan.outputs.test-code == 'true' }}
-    uses: ./.github/workflows/build-dev-binaries.yml
+    uses: $/.github/workflows/build-dev-binaries.yml
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
 
@@ -101,7 +101,7 @@ jobs:
       - plan
       - build-dev-binaries
     if: ${{ needs.plan.outputs.test-smoke == 'true' }}
-    uses: ./.github/workflows/test-smoke.yml
+    uses: $/.github/workflows/test-smoke.yml
     with:
       sha: ${{ github.sha }}
 
@@ -110,7 +110,7 @@ jobs:
       - plan
       - build-dev-binaries
     if: ${{ needs.plan.outputs.test-integration == 'true' }}
-    uses: ./.github/workflows/test-integration.yml
+    uses: $/.github/workflows/test-integration.yml
     secrets: inherit
     permissions:
       id-token: write
@@ -122,7 +122,7 @@ jobs:
       - plan
       - build-dev-binaries
     if: ${{ needs.plan.outputs.test-system == 'true' }}
-    uses: ./.github/workflows/test-system.yml
+    uses: $/.github/workflows/test-system.yml
     with:
       sha: ${{ github.sha }}
 
@@ -131,20 +131,20 @@ jobs:
       - plan
       - build-dev-binaries
     if: ${{ needs.plan.outputs.test-ecosystem == 'true' }}
-    uses: ./.github/workflows/test-ecosystem.yml
+    uses: $/.github/workflows/test-ecosystem.yml
     with:
       sha: ${{ github.sha }}
 
   build-release-binaries:
     needs: plan
     if: ${{ needs.plan.outputs.build-release-binaries == 'true' }}
-    uses: ./.github/workflows/build-release-binaries.yml
+    uses: $/.github/workflows/build-release-binaries.yml
     secrets: inherit
 
   build-docker:
     needs: plan
     if: ${{ needs.plan.outputs.build-docker == 'true' }}
-    uses: ./.github/workflows/build-docker.yml
+    uses: $/.github/workflows/build-docker.yml
     with:
       push-dev: ${{ needs.plan.outputs.push-docker == 'true' }}
     secrets: inherit
@@ -157,7 +157,7 @@ jobs:
   bench:
     needs: plan
     if: ${{ needs.plan.outputs.run-bench == 'true' }}
-    uses: ./.github/workflows/bench.yml
+    uses: $/.github/workflows/bench.yml
     secrets: inherit
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -198,7 +198,7 @@ jobs:
       contents: read
       id-token: write
       issues: read
-    uses: ./.github/workflows/reproduce-bug.yml
+    uses: $/.github/workflows/reproduce-bug.yml
     with:
       issue: ${{ inputs.issue || github.event.issue.number }}
       issue-type: ${{ fromJSON(needs.triage.outputs.result).type }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -203,4 +203,4 @@ jobs:
       issue: ${{ inputs.issue || github.event.issue.number }}
       issue-type: ${{ fromJSON(needs.triage.outputs.result).type }}
       runner: ubuntu-latest
-    secrets: inherit # zizmor: ignore[secrets-inherit] -- protected environment secrets are needed for reproduction
+    secrets: inherit

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix: ${{ fromJSON(needs.identify.outputs.matrix) }}
-    uses: ./.github/workflows/rebase-conflicted-pull-request.yml
+    uses: $/.github/workflows/rebase-conflicted-pull-request.yml
     secrets: inherit # zizmor: ignore[secrets-inherit] required for the automations environment, as in release.yml
     with:
       number: ${{ matrix.number }}

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -119,7 +119,7 @@ jobs:
       max-parallel: 4
       matrix: ${{ fromJSON(needs.identify.outputs.matrix) }}
     uses: $/.github/workflows/rebase-conflicted-pull-request.yml
-    secrets: inherit # zizmor: ignore[secrets-inherit] required for the automations environment, as in release.yml
+    secrets: inherit
     with:
       number: ${{ matrix.number }}
       base-ref: ${{ matrix.base_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
     needs:
       - plan
     if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run' }}
-    uses: ./.github/workflows/build-release-binaries.yml
+    uses: $/.github/workflows/build-release-binaries.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -127,7 +127,7 @@ jobs:
       - plan
       - release-gate
     if: ${{ always() && needs.plan.result == 'success' && (needs.release-gate.result == 'success' || needs.release-gate.result == 'skipped') && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run') }}
-    uses: ./.github/workflows/build-docker.yml
+    uses: $/.github/workflows/build-docker.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -280,7 +280,7 @@ jobs:
       - host
       - release-gate
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    uses: ./.github/workflows/publish-pypi.yml
+    uses: $/.github/workflows/publish-pypi.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -296,7 +296,7 @@ jobs:
       - release-gate
       - publish-pypi # DIRTY: see #16989
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    uses: ./.github/workflows/publish-crates.yml
+    uses: $/.github/workflows/publish-crates.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -381,7 +381,7 @@ jobs:
     # Use `always() && ...` so this job gates only on whether `publish-github`
     # completed successfully.
     if: ${{ always() && needs.publish-github.result == 'success' }}
-    uses: ./.github/workflows/publish-docs.yml
+    uses: $/.github/workflows/publish-docs.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -391,7 +391,7 @@ jobs:
       - plan
       - publish-github
     if: ${{ always() && needs.publish-github.result == 'success' }}
-    uses: ./.github/workflows/publish-versions.yml
+    uses: $/.github/workflows/publish-versions.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -401,7 +401,7 @@ jobs:
       - plan
       - publish-github
     if: ${{ always() && needs.publish-github.result == 'success' }}
-    uses: ./.github/workflows/publish-mirror.yml
+    uses: $/.github/workflows/publish-mirror.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  secrets-inherit:
+    # Disable the secrets-inherit rule entirely.
+    # We use `secrets: inherit` pervasively in uv's CI to orchestrate reusable
+    # workflows in various contexts/with various inputs. Removing it would
+    # be extremely troublesome/high-risk at the moment.
+    disable: true


### PR DESCRIPTION
## Summary

Context: https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/

This switches us from `uses: ./...` to `uses: $/`. GHA prefers this syntax since it anchors the usage in the actual repository state, rather than whatever filesystem state the runner happens to have at that moment.

(zizmor does not suggest this yet, but will soon.)

## Test Plan

NFC, CI only. We _may_ need to bump zizmor-action since only the latest release knows about this syntax.
