### PR TITLE
Consistently use creation time for directory `cache-keys` entries regardless of libc

### DIFF
--- a/crates/uv-cache-info/src/cache_info.rs
+++ b/crates/uv-cache-info/src/cache_info.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use tracing::{debug, info_span, warn};
 
-use uv_fs::Simplified;
+use uv_fs::{Simplified, created_time};
 
 use crate::git_info::{Commit, Tags};
 use crate::glob::cluster_globs;
@@ -160,7 +160,7 @@ impl CacheInfo {
                         continue;
                     }
 
-                    if let Ok(created) = metadata.created() {
+                    if let Ok(created) = created_time(&path, &metadata) {
                         // Prefer the creation time.
                         directories.insert(
                             dir,

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -1,11 +1,17 @@
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+#[cfg(target_os = "linux")]
+use std::time::{Duration, UNIX_EPOCH};
 
 #[cfg(feature = "tokio")]
 use std::io::Read;
 
 #[cfg(feature = "tokio")]
 use encoding_rs_io::DecodeReaderBytes;
+#[cfg(target_os = "linux")]
+use rustix::fs::{AtFlags, CWD as RUSTIX_CWD, StatxFlags, statx};
 use tempfile::NamedTempFile;
 use tracing::{debug, warn};
 
@@ -21,6 +27,50 @@ mod path;
 mod read;
 mod space;
 pub mod which;
+
+/// Return a path's creation time, including on Linux targets where [`std::fs::Metadata::created`]
+/// does not expose the filesystem birth time.
+pub fn created_time(path: &Path, metadata: &std::fs::Metadata) -> io::Result<SystemTime> {
+    #[cfg(target_os = "linux")]
+    {
+        let _ = metadata;
+
+        let metadata = statx(
+            RUSTIX_CWD,
+            path,
+            AtFlags::empty(),
+            StatxFlags::BASIC_STATS | StatxFlags::BTIME,
+        )?;
+
+        if metadata.stx_mask & StatxFlags::BTIME.bits() == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "creation time is not available for the filesystem",
+            ));
+        }
+
+        let birth_time = metadata.stx_btime;
+        let seconds = Duration::from_secs(birth_time.tv_sec.unsigned_abs());
+        let created = if birth_time.tv_sec < 0 {
+            UNIX_EPOCH.checked_sub(seconds)
+        } else {
+            UNIX_EPOCH.checked_add(seconds)
+        };
+
+        created
+            .filter(|_| birth_time.tv_nsec < 1_000_000_000)
+            .and_then(|created| {
+                created.checked_add(Duration::from_nanos(u64::from(birth_time.tv_nsec)))
+            })
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid creation time"))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = path;
+        metadata.created()
+    }
+}
 
 /// Attempt to check if the two paths refer to the same file.
 ///


### PR DESCRIPTION
## Summary

When using musl we would fall back to using the inode, which would cause churn when going between musl backed and glibc backed uv versions on the same host.

Using rustix, this remains consistent as long as the underlying OS supports the call for the specific filesystem.

This will cause a small bit of churn on musl systems, but that churn will just be in the form of a cache invalidation when updating uv.

## Test Plan

Existing coverage for the functionality. Manual tests for checking musl and linux now work the same (but we bypass glibc/musl so it didn't feel worth it to try to come up with an automated regression test here).