### PR TITLE
Represent validated source archives before persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6630,6 +6630,7 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
+ "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-redacted",

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -62,6 +62,8 @@ url = { workspace = true }
 walkdir = { workspace = true }
 
 [dev-dependencies]
+uv-preview = { workspace = true, features = ["testing"] }
+
 indoc = { workspace = true }
 insta = { workspace = true }
 

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -15,9 +15,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use fs_err::tokio as fs;
-use futures::{FutureExt, TryStreamExt};
+use futures::FutureExt;
 use reqwest::{Response, StatusCode};
-use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{Instrument, debug, info_span, instrument, warn};
 use url::Url;
 
@@ -35,7 +34,6 @@ use uv_distribution_types::{
     ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, HashPolicy, Hashed, IndexUrl,
     PathSourceUrl, RemoteSource, RequirementSource, RequiresPython, SourceDist, SourceUrl,
 };
-use uv_extract::hash::Hasher;
 use uv_fs::{Simplified, rename_with_retry, write_atomic};
 use uv_git::{Fetch, GIT_LFS, GitError, GitHttpSettings, GitResolver};
 use uv_git_types::{GitHubRepository, GitOid, GitUrl};
@@ -54,10 +52,12 @@ use crate::hash::http_hash_algorithms;
 use crate::metadata::{ArchiveMetadata, GitWorkspaceMember, Metadata};
 use crate::source::built_wheel_metadata::{BuiltWheelFile, BuiltWheelMetadata};
 use crate::source::revision::Revision;
+use crate::source::validated_archive::ValidatedSourceArchive;
 use crate::{Reporter, RequiresDist};
 
 mod built_wheel_metadata;
 mod revision;
+mod validated_archive;
 
 /// Access distribution metadata without requiring a build interpreter.
 ///
@@ -2813,7 +2813,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .await
     }
 
-    /// Download and unzip a source distribution into the cache from an HTTP response.
+    /// Download, extract, validate, and persist a source distribution into the cache.
     async fn download_archive(
         &self,
         response: Response,
@@ -2822,87 +2822,19 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         target: &Path,
         algorithms: &[HashAlgorithm],
     ) -> Result<(Vec<HashDigest>, u64), Error> {
-        let temp_dir = tempfile::tempdir_in(
-            self.build_context
-                .cache()
-                .bucket(CacheBucket::SourceDistributions),
+        let archive = ValidatedSourceArchive::extract_http(
+            response,
+            source,
+            ext,
+            self.build_context.cache(),
+            algorithms,
         )
-        .map_err(Error::CacheWrite)?;
-
-        let reader = response
-            .bytes_stream()
-            .map_err(std::io::Error::other)
-            .into_async_read();
-
-        // Create a hasher for each hash algorithm.
-        let mut hashers = algorithms
-            .iter()
-            .copied()
-            .map(Hasher::from)
-            .collect::<Vec<_>>();
-        let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
-
-        // Download and unzip the source distribution into a temporary directory.
-        let span = info_span!("download_source_dist", source_dist = %source);
-        uv_extract::stream::archive(&mut hasher, ext, temp_dir.path())
-            .await
-            .map_err(|err| Error::Extract(source.to_string(), err))?;
-        drop(span);
-
-        let expected_size = match source {
-            BuildableSource::Dist(SourceDist::Registry(dist)) if dist.size_is_authoritative => {
-                dist.size()
-            }
-            BuildableSource::Dist(SourceDist::DirectUrl(dist)) => dist.size(),
-            _ => None,
-        };
-
-        // If necessary, exhaust the reader to compute the hash or validate the archive size.
-        if !algorithms.is_empty() || expected_size.is_some() {
-            hasher.finish().await.map_err(Error::HashExhaustion)?;
-        }
-        if let Some(expected) = expected_size
-            && hasher.bytes_read() != expected
-        {
-            return Err(Error::MismatchedSize {
-                distribution: source.to_string(),
-                expected,
-                actual: hasher.bytes_read(),
-            });
-        }
-
-        let size = hasher.bytes_read();
-        let hashes = hashers.into_iter().map(HashDigest::from).collect();
-
-        // Extract the top-level directory.
-        let extracted = match uv_extract::strip_component(temp_dir.path()) {
-            Ok(top_level) => top_level,
-            Err(uv_extract::Error::NonSingularArchive(_)) => temp_dir.keep(),
-            Err(err) => {
-                return Err(Error::Extract(
-                    temp_dir.path().to_string_lossy().into_owned(),
-                    err,
-                ));
-            }
-        };
-
-        // Persist it to the cache.
-        fs_err::tokio::create_dir_all(target.parent().expect("Cache entry to have parent"))
-            .await
-            .map_err(Error::CacheWrite)?;
-        if let Err(err) = rename_with_retry(extracted, target).await {
-            // If the directory already exists, accept it.
-            if err.kind() == std::io::ErrorKind::AlreadyExists {
-                warn!("Directory already exists: {}", target.display());
-            } else {
-                return Err(Error::CacheWrite(err));
-            }
-        }
-
-        Ok((hashes, size))
+        .await?;
+        let metadata = archive.persist(target).await?;
+        Ok((metadata.hashes, metadata.size))
     }
 
-    /// Extract a local archive, and store it at the given [`CacheEntry`].
+    /// Extract, validate, and persist a local source archive into the cache.
     async fn persist_archive(
         &self,
         path: &Path,
@@ -2910,64 +2842,14 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         target: &Path,
         algorithms: &[HashAlgorithm],
     ) -> Result<Vec<HashDigest>, Error> {
-        debug!("Unpacking for build: {}", path.display());
-
-        let temp_dir = tempfile::tempdir_in(
-            self.build_context
-                .cache()
-                .bucket(CacheBucket::SourceDistributions),
+        let archive = ValidatedSourceArchive::extract_local(
+            path,
+            ext,
+            self.build_context.cache(),
+            algorithms,
         )
-        .map_err(Error::CacheWrite)?;
-        let reader = fs_err::tokio::File::open(&path)
-            .await
-            .map_err(Error::CacheRead)?;
-
-        // Create a hasher for each hash algorithm.
-        let mut hashers = algorithms
-            .iter()
-            .copied()
-            .map(Hasher::from)
-            .collect::<Vec<_>>();
-        let mut hasher = uv_extract::hash::HashReader::new(reader, &mut hashers);
-
-        // Unzip the archive into a temporary directory.
-        uv_extract::stream::archive(&mut hasher, ext, &temp_dir.path())
-            .await
-            .map_err(|err| Error::Extract(temp_dir.path().to_string_lossy().into_owned(), err))?;
-
-        // If necessary, exhaust the reader to compute the hash.
-        if !algorithms.is_empty() {
-            hasher.finish().await.map_err(Error::HashExhaustion)?;
-        }
-
-        let hashes = hashers.into_iter().map(HashDigest::from).collect();
-
-        // Extract the top-level directory from the archive.
-        let extracted = match uv_extract::strip_component(temp_dir.path()) {
-            Ok(top_level) => top_level,
-            Err(uv_extract::Error::NonSingularArchive(_)) => temp_dir.path().to_path_buf(),
-            Err(err) => {
-                return Err(Error::Extract(
-                    temp_dir.path().to_string_lossy().into_owned(),
-                    err,
-                ));
-            }
-        };
-
-        // Persist it to the cache.
-        fs_err::tokio::create_dir_all(target.parent().expect("Cache entry to have parent"))
-            .await
-            .map_err(Error::CacheWrite)?;
-        if let Err(err) = rename_with_retry(extracted, target).await {
-            // If the directory already exists, accept it.
-            if err.kind() == std::io::ErrorKind::DirectoryNotEmpty {
-                warn!("Directory already exists: {}", target.display());
-            } else {
-                return Err(Error::CacheWrite(err));
-            }
-        }
-
-        Ok(hashes)
+        .await?;
+        Ok(archive.persist(target).await?.hashes)
     }
 
     /// For Git directories, we check them out into the cache, so we need to avoid workspace

--- a/crates/uv-distribution/src/source/validated_archive.rs
+++ b/crates/uv-distribution/src/source/validated_archive.rs
@@ -4,13 +4,14 @@ use std::path::Path;
 use futures::TryStreamExt;
 use reqwest::Response;
 use tempfile::TempDir;
+use tokio::io::AsyncRead;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
-use tracing::{debug, info_span, warn};
+use tracing::{Span, debug, info_span, warn};
 
 use uv_cache::{Cache, CacheBucket};
 use uv_distribution_filename::SourceDistExtension;
 use uv_distribution_types::{BuildableSource, RemoteSource, SourceDist};
-use uv_extract::hash::Hasher;
+use uv_extract::hash::{HashReader, Hasher};
 use uv_fs::rename_with_retry;
 use uv_pypi_types::{HashAlgorithm, HashDigest};
 
@@ -33,7 +34,11 @@ pub(super) struct SourceArchiveMetadata {
     pub(super) size: u64,
 }
 
-/// Preserve the existing persistence behavior for HTTP and local archives.
+/// Controls cache-rename collisions and cleanup of non-singular archives.
+///
+/// HTTP archives accept [`ErrorKind::AlreadyExists`] and use [`TempDir::keep`] when the archive
+/// contains multiple top-level entries. Local archives accept [`ErrorKind::DirectoryNotEmpty`] and
+/// retain automatic temporary-directory cleanup.
 enum ArchiveOrigin {
     Http,
     Local,
@@ -56,21 +61,6 @@ impl ValidatedSourceArchive {
             .map_err(std::io::Error::other)
             .into_async_read();
 
-        // Create a hasher for each hash algorithm.
-        let mut hashers = algorithms
-            .iter()
-            .copied()
-            .map(Hasher::from)
-            .collect::<Vec<_>>();
-        let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
-
-        // Download and unzip the source distribution into a temporary directory.
-        let span = info_span!("download_source_dist", source_dist = %source);
-        uv_extract::stream::archive(&mut hasher, ext, temp_dir.path())
-            .await
-            .map_err(|err| Error::Extract(source.to_string(), err))?;
-        drop(span);
-
         let expected_size = match source {
             BuildableSource::Dist(SourceDist::Registry(dist)) if dist.size_is_authoritative => {
                 dist.size()
@@ -78,29 +68,17 @@ impl ValidatedSourceArchive {
             BuildableSource::Dist(SourceDist::DirectUrl(dist)) => dist.size(),
             _ => None,
         };
-
-        // If necessary, exhaust the reader to compute the hash or validate the archive size.
-        if !algorithms.is_empty() || expected_size.is_some() {
-            hasher.finish().await.map_err(Error::HashExhaustion)?;
-        }
-        if let Some(expected) = expected_size
-            && hasher.bytes_read() != expected
-        {
-            return Err(Error::MismatchedSize {
-                distribution: source.to_string(),
-                expected,
-                actual: hasher.bytes_read(),
-            });
-        }
-
-        let size = hasher.bytes_read();
-        let hashes = hashers.into_iter().map(HashDigest::from).collect();
-
-        Ok(Self {
-            staging_dir: temp_dir,
-            metadata: SourceArchiveMetadata { hashes, size },
-            origin: ArchiveOrigin::Http,
-        })
+        Self::extract(
+            reader.compat(),
+            ext,
+            temp_dir,
+            algorithms,
+            ArchiveOrigin::Http,
+            expected_size,
+            |_| source.to_string(),
+            || Some(info_span!("download_source_dist", source_dist = %source)),
+        )
+        .await
     }
 
     /// Extract a local source archive and compute its requested hashes.
@@ -117,32 +95,65 @@ impl ValidatedSourceArchive {
         let reader = fs_err::tokio::File::open(&path)
             .await
             .map_err(Error::CacheRead)?;
+        Self::extract(
+            reader,
+            ext,
+            temp_dir,
+            algorithms,
+            ArchiveOrigin::Local,
+            None,
+            |path| path.to_string_lossy().into_owned(),
+            || None,
+        )
+        .await
+    }
 
+    /// Extract into private staging and complete the requested checks before constructing a value.
+    async fn extract(
+        reader: impl AsyncRead + Unpin,
+        ext: SourceDistExtension,
+        staging_dir: TempDir,
+        algorithms: &[HashAlgorithm],
+        origin: ArchiveOrigin,
+        expected_size: Option<u64>,
+        error_context: impl Fn(&Path) -> String,
+        make_span: impl FnOnce() -> Option<Span>,
+    ) -> Result<Self, Error> {
         // Create a hasher for each hash algorithm.
         let mut hashers = algorithms
             .iter()
             .copied()
             .map(Hasher::from)
             .collect::<Vec<_>>();
-        let mut hasher = uv_extract::hash::HashReader::new(reader, &mut hashers);
+        let mut hasher = HashReader::new(reader, &mut hashers);
 
-        // Unzip the archive into a temporary directory.
-        uv_extract::stream::archive(&mut hasher, ext, &temp_dir.path())
+        let span = make_span();
+        uv_extract::stream::archive(&mut hasher, ext, staging_dir.path())
             .await
-            .map_err(|err| Error::Extract(temp_dir.path().to_string_lossy().into_owned(), err))?;
+            .map_err(|err| Error::Extract(error_context(staging_dir.path()), err))?;
+        drop(span);
 
-        // If necessary, exhaust the reader to compute the hash.
-        if !algorithms.is_empty() {
+        // If necessary, exhaust the reader to compute hashes or validate the archive size.
+        if !algorithms.is_empty() || expected_size.is_some() {
             hasher.finish().await.map_err(Error::HashExhaustion)?;
+        }
+        if let Some(expected) = expected_size
+            && hasher.bytes_read() != expected
+        {
+            return Err(Error::MismatchedSize {
+                distribution: error_context(staging_dir.path()),
+                expected,
+                actual: hasher.bytes_read(),
+            });
         }
 
         let size = hasher.bytes_read();
         let hashes = hashers.into_iter().map(HashDigest::from).collect();
 
         Ok(Self {
-            staging_dir: temp_dir,
+            staging_dir,
             metadata: SourceArchiveMetadata { hashes, size },
-            origin: ArchiveOrigin::Local,
+            origin,
         })
     }
 
@@ -187,5 +198,84 @@ impl ValidatedSourceArchive {
         }
 
         Ok(metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use anyhow::Result;
+
+    use uv_distribution_filename::LegacySourceDistExtension;
+
+    use super::*;
+
+    // Two zero-filled records form an empty, valid tar archive.
+    const EMPTY_TAR: &[u8] = &[0; 1024];
+    const TAR: SourceDistExtension = SourceDistExtension::Legacy(LegacySourceDistExtension::Tar);
+
+    async fn extract(
+        bytes: &[u8],
+        trailing_read: &Cell<bool>,
+        algorithms: &[HashAlgorithm],
+        expected_size: Option<u64>,
+    ) -> Result<ValidatedSourceArchive, Error> {
+        let reader = futures::stream::iter([
+            Ok(bytes),
+            Err(std::io::Error::other("unexpected trailing read")),
+        ])
+        .inspect_err(|_| trailing_read.set(true))
+        .into_async_read()
+        .compat();
+        let staging_dir = tempfile::tempdir().map_err(Error::CacheWrite)?;
+        ValidatedSourceArchive::extract(
+            reader,
+            TAR,
+            staging_dir,
+            algorithms,
+            ArchiveOrigin::Http,
+            expected_size,
+            |_| "source.tar".to_owned(),
+            || None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn reader_is_exhausted_only_for_hashes_or_size() -> Result<()> {
+        let _preview = uv_preview::test::with_features(&[]);
+        let trailing_read = Cell::new(false);
+        extract(EMPTY_TAR, &trailing_read, &[], None).await?;
+        assert!(!trailing_read.get());
+
+        for (algorithms, size) in [
+            (&[HashAlgorithm::Sha256][..], None),
+            (&[][..], Some(EMPTY_TAR.len() as u64)),
+        ] {
+            assert!(matches!(
+                extract(EMPTY_TAR, &trailing_read, algorithms, size).await,
+                Err(Error::HashExhaustion(_))
+            ));
+            assert!(trailing_read.replace(false));
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parser_error_precedes_trailing_read() {
+        let _preview = uv_preview::test::with_features(&[]);
+        let trailing_read = Cell::new(false);
+        assert!(matches!(
+            extract(
+                &[0xff; 512],
+                &trailing_read,
+                &[HashAlgorithm::Sha256],
+                Some(1)
+            )
+            .await,
+            Err(Error::Extract(_, _))
+        ));
+        assert!(!trailing_read.get());
     }
 }

--- a/crates/uv-distribution/src/source/validated_archive.rs
+++ b/crates/uv-distribution/src/source/validated_archive.rs
@@ -1,0 +1,191 @@
+use std::io::ErrorKind;
+use std::path::Path;
+
+use futures::TryStreamExt;
+use reqwest::Response;
+use tempfile::TempDir;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
+use tracing::{debug, info_span, warn};
+
+use uv_cache::{Cache, CacheBucket};
+use uv_distribution_filename::SourceDistExtension;
+use uv_distribution_types::{BuildableSource, RemoteSource, SourceDist};
+use uv_extract::hash::Hasher;
+use uv_fs::rename_with_retry;
+use uv_pypi_types::{HashAlgorithm, HashDigest};
+
+use crate::error::Error;
+
+/// An extracted source archive that satisfies the checks requested during extraction.
+///
+/// The staging directory and fields are private to this module. Callers can only obtain this type
+/// through extraction, so only a validated archive can be persisted. Persisting consumes the value
+/// and returns the metadata computed during extraction.
+pub(super) struct ValidatedSourceArchive {
+    staging_dir: TempDir,
+    metadata: SourceArchiveMetadata,
+    origin: ArchiveOrigin,
+}
+
+/// Metadata computed while consuming a source archive.
+pub(super) struct SourceArchiveMetadata {
+    pub(super) hashes: Vec<HashDigest>,
+    pub(super) size: u64,
+}
+
+/// Preserve the existing persistence behavior for HTTP and local archives.
+enum ArchiveOrigin {
+    Http,
+    Local,
+}
+
+impl ValidatedSourceArchive {
+    /// Download and extract a source distribution, computing its hashes and checking its size.
+    pub(super) async fn extract_http(
+        response: Response,
+        source: &BuildableSource<'_>,
+        ext: SourceDistExtension,
+        cache: &Cache,
+        algorithms: &[HashAlgorithm],
+    ) -> Result<Self, Error> {
+        let temp_dir = tempfile::tempdir_in(cache.bucket(CacheBucket::SourceDistributions))
+            .map_err(Error::CacheWrite)?;
+
+        let reader = response
+            .bytes_stream()
+            .map_err(std::io::Error::other)
+            .into_async_read();
+
+        // Create a hasher for each hash algorithm.
+        let mut hashers = algorithms
+            .iter()
+            .copied()
+            .map(Hasher::from)
+            .collect::<Vec<_>>();
+        let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
+
+        // Download and unzip the source distribution into a temporary directory.
+        let span = info_span!("download_source_dist", source_dist = %source);
+        uv_extract::stream::archive(&mut hasher, ext, temp_dir.path())
+            .await
+            .map_err(|err| Error::Extract(source.to_string(), err))?;
+        drop(span);
+
+        let expected_size = match source {
+            BuildableSource::Dist(SourceDist::Registry(dist)) if dist.size_is_authoritative => {
+                dist.size()
+            }
+            BuildableSource::Dist(SourceDist::DirectUrl(dist)) => dist.size(),
+            _ => None,
+        };
+
+        // If necessary, exhaust the reader to compute the hash or validate the archive size.
+        if !algorithms.is_empty() || expected_size.is_some() {
+            hasher.finish().await.map_err(Error::HashExhaustion)?;
+        }
+        if let Some(expected) = expected_size
+            && hasher.bytes_read() != expected
+        {
+            return Err(Error::MismatchedSize {
+                distribution: source.to_string(),
+                expected,
+                actual: hasher.bytes_read(),
+            });
+        }
+
+        let size = hasher.bytes_read();
+        let hashes = hashers.into_iter().map(HashDigest::from).collect();
+
+        Ok(Self {
+            staging_dir: temp_dir,
+            metadata: SourceArchiveMetadata { hashes, size },
+            origin: ArchiveOrigin::Http,
+        })
+    }
+
+    /// Extract a local source archive and compute its requested hashes.
+    pub(super) async fn extract_local(
+        path: &Path,
+        ext: SourceDistExtension,
+        cache: &Cache,
+        algorithms: &[HashAlgorithm],
+    ) -> Result<Self, Error> {
+        debug!("Unpacking for build: {}", path.display());
+
+        let temp_dir = tempfile::tempdir_in(cache.bucket(CacheBucket::SourceDistributions))
+            .map_err(Error::CacheWrite)?;
+        let reader = fs_err::tokio::File::open(&path)
+            .await
+            .map_err(Error::CacheRead)?;
+
+        // Create a hasher for each hash algorithm.
+        let mut hashers = algorithms
+            .iter()
+            .copied()
+            .map(Hasher::from)
+            .collect::<Vec<_>>();
+        let mut hasher = uv_extract::hash::HashReader::new(reader, &mut hashers);
+
+        // Unzip the archive into a temporary directory.
+        uv_extract::stream::archive(&mut hasher, ext, &temp_dir.path())
+            .await
+            .map_err(|err| Error::Extract(temp_dir.path().to_string_lossy().into_owned(), err))?;
+
+        // If necessary, exhaust the reader to compute the hash.
+        if !algorithms.is_empty() {
+            hasher.finish().await.map_err(Error::HashExhaustion)?;
+        }
+
+        let size = hasher.bytes_read();
+        let hashes = hashers.into_iter().map(HashDigest::from).collect();
+
+        Ok(Self {
+            staging_dir: temp_dir,
+            metadata: SourceArchiveMetadata { hashes, size },
+            origin: ArchiveOrigin::Local,
+        })
+    }
+
+    /// Persist the validated source tree and return metadata computed during extraction.
+    pub(super) async fn persist(self, target: &Path) -> Result<SourceArchiveMetadata, Error> {
+        let Self {
+            staging_dir: temp_dir,
+            metadata,
+            origin,
+        } = self;
+        let existing_directory = match origin {
+            ArchiveOrigin::Http => ErrorKind::AlreadyExists,
+            ArchiveOrigin::Local => ErrorKind::DirectoryNotEmpty,
+        };
+
+        // Extract the top-level directory.
+        let extracted = match uv_extract::strip_component(temp_dir.path()) {
+            Ok(top_level) => top_level,
+            Err(uv_extract::Error::NonSingularArchive(_)) => match origin {
+                ArchiveOrigin::Http => temp_dir.keep(),
+                ArchiveOrigin::Local => temp_dir.path().to_path_buf(),
+            },
+            Err(err) => {
+                return Err(Error::Extract(
+                    temp_dir.path().to_string_lossy().into_owned(),
+                    err,
+                ));
+            }
+        };
+
+        // Persist it to the cache.
+        fs_err::tokio::create_dir_all(target.parent().expect("Cache entry to have parent"))
+            .await
+            .map_err(Error::CacheWrite)?;
+        if let Err(err) = rename_with_retry(extracted, target).await {
+            // If the directory already exists, accept it.
+            if err.kind() == existing_directory {
+                warn!("Directory already exists: {}", target.display());
+            } else {
+                return Err(Error::CacheWrite(err));
+            }
+        }
+
+        Ok(metadata)
+    }
+}

--- a/crates/uv-distribution/src/source/validated_archive.rs
+++ b/crates/uv-distribution/src/source/validated_archive.rs
@@ -75,7 +75,7 @@ impl ValidatedSourceArchive {
             algorithms,
             ArchiveOrigin::Http,
             expected_size,
-            |_| source.to_string(),
+            source.to_string(),
             || Some(info_span!("download_source_dist", source_dist = %source)),
         )
         .await
@@ -95,6 +95,7 @@ impl ValidatedSourceArchive {
         let reader = fs_err::tokio::File::open(&path)
             .await
             .map_err(Error::CacheRead)?;
+        let error_context = temp_dir.path().to_string_lossy().into_owned();
         Self::extract(
             reader,
             ext,
@@ -102,7 +103,7 @@ impl ValidatedSourceArchive {
             algorithms,
             ArchiveOrigin::Local,
             None,
-            |path| path.to_string_lossy().into_owned(),
+            error_context,
             || None,
         )
         .await
@@ -116,7 +117,7 @@ impl ValidatedSourceArchive {
         algorithms: &[HashAlgorithm],
         origin: ArchiveOrigin,
         expected_size: Option<u64>,
-        error_context: impl Fn(&Path) -> String,
+        error_context: String,
         make_span: impl FnOnce() -> Option<Span>,
     ) -> Result<Self, Error> {
         // Create a hasher for each hash algorithm.
@@ -128,9 +129,9 @@ impl ValidatedSourceArchive {
         let mut hasher = HashReader::new(reader, &mut hashers);
 
         let span = make_span();
-        uv_extract::stream::archive(&mut hasher, ext, staging_dir.path())
-            .await
-            .map_err(|err| Error::Extract(error_context(staging_dir.path()), err))?;
+        if let Err(err) = uv_extract::stream::archive(&mut hasher, ext, staging_dir.path()).await {
+            return Err(Error::Extract(error_context, err));
+        }
         drop(span);
 
         // If necessary, exhaust the reader to compute hashes or validate the archive size.
@@ -141,7 +142,7 @@ impl ValidatedSourceArchive {
             && hasher.bytes_read() != expected
         {
             return Err(Error::MismatchedSize {
-                distribution: error_context(staging_dir.path()),
+                distribution: error_context,
                 expected,
                 actual: hasher.bytes_read(),
             });
@@ -207,13 +208,7 @@ mod tests {
 
     use anyhow::Result;
 
-    use uv_distribution_filename::LegacySourceDistExtension;
-
     use super::*;
-
-    // Two zero-filled records form an empty, valid tar archive.
-    const EMPTY_TAR: &[u8] = &[0; 1024];
-    const TAR: SourceDistExtension = SourceDistExtension::Legacy(LegacySourceDistExtension::Tar);
 
     async fn extract(
         bytes: &[u8],
@@ -231,12 +226,12 @@ mod tests {
         let staging_dir = tempfile::tempdir().map_err(Error::CacheWrite)?;
         ValidatedSourceArchive::extract(
             reader,
-            TAR,
+            SourceDistExtension::TarGz,
             staging_dir,
             algorithms,
             ArchiveOrigin::Http,
             expected_size,
-            |_| "source.tar".to_owned(),
+            "source.tar.gz".to_owned(),
             || None,
         )
         .await
@@ -245,16 +240,20 @@ mod tests {
     #[tokio::test]
     async fn reader_is_exhausted_only_for_hashes_or_size() -> Result<()> {
         let _preview = uv_preview::test::with_features(&[]);
+        let bytes = fs_err::read(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../test/links/basic_package-0.1.0.tar.gz"),
+        )?;
         let trailing_read = Cell::new(false);
-        extract(EMPTY_TAR, &trailing_read, &[], None).await?;
+        extract(&bytes, &trailing_read, &[], None).await?;
         assert!(!trailing_read.get());
 
         for (algorithms, size) in [
             (&[HashAlgorithm::Sha256][..], None),
-            (&[][..], Some(EMPTY_TAR.len() as u64)),
+            (&[][..], Some(bytes.len() as u64)),
         ] {
             assert!(matches!(
-                extract(EMPTY_TAR, &trailing_read, algorithms, size).await,
+                extract(&bytes, &trailing_read, algorithms, size).await,
                 Err(Error::HashExhaustion(_))
             ));
             assert!(trailing_read.replace(false));


### PR DESCRIPTION
Source archive helpers currently extract an archive and save it to the cache in the same call. Separate those steps so the type system records that extraction and its existing checks have completed before persistence.

Introduce a private `ValidatedSourceArchive` that owns the temporary directory. Its HTTP and local constructors retain their transport setup, diagnostics, and cleanup behavior, while a private reader helper performs the shared extraction and hash collection. The consuming `persist` method saves the source tree and returns the collected hashes and byte count. This preserves existing behavior; it does not add trusted-hash comparisons or change cache repair.

#21247 separates hash generation from verification, and #21248 checks caller-supplied hashes before persistence.
