### PR TITLE
Document removing uv-receipt.json after uninstall on Windows

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -284,6 +284,41 @@ If you need to remove uv from your system, follow these steps:
         uninstall. Upgrading from an older version will not automatically remove the binaries from
         `~/.cargo/bin`.
 
+### Removing the standalone installer receipt on Windows
+
+!!! note
+
+    Only relevant if uv was installed via the standalone installer and you intend to switch to a
+    different distribution channel such as [WinGet](#winget).
+
+When uv is installed via the standalone installer on Windows, a receipt file is written to
+`%LOCALAPPDATA%\uv\uv-receipt.json`. Removing the binaries as described above does not delete
+the receipt. If left in place, the receipt confuses `uv self update` and other tooling, producing
+errors like:
+
+```text
+The current executable is at ... but the standalone installer was used to install uv to ...
+Are multiple copies of uv installed?
+```
+
+To complete the uninstallation, delete the receipt (or, more conveniently, the entire
+`%LOCALAPPDATA%\uv\` directory):
+
+=== "PowerShell"
+
+    ```pwsh-session
+    PS> rm $env:LOCALAPPDATA\uv\uv-receipt.json
+    ```
+
+=== "Command Prompt"
+
+    ```console
+    $ del "%LOCALAPPDATA%\uv\uv-receipt.json"
+    ```
+
+If you no longer need the cached Python interpreters or installed tools, the rest of the contents
+of `%LOCALAPPDATA%\uv\` can be removed as well.
+
 ## Next steps
 
 See the [first steps](./first-steps.md) or jump straight to the [guides](../guides/index.md) to


### PR DESCRIPTION
Resolves #21127.

The standalone installer writes **%LOCALAPPDATA%\\uv\\uv-receipt.json** on
Windows. Following the existing uninstallation steps removes the binaries
but leaves the receipt in place, which then confuses **uv self update**
and other tooling with:

    The current executable is at ... but the standalone installer was
    used to install uv to ... Are multiple copies of uv installed?

This is most often hit by users switching from the standalone installer
to another distribution channel such as WinGet (see the report).

This PR documents the extra Windows-only cleanup in the uninstallation
section of the getting-started docs. The note is gated on the
standalone-installer → alternate-channel workflow so the steps only
appear relevant to readers who actually need them.

Docs-only change; no source code touched and the project policy is that
changelog entries are produced by scripts/release.sh, so none added
here.