### PR TITLE
Report physical disk usage with uv cache size

### DIFF
--- a/crates/uv-dev/src/generate_preview_features_reference.rs
+++ b/crates/uv-dev/src/generate_preview_features_reference.rs
@@ -111,7 +111,7 @@ mod tests {
         - `audit-command`: Allows using `uv audit` and `uv tool audit`.
         - `auth-helper`: Allows using `uv auth helper` as a credential helper for external tools.
         - `azure-endpoint`: Allows signing requests to Azure Blob Storage endpoints with Azure credentials.
-        - `cache-physical-space`: Reports the physical disk space reclaimed by cache cleanup, accounting for hardlinks and copy-on-write clones.
+        - `cache-physical-space`: Reports physical cache size and cleanup disk space, accounting for hardlinks and copy-on-write clones.
         - `cache-size`: Allows using `uv cache size`.
         - `centralized-project-envs`: Stores [project virtual environments](./projects/layout.md#centralized-project-environments)
           in the uv cache.

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -12,7 +12,7 @@ use tracing::{debug, warn};
 pub use crate::locked_file::*;
 pub use crate::path::*;
 pub use crate::read::ValidatedReader;
-pub use crate::space::{physical_space, supports_physical_space};
+pub use crate::space::{physical_disk_usage, physical_space, supports_physical_space};
 
 pub mod cachedir;
 pub mod link;

--- a/crates/uv-fs/src/space.rs
+++ b/crates/uv-fs/src/space.rs
@@ -18,6 +18,29 @@ use linux_raw_sys::ioctl::{
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
 use rustc_hash::{FxHashMap, FxHashSet};
 
+/// A filesystem and the allocation-block size used for its physical extents.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+struct Filesystem {
+    device: u64,
+    block_size: u64,
+}
+
+/// A physical file extent before it has been aligned to filesystem blocks.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+struct FileExtent {
+    start: u64,
+    length: u64,
+}
+
+/// A physical extent aligned to its filesystem's allocation blocks.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+#[derive(Clone, Copy)]
+struct PhysicalExtent {
+    start: u64,
+    end: u64,
+}
+
 /// Return whether the current platform can identify individual files' physical storage.
 pub const fn supports_physical_space() -> bool {
     cfg!(any(
@@ -36,7 +59,7 @@ pub const fn supports_physical_space() -> bool {
 pub fn physical_disk_usage(path: &Path) -> io::Result<u64> {
     let mut seen_files = FxHashSet::default();
     let mut filesystem_block_sizes = FxHashMap::default();
-    let mut physical_extents: FxHashMap<(u64, u64), Vec<(u64, u64)>> = FxHashMap::default();
+    let mut physical_extents: FxHashMap<Filesystem, Vec<PhysicalExtent>> = FxHashMap::default();
     let mut untracked_bytes = 0_u64;
 
     for entry in walkdir::WalkDir::new(path).follow_links(false) {
@@ -80,9 +103,12 @@ pub fn physical_disk_usage(path: &Path) -> io::Result<u64> {
         match file_physical_extents(&file, &metadata) {
             Ok(extents) => {
                 let device_extents = physical_extents
-                    .entry((metadata.dev(), block_size))
+                    .entry(Filesystem {
+                        device: metadata.dev(),
+                        block_size,
+                    })
                     .or_default();
-                for (start, length) in extents {
+                for FileExtent { start, length } in extents {
                     let end = start.checked_add(length).ok_or_else(|| {
                         io::Error::new(
                             io::ErrorKind::InvalidData,
@@ -97,7 +123,10 @@ pub fn physical_disk_usage(path: &Path) -> io::Result<u64> {
                                 "an aligned physical extent exceeds the filesystem address space",
                             )
                         })?;
-                    device_extents.push((aligned_start, aligned_end));
+                    device_extents.push(PhysicalExtent {
+                        start: aligned_start,
+                        end: aligned_end,
+                    });
                 }
             }
             Err(error) => {
@@ -111,25 +140,26 @@ pub fn physical_disk_usage(path: &Path) -> io::Result<u64> {
     }
 
     for extents in physical_extents.values_mut() {
-        extents.sort_unstable_by_key(|&(start, _)| start);
-        let mut current: Option<(u64, u64)> = None;
+        extents.sort_unstable_by_key(|extent| extent.start);
+        let mut current: Option<PhysicalExtent> = None;
 
-        for &(start, end) in extents.iter() {
-            if let Some((current_start, current_end)) = current {
-                if start <= current_end {
-                    current = Some((current_start, current_end.max(end)));
+        for &extent in extents.iter() {
+            if let Some(current_extent) = current.as_mut() {
+                if extent.start <= current_extent.end {
+                    current_extent.end = current_extent.end.max(extent.end);
                 } else {
-                    untracked_bytes =
-                        untracked_bytes.saturating_add(current_end.saturating_sub(current_start));
-                    current = Some((start, end));
+                    untracked_bytes = untracked_bytes
+                        .saturating_add(current_extent.end.saturating_sub(current_extent.start));
+                    *current_extent = extent;
                 }
             } else {
-                current = Some((start, end));
+                current = Some(extent);
             }
         }
 
-        if let Some((start, end)) = current {
-            untracked_bytes = untracked_bytes.saturating_add(end.saturating_sub(start));
+        if let Some(extent) = current {
+            untracked_bytes =
+                untracked_bytes.saturating_add(extent.end.saturating_sub(extent.start));
         }
     }
 
@@ -192,7 +222,7 @@ pub fn physical_space(path: &Path, metadata: &std::fs::Metadata) -> io::Result<u
 fn file_physical_extents(
     file: &fs_err::File,
     metadata: &std::fs::Metadata,
-) -> io::Result<Vec<(u64, u64)>> {
+) -> io::Result<Vec<FileExtent>> {
     let mut extents = Vec::new();
     let mut offset = 0_u64;
 
@@ -236,7 +266,10 @@ fn file_physical_extents(
             }
 
             let length = contiguous.min(end - extent_offset);
-            extents.push((physical, length));
+            extents.push(FileExtent {
+                start: physical,
+                length,
+            });
             extent_offset = extent_offset.saturating_add(length);
         }
 
@@ -325,7 +358,7 @@ fn linux_physical_space(path: &Path) -> io::Result<u64> {
 fn file_physical_extents(
     file: &fs_err::File,
     _metadata: &std::fs::Metadata,
-) -> io::Result<Vec<(u64, u64)>> {
+) -> io::Result<Vec<FileExtent>> {
     let mut extents = Vec::new();
 
     linux_file_extents(file, |extent| {
@@ -343,7 +376,10 @@ fn file_physical_extents(
             ));
         }
 
-        extents.push((extent.physical, extent.length));
+        extents.push(FileExtent {
+            start: extent.physical,
+            length: extent.length,
+        });
         Ok(())
     })?;
 

--- a/crates/uv-fs/src/space.rs
+++ b/crates/uv-fs/src/space.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use std::ffi::CString;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
+use std::os::fd::AsRawFd;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
@@ -13,6 +15,8 @@ use linux_raw_sys::ioctl::{
     FIEMAP_EXTENT_DATA_INLINE, FIEMAP_EXTENT_DELALLOC, FIEMAP_EXTENT_ENCODED, FIEMAP_EXTENT_LAST,
     FIEMAP_EXTENT_NOT_ALIGNED, FIEMAP_EXTENT_SHARED, FIEMAP_EXTENT_UNKNOWN, FS_IOC_FIEMAP,
 };
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Return whether the current platform can identify individual files' physical storage.
 pub const fn supports_physical_space() -> bool {
@@ -20,6 +24,124 @@ pub const fn supports_physical_space() -> bool {
         target_os = "linux",
         target_os = "macos",
         target_os = "ios"
+    ))
+}
+
+/// Return the physical file data and directory storage referenced by `path`.
+///
+/// Hardlinks are counted once by their device and inode, while copy-on-write clones are counted
+/// once by the physical filesystem blocks they reference. Unlike [`physical_space`], shared data
+/// referenced outside `path` is still attributed to this tree.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+pub fn physical_disk_usage(path: &Path) -> io::Result<u64> {
+    let mut seen_files = FxHashSet::default();
+    let mut filesystem_block_sizes = FxHashMap::default();
+    let mut physical_extents: FxHashMap<(u64, u64), Vec<(u64, u64)>> = FxHashMap::default();
+    let mut untracked_bytes = 0_u64;
+
+    for entry in walkdir::WalkDir::new(path).follow_links(false) {
+        let entry = entry.map_err(io::Error::other)?;
+        let metadata = fs_err::symlink_metadata(entry.path())?;
+        let allocated_bytes = metadata.blocks().saturating_mul(512);
+
+        if !metadata.is_file() {
+            untracked_bytes = untracked_bytes.saturating_add(allocated_bytes);
+            continue;
+        }
+
+        if !seen_files.insert((metadata.dev(), metadata.ino())) {
+            continue;
+        }
+
+        if allocated_bytes == 0 {
+            continue;
+        }
+
+        let file = fs_err::File::open(entry.path())?;
+        let block_size = if let Some(&block_size) = filesystem_block_sizes.get(&metadata.dev()) {
+            block_size
+        } else {
+            let filesystem = rustix::fs::fstatvfs(&file)?;
+            let block_size = if filesystem.f_frsize == 0 {
+                filesystem.f_bsize
+            } else {
+                filesystem.f_frsize
+            };
+            filesystem_block_sizes.insert(metadata.dev(), block_size);
+            block_size
+        };
+        if block_size == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "the filesystem reported a zero-byte allocation block",
+            ));
+        }
+
+        match file_physical_extents(&file, &metadata) {
+            Ok(extents) => {
+                let device_extents = physical_extents
+                    .entry((metadata.dev(), block_size))
+                    .or_default();
+                for (start, length) in extents {
+                    let end = start.checked_add(length).ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "a physical extent exceeds the filesystem address space",
+                        )
+                    })?;
+                    let aligned_start = (start / block_size).saturating_mul(block_size);
+                    let aligned_end =
+                        end.checked_next_multiple_of(block_size).ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "an aligned physical extent exceeds the filesystem address space",
+                            )
+                        })?;
+                    device_extents.push((aligned_start, aligned_end));
+                }
+            }
+            Err(error) => {
+                tracing::debug!(
+                    "Failed to map physical storage for {}: {error}",
+                    entry.path().display()
+                );
+                untracked_bytes = untracked_bytes.saturating_add(allocated_bytes);
+            }
+        }
+    }
+
+    for extents in physical_extents.values_mut() {
+        extents.sort_unstable_by_key(|&(start, _)| start);
+        let mut current: Option<(u64, u64)> = None;
+
+        for &(start, end) in extents.iter() {
+            if let Some((current_start, current_end)) = current {
+                if start <= current_end {
+                    current = Some((current_start, current_end.max(end)));
+                } else {
+                    untracked_bytes =
+                        untracked_bytes.saturating_add(current_end.saturating_sub(current_start));
+                    current = Some((start, end));
+                }
+            } else {
+                current = Some((start, end));
+            }
+        }
+
+        if let Some((start, end)) = current {
+            untracked_bytes = untracked_bytes.saturating_add(end.saturating_sub(start));
+        }
+    }
+
+    Ok(untracked_bytes)
+}
+
+/// Return the physical file data and directory storage referenced by `path`.
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "ios")))]
+pub fn physical_disk_usage(_path: &Path) -> io::Result<u64> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "physical disk usage is unsupported on this platform",
     ))
 }
 
@@ -63,6 +185,65 @@ pub fn physical_space(path: &Path, metadata: &std::fs::Metadata) -> io::Result<u
             "per-file space measurement is unsupported on this platform",
         ))
     }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[expect(unsafe_code)]
+fn file_physical_extents(
+    file: &fs_err::File,
+    metadata: &std::fs::Metadata,
+) -> io::Result<Vec<(u64, u64)>> {
+    let mut extents = Vec::new();
+    let mut offset = 0_u64;
+
+    while offset < metadata.len() {
+        let start = match rustix::fs::seek(file, rustix::fs::SeekFrom::Data(offset)) {
+            Ok(start) => start,
+            Err(rustix::io::Errno::NXIO) => break,
+            Err(error) => return Err(error.into()),
+        };
+        let end = rustix::fs::seek(file, rustix::fs::SeekFrom::Hole(start))?.min(metadata.len());
+        if end <= start {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "the filesystem returned a non-advancing data extent",
+            ));
+        }
+
+        let mut extent_offset = start;
+        while extent_offset < end {
+            let mut request = libc::log2phys {
+                l2p_flags: 0,
+                l2p_contigbytes: i64::try_from(end - extent_offset).map_err(io::Error::other)?,
+                l2p_devoffset: i64::try_from(extent_offset).map_err(io::Error::other)?,
+            };
+
+            // SAFETY: `file` is an open readable file, and `request` is a valid, initialized
+            // `log2phys` buffer that remains live for the duration of the `fcntl` call.
+            let result =
+                unsafe { libc::fcntl(file.as_raw_fd(), libc::F_LOG2PHYS_EXT, &raw mut request) };
+            if result < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            let contiguous = u64::try_from(request.l2p_contigbytes).map_err(io::Error::other)?;
+            let physical = u64::try_from(request.l2p_devoffset).map_err(io::Error::other)?;
+            if contiguous == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "the filesystem returned a zero-length physical extent",
+                ));
+            }
+
+            let length = contiguous.min(end - extent_offset);
+            extents.push((physical, length));
+            extent_offset = extent_offset.saturating_add(length);
+        }
+
+        offset = end;
+    }
+
+    Ok(extents)
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -111,41 +292,105 @@ fn apple_physical_space(path: &Path) -> io::Result<u64> {
 }
 
 #[cfg(target_os = "linux")]
-#[expect(unsafe_code)]
 fn linux_physical_space(path: &Path) -> io::Result<u64> {
-    const MAX_EXTENTS: usize = 32;
-
-    #[derive(Default)]
-    #[repr(C)]
-    struct Fiemap {
-        start: u64,
-        length: u64,
-        flags: u32,
-        mapped_extents: u32,
-        extent_count: u32,
-        reserved: u32,
-    }
-
-    #[derive(Clone, Copy, Default)]
-    #[repr(C)]
-    struct FiemapExtent {
-        logical: u64,
-        physical: u64,
-        length: u64,
-        reserved64: [u64; 2],
-        flags: u32,
-        reserved: [u32; 3],
-    }
-
-    #[derive(Default)]
-    #[repr(C)]
-    struct FiemapBuffer {
-        header: Fiemap,
-        extents: [FiemapExtent; MAX_EXTENTS],
-    }
-
     let file = fs_err::File::open(path)?;
     let mut physical = 0_u64;
+
+    linux_file_extents(&file, |extent| {
+        if extent.flags
+            & (FIEMAP_EXTENT_DELALLOC | FIEMAP_EXTENT_DATA_INLINE | FIEMAP_EXTENT_SHARED)
+            != 0
+        {
+            return Ok(());
+        }
+
+        if extent.flags
+            & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_ENCODED | FIEMAP_EXTENT_NOT_ALIGNED)
+            != 0
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "the filesystem cannot report the physical size of an extent",
+            ));
+        }
+
+        physical = physical.saturating_add(extent.length);
+        Ok(())
+    })?;
+
+    Ok(physical)
+}
+
+#[cfg(target_os = "linux")]
+fn file_physical_extents(
+    file: &fs_err::File,
+    _metadata: &std::fs::Metadata,
+) -> io::Result<Vec<(u64, u64)>> {
+    let mut extents = Vec::new();
+
+    linux_file_extents(file, |extent| {
+        if extent.flags & (FIEMAP_EXTENT_DELALLOC | FIEMAP_EXTENT_DATA_INLINE) != 0 {
+            return Ok(());
+        }
+
+        if extent.flags
+            & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_ENCODED | FIEMAP_EXTENT_NOT_ALIGNED)
+            != 0
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "the filesystem cannot report the physical location of an extent",
+            ));
+        }
+
+        extents.push((extent.physical, extent.length));
+        Ok(())
+    })?;
+
+    Ok(extents)
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+#[repr(C)]
+struct Fiemap {
+    start: u64,
+    length: u64,
+    flags: u32,
+    mapped_extents: u32,
+    extent_count: u32,
+    reserved: u32,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+struct FiemapExtent {
+    logical: u64,
+    physical: u64,
+    length: u64,
+    reserved64: [u64; 2],
+    flags: u32,
+    reserved: [u32; 3],
+}
+
+#[cfg(target_os = "linux")]
+const MAX_EXTENTS: usize = 32;
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+#[repr(C)]
+struct FiemapBuffer {
+    header: Fiemap,
+    extents: [FiemapExtent; MAX_EXTENTS],
+}
+
+#[cfg(target_os = "linux")]
+#[expect(unsafe_code)]
+fn linux_file_extents(
+    file: &fs_err::File,
+    mut on_extent: impl FnMut(&FiemapExtent) -> io::Result<()>,
+) -> io::Result<()> {
     let mut start = 0_u64;
 
     loop {
@@ -163,7 +408,7 @@ fn linux_physical_space(path: &Path) -> io::Result<u64> {
         // expected fiemap header followed by enough initialized storage for all requested extents.
         unsafe {
             rustix::ioctl::ioctl(
-                &file,
+                file,
                 rustix::ioctl::Updater::<{ FS_IOC_FIEMAP as rustix::ioctl::Opcode }, _>::new(
                     &mut request,
                 ),
@@ -179,33 +424,16 @@ fn linux_physical_space(path: &Path) -> io::Result<u64> {
             ));
         }
         if mapped_extents == 0 {
-            return Ok(physical);
+            return Ok(());
         }
 
         for extent in &request.extents[..mapped_extents] {
-            if extent.flags
-                & (FIEMAP_EXTENT_DELALLOC | FIEMAP_EXTENT_DATA_INLINE | FIEMAP_EXTENT_SHARED)
-                != 0
-            {
-                continue;
-            }
-
-            if extent.flags
-                & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_ENCODED | FIEMAP_EXTENT_NOT_ALIGNED)
-                != 0
-            {
-                return Err(io::Error::new(
-                    io::ErrorKind::Unsupported,
-                    "the filesystem cannot report the physical size of an extent",
-                ));
-            }
-
-            physical = physical.saturating_add(extent.length);
+            on_extent(extent)?;
         }
 
         let last_extent = &request.extents[mapped_extents - 1];
         if last_extent.flags & FIEMAP_EXTENT_LAST != 0 {
-            return Ok(physical);
+            return Ok(());
         }
 
         let next = last_extent.logical.saturating_add(last_extent.length);

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -253,7 +253,7 @@ pub enum PreviewFeature {
     S3Endpoint,
     /// Allows using `uv cache size`.
     CacheSize,
-    /// Reports the physical disk space reclaimed by cache cleanup, accounting for hardlinks and copy-on-write clones.
+    /// Reports physical cache size and cleanup disk space, accounting for hardlinks and copy-on-write clones.
     CachePhysicalSpace,
     /// Rejects the deprecated `--project` option in `uv init`.
     InitProjectFlag,

--- a/crates/uv/src/commands/cache_size.rs
+++ b/crates/uv/src/commands/cache_size.rs
@@ -40,9 +40,13 @@ pub(crate) fn cache_size(
         return Ok(ExitStatus::Success);
     }
 
-    let disk_usage = DiskUsage::new(vec![cache.root().to_path_buf()]);
-
-    let total_bytes = disk_usage.count_ignoring_errors();
+    let total_bytes = if preview.is_enabled(PreviewFeature::CachePhysicalSpace)
+        && uv_fs::supports_physical_space()
+    {
+        uv_fs::physical_disk_usage(cache.root())?
+    } else {
+        DiskUsage::new(vec![cache.root().to_path_buf()]).count_ignoring_errors()
+    };
 
     if human_readable {
         let (bytes, unit) = human_readable_bytes(total_bytes);

--- a/crates/uv/tests/build/cache_size.rs
+++ b/crates/uv/tests/build/cache_size.rs
@@ -1,5 +1,13 @@
+#[cfg(unix)]
+use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
+#[cfg(unix)]
+use assert_fs::prelude::*;
 
+#[cfg(unix)]
+use uv_fs::link::{LinkMode, LinkOptions, link_dir};
+#[cfg(unix)]
+use uv_static::EnvVars;
 use uv_test::{TestContext, uv_snapshot};
 
 /// Preserve cache sizes in snapshots so human-readable and machine output remain distinguishable.
@@ -56,6 +64,124 @@ fn cache_size_with_packages_human() {
     ----- stdout -----
     [SIZE]
     ");
+}
+
+/// Physical cache sizing should count copy-on-write clones within the cache only once.
+#[cfg(unix)]
+#[test]
+fn cache_size_physical_cached_clones() -> Result<()> {
+    let context = copy_on_write_test_context()?;
+    context.clean().assert().success();
+
+    let original = context.cache_dir.child("original");
+    original.create_dir_all()?;
+    original
+        .child("original.bin")
+        .write_binary(&vec![42; 1024 * 1024])?;
+
+    let cloned = context.cache_dir.child("cloned");
+    let link_mode = link_dir(&original, &cloned, &LinkOptions::new(LinkMode::Clone))?;
+    if link_mode != LinkMode::Clone {
+        assert!(
+            std::env::var_os(EnvVars::UV_INTERNAL__TEST_COW_FS).is_none(),
+            "the configured copy-on-write filesystem did not clone the cached file"
+        );
+        return Ok(());
+    }
+
+    let filters = cache_size_filters(&context);
+
+    uv_snapshot!(&filters, context.cache_size().arg("--preview-features").arg("cache-size").arg("--human"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    2.0MiB
+    ");
+
+    uv_snapshot!(&filters, context.cache_size().arg("--preview-features").arg("cache-size,cache-physical-space").arg("--human"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    1.0MiB
+    ");
+
+    assert!(original.child("original.bin").is_file());
+    assert!(cloned.child("original.bin").is_file());
+
+    Ok(())
+}
+
+/// A clone retained outside the cache still contributes once to the cache's physical footprint.
+#[cfg(unix)]
+#[test]
+fn cache_size_physical_external_clone() -> Result<()> {
+    let context = copy_on_write_test_context()?;
+    context.clean().assert().success();
+
+    let retained = context.cache_dir.path().with_file_name("retained");
+    fs_err::create_dir_all(&retained)?;
+    let original = retained.join("original.bin");
+    fs_err::write(&original, vec![42; 1024 * 1024])?;
+
+    let cloned = context.cache_dir.child("cloned");
+    let link_mode = link_dir(&retained, &cloned, &LinkOptions::new(LinkMode::Clone))?;
+    if link_mode != LinkMode::Clone {
+        assert!(
+            std::env::var_os(EnvVars::UV_INTERNAL__TEST_COW_FS).is_none(),
+            "the configured copy-on-write filesystem did not clone the cached file"
+        );
+        return Ok(());
+    }
+
+    uv_snapshot!(cache_size_filters(&context), context.cache_size().arg("--preview-features").arg("cache-size,cache-physical-space").arg("--human"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    1.0MiB
+    ");
+
+    assert!(original.is_file());
+
+    Ok(())
+}
+
+/// Physical cache sizing should count hardlinked files once, including links retained elsewhere.
+#[cfg(unix)]
+#[test]
+fn cache_size_physical_hardlinked_files() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.clean().assert().success();
+    context.cache_dir.create_dir_all()?;
+
+    let original = context.cache_dir.child("original.bin");
+    original.write_binary(&vec![42; 1024 * 1024])?;
+    let cached = context.cache_dir.child("hardlinked.bin");
+    fs_err::hard_link(&original, &cached)?;
+    let retained = context.cache_dir.path().with_file_name("retained.bin");
+    fs_err::hard_link(&original, &retained)?;
+
+    uv_snapshot!(cache_size_filters(&context), context.cache_size().arg("--preview-features").arg("cache-size,cache-physical-space").arg("--human"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    1.0MiB
+    ");
+
+    assert!(retained.is_file());
+
+    Ok(())
+}
+
+/// Put the cache on CI's configured copy-on-write volume, when available.
+#[cfg(unix)]
+fn copy_on_write_test_context() -> Result<TestContext> {
+    let context = uv_test::test_context!("3.12");
+    if std::env::var_os(EnvVars::UV_INTERNAL__TEST_COW_FS).is_none() {
+        return Ok(context);
+    }
+
+    let Some(context) = context.with_cache_on_cow_fs()? else {
+        anyhow::bail!("the configured copy-on-write cache filesystem was unavailable");
+    };
+
+    let cache_dir = context.cache_dir.path().to_path_buf();
+    Ok(context.with_filtered_path(&cache_dir, "CACHE_DIR"))
 }
 
 /// Explicit output formats override terminal detection.

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -152,9 +152,17 @@ reclaimed, accounting for hardlinks and copy-on-write clones:
 $ uv cache clean --preview-features cache-physical-space
 ```
 
-If an entry's allocated size cannot be measured, such as a compressed extent on Btrfs, uv reports a
-lower bound for the space reclaimed from the remaining entries. The preview feature is currently
-supported on macOS and Linux; other platforms continue reporting the logical removed size.
+The same preview feature can be used with `uv cache size` to count physical blocks shared by
+hardlinks or copy-on-write clones within the cache only once:
+
+```console
+$ uv cache size --preview-features cache-size,cache-physical-space
+```
+
+If an entry's allocated size cannot be measured during cleanup, such as a compressed extent on
+Btrfs, uv reports a lower bound for the space reclaimed from the remaining entries. The preview
+feature is currently supported on macOS and Linux; other platforms continue reporting the logical
+removed size.
 
 uv blocks cache-modifying operations while other uv commands are running. By default, those
 `uv cache` commands have a 5 min timeout waiting for other uv processes to terminate to avoid


### PR DESCRIPTION
## Summary

Previously, `uv cache size` counted every cached file independently, so hardlinks and copy-on-write clones could inflate the reported cache footprint.

When `cache-physical-space` is enabled, we now count each hardlinked inode and shared physical extent once within the cache. Storage shared with files outside the cache still contributes to the cache's footprint.

For two cached copy-on-write clones of the same 1 MiB file:

```console
$ uv cache size --preview-features cache-size --human
2.0MiB
$ uv cache size --preview-features cache-size,cache-physical-space --human
1.0MiB
```

Physical extent inspection is supported on macOS and Linux; other platforms retain the existing behavior.
