### PR TITLE
Do not treat a URL ending in `.py` as a script path

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -25,7 +25,7 @@ use uv_distribution_types::{
 use uv_installer::{InstallationStrategy, SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
 use uv_pep440::{VersionSpecifier, VersionSpecifiers};
-use uv_pep508::MarkerTree;
+use uv_pep508::{MarkerTree, Scheme, split_scheme};
 use uv_preview::Preview;
 use uv_python::{
     ConfigDiscovery, EnvironmentPreference, PythonDownloads, PythonEnvironment, PythonInstallation,
@@ -129,6 +129,13 @@ pub(crate) async fn run(
             .is_some_and(|ext| ext.eq_ignore_ascii_case("py") || ext.eq_ignore_ascii_case("pyw"))
     }
 
+    /// Whether the target names a URL requirement rather than a path. A repository can be named
+    /// `foo.py`, so `git+https://github.com/example/foo.py` has a `.py` extension without being a
+    /// script. Requires a known scheme so that a Windows drive letter is not read as one.
+    fn is_url_requirement(target: &str) -> bool {
+        split_scheme(target).is_some_and(|(scheme, _)| Scheme::parse(scheme).is_some())
+    }
+
     if settings.resolver.torch_backend.is_some() {
         warn_user_once!(
             "The `--torch-backend` option is experimental and may change without warning."
@@ -160,7 +167,7 @@ pub(crate) async fn run(
     };
 
     if let Some(ref from) = from {
-        if has_python_script_ext(Path::new(from)) {
+        if !is_url_requirement(from) && has_python_script_ext(Path::new(from)) {
             let package_name = PackageName::from_str(from)?;
             return Err(ToolRunScriptError::FromScript {
                 package_name,
@@ -173,7 +180,7 @@ pub(crate) async fn run(
         let target_path = Path::new(target);
 
         // If the user tries to invoke `uvx script.py`, hint them towards `uv run`.
-        if has_python_script_ext(target_path) {
+        if !is_url_requirement(target) && has_python_script_ext(target_path) {
             return if target_path.try_exists()? {
                 Err(ToolRunScriptError::TargetScriptExists {
                     path: target_path.to_path_buf(),

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -25,7 +25,7 @@ use uv_distribution_types::{
 use uv_installer::{InstallationStrategy, SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
 use uv_pep440::{VersionSpecifier, VersionSpecifiers};
-use uv_pep508::{MarkerTree, Scheme, split_scheme};
+use uv_pep508::MarkerTree;
 use uv_preview::Preview;
 use uv_python::{
     ConfigDiscovery, EnvironmentPreference, PythonDownloads, PythonEnvironment, PythonInstallation,
@@ -123,17 +123,27 @@ pub(crate) async fn run(
     no_env_file: bool,
     preview: Preview,
 ) -> anyhow::Result<ExitStatus> {
-    /// Whether or not a path looks like a Python script based on the file extension.
-    fn has_python_script_ext(path: &Path) -> bool {
-        path.extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("py") || ext.eq_ignore_ascii_case("pyw"))
-    }
+    /// Whether the target looks like a Python script rather than a package source.
+    fn is_python_script(target: &str) -> bool {
+        let has_script_extension = Path::new(target)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("py") || ext.eq_ignore_ascii_case("pyw"));
+        if !has_script_extension {
+            return false;
+        }
 
-    /// Whether the target names a URL requirement rather than a path. A repository can be named
-    /// `foo.py`, so `git+https://github.com/example/foo.py` has a `.py` extension without being a
-    /// script. Requires a known scheme so that a Windows drive letter is not read as one.
-    fn is_url_requirement(target: &str) -> bool {
-        split_scheme(target).is_some_and(|(scheme, _)| Scheme::parse(scheme).is_some())
+        // A package source can end in `.py`, including named and unnamed Git requirements.
+        // Bare names like `script.py` remain ambiguous and should still receive the script hint.
+        match RequirementsSpecification::parse_package(target) {
+            Ok(requirement) => matches!(
+                requirement.requirement,
+                UnresolvedRequirement::Named(Requirement {
+                    source: RequirementSource::Registry { .. },
+                    ..
+                })
+            ),
+            Err(_) => true,
+        }
     }
 
     if settings.resolver.torch_backend.is_some() {
@@ -167,7 +177,7 @@ pub(crate) async fn run(
     };
 
     if let Some(ref from) = from {
-        if !is_url_requirement(from) && has_python_script_ext(Path::new(from)) {
+        if is_python_script(from) {
             let package_name = PackageName::from_str(from)?;
             return Err(ToolRunScriptError::FromScript {
                 package_name,
@@ -180,7 +190,7 @@ pub(crate) async fn run(
         let target_path = Path::new(target);
 
         // If the user tries to invoke `uvx script.py`, hint them towards `uv run`.
-        if !is_url_requirement(target) && has_python_script_ext(target_path) {
+        if is_python_script(target) {
             return if target_path.try_exists()? {
                 Err(ToolRunScriptError::TargetScriptExists {
                     path: target_path.to_path_buf(),

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -3046,7 +3046,10 @@ fn tool_run_with_script_and_from_script() {
 }
 
 /// A repository can be named `foo.py`, so a URL requirement is not a script path.
+// The `--offline` git error text is not reproducible on Windows, where the test harness
+// cannot execute its bundled `git.exe`.
 #[test]
+#[cfg(not(windows))]
 fn tool_run_with_url_ending_in_py() {
     let context = uv_test::test_context!("3.12").with_filtered_counts();
 
@@ -3063,7 +3066,10 @@ fn tool_run_with_url_ending_in_py() {
 }
 
 /// As above, but passed to `--from`.
+// The `--offline` git error text is not reproducible on Windows, where the test harness
+// cannot execute its bundled `git.exe`.
 #[test]
+#[cfg(not(windows))]
 fn tool_run_with_from_url_ending_in_py() {
     let context = uv_test::test_context!("3.12").with_filtered_counts();
 

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -2961,6 +2961,15 @@ fn tool_run_with_existing_py_script() -> anyhow::Result<()> {
 
     hint: Use `uv run script.py` instead
     ");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg(context.temp_dir.child("script.py").path()), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: It looks like you tried to run a Python script at `[TEMP_DIR]/script.py`, which is not supported by `uv tool run`
+
+    hint: Use `uv run [TEMP_DIR]/script.py` instead
+    ");
     Ok(())
 }
 
@@ -3046,10 +3055,8 @@ fn tool_run_with_script_and_from_script() {
 }
 
 /// A repository can be named `foo.py`, so a URL requirement is not a script path.
-// The `--offline` git error text is not reproducible on Windows, where the test harness
-// cannot execute its bundled `git.exe`.
 #[test]
-#[cfg(not(windows))]
+#[cfg(feature = "test-git")]
 fn tool_run_with_url_ending_in_py() {
     let context = uv_test::test_context!("3.12").with_filtered_counts();
 
@@ -3063,13 +3070,22 @@ fn tool_run_with_url_ending_in_py() {
       Caused by: failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
       Caused by: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
     ");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--offline")
+        .arg("easyeda2kicad @ git+https://github.com/uPesy/easyeda2kicad.py"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+      × Failed to download and build `easyeda2kicad @ git+https://github.com/uPesy/easyeda2kicad.py`
+      ├─▶ Git operation failed
+      ├─▶ failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
+      ╰─▶ Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+    ");
 }
 
 /// As above, but passed to `--from`.
-// The `--offline` git error text is not reproducible on Windows, where the test harness
-// cannot execute its bundled `git.exe`.
 #[test]
-#[cfg(not(windows))]
+#[cfg(feature = "test-git")]
 fn tool_run_with_from_url_ending_in_py() {
     let context = uv_test::test_context!("3.12").with_filtered_counts();
 
@@ -3084,6 +3100,19 @@ fn tool_run_with_from_url_ending_in_py() {
       Caused by: Git operation failed
       Caused by: failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
       Caused by: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+    ");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--offline")
+        .arg("--from")
+        .arg("easyeda2kicad @ git+https://github.com/uPesy/easyeda2kicad.py")
+        .arg("easyeda2kicad"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+      × Failed to download and build `easyeda2kicad @ git+https://github.com/uPesy/easyeda2kicad.py`
+      ├─▶ Git operation failed
+      ├─▶ failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
+      ╰─▶ Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
     ");
 }
 

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -3045,6 +3045,42 @@ fn tool_run_with_script_and_from_script() {
     ");
 }
 
+/// A repository can be named `foo.py`, so a URL requirement is not a script path.
+#[test]
+fn tool_run_with_url_ending_in_py() {
+    let context = uv_test::test_context!("3.12").with_filtered_counts();
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--offline")
+        .arg("git+https://github.com/uPesy/easyeda2kicad.py"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    error: Failed to resolve `--with` requirement
+      Caused by: Git operation failed
+      Caused by: failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
+      Caused by: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+    ");
+}
+
+/// As above, but passed to `--from`.
+#[test]
+fn tool_run_with_from_url_ending_in_py() {
+    let context = uv_test::test_context!("3.12").with_filtered_counts();
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--offline")
+        .arg("--from")
+        .arg("git+https://github.com/uPesy/easyeda2kicad.py")
+        .arg("easyeda2kicad"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    error: Failed to resolve `--with` requirement
+      Caused by: Git operation failed
+      Caused by: failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
+      Caused by: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+    ");
+}
+
 /// Test that when a user provides `--verbose` to the subcommand,
 /// we show a helpful hint.
 #[test]


### PR DESCRIPTION
`uvx git+https://github.com/uPesy/easyeda2kicad.py` fails with "Not a valid package or extra name".

`has_python_script_ext` calls `Path::extension()` on the raw argument, so any URL whose last segment ends in `.py` is read as a script path. uv then parses the whole URL as a package name, which is where the message comes from.

This skips the script check when the argument carries a scheme `Scheme::parse` recognises. Pairing `split_scheme` with `Scheme::parse` is deliberate and matches the existing use in `verbatim_url.rs`: a bare `split_scheme` would read the `C:` in `C:\script.py` as a scheme and break script detection on Windows.

Before:

```console
$ uv tool run --offline git+https://github.com/uPesy/easyeda2kicad.py
error: Not a valid package or extra name: "git+https://github.com/uPesy/easyeda2kicad.py"
```

After, it reaches the git fetch and stops only on `--offline`:

```console
Updating https://github.com/uPesy/easyeda2kicad.py (HEAD)
error: ... Remote Git fetches are not allowed because network connectivity is disabled
```

Two tests added beside the existing script tests. They use `--offline`, so they exercise the parse without touching the network. Both fail without the change with the exact error above. The existing `script.py`, missing-`script.py` and `--from script.py` behaviours are unchanged.

Closes #21141