### PR TITLE
Separate hash generation policy from verification policy

### DIFF
--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -18,7 +18,7 @@ use uv_pep508::RequirementOrigin;
 use uv_pypi_types::PyProjectToml;
 use uv_redacted::DisplaySafeUrl;
 use uv_resolver::{InMemoryIndex, MetadataResponse};
-use uv_types::{BuildContext, HashStrategy};
+use uv_types::{BuildContext, HashStrategy, HashVerification};
 
 #[derive(Debug, Clone)]
 pub enum SourceTree {
@@ -205,16 +205,20 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
 
         // Determine the hash policy. Since we don't have a package name, we perform a
         // manual match.
-        let hashes = match self.hasher {
-            HashStrategy::None => HashPolicy::None,
-            HashStrategy::Generate(mode) => HashPolicy::Generate(*mode),
-            HashStrategy::Verify(_) => HashPolicy::Generate(HashGeneration::All),
-            HashStrategy::Require(_) => {
+        let hashes = match self.hasher.verification() {
+            HashVerification::Required(_) => {
                 return Err(anyhow::anyhow!(
                     "Hash-checking is not supported for local directories: {}",
                     path.user_display()
                 ));
             }
+            HashVerification::IfPresent(_) => {
+                HashPolicy::Generate(self.hasher.generation().unwrap_or(HashGeneration::All))
+            }
+            HashVerification::None => self
+                .hasher
+                .generation()
+                .map_or(HashPolicy::None, HashPolicy::Generate),
         };
 
         // Fetch the metadata for the distribution.

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -58,7 +58,7 @@ impl HashStrategy {
 
     /// Set verification independently of hash generation.
     #[must_use]
-    pub fn with_verification(mut self, verification: HashVerification) -> Self {
+    fn with_verification(mut self, verification: HashVerification) -> Self {
         self.verification = verification;
         self
     }

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -15,130 +15,133 @@ use uv_pep440::Version;
 use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, HashError, ResolverMarkerEnvironment};
 use uv_redacted::DisplaySafeUrl;
 
+/// Hash generation and verification policies for a resolution.
+///
+/// Verification takes precedence for distributions with trusted hashes. The generation policy
+/// applies to the remaining distributions.
 #[derive(Debug, Default, Clone)]
-pub enum HashStrategy {
-    /// No hash policy is specified.
+pub struct HashStrategy {
+    generation: Option<HashGeneration>,
+    verification: HashVerification,
+}
+
+/// The trusted hashes to enforce when retrieving distributions.
+#[derive(Debug, Default, Clone)]
+pub enum HashVerification {
+    /// Hashes do not need to be validated.
     #[default]
     None,
-    /// Hashes should be generated (specifically, a SHA-256 hash), but not validated.
-    Generate(HashGeneration),
-    /// Hashes should be validated, if present, but ignored if absent.
-    ///
-    /// If necessary, hashes should be generated to ensure that the archive is valid.
-    Verify(Arc<FxHashMap<VersionId, Vec<HashDigest>>>),
-    /// Hashes should be validated against a pre-defined list of hashes.
-    ///
-    /// If necessary, hashes should be generated to ensure that the archive is valid.
-    Require(Arc<FxHashMap<VersionId, Vec<HashDigest>>>),
+    /// Validate known hashes, without requiring hashes for other distributions.
+    IfPresent(Arc<FxHashMap<VersionId, Vec<HashDigest>>>),
+    /// Every distribution must have a matching trusted hash.
+    Required(Arc<FxHashMap<VersionId, Vec<HashDigest>>>),
 }
 
 impl HashStrategy {
+    /// Generate hashes according to the given policy.
+    pub fn generate(generation: HashGeneration) -> Self {
+        Self {
+            generation: Some(generation),
+            ..Self::default()
+        }
+    }
+
+    /// Validate hashes when present.
+    pub fn verify(hashes: Arc<FxHashMap<VersionId, Vec<HashDigest>>>) -> Self {
+        Self::default().with_verification(HashVerification::IfPresent(hashes))
+    }
+
+    /// Require a matching trusted hash for every distribution.
+    fn require(hashes: Arc<FxHashMap<VersionId, Vec<HashDigest>>>) -> Self {
+        Self::default().with_verification(HashVerification::Required(hashes))
+    }
+
+    /// Set verification independently of hash generation.
+    #[must_use]
+    pub fn with_verification(mut self, verification: HashVerification) -> Self {
+        self.verification = verification;
+        self
+    }
+
+    /// Return the hash generation policy.
+    pub fn generation(&self) -> Option<HashGeneration> {
+        self.generation
+    }
+
+    /// Return the hash verification policy.
+    pub fn verification(&self) -> &HashVerification {
+        &self.verification
+    }
+
     /// Return the [`HashPolicy`] for the given distribution.
     pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> HashPolicy<'_> {
-        match self {
-            Self::None => HashPolicy::None,
-            Self::Generate(mode) => HashPolicy::Generate(*mode),
-            Self::Verify(hashes) => {
-                let id = distribution.version_id();
-                if let Some(hashes) = hashes.get(&id) {
-                    hash_policy(&id, hashes.as_slice())
-                } else {
-                    HashPolicy::None
-                }
-            }
-            Self::Require(hashes) => {
-                let id = distribution.version_id();
-                hash_policy(&id, hashes.get(&id).map(Vec::as_slice).unwrap_or_default())
-            }
-        }
+        self.get_id(|| distribution.version_id())
     }
 
     /// Return the [`HashPolicy`] for the given registry-based package.
     pub fn get_package(&self, name: &PackageName, version: &Version) -> HashPolicy<'_> {
-        let id = VersionId::from_registry(name.clone(), version.clone());
-        match self {
-            Self::None => HashPolicy::None,
-            Self::Generate(mode) => HashPolicy::Generate(*mode),
-            Self::Verify(hashes) => {
-                if let Some(hashes) = hashes.get(&id) {
-                    HashPolicy::Any(hashes.as_slice())
-                } else {
-                    HashPolicy::None
-                }
-            }
-            Self::Require(hashes) => {
-                HashPolicy::Any(hashes.get(&id).map(Vec::as_slice).unwrap_or_default())
-            }
-        }
+        self.get_id(|| VersionId::from_registry(name.clone(), version.clone()))
     }
 
     /// Return the [`HashPolicy`] for the given direct URL package.
     ///
     /// A direct URL identifies a single concrete artifact, so every provided digest must match.
     pub fn get_url(&self, url: &DisplaySafeUrl) -> HashPolicy<'_> {
-        let id = VersionId::from_url(url);
-        match self {
-            Self::None => HashPolicy::None,
-            Self::Generate(mode) => HashPolicy::Generate(*mode),
-            Self::Verify(hashes) => {
+        self.get_id(|| VersionId::from_url(url))
+    }
+
+    /// Construct an identity only when verification requires a lookup.
+    fn get_id(&self, id: impl FnOnce() -> VersionId) -> HashPolicy<'_> {
+        match &self.verification {
+            HashVerification::IfPresent(hashes) => {
+                let id = id();
                 if let Some(hashes) = hashes.get(&id) {
-                    HashPolicy::All(hashes.as_slice())
-                } else {
-                    HashPolicy::None
+                    return hash_policy(&id, hashes);
                 }
             }
-            Self::Require(hashes) => {
-                HashPolicy::All(hashes.get(&id).map(Vec::as_slice).unwrap_or_default())
+            HashVerification::Required(hashes) => {
+                let id = id();
+                return hash_policy(&id, hashes.get(&id).map(Vec::as_slice).unwrap_or_default());
             }
+            HashVerification::None => {}
         }
+        self.generation
+            .map_or(HashPolicy::None, HashPolicy::Generate)
     }
 
     /// Returns `true` if the given registry-based package is allowed.
     pub fn allows_package(&self, name: &PackageName, version: &Version) -> bool {
-        match self {
-            Self::None => true,
-            Self::Generate(_) => true,
-            Self::Verify(_) => true,
-            Self::Require(hashes) => {
+        match &self.verification {
+            HashVerification::Required(hashes) => {
                 hashes.contains_key(&VersionId::from_registry(name.clone(), version.clone()))
             }
+            HashVerification::None | HashVerification::IfPresent(_) => true,
         }
     }
 
     /// Returns `true` if the given direct URL package is allowed.
     pub fn allows_url(&self, url: &DisplaySafeUrl) -> bool {
-        match self {
-            Self::None => true,
-            Self::Generate(_) => true,
-            Self::Verify(_) => true,
-            Self::Require(hashes) => hashes.contains_key(&VersionId::from_url(url)),
+        match &self.verification {
+            HashVerification::Required(hashes) => hashes.contains_key(&VersionId::from_url(url)),
+            HashVerification::None | HashVerification::IfPresent(_) => true,
         }
     }
 
     /// Return a [`HashStrategy`] augmented with archive URL hashes discovered in additional
     /// requirements after the initial command-line parse.
     pub fn augment_with_requirements<'a>(
-        self,
+        mut self,
         requirements: impl Iterator<Item = &'a Requirement>,
     ) -> Result<Self, HashStrategyError> {
-        Ok(match self {
-            Self::None => Self::None,
-            Self::Generate(mode) => Self::Generate(mode),
-            Self::Verify(existing) => {
-                if let Some(hashes) = Self::augment_hashes(existing.as_ref(), requirements)? {
-                    Self::Verify(Arc::new(hashes))
-                } else {
-                    Self::Verify(existing)
+        match &mut self.verification {
+            HashVerification::None => {}
+            HashVerification::IfPresent(existing) | HashVerification::Required(existing) => {
+                if let Some(hashes) = Self::augment_hashes(existing, requirements)? {
+                    *existing = Arc::new(hashes);
                 }
             }
-            Self::Require(existing) => {
-                if let Some(hashes) = Self::augment_hashes(existing.as_ref(), requirements)? {
-                    Self::Require(Arc::new(hashes))
-                } else {
-                    Self::Require(existing)
-                }
-            }
-        })
+        }
+        Ok(self)
     }
 
     /// Generate the required hashes from a set of [`UnresolvedRequirement`] entries.
@@ -297,8 +300,8 @@ impl HashStrategy {
             .chain(requirement_hashes)
             .collect();
         match mode {
-            HashCheckingMode::Verify => Ok(Self::Verify(Arc::new(hashes))),
-            HashCheckingMode::Require => Ok(Self::Require(Arc::new(hashes))),
+            HashCheckingMode::Verify => Ok(Self::verify(Arc::new(hashes))),
+            HashCheckingMode::Require => Ok(Self::require(Arc::new(hashes))),
         }
     }
 
@@ -324,8 +327,8 @@ impl HashStrategy {
         }
 
         match mode {
-            HashCheckingMode::Verify => Ok(Self::Verify(Arc::new(hashes))),
-            HashCheckingMode::Require => Ok(Self::Require(Arc::new(hashes))),
+            HashCheckingMode::Verify => Ok(Self::verify(Arc::new(hashes))),
+            HashCheckingMode::Require => Ok(Self::require(Arc::new(hashes))),
         }
     }
 
@@ -510,15 +513,23 @@ pub enum HashStrategyError {
 
 #[cfg(test)]
 mod tests {
+    use std::slice;
     use std::str::FromStr;
+    use std::sync::Arc;
+
+    use rustc_hash::FxHashMap;
     use uv_configuration::HashCheckingMode;
     use uv_distribution_filename::DistExtension;
     use uv_distribution_types::{
-        HashPolicy, Requirement, RequirementSource, UnresolvedRequirement,
+        HashGeneration, HashPolicy, Requirement, RequirementSource, UnresolvedRequirement,
+        VersionId,
     };
+    use uv_normalize::PackageName;
+    use uv_pep440::Version;
     use uv_pypi_types::HashDigest;
+    use uv_redacted::DisplaySafeUrl;
 
-    use super::HashStrategy;
+    use super::{HashStrategy, HashVerification};
 
     fn requirement(url: &str) -> Requirement {
         Requirement {
@@ -576,5 +587,61 @@ mod tests {
             };
             assert_eq!(hasher.get_url(url), HashPolicy::All(expected.as_slice()));
         }
+    }
+
+    #[test]
+    fn generate_and_verify_validates_known_hashes_and_generates_unknown_hashes()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let url: DisplaySafeUrl = "https://example.com/anyio-4.0.0.tar.gz".parse()?;
+        let unknown_url: DisplaySafeUrl = "https://example.com/anyio-4.1.0.tar.gz".parse()?;
+        let name: PackageName = "anyio".parse()?;
+        let version: Version = "4.0.0".parse()?;
+        let unknown_version: Version = "4.1.0".parse()?;
+        let digest = HashDigest::from_str(
+            "sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f",
+        )?;
+        let hashes = FxHashMap::from_iter([
+            (VersionId::from_url(&url), vec![digest.clone()]),
+            (
+                VersionId::from_registry(name.clone(), version.clone()),
+                vec![digest.clone()],
+            ),
+        ]);
+        let strategy = HashStrategy::generate(HashGeneration::All)
+            .with_verification(HashVerification::IfPresent(Arc::new(hashes)));
+
+        assert_eq!(
+            strategy.get_url(&url),
+            HashPolicy::All(slice::from_ref(&digest))
+        );
+        assert_eq!(
+            strategy.get_url(&unknown_url),
+            HashPolicy::Generate(HashGeneration::All)
+        );
+        assert_eq!(
+            strategy.get_package(&name, &version),
+            HashPolicy::Any(slice::from_ref(&digest))
+        );
+        assert_eq!(
+            strategy.get_package(&name, &unknown_version),
+            HashPolicy::Generate(HashGeneration::All)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn required_hashes_take_precedence_over_generation() -> Result<(), Box<dyn std::error::Error>> {
+        let url: DisplaySafeUrl = "https://example.com/anyio-4.0.0.tar.gz".parse()?;
+        let name: PackageName = "anyio".parse()?;
+        let version: Version = "4.0.0".parse()?;
+        let strategy = HashStrategy::generate(HashGeneration::All)
+            .with_verification(HashVerification::Required(Arc::default()));
+
+        assert_eq!(strategy.get_url(&url), HashPolicy::All(&[]));
+        assert_eq!(strategy.get_package(&name, &version), HashPolicy::Any(&[]));
+        assert!(!strategy.allows_url(&url));
+        assert!(!strategy.allows_package(&name, &version));
+        Ok(())
     }
 }

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -649,7 +649,7 @@ async fn build_package(
             hash_checking,
         )?
     } else {
-        HashStrategy::None
+        HashStrategy::default()
     };
 
     let build_constraints = Constraints::from_requirements(

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -414,9 +414,9 @@ pub(crate) async fn pip_compile(
     // Generate, but don't enforce hashes for the requirements. PEP 751 _requires_ a hash to be
     // present, but otherwise, we omit them by default.
     let hasher = if generate_hashes || matches!(format, PipCompileFormat::PylockToml) {
-        HashStrategy::Generate(HashGeneration::All)
+        HashStrategy::generate(HashGeneration::All)
     } else {
-        HashStrategy::None
+        HashStrategy::default()
     };
 
     // Incorporate any index locations from the provided sources.
@@ -516,7 +516,7 @@ pub(crate) async fn pip_compile(
     };
 
     // Don't enforce hashes in `pip compile`.
-    let build_hashes = HashStrategy::None;
+    let build_hashes = HashStrategy::default();
     let build_constraints = Constraints::from_requirements(
         build_constraints
             .iter()

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -407,7 +407,7 @@ pub(crate) async fn pip_install(
             hash_checking,
         )?
     } else {
-        HashStrategy::None
+        HashStrategy::default()
     };
 
     // Incorporate any index locations from the provided sources.
@@ -492,7 +492,7 @@ pub(crate) async fn pip_install(
             HashCheckingMode::Verify,
         )?
     } else {
-        HashStrategy::None
+        HashStrategy::default()
     };
     let build_constraints = Constraints::from_requirements(
         build_constraints

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -279,7 +279,7 @@ pub(crate) async fn pip_sync(
             hash_checking,
         )?
     } else {
-        HashStrategy::None
+        HashStrategy::default()
     };
 
     // Incorporate any index locations from the provided sources.
@@ -364,7 +364,7 @@ pub(crate) async fn pip_sync(
             HashCheckingMode::Verify,
         )?
     } else {
-        HashStrategy::None
+        HashStrategy::default()
     };
     let build_constraints = Constraints::from_requirements(
         build_constraints

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -22,7 +22,7 @@ use uv_distribution_types::{
 use uv_preview::Preview;
 use uv_python::{Interpreter, PythonEnvironment, canonicalize_executable};
 use uv_settings::MalwareCheckSettings;
-use uv_types::{HashStrategy, SourceTreeEditablePolicy};
+use uv_types::{HashStrategy, HashVerification, SourceTreeEditablePolicy};
 use uv_workspace::WorkspaceCache;
 
 /// An ephemeral [`PythonEnvironment`] for running an individual command.
@@ -121,12 +121,12 @@ fn cached_environment_resolution_hash(
     resolution_hash: String,
     hash_strategy: &HashStrategy,
 ) -> String {
-    match hash_strategy {
+    match hash_strategy.verification() {
         // Preserve existing cache identities for environments materialized without verification.
-        HashStrategy::None | HashStrategy::Generate(_) => resolution_hash,
+        HashVerification::None => resolution_hash,
         // Never reuse an environment materialized without hash verification for a lock-backed
         // resolution with the same distributions and expected hashes.
-        HashStrategy::Verify(_) | HashStrategy::Require(_) => {
+        HashVerification::IfPresent(_) | HashVerification::Required(_) => {
             hash_digest(&("verify", resolution_hash))
         }
     }
@@ -416,10 +416,10 @@ mod tests {
     fn verified_cached_environment_uses_separate_resolution_hash() {
         let resolution_hash = hash_digest(&["ty==0.0.17"]);
         let unverified =
-            cached_environment_resolution_hash(resolution_hash.clone(), &HashStrategy::None);
+            cached_environment_resolution_hash(resolution_hash.clone(), &HashStrategy::default());
         let verified = cached_environment_resolution_hash(
             resolution_hash.clone(),
-            &HashStrategy::Verify(Arc::default()),
+            &HashStrategy::verify(Arc::default()),
         );
 
         assert_eq!(unverified, resolution_hash);

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -835,7 +835,7 @@ async fn do_lock(
         .build_options(build_options.clone())
         .artifact_environments(artifact_environments.clone())
         .build();
-    let hasher = HashStrategy::Generate(HashGeneration::Url);
+    let hasher = HashStrategy::generate(HashGeneration::Url);
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them
     // optional on the downstream APIs.

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -2657,7 +2657,7 @@ pub(crate) async fn resolve_environment(
     let groups = BTreeMap::new();
     let hasher = match resolution_scope {
         EnvironmentResolution::Specific => HashStrategy::default(),
-        EnvironmentResolution::Universal => HashStrategy::Generate(HashGeneration::Url),
+        EnvironmentResolution::Universal => HashStrategy::generate(HashGeneration::Url),
     };
     let build_hasher = HashStrategy::default();
 

--- a/crates/uv/src/commands/pylock.rs
+++ b/crates/uv/src/commands/pylock.rs
@@ -92,7 +92,7 @@ pub(crate) fn resolve_pylock_toml(
     let hasher = if let Some(hash_checking) = hash_checking {
         HashStrategy::from_resolution(&resolution, hash_checking)?
     } else {
-        HashStrategy::None
+        HashStrategy::default()
     };
 
     Ok((resolution, hasher))

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -463,7 +463,7 @@ impl ToolLock {
             .index_strategy(*index_strategy)
             .build_options(build_options.clone())
             .build();
-        let hasher = HashStrategy::Generate(HashGeneration::Url);
+        let hasher = HashStrategy::generate(HashGeneration::Url);
         let build_hasher = HashStrategy::default();
 
         let flat_index = {

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -308,7 +308,7 @@ pub(crate) async fn venv(
             FlatIndex::from_entries(
                 entries,
                 Some(tags),
-                &HashStrategy::None,
+                &HashStrategy::default(),
                 &BuildOptions::new(NoBinary::None, NoBuild::All),
             )
         };


### PR DESCRIPTION
`HashStrategy` currently represents hash generation and verification as mutually exclusive choices. A resolution may need both: verify artifacts whose hashes have been supplied, while generating hashes for new artifacts.

Store generation separately from `HashVerification` in `HashStrategy`. Each distribution still receives a `HashPolicy` specifying whether to generate or check hashes. Update existing call sites to use the separate settings while preserving their hash inputs and which hashes uv treats as trusted. Generation remains available for artifacts without supplied hashes, unless the caller requires a hash for every artifact. This does not read hashes from `uv.lock` or add new archive comparisons.

Based on #21246. #21248 checks caller-supplied hashes before source archives enter the cache. #21223 reads hashes from an existing `uv.lock` and supplies them for verification.
