### PR TITLE
Preserve inline comments when updating dependencies

### DIFF
--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1894,6 +1894,19 @@ fn reformat_array_multiline(deps: &mut Array) {
         Box::new(iter)
     }
 
+    // Without a trailing comma, `toml_edit` stores comments after the final item in its
+    // suffix. Once we add a trailing comma, those comments must follow the comma instead.
+    if !deps.trailing_comma()
+        && let Some(last) = deps.iter_mut().last()
+        && let Some(suffix) = last.decor().suffix().and_then(RawString::as_str)
+        && suffix.contains('#')
+    {
+        let suffix = suffix.to_string();
+        last.decor_mut().set_suffix("");
+        let trailing = deps.trailing().as_str().unwrap_or_default();
+        deps.set_trailing(format!("{suffix}{trailing}"));
+    }
+
     let mut indentation_prefix = None;
 
     // Calculate the indentation prefix based on the indentation of the first dependency entry.

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -11452,6 +11452,54 @@ fn add_preserves_end_of_line_comment_on_non_last_deps() -> Result<()> {
 }
 
 #[test]
+fn add_preserves_end_of_line_comment_on_updated_optional_dependency() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [project.optional-dependencies]
+        typing = [
+            "pandas-stubs>=2.0.2",
+            "narwhals>=1.42.0" # narwhals are toothed whales native to the Arctic
+        ]
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("narwhals>=1.42").arg("--optional=typing").arg("--frozen"), @"
+    exit_code: 0 (success)
+    ");
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [project.optional-dependencies]
+        typing = [
+            "pandas-stubs>=2.0.2",
+            "narwhals>=1.42", # narwhals are toothed whales native to the Arctic
+        ]
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+#[test]
 fn add_direct_url_subdirectory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
## Summary

We now preserve inline comments attached to the final dependency in a TOML array when `uv add` updates an existing requirement and the entry does not end in a comma.

Without a trailing comma, `toml_edit` stores the inline comment in the final item's suffix. Our array formatter previously treated that suffix as a prefix, moving the comment onto the preceding dependency. Move the suffix into the array's trailing decoration before adding the comma so the comment remains attached to the updated dependency.

For example, given:

```toml
typing = [
    "pandas-stubs>=2.0.2",
    "narwhals>=1.42.0" # narwhals are toothed whales
]
```

Updating `narwhals` now produces:

```toml
typing = [
    "pandas-stubs>=2.0.2",
    "narwhals>=1.42", # narwhals are toothed whales
]
```

Closes https://github.com/astral-sh/uv/issues/21006.
