### PR TITLE
Enable PGO for Linux ARM64 uv releases

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -563,7 +563,7 @@ jobs:
 
             if [[ "${{ matrix.platform.target }}" == "aarch64-unknown-linux-gnu" ]]; then
                 rustup component add llvm-tools-preview
-                /opt/python/cp311-cp311/bin/python scripts/build_uv_pgo.py \
+                python${{ env.PYTHON_VERSION }} scripts/build_uv_pgo.py \
                     --target "${{ matrix.platform.target }}" \
                     --target-dir "$PWD/target/uv-pgo" \
                     --train-only

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -517,8 +517,8 @@ jobs:
 
   linux-arm:
     name: ${{ matrix.platform.target }}
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 30
+    runs-on: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && 'ubuntu-24.04-arm' || 'depot-ubuntu-24.04-8' }}
+    timeout-minutes: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && 60 || 30 }}
     strategy:
       matrix:
         platform:
@@ -560,6 +560,16 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
+
+            if [[ "${{ matrix.platform.target }}" == "aarch64-unknown-linux-gnu" ]]; then
+                rustup component add llvm-tools-preview
+                /opt/python/cp311-cp311/bin/python scripts/build_uv_pgo.py \
+                    --target "${{ matrix.platform.target }}" \
+                    --target-dir "$PWD/target/uv-pgo" \
+                    --train-only
+
+                export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=$PWD/target/uv-pgo/uv.profdata"
+            fi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
       - uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -517,7 +517,7 @@ jobs:
 
   linux-arm:
     name: ${{ matrix.platform.target }}
-    runs-on: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && 'ubuntu-24.04-arm' || 'depot-ubuntu-24.04-8' }}
+    runs-on: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && 'depot-ubuntu-24.04-arm-8' || 'depot-ubuntu-24.04-8' }}
     timeout-minutes: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && 60 || 30 }}
     strategy:
       matrix:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -517,13 +517,16 @@ jobs:
 
   linux-arm:
     name: ${{ matrix.platform.target }}
-    runs-on: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && 'depot-ubuntu-24.04-arm-8' || 'depot-ubuntu-24.04-8' }}
-    timeout-minutes: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && 60 || 30 }}
+    runs-on: ${{ matrix.platform.runner }}
+    timeout-minutes: ${{ matrix.platform.pgo && 60 || 30 }}
     strategy:
       matrix:
         platform:
+          # PGO requires a native runner; the 32-bit ARM targets are cross-compiled.
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
+            runner: depot-ubuntu-24.04-arm-8
+            pgo: true
             # see https://github.com/astral-sh/ruff/issues/3791
             # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
@@ -531,9 +534,13 @@ jobs:
             manylinux: 2_28
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7
+            runner: depot-ubuntu-24.04-8
+            pgo: false
             manylinux: 2_17
           - target: arm-unknown-linux-musleabihf
             arch: arm
+            runner: depot-ubuntu-24.04-8
+            pgo: false
             # Special case: armv6l is linux_armv6l, no manylinux or musllinux.
             # "auto" instead of "off" to get the cross container
             manylinux: auto
@@ -561,7 +568,7 @@ jobs:
           before-script-linux: |
             scripts/install-cargo-extensions.sh
 
-            if [[ "${{ matrix.platform.target }}" == "aarch64-unknown-linux-gnu" ]]; then
+            if [[ "${{ matrix.platform.pgo }}" == "true" ]]; then
                 rustup component add llvm-tools-preview
                 python${{ env.PYTHON_VERSION }} scripts/build_uv_pgo.py \
                     --target "${{ matrix.platform.target }}" \


### PR DESCRIPTION
## Summary

This PR enables PGO for uv's Linux ARM64 releases, following the approach outlined in https://github.com/astral-sh/uv/pull/21001. (To enable PGO, we also move to a native ARM64 runner.)
