### PR TITLE
Apply Dependabot always-authenticate bypass to partial credentials

### DIFF
--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -589,7 +589,13 @@ impl AuthMiddleware {
             return next.run(request, extensions).await;
         };
         let url = DisplaySafeUrl::from_url(request.url().clone());
-        if matches!(auth_policy, AuthPolicy::Always) && !credentials.is_authenticated() {
+        // Dependabot intercepts HTTP requests and injects credentials, which means that we
+        // cannot eagerly enforce an `AuthPolicy` as we don't know whether credentials will be
+        // added outside of uv.
+        if matches!(auth_policy, AuthPolicy::Always)
+            && !credentials.is_authenticated()
+            && !*IS_DEPENDABOT
+        {
             return Err(Error::Middleware(format_err!(
                 "Incomplete credentials for {url}"
             )));

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -13639,6 +13639,91 @@ fn add_auth_policy_always_with_username_no_password() -> Result<()> {
     Ok(())
 }
 
+/// In authentication "always", requests without credentials are still sent
+/// when running under Dependabot, which injects credentials outside of uv.
+#[tokio::test]
+async fn add_auth_policy_always_without_credentials_dependabot() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc!(
+        r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.11, <4"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "my-index"
+        url = "{proxy_uri}/simple"
+        authenticate = "always"
+        default = true
+        "#,
+        proxy_uri = proxy.uri()
+    ))?;
+
+    uv_snapshot!(context.filters(), context.add().arg("anyio")
+        .env(EnvVars::DEPENDABOT, "true"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 3 packages in [TIME]
+    Installed 3 packages in [TIME]
+     + anyio==4.3.0
+     + idna==3.6
+     + sniffio==1.3.1
+    "
+    );
+
+    context.assert_command("import anyio").success();
+    Ok(())
+}
+
+/// In authentication "always", requests with a username but no discoverable
+/// password are still sent when running under Dependabot, which injects
+/// credentials outside of uv.
+#[tokio::test]
+async fn add_auth_policy_always_with_username_no_password_dependabot() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc!(
+        r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.11, <4"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "my-index"
+        url = "{index_url}"
+        authenticate = "always"
+        default = true
+        "#,
+        index_url = proxy.username_url("public", "/simple")
+    ))?;
+
+    uv_snapshot!(context.filters(), context.add().arg("anyio")
+        .env(EnvVars::DEPENDABOT, "true"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 3 packages in [TIME]
+    Installed 3 packages in [TIME]
+     + anyio==4.3.0
+     + idna==3.6
+     + sniffio==1.3.1
+    "
+    );
+
+    context.assert_command("import anyio").success();
+    Ok(())
+}
+
 /// In authentication "never", even if the correct credentials are supplied
 /// in the URL, no authenticated requests will be allowed.
 #[tokio::test]


### PR DESCRIPTION
## Summary

This applies more Dependabot always workarounds that match what was done in #16773 (which notes dependabot injects the credentials)

We inject usernames via the pyproject.toml for keyring so that interactive users have an easier experience, when dependabot runs uv and finds the partial credentials it takes a different pathway, this change covers that which currently fails for us with errors like:

```
error: Failed to fetch: `https://pkgs.dev.azure.com/…/simple/<package>/`
  Caused by: Incomplete credentials for https://pkgs.dev.azure.com/…/simple/<package>/
```

there's some useful side context on:

dependabot/dependabot-core#15207

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Some new tests:

- `add_auth_policy_always_without_credentials_dependabot` - existing bypass
- `add_auth_policy_always_with_username_no_password_dependabot` - new partial credentials route

I also used a coding agent locally to reproduce when the failure started for us (which was related to dependabot/dependabot-core#14382) and confirms this change should fix the issues for us.