### PR TITLE
Fix `uv tool uninstall` failing on malformed receipts

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -134,12 +134,11 @@ async fn do_uninstall(
         let mut entrypoints = vec![];
         for name in names {
             let receipt = match installed_tools.get_tool_receipt(&name) {
-                Ok(Some(receipt)) => Some(receipt),
-                Ok(None) => None,
-                // If the receipt is malformed, treat it the same as a missing receipt so we can
-                // still remove the dangling environment.
-                Err(uv_tool::Error::ReceiptRead(..)) => None,
-                Err(err) => return Err(err.into()),
+                Ok(receipt) => receipt,
+                // If the receipt is malformed (e.g., invalid TOML or non-UTF-8 content), treat
+                // it the same as a missing receipt so we can still remove the dangling
+                // environment.
+                Err(_) => None,
             };
             let Some(receipt) = receipt else {
                 // If the tool is not installed properly, attempt to remove the environment anyway.

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,7 +133,15 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
+            let receipt = match installed_tools.get_tool_receipt(&name) {
+                Ok(Some(receipt)) => Some(receipt),
+                Ok(None) => None,
+                // If the receipt is malformed, treat it the same as a missing receipt so we can
+                // still remove the dangling environment.
+                Err(uv_tool::Error::ReceiptRead(..)) => None,
+                Err(err) => return Err(err.into()),
+            };
+            let Some(receipt) = receipt else {
                 // If the tool is not installed properly, attempt to remove the environment anyway.
                 match installed_tools.remove_environment(&name) {
                     Ok(()) => {

--- a/crates/uv/tests/tool/tool_uninstall.rs
+++ b/crates/uv/tests/tool/tool_uninstall.rs
@@ -170,3 +170,26 @@ fn tool_uninstall_all_missing_receipt() {
     Removed dangling environment for `black`
     ");
 }
+
+#[test]
+fn tool_uninstall_malformed_receipt() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_exe_suffix()
+        .with_tool_dirs();
+    let tool_dir = context.temp_dir.child("tools");
+
+    // Install `black`
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .assert()
+        .success();
+
+    fs_err::write(tool_dir.join("black").join("uv-receipt.toml"), "invalid\n").unwrap();
+
+    uv_snapshot!(context.filters(), context.tool_uninstall().arg("black"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed dangling environment for `black`
+    ");
+}


### PR DESCRIPTION
Fixes #19630

`uv tool uninstall <name>` currently propagates the TOML parse error when a tool's `uv-receipt.toml` is malformed, even though `uv tool list` suggests running `uv tool uninstall <name>` to recover from exactly this situation. This brings the named-tool uninstall path in line with the existing `uv tool uninstall` (no args) and `--all` behavior, which already treats a malformed receipt like a missing one and removes the dangling environment with a warning.

Added a regression test (`tool_uninstall_malformed_receipt`) matching the style of the existing missing-receipt tests.