### PR TITLE
Mention the install receipt in the uninstallation instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -284,6 +284,26 @@ If you need to remove uv from your system, follow these steps:
         uninstall. Upgrading from an older version will not automatically remove the binaries from
         `~/.cargo/bin`.
 
+3.  Remove the install receipt, if the standalone installer was used:
+
+    === "macOS and Linux"
+
+        ```console
+        $ rm "${XDG_CONFIG_HOME:-$HOME/.config}/uv/uv-receipt.json"
+        ```
+
+    === "Windows"
+
+        ```pwsh-session
+        PS> rm "$env:LOCALAPPDATA\uv\uv-receipt.json"
+        ```
+
+    !!! note
+
+        The receipt records where the standalone installer put uv. Leaving it in place makes a later
+        `uv self update` report that multiple copies of uv are installed, even after uv has been
+        reinstalled through a package manager.
+
 ## Next steps
 
 See the [first steps](./first-steps.md) or jump straight to the [guides](../guides/index.md) to


### PR DESCRIPTION
Following the documented uninstall steps leaves the install receipt behind. `uv self update` then reports that multiple copies of uv are installed, even after uv has been reinstalled through a package manager, which is what #21127 ran into:

> The current executable is at `...` but the standalone installer was used to install uv to `...`. Are multiple copies of uv installed?

Adds a third step removing `uv-receipt.json`, using the same platform tabs as the steps above it.

Paths are taken from the installers rather than inferred. `install.sh`:

```sh
# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
    RECEIPT_HOME="$LOCALAPPDATA/uv"
else
    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/uv"
```

and the file is written as `"$RECEIPT_HOME/$APP_NAME-receipt.json"`. `install.ps1` uses `${env:LOCALAPPDATA}\uv` unless `XDG_CONFIG_HOME` is set.

The step is conditional on the standalone installer, since a package-manager install writes no receipt.

Docs only, no behaviour change. `prettier@3.9.0 --check` passes.

Closes #21127