### PR TITLE
Disable local ThinLTO in fast-build test profiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         id: rust-cache
         with:
           prefix-key: v1-rust-workspace
+          key: ${{ hashFiles('Cargo.toml') }}
           cache-workspace-crates: "true"
           save-if: ${{ inputs.save-rust-cache == 'true' }}
 
@@ -160,6 +161,7 @@ jobs:
         id: rust-cache
         with:
           prefix-key: v1-rust-workspace
+          key: ${{ hashFiles('Cargo.toml') }}
           cache-workspace-crates: "true"
           save-if: ${{ inputs.save-rust-cache == 'true' }}
 
@@ -278,6 +280,7 @@ jobs:
         id: rust-cache
         with:
           prefix-key: v1-rust-workspace
+          key: ${{ hashFiles('Cargo.toml') }}
           workspaces: ${{ env.UV_WORKSPACE }}
           cache-workspace-crates: "true"
           # Use the same cache entry across the partitions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -434,6 +434,8 @@ lto = false
 [profile.fast-build]
 inherits = "dev"
 opt-level = 1
+# Disable the local ThinLTO implicitly enabled by `opt-level = 1`.
+lto = "off"
 debug = 0
 strip = "debuginfo"
 


### PR DESCRIPTION
## Summary

The `fast-build` test profile sets `opt-level = 1`, which implicitly enables local ThinLTO across each crate's codegen units. Explicitly disable local ThinLTO so this profile prioritizes faster compilation. The `fast-build-nightly` profile used by Linux, macOS, and Windows CI inherits the change; ordinary development, profiling, and release builds are unchanged.

Also include the root `Cargo.toml` in each test job's Rust cache key. `rust-cache` hashes workspace package manifests by default, but our virtual workspace root contains the profile settings and is omitted from that hash. Without the explicit root-manifest hash, CI can restore an exact cache hit containing artifacts from the previous profile and skip saving updated artifacts. Windows partitions continue sharing their cache.

## Benchmarks

Medians from six recent warm-cache `main` runs and five warm-cache PR runs, matched by platform and Windows partition. All 55 jobs had exact cache hits and ran the same tests; the initial cache-population run is excluded. CI sets `CARGO_INCREMENTAL=0` throughout. Compilation is Cargo's reported build time, test execution is Nextest's reported runtime, and total is the GitHub `Cargo test` step. Percentages use unrounded medians.

| Job         |             Compilation |          Test execution |                  Total |
| ----------- | ----------------------: | ----------------------: | ---------------------: |
| Linux       |  56.5 → 42.8 s (-24.3%) |   92.6 → 92.5 s (-0.1%) |  149.5 → 136 s (-9.0%) |
| macOS       |  64.0 → 45.1 s (-29.5%) | 251.0 → 250.7 s (-0.1%) |  318.5 → 298 s (-6.4%) |
| Windows 1/3 | 102.5 → 74.0 s (-27.8%) |   89.4 → 93.5 s (+4.6%) | 195.5 → 171 s (-12.5%) |
| Windows 2/3 | 111.0 → 92.0 s (-17.1%) |   60.6 → 63.8 s (+5.2%) | 183.0 → 161 s (-12.0%) |
| Windows 3/3 | 112.5 → 72.0 s (-36.0%) |  73.1 → 80.4 s (+10.1%) | 192.5 → 165 s (-14.3%) |

The Windows partitions run concurrently; their median critical path decreases from 205.5 s to 186 s (-9.5%). Test execution is effectively unchanged on Linux and macOS and somewhat slower on Windows, but every job is faster overall. Runner speed varies between jobs, so the comparison uses per-platform medians instead of individual runs.
