### PR TITLE
Point `--default` at the requested patch instead of the minor version link

### DIFF
--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -442,6 +442,26 @@ async fn perform_install(
         })
         .collect::<IndexSet<_>>();
 
+    // An explicit patch request pins the executables to that patch instead of routing
+    // them through the shared minor version link, which would leave them resolving to
+    // whichever patch that link already targets.
+    let requested_patch_versions = requests
+        .iter()
+        .filter_map(|request| {
+            if let PythonRequest::Version(VersionRequest::MajorMinorPatch(
+                major,
+                minor,
+                patch,
+                ..,
+            )) = request.python_request()
+            {
+                uv_pep440::Version::from_str(&format!("{major}.{minor}.{patch}")).ok()
+            } else {
+                None
+            }
+        })
+        .collect::<IndexSet<_>>();
+
     if let PythonUpgrade::Enabled(source) = upgrade {
         if let Some(request) = requests.iter().find(|request| {
             request.request.includes_patch() || request.request.includes_prerelease()
@@ -682,8 +702,11 @@ async fn perform_install(
             e.warn_user(installation);
         }
 
-        let upgradeable = (default || is_default_install)
-            || requested_minor_versions.contains(&installation.key().version().python_version());
+        let upgradeable = !requested_patch_versions
+            .contains(&installation.key().version().python_full_version())
+            && ((default || is_default_install)
+                || requested_minor_versions
+                    .contains(&installation.key().version().python_version()));
 
         if let Some(bin_dir) = bin_dir.as_ref() {
             create_bin_links(

--- a/crates/uv/tests/python/python_install.rs
+++ b/crates/uv/tests/python/python_install.rs
@@ -2189,6 +2189,48 @@ fn python_install_default_prerelease() {
     bin_python_default.assert(predicate::path::exists());
 }
 
+/// `--default` with an explicit patch moves the default executables to that patch, even
+/// when a newer patch of the same minor version is already the default. Without bypassing
+/// the minor version link the executables keep resolving to the newer patch.
+///
+/// <https://github.com/astral-sh/uv/issues/21125>
+#[test]
+fn python_install_default_older_patch() {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_managed_python_dirs()
+        .with_python_download_cache();
+
+    context
+        .python_install()
+        .arg("--default")
+        .arg("3.12.8")
+        .assert()
+        .success();
+
+    context
+        .python_install()
+        .arg("--default")
+        .arg("3.12.6")
+        .assert()
+        .success();
+
+    let bin_python = context
+        .bin_dir
+        .child(format!("python3{}", std::env::consts::EXE_SUFFIX));
+
+    if cfg!(unix) {
+        insta::with_settings!({
+            filters => context.filters(),
+        }, {
+            insta::assert_snapshot!(
+                canonicalize_link_path(&bin_python), @"[TEMP_DIR]/managed/cpython-3.12.6-[PLATFORM]/bin/python3.12"
+            );
+        });
+    }
+}
+
 #[test]
 fn python_install_default_from_env() {
     let context = uv_test::test_context_with_versions!(&[])


### PR DESCRIPTION
Following up on #21125.

`uv python install --default 3.12.6` over an existing 3.12.8 default reports
success for all three executables, but they keep resolving to 3.12.8.

With `--default`, `upgradeable` is unconditionally true, so `create_bin_links`
resolves each entry through `PythonMinorVersionLink::from_installation`. All
three bin entries point at the shared `cpython-3.12-...` link, which still
selects the newer patch, so the rewrite is a no-op:

```
bin/python3                            -> python/cpython-3.12-.../bin/python3.12
python/cpython-3.12-macos-aarch64-none -> python/cpython-3.12.8-macos-aarch64-none
```

Per @zanieb's review, this now bypasses the minor version link for an explicit
patch request and points the executables straight at the interpreter, rather
than warning about a switch that did not happen. Requests without a patch are
unaffected and keep the upgradeable link.

Rebased onto current `main`, since the previous revision was based on a stale
base.

The regression test installs `--default 3.12.8`, then `--default 3.12.6`, and
asserts what `python3` resolves to. On `main` it resolves to
`cpython-3.12.8-.../bin/python3.12`; with this change it resolves to
`cpython-3.12.6-.../bin/python3.12`.

`cargo test -p uv --test python` gives 190 passed, 1 failed. The failure is
`python_find::python_find_cached_launcher_override`, which fails identically on
an unmodified checkout here. `rustfmt` is clean. I could not run `clippy`
locally: the pinned toolchain does not have the component available in this
environment, so CI is the check for that.
