### PR TITLE
Fall back to logical cache accounting on unsupported filesystems

### DIFF
--- a/crates/uv-cache/src/removal.rs
+++ b/crates/uv-cache/src/removal.rs
@@ -6,6 +6,7 @@ use std::io;
 use std::path::Path;
 
 use tracing::debug;
+use uv_fs::PhysicalSpaceError;
 
 use crate::CleanReporter;
 
@@ -93,7 +94,15 @@ impl Removal {
                 Ok(physical) => {
                     self.physical_bytes = Some(physical_bytes.saturating_add(physical));
                 }
-                Err(error) => {
+                Err(PhysicalSpaceError::UnsupportedFilesystem) => {
+                    debug!(
+                        "Physical space accounting is unsupported for {}; falling back to logical space",
+                        path.display()
+                    );
+                    self.physical_bytes = None;
+                    self.physical_bytes_incomplete = false;
+                }
+                Err(PhysicalSpaceError::UnmeasurableFile(error)) => {
                     debug!(
                         "Failed to measure physical space for {}: {error}",
                         path.display()
@@ -233,7 +242,8 @@ impl std::ops::AddAssign for Removal {
             .physical_bytes
             .zip(other.physical_bytes)
             .map(|(left, right)| left.saturating_add(right));
-        self.physical_bytes_incomplete |= other.physical_bytes_incomplete;
+        self.physical_bytes_incomplete = self.physical_bytes.is_some()
+            && (self.physical_bytes_incomplete || other.physical_bytes_incomplete);
     }
 }
 

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -12,7 +12,7 @@ use tracing::{debug, warn};
 pub use crate::locked_file::*;
 pub use crate::path::*;
 pub use crate::read::ValidatedReader;
-pub use crate::space::{physical_space, supports_physical_space};
+pub use crate::space::{PhysicalSpaceError, physical_space, supports_physical_space};
 
 pub mod cachedir;
 pub mod link;

--- a/crates/uv-fs/src/space.rs
+++ b/crates/uv-fs/src/space.rs
@@ -13,6 +13,20 @@ use linux_raw_sys::ioctl::{
     FIEMAP_EXTENT_DATA_INLINE, FIEMAP_EXTENT_DELALLOC, FIEMAP_EXTENT_ENCODED, FIEMAP_EXTENT_LAST,
     FIEMAP_EXTENT_NOT_ALIGNED, FIEMAP_EXTENT_SHARED, FIEMAP_EXTENT_UNKNOWN, FS_IOC_FIEMAP,
 };
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+use rustix::io::Errno;
+use thiserror::Error;
+
+/// An error encountered while measuring a file's physical storage.
+#[derive(Debug, Error)]
+pub enum PhysicalSpaceError {
+    /// The filesystem cannot report exclusively owned physical storage.
+    #[error("the filesystem does not support physical space accounting")]
+    UnsupportedFilesystem,
+    /// The file's physical storage could not be measured.
+    #[error(transparent)]
+    UnmeasurableFile(#[from] io::Error),
+}
 
 /// Return whether the current platform can identify individual files' physical storage.
 pub const fn supports_physical_space() -> bool {
@@ -27,7 +41,10 @@ pub const fn supports_physical_space() -> bool {
 ///
 /// The result excludes data retained by another hardlink, copy-on-write clone, or snapshot.
 /// Filesystem metadata is not included.
-pub fn physical_space(path: &Path, metadata: &std::fs::Metadata) -> io::Result<u64> {
+pub fn physical_space(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+) -> Result<u64, PhysicalSpaceError> {
     if !metadata.is_file() {
         #[cfg(unix)]
         {
@@ -58,16 +75,13 @@ pub fn physical_space(path: &Path, metadata: &std::fs::Metadata) -> io::Result<u
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "ios")))]
     {
         let _ = path;
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "per-file space measurement is unsupported on this platform",
-        ))
+        Err(PhysicalSpaceError::UnsupportedFilesystem)
     }
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[expect(unsafe_code)]
-fn apple_physical_space(path: &Path) -> io::Result<u64> {
+fn apple_physical_space(path: &Path) -> Result<u64, PhysicalSpaceError> {
     let path = CString::new(path.as_os_str().as_bytes())
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
     let mut attributes = libc::attrlist {
@@ -94,25 +108,26 @@ fn apple_physical_space(path: &Path) -> io::Result<u64> {
         )
     };
     if result != 0 {
-        return Err(io::Error::last_os_error());
+        let error = io::Error::last_os_error();
+        if Errno::from_io_error(&error) == Some(Errno::NOTSUP) {
+            return Err(PhysicalSpaceError::UnsupportedFilesystem);
+        }
+        return Err(error.into());
     }
 
     let returned_fork_attributes =
         u32::from_ne_bytes(response[20..24].try_into().map_err(io::Error::other)?);
     if returned_fork_attributes & libc::ATTR_CMNEXT_PRIVATESIZE == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "the filesystem does not report private file sizes",
-        ));
+        return Err(PhysicalSpaceError::UnsupportedFilesystem);
     }
 
     let private_size = i64::from_ne_bytes(response[24..32].try_into().map_err(io::Error::other)?);
-    u64::try_from(private_size).map_err(io::Error::other)
+    Ok(u64::try_from(private_size).map_err(io::Error::other)?)
 }
 
 #[cfg(target_os = "linux")]
 #[expect(unsafe_code)]
-fn linux_physical_space(path: &Path) -> io::Result<u64> {
+fn linux_physical_space(path: &Path) -> Result<u64, PhysicalSpaceError> {
     const MAX_EXTENTS: usize = 32;
 
     #[derive(Default)]
@@ -167,8 +182,13 @@ fn linux_physical_space(path: &Path) -> io::Result<u64> {
                 rustix::ioctl::Updater::<{ FS_IOC_FIEMAP as rustix::ioctl::Opcode }, _>::new(
                     &mut request,
                 ),
-            )?;
+            )
         }
+        .map_err(|error| match error {
+            // Linux returns `ENOTTY` when the ioctl is unsupported for this file.
+            Errno::NOTSUP | Errno::NOTTY => PhysicalSpaceError::UnsupportedFilesystem,
+            error => PhysicalSpaceError::UnmeasurableFile(error.into()),
+        })?;
 
         let mapped_extents =
             usize::try_from(request.header.mapped_extents).map_err(io::Error::other)?;
@@ -176,7 +196,8 @@ fn linux_physical_space(path: &Path) -> io::Result<u64> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "the filesystem returned more extents than requested",
-            ));
+            )
+            .into());
         }
         if mapped_extents == 0 {
             return Ok(physical);
@@ -197,7 +218,8 @@ fn linux_physical_space(path: &Path) -> io::Result<u64> {
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
                     "the filesystem cannot report the physical size of an extent",
-                ));
+                )
+                .into());
             }
 
             physical = physical.saturating_add(extent.length);
@@ -213,7 +235,8 @@ fn linux_physical_space(path: &Path) -> io::Result<u64> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "the filesystem returned a non-advancing extent",
-            ));
+            )
+            .into());
         }
         start = next;
     }

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -95,6 +95,32 @@ fn clean_all_hardlinked_file() -> Result<()> {
     Ok(())
 }
 
+/// `cache clean` should fall back to logical space on unsupported filesystems.
+#[cfg(unix)]
+#[test]
+fn clean_all_physical_space_unsupported_fs() -> Result<()> {
+    let Some(context) = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_cache_on_alt_fs()?
+    else {
+        return Ok(());
+    };
+
+    context
+        .cache_dir
+        .child("cached.bin")
+        .write_binary(&vec![42; 1024 * 1024])?;
+
+    uv_snapshot!(context.filters(), context.clean().arg("--preview-features").arg("cache-physical-space"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Clearing cache at: [ALT_FS]/[CACHE_DIR]/
+    Removed [N] files (1.0MiB)
+    ");
+
+    Ok(())
+}
+
 /// `cache clean` should report physical space for copy-on-write clones in preview mode.
 #[cfg(unix)]
 #[test]

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -74,6 +74,30 @@ fn prune_hardlinked_file() -> Result<()> {
     Ok(())
 }
 
+/// `cache prune` should fall back to logical space on unsupported filesystems.
+#[cfg(unix)]
+#[test]
+fn prune_physical_space_unsupported_fs() -> Result<()> {
+    let Some(context) = uv_test::test_context!("3.12").with_cache_on_alt_fs()? else {
+        return Ok(());
+    };
+
+    let stale = context.cache_dir.child("stale-v0");
+    stale.create_dir_all()?;
+    stale
+        .child("cached.bin")
+        .write_binary(&vec![42; 1024 * 1024])?;
+
+    uv_snapshot!(context.filters(), context.prune().arg("--preview-features").arg("cache-physical-space"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Pruning cache at: [ALT_FS]/[CACHE_DIR]/
+    Removed 1 file (1.0MiB)
+    ");
+
+    Ok(())
+}
+
 /// `cache prune` should remove any stale top-level directories from the cache.
 #[test]
 fn prune_stale_directory() -> Result<()> {


### PR DESCRIPTION
## Summary

#20925 introduces more accurate space accounting under preview, but this will fail on unsupported filesystems. We already have code which works for these filesystems so this PR introduces a special error handling case for this situation and reverts to the old method.

## Test Plan

New test cases added.