### PR TITLE
Add dependency cooldown to PGO build script

### DIFF
--- a/scripts/build_uv_pgo.py
+++ b/scripts/build_uv_pgo.py
@@ -3,6 +3,8 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = []
+# [tool.uv]
+# exclude-newer = "P7D"
 # ///
 
 from __future__ import annotations

--- a/scripts/build_uv_pgo.py.lock
+++ b/scripts/build_uv_pgo.py.lock
@@ -1,3 +1,7 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"


### PR DESCRIPTION
## Summary

The PGO build script was introduced after we added seven-day dependency cooldowns to our PEP 723 scripts, so its inline metadata and lockfile did not include the repository-wide `exclude-newer` setting. As a result, script lockfile validation and locked script type checking both fail on `main`.

Declare the same `P7D` cooldown as the other scripts and regenerate the script lockfile so both CI checks accept it.

Closes https://github.com/astral-sh/uv-dev/issues/777.
