### PR TITLE
remove references to pyx in RFC 9457 handling code

### DIFF
--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1184,7 +1184,7 @@ async fn handle_response(
         ));
     }
 
-    // Try to parse as RFC 9457 Problem Details (e.g., from pyx).
+    // Try to parse as RFC 9457 Problem Details.
     if content_type.as_deref() == Some(uv_client::ProblemDetails::CONTENT_TYPE)
         && let Some(problem) =
             uv_client::ProblemDetails::try_from_response_body(upload_error.as_bytes())
@@ -2102,7 +2102,7 @@ mod tests {
         );
     }
 
-    /// pyx returns `application/problem+json` with RFC 9457 Problem Details.
+    /// Handle `application/problem+json` errors with RFC 9457 Problem Details.
     #[tokio::test]
     async fn upload_error_problem_details() {
         let mock_server = MockServer::start().await;

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -751,7 +751,7 @@ async fn upload_error_pypi_json() {
     );
 }
 
-/// pyx returns `application/problem+json` errors with RFC 9457 Problem Details.
+/// Handle `application/problem+json` errors with RFC 9457 Problem Details.
 #[tokio::test]
 async fn upload_error_problem_details() {
     let context = uv_test::test_context!("3.12").with_filtered_sizes();


### PR DESCRIPTION
I'm not sure that RFC 9457 is implemented on many other indices, but there is some signal we'll see a PEP soon: https://discuss.python.org/t/pre-pep-discussion-rfc-9457-error-responses-for-package-registries/105453/26