### PR TITLE
Reuse direct URL wheels across hash fragments

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -242,6 +242,7 @@ impl CachedClient {
     >(
         &self,
         req: Request,
+        cache_read_entry: &CacheEntry,
         cache_entry: &CacheEntry,
         cache_control: CacheControl,
         response_callback: Callback,
@@ -250,7 +251,7 @@ impl CachedClient {
 
         if matches!(cache_control, CacheControl::AllowStale) {
             let (req, cached) = self
-                .read_and_decode_stale_cache::<Payload>(req, cache_entry)
+                .read_and_decode_stale_cache::<Payload>(req, cache_read_entry)
                 .await;
             match cached {
                 Ok(Some(payload)) => return Ok(payload),
@@ -259,14 +260,17 @@ impl CachedClient {
                     DisplaySafeUrl::from_url(req.url().clone())
                 ),
                 Err(err) if err.is_file_not_exists() => {
-                    trace!("No cache entry exists for {}", cache_entry.path().display());
+                    trace!(
+                        "No cache entry exists for {}",
+                        cache_read_entry.path().display()
+                    );
                 }
                 Err(err) => {
                     warn!(
                         "Broken cache entry at {}, removing: {err}",
-                        cache_entry.path().display()
+                        cache_read_entry.path().display()
                     );
-                    let _ = fs_err::tokio::remove_file(&cache_entry.path()).await;
+                    let _ = fs_err::tokio::remove_file(cache_read_entry.path()).await;
                 }
             }
 
@@ -283,7 +287,7 @@ impl CachedClient {
         }
 
         let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
-        let cached_response = if let Some(cached) = self.read_cache(cache_entry).await {
+        let cached_response = if let Some(cached) = self.read_cache(cache_read_entry).await {
             self.send_cached(req, cache_control.clone(), cached)
                 .boxed_local()
                 .await?
@@ -327,6 +331,9 @@ impl CachedClient {
                 async {
                     let data_with_cache_policy_bytes =
                         DataWithCachePolicy::serialize(&new_policy, &cached.data)?;
+                    fs_err::tokio::create_dir_all(cache_entry.dir())
+                        .await
+                        .map_err(ErrorKind::CacheWrite)?;
                     write_atomic(cache_entry.path(), data_with_cache_policy_bytes)
                         .await
                         .map_err(ErrorKind::CacheWrite)?;
@@ -713,11 +720,42 @@ impl CachedClient {
         cache_control: CacheControl,
         response_callback: Callback,
     ) -> Result<Payload, CachedClientError<CallBackError>> {
+        self.get_serde_with_retry_from(
+            req,
+            cache_entry,
+            cache_entry,
+            cache_control,
+            response_callback,
+        )
+        .await
+    }
+
+    /// Make a cached request, reading from one entry and writing new or revalidated responses to
+    /// another. This allows callers to reuse an older cache key without continuing to populate it.
+    #[instrument(skip_all)]
+    pub async fn get_serde_with_retry_from<
+        Payload: Serialize + DeserializeOwned + Send + 'static,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+    >(
+        &self,
+        req: Request,
+        cache_read_entry: &CacheEntry,
+        cache_entry: &CacheEntry,
+        cache_control: CacheControl,
+        response_callback: Callback,
+    ) -> Result<Payload, CachedClientError<CallBackError>> {
         let payload = self
-            .get_cacheable_with_retry(req, cache_entry, cache_control, async |resp| {
-                let payload = response_callback(resp).await?;
-                Ok(SerdeCacheable { inner: payload })
-            })
+            .get_cacheable_with_retry_from(
+                req,
+                cache_read_entry,
+                cache_entry,
+                cache_control,
+                async |resp| {
+                    let payload = response_callback(resp).await?;
+                    Ok(SerdeCacheable { inner: payload })
+                },
+            )
             .await?;
         Ok(payload)
     }
@@ -737,12 +775,36 @@ impl CachedClient {
         cache_control: CacheControl,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
+        self.get_cacheable_with_retry_from(
+            req,
+            cache_entry,
+            cache_entry,
+            cache_control,
+            response_callback,
+        )
+        .boxed_local()
+        .await
+    }
+
+    async fn get_cacheable_with_retry_from<
+        Payload: Cacheable + 'static,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+    >(
+        &self,
+        req: Request,
+        cache_read_entry: &CacheEntry,
+        cache_entry: &CacheEntry,
+        cache_control: CacheControl,
+        response_callback: Callback,
+    ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let mut retry_state = RetryState::start(self.uncached().retry_policy(), req.url().clone());
         loop {
             let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
             let result = self
                 .get_cacheable(
                     fresh_req,
+                    cache_read_entry,
                     cache_entry,
                     cache_control.clone(),
                     &response_callback,

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -283,8 +283,13 @@ impl ArchivedCachePolicy {
     /// checks because those produce [`BeforeRequest::Stale`], which an allow-stale caller accepts.
     pub(crate) fn matches_stale_request(&self, request: &reqwest::Request) -> bool {
         self.is_storable()
-            && self.request.uri == request.url().as_str()
+            && self.matches_uri(request)
             && (request.method() == http::Method::GET || request.method() == http::Method::HEAD)
+    }
+
+    /// Fragments are not part of the HTTP request target. Older cache entries may include them.
+    fn matches_uri(&self, request: &reqwest::Request) -> bool {
+        self.request.uri.split('#').next() == request.url().as_str().split('#').next()
     }
 
     /// Determines what caching behavior is correct given an existing
@@ -329,7 +334,7 @@ impl ArchivedCachePolicy {
         //
         // "the presented target URI and that of the stored response match,
         // and..."
-        if self.request.uri != request.url().as_str() {
+        if !self.matches_uri(request) {
             tracing::trace!(
                 "Request {} does not match cache URL of {}",
                 request.url(),

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -274,7 +274,7 @@ pub struct DirectUrlBuiltDist {
     /// We require that wheel urls end in the full wheel filename, e.g.
     /// `https://example.org/packages/flask-3.0.0-py3-none-any.whl`
     pub filename: WheelFilename,
-    /// The URL without the subdirectory fragment.
+    /// The URL without fragments (which are not used in comparisons)
     pub location: Box<DisplaySafeUrl>,
     /// The URL as it was provided by the user.
     pub url: VerbatimUrl,

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1,9 +1,11 @@
 use std::cmp::Reverse;
 use std::future::Future;
 use std::io;
+use std::iter::once;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
@@ -13,7 +15,7 @@ use rustc_hash::FxHashMap;
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
 use tokio::sync::Semaphore;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
-use tracing::{Instrument, info_span, instrument, warn};
+use tracing::{Instrument, debug, info_span, instrument, warn};
 use url::Url;
 
 use uv_cache::{ArchiveFileId, ArchiveId, Cache, CacheBucket, CacheEntry, WheelCache};
@@ -24,8 +26,8 @@ use uv_client::{
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
-    BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, HashPolicy, Hashed, IndexUrl,
-    InstalledDist, Name, SourceDist,
+    BuildInfo, BuildableSource, BuiltDist, DirectUrlBuiltDist, Dist, DistRef, HashPolicy, Hashed,
+    IndexUrl, InstalledDist, Name, SourceDist,
 };
 use uv_extract::dirhash::{DirectoryDigest, HashedFile};
 use uv_extract::hash::Hasher;
@@ -33,7 +35,7 @@ use uv_fs::{LockedFile, write_atomic};
 use uv_git::{GIT_LFS, GitError};
 use uv_platform_tags::Tags;
 use uv_preview::PreviewFeature;
-use uv_pypi_types::{HashDigest, HashDigests, PyProjectToml};
+use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, PyProjectToml};
 use uv_python::PythonVariant;
 use uv_redacted::DisplaySafeUrl;
 use uv_types::{BuildContext, BuildStack};
@@ -41,7 +43,7 @@ use uv_types::{BuildContext, BuildStack};
 use crate::archive::Archive;
 use crate::error::PythonVersion;
 use crate::extracted_wheel::{ExtractedWheel, HashedWheel, WheelExtractor};
-use crate::hash::http_hash_algorithms;
+use crate::hash::{http_wheel_hash_algorithms, url_hashes_for_generation};
 use crate::metadata::{ArchiveMetadata, Metadata};
 use crate::source::SourceDistributionBuilder;
 use crate::{Error, LocalWheel, Reporter, RequiresDist};
@@ -311,17 +313,18 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             }
 
             BuiltDist::DirectUrl(wheel) => {
-                // Create a cache entry for the wheel.
+                // Key the wheel by its location, so a hash fragment does not prevent reuse
+                // when the same wheel is read from a lockfile. Hashes are checked separately.
                 let wheel_entry = self.build_context.cache().entry(
                     CacheBucket::Wheels,
-                    WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
+                    WheelCache::Url(&wheel.location).wheel_dir(wheel.name().as_ref()),
                     wheel.filename.cache_key(),
                 );
 
                 // Download and unzip.
                 match self
                     .stream_wheel(
-                        wheel.url.raw().clone(),
+                        (*wheel.location).clone(),
                         None,
                         &wheel.filename,
                         wheel.size,
@@ -358,7 +361,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         // download the wheel directly.
                         let archive = self
                             .download_wheel(
-                                wheel.url.raw().clone(),
+                                (*wheel.location).clone(),
                                 None,
                                 &wheel.filename,
                                 wheel.size,
@@ -569,7 +572,16 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             } else {
                 wheel.metadata()?
             };
-            let hashes = wheel.hashes;
+            // Other URL digests are retained in the cache for reuse, not generated output.
+            let hashes = if matches!(dist, BuiltDist::DirectUrl(_)) {
+                wheel
+                    .hashes
+                    .into_iter()
+                    .filter(|digest| digest.algorithm() == HashAlgorithm::Sha256)
+                    .collect()
+            } else {
+                wheel.hashes
+            };
             return Ok(ArchiveMetadata {
                 metadata: Metadata::from_metadata23(metadata),
                 hashes,
@@ -687,12 +699,17 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             BuiltDist::DirectUrl(_) => size,
             _ => None,
         };
+        let is_online_direct_url = self.client.unmanaged.connectivity().is_online()
+            && matches!(dist, BuiltDist::DirectUrl(_));
 
         // Acquire an advisory lock, to guard against concurrent writes.
         let _lock = Self::lock_wheel(wheel_entry, filename).await?;
 
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
+        let cache_read_entry = self.wheel_cache_read_entry(dist, hashes, &http_entry);
+        let url_hashes = url_hashes_for_generation(dist, hashes);
+        let downloaded = AtomicBool::new(false);
 
         let download = |response: reqwest::Response| {
             async {
@@ -711,7 +728,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .into_async_read();
 
                 // Create a hasher for each hash algorithm.
-                let algorithms = http_hash_algorithms(hashes);
+                let algorithms = http_wheel_hash_algorithms(dist, hashes);
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
@@ -761,6 +778,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
+                downloaded.store(true, Ordering::Relaxed);
                 Ok(Archive::new(
                     id,
                     hashers.into_iter().map(HashDigest::from).collect(),
@@ -788,7 +806,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             Connectivity::Online => CacheControl::from(
                 self.build_context
                     .cache()
-                    .freshness(&http_entry, Some(&filename.name), None)
+                    .freshness(&cache_read_entry, Some(&filename.name), None)
                     .map_err(Error::CacheRead)?,
             ),
             Connectivity::Offline => CacheControl::AllowStale,
@@ -797,8 +815,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         let archive = self
             .client
             .managed(|client| {
-                client.cached_client().get_serde_with_retry(
+                client.cached_client().get_serde_with_retry_from(
                     req,
+                    &cache_read_entry,
                     &http_entry,
                     cache_control.clone(),
                     download,
@@ -812,6 +831,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
+            && !is_online_direct_url
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
@@ -820,9 +840,27 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             });
         }
 
-        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
+        // A direct URL's contents can change even while its HTTP response is fresh. Online,
+        // refresh if the cached hashes or size do not match. Offline, preserve mismatch errors.
+        // Also refresh if the archive is missing required hashes or size, or has been removed.
         let archive = Some(archive)
-            .filter(|archive| archive.has_digests(hashes))
+            .filter(|archive| {
+                let downloaded = downloaded.load(Ordering::Relaxed);
+                // Another process may have replaced the shared pointer since the initial lookup.
+                if !downloaded
+                    && cache_read_entry.path() == http_entry.path()
+                    && let Some(url_hashes) = &url_hashes
+                    && !archive.satisfies(HashPolicy::All(url_hashes.as_slice()))
+                {
+                    return false;
+                }
+                if is_online_direct_url && !downloaded {
+                    archive.satisfies(hashes)
+                        && expected_size.is_none_or(|expected| archive.size == Some(expected))
+                } else {
+                    archive.has_digests(hashes)
+                }
+            })
             .filter(|archive| archive.exists(self.build_context.cache()))
             .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
@@ -867,6 +905,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             BuiltDist::DirectUrl(_) => size,
             _ => None,
         };
+        let is_online_direct_url = self.client.unmanaged.connectivity().is_online()
+            && matches!(dist, BuiltDist::DirectUrl(_));
 
         let content_addressed_cache = self.content_addressed_cache;
 
@@ -875,6 +915,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
+        let cache_read_entry = self.wheel_cache_read_entry(dist, hashes, &http_entry);
+        let url_hashes = url_hashes_for_generation(dist, hashes);
+        let downloaded = AtomicBool::new(false);
 
         let download = |response: reqwest::Response| {
             async {
@@ -891,7 +934,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .bytes_stream()
                     .map_err(|err| self.handle_response_errors(err))
                     .into_async_read();
-                let algorithms = http_hash_algorithms(hashes);
+                let algorithms = http_wheel_hash_algorithms(dist, hashes);
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
@@ -961,6 +1004,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
+                downloaded.store(true, Ordering::Relaxed);
                 Ok(Archive::new(
                     id,
                     hashes,
@@ -988,7 +1032,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             Connectivity::Online => CacheControl::from(
                 self.build_context
                     .cache()
-                    .freshness(&http_entry, Some(&filename.name), None)
+                    .freshness(&cache_read_entry, Some(&filename.name), None)
                     .map_err(Error::CacheRead)?,
             ),
             Connectivity::Offline => CacheControl::AllowStale,
@@ -997,8 +1041,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         let archive = self
             .client
             .managed(|client| {
-                client.cached_client().get_serde_with_retry(
+                client.cached_client().get_serde_with_retry_from(
                     req,
+                    &cache_read_entry,
                     &http_entry,
                     cache_control.clone(),
                     download,
@@ -1012,6 +1057,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
+            && !is_online_direct_url
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
@@ -1020,9 +1066,27 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             });
         }
 
-        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
+        // A direct URL's contents can change even while its HTTP response is fresh. Online,
+        // refresh if the cached hashes or size do not match. Offline, preserve mismatch errors.
+        // Also refresh if the archive is missing required hashes or size, or has been removed.
         let archive = Some(archive)
-            .filter(|archive| archive.has_digests(hashes))
+            .filter(|archive| {
+                let downloaded = downloaded.load(Ordering::Relaxed);
+                // Another process may have replaced the shared pointer since the initial lookup.
+                if !downloaded
+                    && cache_read_entry.path() == http_entry.path()
+                    && let Some(url_hashes) = &url_hashes
+                    && !archive.satisfies(HashPolicy::All(url_hashes.as_slice()))
+                {
+                    return false;
+                }
+                if is_online_direct_url && !downloaded {
+                    archive.satisfies(hashes)
+                        && expected_size.is_none_or(|expected| archive.size == Some(expected))
+                } else {
+                    archive.has_digests(hashes)
+                }
+            })
             .filter(|archive| archive.exists(self.build_context.cache()))
             .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
@@ -1245,6 +1309,40 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .map_err(Error::CacheWrite)
     }
 
+    /// Find the cached response to read, while keeping new downloads under the canonical key.
+    fn wheel_cache_read_entry(
+        &self,
+        dist: &BuiltDist,
+        hashes: HashPolicy<'_>,
+        http_entry: &CacheEntry,
+    ) -> CacheEntry {
+        let BuiltDist::DirectUrl(wheel) = dist else {
+            return http_entry.clone();
+        };
+        let cache = self.build_context.cache();
+        let url_hashes = url_hashes_for_generation(dist, hashes);
+        let cache_hashes = url_hashes
+            .as_ref()
+            .map_or(hashes, |hashes| HashPolicy::All(hashes.as_slice()));
+        if let Some((entry, pointer)) =
+            HttpArchivePointer::read_from_direct_url(cache, wheel, cache_hashes)
+            && pointer.archive.has_digests(hashes)
+        {
+            return entry;
+        }
+
+        // Generation does not validate fresh downloads. If the shared entry does not match the
+        // explicit URL hash, retain the old verbatim-key lookup instead of returning other bytes.
+        if url_hashes.is_some() {
+            return cache.entry(
+                CacheBucket::Wheels,
+                WheelCache::Url(wheel.url.raw()).wheel_dir(wheel.name().as_ref()),
+                format!("{}.http", wheel.filename.cache_key()),
+            );
+        }
+        http_entry.clone()
+    }
+
     /// Returns a GET [`reqwest::Request`] for the given URL.
     fn request(&self, url: DisplaySafeUrl) -> Result<reqwest::Request, reqwest::Error> {
         self.client
@@ -1433,8 +1531,44 @@ pub struct HttpArchivePointer {
 }
 
 impl HttpArchivePointer {
+    /// Find a cached direct wheel with matching hashes and size, and an existing archive.
+    ///
+    /// Prefer its fragment-free location, then try the verbatim URL used by older versions of uv.
+    /// Return the matching entry so downloads can apply its HTTP cache policy in either mode.
+    pub fn read_from_direct_url(
+        cache: &Cache,
+        wheel: &DirectUrlBuiltDist,
+        hashes: HashPolicy<'_>,
+    ) -> Option<(CacheEntry, Self)> {
+        once(wheel.location.as_ref())
+            .chain((wheel.location.as_ref() != wheel.url.raw()).then_some(wheel.url.raw()))
+            .find_map(|location| {
+                let entry = cache.entry(
+                    CacheBucket::Wheels,
+                    WheelCache::Url(location).wheel_dir(wheel.name().as_ref()),
+                    format!("{}.http", wheel.filename.cache_key()),
+                );
+                match Self::read_from(&entry) {
+                    Ok(Some(pointer))
+                        if pointer.archive.satisfies(hashes)
+                            && wheel
+                                .size
+                                .is_none_or(|size| pointer.archive.size == Some(size))
+                            && pointer.archive.exists(cache) =>
+                    {
+                        Some((entry, pointer))
+                    }
+                    Ok(_) => None,
+                    Err(err) => {
+                        debug!("Failed to deserialize cached URL wheel for {wheel}: {err}");
+                        None
+                    }
+                }
+            })
+    }
+
     /// Read an [`HttpArchivePointer`] from the cache.
-    pub fn read_from(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
+    pub(crate) fn read_from(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
         match fs_err::File::open(path.as_ref()) {
             Ok(file) => {
                 let data = DataWithCachePolicy::from_reader(file)?.data;

--- a/crates/uv-distribution/src/hash.rs
+++ b/crates/uv-distribution/src/hash.rs
@@ -1,5 +1,5 @@
-use uv_distribution_types::HashPolicy;
-use uv_pypi_types::HashAlgorithm;
+use uv_distribution_types::{BuiltDist, HashPolicy};
+use uv_pypi_types::{HashAlgorithm, HashDigests, Hashes};
 
 /// Return the algorithms to compute for an HTTP distribution.
 pub(crate) fn http_hash_algorithms(hashes: HashPolicy<'_>) -> Vec<HashAlgorithm> {
@@ -8,4 +8,36 @@ pub(crate) fn http_hash_algorithms(hashes: HashPolicy<'_>) -> Vec<HashAlgorithm>
     algorithms.sort();
     algorithms.dedup();
     algorithms
+}
+
+/// Return the URL hash that must match before reusing a shared wheel cache entry during generation.
+pub(crate) fn url_hashes_for_generation(
+    dist: &BuiltDist,
+    hashes: HashPolicy<'_>,
+) -> Option<HashDigests> {
+    if !hashes.is_generate(dist) {
+        return None;
+    }
+    let BuiltDist::DirectUrl(wheel) = dist else {
+        return None;
+    };
+    wheel
+        .url
+        .fragment()?
+        .split('&')
+        .find_map(|fragment| Hashes::parse_fragment(fragment).ok())
+        .map(HashDigests::from)
+}
+
+/// Include the URL's hash algorithm so subsequent generation can reuse the canonical wheel entry.
+pub(crate) fn http_wheel_hash_algorithms(
+    dist: &BuiltDist,
+    hashes: HashPolicy<'_>,
+) -> Vec<HashAlgorithm> {
+    let url_hashes = url_hashes_for_generation(dist, hashes);
+    http_hash_algorithms(
+        url_hashes
+            .as_ref()
+            .map_or(hashes, |hashes| HashPolicy::All(hashes.as_slice())),
+    )
 }

--- a/crates/uv-distribution/src/hash.rs
+++ b/crates/uv-distribution/src/hash.rs
@@ -2,7 +2,7 @@ use uv_distribution_types::{BuiltDist, HashPolicy};
 use uv_pypi_types::{HashAlgorithm, HashDigests, Hashes};
 
 /// Return the algorithms to compute for an HTTP distribution.
-pub(crate) fn http_hash_algorithms(hashes: HashPolicy<'_>) -> Vec<HashAlgorithm> {
+fn http_hash_algorithms(hashes: HashPolicy<'_>) -> Vec<HashAlgorithm> {
     let mut algorithms = hashes.algorithms();
     algorithms.push(HashAlgorithm::Sha256);
     algorithms.sort();

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -426,46 +426,29 @@ impl<'a> Planner<'a> {
 
                     // Find the exact wheel from the cache, since we know the filename in
                     // advance.
-                    let cache_entry = cache
-                        .shard(
-                            CacheBucket::Wheels,
-                            WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
-                        )
-                        .entry(format!("{}.http", wheel.filename.cache_key()));
+                    if let Some((_, pointer)) = HttpArchivePointer::read_from_direct_url(
+                        cache,
+                        wheel,
+                        hasher.get(dist.as_ref()),
+                    ) {
+                        let cache_info = pointer.to_cache_info();
+                        let build_info = pointer.to_build_info();
+                        let archive = pointer.into_archive();
+                        let cached_dist = CachedDirectUrlDist {
+                            filename: wheel.filename.clone(),
+                            url: VerbatimParsedUrl {
+                                parsed_url: wheel.to_parsed_url(),
+                                verbatim: wheel.url.clone(),
+                            },
+                            hashes: archive.hashes,
+                            cache_info,
+                            build_info,
+                            path: cache.archive(&archive.id).into_boxed_path(),
+                        };
 
-                    // Read the HTTP pointer.
-                    match HttpArchivePointer::read_from(&cache_entry) {
-                        Ok(Some(pointer)) => {
-                            let cache_info = pointer.to_cache_info();
-                            let build_info = pointer.to_build_info();
-                            let archive = pointer.into_archive();
-                            if archive.satisfies(hasher.get(dist.as_ref())) {
-                                let cached_dist = CachedDirectUrlDist {
-                                    filename: wheel.filename.clone(),
-                                    url: VerbatimParsedUrl {
-                                        parsed_url: wheel.to_parsed_url(),
-                                        verbatim: wheel.url.clone(),
-                                    },
-                                    hashes: archive.hashes,
-                                    cache_info,
-                                    build_info,
-                                    path: cache.archive(&archive.id).into_boxed_path(),
-                                };
-
-                                debug!("URL wheel requirement already cached: {cached_dist}");
-                                cached.push(CachedDist::Url(cached_dist));
-                                continue;
-                            }
-                            debug!(
-                                "Cached URL wheel requirement does not match expected hash policy for: {wheel}"
-                            );
-                        }
-                        Ok(None) => {}
-                        Err(err) => {
-                            debug!(
-                                "Failed to deserialize cached URL wheel requirement for: {wheel} ({err})"
-                            );
-                        }
+                        debug!("URL wheel requirement already cached: {cached_dist}");
+                        cached.push(CachedDist::Url(cached_dist));
+                        continue;
                     }
                 }
                 Dist::Built(BuiltDist::Path(wheel)) => {

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1928,9 +1928,11 @@ impl PylockTomlArchive {
             match ext {
                 DistExtension::Wheel => {
                     let filename = WheelFilename::from_str(&filename)?;
+                    let mut location = url.clone();
+                    location.set_fragment(None);
                     Ok(Dist::Built(BuiltDist::DirectUrl(DirectUrlBuiltDist {
                         filename,
-                        location: Box::new(url.clone()),
+                        location: Box::new(location),
                         url: VerbatimUrl::from_url(url.clone()),
                         size: self.size,
                     })))

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -1,12 +1,13 @@
 use std::env::consts::EXE_SUFFIX;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use fs_err as fs;
 use indoc::{formatdoc, indoc};
 use predicates::Predicate;
+use sha2::{Digest, Sha256};
 use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -4877,6 +4878,91 @@ fn require_hashes_url() -> Result<()> {
      + iniconfig==2.0.0 (from https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl#sha256=b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374)
     "
     );
+
+    Ok(())
+}
+
+/// Changed hashes must refresh a direct wheel even when its HTTP cache is still fresh.
+#[tokio::test]
+async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel_filename = "ok-1.0.0-py3-none-any.whl";
+    let wheel = fs::read(
+        context
+            .workspace_root
+            .join("test/links")
+            .join(wheel_filename),
+    )?;
+    // Give the valid fixture a ZIP comment, changing its hash without changing its contents.
+    let Some(prefix) = wheel.strip_suffix(&[0, 0]) else {
+        bail!("expected a wheel fixture without a ZIP comment");
+    };
+    let comment = b"replacement archive";
+    let mut replacement = prefix.to_vec();
+    replacement.extend_from_slice(&u16::try_from(comment.len())?.to_le_bytes());
+    replacement.extend_from_slice(comment);
+    let original_hash = hex::encode(Sha256::digest(&wheel));
+    let replacement_hash = hex::encode(Sha256::digest(&replacement));
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([
+            (original_hash.as_str(), "[ORIGINAL_HASH]"),
+            (replacement_hash.as_str(), "[REPLACEMENT_HASH]"),
+        ])
+        .collect::<Vec<_>>();
+
+    let server = MockServer::start().await;
+    let response = |wheel| {
+        ResponseTemplate::new(200)
+            .insert_header("Cache-Control", "max-age=3600")
+            .set_body_bytes(wheel)
+    };
+    Mock::given(path(format!("/{wheel_filename}")))
+        .respond_with(response(wheel))
+        .mount(&server)
+        .await;
+    let wheel_url = format!("{}/{wheel_filename}", server.uri());
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str(&format!("ok @ {wheel_url} --hash=sha256:{original_hash}\n"))?;
+
+    uv_snapshot!(filters.clone(), context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    // Require another install without `--reinstall`, which also refreshes the cache.
+    context.pip_uninstall().arg("ok").assert().success();
+    server.reset().await;
+    Mock::given(path(format!("/{wheel_filename}")))
+        .respond_with(response(replacement))
+        .mount(&server)
+        .await;
+    requirements_txt.write_str(&format!(
+        "ok @ {wheel_url} --hash=sha256:{replacement_hash}\n"
+    ))?;
+
+    uv_snapshot!(filters, context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+      × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
+      ╰─▶ Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
+
+          Expected:
+            sha256:[REPLACEMENT_HASH]
+
+          Computed:
+            sha256:[ORIGINAL_HASH]
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -1,18 +1,24 @@
 use std::env::consts::EXE_SUFFIX;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use fs_err as fs;
 use indoc::{formatdoc, indoc};
 use predicates::Predicate;
+use reqwest::{Method, Request};
 use sha2::{Digest, Sha256};
 use url::Url;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+use uv_cache::{Cache, CacheBucket, WheelCache};
+use uv_client::{BaseClientBuilder, CacheControl, CachedClient, Error as ClientError};
+use uv_distribution::HttpArchivePointer;
+use uv_distribution_types::{DirectUrlBuiltDist, HashPolicy};
 use uv_fs::{Simplified, copy_dir_all};
+use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 use uv_test::find_links::FindLinksServer;
 use uv_test::packse::PackseServer;
@@ -4882,51 +4888,114 @@ fn require_hashes_url() -> Result<()> {
     Ok(())
 }
 
-/// Changed hashes must refresh a direct wheel even when its HTTP cache is still fresh.
+/// Direct-wheel cache reuse must respect changed hashes and sizes across input formats.
 #[tokio::test]
 async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let wheel_filename = "ok-1.0.0-py3-none-any.whl";
-    let wheel = fs::read(
+    let original = fs::read(
         context
             .workspace_root
             .join("test/links")
             .join(wheel_filename),
     )?;
-    // Give the valid fixture a ZIP comment, changing its hash without changing its contents.
-    let Some(prefix) = wheel.strip_suffix(&[0, 0]) else {
+    // A ZIP comment changes the archive's hash and size without changing its contents.
+    let Some(prefix) = original.strip_suffix(&[0, 0]) else {
         bail!("expected a wheel fixture without a ZIP comment");
     };
     let comment = b"replacement archive";
     let mut replacement = prefix.to_vec();
     replacement.extend_from_slice(&u16::try_from(comment.len())?.to_le_bytes());
     replacement.extend_from_slice(comment);
-    let original_hash = hex::encode(Sha256::digest(&wheel));
+    let original_size = original.len();
+    let replacement_size = replacement.len();
+    let original_hash = hex::encode(Sha256::digest(&original));
     let replacement_hash = hex::encode(Sha256::digest(&replacement));
-    let filters = context
-        .filters()
-        .into_iter()
-        .chain([
-            (original_hash.as_str(), "[ORIGINAL_HASH]"),
-            (replacement_hash.as_str(), "[REPLACEMENT_HASH]"),
-        ])
-        .collect::<Vec<_>>();
+    let context = context
+        .with_filter((original_hash.as_str(), "[ORIGINAL_HASH]"))
+        .with_filter((replacement_hash.as_str(), "[REPLACEMENT_HASH]"));
 
     let server = MockServer::start().await;
-    let response = |wheel| {
+    let response = |contents: &[u8]| {
         ResponseTemplate::new(200)
             .insert_header("Cache-Control", "max-age=3600")
-            .set_body_bytes(wheel)
+            .set_body_bytes(contents)
     };
+    let wheel_url = format!("{}/{wheel_filename}", server.uri());
+    let generation_url = format!("{wheel_url}?generate");
+    let size_url = format!("{wheel_url}?size");
+    let lockfile = |url: &str, size: usize, hash: &str| {
+        formatdoc! {
+            r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "ok"
+        version = "1.0.0"
+        archive = {{ url = "{url}", size = {size}, hashes = {{ sha256 = "{hash}" }} }}
+        "#,
+        }
+    };
+    let requirements_in = context.temp_dir.child("requirements.in");
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+
     Mock::given(path(format!("/{wheel_filename}")))
-        .respond_with(response(wheel))
+        .respond_with(response(&original))
         .mount(&server)
         .await;
-    let wheel_url = format!("{}/{wheel_filename}", server.uri());
-    let requirements_txt = context.temp_dir.child("requirements.txt");
+    // Seed independent entries so generation cannot mask a stale validation entry.
+    requirements_in.write_str(&format!("ok @ {generation_url}#sha256={original_hash}\n"))?;
+    context
+        .pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes")
+        .assert()
+        .success();
     requirements_txt.write_str(&format!("ok @ {wheel_url} --hash=sha256:{original_hash}\n"))?;
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .assert()
+        .success();
+    context.pip_uninstall().arg("ok").assert().success();
 
-    uv_snapshot!(filters.clone(), context.pip_sync()
+    server.reset().await;
+    Mock::given(path(format!("/{wheel_filename}")))
+        .respond_with(response(&replacement))
+        .mount(&server)
+        .await;
+    requirements_in.write_str(&format!(
+        "ok @ {generation_url}#sha256={replacement_hash}\n"
+    ))?;
+    uv_snapshot!(context.filters(), context.pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes"), @r"
+    exit_code: 0 (success)
+    ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv pip compile --cache-dir [CACHE_DIR] requirements.in --generate-hashes
+    ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl?generate#sha256=[REPLACEMENT_HASH] \
+        --hash=sha256:[REPLACEMENT_HASH]
+        # via -r requirements.in
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    requirements_txt.write_str(&format!(
+        "ok @ {wheel_url} --hash=sha256:{replacement_hash}\n"
+    ))?;
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .arg("--offline")
+        .assert()
+        .failure();
+    uv_snapshot!(context.filters(), context.pip_sync()
         .arg("requirements.txt")
         .arg("--require-hashes"), @"
     exit_code: 0 (success)
@@ -4937,25 +5006,71 @@ async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
      + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
     ");
 
-    // Require another install without `--reinstall`, which also refreshes the cache.
+    // Seed another entry for a size-only refresh, with hash checking disabled below.
+    requirements_in.write_str(&format!("ok @ {size_url}\n"))?;
+    context
+        .pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes")
+        .assert()
+        .success();
     context.pip_uninstall().arg("ok").assert().success();
+
+    // Both pylock URL forms must reuse the requirements cache offline.
+    for url in [
+        generation_url.clone(),
+        format!("{generation_url}#sha256={replacement_hash}"),
+    ] {
+        pylock_toml.write_str(&lockfile(&url, replacement_size, &replacement_hash))?;
+        context
+            .pip_sync()
+            .arg("--preview")
+            .arg("--offline")
+            .arg("pylock.toml")
+            .assert()
+            .success();
+        context.pip_uninstall().arg("ok").assert().success();
+    }
+
     server.reset().await;
     Mock::given(path(format!("/{wheel_filename}")))
-        .respond_with(response(replacement))
+        .respond_with(response(&original))
         .mount(&server)
         .await;
-    requirements_txt.write_str(&format!(
-        "ok @ {wheel_url} --hash=sha256:{replacement_hash}\n"
-    ))?;
+    pylock_toml.write_str(&lockfile(&size_url, original_size, &original_hash))?;
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("--no-verify-hashes")
+        .arg("pylock.toml"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl?size)
+    ");
+    context.pip_uninstall().arg("ok").assert().success();
 
-    uv_snapshot!(filters, context.pip_sync()
-        .arg("requirements.txt")
-        .arg("--require-hashes"), @"
+    // A genuinely cold mismatch must preserve the integrity error after one full GET.
+    server.reset().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{wheel_filename}")))
+        .respond_with(response(&original))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    pylock_toml.write_str(&lockfile(
+        &format!("{wheel_url}?cold"),
+        original_size,
+        &replacement_hash,
+    ))?;
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml"), @"
     exit_code: 1 (failure)
     ----- stderr -----
-    Resolved 1 package in [TIME]
-      × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
-      ╰─▶ Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
+      × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl?cold`
+      ╰─▶ Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl?cold`
 
           Expected:
             sha256:[REPLACEMENT_HASH]
@@ -4963,7 +5078,124 @@ async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
           Computed:
             sha256:[ORIGINAL_HASH]
     ");
+    server.verify().await;
+    Ok(())
+}
 
+/// Legacy fragment-bearing entries remain usable offline and revalidate into the canonical key.
+#[tokio::test]
+async fn require_hashes_url_legacy_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel_filename = "ok-1.0.0-py3-none-any.whl";
+    let contents = fs::read(
+        context
+            .workspace_root
+            .join("test/links")
+            .join(wheel_filename),
+    )?;
+    let hash = hex::encode(Sha256::digest(&contents));
+    let context = context.with_filter((hash.as_str(), "[HASH]"));
+    let server = MockServer::start().await;
+    Mock::given(path(format!("/{wheel_filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Cache-Control", "max-age=3600")
+                .insert_header("ETag", "\"original\"")
+                .set_body_bytes(contents),
+        )
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/{wheel_filename}", server.uri());
+    let wheel = DirectUrlBuiltDist {
+        filename: wheel_filename.parse()?,
+        location: Box::new(DisplaySafeUrl::parse(&url)?),
+        url: format!("{url}#sha256={hash}").parse()?,
+        size: None,
+    };
+    context
+        .temp_dir
+        .child("requirements.txt")
+        .write_str(&format!("ok @ {}\n", wheel.url))?;
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .assert()
+        .success();
+
+    // Re-create the old layout, including the fragment in the stored HTTP request URI.
+    let cache = Cache::from_path(context.cache_dir.path());
+    let (canonical, pointer) =
+        HttpArchivePointer::read_from_direct_url(&cache, &wheel, HashPolicy::None)
+            .context("expected the downloaded wheel in the cache")?;
+    let archive = pointer.into_archive();
+    let legacy = cache.entry(
+        CacheBucket::Wheels,
+        WheelCache::Url(wheel.url.raw()).wheel_dir("ok"),
+        format!("{}.http", wheel.filename.cache_key()),
+    );
+    CachedClient::new(BaseClientBuilder::default().build()?)
+        .get_serde_with_retry(
+            Request::new(Method::GET, Url::from(wheel.url.raw().clone())),
+            &legacy,
+            CacheControl::None,
+            async |_| Ok::<_, ClientError>(archive.clone()),
+        )
+        .await
+        .map_err(ClientError::from)?;
+    fs::rename(
+        canonical.with_file(wheel.filename.cache_key()),
+        legacy.with_file(wheel.filename.cache_key()),
+    )?;
+    fs::remove_file(canonical.path())?;
+    let legacy_bytes = fs::read(legacy.path())?;
+    server.reset().await;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .arg("--reinstall")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha256=[HASH])
+    ");
+    assert!(!canonical.path().exists());
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
+
+    // Revalidate using the legacy ETag; a 304 must create the canonical entry.
+    for request_method in ["HEAD", "GET"] {
+        Mock::given(method(request_method))
+            .and(path(format!("/{wheel_filename}")))
+            .and(header("if-none-match", "\"original\""))
+            .respond_with(
+                ResponseTemplate::new(304)
+                    .insert_header("Cache-Control", "max-age=3600")
+                    .insert_header("ETag", "\"original\""),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+    }
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .arg("--reinstall")
+        .assert()
+        .success();
+    assert!(canonical.path().exists());
+    assert_eq!(fs::read(legacy.path())?, legacy_bytes);
+    server.verify().await;
     Ok(())
 }
 


### PR DESCRIPTION
Direct wheel requirements can include hash fragments, but lockfiles store the fragment-free URL. Using the original requirement URL as the wheel cache key can therefore prevent an offline sync from reusing an already-downloaded wheel.

Use the fragment-free location for new cache entries and retain a fallback for older fragment-bearing entries. Check the expected hashes, size, and archive existence before reuse. When online, refresh a cached direct wheel if its contents no longer match the required hash or size, even when its HTTP response is still fresh.

The regression tests cover offline reuse from lockfiles, offline hash mismatches, and changed contents at the same URL.
