### PR TITLE
Preserve usernames in legacy index receipts

### DIFF
--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -118,18 +118,6 @@ impl IndexUrl {
         }
     }
 
-    /// Return the URL with any password removed, retaining the username.
-    pub(crate) fn without_password(&self) -> Cow<'_, DisplaySafeUrl> {
-        let url = self.url();
-        if url.password().is_none() {
-            Cow::Borrowed(url)
-        } else {
-            let mut url = url.clone();
-            let _ = url.set_password(None);
-            Cow::Owned(url)
-        }
-    }
-
     /// Warn user if the given URL was provided as an ambiguous relative path.
     ///
     /// This is a temporary warning. Ambiguous values will not be
@@ -311,7 +299,7 @@ impl IndexLocations {
 }
 
 /// Returns `true` if two [`IndexUrl`]s refer to the same index.
-fn is_same_index(a: &IndexUrl, b: &IndexUrl) -> bool {
+pub(crate) fn is_same_index(a: &IndexUrl, b: &IndexUrl) -> bool {
     RealmRef::from(&**b.url()) == RealmRef::from(&**a.url())
         && CanonicalUrl::new(a.url().clone()) == CanonicalUrl::new(b.url().clone())
 }

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -119,7 +119,7 @@ impl IndexUrl {
     }
 
     /// Return the URL with any password removed, retaining the username.
-    pub fn without_password(&self) -> Cow<'_, DisplaySafeUrl> {
+    pub(crate) fn without_password(&self) -> Cow<'_, DisplaySafeUrl> {
         let url = self.url();
         if url.password().is_none() {
             Cow::Borrowed(url)

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -118,6 +118,18 @@ impl IndexUrl {
         }
     }
 
+    /// Return the URL with any password removed, retaining the username.
+    pub fn without_password(&self) -> Cow<'_, DisplaySafeUrl> {
+        let url = self.url();
+        if url.password().is_none() {
+            Cow::Borrowed(url)
+        } else {
+            let mut url = url.clone();
+            let _ = url.set_password(None);
+            Cow::Owned(url)
+        }
+    }
+
     /// Warn user if the given URL was provided as an ambiguous relative path.
     ///
     /// This is a temporary warning. Ambiguous values will not be

--- a/crates/uv-distribution-types/src/pip_index.rs
+++ b/crates/uv-distribution-types/src/pip_index.rs
@@ -42,7 +42,7 @@ macro_rules! impl_index {
             where
                 S: serde::Serializer,
             {
-                self.0.url().serialize(serializer)
+                self.0.url().without_password().serialize(serializer)
             }
         }
 

--- a/crates/uv-distribution-types/src/pip_index.rs
+++ b/crates/uv-distribution-types/src/pip_index.rs
@@ -9,6 +9,20 @@ use std::path::Path;
 
 use crate::{Index, IndexUrl, Origin};
 
+impl PipIndex {
+    /// Preserve credentials from a lower-precedence index when both URLs refer to the same index.
+    #[must_use]
+    pub fn with_credentials_from(mut self, other: &Self) -> Self {
+        if self.0.url().url().username().is_empty()
+            && self.0.url().url().password().is_none()
+            && crate::index_url::is_same_index(self.0.url(), other.0.url())
+        {
+            self.0.url = other.0.url.clone();
+        }
+        self
+    }
+}
+
 macro_rules! impl_index {
     ($name:ident, $from:expr) => {
         #[derive(Debug, Clone, Eq, PartialEq)]
@@ -42,7 +56,7 @@ macro_rules! impl_index {
             where
                 S: serde::Serializer,
             {
-                self.0.url().without_password().serialize(serializer)
+                self.0.url().serialize(serializer)
             }
         }
 

--- a/crates/uv-settings/src/combine.rs
+++ b/crates/uv-settings/src/combine.rs
@@ -108,7 +108,6 @@ impl_combine_or!(NonZeroUsize);
 impl_combine_or!(PathBuf);
 impl_combine_or!(PipExtraIndex);
 impl_combine_or!(PipFindLinks);
-impl_combine_or!(PipIndex);
 impl_combine_or!(PrereleaseMode);
 impl_combine_or!(PreviewOption);
 impl_combine_or!(ProxyUrl);
@@ -125,6 +124,15 @@ impl_combine_or!(TorchMode);
 impl_combine_or!(TrustedPublishing);
 impl_combine_or!(Url);
 impl_combine_or!(bool);
+
+impl Combine for Option<PipIndex> {
+    fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Some(index), Some(other)) => Some(index.with_credentials_from(&other)),
+            (index, other) => index.or(other),
+        }
+    }
+}
 
 impl<T> Combine for Option<Vec<T>> {
     /// Combine two vectors by extending the vector in `self` with the vector in `other`, if they're

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -5507,6 +5507,52 @@ async fn tool_install_credentials() {
     });
 }
 
+/// When installing from a legacy index URL, the username should be preserved in the receipt.
+#[tokio::test]
+async fn tool_install_index_url_username() -> Result<()> {
+    let proxy = crate::pypi_proxy::start().await;
+    let context = uv_test::test_context!("3.12")
+        .with_exclude_newer("2025-01-18T00:00:00Z")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("executable-application")
+        .arg("--index-url")
+        .arg(proxy.username_url("public", "/simple"))
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + executable-application==0.3.0
+    Installed 1 executable: app
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("executable-application").join("uv-receipt.toml")).unwrap(), @r#"
+        [tool]
+        requirements = [{ name = "executable-application" }]
+        entrypoints = [
+            { name = "app", install-path = "[TEMP_DIR]/bin/app", from = "executable-application" },
+        ]
+
+        [tool.options]
+        index-url = "http://public@[LOCALHOST]/simple"
+        exclude-newer = "2025-01-18T00:00:00Z"
+        "#);
+    });
+
+    Ok(())
+}
+
 /// When installing from an authenticated index, the credentials should be omitted from the receipt.
 #[tokio::test]
 async fn tool_install_default_credentials() -> Result<()> {

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -20,7 +20,7 @@ use uv_fs::Simplified;
 use uv_fs::copy_dir_all;
 use uv_static::EnvVars;
 
-use uv_test::uv_snapshot;
+use uv_test::{uv_snapshot, venv_bin_path};
 
 #[cfg(feature = "test-git")]
 fn tool_install_git_path(bin_dir: &ChildPath) -> OsString {
@@ -5507,9 +5507,24 @@ async fn tool_install_credentials() {
     });
 }
 
-/// When installing from a legacy index URL, the username should be preserved in the receipt.
+/// When upgrading from a legacy index URL, matching configured credentials should be preserved.
 #[tokio::test]
 async fn tool_install_index_url_username() -> Result<()> {
+    let keyring_context = uv_test::test_context!("3.12");
+
+    // Install our keyring plugin.
+    keyring_context
+        .pip_install()
+        .arg(
+            keyring_context
+                .workspace_root
+                .join("test")
+                .join("packages")
+                .join("keyring_test_plugin"),
+        )
+        .assert()
+        .success();
+
     let proxy = crate::pypi_proxy::start().await;
     let context = uv_test::test_context!("3.12")
         .with_exclude_newer("2025-01-18T00:00:00Z")
@@ -5517,16 +5532,30 @@ async fn tool_install_index_url_username() -> Result<()> {
         .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
+    let path = std::env::join_paths([venv_bin_path(&keyring_context.venv), bin_dir.to_path_buf()])?;
+
+    // Configure a legacy index URL with a username supplied to the keyring provider.
+    let uv_toml = context.temp_dir.child("uv.toml");
+    uv_toml.write_str(&format!(
+        indoc::indoc! {r#"
+        index-url = "{}"
+        keyring-provider = "subprocess"
+    "#},
+        proxy.username_url("public", "/basic-auth/simple")
+    ))?;
 
     uv_snapshot!(context.filters(), context.tool_install()
         .arg("executable-application")
-        .arg("--index-url")
-        .arg(proxy.username_url("public", "/simple"))
+        .arg("--config-file")
+        .arg(uv_toml.as_os_str())
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
-        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+        .env(EnvVars::KEYRING_TEST_CREDENTIALS, format!(r#"{{"{host}": {{"public": "heron"}}}}"#, host = proxy.host_port()))
+        .env(EnvVars::PATH, &path), @"
     exit_code: 0 (success)
     ----- stderr -----
+    Keyring request for public@http://[LOCALHOST]/basic-auth/simple
+    Keyring request for public@[LOCALHOST]
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -5545,10 +5574,28 @@ async fn tool_install_index_url_username() -> Result<()> {
         ]
 
         [tool.options]
-        index-url = "http://public@[LOCALHOST]/simple"
+        index-url = "http://[LOCALHOST]/basic-auth/simple"
+        keyring-provider = "subprocess"
         exclude-newer = "2025-01-18T00:00:00Z"
         "#);
     });
+
+    // The receipt URL is redacted, but the matching configured URL should restore the username
+    // so the keyring can authenticate the upgrade.
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("executable-application")
+        .arg("--config-file")
+        .arg(uv_toml.as_os_str())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::KEYRING_TEST_CREDENTIALS, format!(r#"{{"{host}": {{"public": "heron"}}}}"#, host = proxy.host_port()))
+        .env(EnvVars::PATH, &path), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Keyring request for public@http://[LOCALHOST]/basic-auth/simple
+    Keyring request for public@[LOCALHOST]
+    Nothing to upgrade
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Legacy --index-url values in tool receipts currently lose username-only credentials during serialization. Preserve the username while continuing to remove passwords for legacy index-url, extra-index-url, and find-links receipt values. Modern named index receipts remain fully redacted.

Fixes #21216

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test --package uv --test tool --no-default-features --features test-python,test-pypi tool_install_index_url_username`
- `cargo clippy --package uv --test tool --no-default-features --features test-python,test-pypi -- -D warnings`