### PR TITLE
Stabilize publish index readiness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
   # attestations and PyPI does not support attestations in reusable workflows.
   test-publish:
     name: "test uv publish"
-    timeout-minutes: 60
+    timeout-minutes: 20
     needs:
       - plan
       - build-dev-binaries
@@ -290,17 +290,6 @@ jobs:
           UV_TEST_PUBLISH_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
           UV_TEST_PUBLISH_GITLAB_PYPI_OIDC_TOKEN: ${{ steps.load-gitlab-oidc-token.outputs.GITLAB_PYPI_OIDC_TOKEN }}
           UV_TEST_PUBLISH_GITLAB_PYX_OIDC_TOKEN: ${{ steps.load-gitlab-oidc-token.outputs.GITLAB_PYX_OIDC_TOKEN }}
-
-      - name: "Stress test PyPI keyring publishing"
-        run: |
-          for attempt in $(seq 1 100); do
-            echo "::group::PyPI keyring publishing sample ${attempt}/100"
-            ./uv run --no-project -p "${PYTHON_VERSION}" scripts/publish/test_publish.py --uv ./uv pypi-keyring
-            echo "::endgroup::"
-          done
-        env:
-          RUST_LOG: uv=debug,uv_publish=trace
-          UV_TEST_PUBLISH_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
   required-checks-passed:
     name: "all required jobs passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
   # attestations and PyPI does not support attestations in reusable workflows.
   test-publish:
     name: "test uv publish"
-    timeout-minutes: 20
+    timeout-minutes: 60
     needs:
       - plan
       - build-dev-binaries
@@ -290,6 +290,17 @@ jobs:
           UV_TEST_PUBLISH_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
           UV_TEST_PUBLISH_GITLAB_PYPI_OIDC_TOKEN: ${{ steps.load-gitlab-oidc-token.outputs.GITLAB_PYPI_OIDC_TOKEN }}
           UV_TEST_PUBLISH_GITLAB_PYX_OIDC_TOKEN: ${{ steps.load-gitlab-oidc-token.outputs.GITLAB_PYX_OIDC_TOKEN }}
+
+      - name: "Stress test PyPI keyring publishing"
+        run: |
+          for attempt in $(seq 1 100); do
+            echo "::group::PyPI keyring publishing sample ${attempt}/100"
+            ./uv run --no-project -p "${PYTHON_VERSION}" scripts/publish/test_publish.py --uv ./uv pypi-keyring
+            echo "::endgroup::"
+          done
+        env:
+          RUST_LOG: uv=debug,uv_publish=trace
+          UV_TEST_PUBLISH_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
   required-checks-passed:
     name: "all required jobs passed"

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -597,7 +597,6 @@ def test_reupload_with_check_url(
         f"\n=== 3. Publishing {plan.configuration.project_name} {version} again with {mode} ===",
         file=sys.stderr,
     )
-    wait_for_index(plan, version)
     # Test twine-style and index-style uploads for different packages.
     if index := plan.configuration.index:
         args = [
@@ -617,25 +616,37 @@ def test_reupload_with_check_url(
             plan.configuration.index_url,
             *plan.extra_args,
         ]
-    output = run(
-        args,
-        cwd=project_dir,
-        env=plan.full_env(),
-        text=True,
-        check=True,
-        stderr=PIPE,
-    ).stderr
+    for attempt in range(5):
+        wait_for_index(plan, version)
+        output = run(
+            args,
+            cwd=project_dir,
+            env=plan.full_env(),
+            text=True,
+            check=True,
+            stderr=PIPE,
+        ).stderr
 
-    if output.count("Uploading") != 0 or output.count("already exists") != len(
-        expected_filenames
-    ):
-        raise RuntimeError(
-            f"Re-upload with check URL failed for {plan.target} "
-            f"({plan.configuration.publish_url}): "
-            f"{output.count('Uploading')} != 0, "
-            f"{output.count('already exists')} != {len(expected_filenames)}\n"
-            f"---\n{output}\n---"
-        )
+        if output.count("Uploading") == 0 and output.count("already exists") == len(
+            expected_filenames
+        ):
+            return
+
+        if attempt < 4:
+            print(
+                f"Index returned inconsistent files for "
+                f"{plan.configuration.project_name}=={version}; "
+                f"retrying check URL upload ({attempt + 1}/4)",
+                file=sys.stderr,
+            )
+
+    raise RuntimeError(
+        f"Re-upload with check URL failed for {plan.target} "
+        f"({plan.configuration.publish_url}): "
+        f"{output.count('Uploading')} != 0, "
+        f"{output.count('already exists')} != {len(expected_filenames)}\n"
+        f"---\n{output}\n---"
+    )
 
 
 def test_reupload_modified_files(

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -414,7 +414,7 @@ def wait_for_index(
                 "-",
             ],
             text=True,
-            input=f"{plan.configuration.project_name}",
+            input=f"{plan.configuration.project_name}=={version}",
             stdout=PIPE,
             env=plan.full_env(),
             check=False,

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -391,7 +391,11 @@ def wait_for_index(
     upload. We need to specifically run this through uv since to query the same cache
     (invalidation) as the registry client in skip existing in uv publish will later,
     just `get_filenames` fails non-deterministically.
+
+    Require consecutive successful checks since index responses can briefly disagree
+    after an upload.
     """
+    consecutive_successes = 0
     for _ in range(50):
         result = run(
             [
@@ -417,29 +421,35 @@ def wait_for_index(
         )
         # codeberg sometimes times out
         if result.returncode != 0:
+            consecutive_successes = 0
             print(
                 f"uv pip compile not updated, missing 2 files for {version}, "
                 + f"sleeping for 2s: `{plan.configuration.index_url}`:\n",
                 file=sys.stderr,
             )
-            sleep(2)
-            continue
-
-        if (
+        elif (
             f"{plan.configuration.project_name}=={version}" in result.stdout
             and result.stdout.count("--hash") == 2
         ):
-            break
-
-        print(
-            f"uv pip compile not updated, missing 2 files for {version}, "
-            + f"sleeping for 2s: `{plan.configuration.index_url}`:\n"
-            + "```\n"
-            + result.stdout.replace("\\\n    ", "")
-            + "```",
-            file=sys.stderr,
-        )
+            consecutive_successes += 1
+            if consecutive_successes == 3:
+                return
+        else:
+            consecutive_successes = 0
+            print(
+                f"uv pip compile not updated, missing 2 files for {version}, "
+                + f"sleeping for 2s: `{plan.configuration.index_url}`:\n"
+                + "```\n"
+                + result.stdout.replace("\\\n    ", "")
+                + "```",
+                file=sys.stderr,
+            )
         sleep(2)
+
+    raise RuntimeError(
+        f"Index did not consistently expose both files for "
+        f"{plan.configuration.project_name}=={version}"
+    )
 
 
 def get_fresh_version(plan: Plan) -> Version:

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -681,7 +681,6 @@ def test_reupload_modified_files(
         f"again with skip existing (error test) ===",
         file=sys.stderr,
     )
-    wait_for_index(plan, version)
     args = [
         plan.uv,
         "publish",
@@ -691,25 +690,37 @@ def test_reupload_modified_files(
         plan.configuration.index_url,
         *plan.extra_args,
     ]
-    result = run(
-        args,
-        cwd=modified_project_dir,
-        env=plan.full_env(),
-        text=True,
-        stderr=PIPE,
-        check=False,
-    )
-
-    if (
-        result.returncode == 0
-        or "Local file and index file do not match for" not in result.stderr
-    ):
-        raise RuntimeError(
-            f"Re-upload with mismatching files should not have been started "
-            f"for {plan.target} ({plan.configuration.publish_url}): "
-            f"Exit code {result.returncode}\n"
-            f"---\n{result.stderr}\n---"
+    for attempt in range(5):
+        wait_for_index(plan, version)
+        result = run(
+            args,
+            cwd=modified_project_dir,
+            env=plan.full_env(),
+            text=True,
+            stderr=PIPE,
+            check=False,
         )
+
+        if (
+            result.returncode != 0
+            and "Local file and index file do not match for" in result.stderr
+        ):
+            return
+
+        if attempt < 4:
+            print(
+                f"Index returned inconsistent files for "
+                f"{plan.configuration.project_name}=={version}; "
+                f"retrying modified file check ({attempt + 1}/4)",
+                file=sys.stderr,
+            )
+
+    raise RuntimeError(
+        f"Re-upload with mismatching files should not have been started "
+        f"for {plan.target} ({plan.configuration.publish_url}): "
+        f"Exit code {result.returncode}\n"
+        f"---\n{result.stderr}\n---"
+    )
 
 
 def test_publish_project(plan: Plan, client: httpx.Client):


### PR DESCRIPTION
Publishing smoke tests can fail when TestPyPI briefly serves inconsistent simple-index responses after an upload. `wait_for_index` previously accepted the first response containing both artifacts, while concurrent runs could also make its unpinned lookup select a newer release. Resolve the exact uploaded version, require consecutive refreshed index responses, and retry both check-URL publishing assertions when subsequent index responses still regress. Fail explicitly if the index never stabilizes or existing and modified artifacts are not handled correctly after bounded retries.