### PR TITLE
Suggest a newer patch release when an unbuilt Python version is requested

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2860,7 +2860,7 @@ impl VersionRequest {
     }
 
     /// Return the patch version segment of the request, if any.
-    fn patch(&self) -> Option<u8> {
+    pub(crate) fn patch(&self) -> Option<u8> {
         match self {
             Self::Any | Self::Default | Self::Range(_, _) => None,
             Self::Major(_, _) => None,
@@ -3197,7 +3197,7 @@ impl VersionRequest {
     ///
     /// If the patch version is not present, the request is returned unchanged.
     #[must_use]
-    fn without_patch(self) -> Self {
+    pub(crate) fn without_patch(self) -> Self {
         match self {
             Self::Default => Self::Default,
             Self::Any => Self::Any,

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1016,6 +1016,26 @@ impl ManagedPythonDownloadList {
         Err(Error::NoDownloadFound(request.clone()))
     }
 
+    /// If `request` pins an exact patch version that has no matching download, return the newest
+    /// available download for the same minor version (any patch). Used to hint at a supported
+    /// release when an unbuilt patch such as `3.11.0` is requested.
+    ///
+    /// See <https://github.com/astral-sh/uv/issues/16869>.
+    pub(crate) fn newer_patch(
+        &self,
+        request: &PythonDownloadRequest,
+    ) -> Option<&ManagedPythonDownload> {
+        let version = request.version.as_ref()?;
+        // Only meaningful when an exact patch was requested.
+        version.patch()?;
+        let minor_request = request
+            .clone()
+            .with_version(version.clone().without_patch())
+            .fill()
+            .ok()?;
+        self.find(&minor_request).ok()
+    }
+
     /// Load available Python distributions from a provided source or the compiled-in list.
     ///
     /// Returns an error if the provided list could not be opened, if the JSON is invalid, or if it
@@ -1864,6 +1884,19 @@ mod tests {
     use uv_platform::{Arch, Libc, Os, Platform};
 
     use super::*;
+
+    #[test]
+    fn newer_patch_suggested_for_unbuilt_exact_version() {
+        let downloads =
+            ManagedPythonDownloadList::new_only_embedded().expect("embedded downloads load");
+        // python-build-standalone never built cpython-3.11.0, but newer 3.11.x releases exist.
+        let request = PythonDownloadRequest::from_str("cpython-3.11.0-linux-x86_64-gnu")
+            .expect("request should parse");
+        let hinted = downloads
+            .newer_patch(&request)
+            .expect("a newer 3.11 patch should be suggested");
+        assert_eq!(hinted.key().minor(), 11);
+    }
 
     /// Parse a request with all of its fields.
     #[test]

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -243,6 +243,14 @@ impl PythonInstallation {
                     if matches!(request, PythonRequest::Default | PythonRequest::Any) {
                         return Err(err);
                     }
+                    // If an exact patch was requested but a newer patch of the same minor is
+                    // available, suggest it (e.g. `3.11.0` -> `3.11.14`).
+                    if let Some(download) = download_list.newer_patch(&download_request) {
+                        return Err(err.with_hint(MissingPythonHint::NewerPatchAvailable {
+                            request: request.clone(),
+                            available: download.key().version(),
+                        }));
+                    }
                     return Err(err.with_hint(MissingPythonHint::RequiresUpdate));
                 }
                 None

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -121,6 +121,11 @@ pub enum MissingPythonHint {
     PreferenceOnlySystem(PythonRequest),
     /// uv is in offline mode.
     Offline(PythonRequest),
+    /// A newer patch release of the same minor version is available to download.
+    NewerPatchAvailable {
+        request: PythonRequest,
+        available: PythonVersion,
+    },
 }
 
 impl MissingPythonHint {
@@ -168,6 +173,13 @@ impl std::fmt::Display for MissingPythonHint {
                     f,
                     "A managed Python download is available{}, but uv is set to offline mode",
                     Self::for_request(request),
+                )
+            }
+            Self::NewerPatchAvailable { request, available } => {
+                write!(
+                    f,
+                    "Python `{}` is not available to download, but `{available}` is. Older patch releases are often not built; try requesting `{available}` instead.",
+                    request.to_canonical_string(),
                 )
             }
         }


### PR DESCRIPTION
## Summary

Closes #16869.

`uv venv --python 3.11.0` fails with a generic "No interpreter found for Python 3.11.0 in managed installations or search path". The real reason is that python-build-standalone never built a few early patch releases like `3.11.0`, while newer `3.11.x` are available, and the error doesn't hint at that.

Following the suggestion in the issue, when an exact patch has no download available but a newer patch of the same minor version does, I add a hint pointing at the available version:

```
hint: Python `3.11.0` is not available to download, but `3.11.14` is. Older patch releases are often not built; try requesting `3.11.14` instead.
```

This is a hint only; parsing and resolution behaviour are unchanged. It reuses the existing `find()`/`fill()` on the download list so the suggestion is for the user's platform, and only triggers when an exact patch was requested.

## Test Plan

Added a unit test in `uv-python` (`newer_patch_suggested_for_unbuilt_exact_version`) that uses the embedded download list, so it's deterministic and offline.

- `cargo test -p uv-python --lib` (142 passed)
- `cargo clippy -p uv-python --all-targets` (clean)
- `cargo fmt -p uv-python -- --check` (clean)

The existing `sync_python_missing_download_hint` test (which requests `3.100`, a minor version) is unaffected, since the hint only applies to exact patch requests.
