### PR TITLE
Fix human-readable size rounding at unit boundaries

### DIFF
--- a/crates/uv-console/Cargo.toml
+++ b/crates/uv-console/Cargo.toml
@@ -11,7 +11,6 @@ license = { workspace = true }
 
 [lib]
 doctest = false
-test = false
 
 [lints]
 workspace = true

--- a/crates/uv-console/src/lib.rs
+++ b/crates/uv-console/src/lib.rs
@@ -298,22 +298,28 @@ pub fn input(prompt: &str, term: &Term) -> std::io::Result<String> {
 }
 
 /// Formats a number of bytes into a human readable IEC-prefixed size (binary units).
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss
-)]
+#[expect(clippy::cast_precision_loss)]
 pub fn human_readable_bytes(bytes: u64) -> impl fmt::Display {
     const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
 
     fmt::from_fn(move |formatter| {
-        let bytes_f32 = bytes as f32;
-        let i = ((bytes_f32.log2() / 10.0) as usize).min(UNITS.len() - 1);
-        let quantity = bytes_f32 / 1024_f32.powi(i as i32);
+        let rounding_margin = formatter
+            .precision()
+            .and_then(|precision| i32::try_from(precision).ok())
+            .map_or(0.0, |precision| 0.5 / 10_f64.powi(precision));
+        let mut quantity = bytes as f64;
+        let [mut unit, units @ ..] = UNITS;
+
+        for next_unit in units {
+            if 1024.0 - quantity > rounding_margin {
+                break;
+            }
+            quantity /= 1024.0;
+            unit = next_unit;
+        }
 
         fmt::Display::fmt(&quantity, formatter)?;
-        formatter.write_str(UNITS[i])
+        formatter.write_str(unit)
     })
 }
 
@@ -323,11 +329,39 @@ mod tests {
 
     #[test]
     fn human_readable_sizes() {
+        const MIB: u64 = 1024_u64.pow(2);
+        const PIB: u64 = 1024_u64.pow(5);
+
         assert_eq!(format!("{}", human_readable_bytes(0)), "0B");
         assert_eq!(format!("{}", human_readable_bytes(1024)), "1KiB");
         assert_eq!(format!("{}", human_readable_bytes(1536)), "1.5KiB");
         assert_eq!(format!("{}", human_readable_bytes(u64::MAX)), "16EiB");
+        assert_eq!(
+            format!("{}", human_readable_bytes(MIB - 51)),
+            "1023.9501953125KiB"
+        );
 
         assert_eq!(format!("{:.2}", human_readable_bytes(1023)), "1023.00B");
+        assert_eq!(format!("{:.0}", human_readable_bytes(MIB - 513)), "1023KiB");
+        assert_eq!(format!("{:.0}", human_readable_bytes(MIB - 512)), "1MiB");
+        assert_eq!(
+            format!("{:.1}", human_readable_bytes(MIB - 52)),
+            "1023.9KiB"
+        );
+        assert_eq!(format!("{:.1}", human_readable_bytes(MIB - 51)), "1.0MiB");
+        assert_eq!(
+            format!("{:.2}", human_readable_bytes(MIB - 51)),
+            "1023.95KiB"
+        );
+
+        assert_eq!(
+            format!("{:.10}", human_readable_bytes(PIB - 55)),
+            "1023.9999999999TiB"
+        );
+        // Specifically trigger a floating point imprecision corner case.
+        assert_eq!(
+            format!("{:.1}", human_readable_bytes(PIB * 1024 - PIB / 20 - 1)),
+            "1.0EiB"
+        );
     }
 }

--- a/crates/uv-console/src/lib.rs
+++ b/crates/uv-console/src/lib.rs
@@ -1,5 +1,5 @@
 use console::{Key, Term, measure_text_width, style};
-use std::{cmp::Ordering, iter};
+use std::{cmp::Ordering, fmt, iter};
 
 /// Prompt the user for confirmation in the given [`Term`].
 ///
@@ -297,18 +297,37 @@ pub fn input(prompt: &str, term: &Term) -> std::io::Result<String> {
     Ok(input)
 }
 
-/// Formats a number of bytes into a human readable SI-prefixed size (binary units).
-///
-/// Returns a tuple of `(quantity, units)`.
+/// Formats a number of bytes into a human readable IEC-prefixed size (binary units).
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )]
-pub fn human_readable_bytes(bytes: u64) -> (f32, &'static str) {
+pub fn human_readable_bytes(bytes: u64) -> impl fmt::Display {
     const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
-    let bytes_f32 = bytes as f32;
-    let i = ((bytes_f32.log2() / 10.0) as usize).min(UNITS.len() - 1);
-    (bytes_f32 / 1024_f32.powi(i as i32), UNITS[i])
+
+    fmt::from_fn(move |formatter| {
+        let bytes_f32 = bytes as f32;
+        let i = ((bytes_f32.log2() / 10.0) as usize).min(UNITS.len() - 1);
+        let quantity = bytes_f32 / 1024_f32.powi(i as i32);
+
+        fmt::Display::fmt(&quantity, formatter)?;
+        formatter.write_str(UNITS[i])
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::human_readable_bytes;
+
+    #[test]
+    fn human_readable_sizes() {
+        assert_eq!(format!("{}", human_readable_bytes(0)), "0B");
+        assert_eq!(format!("{}", human_readable_bytes(1024)), "1KiB");
+        assert_eq!(format!("{}", human_readable_bytes(1536)), "1.5KiB");
+        assert_eq!(format!("{}", human_readable_bytes(u64::MAX)), "16EiB");
+
+        assert_eq!(format!("{:.2}", human_readable_bytes(1023)), "1023.00B");
+    }
 }

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -558,9 +558,9 @@ impl<'env> TreeDisplay<'env> {
             // Keep it simple: use the first wheel entry that includes a size.
             if self.show_sizes {
                 if let Some(size_bytes) = package.wheels.iter().find_map(|wheel| wheel.size) {
-                    let (bytes, unit) = human_readable_bytes(size_bytes);
+                    let bytes = human_readable_bytes(size_bytes);
                     line.push(' ');
-                    line.push_str(format!("{}", format!("({bytes:.1}{unit})").dimmed()).as_str());
+                    line.push_str(format!("{}", format!("({bytes:.1})").dimmed()).as_str());
                 }
             }
 

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -105,8 +105,7 @@ pub(crate) async fn cache_clean(
         let bytes = if reported_bytes < 1024 {
             format!("{reported_bytes}B")
         } else {
-            let (bytes, unit) = human_readable_bytes(reported_bytes);
-            format!("{bytes:.1}{unit}")
+            format!("{:.1}", human_readable_bytes(reported_bytes))
         };
         if summary.physical_bytes_incomplete {
             write!(printer.stderr(), " (at least {})", bytes.green())?;

--- a/crates/uv/src/commands/cache_prune.rs
+++ b/crates/uv/src/commands/cache_prune.rs
@@ -92,8 +92,7 @@ pub(crate) async fn cache_prune(
         let bytes = if reported_bytes < 1024 {
             format!("{reported_bytes}B")
         } else {
-            let (bytes, unit) = human_readable_bytes(reported_bytes);
-            format!("{bytes:.1}{unit}")
+            format!("{:.1}", human_readable_bytes(reported_bytes))
         };
         if summary.physical_bytes_incomplete {
             write!(printer.stderr(), " (at least {})", bytes.green())?;

--- a/crates/uv/src/commands/cache_size.rs
+++ b/crates/uv/src/commands/cache_size.rs
@@ -45,8 +45,8 @@ pub(crate) fn cache_size(
     let total_bytes = disk_usage.count_ignoring_errors();
 
     if human_readable {
-        let (bytes, unit) = human_readable_bytes(total_bytes);
-        writeln!(printer.stdout_important(), "{bytes:.1}{unit}")?;
+        let bytes = human_readable_bytes(total_bytes);
+        writeln!(printer.stdout_important(), "{bytes:.1}")?;
     } else {
         writeln!(printer.stdout_important(), "{total_bytes}")?;
     }

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -251,15 +251,14 @@ pub(crate) async fn publish(
             }
         }
 
-        let size = fs_err::metadata(&group.file)?.len();
-        let (bytes, unit) = human_readable_bytes(size);
+        let bytes = human_readable_bytes(fs_err::metadata(&group.file)?.len());
         if dry_run {
             writeln!(
                 printer.stderr(),
                 "{} {} {}",
                 "Checking".bold().cyan(),
                 group.filename,
-                format!("({bytes:.1}{unit})").dimmed()
+                format!("({bytes:.1})").dimmed()
             )?;
         } else {
             writeln!(
@@ -267,7 +266,7 @@ pub(crate) async fn publish(
                 "{} {} {}",
                 "Hashing".bold().green(),
                 group.filename,
-                format!("({bytes:.1}{unit})").dimmed()
+                format!("({bytes:.1})").dimmed()
             )?;
         }
 
@@ -297,7 +296,7 @@ pub(crate) async fn publish(
             "{} {} {}",
             "Uploading".bold().green(),
             group.filename,
-            format!("({bytes:.1}{unit})").dimmed()
+            format!("({bytes:.1})").dimmed()
         )?;
 
         let uploaded = if direct {

--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -264,13 +264,12 @@ impl ProgressReporter {
             // If the file is larger than 1MB, show a message to indicate that this may take
             // a while keeping the log concise.
             if multi_progress.is_hidden() && !*HAS_UV_TEST_NO_CLI_PROGRESS && size > 1024 * 1024 {
-                let (bytes, unit) = human_readable_bytes(size);
                 let _ = writeln!(
                     self.printer.stderr(),
                     "{} {} {}",
                     direction.as_str().bold().cyan(),
                     name,
-                    format!("({bytes:.1}{unit})").dimmed()
+                    format!("({:.1})", human_readable_bytes(size)).dimmed()
                 );
             }
             progress.set_message(name);


### PR DESCRIPTION
## Summary

I noticed that we'd print 1024.0KiB if we were just shy of 1.0MiB which is kind of weird. numfmt and humanize (common existing other ecosystem implementations of this) handle this correctly to avoid this case.

It was bugging me, alright?

There's also a small cleanup by returning impl Display (the commit is separate for ease of review).

## Test Plan

Unit tests.