### PR TITLE
Simplify editable requirement errors and hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7334,6 +7334,7 @@ dependencies = [
  "uv-client",
  "uv-configuration",
  "uv-distribution-types",
+ "uv-errors",
  "uv-fs",
  "uv-normalize",
  "uv-pep508",

--- a/crates/uv-pypi-types/src/parsed_url.rs
+++ b/crates/uv-pypi-types/src/parsed_url.rs
@@ -40,6 +40,19 @@ pub enum ParsedUrlError {
     MissingExtensionPath(PathBuf, ExtensionError),
 }
 
+/// An error converting a parsed URL into an editable source.
+#[derive(Debug, Error)]
+pub enum MakeEditableError {
+    #[error("Local archives cannot be editable")]
+    LocalArchive,
+
+    #[error("Remote archives cannot be editable")]
+    RemoteArchive,
+
+    #[error("Git sources cannot be editable")]
+    Git,
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, PartialOrd, Eq, Ord)]
 pub struct VerbatimParsedUrl {
     pub parsed_url: ParsedUrl,
@@ -56,6 +69,15 @@ impl VerbatimParsedUrl {
     /// Returns `true` if the URL is editable.
     pub fn is_editable(&self) -> bool {
         self.parsed_url.is_editable()
+    }
+
+    /// Make the URL an editable source.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MakeEditableError`] if the URL does not refer to a local directory.
+    pub fn make_editable(&mut self) -> Result<(), MakeEditableError> {
+        self.parsed_url.make_editable()
     }
 }
 
@@ -211,6 +233,23 @@ impl ParsedUrl {
                 ..
             })
         )
+    }
+
+    /// Make the URL an editable source.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MakeEditableError`] if the URL does not refer to a local directory.
+    fn make_editable(&mut self) -> Result<(), MakeEditableError> {
+        match self {
+            Self::Directory(directory) => {
+                directory.editable = Some(true);
+                Ok(())
+            }
+            Self::Path(_) => Err(MakeEditableError::LocalArchive),
+            Self::Archive(_) => Err(MakeEditableError::RemoteArchive),
+            Self::GitDirectory(_) | Self::GitPath(_) => Err(MakeEditableError::Git),
+        }
     }
 }
 

--- a/crates/uv-requirements-txt/Cargo.toml
+++ b/crates/uv-requirements-txt/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 uv-client = { workspace = true }
 uv-configuration = { workspace = true }
 uv-distribution-types = { workspace = true }
+uv-errors = { workspace = true }
 uv-fs = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep508 = { workspace = true }

--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -59,8 +59,7 @@ use uv_pypi_types::VerbatimParsedUrl;
 use uv_redacted::DisplaySafeUrl;
 use uv_redacted::DisplaySafeUrlError;
 
-use crate::requirement::EditableError;
-pub use crate::requirement::RequirementsTxtRequirement;
+pub use crate::requirement::{MakeEditableError, RequirementsTxtRequirement};
 use crate::shquote::unquote;
 
 mod requirement;
@@ -745,16 +744,17 @@ fn parse_entry(
             Some(requirements_txt)
         };
 
-        let (requirement, hashes) =
+        let (mut requirement, hashes) =
             parse_requirement_and_hashes(s, content, source, working_dir, true)?;
-        let requirement =
-            requirement
-                .into_editable()
-                .map_err(|err| RequirementsTxtParserError::NonEditable {
-                    source: err,
-                    start,
-                    end: s.cursor(),
-                })?;
+        requirement
+            .make_editable()
+            .map_err(|source| RequirementsTxtParserError::NonEditable {
+                source,
+                requirement: requirement.to_string(),
+                start,
+                end: s.cursor(),
+                line: calculate_row_column(content, start).0,
+            })?;
         RequirementsTxtStatement::EditableRequirementEntry(RequirementEntry {
             requirement,
             hashes,
@@ -1170,9 +1170,11 @@ pub enum RequirementsTxtParserError {
     UnsupportedUrl(String),
     MissingRequirementPrefix(String),
     NonEditable {
-        source: EditableError,
+        source: MakeEditableError,
+        requirement: String,
         start: usize,
         end: usize,
+        line: usize,
     },
     NoBinary {
         source: uv_normalize::InvalidNameError,
@@ -1245,8 +1247,13 @@ impl Display for RequirementsTxtParserError {
             Self::UnsupportedUrl(url) => {
                 write!(f, "Unsupported URL (expected a `file://` scheme): `{url}`")
             }
-            Self::NonEditable { .. } => {
-                write!(f, "Unsupported editable requirement")
+            Self::NonEditable {
+                requirement, line, ..
+            } => {
+                write!(
+                    f,
+                    "Unsupported editable requirement at line {line}: `{requirement}`"
+                )
             }
             Self::MissingRequirementPrefix(given) => {
                 write!(
@@ -1382,10 +1389,12 @@ impl Display for RequirementsTxtFileError {
                     self.file.user_display(),
                 )
             }
-            RequirementsTxtParserError::NonEditable { .. } => {
+            RequirementsTxtParserError::NonEditable {
+                requirement, line, ..
+            } => {
                 write!(
                     f,
-                    "Unsupported editable requirement in `{}`",
+                    "Unsupported editable requirement in `{}` at line {line}: `{requirement}`",
                     self.file.user_display(),
                 )
             }
@@ -1898,8 +1907,8 @@ mod test {
             filters => filters
         }, {
             insta::assert_snapshot!(errors, @"
-            Unsupported editable requirement in `<REQUIREMENTS_TXT>`
-            Editable must refer to a local directory, not an HTTPS URL: `https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.gz`
+            Unsupported editable requirement in `<REQUIREMENTS_TXT>` at line 1: `https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.gz`
+            Remote archives cannot be editable
             ");
         });
 

--- a/crates/uv-requirements-txt/src/requirement.rs
+++ b/crates/uv-requirements-txt/src/requirement.rs
@@ -1,38 +1,26 @@
 use std::fmt::Display;
 use std::path::Path;
 
-use uv_normalize::PackageName;
+use uv_errors::{Hint, Hints};
 use uv_pep508::{
     Pep508Error, Pep508ErrorSource, RequirementOrigin, TracingReporter, UnnamedRequirement,
     VersionOrUrl,
 };
-use uv_pypi_types::{MakeEditableError, VerbatimParsedUrl};
+use uv_pypi_types::VerbatimParsedUrl;
 
 #[derive(Debug, thiserror::Error)]
-pub enum EditableError {
-    #[error("Editable `{0}` must refer to a local directory")]
-    MissingVersion(PackageName),
+pub enum MakeEditableError {
+    #[error("Registry requirements cannot be editable")]
+    Registry,
 
-    #[error("Editable `{0}` must refer to a local directory, not a versioned package")]
-    Versioned(PackageName),
+    #[error(transparent)]
+    Url(#[from] uv_pypi_types::MakeEditableError),
+}
 
-    #[error("Editable `{0}` must refer to a local directory, not an archive: `{1}`")]
-    File(PackageName, String),
-
-    #[error("Editable `{0}` must refer to a local directory, not an HTTPS URL: `{1}`")]
-    Https(PackageName, String),
-
-    #[error("Editable `{0}` must refer to a local directory, not a Git URL: `{1}`")]
-    Git(PackageName, String),
-
-    #[error("Editable must refer to a local directory, not an archive: `{0}`")]
-    UnnamedFile(String),
-
-    #[error("Editable must refer to a local directory, not an HTTPS URL: `{0}`")]
-    UnnamedHttps(String),
-
-    #[error("Editable must refer to a local directory, not a Git URL: `{0}`")]
-    UnnamedGit(String),
+impl Hint for MakeEditableError {
+    fn hints(&self) -> Hints<'_> {
+        Hints::from("Editable requirements must refer to a local directory")
+    }
 }
 
 /// A requirement specifier in a `requirements.txt` file.
@@ -58,55 +46,24 @@ impl RequirementsTxtRequirement {
         }
     }
 
-    /// Convert the [`RequirementsTxtRequirement`] into an editable requirement.
+    /// Make the [`RequirementsTxtRequirement`] editable in place.
     ///
     /// # Errors
     ///
-    /// Returns [`EditableError`] if the requirement cannot be interpreted as editable.
-    /// Specifically, only local directory URLs are supported.
-    pub fn into_editable(self) -> Result<Self, EditableError> {
-        match self {
-            Self::Named(mut requirement) => {
-                let Some(version_or_url) = requirement.version_or_url.as_mut() else {
-                    return Err(EditableError::MissingVersion(requirement.name));
+    /// Returns [`MakeEditableError`] if the requirement does not refer to a local directory.
+    pub fn make_editable(&mut self) -> Result<(), MakeEditableError> {
+        let url = match self {
+            Self::Named(requirement) => {
+                let Some(VersionOrUrl::Url(url)) = requirement.version_or_url.as_mut() else {
+                    return Err(MakeEditableError::Registry);
                 };
-
-                let VersionOrUrl::Url(url) = version_or_url else {
-                    return Err(EditableError::Versioned(requirement.name));
-                };
-
-                if let Err(error) = url.make_editable() {
-                    let display_url = url.to_string();
-                    return Err(match error {
-                        MakeEditableError::LocalArchive => {
-                            EditableError::File(requirement.name, display_url)
-                        }
-                        MakeEditableError::RemoteArchive => {
-                            EditableError::Https(requirement.name, display_url)
-                        }
-                        MakeEditableError::Git => EditableError::Git(requirement.name, display_url),
-                    });
-                }
-
-                Ok(Self::Named(requirement))
+                url
             }
-            Self::Unnamed(mut requirement) => {
-                if let Err(error) = requirement.url.make_editable() {
-                    let display_requirement = requirement.to_string();
-                    return Err(match error {
-                        MakeEditableError::LocalArchive => {
-                            EditableError::UnnamedFile(display_requirement)
-                        }
-                        MakeEditableError::RemoteArchive => {
-                            EditableError::UnnamedHttps(display_requirement)
-                        }
-                        MakeEditableError::Git => EditableError::UnnamedGit(display_requirement),
-                    });
-                }
+            Self::Unnamed(requirement) => &mut requirement.url,
+        };
 
-                Ok(Self::Unnamed(requirement))
-            }
-        }
+        url.make_editable()?;
+        Ok(())
     }
 
     /// Parse a requirement as seen in a `requirements.txt` file.

--- a/crates/uv-requirements-txt/src/requirement.rs
+++ b/crates/uv-requirements-txt/src/requirement.rs
@@ -4,8 +4,9 @@ use std::path::Path;
 use uv_normalize::PackageName;
 use uv_pep508::{
     Pep508Error, Pep508ErrorSource, RequirementOrigin, TracingReporter, UnnamedRequirement,
+    VersionOrUrl,
 };
-use uv_pypi_types::{ParsedDirectoryUrl, ParsedUrl, VerbatimParsedUrl};
+use uv_pypi_types::{MakeEditableError, VerbatimParsedUrl};
 
 #[derive(Debug, thiserror::Error)]
 pub enum EditableError {
@@ -65,69 +66,45 @@ impl RequirementsTxtRequirement {
     /// Specifically, only local directory URLs are supported.
     pub fn into_editable(self) -> Result<Self, EditableError> {
         match self {
-            Self::Named(requirement) => {
-                let Some(version_or_url) = requirement.version_or_url else {
+            Self::Named(mut requirement) => {
+                let Some(version_or_url) = requirement.version_or_url.as_mut() else {
                     return Err(EditableError::MissingVersion(requirement.name));
                 };
 
-                let uv_pep508::VersionOrUrl::Url(url) = version_or_url else {
+                let VersionOrUrl::Url(url) = version_or_url else {
                     return Err(EditableError::Versioned(requirement.name));
                 };
 
-                let parsed_url = match url.parsed_url {
-                    ParsedUrl::Directory(parsed_url) => parsed_url,
-                    ParsedUrl::Path(_) => {
-                        return Err(EditableError::File(requirement.name, url.to_string()));
-                    }
-                    ParsedUrl::Archive(_) => {
-                        return Err(EditableError::Https(requirement.name, url.to_string()));
-                    }
-                    ParsedUrl::GitDirectory(_) => {
-                        return Err(EditableError::Git(requirement.name, url.to_string()));
-                    }
-                    ParsedUrl::GitPath(_) => {
-                        return Err(EditableError::Git(requirement.name, url.to_string()));
-                    }
-                };
+                if let Err(error) = url.make_editable() {
+                    let display_url = url.to_string();
+                    return Err(match error {
+                        MakeEditableError::LocalArchive => {
+                            EditableError::File(requirement.name, display_url)
+                        }
+                        MakeEditableError::RemoteArchive => {
+                            EditableError::Https(requirement.name, display_url)
+                        }
+                        MakeEditableError::Git => EditableError::Git(requirement.name, display_url),
+                    });
+                }
 
-                Ok(Self::Named(uv_pep508::Requirement {
-                    version_or_url: Some(uv_pep508::VersionOrUrl::Url(VerbatimParsedUrl {
-                        verbatim: url.verbatim,
-                        parsed_url: ParsedUrl::Directory(ParsedDirectoryUrl {
-                            editable: Some(true),
-                            ..parsed_url
-                        }),
-                    })),
-                    ..requirement
-                }))
+                Ok(Self::Named(requirement))
             }
-            Self::Unnamed(requirement) => {
-                let parsed_url = match requirement.url.parsed_url {
-                    ParsedUrl::Directory(parsed_url) => parsed_url,
-                    ParsedUrl::Path(_) => {
-                        return Err(EditableError::UnnamedFile(requirement.to_string()));
-                    }
-                    ParsedUrl::Archive(_) => {
-                        return Err(EditableError::UnnamedHttps(requirement.to_string()));
-                    }
-                    ParsedUrl::GitDirectory(_) => {
-                        return Err(EditableError::UnnamedGit(requirement.to_string()));
-                    }
-                    ParsedUrl::GitPath(_) => {
-                        return Err(EditableError::UnnamedGit(requirement.to_string()));
-                    }
-                };
+            Self::Unnamed(mut requirement) => {
+                if let Err(error) = requirement.url.make_editable() {
+                    let display_requirement = requirement.to_string();
+                    return Err(match error {
+                        MakeEditableError::LocalArchive => {
+                            EditableError::UnnamedFile(display_requirement)
+                        }
+                        MakeEditableError::RemoteArchive => {
+                            EditableError::UnnamedHttps(display_requirement)
+                        }
+                        MakeEditableError::Git => EditableError::UnnamedGit(display_requirement),
+                    });
+                }
 
-                Ok(Self::Unnamed(UnnamedRequirement {
-                    url: VerbatimParsedUrl {
-                        verbatim: requirement.url.verbatim,
-                        parsed_url: ParsedUrl::Directory(ParsedDirectoryUrl {
-                            editable: Some(true),
-                            ..parsed_url
-                        }),
-                    },
-                    ..requirement
-                }))
+                Ok(Self::Unnamed(requirement))
             }
         }
     }

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -261,12 +261,16 @@ impl RequirementsSpecification {
                 )],
                 ..Self::default()
             },
-            RequirementsSource::Editable(requirement) => Self {
-                requirements: vec![UnresolvedRequirementSpecification::from(
-                    requirement.clone().into_editable()?,
-                )],
-                ..Self::default()
-            },
+            RequirementsSource::Editable(requirement) => {
+                let mut requirement = requirement.clone();
+                requirement.make_editable().with_context(|| {
+                    format!("Unsupported editable requirement: `{requirement}`")
+                })?;
+                Self {
+                    requirements: vec![UnresolvedRequirementSpecification::from(requirement)],
+                    ..Self::default()
+                }
+            }
             RequirementsSource::RequirementsTxt(path) => {
                 if !(path.starts_with("http://") || path.starts_with("https://") || path.exists()) {
                     return Err(anyhow::anyhow!("File not found: `{}`", path.user_display()));

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -252,6 +252,7 @@ pub(crate) fn hints_for_error(err: &anyhow::Error) -> Hints<'static> {
         collect_hint::<uv_distribution::Error>(cause, &mut hints);
         collect_hint::<uv_python::BrokenLink>(cause, &mut hints);
         collect_hint::<uv_resolver::PylockTomlError>(cause, &mut hints);
+        collect_hint::<uv_requirements_txt::MakeEditableError>(cause, &mut hints);
         collect_hint::<uv_python::InterpreterError>(cause, &mut hints);
         collect_hint::<uv_workspace::pyproject::SourceError>(cause, &mut hints);
         collect_hint::<uv_distribution::LoweringError>(cause, &mut hints);

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -6120,8 +6120,10 @@ fn missing_editable_file() -> Result<()> {
             .arg("requirements.in"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    error: Unsupported editable requirement in `requirements.in`
-      Caused by: Editable must refer to a local directory, not an archive: `file://[TEMP_DIR]/foo/anyio-3.7.0.tar.gz`
+    error: Unsupported editable requirement in `requirements.in` at line 1: `file://[TEMP_DIR]/foo/anyio-3.7.0.tar.gz`
+      Caused by: Local archives cannot be editable
+
+    hint: Editable requirements must refer to a local directory
     ");
 
     Ok(())

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -2305,8 +2305,10 @@ fn invalid_editable_no_url() -> Result<()> {
         .arg("requirements.txt"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    error: Unsupported editable requirement in `requirements.txt`
-      Caused by: Editable `black` must refer to a local directory, not a versioned package
+    error: Unsupported editable requirement in `requirements.txt` at line 1: `black==0.1.0`
+      Caused by: Registry requirements cannot be editable
+
+    hint: Editable requirements must refer to a local directory
     "
     );
 
@@ -2314,23 +2316,43 @@ fn invalid_editable_no_url() -> Result<()> {
 }
 
 #[test]
-fn invalid_editable_unnamed_https_url() -> Result<()> {
+fn invalid_editable_unnamed_remote_url_requirements_txt() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
-    requirements_txt.write_str("-e https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl")?;
+    requirements_txt
+        .write_str("-e http://user:password@example.com/black-1.0.0-py3-none-any.whl")?;
 
     uv_snapshot!(context.filters(), context.pip_install()
         .arg("-r")
         .arg("requirements.txt"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    error: Unsupported editable requirement in `requirements.txt`
-      Caused by: Editable must refer to a local directory, not an HTTPS URL: `https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl`
+    error: Unsupported editable requirement in `requirements.txt` at line 1: `http://user:****@example.com/black-1.0.0-py3-none-any.whl`
+      Caused by: Remote archives cannot be editable
+
+    hint: Editable requirements must refer to a local directory
     "
     );
 
     Ok(())
+}
+
+#[test]
+fn invalid_editable_unnamed_remote_url_cli() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("-e")
+        .arg("http://user:password@example.com/black-1.0.0-py3-none-any.whl"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Unsupported editable requirement: `http://user:****@example.com/black-1.0.0-py3-none-any.whl`
+      Caused by: Remote archives cannot be editable
+
+    hint: Editable requirements must refer to a local directory
+    "
+    );
 }
 
 #[test]
@@ -2338,15 +2360,21 @@ fn invalid_editable_named_https_url() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
-    requirements_txt.write_str("-e black @ https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl")?;
+    requirements_txt.write_str(indoc! {"
+        # This requirement is not editable.
+        anyio==3.7.0
+        -e black @ https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl
+    "})?;
 
     uv_snapshot!(context.filters(), context.pip_install()
         .arg("-r")
         .arg("requirements.txt"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    error: Unsupported editable requirement in `requirements.txt`
-      Caused by: Editable `black` must refer to a local directory, not an HTTPS URL: `https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl`
+    error: Unsupported editable requirement in `requirements.txt` at line 3: `black @ https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl`
+      Caused by: Remote archives cannot be editable
+
+    hint: Editable requirements must refer to a local directory
     "
     );
 


### PR DESCRIPTION
## Summary

This PR does three things:

* It fixes an issue where we were printing raw URLs in errors which could themselves contain credentials.
* It cleans up the error messages for end users, into a form which in my opinion is cleaner and clearer.
* It makes the underlying code simpler. ~~Which I need as a preparatory change for #20631.~~ (turns out I might not need it in the end)

## Test Plan

Snapshots adjusted, and a test-case for the issue has been added.