### PR TITLE
ci: use perf for CodSpeed walltime benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,6 +89,8 @@ jobs:
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        env:
+          CODSPEED_WALLTIME_PROFILER: perf
         with:
           run: cargo codspeed run
           mode: walltime

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,6 +90,8 @@ jobs:
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
         env:
+          # Action v5 defaults to Samply, but uv's uploaded Samply profile currently exceeds the memory available to CodSpeed's flamegraph processor
+          # TODO: remove when codspeed repairs support for large Samply results
           CODSPEED_WALLTIME_PROFILER: perf
         with:
           run: cargo codspeed run


### PR DESCRIPTION
## Summary

Keep CodSpeed Action v5 while restoring `perf` as the walltime profiler on Linux.

Action v5 defaults to Samply, but uv's uploaded Samply profile currently exceeds the memory available to CodSpeed's flamegraph processor. Setting `CODSPEED_WALLTIME_PROFILER` on the walltime step restores the v4 behavior and avoids the resulting flamegraph errors.
