### PR TITLE
Avoid re-encoding activated conflict items per dependency

### DIFF
--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -22,6 +22,7 @@ use crate::lock::{
     Dependency, DependencySelectionContext, HashedDist, LockErrorKind, Package, PackageId,
     SelectedDependency, TagPolicy,
 };
+use crate::universal_marker::ActivatedConflictItems;
 use crate::{Lock, LockError, UniversalMarker};
 
 fn newly_activated_extras<'lock>(
@@ -60,6 +61,24 @@ fn add_reachability<'lock>(
             entry.insert(marker);
             true
         }
+    }
+}
+
+/// Returns the dependencies a queued package contributes, either its own or those of one extra.
+fn package_dependencies<'a>(
+    package: &'a Package,
+    extra: Option<&ExtraName>,
+) -> impl Iterator<Item = &'a Dependency> {
+    if let Some(extra) = extra {
+        Either::Left(
+            package
+                .optional_dependencies
+                .get(extra)
+                .into_iter()
+                .flatten(),
+        )
+    } else {
+        Either::Right(package.dependencies.iter())
     }
 }
 
@@ -639,18 +658,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 else {
                     continue;
                 };
-                let deps = if let Some(extra) = extra {
-                    Either::Left(
-                        package
-                            .optional_dependencies
-                            .get(extra)
-                            .into_iter()
-                            .flatten(),
-                    )
-                } else {
-                    Either::Right(package.dependencies.iter())
-                };
-                for dep in deps {
+                for dep in package_dependencies(package, extra) {
                     let mut dep_reachability = dep.complexified_marker;
                     dep_reachability.and(parent_reachability);
                     let additional_activated_extras =
@@ -726,28 +734,23 @@ trait InstallableExt<'lock>: Installable<'lock> {
             }
         }
 
+        // Unlike the traversals above, this one never activates an extra, so the activated set is
+        // fixed for its duration and can be encoded once instead of once per dependency.
+        let activated = ActivatedConflictItems::new(
+            activated_projects.iter().copied(),
+            activated_extras.iter().copied(),
+            activated_groups.iter().copied(),
+        );
+
         while let Some((package, extra)) = queue.pop_front() {
-            let deps = if let Some(extra) = extra {
-                Either::Left(
-                    package
-                        .optional_dependencies
-                        .get(extra)
-                        .into_iter()
-                        .flatten(),
-                )
-            } else {
-                Either::Right(package.dependencies.iter())
-            };
-            for dep in deps {
+            for dep in package_dependencies(package, extra) {
                 if validate_conflicts && dep.complexified_marker.has_conflict_marker() {
                     dependencies_for_conflict_validation.push((package, dep));
                 }
-                if !dep.complexified_marker.evaluate(
-                    marker_env,
-                    activated_projects.iter().copied(),
-                    activated_extras.iter().copied(),
-                    activated_groups.iter().copied(),
-                ) {
+                if !dep
+                    .complexified_marker
+                    .evaluate_activated(marker_env, &activated)
+                {
                     continue;
                 }
 

--- a/crates/uv-resolver/src/universal_marker.rs
+++ b/crates/uv-resolver/src/universal_marker.rs
@@ -81,6 +81,34 @@ pub struct UniversalMarker {
     pep508: MarkerTree,
 }
 
+/// An activated set of projects, extras, and groups, encoded once for repeated
+/// [`UniversalMarker::evaluate_activated`] calls.
+#[derive(Debug)]
+pub(crate) struct ActivatedConflictItems(Vec<ExtraName>);
+
+impl ActivatedConflictItems {
+    /// Encodes the given activated projects, extras, and groups.
+    ///
+    /// Each extra and group must be scoped to the particular package that it's enabled for.
+    pub(crate) fn new<P, E, G>(
+        projects: impl Iterator<Item = P>,
+        extras: impl Iterator<Item = (P, E)>,
+        groups: impl Iterator<Item = (P, G)>,
+    ) -> Self
+    where
+        P: Borrow<PackageName>,
+        E: Borrow<ExtraName>,
+        G: Borrow<GroupName>,
+    {
+        let projects = projects.map(|package| encode_project(package.borrow()));
+        let extras =
+            extras.map(|(package, extra)| encode_package_extra(package.borrow(), extra.borrow()));
+        let groups =
+            groups.map(|(package, group)| encode_package_group(package.borrow(), group.borrow()));
+        Self(projects.chain(extras).chain(groups).collect())
+    }
+}
+
 impl UniversalMarker {
     /// A constant universal marker that always evaluates to `true`.
     pub(crate) const TRUE: Self = Self {
@@ -307,7 +335,7 @@ impl UniversalMarker {
     }
 
     /// Returns true if this universal marker is satisfied by the given marker
-    /// environment and list of activated extras and groups.
+    /// environment and list of activated projects, extras, and groups.
     ///
     /// The activated extras and groups should be the complete set activated
     /// for a particular context. And each extra and group must be scoped to
@@ -324,18 +352,17 @@ impl UniversalMarker {
         E: Borrow<ExtraName>,
         G: Borrow<GroupName>,
     {
-        let projects = projects.map(|package| encode_project(package.borrow()));
-        let extras =
-            extras.map(|(package, extra)| encode_package_extra(package.borrow(), extra.borrow()));
-        let groups =
-            groups.map(|(package, group)| encode_package_group(package.borrow(), group.borrow()));
-        self.marker.evaluate(
-            env,
-            &projects
-                .chain(extras)
-                .chain(groups)
-                .collect::<Vec<ExtraName>>(),
-        )
+        let activated = ActivatedConflictItems::new(projects, extras, groups);
+        self.evaluate_activated(env, &activated)
+    }
+
+    /// Returns true if this universal marker is satisfied by an already encoded activated set.
+    pub(crate) fn evaluate_activated(
+        self,
+        env: &MarkerEnvironment,
+        activated: &ActivatedConflictItems,
+    ) -> bool {
+        self.marker.evaluate(env, &activated.0)
     }
 
     /// Returns true if the marker always evaluates to true if the given set of extras is activated.
@@ -878,6 +905,7 @@ mod tests {
     use super::*;
     use std::str::FromStr;
 
+    use uv_pep508::MarkerEnvironmentBuilder;
     use uv_pypi_types::ConflictSet;
 
     /// Creates a collection of declared conflicts from the sets
@@ -913,6 +941,24 @@ mod tests {
         ExtraName::from_str(name).unwrap()
     }
 
+    /// Creates a marker environment for evaluating universal markers.
+    fn marker_environment() -> MarkerEnvironment {
+        MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
+            implementation_name: "cpython",
+            implementation_version: "3.12.0",
+            os_name: "posix",
+            platform_machine: "arm64",
+            platform_python_implementation: "CPython",
+            platform_release: "23.0.0",
+            platform_system: "Darwin",
+            platform_version: "test",
+            python_full_version: "3.12.0",
+            python_version: "3.12",
+            sys_platform: "darwin",
+        })
+        .expect("valid marker environment")
+    }
+
     /// Shortcut for creating a conflict marker from an extra name.
     fn create_extra_marker(name: &str) -> ConflictMarker {
         ConflictMarker::extra(&create_package("pkg"), &create_extra(name))
@@ -946,6 +992,36 @@ mod tests {
         cm.marker
             .try_to_string()
             .unwrap_or_else(|| "true".to_string())
+    }
+
+    /// This tests that an activated set encodes all three kinds of conflict
+    /// item, and nothing that was not activated.
+    #[test]
+    fn activated_conflict_items_encode_every_kind() {
+        let package = create_package("project");
+        let extra = create_extra("feature");
+        let group = GroupName::from_str("dev").expect("valid group name");
+        let marker = UniversalMarker::new(
+            MarkerTree::TRUE,
+            ConflictMarker::project(&package)
+                .and(ConflictMarker::extra(&package, &extra))
+                .and(ConflictMarker::group(&package, &group)),
+        );
+        let env = marker_environment();
+
+        let activated = ActivatedConflictItems::new(
+            [&package].into_iter(),
+            [(&package, &extra)].into_iter(),
+            [(&package, &group)].into_iter(),
+        );
+        assert!(marker.evaluate_activated(&env, &activated));
+
+        let without_group = ActivatedConflictItems::new(
+            [&package].into_iter(),
+            [(&package, &extra)].into_iter(),
+            std::iter::empty::<(&PackageName, &GroupName)>(),
+        );
+        assert!(!marker.evaluate_activated(&env, &without_group));
     }
 
     /// This tests the conversion from declared conflicts into a conflict


### PR DESCRIPTION
This is another optimization inspired by nab, I'm not using my codex credits for anything else at the moment, so I have it working on whether those optimizations translate to uv, I know y'all need those spare tokens ;o).

`Installable::to_resolution` ends by walking the locked graph and evaluating a conflict marker on every dependency edge. Each call re-encodes the activated projects, extras, and groups into a fresh `Vec<ExtraName>`, a `format!` per item, but the set is final before the walk starts.

`ActivatedConflictItems` encodes it once. The earlier passes can still activate an extra, so they keep encoding per edge. A lock with no declared conflicts has an empty activated set and nothing to reuse.

The star example is `uv sync --frozen --dry-run --all-extras --group alpha` on a project pulling `apache-airflow[all]`. Profiling builds, median of 60 runs, and the sync plan is byte-identical:

  | extras | activated items | wall | instructions |
  | ---: | ---: | ---: | ---: |
  | 40 | 61 | 53 → 42 ms | 428.2M → 264.0M |
  | 2 | 23 | 44 → 37 ms | 248.4M → 173.4M |

  <details>
  <summary>Reproduction</summary>

  pyproject.toml:

  ```toml
  [project]
  name = "mre"
  version = "0.1.0"
  requires-python = ">=3.12,<3.13"
  dependencies = ["apache-airflow[all]==2.10.5"]

  [project.optional-dependencies]
  e00 = ["idna"]
  e01 = ["idna"]

  [dependency-groups]
  alpha = ["idna"]
  beta = ["idna"]

  [tool.uv]
  conflicts = [[{ group = "alpha" }, { group = "beta" }]]

  [build-system]
  requires = ["hatchling"]
  build-backend = "hatchling.build"
  ```

  Commands:

  ```console
  $ uv lock --exclude-newer 2026-07-01
  $ uv venv
  $ uv sync --frozen --dry-run --all-extras --group alpha
  ```

  The first row adds `e02` through `e39`.

  </details>