### PR TITLE
Parse PyPI Simple API JSON responses directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7020,6 +7020,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "mailparse",
+ "memchr",
  "petgraph",
  "regex",
  "rkyv",

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -685,7 +685,7 @@ impl RegistryClient {
                             )
                         })?;
 
-                        let data: PypiSimpleDetail = serde_json::from_slice(bytes.as_ref())
+                        let data = PypiSimpleDetail::from_json(bytes.as_ref())
                             .map_err(|err| Error::from_json_err(err, url.clone()))?;
 
                         SimpleDetailMetadata::from_pypi_files(

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -30,12 +30,14 @@ indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 jiff = { workspace = true, features = ["serde"] }
 mailparse = { workspace = true }
+memchr = { workspace = true }
 petgraph = { workspace = true }
 regex = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde-untagged = { workspace = true }
 thiserror = { workspace = true }
 toml_edit = { workspace = true }
@@ -45,7 +47,6 @@ url = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 insta = { workspace = true }
-serde_json = { workspace = true }
 
 [features]
 schemars = ["dep:schemars", "uv-normalize/schemars"]

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -30,7 +30,9 @@ pub struct PypiSimpleDetail {
 }
 
 impl PypiSimpleDetail {
-    /// Parse a Simple API JSON response, falling back to Serde for unsupported syntax.
+    /// Parse a PyPI Simple API JSON response directly whenever possible.
+    ///
+    /// Fall back to Serde for unsupported input, preserving its behavior and errors.
     pub fn from_json(input: &[u8]) -> Result<Self, serde_json::Error> {
         parser::parse(input).map_or_else(|| serde_json::from_slice(input), Ok)
     }
@@ -897,7 +899,7 @@ pub enum HashError {
 mod tests {
     use std::sync::Arc;
 
-    use crate::{CoreMetadata, HashError, Hashes, PypiSimpleDetail, Status, Yanked};
+    use crate::{CoreMetadata, HashError, Hashes, PypiSimpleDetail, Status};
 
     fn parse_pypi_simple_json(json: &str) -> Result<PypiSimpleDetail, serde_json::Error> {
         let expected: PypiSimpleDetail = serde_json::from_str(json)?;
@@ -1043,45 +1045,14 @@ mod tests {
         "#;
 
         let detail = parse_pypi_simple_json(json)?;
-
-        assert_eq!(detail.project_status.status, Status::Archived);
-        assert_eq!(
-            detail.project_status.reason.as_deref(),
-            Some("This project is no longer maintained.")
-        );
-        assert_eq!(detail.files.len(), 2);
-
-        let source = &detail.files[0];
-        assert_eq!(source.filename.as_ref(), "example-1.0.0.tar.gz");
-        assert_eq!(source.size, Some(424_460));
-        assert!(source.upload_time.is_some());
-        assert_eq!(source.hashes.md5.as_deref(), Some("file-md5"));
-        assert_eq!(source.hashes.sha256.as_deref(), Some("file-sha256"));
-        assert_eq!(source.hashes.sha384.as_deref(), Some("file-sha384"));
-        assert_eq!(source.hashes.sha512.as_deref(), Some("file-sha512"));
-        assert_eq!(source.hashes.blake2b.as_deref(), Some("file-blake2b"));
-        assert!(matches!(
-            source.core_metadata,
-            Some(CoreMetadata::Hashes(ref hashes))
-                if hashes.sha256.as_deref() == Some("metadata-sha256")
-        ));
-        assert!(matches!(
-            source.yanked.as_deref(),
-            Some(Yanked::Reason(reason)) if reason.as_ref() == "Withdrawn for testing"
-        ));
-
-        let wheel = &detail.files[1];
-        assert!(matches!(
-            wheel.core_metadata,
-            Some(CoreMetadata::Bool(true))
-        ));
-        assert!(matches!(wheel.yanked.as_deref(), Some(Yanked::Bool(false))));
-
-        let Some(Ok(source_requires_python)) = source.requires_python.as_ref() else {
-            return Err(serde::de::Error::custom("missing source requires-python"));
+        let [source, wheel] = detail.files.as_slice() else {
+            return Err(serde::de::Error::custom("expected two files"));
         };
-        let Some(Ok(wheel_requires_python)) = wheel.requires_python.as_ref() else {
-            return Err(serde::de::Error::custom("missing wheel requires-python"));
+        let (Some(Ok(source_requires_python)), Some(Ok(wheel_requires_python))) = (
+            source.requires_python.as_ref(),
+            wheel.requires_python.as_ref(),
+        ) else {
+            return Err(serde::de::Error::custom("missing requires-python"));
         };
         assert!(Arc::ptr_eq(source_requires_python, wheel_requires_python));
 
@@ -1182,18 +1153,6 @@ mod tests {
 
         assert_eq!(detail.project_status.reason.as_deref(), Some("Archived 🚀"));
         assert_eq!(detail.files[0].filename.as_ref(), "example-1.0.tar.gz");
-        assert_eq!(
-            detail.files[0].hashes.sha256.as_deref(),
-            Some("escaped-hash")
-        );
-        assert_eq!(
-            detail.files[0].url.as_ref(),
-            "https://example.com/example-1.0.tar.gz"
-        );
-        assert!(matches!(
-            detail.files[0].yanked.as_deref(),
-            Some(Yanked::Reason(reason)) if reason.as_ref() == "Quoted \"reason\"\nsecond line"
-        ));
 
         Ok(())
     }
@@ -1222,11 +1181,6 @@ mod tests {
         "#;
 
         let detail = parse_pypi_simple_json(json)?;
-
-        assert_eq!(detail.files[0].filename.as_ref(), "example-1.0.tar.gz");
-        assert!(detail.files[0].hashes.sha256.is_none());
-        assert!(detail.files[0].requires_python.is_none());
-        assert!(detail.files[0].core_metadata.is_none());
         assert!(
             detail.files[1]
                 .requires_python
@@ -1242,18 +1196,14 @@ mod tests {
         let invalid = [
             "",
             "null",
-            "[]",
             "{}",
             r#"{"files":null}"#,
-            r#"{"files":{}}"#,
             r#"{"files":[null]}"#,
             r#"{"files":[],}"#,
             r#"{"files":[]} trailing"#,
             r#"{"files":[],"files":[]}"#,
             r#"{"files":[],"ignored":01}"#,
-            r#"{"files":[],"ignored":-01}"#,
             r#"{"files":[],"ignored":1.}"#,
-            r#"{"files":[],"ignored":1e}"#,
             r#"{"files":[],"ignored":1e+}"#,
             r#"{"files":[],"ignored":+1}"#,
             r#"{"files":[],"ignored":tru}"#,
@@ -1280,7 +1230,6 @@ mod tests {
             r#"{"files":[{"filename":"file","hashes":{},"url":"file","requires-python":false}]}"#,
             r#"{"files":[{"filename":"file","hashes":{},"url":"file","core-metadata":42}]}"#,
             r#"{"files":[{"filename":"file","hashes":{},"url":"file","yanked":null}]}"#,
-            r#"{"files":[{"filename":"file","hashes":{},"url":"file","yanked":42}]}"#,
             r#"{"files":[{"filename":"\uD800","hashes":{},"url":"file"}]}"#,
         ];
 
@@ -1304,8 +1253,7 @@ mod tests {
             "[".repeat(128),
             "]".repeat(128)
         );
-        assert!(serde_json::from_str::<PypiSimpleDetail>(&excessive_nesting).is_ok());
-        assert!(PypiSimpleDetail::from_json(excessive_nesting.as_bytes()).is_ok());
+        assert!(parse_pypi_simple_json(&excessive_nesting).is_ok());
     }
 }
 

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -14,6 +14,8 @@ use uv_small_str::SmallString;
 use crate::lenient_requirement::LenientVersionSpecifiers;
 use crate::{ProjectStatus, VerbatimParsedUrl};
 
+mod parser;
+
 /// A collection of "files" from `PyPI`'s JSON API for a single package, as served by the
 /// `vnd.pypi.simple.v1` media type.
 #[derive(Debug, Clone, Deserialize)]
@@ -25,6 +27,13 @@ pub struct PypiSimpleDetail {
     /// The list of [`PypiFile`]s available for download.
     #[serde(deserialize_with = "deserialize_pypi_files")]
     pub files: Vec<PypiFile>,
+}
+
+impl PypiSimpleDetail {
+    /// Parse a Simple API JSON response, falling back to Serde for unsupported syntax.
+    pub fn from_json(input: &[u8]) -> Result<Self, serde_json::Error> {
+        parser::parse(input).map_or_else(|| serde_json::from_slice(input), Ok)
+    }
 }
 
 /// A single (remote) file belonging to a package, either a wheel or a source distribution, as
@@ -886,7 +895,18 @@ pub enum HashError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{HashError, Hashes};
+    use std::sync::Arc;
+
+    use crate::{CoreMetadata, HashError, Hashes, PypiSimpleDetail, Status, Yanked};
+
+    fn parse_pypi_simple_json(json: &str) -> Result<PypiSimpleDetail, serde_json::Error> {
+        let expected: PypiSimpleDetail = serde_json::from_str(json)?;
+        let actual = PypiSimpleDetail::from_json(json.as_bytes())?;
+
+        assert_eq!(format!("{actual:#?}"), format!("{expected:#?}"));
+
+        Ok(actual)
+    }
 
     #[test]
     fn parse_hashes() -> Result<(), HashError> {
@@ -974,6 +994,318 @@ mod tests {
         assert!(result.is_err());
 
         Ok(())
+    }
+
+    #[test]
+    fn parse_pypi_simple_json_response() -> Result<(), serde_json::Error> {
+        let json = r#"
+        {
+            "ignored-before-files": {"nested": [true, null, 42, {"value": "ignored"}]},
+            "project-status": {
+                "reason": "This project is no longer maintained.",
+                "status": "archived",
+                "ignored": false
+            },
+            "files": [
+                {
+                    "requires-python": ">=3.8",
+                    "unknown": {"nested": [false, null, "ignored"]},
+                    "data-dist-info-metadata": null,
+                    "core-metadata": {"sha256": "metadata-sha256"},
+                    "dist-info-metadata": false,
+                    "filename": "example-1.0.0.tar.gz",
+                    "hashes": {
+                        "unknown": {"nested": [true, null]},
+                        "sha512": "file-sha512",
+                        "blake2b": "file-blake2b",
+                        "sha384": "file-sha384",
+                        "md5": "file-md5",
+                        "sha256": "file-sha256"
+                    },
+                    "upload-time": "2022-08-04T10:42:02.190074Z",
+                    "size": 424460,
+                    "url": "https://example.com/example-1.0.0.tar.gz",
+                    "yanked": "Withdrawn for testing"
+                },
+                {
+                    "hashes": {"sha256": "wheel-sha256"},
+                    "url": "https://example.com/example-1.0.0-py3-none-any.whl",
+                    "yanked": false,
+                    "requires-python": ">=3.8",
+                    "dist-info-metadata": true,
+                    "filename": "example-1.0.0-py3-none-any.whl"
+                }
+            ],
+            "meta": {"api-version": "1.4", "_last-serial": 15765070},
+            "name": "example",
+            "versions": ["1.0.0"]
+        }
+        "#;
+
+        let detail = parse_pypi_simple_json(json)?;
+
+        assert_eq!(detail.project_status.status, Status::Archived);
+        assert_eq!(
+            detail.project_status.reason.as_deref(),
+            Some("This project is no longer maintained.")
+        );
+        assert_eq!(detail.files.len(), 2);
+
+        let source = &detail.files[0];
+        assert_eq!(source.filename.as_ref(), "example-1.0.0.tar.gz");
+        assert_eq!(source.size, Some(424_460));
+        assert!(source.upload_time.is_some());
+        assert_eq!(source.hashes.md5.as_deref(), Some("file-md5"));
+        assert_eq!(source.hashes.sha256.as_deref(), Some("file-sha256"));
+        assert_eq!(source.hashes.sha384.as_deref(), Some("file-sha384"));
+        assert_eq!(source.hashes.sha512.as_deref(), Some("file-sha512"));
+        assert_eq!(source.hashes.blake2b.as_deref(), Some("file-blake2b"));
+        assert!(matches!(
+            source.core_metadata,
+            Some(CoreMetadata::Hashes(ref hashes))
+                if hashes.sha256.as_deref() == Some("metadata-sha256")
+        ));
+        assert!(matches!(
+            source.yanked.as_deref(),
+            Some(Yanked::Reason(reason)) if reason.as_ref() == "Withdrawn for testing"
+        ));
+
+        let wheel = &detail.files[1];
+        assert!(matches!(
+            wheel.core_metadata,
+            Some(CoreMetadata::Bool(true))
+        ));
+        assert!(matches!(wheel.yanked.as_deref(), Some(Yanked::Bool(false))));
+
+        let Some(Ok(source_requires_python)) = source.requires_python.as_ref() else {
+            return Err(serde::de::Error::custom("missing source requires-python"));
+        };
+        let Some(Ok(wheel_requires_python)) = wheel.requires_python.as_ref() else {
+            return Err(serde::de::Error::custom("missing wheel requires-python"));
+        };
+        assert!(Arc::ptr_eq(source_requires_python, wheel_requires_python));
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_pypi_simple_json_metadata_aliases() -> Result<(), serde_json::Error> {
+        let cases = [
+            (
+                r#""core-metadata": null, "dist-info-metadata": true, "data-dist-info-metadata": false"#,
+                Some(true),
+            ),
+            (
+                r#""data-dist-info-metadata": false, "core-metadata": "ignored""#,
+                Some(false),
+            ),
+            (
+                r#""dist-info-metadata": {"sha256": "metadata"}, "core-metadata": true"#,
+                Some(true),
+            ),
+            (r#""core-metadata": null, "dist-info-metadata": null"#, None),
+        ];
+
+        for (metadata, expected) in cases {
+            let json = format!(
+                r#"{{"files":[{{{metadata},"filename":"example-1.0.tar.gz","hashes":{{}},"url":"https://example.com/example-1.0.tar.gz"}}]}}"#
+            );
+            let detail = parse_pypi_simple_json(&json)?;
+
+            assert_eq!(
+                detail.files[0]
+                    .core_metadata
+                    .as_ref()
+                    .map(CoreMetadata::is_available),
+                expected,
+                "unexpected metadata for {metadata}"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_pypi_simple_json_project_status() -> Result<(), serde_json::Error> {
+        let cases = [
+            (r#"{"files":[]}"#, Status::Active, None),
+            (r#"{"files":[],"project-status":{}}"#, Status::Active, None),
+            (
+                r#"{"files":[],"project-status":{"status":"unknown","reason":null}}"#,
+                Status::Active,
+                None,
+            ),
+            (
+                r#"{"project-status":{"status":"quarantined","reason":"unsafe"},"files":[]}"#,
+                Status::Quarantined,
+                Some("unsafe"),
+            ),
+            (
+                r#"{"files":[],"project-status":{"status":"deprecated"}}"#,
+                Status::Deprecated,
+                None,
+            ),
+        ];
+
+        for (json, expected_status, expected_reason) in cases {
+            let detail = parse_pypi_simple_json(json)?;
+
+            assert_eq!(detail.project_status.status, expected_status);
+            assert_eq!(detail.project_status.reason.as_deref(), expected_reason);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_pypi_simple_json_escaped_strings() -> Result<(), serde_json::Error> {
+        let json = r#"
+        {
+            "igno\u0072ed": {"escaped": "\uD83D\uDE80 \"quoted\"\n"},
+            "project-status": {
+                "status": "archived",
+                "reason": "Archived \uD83D\uDE80"
+            },
+            "fi\u006ces": [
+                {
+                    "filename": "example-\u0031.0.tar.gz",
+                    "hashes": {"sha\u003256": "escaped-hash"},
+                    "requires-python": "\u003e=3.8",
+                    "url": "https:\/\/example.com\/example-1.0.tar.gz",
+                    "yanked": "Quoted \"reason\"\nsecond line"
+                }
+            ]
+        }
+        "#;
+
+        let detail = parse_pypi_simple_json(json)?;
+
+        assert_eq!(detail.project_status.reason.as_deref(), Some("Archived 🚀"));
+        assert_eq!(detail.files[0].filename.as_ref(), "example-1.0.tar.gz");
+        assert_eq!(
+            detail.files[0].hashes.sha256.as_deref(),
+            Some("escaped-hash")
+        );
+        assert_eq!(
+            detail.files[0].url.as_ref(),
+            "https://example.com/example-1.0.tar.gz"
+        );
+        assert!(matches!(
+            detail.files[0].yanked.as_deref(),
+            Some(Yanked::Reason(reason)) if reason.as_ref() == "Quoted \"reason\"\nsecond line"
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_pypi_simple_json_optional_fields() -> Result<(), serde_json::Error> {
+        let json = r#"
+        {
+            "files": [
+                {
+                    "filename": "overwritten.tar.gz",
+                    "filename": "example-1.0.tar.gz",
+                    "hashes": {"sha256": null, "unsupported": [true, null, {}]},
+                    "requires-python": null,
+                    "core-metadata": null,
+                    "url": "https://example.com/example-1.0.tar.gz"
+                },
+                {
+                    "filename": "example-2.0.tar.gz",
+                    "hashes": {},
+                    "requires-python": ">=3.8,,<4",
+                    "url": "https://example.com/example-2.0.tar.gz"
+                }
+            ]
+        }
+        "#;
+
+        let detail = parse_pypi_simple_json(json)?;
+
+        assert_eq!(detail.files[0].filename.as_ref(), "example-1.0.tar.gz");
+        assert!(detail.files[0].hashes.sha256.is_none());
+        assert!(detail.files[0].requires_python.is_none());
+        assert!(detail.files[0].core_metadata.is_none());
+        assert!(
+            detail.files[1]
+                .requires_python
+                .as_ref()
+                .is_some_and(Result::is_err)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_pypi_simple_json_rejects_invalid_input() {
+        let invalid = [
+            "",
+            "null",
+            "[]",
+            "{}",
+            r#"{"files":null}"#,
+            r#"{"files":{}}"#,
+            r#"{"files":[null]}"#,
+            r#"{"files":[],}"#,
+            r#"{"files":[]} trailing"#,
+            r#"{"files":[],"files":[]}"#,
+            r#"{"files":[],"ignored":01}"#,
+            r#"{"files":[],"ignored":-01}"#,
+            r#"{"files":[],"ignored":1.}"#,
+            r#"{"files":[],"ignored":1e}"#,
+            r#"{"files":[],"ignored":1e+}"#,
+            r#"{"files":[],"ignored":+1}"#,
+            r#"{"files":[],"ignored":tru}"#,
+            r#"{"files":[],"ignored":{"nested":[true,]}}"#,
+            "{\"files\":[],\"ignored\":\"line\nbreak\"}",
+            r#"{"files":[],"project-status":null}"#,
+            r#"{"files":[],"project-status":{"status":null}}"#,
+            r#"{"files":[],"project-status":{"reason":42}}"#,
+            r#"{"files":[],"project-status":{},"project-status":{}}"#,
+            r#"{"files":[{"hashes":{},"url":"file"}]}"#,
+            r#"{"files":[{"filename":"file","url":"file"}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{}}]}"#,
+            r#"{"files":[{"filename":null,"hashes":{},"url":"file"}]}"#,
+            r#"{"files":[{"filename":"file","hashes":null,"url":"file"}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":null}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{"sha256":42},"url":"file"}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{"sha256":"one","sha256":"two"},"url":"file"}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","size":null}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","size":-1}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","size":1.5}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","size":18446744073709551616}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","upload-time":null}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","upload-time":"invalid"}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","requires-python":false}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","core-metadata":42}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","yanked":null}]}"#,
+            r#"{"files":[{"filename":"file","hashes":{},"url":"file","yanked":42}]}"#,
+            r#"{"files":[{"filename":"\uD800","hashes":{},"url":"file"}]}"#,
+        ];
+
+        for json in invalid {
+            let expected = serde_json::from_str::<PypiSimpleDetail>(json);
+            let actual = PypiSimpleDetail::from_json(json.as_bytes());
+
+            assert!(expected.is_err(), "Serde unexpectedly accepted {json}");
+            assert!(
+                actual.is_err(),
+                "the dedicated parser unexpectedly accepted {json}"
+            );
+        }
+
+        let invalid_utf8 = b"{\"files\":[{\"filename\":\"\xff\",\"hashes\":{},\"url\":\"file\"}]}";
+        assert!(serde_json::from_slice::<PypiSimpleDetail>(invalid_utf8).is_err());
+        assert!(PypiSimpleDetail::from_json(invalid_utf8).is_err());
+
+        let excessive_nesting = format!(
+            "{{\"files\":[],\"ignored\":{}null{}}}",
+            "[".repeat(128),
+            "]".repeat(128)
+        );
+        assert!(serde_json::from_str::<PypiSimpleDetail>(&excessive_nesting).is_ok());
+        assert!(PypiSimpleDetail::from_json(excessive_nesting.as_bytes()).is_ok());
     }
 }
 

--- a/crates/uv-pypi-types/src/simple_json/parser.rs
+++ b/crates/uv-pypi-types/src/simple_json/parser.rs
@@ -7,7 +7,9 @@ use uv_small_str::SmallString;
 use super::{CoreMetadata, Hashes, PypiFile, PypiSimpleDetail, RequiresPythonInterner, Yanked};
 use crate::{ProjectStatus, Status};
 
-/// Returns `None` for syntax that should be handled by the general JSON parser.
+/// Parses an unescaped PyPI Simple API response without intermediate wire values.
+///
+/// Returns `None` when Serde must handle unsupported input or report a parsing error.
 pub(super) fn parse(input: &[u8]) -> Option<PypiSimpleDetail> {
     if memchr(b'\\', input).is_some() {
         return None;
@@ -20,16 +22,19 @@ pub(super) fn parse(input: &[u8]) -> Option<PypiSimpleDetail> {
     (parser.offset == input.len()).then_some(detail)
 }
 
+/// A cursor over validated UTF-8 containing no JSON escape sequences.
 struct Parser<'input> {
     input: &'input str,
     offset: usize,
 }
 
+/// Distinguishes an object key from the end of an otherwise valid object.
 enum ObjectKey<'input> {
     Key(&'input str),
     End,
 }
 
+/// Distinguishes a successfully parsed JSON `null` from a parsing failure.
 enum Nullable<T> {
     Value(T),
     Null,
@@ -45,6 +50,7 @@ impl<T> Nullable<T> {
 }
 
 impl<'input> Parser<'input> {
+    /// Parses the project object while rejecting duplicate known top-level fields.
     fn detail(&mut self) -> Option<PypiSimpleDetail> {
         self.skip_whitespace();
         self.consume(b'{')?;
@@ -55,18 +61,11 @@ impl<'input> Parser<'input> {
 
         while let ObjectKey::Key(key) = self.object_key(&mut first)? {
             match key {
-                "files" => {
-                    if files.is_some() {
-                        return None;
-                    }
-                    files = Some(self.files()?);
-                }
-                "project-status" => {
-                    if project_status.is_some() {
-                        return None;
-                    }
+                "files" if files.is_none() => files = Some(self.files()?),
+                "project-status" if project_status.is_none() => {
                     project_status = Some(self.project_status()?);
                 }
+                "files" | "project-status" => return None,
                 _ => self.skip_value(0)?,
             }
         }
@@ -77,6 +76,7 @@ impl<'input> Parser<'input> {
         })
     }
 
+    /// Parses distributions using one interner for repeated Python requirements.
     fn files(&mut self) -> Option<Vec<PypiFile>> {
         self.consume(b'[')?;
 
@@ -91,6 +91,7 @@ impl<'input> Parser<'input> {
         Some(files)
     }
 
+    /// Builds a [`PypiFile`] directly while preserving metadata-alias precedence.
     fn file(&mut self, interner: &mut RequiresPythonInterner) -> Option<PypiFile> {
         self.consume(b'{')?;
 
@@ -134,6 +135,7 @@ impl<'input> Parser<'input> {
         })
     }
 
+    /// Parses known hashes, optimizing the common SHA-256-only representation.
     fn hashes(&mut self) -> Option<Hashes> {
         if let Some(digest) = self.single_sha256_digest() {
             return Some(Hashes {
@@ -172,6 +174,7 @@ impl<'input> Parser<'input> {
         Some(hashes)
     }
 
+    /// Consumes a compact `{"sha256":"..."}` object without advancing on mismatch.
     fn single_sha256_digest(&mut self) -> Option<&'input str> {
         const PREFIX: &[u8] = b"{\"sha256\":\"";
 
@@ -212,36 +215,33 @@ impl<'input> Parser<'input> {
         }
     }
 
+    /// Parses project status with Serde-compatible defaults and duplicate detection.
     fn project_status(&mut self) -> Option<ProjectStatus> {
         self.consume(b'{')?;
 
-        let mut project_status = ProjectStatus::default();
-        let mut seen_status = false;
+        let mut status = None;
+        let mut reason = None;
         let mut seen_reason = false;
         let mut first = true;
 
         while let ObjectKey::Key(key) = self.object_key(&mut first)? {
             match key {
-                "status" => {
-                    if seen_status {
-                        return None;
-                    }
-                    seen_status = true;
-                    project_status.status = Status::new(self.string()?).unwrap_or_default();
+                "status" if status.is_none() => {
+                    status = Some(Status::new(self.string()?).unwrap_or_default());
                 }
-                "reason" => {
-                    if seen_reason {
-                        return None;
-                    }
+                "reason" if !seen_reason => {
                     seen_reason = true;
-                    project_status.reason =
-                        self.nullable_string()?.into_option().map(SmallString::from);
+                    reason = self.nullable_string()?.into_option().map(SmallString::from);
                 }
+                "status" | "reason" => return None,
                 _ => self.skip_value(0)?,
             }
         }
 
-        Some(project_status)
+        Some(ProjectStatus {
+            status: status.unwrap_or_default(),
+            reason,
+        })
     }
 
     fn object_key(&mut self, first: &mut bool) -> Option<ObjectKey<'input>> {
@@ -286,6 +286,7 @@ impl<'input> Parser<'input> {
         Some(true)
     }
 
+    /// Borrows an unescaped JSON string while rejecting raw control characters.
     fn string(&mut self) -> Option<&'input str> {
         self.consume(b'"')?;
         let start = self.offset;
@@ -310,6 +311,7 @@ impl<'input> Parser<'input> {
         }
     }
 
+    /// Parses a `u64`, rejecting leading zeros and integer overflow.
     fn unsigned_integer(&mut self) -> Option<u64> {
         let first = self.peek()?;
         if !first.is_ascii_digit() {
@@ -334,19 +336,16 @@ impl<'input> Parser<'input> {
     }
 
     fn boolean(&mut self) -> Option<bool> {
-        match self.peek()? {
-            b't' => {
-                self.literal(b"true")?;
-                Some(true)
-            }
-            b'f' => {
-                self.literal(b"false")?;
-                Some(false)
-            }
-            _ => None,
-        }
+        let (literal, value) = match self.peek()? {
+            b't' => (b"true".as_slice(), true),
+            b'f' => (b"false".as_slice(), false),
+            _ => return None,
+        };
+        self.literal(literal)?;
+        Some(value)
     }
 
+    /// Validates and skips an ignored value, leaving excessive nesting to Serde.
     fn skip_value(&mut self, depth: u8) -> Option<()> {
         if depth >= 64 {
             return None;
@@ -381,6 +380,7 @@ impl<'input> Parser<'input> {
         Some(())
     }
 
+    /// Validates an ignored JSON number without allocating or converting its value.
     fn skip_number(&mut self) -> Option<()> {
         if self.peek()? == b'-' {
             self.offset += 1;
@@ -393,17 +393,13 @@ impl<'input> Parser<'input> {
                     return None;
                 }
             }
-            b'1'..=b'9' => self.skip_digits(),
+            b'1'..=b'9' => self.skip_digits()?,
             _ => return None,
         }
 
         if self.peek() == Some(b'.') {
             self.offset += 1;
-            let start = self.offset;
-            self.skip_digits();
-            if self.offset == start {
-                return None;
-            }
+            self.skip_digits()?;
         }
 
         if matches!(self.peek(), Some(b'e' | b'E')) {
@@ -411,20 +407,19 @@ impl<'input> Parser<'input> {
             if matches!(self.peek(), Some(b'+' | b'-')) {
                 self.offset += 1;
             }
-            let start = self.offset;
-            self.skip_digits();
-            if self.offset == start {
-                return None;
-            }
+            self.skip_digits()?;
         }
 
         Some(())
     }
 
-    fn skip_digits(&mut self) {
+    /// Consumes at least one decimal digit.
+    fn skip_digits(&mut self) -> Option<()> {
+        let start = self.offset;
         while self.peek().is_some_and(|byte| byte.is_ascii_digit()) {
             self.offset += 1;
         }
+        (self.offset != start).then_some(())
     }
 
     fn skip_whitespace(&mut self) {
@@ -434,17 +429,12 @@ impl<'input> Parser<'input> {
     }
 
     fn literal(&mut self, literal: &[u8]) -> Option<()> {
-        if self
-            .input
+        self.input
             .as_bytes()
             .get(self.offset..)?
-            .starts_with(literal)
-        {
-            self.offset += literal.len();
-            Some(())
-        } else {
-            None
-        }
+            .strip_prefix(literal)?;
+        self.offset += literal.len();
+        Some(())
     }
 
     fn consume(&mut self, expected: u8) -> Option<()> {

--- a/crates/uv-pypi-types/src/simple_json/parser.rs
+++ b/crates/uv-pypi-types/src/simple_json/parser.rs
@@ -1,0 +1,534 @@
+//! Parses the common, unescaped form of PyPI Simple API responses directly.
+
+use jiff::Timestamp;
+use memchr::memchr;
+use uv_small_str::SmallString;
+
+use super::{CoreMetadata, Hashes, PypiFile, PypiSimpleDetail, RequiresPythonInterner, Yanked};
+use crate::{ProjectStatus, Status};
+
+/// Returns `None` for syntax that should be handled by the general JSON parser.
+pub(super) fn parse(input: &[u8]) -> Option<PypiSimpleDetail> {
+    if memchr(b'\\', input).is_some() {
+        return None;
+    }
+
+    let input = std::str::from_utf8(input).ok()?;
+    let mut parser = Parser { input, offset: 0 };
+    let detail = parser.detail()?;
+    parser.skip_whitespace();
+    (parser.offset == input.len()).then_some(detail)
+}
+
+struct Parser<'input> {
+    input: &'input str,
+    offset: usize,
+}
+
+enum ObjectKey<'input> {
+    Key(&'input str),
+    End,
+}
+
+enum Nullable<T> {
+    Value(T),
+    Null,
+}
+
+impl<T> Nullable<T> {
+    fn into_option(self) -> Option<T> {
+        match self {
+            Self::Value(value) => Some(value),
+            Self::Null => None,
+        }
+    }
+}
+
+impl<'input> Parser<'input> {
+    fn detail(&mut self) -> Option<PypiSimpleDetail> {
+        self.skip_whitespace();
+        self.consume(b'{')?;
+
+        let mut files = None;
+        let mut project_status = None;
+        let mut first = true;
+
+        while let ObjectKey::Key(key) = self.object_key(&mut first)? {
+            match key {
+                "files" => {
+                    if files.is_some() {
+                        return None;
+                    }
+                    files = Some(self.files()?);
+                }
+                "project-status" => {
+                    if project_status.is_some() {
+                        return None;
+                    }
+                    project_status = Some(self.project_status()?);
+                }
+                _ => self.skip_value(0)?,
+            }
+        }
+
+        Some(PypiSimpleDetail {
+            files: files?,
+            project_status: project_status.unwrap_or_default(),
+        })
+    }
+
+    fn files(&mut self) -> Option<Vec<PypiFile>> {
+        self.consume(b'[')?;
+
+        let mut files = Vec::new();
+        let mut interner = RequiresPythonInterner::default();
+        let mut first = true;
+
+        while self.array_item(&mut first)? {
+            files.push(self.file(&mut interner)?);
+        }
+
+        Some(files)
+    }
+
+    fn file(&mut self, interner: &mut RequiresPythonInterner) -> Option<PypiFile> {
+        self.consume(b'{')?;
+
+        let mut core_metadata = None;
+        let mut filename = None;
+        let mut hashes = None;
+        let mut requires_python = None;
+        let mut size = None;
+        let mut upload_time = None;
+        let mut url = None;
+        let mut yanked = None;
+        let mut first = true;
+
+        while let ObjectKey::Key(key) = self.object_key(&mut first)? {
+            match key {
+                "core-metadata" | "dist-info-metadata" | "data-dist-info-metadata"
+                    if core_metadata.is_none() =>
+                {
+                    core_metadata = self.core_metadata()?.into_option();
+                }
+                "filename" => filename = Some(SmallString::from(self.string()?)),
+                "hashes" => hashes = Some(self.hashes()?),
+                "requires-python" => requires_python = self.nullable_string()?.into_option(),
+                "size" => size = Some(self.unsigned_integer()?),
+                "upload-time" => upload_time = Some(self.string()?.parse::<Timestamp>().ok()?),
+                "url" => url = Some(SmallString::from(self.string()?)),
+                "yanked" => yanked = Some(Box::new(self.yanked()?)),
+                _ => self.skip_value(0)?,
+            }
+        }
+
+        Some(PypiFile {
+            core_metadata,
+            filename: filename?,
+            hashes: hashes?,
+            requires_python: requires_python.map(|value| interner.parse(value)),
+            size,
+            upload_time,
+            url: url?,
+            yanked,
+        })
+    }
+
+    fn hashes(&mut self) -> Option<Hashes> {
+        if let Some(digest) = self.single_sha256_digest() {
+            return Some(Hashes {
+                sha256: Some(SmallString::from(digest)),
+                ..Hashes::default()
+            });
+        }
+
+        self.consume(b'{')?;
+
+        let mut hashes = Hashes::default();
+        let mut seen = 0_u8;
+        let mut first = true;
+
+        while let ObjectKey::Key(key) = self.object_key(&mut first)? {
+            let (bit, digest) = match key {
+                "md5" => (1, &mut hashes.md5),
+                "sha256" => (1 << 1, &mut hashes.sha256),
+                "sha384" => (1 << 2, &mut hashes.sha384),
+                "sha512" => (1 << 3, &mut hashes.sha512),
+                "blake2b" => (1 << 4, &mut hashes.blake2b),
+                _ => {
+                    self.skip_value(0)?;
+                    continue;
+                }
+            };
+
+            if seen & bit != 0 {
+                return None;
+            }
+            seen |= bit;
+
+            *digest = self.nullable_string()?.into_option().map(SmallString::from);
+        }
+
+        Some(hashes)
+    }
+
+    fn single_sha256_digest(&mut self) -> Option<&'input str> {
+        const PREFIX: &[u8] = b"{\"sha256\":\"";
+
+        let remaining = self.input.as_bytes().get(self.offset..)?;
+        let value = remaining.strip_prefix(PREFIX)?;
+        let length = memchr(b'"', value)?;
+        if value.get(length + 1) != Some(&b'}') {
+            return None;
+        }
+
+        let bytes = &value[..length];
+        if bytes.iter().copied().min().is_some_and(|byte| byte < 0x20) {
+            return None;
+        }
+
+        let start = self.offset + PREFIX.len();
+        self.offset += PREFIX.len() + length + 2;
+        Some(&self.input[start..start + length])
+    }
+
+    fn core_metadata(&mut self) -> Option<Nullable<CoreMetadata>> {
+        match self.peek()? {
+            b'n' => {
+                self.literal(b"null")?;
+                Some(Nullable::Null)
+            }
+            b't' | b'f' => Some(Nullable::Value(CoreMetadata::Bool(self.boolean()?))),
+            b'{' => Some(Nullable::Value(CoreMetadata::Hashes(self.hashes()?))),
+            _ => None,
+        }
+    }
+
+    fn yanked(&mut self) -> Option<Yanked> {
+        match self.peek()? {
+            b't' | b'f' => Some(Yanked::Bool(self.boolean()?)),
+            b'"' => Some(Yanked::Reason(SmallString::from(self.string()?))),
+            _ => None,
+        }
+    }
+
+    fn project_status(&mut self) -> Option<ProjectStatus> {
+        self.consume(b'{')?;
+
+        let mut project_status = ProjectStatus::default();
+        let mut seen_status = false;
+        let mut seen_reason = false;
+        let mut first = true;
+
+        while let ObjectKey::Key(key) = self.object_key(&mut first)? {
+            match key {
+                "status" => {
+                    if seen_status {
+                        return None;
+                    }
+                    seen_status = true;
+                    project_status.status = Status::new(self.string()?).unwrap_or_default();
+                }
+                "reason" => {
+                    if seen_reason {
+                        return None;
+                    }
+                    seen_reason = true;
+                    project_status.reason =
+                        self.nullable_string()?.into_option().map(SmallString::from);
+                }
+                _ => self.skip_value(0)?,
+            }
+        }
+
+        Some(project_status)
+    }
+
+    fn object_key(&mut self, first: &mut bool) -> Option<ObjectKey<'input>> {
+        self.skip_whitespace();
+
+        if self.peek()? == b'}' {
+            self.offset += 1;
+            return Some(ObjectKey::End);
+        }
+
+        if !*first {
+            self.consume(b',')?;
+            self.skip_whitespace();
+        }
+
+        let key = self.string()?;
+        self.skip_whitespace();
+        self.consume(b':')?;
+        self.skip_whitespace();
+        *first = false;
+
+        Some(ObjectKey::Key(key))
+    }
+
+    fn array_item(&mut self, first: &mut bool) -> Option<bool> {
+        self.skip_whitespace();
+
+        if self.peek()? == b']' {
+            self.offset += 1;
+            return Some(false);
+        }
+
+        if !*first {
+            self.consume(b',')?;
+            self.skip_whitespace();
+            if self.peek()? == b']' {
+                return None;
+            }
+        }
+
+        *first = false;
+        Some(true)
+    }
+
+    fn string(&mut self) -> Option<&'input str> {
+        self.consume(b'"')?;
+        let start = self.offset;
+        let remaining = &self.input.as_bytes()[start..];
+        let length = memchr(b'"', remaining)?;
+        let bytes = &remaining[..length];
+
+        if bytes.iter().copied().min().is_some_and(|byte| byte < 0x20) {
+            return None;
+        }
+
+        self.offset += length + 1;
+        Some(&self.input[start..start + length])
+    }
+
+    fn nullable_string(&mut self) -> Option<Nullable<&'input str>> {
+        if self.peek()? == b'n' {
+            self.literal(b"null")?;
+            Some(Nullable::Null)
+        } else {
+            self.string().map(Nullable::Value)
+        }
+    }
+
+    fn unsigned_integer(&mut self) -> Option<u64> {
+        let first = self.peek()?;
+        if !first.is_ascii_digit() {
+            return None;
+        }
+
+        if first == b'0' {
+            self.offset += 1;
+            if self.peek().is_some_and(|byte| byte.is_ascii_digit()) {
+                return None;
+            }
+            return Some(0);
+        }
+
+        let mut value = 0_u64;
+        while let Some(byte @ b'0'..=b'9') = self.peek() {
+            value = value.checked_mul(10)?.checked_add(u64::from(byte - b'0'))?;
+            self.offset += 1;
+        }
+
+        Some(value)
+    }
+
+    fn boolean(&mut self) -> Option<bool> {
+        match self.peek()? {
+            b't' => {
+                self.literal(b"true")?;
+                Some(true)
+            }
+            b'f' => {
+                self.literal(b"false")?;
+                Some(false)
+            }
+            _ => None,
+        }
+    }
+
+    fn skip_value(&mut self, depth: u8) -> Option<()> {
+        if depth >= 64 {
+            return None;
+        }
+
+        match self.peek()? {
+            b'{' => {
+                self.offset += 1;
+                let mut first = true;
+                while let ObjectKey::Key(_) = self.object_key(&mut first)? {
+                    self.skip_value(depth + 1)?;
+                }
+            }
+            b'[' => {
+                self.offset += 1;
+                let mut first = true;
+                while self.array_item(&mut first)? {
+                    self.skip_value(depth + 1)?;
+                }
+            }
+            b'"' => {
+                self.string()?;
+            }
+            b't' | b'f' => {
+                self.boolean()?;
+            }
+            b'n' => self.literal(b"null")?,
+            b'-' | b'0'..=b'9' => self.skip_number()?,
+            _ => return None,
+        }
+
+        Some(())
+    }
+
+    fn skip_number(&mut self) -> Option<()> {
+        if self.peek()? == b'-' {
+            self.offset += 1;
+        }
+
+        match self.peek()? {
+            b'0' => {
+                self.offset += 1;
+                if self.peek().is_some_and(|byte| byte.is_ascii_digit()) {
+                    return None;
+                }
+            }
+            b'1'..=b'9' => self.skip_digits(),
+            _ => return None,
+        }
+
+        if self.peek() == Some(b'.') {
+            self.offset += 1;
+            let start = self.offset;
+            self.skip_digits();
+            if self.offset == start {
+                return None;
+            }
+        }
+
+        if matches!(self.peek(), Some(b'e' | b'E')) {
+            self.offset += 1;
+            if matches!(self.peek(), Some(b'+' | b'-')) {
+                self.offset += 1;
+            }
+            let start = self.offset;
+            self.skip_digits();
+            if self.offset == start {
+                return None;
+            }
+        }
+
+        Some(())
+    }
+
+    fn skip_digits(&mut self) {
+        while self.peek().is_some_and(|byte| byte.is_ascii_digit()) {
+            self.offset += 1;
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\n' | b'\r' | b'\t')) {
+            self.offset += 1;
+        }
+    }
+
+    fn literal(&mut self, literal: &[u8]) -> Option<()> {
+        if self
+            .input
+            .as_bytes()
+            .get(self.offset..)?
+            .starts_with(literal)
+        {
+            self.offset += literal.len();
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn consume(&mut self, expected: u8) -> Option<()> {
+        if self.peek()? == expected {
+            self.offset += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.input.as_bytes().get(self.offset).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::parse;
+    use crate::{CoreMetadata, PypiSimpleDetail, Status};
+
+    #[test]
+    fn parses_common_pypi_response_directly() -> Result<(), Box<dyn std::error::Error>> {
+        let input = br#"{
+            "meta": {"api-version": "1.4", "serial": 42},
+            "files": [
+                {
+                    "provenance": null,
+                    "size": 123,
+                    "yanked": false,
+                    "core-metadata": {"sha256": "metadata-digest"},
+                    "data-dist-info-metadata": false,
+                    "filename": "example-1.0.tar.gz",
+                    "hashes": {"sha256": "file-digest"},
+                    "url": "https://example.com/example-1.0.tar.gz",
+                    "requires-python": ">=3.8",
+                    "upload-time": "2022-08-04T10:42:02.190074Z"
+                },
+                {
+                    "filename": "example-1.0-py3-none-any.whl",
+                    "hashes": {},
+                    "url": "https://example.com/example-1.0-py3-none-any.whl",
+                    "requires-python": ">=3.8"
+                }
+            ],
+            "project-status": {"status": "archived", "reason": "Retired"},
+            "versions": ["1.0"]
+        }"#;
+
+        let Some(actual) = parse(input) else {
+            return Err("the common PyPI response must use the direct parser".into());
+        };
+        let expected: PypiSimpleDetail = serde_json::from_slice(input)?;
+
+        assert_eq!(format!("{actual:#?}"), format!("{expected:#?}"));
+        assert_eq!(actual.project_status.status, Status::Archived);
+        assert!(matches!(
+            actual.files[0].core_metadata,
+            Some(CoreMetadata::Hashes(_))
+        ));
+
+        let Some(Ok(first)) = actual.files[0].requires_python.as_ref() else {
+            return Err("the first file must have a valid Python requirement".into());
+        };
+        let Some(Ok(second)) = actual.files[1].requires_python.as_ref() else {
+            return Err("the second file must have a valid Python requirement".into());
+        };
+        assert!(Arc::ptr_eq(first, second));
+
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_strings_and_duplicate_fields_use_fallback() {
+        for input in [
+            br#"{"files":[],"ignored":"escaped\nvalue"}"#.as_slice(),
+            br#"{"files":[],"files":[]}"#.as_slice(),
+            br#"{"files":[],"project-status":{},"project-status":{}}"#.as_slice(),
+            br#"{"files":[]} trailing"#.as_slice(),
+            b"{\"files\":[],\"ignored\":\"raw\nnewline\"}",
+        ] {
+            assert!(parse(input).is_none());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PyPI Simple API project responses currently deserialize through Serde into an intermediate `Vec<PypiFileWire>` before converting each entry into `PypiFile`. For packages with thousands of distributions, that extra pass, generic JSON dispatch, and temporary string allocations make index decoding unnecessarily expensive.

Parse ordinary unescaped responses directly into `PypiFile`, borrowing JSON strings while parsing, retaining the existing `requires-python` interner, and recognizing the common single-SHA-256 hash representation. Continue parsing upload timestamps with Jiff. Inputs with escaped strings, unsupported representations, malformed syntax, or invalid UTF-8 fall back to the existing `serde_json` implementation, preserving compatibility and diagnostics. Pyx, MessagePack, HTML, and root-index responses are unchanged.

The parser matches Serde across 558 differential cases, including malformed inputs, metadata aliases, duplicate fields, ignored values, project statuses, timestamp edge cases, and shared `requires-python` allocations; the `uv-pypi-types` and registry-client tests, Clippy, and a mock-index installation also pass.

## Benchmarks

Medians from 101 warmed, randomized, paired measurements against captured PyPI Simple API responses. These measurements cover JSON parsing only, not complete uv command execution.

| Input          | Files | `serde_json` |   Direct |               Result |
| -------------- | ----: | -----------: | -------: | -------------------: |
| NumPy, 2.89 MB | 4,100 |     2.744 ms | 1.594 ms | 1.72× faster (41.9%) |
| Ruff, 4.80 MB  | 7,026 |     4.672 ms | 2.563 ms | 1.82× faster (45.1%) |
