### PR TITLE
Add SOCKS proxy support for publish tests

### DIFF
--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -5,6 +5,7 @@
 #     "packaging>=24.1,<25",
 #     "pypi-attestations==0.0.28",
 #     "sigstore==4.1.0",
+#     "socksio",
 # ]
 # ///
 

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -1,11 +1,10 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "httpx>=0.28.1,<0.29",
+#     "httpx[socks]>=0.28.1,<0.29",
 #     "packaging>=24.1,<25",
 #     "pypi-attestations==0.0.28",
 #     "sigstore==4.1.0",
-#     "socksio",
 # ]
 # ///
 

--- a/scripts/publish/test_publish.py.lock
+++ b/scripts/publish/test_publish.py.lock
@@ -4,11 +4,10 @@ requires-python = ">=3.12"
 
 [manifest]
 requirements = [
-    { name = "httpx", specifier = ">=0.28.1,<0.29" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.28.1,<0.29" },
     { name = "packaging", specifier = ">=24.1,<25" },
     { name = "pypi-attestations", specifier = "==0.0.28" },
     { name = "sigstore", specifier = "==4.1.0" },
-    { name = "socksio" },
 ]
 
 [[package]]
@@ -270,6 +269,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]

--- a/scripts/publish/test_publish.py.lock
+++ b/scripts/publish/test_publish.py.lock
@@ -8,6 +8,7 @@ requirements = [
     { name = "packaging", specifier = ">=24.1,<25" },
     { name = "pypi-attestations", specifier = "==0.0.28" },
     { name = "sigstore", specifier = "==4.1.0" },
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -625,6 +626,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enable the HTTPX SOCKS extra in the publish integration script and update its lockfile.