### PR TITLE
Revert "ci: use perf for CodSpeed walltime benchmarks"

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,10 +89,6 @@ jobs:
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
-        env:
-          # Action v5 defaults to Samply, but uv's uploaded Samply profile currently exceeds the memory available to CodSpeed's flamegraph processor
-          # TODO: remove when codspeed repairs support for large Samply results
-          CODSPEED_WALLTIME_PROFILER: perf
         with:
           run: cargo codspeed run
           mode: walltime


### PR DESCRIPTION
Reverts astral-sh/uv#21055, CodSpeed team reports that their backend can now support uv's samply results