### PR TITLE
Authorize issue-comment context persistence

### DIFF
--- a/.github/ost-simple-sts.json
+++ b/.github/ost-simple-sts.json
@@ -58,6 +58,14 @@
     {
       "caller": "uv",
       "environment": "automations",
+      "caller_workflow": "update-issue-context.yml",
+      "on": ["issue_comment"],
+      "permissions": { "contents": "write" },
+      "target": "uv-dev"
+    },
+    {
+      "caller": "uv",
+      "environment": "automations",
       "caller_workflow": "issue-triage.yml",
       "reusable_workflow": "reproduce-bug.yml",
       "on": ["issues", "workflow_dispatch"],


### PR DESCRIPTION
third time is a charm, (now that [ost-simple-sts supports issue_comments](https://github.com/open-security-tools/ost-simple-sts/releases/tag/v0.0.5)) authorize automation for shuffling issue-context around on issue comment events