### PR TITLE
Add `--output-format` to `uv cache size`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -79,6 +79,17 @@ pub enum AuditOutputFormat {
     Sarif,
 }
 
+#[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
+pub enum CacheSizeOutputFormat {
+    /// Display a human-readable size in terminals and raw bytes otherwise.
+    #[default]
+    Auto,
+    /// Display the cache size in a human-readable format.
+    Human,
+    /// Display the cache size in raw bytes.
+    Machine,
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum TreeFormat {
     /// Display the dependency graph as a human-readable tree.
@@ -914,8 +925,8 @@ pub enum CacheCommand {
     /// Show the cache size.
     ///
     /// Displays the total size of the cache directory. This includes all downloaded and built
-    /// wheels, source distributions, and other cached data. By default, outputs the size in raw
-    /// bytes; use `--human` for human-readable output.
+    /// wheels, source distributions, and other cached data. By default, displays a human-readable
+    /// size when the output is a terminal and raw bytes otherwise.
     Size(SizeArgs),
 }
 
@@ -961,8 +972,17 @@ pub struct PruneArgs {
 
 #[derive(Args, Debug)]
 pub struct SizeArgs {
+    /// Select the output format.
+    #[arg(long, value_enum, default_value_t = CacheSizeOutputFormat::default())]
+    pub output_format: CacheSizeOutputFormat,
+
     /// Display the cache size in human-readable format (e.g., `1.2 GiB` instead of raw bytes).
-    #[arg(long = "human", short = 'H', alias = "human-readable")]
+    #[arg(
+        long = "human",
+        short = 'H',
+        alias = "human-readable",
+        conflicts_with = "output_format"
+    )]
     pub human: bool,
 }
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -976,7 +976,7 @@ pub struct SizeArgs {
     #[arg(long, value_enum, default_value_t = CacheSizeOutputFormat::default())]
     pub output_format: CacheSizeOutputFormat,
 
-    /// Display the cache size in human-readable format (e.g., `1.2 GiB` instead of raw bytes).
+    /// Display the cache size in human-readable format (e.g., `1.2GiB` instead of raw bytes).
     #[arg(
         long = "human",
         short = 'H',

--- a/crates/uv/src/commands/cache_size.rs
+++ b/crates/uv/src/commands/cache_size.rs
@@ -1,18 +1,20 @@
 use std::fmt::Write;
 
+use anstream::stream::IsTerminal;
 use anyhow::Result;
 use diskus::DiskUsage;
 
 use crate::commands::{ExitStatus, human_readable_bytes};
 use crate::printer::Printer;
 use uv_cache::Cache;
+use uv_cli::CacheSizeOutputFormat;
 use uv_preview::{Preview, PreviewFeature};
 use uv_warnings::warn_user;
 
 /// Display the total size of the cache.
 pub(crate) fn cache_size(
     cache: &Cache,
-    human_readable: bool,
+    output_format: CacheSizeOutputFormat,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -22,6 +24,12 @@ pub(crate) fn cache_size(
             PreviewFeature::CacheSize
         );
     }
+
+    let human_readable = match output_format {
+        CacheSizeOutputFormat::Auto => std::io::stdout().is_terminal(),
+        CacheSizeOutputFormat::Human => true,
+        CacheSizeOutputFormat::Machine => false,
+    };
 
     if !cache.root().exists() {
         if human_readable {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -28,9 +28,9 @@ use uv_cache_info::Timestamp;
 use uv_cli::SelfUpdateArgs;
 use uv_cli::{
     AuthCommand, AuthHelperCommand, AuthNamespace, BuildBackendCommand, CacheCommand,
-    CacheNamespace, Cli, Commands, PipCommand, PipNamespace, ProjectCommand, PythonCommand,
-    PythonNamespace, SelfCommand, SelfNamespace, ToolCommand, ToolNamespace, TopLevelArgs,
-    WorkspaceCommand, WorkspaceNamespace, compat::CompatArgs, options::ArgumentError,
+    CacheNamespace, CacheSizeOutputFormat, Cli, Commands, PipCommand, PipNamespace, ProjectCommand,
+    PythonCommand, PythonNamespace, SelfCommand, SelfNamespace, ToolCommand, ToolNamespace,
+    TopLevelArgs, WorkspaceCommand, WorkspaceNamespace, compat::CompatArgs, options::ArgumentError,
 };
 use uv_client::BaseClientBuilder;
 use uv_configuration::min_stack_size;
@@ -1304,7 +1304,14 @@ async fn run_with_workspace_cache(
         }) => commands::cache_dir(&cache, printer),
         Commands::Cache(CacheNamespace {
             command: CacheCommand::Size(args),
-        }) => commands::cache_size(&cache, args.human, printer, globals.preview),
+        }) => {
+            let output_format = if args.human {
+                CacheSizeOutputFormat::Human
+            } else {
+                args.output_format
+            };
+            commands::cache_size(&cache, output_format, printer, globals.preview)
+        }
         Commands::Build(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::BuildSettings::resolve(args, filesystem, environment)?;

--- a/crates/uv/tests/build/cache_size.rs
+++ b/crates/uv/tests/build/cache_size.rs
@@ -1,6 +1,15 @@
 use assert_cmd::assert::OutputAssertExt;
 
-use uv_test::uv_snapshot;
+use uv_test::{TestContext, uv_snapshot};
+
+/// Preserve cache sizes in snapshots so human-readable and machine output remain distinguishable.
+fn cache_size_filters(context: &TestContext) -> Vec<(&str, &str)> {
+    context
+        .filters()
+        .into_iter()
+        .filter(|(_, replacement)| *replacement != "$1[SIZE]")
+        .collect()
+}
 
 /// Test that `cache size` returns 0 for an empty cache directory (raw output).
 #[test]
@@ -46,5 +55,72 @@ fn cache_size_with_packages_human() {
     exit_code: 0 (success)
     ----- stdout -----
     [SIZE]
+    ");
+}
+
+/// Explicit output formats override terminal detection.
+#[test]
+fn cache_size_output_formats() {
+    let context = uv_test::test_context!("3.12");
+    context.clean().assert().success();
+
+    uv_snapshot!(context.cache_size().arg("--preview").arg("--output-format").arg("auto"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    0
+    ");
+
+    uv_snapshot!(cache_size_filters(&context), context.cache_size().arg("--preview").arg("--output-format").arg("human"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    0B
+    ");
+
+    uv_snapshot!(context.cache_size().arg("--preview").arg("--output-format").arg("machine"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    0
+    ");
+}
+
+/// Existing human-readable flags remain equivalent to `--output-format human`.
+#[test]
+fn cache_size_human_aliases() {
+    let context = uv_test::test_context!("3.12");
+    context.clean().assert().success();
+    let filters = cache_size_filters(&context);
+
+    uv_snapshot!(&filters, context.cache_size().arg("--preview").arg("--human"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    0B
+    ");
+
+    uv_snapshot!(&filters, context.cache_size().arg("--preview").arg("-H"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    0B
+    ");
+
+    uv_snapshot!(&filters, context.cache_size().arg("--preview").arg("--human-readable"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    0B
+    ");
+}
+
+/// Legacy human-readable flags cannot be combined with an explicit output format.
+#[test]
+fn cache_size_output_format_conflicts_with_human() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.cache_size().arg("--preview").arg("--human").arg("--output-format").arg("machine"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: the argument '--human' cannot be used with '--output-format <OUTPUT_FORMAT>'
+
+    Usage: uv cache size --cache-dir [CACHE_DIR] --human
+
+    For more information, try '--help'.
     ");
 }


### PR DESCRIPTION
## Summary

Closes #20984.

This serves two purposes:

1. It aligns `uv cache size` with the `--output-format` pattern we use elsewhere for selecting/configuring output presentation.
2. It makes the default presentation more useful to humans, by doing the equivalent of `--human` if `stdout` is detected to be a terminal.

The existing `-H, --human` flag is preserved, although arguably we could remove it entirely since this is all in preview.

## Test Plan

Added integration tests.

Note: I intentionally omitted integration tests for `--output-format=auto`, since I couldn't find a pre-existing test pattern for producing a PTY/interactive TTY. It'd be pretty easy to add with Python's `pty` though.