### PR TITLE
Disable profiling for wall-time CodSpeed benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,6 +89,8 @@ jobs:
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        env:
+          CODSPEED_PROFILER_ENABLED: false
         with:
           run: cargo codspeed run
           mode: walltime


### PR DESCRIPTION
The wall-time benchmark workflow currently collects flamegraphs through the CodSpeed profiler, which can increase the duration of the benchmark job. Disable this optional profiling for wall-time runs to test its effect on CI duration while continuing to collect and upload benchmark timings.