### PR TITLE
Fix two typos in the Docker guide

### DIFF
--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -431,7 +431,7 @@ _contents_ are not copied into the image until the final `uv sync` command.
 If you're using a [workspace](../../concepts/projects/workspaces.md), then a couple changes are
 needed:
 
-- Use `--frozen` instead of `--locked` during the initially sync.
+- Use `--frozen` instead of `--locked` during the initial sync.
 - Use the `--no-install-workspace` flag which excludes the project _and_ any workspace members.
 
 ```dockerfile title="Dockerfile"
@@ -517,7 +517,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
 
 ### Installing a package
 
-The system Python environment is safe to use this context, since a container is already isolated.
+The system Python environment is safe to use in this context, since a container is already isolated.
 The `--system` flag can be used to install in the system environment:
 
 ```dockerfile title="Dockerfile"


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

  Fixes two typos in the Docker integration guide:

  - "during the initially sync" → "during the initial sync".
  - "safe to use this context" → "safe to use in this context"
## Test Plan
N/A
