### PR TITLE
Avoid materializing complements during resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,8 +218,7 @@ dependencies = [
 [[package]]
 name = "astral-pubgrub"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d7afca402bd7d9ad342f48ce8dcba9bfd72c8e66c2908eb263c1cb7fc16ebd"
+source = "git+https://github.com/notatallshaw/pubgrub?branch=perf%2Ffused-difference#4b06fe0a841a82659869f24960f790b494cb8c6d"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -293,8 +292,7 @@ dependencies = [
 [[package]]
 name = "astral-version-ranges"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14445f6708e9a60d5098b6d6f99dbe7b5b347178b2736e1fad7a87b04e289791"
+source = "git+https://github.com/notatallshaw/pubgrub?branch=perf%2Ffused-difference#4b06fe0a841a82659869f24960f790b494cb8c6d"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,9 @@ dependencies = [
 
 [[package]]
 name = "astral-pubgrub"
-version = "0.6.0"
-source = "git+https://github.com/notatallshaw/pubgrub?branch=perf%2Ffused-difference#4b06fe0a841a82659869f24960f790b494cb8c6d"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256f4b5dd820e4766065c4fefa7fefb7dda0234f8ced054b4ea6909af6a92c86"
 dependencies = [
  "astral-version-ranges",
  "indexmap",
@@ -291,8 +292,9 @@ dependencies = [
 
 [[package]]
 name = "astral-version-ranges"
-version = "0.2.1"
-source = "git+https://github.com/notatallshaw/pubgrub?branch=perf%2Ffused-difference#4b06fe0a841a82659869f24960f790b494cb8c6d"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81129e143a7bcea263d5a2c50b8be47ac58365dde618bc1ac50f69f497c9cb63"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -463,3 +463,7 @@ codegen-units = 1
 # The profile that 'cargo dist' will build with.
 [profile.dist]
 inherits = "release"
+
+[patch.crates-io]
+astral-pubgrub = { git = "https://github.com/notatallshaw/pubgrub", branch = "perf/fused-difference" }
+astral-version-ranges = { git = "https://github.com/notatallshaw/pubgrub", branch = "perf/fused-difference" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
-pubgrub = { version = "0.6.0", package = "astral-pubgrub" }
+pubgrub = { version = "0.6.1", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
 rand = { version = "0.9.4" }
 rayon = { version = "1.10.0" }
@@ -286,7 +286,7 @@ unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.16.0" }
-version-ranges = { version = "0.2.1", package = "astral-version-ranges" }
+version-ranges = { version = "0.2.2", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }
@@ -463,7 +463,3 @@ codegen-units = 1
 # The profile that 'cargo dist' will build with.
 [profile.dist]
 inherits = "release"
-
-[patch.crates-io]
-astral-pubgrub = { git = "https://github.com/notatallshaw/pubgrub", branch = "perf/fused-difference" }
-astral-version-ranges = { git = "https://github.com/notatallshaw/pubgrub", branch = "perf/fused-difference" }

--- a/crates/uv-resolver/src/pubgrub/range.rs
+++ b/crates/uv-resolver/src/pubgrub/range.rs
@@ -176,6 +176,10 @@ impl Range<Version> {
         self.binary_op(other, Ranges::intersection)
     }
 
+    pub(crate) fn difference(&self, other: &Self) -> Self {
+        self.binary_op(other, Ranges::difference)
+    }
+
     pub(crate) fn union(&self, other: &Self) -> Self {
         self.binary_op(other, Ranges::union)
     }
@@ -233,6 +237,10 @@ impl VersionSet for Range<Version> {
 
     fn intersection(&self, other: &Self) -> Self {
         Self::intersection(self, other)
+    }
+
+    fn difference(&self, other: &Self) -> Self {
+        Self::difference(self, other)
     }
 
     fn contains(&self, version: &Self::V) -> bool {
@@ -369,6 +377,15 @@ mod tests {
             for right in &ranges {
                 assert_matches_recanonicalized(&left.intersection(right));
                 assert_matches_recanonicalized(&left.union(right));
+                assert_matches_recanonicalized(&left.difference(right));
+                assert_eq!(
+                    left.difference(right),
+                    left.intersection(&right.complement())
+                );
+                assert_eq!(
+                    left.difference(right).encoded_versions(),
+                    left.intersection(&right.complement()).encoded_versions()
+                );
             }
         }
     }

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -231,9 +231,8 @@ impl BatchPrefetcherRunner {
                     if let Some(candidate) =
                         selector.select_no_preference(name, &compatible, version_map, env)
                     {
-                        let compatible = compatible.intersection(
-                            &Range::singleton(candidate.version().clone()).complement(),
-                        );
+                        let compatible =
+                            compatible.difference(&Range::singleton(candidate.version().clone()));
                         phase = BatchPrefetchStrategy::Compatible {
                             compatible,
                             previous: candidate.version().clone(),
@@ -259,7 +258,7 @@ impl BatchPrefetcherRunner {
                         range = match unchangeable_constraints {
                             Term::Positive(constraints) => range.intersection(constraints),
                             Term::Negative(negative_constraints) => {
-                                range.intersection(&negative_constraints.complement())
+                                range.difference(negative_constraints)
                             }
                         };
                     }


### PR DESCRIPTION
More performance updates from nab, and the uv side of astral-sh/pubgrub#77. This forwards `difference` through uv's `Range` wrapper for both the encoded and canonical representations, and uses it in the batch prefetcher in place of intersecting with complements.

The second commit temporarily pins the pubgrub crates to that branch so the change builds end to end, and is dropped once the crates release.

On my machine I observed some small speed ups in conflict heavy scenarios:

| resolve | wall time |
|---|---|
| `pip compile` boto3+awscli, `--python-version 3.6` | -3.5 to -3.9% |
| `lock` boto3+awscli | -2.8 to -3.6% |
| `pip compile` airflow[all], `--python-version 3.8` | no change |
| small warm resolves | no change |