### PR TITLE
Document that `uvx` reuses an install only when settings match

### DIFF
--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -106,6 +106,23 @@ $ uvx --isolated ruff --version
 0.6.2
 ```
 
+!!! note
+
+    `uvx` reuses the installed version only when the resolver settings recorded at install time
+    match the current invocation. A tool installed with options such as `--exclude-newer` is
+    considered incompatible with a plain `uvx` invocation, which resolves a fresh environment
+    instead:
+
+    ```console
+    $ uv tool install --exclude-newer 2023-01-01 pycowsay
+     + pycowsay==0.0.0.1
+    $ uvx pycowsay --version
+    0.0.0.2
+    ```
+
+    To run the version that was installed, invoke its executable directly rather than through
+    `uvx`.
+
 `uv tool install` will also respect the `{package}@{version}` and `{package}@latest` specifiers, as
 in:
 

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -74,7 +74,8 @@ $ uvx ruff@latest --version
 0.6.2
 ```
 
-Once a tool is installed with `uv tool install`, `uvx` will use the installed version by default.
+Once a tool is installed with `uv tool install`, `uvx` will use the installed version by default,
+provided the settings for the invocation match those recorded when the tool was installed.
 
 For example, after installing an older version of Ruff:
 
@@ -105,23 +106,6 @@ version:
 $ uvx --isolated ruff --version
 0.6.2
 ```
-
-!!! note
-
-    `uvx` reuses the installed version only when the resolver settings recorded at install time
-    match the current invocation. A tool installed with options such as `--exclude-newer` is
-    considered incompatible with a plain `uvx` invocation, which resolves a fresh environment
-    instead:
-
-    ```console
-    $ uv tool install --exclude-newer 2023-01-01 pycowsay
-     + pycowsay==0.0.0.1
-    $ uvx pycowsay --version
-    0.0.0.2
-    ```
-
-    To run the version that was installed, invoke its executable directly rather than through
-    `uvx`.
 
 `uv tool install` will also respect the `{package}@{version}` and `{package}@latest` specifiers, as
 in:


### PR DESCRIPTION
The tools concept doc says "Once a tool is installed with `uv tool install`, `uvx` will use the installed version by default", with no qualification. That is not true when the install recorded resolver settings the `uvx` invocation does not carry:

```console
$ uv tool install --exclude-newer 2023-01-01 pycowsay
 + pycowsay==0.0.0.1
$ uvx pycowsay --version
0.0.0.2
```

Adds a note describing that, using the explanation from #20981, and points at running the installed executable directly as the intended pattern.

Docs only, no behaviour change.

Closes #20981