### PR TITLE
Fix recursive extras with mixed production markers

### DIFF
--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -367,12 +367,6 @@ impl FlatRequiresDist {
             return Self(requirements);
         }
 
-        // Memoize the top level extras, in the same order as `requirements`
-        let top_level_extras: Vec<_> = requirements
-            .iter()
-            .map(|req| req.marker.top_level_extra_name())
-            .collect();
-
         // Transitively process all extras that are recursively included.
         let mut flattened = requirements.to_vec();
         let mut seen = FxHashSet::<(ExtraName, MarkerTree)>::default();
@@ -386,21 +380,27 @@ impl FlatRequiresDist {
                 continue;
             }
 
-            // Find the requirements for the extra.
-            for (requirement, top_level_extra) in requirements.iter().zip(top_level_extras.iter()) {
-                if top_level_extra.as_deref() != Some(&extra) {
+            // Find the optional portion of each requirement for this extra. A requirement can
+            // also apply in production, as in `sys_platform == 'win32' or extra == 'base'`.
+            for requirement in &requirements {
+                let production_marker = requirement.marker.simplify_not_extras_with(|_| true);
+                let extra_marker = requirement
+                    .marker
+                    .simplify_extras(slice::from_ref(&extra))
+                    .simplify_not_extras_with(|candidate| candidate != &extra)
+                    .and(production_marker.negate());
+                if extra_marker.is_false() {
                     continue;
                 }
                 let requirement = {
-                    let mut marker = marker;
-                    marker = marker.and(requirement.marker);
+                    let marker = marker.and(extra_marker);
                     Requirement {
                         name: requirement.name.clone(),
                         extras: requirement.extras.clone(),
                         groups: requirement.groups.clone(),
                         source: requirement.source.clone(),
                         origin: requirement.origin.clone(),
-                        marker: marker.simplify_extras(slice::from_ref(&extra)),
+                        marker,
                     }
                 };
                 if requirement.name == *name {

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -10797,7 +10797,7 @@ dev = [
     Ok(())
 }
 
-/// Resolve from a `pyproject.toml` file with a recursive extra, with a marker attached.
+/// Resolve a recursive extra with requirements shared between production and another extra.
 #[cfg(feature = "test-universal")]
 #[test]
 fn compile_pyproject_toml_recursive_extra_marker() -> Result<()> {
@@ -10809,13 +10809,12 @@ fn compile_pyproject_toml_recursive_extra_marker() -> Result<()> {
 name = "project"
 version = "0.0.1"
 dependencies = [
-    "anyio"
+    "anyio",
+    "iniconfig ; sys_platform == 'win32' or extra == 'test'",
 ]
 
 [project.optional-dependencies]
-test = [
-    "iniconfig",
-]
+test = []
 dev = [
     "project[test] ; sys_platform == 'darwin'",
 ]
@@ -10835,7 +10834,7 @@ dev = [
         # via project (pyproject.toml)
     idna==3.6
         # via anyio
-    iniconfig==2.0.0 ; sys_platform == 'darwin'
+    iniconfig==2.0.0 ; sys_platform == 'win32'
         # via project (pyproject.toml)
     sniffio==1.3.1
         # via anyio

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -10834,7 +10834,7 @@ dev = [
         # via project (pyproject.toml)
     idna==3.6
         # via anyio
-    iniconfig==2.0.0 ; sys_platform == 'win32'
+    iniconfig==2.0.0 ; sys_platform == 'darwin' or sys_platform == 'win32'
         # via project (pyproject.toml)
     sniffio==1.3.1
         # via anyio


### PR DESCRIPTION
Recursive extras were omitted when a dependency marker also included a production condition. For example, when `dev` recursively selects `test` on macOS, `iniconfig; sys_platform == 'win32' or extra == 'test'` was only retained for Windows.

Split mixed markers into their production and extra-specific portions before flattening recursive extras, matching the resolver's existing marker handling.