### PR TITLE
explicitly allow project building in uv publish tests

### DIFF
--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -360,7 +360,7 @@ def build_project_at_version(
         )
         init_py.write_text("x = 1")
 
-    # Build the project, explicitly overriding no-build from the project's uv.toml.
+    # Build the project, explicitly overriding no-build from the project's pyprojec.toml
     check_call([uv, "build", "--build"], cwd=project_root)
     # Test that we ignore unknown any file.
     project_root.joinpath("dist").joinpath(".DS_Store").touch()

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -360,8 +360,8 @@ def build_project_at_version(
         )
         init_py.write_text("x = 1")
 
-    # Build the project
-    check_call([uv, "build"], cwd=project_root)
+    # Build the project, explicitly overriding no-build from the project's uv.toml.
+    check_call([uv, "build", "--build"], cwd=project_root)
     # Test that we ignore unknown any file.
     project_root.joinpath("dist").joinpath(".DS_Store").touch()
 

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -360,7 +360,7 @@ def build_project_at_version(
         )
         init_py.write_text("x = 1")
 
-    # Build the project, explicitly overriding no-build from the project's pyprojec.toml
+    # Build the project, explicitly overriding no-build from the project's pyproject.toml
     check_call([uv, "build", "--build"], cwd=project_root)
     # Test that we ignore unknown any file.
     project_root.joinpath("dist").joinpath(".DS_Store").touch()


### PR DESCRIPTION
https://github.com/astral-sh/uv/pull/21195 introduced no-build setting at project root which was picked up when test_publish.py goes to build projects.

explicitly set --build to override in tests rather than adding another ~~uv.toml~ config file in scripts/publish
