### PR TITLE
Fix relative indexes in scrolls

### DIFF
--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -7,7 +7,7 @@ use tracing::info_span;
 use uv_client::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT_UPLOAD};
 use uv_configuration::RequiredVersion;
 use uv_dirs::{system_config_file, user_config_dir};
-use uv_distribution_types::Origin;
+use uv_distribution_types::{IndexUrlError, Origin};
 use uv_flags::EnvironmentFlags;
 use uv_fs::Simplified;
 use uv_normalize::{GroupName, PackageName};
@@ -31,6 +31,11 @@ impl FilesystemOptions {
     /// Convert the [`FilesystemOptions`] into [`Options`].
     pub fn into_options(self) -> Options {
         self.0
+    }
+
+    /// Resolve the [`FilesystemOptions`] relative to the given root directory.
+    pub fn relative_to(self, root_dir: &Path) -> Result<Self, IndexUrlError> {
+        Ok(Self(self.0.relative_to(root_dir)?))
     }
 }
 

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -695,12 +695,9 @@ pub(crate) async fn add(
     // Add any indexes that were provided on the command-line, in priority order.
     if !raw {
         let root_dir = match &target {
-            AddTarget::Script(script, _) => script.path.parent().ok_or_else(|| {
-                anyhow!(
-                    "Script path has no parent directory: {}",
-                    script.path.display()
-                )
-            })?,
+            AddTarget::Script(script, _) => {
+                script.path.parent().expect("script path has no parent")
+            }
             AddTarget::Project(project, _) => project.root(),
         };
         let locations = IndexLocations::new(indexes, Vec::new(), false);

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -26,7 +26,7 @@ use uv_distribution_types::{
     Identifier, Index, IndexLocations, IndexName, IndexUrl, NameRequirementSpecification,
     Requirement, RequirementSource, UnresolvedRequirement,
 };
-use uv_fs::{CWD, LockedFile, LockedFileError, Simplified};
+use uv_fs::{LockedFile, LockedFileError, Simplified};
 use uv_git::store_credentials;
 use uv_normalize::{DEV_DEPENDENCIES, DefaultExtras, DefaultGroups, ExtraName, PackageName};
 use uv_pep508::{MarkerTree, VersionOrUrl};
@@ -695,7 +695,12 @@ pub(crate) async fn add(
     // Add any indexes that were provided on the command-line, in priority order.
     if !raw {
         let root_dir = match &target {
-            AddTarget::Script(_, _) => CWD.as_path(),
+            AddTarget::Script(script, _) => script.path.parent().ok_or_else(|| {
+                anyhow!(
+                    "Script path has no parent directory: {}",
+                    script.path.display()
+                )
+            })?,
             AddTarget::Project(project, _) => project.root(),
         };
         let locations = IndexLocations::new(indexes, Vec::new(), false);

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -313,7 +313,7 @@ pub(crate) enum ProjectError {
     IndexCredentials(#[from] IndexCredentialsError),
 
     #[error(transparent)]
-    Index(#[from] IndexUrlError),
+    IndexUrl(#[from] IndexUrlError),
 
     #[error(transparent)]
     Python(#[from] uv_python::Error),

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -21,7 +21,7 @@ use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies, LoweredRequirement};
 use uv_distribution_types::{
     ExtraBuildRequirement, ExtraBuildRequires, HashGeneration, Index, IndexCredentialsError,
-    Requirement, RequiresPython, Resolution, UnresolvedRequirement,
+    IndexUrlError, Requirement, RequiresPython, Resolution, UnresolvedRequirement,
     UnresolvedRequirementSpecification,
 };
 use uv_fs::{CWD, LockedFile, LockedFileError, LockedFileMode, Simplified, verbatim_path};
@@ -311,6 +311,9 @@ pub(crate) enum ProjectError {
 
     #[error(transparent)]
     IndexCredentials(#[from] IndexCredentialsError),
+
+    #[error(transparent)]
+    Index(#[from] IndexUrlError),
 
     #[error(transparent)]
     Python(#[from] uv_python::Error),
@@ -3319,7 +3322,12 @@ pub(crate) async fn script_specification(
     };
 
     let script_dir = script.directory()?;
-    let script_indexes = script.indexes(&settings.sources);
+    let script_indexes = script
+        .indexes(&settings.sources)
+        .iter()
+        .cloned()
+        .map(|index| index.relative_to(&script_dir))
+        .collect::<Result<Vec<_>, _>>()?;
     let script_sources = script.sources(&settings.sources);
 
     let mut requirements = Vec::new();
@@ -3329,7 +3337,7 @@ pub(crate) async fn script_specification(
                 requirement,
                 script_dir.as_ref(),
                 script_sources.as_ref(),
-                script_indexes,
+                &script_indexes,
                 &settings.index_locations,
                 cache,
                 workspace_cache,
@@ -3356,7 +3364,7 @@ pub(crate) async fn script_specification(
                 requirement,
                 script_dir.as_ref(),
                 script_sources.as_ref(),
-                script_indexes,
+                &script_indexes,
                 &settings.index_locations,
                 cache,
                 workspace_cache,
@@ -3386,7 +3394,7 @@ pub(crate) async fn script_specification(
                             requirement,
                             script_dir.as_ref(),
                             script_sources.as_ref(),
-                            script_indexes,
+                            &script_indexes,
                             &settings.index_locations,
                             cache,
                             workspace_cache,
@@ -3406,7 +3414,7 @@ pub(crate) async fn script_specification(
                                 requirement,
                                 script_dir.as_ref(),
                                 script_sources.as_ref(),
-                                script_indexes,
+                                &script_indexes,
                                 &settings.index_locations,
                                 cache,
                                 workspace_cache,
@@ -3453,7 +3461,12 @@ pub(crate) async fn script_extra_build_requires(
     credentials_cache: &CredentialsCache,
 ) -> Result<LoweredExtraBuildDependencies, ProjectError> {
     let script_dir = script.directory()?;
-    let script_indexes = script.indexes(&settings.sources);
+    let script_indexes = script
+        .indexes(&settings.sources)
+        .iter()
+        .cloned()
+        .map(|index| index.relative_to(&script_dir))
+        .collect::<Result<Vec<_>, _>>()?;
     let script_sources = script.sources(&settings.sources);
 
     // Collect any `tool.uv.extra-build-dependencies` from the script.
@@ -3480,7 +3493,7 @@ pub(crate) async fn script_extra_build_requires(
                     requirement,
                     script_dir.as_ref(),
                     script_sources.as_ref(),
-                    script_indexes,
+                    &script_indexes,
                     &settings.index_locations,
                     cache,
                     workspace_cache,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -44,7 +44,7 @@ use uv_pypi_types::{ParsedDirectoryUrl, ParsedUrl};
 use uv_python::{ConfigDiscovery, PythonRequest};
 use uv_requirements::{GroupsSpecification, RequirementsSource};
 use uv_requirements_txt::RequirementsTxtRequirement;
-use uv_scripts::{Pep723Error, Pep723Item, Pep723Script};
+use uv_scripts::{Pep723Error, Pep723Item, Pep723ItemRef, Pep723Script};
 use uv_settings::{Combine, EnvironmentOptions, FilesystemOptions, Options};
 use uv_static::EnvVars;
 use uv_warnings::{warn_user, warn_user_once};
@@ -487,14 +487,22 @@ async fn run_with_workspace_cache(
     };
 
     // If the target is a PEP 723 script, merge the metadata into the filesystem metadata.
-    let filesystem = script
+    let script_filesystem = script
         .as_ref()
         .map(Pep723Item::metadata)
         .and_then(|metadata| metadata.tool.as_ref())
         .and_then(|tool| tool.uv.as_ref())
         .map(|uv| Options::simple(uv.globals.clone(), uv.top_level.clone()))
-        .map(FilesystemOptions::from)
-        .combine(filesystem);
+        .map(FilesystemOptions::from);
+    let script_filesystem = if let Some(Pep723Item::Script(script)) = script.as_ref() {
+        let script_dir = Pep723ItemRef::from(script).directory()?;
+        script_filesystem
+            .map(|options| options.relative_to(&script_dir))
+            .transpose()?
+    } else {
+        script_filesystem
+    };
+    let filesystem = script_filesystem.combine(filesystem);
 
     let custom_certificate_file = match &*cli.command {
         Commands::Pip(PipNamespace { cert, .. }) => cert.as_deref(),

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -44,7 +44,7 @@ use uv_pypi_types::{ParsedDirectoryUrl, ParsedUrl};
 use uv_python::{ConfigDiscovery, PythonRequest};
 use uv_requirements::{GroupsSpecification, RequirementsSource};
 use uv_requirements_txt::RequirementsTxtRequirement;
-use uv_scripts::{Pep723Error, Pep723Item, Pep723ItemRef, Pep723Script};
+use uv_scripts::{Pep723Error, Pep723Item, Pep723Script};
 use uv_settings::{Combine, EnvironmentOptions, FilesystemOptions, Options};
 use uv_static::EnvVars;
 use uv_warnings::{warn_user, warn_user_once};
@@ -495,9 +495,9 @@ async fn run_with_workspace_cache(
         .map(|uv| Options::simple(uv.globals.clone(), uv.top_level.clone()))
         .map(FilesystemOptions::from);
     let script_filesystem = if let Some(Pep723Item::Script(script)) = script.as_ref() {
-        let script_dir = Pep723ItemRef::from(script).directory()?;
+        let script_dir = script.path.parent().expect("script path has no parent");
         script_filesystem
-            .map(|options| options.relative_to(&script_dir))
+            .map(|options| options.relative_to(script_dir))
             .transpose()?
     } else {
         script_filesystem

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -10841,7 +10841,7 @@ fn add_index_with_existing_relative_path_in_script() -> Result<()> {
         #
         # [[tool.uv.index]]
         # name = "local"
-        # url = "./links"
+        # url = "../links"
         # format = "flat"
         # ///
     "#})?;
@@ -10872,7 +10872,7 @@ fn add_index_with_existing_relative_path_in_script() -> Result<()> {
         #
         # [[tool.uv.index]]
         # name = "local"
-        # url = "links"
+        # url = "../links"
         # format = "flat"
         #
         # [tool.uv.sources]

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -815,6 +815,60 @@ fn run_pep723_script_index() -> Result<()> {
     Ok(())
 }
 
+/// Run a PEP 723-compatible script with a relative `[[tool.uv.index]]` from another directory.
+#[test]
+fn run_pep723_script_relative_index_from_another_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let scripts = context.temp_dir.child("scripts");
+    let links = scripts.child("links");
+    links.create_dir_all()?;
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+        links.child("ok-1.0.0-py3-none-any.whl"),
+    )?;
+
+    let test_script = scripts.child("main.py");
+    test_script.write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = ["ok"]
+        #
+        # [[tool.uv.index]]
+        # name = "local"
+        # url = "./links"
+        # format = "flat"
+        #
+        # [tool.uv.sources]
+        # ok = { index = "local" }
+        # ///
+
+        import ok
+
+        print("ok imported")
+        "#
+    })?;
+
+    let elsewhere = context.temp_dir.child("elsewhere");
+    elsewhere.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.run().current_dir(elsewhere).arg("--offline").arg(test_script.path()), @r"
+    exit_code: 0 (success)
+    ----- stdout -----
+    ok imported
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0
+    ");
+
+    Ok(())
+}
+
 /// Package-scoped source disabling must not discard unrelated script sources or indexes.
 #[test]
 fn run_pep723_script_no_sources_package() -> Result<()> {

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -869,6 +869,57 @@ fn run_pep723_script_relative_index_from_another_directory() -> Result<()> {
     Ok(())
 }
 
+/// Run a PEP 723-compatible script with a relative default index from another directory.
+#[test]
+fn run_pep723_script_relative_default_index_from_another_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let scripts = context.temp_dir.child("scripts");
+    let links = scripts.child("links");
+    links.create_dir_all()?;
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+        links.child("ok-1.0.0-py3-none-any.whl"),
+    )?;
+
+    let test_script = scripts.child("main.py");
+    test_script.write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = ["ok"]
+        #
+        # [[tool.uv.index]]
+        # name = "local"
+        # url = "./links"
+        # format = "flat"
+        # ///
+
+        import ok
+
+        print("ok imported")
+        "#
+    })?;
+
+    let elsewhere = context.temp_dir.child("elsewhere");
+    elsewhere.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.run().current_dir(elsewhere).arg("--offline").arg(test_script.path()), @r"
+    exit_code: 0 (success)
+    ----- stdout -----
+    ok imported
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0
+    ");
+
+    Ok(())
+}
+
 /// Package-scoped source disabling must not discard unrelated script sources or indexes.
 #[test]
 fn run_pep723_script_no_sources_package() -> Result<()> {

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -815,9 +815,9 @@ fn run_pep723_script_index() -> Result<()> {
     Ok(())
 }
 
-/// Run a PEP 723-compatible script with a relative `[[tool.uv.index]]` from another directory.
+/// Run a PEP 723-compatible script with a relative pinned index from another directory.
 #[test]
-fn run_pep723_script_relative_index_from_another_directory() -> Result<()> {
+fn run_pep723_script_relative_index_pinned() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
     let scripts = context.temp_dir.child("scripts");
@@ -839,6 +839,7 @@ fn run_pep723_script_relative_index_from_another_directory() -> Result<()> {
         # [[tool.uv.index]]
         # name = "local"
         # url = "./links"
+        # explicit = true
         # format = "flat"
         #
         # [tool.uv.sources]
@@ -846,8 +847,6 @@ fn run_pep723_script_relative_index_from_another_directory() -> Result<()> {
         # ///
 
         import ok
-
-        print("ok imported")
         "#
     })?;
 
@@ -856,9 +855,6 @@ fn run_pep723_script_relative_index_from_another_directory() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.run().current_dir(elsewhere).arg("--offline").arg(test_script.path()), @r"
     exit_code: 0 (success)
-    ----- stdout -----
-    ok imported
-
     ----- stderr -----
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
@@ -869,9 +865,9 @@ fn run_pep723_script_relative_index_from_another_directory() -> Result<()> {
     Ok(())
 }
 
-/// Run a PEP 723-compatible script with a relative default index from another directory.
+/// Run a PEP 723-compatible script with a relative unpinned index from another directory.
 #[test]
-fn run_pep723_script_relative_default_index_from_another_directory() -> Result<()> {
+fn run_pep723_script_relative_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
     let scripts = context.temp_dir.child("scripts");
@@ -897,8 +893,6 @@ fn run_pep723_script_relative_default_index_from_another_directory() -> Result<(
         # ///
 
         import ok
-
-        print("ok imported")
         "#
     })?;
 
@@ -907,9 +901,6 @@ fn run_pep723_script_relative_default_index_from_another_directory() -> Result<(
 
     uv_snapshot!(context.filters(), context.run().current_dir(elsewhere).arg("--offline").arg(test_script.path()), @r"
     exit_code: 0 (success)
-    ----- stdout -----
-    ok imported
-
     ----- stderr -----
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -815,57 +815,7 @@ fn run_pep723_script_index() -> Result<()> {
     Ok(())
 }
 
-/// Run a PEP 723-compatible script with a relative pinned index from another directory.
-#[test]
-fn run_pep723_script_relative_index_pinned() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let scripts = context.temp_dir.child("scripts");
-    let links = scripts.child("links");
-    links.create_dir_all()?;
-    fs_err::copy(
-        context
-            .workspace_root
-            .join("test/links/ok-1.0.0-py3-none-any.whl"),
-        links.child("ok-1.0.0-py3-none-any.whl"),
-    )?;
-
-    let test_script = scripts.child("main.py");
-    test_script.write_str(indoc! { r#"
-        # /// script
-        # requires-python = ">=3.11"
-        # dependencies = ["ok"]
-        #
-        # [[tool.uv.index]]
-        # name = "local"
-        # url = "./links"
-        # explicit = true
-        # format = "flat"
-        #
-        # [tool.uv.sources]
-        # ok = { index = "local" }
-        # ///
-
-        import ok
-        "#
-    })?;
-
-    let elsewhere = context.temp_dir.child("elsewhere");
-    elsewhere.create_dir_all()?;
-
-    uv_snapshot!(context.filters(), context.run().current_dir(elsewhere).arg("--offline").arg(test_script.path()), @r"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0
-    ");
-
-    Ok(())
-}
-
-/// Run a PEP 723-compatible script with a relative unpinned index from another directory.
+/// Run a PEP 723-compatible script with a relative index and pinned and unpinned dependencies.
 #[test]
 fn run_pep723_script_relative_index() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -879,20 +829,30 @@ fn run_pep723_script_relative_index() -> Result<()> {
             .join("test/links/ok-1.0.0-py3-none-any.whl"),
         links.child("ok-1.0.0-py3-none-any.whl"),
     )?;
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/validation-1.0.0-py3-none-any.whl"),
+        links.child("validation-1.0.0-py3-none-any.whl"),
+    )?;
 
     let test_script = scripts.child("main.py");
     test_script.write_str(indoc! { r#"
         # /// script
         # requires-python = ">=3.11"
-        # dependencies = ["ok"]
+        # dependencies = ["ok", "validation"]
         #
         # [[tool.uv.index]]
         # name = "local"
         # url = "./links"
         # format = "flat"
+        #
+        # [tool.uv.sources]
+        # ok = { index = "local" }
         # ///
 
         import ok
+        import validation
         "#
     })?;
 
@@ -902,10 +862,11 @@ fn run_pep723_script_relative_index() -> Result<()> {
     uv_snapshot!(context.filters(), context.run().current_dir(elsewhere).arg("--offline").arg(test_script.path()), @r"
     exit_code: 0 (success)
     ----- stderr -----
-    Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
+    Resolved 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
      + ok==1.0.0
+     + validation==1.0.0
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

Relative indexes in PEP 723 scripts were resolved against the current working directory instead of
the script's directory, so a script could work when ran from its own directory but fail when
ran from elsewhere.

This change resolves inline indexes relative to the script and also makes `uv add --script` write index
paths relative to the script. It also applies the same behavior to extra build dependencies

Fixes #21096

## Test Plan

- Added an offline regression test that runs a script with a relative index from another directory
- Ran the focused project and sync tests
- Ran Clippy and rustfmt
