### PR TITLE
Get rid of `Lock::with_manifest`, make `Lock::from_resolution` take the manifest

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -986,12 +986,13 @@ impl<'lock> DependencySelection<'lock> {
 }
 
 impl Lock {
-    /// Initialize a [`Lock`] from a [`ResolverOutput`], applying any index-specific hash
-    /// requirements to registry artifacts.
+    /// Initialize a [`Lock`] from a [`ResolverOutput`] and [`ResolverManifest`], applying any
+    /// index-specific hash requirements to registry artifacts.
     ///
     /// Returns an error if an artifact does not advertise its index's required algorithm.
     pub fn from_resolution(
         resolution: &ResolverOutput,
+        manifest: ResolverManifest,
         root: &Path,
         supported_environments: Vec<MarkerTree>,
         index_locations: &IndexLocations,
@@ -1141,7 +1142,7 @@ impl Lock {
             packages,
             requires_python,
             options,
-            ResolverManifest::default(),
+            manifest,
             Conflicts::empty(),
             supported_environments,
             vec![],
@@ -1291,13 +1292,6 @@ impl Lock {
             manifest,
         };
         Ok(lock)
-    }
-
-    /// Record the requirements that were used to generate this lock.
-    #[must_use]
-    pub fn with_manifest(mut self, manifest: ResolverManifest) -> Self {
-        self.manifest = manifest;
-        self
     }
 
     /// Record the conflicting groups that were used to generate this lock.

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -1108,11 +1108,11 @@ async fn do_lock(
             let previous = existing_lock.map(ValidatedLock::into_lock);
             let lock = Lock::from_resolution(
                 &resolution,
+                manifest,
                 target.install_path(),
                 lock_supported_environments.clone().into_markers(),
                 index_locations,
             )?
-            .with_manifest(manifest)
             .with_conflicts(conflicts)
             .with_required_environments(lock_required_environments.into_markers());
 

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -338,11 +338,11 @@ impl ToolLock {
         manifest: &ResolverManifest,
         index_locations: &IndexLocations,
     ) -> anyhow::Result<Self> {
-        let lock = Lock::from_resolution(resolution, root, Vec::new(), index_locations)?;
         let manifest = manifest.clone().relative_to(root)?;
+        let lock = Lock::from_resolution(resolution, manifest, root, Vec::new(), index_locations)?;
         Ok(Self {
             root: root.to_path_buf(),
-            lock: lock.with_manifest(manifest),
+            lock,
         })
     }
 


### PR DESCRIPTION
## Summary

Minor cleanup related to #20631.

## Test Plan

Existing coverage.