### PR TITLE
Use the versions bot's ruleset bypass when merging

### DIFF
--- a/.github/workflows/publish-versions.yml
+++ b/.github/workflows/publish-versions.yml
@@ -79,4 +79,5 @@ jobs:
         run: |
           # Wait for PR to be created before merging
           sleep 10
-          gh pr merge --squash "$BRANCH_NAME"
+          # Explicitly use the versions bot's pull-request ruleset bypass.
+          gh pr merge --squash --admin "$BRANCH_NAME"

--- a/.github/workflows/publish-versions.yml
+++ b/.github/workflows/publish-versions.yml
@@ -79,5 +79,5 @@ jobs:
         run: |
           # Wait for PR to be created before merging
           sleep 10
-          # Explicitly use the versions bot's pull-request ruleset bypass.
+          # Use admin to bypass required review
           gh pr merge --squash --admin "$BRANCH_NAME"


### PR DESCRIPTION
## Summary

Use `gh pr merge --squash --admin` when merging the versions bot's release-manifest PR. The `versions` ruleset requires human review but grants `astral-versions-bot` a pull-request-only bypass. Plain `gh pr merge` stops at its blocked-PR preflight check instead of attempting the merge with that permission.

This completes the workflow-side change for https://github.com/astral-sh/github-policies/pull/31 and https://github.com/astral-sh/github-policies/pull/34. The failure was observed in https://github.com/astral-sh/versions/pull/163 ([release job](https://github.com/astral-sh/ty/actions/runs/32198672332/job/95944618373)).
