### PR TITLE
Authorize protected actionlint releases

### DIFF
--- a/.github/ost-simple-sts.json
+++ b/.github/ost-simple-sts.json
@@ -1,6 +1,12 @@
 {
   "version": 2,
   "repositories": {
+    "actionlint": {
+      "name": "astral-sh/actionlint",
+      "id": 1339782727,
+      "oidc_subject": "immutable",
+      "owner_id": 115962839
+    },
     "uv": {
       "name": "astral-sh/uv",
       "id": 699532645,
@@ -23,6 +29,14 @@
     "automations": 146796415
   },
   "rules": [
+    {
+      "caller": "actionlint",
+      "environment": "release",
+      "caller_workflow": "release.yml",
+      "on": ["workflow_dispatch"],
+      "permissions": { "contents": "write", "workflows": "write" },
+      "target": "actionlint"
+    },
     {
       "caller": "uv",
       "environment": "release",


### PR DESCRIPTION
Authorize the protected release workflow in `astral-sh/actionlint` to obtain a short-lived token for its own repository. The rule pins actionlint's immutable repository identity and permits only manual dispatches of `release.yml` from the `release` environment, with `contents: write` and `workflows: write`. The workflow permission is needed to create a tag at the approved source commit after `main` advances across workflow changes.

The publisher in astral-sh/actionlint#20 remains disabled until its environment and tag protections are enrolled.
