### PR TITLE
Propagate tool enumeration errors in uv tool upgrade --all

### DIFF
--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -66,8 +66,7 @@ pub(crate) async fn upgrade(
     let names: BTreeMap<PackageName, Vec<Requirement>> = {
         if names.is_empty() {
             installed_tools
-                .tools()
-                .unwrap_or_default()
+                .tools()?
                 .into_iter()
                 .map(|(name, _)| (name, Vec::new()))
                 .collect()

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -94,16 +94,17 @@ fn tool_upgrade_all_ignores_invalid_tool_name() -> Result<()> {
 
     tool_dir.child("tool backup").create_dir_all()?;
 
-    // Silently treating an enumeration error as an empty tool directory hides a broken
-    // installation and exits successfully; see astral-sh/uv#21058.
+    // Enumeration errors should propagate instead of being silently treated as an
+    // empty tool directory; see astral-sh/uv#21058.
     uv_snapshot!(context.filters(), context.tool_upgrade()
         .arg("--all")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::PATH, bin_dir.as_os_str()), @"
-    exit_code: 0 (success)
+    success: false
+    exit_code: 2
     ----- stderr -----
-    Nothing to upgrade
+    error: Not a valid package or extra name: "tool backup". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

When `uv tool upgrade --all` encountered an error while enumerating the tool directory (for example, because a directory under the tool root had an invalid package name), the command used `.unwrap_or_default()` and silently reported `Nothing to upgrade` with a zero exit code, hiding the underlying failure.

This replaces the silent fallback with `?` so the error propagates and the command exits non-zero, matching the behaviour of `uv tool list`.

The existing regression test (`tool_upgrade_all_ignores_invalid_tool_name`) is updated to assert the new, correct behaviour: a non-zero exit with the propagated package-name error.

Closes #21058

## Test Plan

- `cargo nextest run -p uv --test it -- tool_upgrade_all_ignores_invalid_tool_name` (manually verified the snapshot reflects the new behaviour)
- The fix is a one-line change to error propagation; no other call sites of `InstalledTools::tools()` are affected by the new early return.

## Test Output

The updated snapshot for `tool_upgrade_all_ignores_invalid_tool_name`:

```
success: false
exit_code: 2
----- stderr -----
error: Not a valid package or extra name: "tool backup". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
```