### PR TITLE
Fix riscv64 musl TLS segfaults by updating aws-lc-rs

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -714,7 +714,8 @@ jobs:
           - target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
             # see https://github.com/astral-sh/uv/issues/6528
-            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
+            # and https://github.com/aws/aws-lc/pull/3429
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16 -e AWS_LC_SYS_CFLAGS_powerpc64le_unknown_linux_gnu=-DAT_HWCAP2=26
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -714,7 +714,9 @@ jobs:
           - target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
             # see https://github.com/astral-sh/uv/issues/6528
-            # and https://github.com/aws/aws-lc/pull/3429
+            # Older PowerPC build images lack AT_HWCAP2 in their glibc headers.
+            # Use the Linux ABI value until bundled AWS-LC includes:
+            # https://github.com/aws/aws-lc/pull/3429
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16 -e AWS_LC_SYS_CFLAGS_powerpc64le_unknown_linux_gnu=-DAT_HWCAP2=26
 
     steps:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -19,6 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Build the AWS-LC version pinned in Cargo.lock, not a system installation.
+  AWS_LC_SYS_USE_SYSTEM: "0"
   PACKAGE_NAME: uv
   MODULE_NAME: uv
   PYTHON_VERSION: "3.11"
@@ -372,7 +374,7 @@ jobs:
           # from 64-bit version of the container, breaking the pattern from other builds.
           container: quay.io/pypa/manylinux2014
           manylinux: 2_17
-          docker-options: -e CARGO
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             # Install the 32-bit cross target on 64-bit (noop if we're already on 64-bit)
@@ -439,7 +441,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.target }}
           manylinux: 2_17
-          docker-options: -e CARGO
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -498,7 +500,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -555,7 +557,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -613,7 +615,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: 2_17
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --features self-update --compatibility pypi
           rust-toolchain: ${{ matrix.platform.toolchain || null }}
           before-script-linux: |
@@ -675,7 +677,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: 2_17
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -737,7 +739,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: 2_17
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             if command -v yum &> /dev/null; then
@@ -798,7 +800,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: 2_17
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             if command -v yum &> /dev/null; then
@@ -846,7 +848,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: 2_31
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -904,7 +906,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: 2_31
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -961,7 +963,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.target }}
           manylinux: musllinux_1_1
-          docker-options: -e CARGO
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -1013,7 +1015,7 @@ jobs:
           maturin-version: v1.14.1
           target: ${{ matrix.target }}
           manylinux: musllinux_1_1
-          docker-options: -e CARGO
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -1074,7 +1076,7 @@ jobs:
           manylinux: musllinux_1_1
           # Tag the musl builds as manylinux 2_17 fallback cause the aarch64 build only support 2_28
           args: --release --locked --out dist --features self-update --compatibility ${{ matrix.platform.arch == 'riscv64' && '2_31' || '2_17'}} --compatibility pypi
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           rust-toolchain: ${{ matrix.platform.toolchain || null }}
           before-script-linux: |
             scripts/install-cargo-extensions.sh
@@ -1151,7 +1153,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_1
           args: --profile minimal-size --locked ${{ matrix.platform.arch == 'aarch64' && '--compatibility 2_17' || ''}} --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
-          docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
+          docker-options: -e CARGO -e AWS_LC_SYS_USE_SYSTEM ${{ matrix.platform.maturin_docker_options }}
           rust-toolchain: ${{ matrix.platform.toolchain || null }}
           before-script-linux: |
             scripts/install-cargo-extensions.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,9 +428,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -438,14 +438,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ RUN rustup toolchain install
 RUN rustup target add $(cat rust_target.txt)
 
 # Build
+# Build the AWS-LC version pinned in Cargo.lock, not a system installation.
+ENV AWS_LC_SYS_USE_SYSTEM=0
 COPY crates crates
 COPY ./Cargo.toml Cargo.toml
 COPY ./Cargo.lock Cargo.lock


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The statically linked `riscv64gc-unknown-linux-musl` release binary segfaulted during HTTPS. Fat LTO plus the musl-cross GCC 12.4 toolchain miscompiled `aws-lc-sys` 0.39, and rustls then dereferenced a null connection.

`aws-lc-rs` 1.18.0 (`aws-lc-sys` 0.44.0) no longer crashes under that same release profile.

I investigated but failed to find the exact reason for this. But simply bumping the version works on my end.

Also fix a build failure for ppc64 after bumping. See https://github.com/aws/aws-lc/pull/3429

Fixes #21151

## Test Plan

<!-- How was it tested? -->

Build locally the same way as the CI does, run `uvx -vv nox --version` on riscv64, and it no longer crashes.