### PR TITLE
Uniformly print human readable sizes below 1024 bytes without a fractional part

### DIFF
--- a/crates/uv-console/src/lib.rs
+++ b/crates/uv-console/src/lib.rs
@@ -303,6 +303,10 @@ pub fn human_readable_bytes(bytes: u64) -> impl fmt::Display {
     const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
 
     fmt::from_fn(move |formatter| {
+        if bytes < 1024 {
+            return write!(formatter, "{bytes}B");
+        }
+
         let rounding_margin = formatter
             .precision()
             .and_then(|precision| i32::try_from(precision).ok())
@@ -341,7 +345,7 @@ mod tests {
             "1023.9501953125KiB"
         );
 
-        assert_eq!(format!("{:.2}", human_readable_bytes(1023)), "1023.00B");
+        assert_eq!(format!("{:.2}", human_readable_bytes(1023)), "1023B");
         assert_eq!(format!("{:.0}", human_readable_bytes(MIB - 513)), "1023KiB");
         assert_eq!(format!("{:.0}", human_readable_bytes(MIB - 512)), "1MiB");
         assert_eq!(

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -102,15 +102,11 @@ pub(crate) async fn cache_clean(
     // If any, report the physical space, falling back to the logical removed size.
     let reported_bytes = summary.physical_bytes.unwrap_or(summary.logical_bytes);
     if summary.logical_bytes > 0 || reported_bytes > 0 {
-        let bytes = if reported_bytes < 1024 {
-            format!("{reported_bytes}B")
-        } else {
-            format!("{:.1}", human_readable_bytes(reported_bytes))
-        };
+        let bytes = human_readable_bytes(reported_bytes);
         if summary.physical_bytes_incomplete {
-            write!(printer.stderr(), " (at least {})", bytes.green())?;
+            write!(printer.stderr(), " (at least {:.1})", bytes.green())?;
         } else {
-            write!(printer.stderr(), " ({})", bytes.green())?;
+            write!(printer.stderr(), " ({:.1})", bytes.green())?;
         }
     }
 

--- a/crates/uv/src/commands/cache_prune.rs
+++ b/crates/uv/src/commands/cache_prune.rs
@@ -89,15 +89,11 @@ pub(crate) async fn cache_prune(
     // If any, report the physical space, falling back to the logical removed size.
     let reported_bytes = summary.physical_bytes.unwrap_or(summary.logical_bytes);
     if summary.logical_bytes > 0 || reported_bytes > 0 {
-        let bytes = if reported_bytes < 1024 {
-            format!("{reported_bytes}B")
-        } else {
-            format!("{:.1}", human_readable_bytes(reported_bytes))
-        };
+        let bytes = human_readable_bytes(reported_bytes);
         if summary.physical_bytes_incomplete {
-            write!(printer.stderr(), " (at least {})", bytes.green())?;
+            write!(printer.stderr(), " (at least {:.1})", bytes.green())?;
         } else {
-            write!(printer.stderr(), " ({})", bytes.green())?;
+            write!(printer.stderr(), " ({:.1})", bytes.green())?;
         }
     }
 


### PR DESCRIPTION
## Summary

We were doing this in some places, and not in others. I've unified it into the human_readable_bytes function.

## Test Plan

Unit tests.