### PR TITLE
Keep the virtual-environment hint when the interpreter is not in `bin`

### DIFF
--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -132,11 +132,14 @@ impl Hint for Error {
                 }
             }
             Self::Extract(uv_extract::Error::TarCodec(err)) => {
+                let is_python_executable = |path: &Path| {
+                    path.file_name()
+                        .is_some_and(|name| name.to_string_lossy().starts_with("python"))
+                };
+                // An archive entry is only a virtual environment interpreter if it sits in `bin`.
                 let is_virtual_environment_python = |path: &Path| {
                     path.parent().is_some_and(|parent| parent.ends_with("bin"))
-                        && path
-                            .file_name()
-                            .is_some_and(|name| name.to_string_lossy().starts_with("python"))
+                        && is_python_executable(path)
                 };
                 let involves_virtual_environment_python = match err {
                     tar_codec::ExtractError::UnsafePath {
@@ -145,9 +148,12 @@ impl Hint for Error {
                         reason,
                         ..
                     } => {
+                        // `UnsafePath` carries only the link target, never the entry that
+                        // declared it, and a base interpreter is not required to live in `bin`,
+                        // so the target is matched on its file name alone.
                         *context == "symbolic-link target"
                             && matches!(*reason, "is absolute" | "escapes the destination root")
-                            && is_virtual_environment_python(Path::new(value))
+                            && is_python_executable(Path::new(value))
                     }
                     tar_codec::ExtractError::InvalidLink {
                         path,
@@ -157,7 +163,7 @@ impl Hint for Error {
                     } => {
                         *reason == "ambient target is not allowed"
                             && (is_virtual_environment_python(path)
-                                || is_virtual_environment_python(Path::new(target)))
+                                || is_python_executable(Path::new(target)))
                     }
                     _ => false,
                 };

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2726,6 +2726,7 @@ fn force_pep517() -> Result<()> {
 /// Check that we show a hint when there's a venv in the source distribution.
 ///
 /// <https://github.com/astral-sh/uv/issues/15096>
+/// <https://github.com/astral-sh/uv/issues/21128>
 // Windows uses trampolines instead of symlinks. You don't want those in your source distribution
 // either, but that's for the build backend to catch, we're only checking for the unix error hint
 // in uv here.
@@ -2777,8 +2778,14 @@ fn venv_included_in_sdist() -> Result<()> {
     hint: The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.
     ");
 
+    // Point the virtual environment at the test interpreter's `python/3.12/python3` shim to
+    // exercise a base interpreter outside `bin`, as in Gentoo's test layout.
+    let venv_python = context.venv.child("bin").child("python");
+    fs_err::remove_file(&venv_python)?;
+    venv_python.symlink_to_file(context.root.child("python").child("3.12").child("python3"))?;
+
     // The preview tar-codec backend reports a structured unsafe-link error and preserves the same
-    // user-facing hint.
+    // user-facing hint, regardless of the base interpreter's installation layout.
     uv_snapshot!(context.filters(), context
         .build()
         .arg("--preview-features")
@@ -2806,72 +2813,6 @@ fn venv_included_in_sdist() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.build().arg("-qq"), @"
     exit_code: 2 (failure)
-    ");
-
-    Ok(())
-}
-
-/// The virtual-environment hint must survive a base interpreter that does not live in `bin`.
-///
-/// <https://github.com/astral-sh/uv/issues/21128>
-#[cfg(unix)]
-#[test]
-fn venv_included_in_sdist_interpreter_outside_bin() -> Result<()> {
-    let context = uv_test::test_context!("3.12")
-        .with_filter((r"at byte \d+", "at byte [OFFSET]"))
-        .with_filter((r#""[^"]*/python3""#, r#""[INTERPRETER]""#));
-
-    let pyproject_toml = indoc! {r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.12.0"
-
-        [tool.hatch.build.targets.sdist.force-include]
-        ".venv" = ".venv"
-
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
-    "#};
-
-    context
-        .init()
-        .arg("--name")
-        .arg("project")
-        .assert()
-        .success();
-    context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(pyproject_toml)?;
-
-    // A base interpreter at `<root>/python/3.12/python3`, so the link target's parent is the
-    // version rather than `bin`. This is the layout the Gentoo package build produces.
-    let interpreter = context.temp_dir.child("python").child("3.12");
-    interpreter.create_dir_all()?;
-    interpreter.child("python3").touch()?;
-
-    let bin = context.temp_dir.child(".venv").child("bin");
-    bin.create_dir_all()?;
-    let link = bin.child("python");
-    if link.exists() {
-        fs_err::remove_file(&link)?;
-    }
-    fs_err::os::unix::fs::symlink(interpreter.child("python3"), &link)?;
-
-    uv_snapshot!(context.filters(), context
-        .build()
-        .arg("--preview-features")
-        .arg("tar-codec"), @"
-    exit_code: 2 (failure)
-    ----- stderr -----
-    Building source distribution...
-    error: Failed to build `[TEMP_DIR]/`
-      Caused by: Invalid tar file
-      Caused by: at byte [OFFSET]: unsafe symbolic-link target \"[INTERPRETER]\": is absolute
-
-    hint: The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.
     ");
 
     Ok(())

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -2811,6 +2811,72 @@ fn venv_included_in_sdist() -> Result<()> {
     Ok(())
 }
 
+/// The virtual-environment hint must survive a base interpreter that does not live in `bin`.
+///
+/// <https://github.com/astral-sh/uv/issues/21128>
+#[cfg(unix)]
+#[test]
+fn venv_included_in_sdist_interpreter_outside_bin() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filter((r"at byte \d+", "at byte [OFFSET]"))
+        .with_filter((r#""[^"]*/python3""#, r#""[INTERPRETER]""#));
+
+    let pyproject_toml = indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12.0"
+
+        [tool.hatch.build.targets.sdist.force-include]
+        ".venv" = ".venv"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+    "#};
+
+    context
+        .init()
+        .arg("--name")
+        .arg("project")
+        .assert()
+        .success();
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+
+    // A base interpreter at `<root>/python/3.12/python3`, so the link target's parent is the
+    // version rather than `bin`. This is the layout the Gentoo package build produces.
+    let interpreter = context.temp_dir.child("python").child("3.12");
+    interpreter.create_dir_all()?;
+    interpreter.child("python3").touch()?;
+
+    let bin = context.temp_dir.child(".venv").child("bin");
+    bin.create_dir_all()?;
+    let link = bin.child("python");
+    if link.exists() {
+        fs_err::remove_file(&link)?;
+    }
+    fs_err::os::unix::fs::symlink(interpreter.child("python3"), &link)?;
+
+    uv_snapshot!(context.filters(), context
+        .build()
+        .arg("--preview-features")
+        .arg("tar-codec"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Building source distribution...
+    error: Failed to build `[TEMP_DIR]/`
+      Caused by: Invalid tar file
+      Caused by: at byte [OFFSET]: unsafe symbolic-link target \"[INTERPRETER]\": is absolute
+
+    hint: The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.
+    ");
+
+    Ok(())
+}
+
 /// Ensure that workspace discovery works with and without trailing slash.
 ///
 /// <https://github.com/astral-sh/uv/issues/13914>


### PR DESCRIPTION
The `venv_included_in_sdist` snapshot fails in the Gentoo package build. The error line is identical; only the hint is missing:

```
    6       │-  Caused by: at byte [OFFSET]: unsafe symbolic-link target "[PYTHON-3.12]": is absolute
    7       │-
    8       │-hint: The source distribution includes a virtual environment. ...
          6 │+  Caused by: at byte [OFFSET]: unsafe symbolic-link target "[PYTHON-3.12]": is absolute
```

`ExtractError::UnsafePath` carries `position`, `context`, `value` and `reason` — the link target, never the entry that declared it. The target was being matched with `is_virtual_environment_python`, which requires the parent directory to be `bin`. That shape is right for an archive entry like `.venv/bin/python`, but a base interpreter is not required to live in `bin`. Gentoo's build lays them out at `<root>/python/3.12/python3`, where the parent is the version, so the predicate returns false and the hint is dropped.

Reproduced outside the test suite by pointing a venv's `bin/python` at an interpreter whose parent is not `bin`:

```console
$ uv build --preview-features tar-codec
error: Failed to build ...
  Caused by: at byte 1024: unsafe symbolic-link target ".../pydir/python/3.12/python3": is absolute
```

No hint. With the same project and a target at `.../cpython-3.12/bin/python3`, the hint appears. That A/B is the whole bug.

This matches the link target on its file name alone and keeps the stricter entry-shaped check for the entry path in `InvalidLink`.

Added `venv_included_in_sdist_interpreter_outside_bin`, which builds that layout explicitly. It fails without the change and the existing `venv_included_in_sdist` is unaffected. Full `build` suite: 191 passed. `cargo clippy --all-targets` and `cargo fmt --check` clean.

Closes #21128