### PR TITLE
Validate source archives before cache persistence

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -15,8 +15,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use fs_err::tokio as fs;
-use futures::FutureExt;
+use futures::{FutureExt, TryStreamExt};
 use reqwest::{Response, StatusCode};
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{Instrument, debug, info_span, instrument, warn};
 use url::Url;
 
@@ -48,11 +49,10 @@ use uv_workspace::pyproject::ToolUvSources;
 
 use crate::distribution_database::ManagedClient;
 use crate::error::Error;
-use crate::hash::http_hash_algorithms;
 use crate::metadata::{ArchiveMetadata, GitWorkspaceMember, Metadata};
 use crate::source::built_wheel_metadata::{BuiltWheelFile, BuiltWheelMetadata};
 use crate::source::revision::Revision;
-use crate::source::validated_archive::ValidatedSourceArchive;
+use crate::source::validated_archive::{ArchiveValidation, ValidatedSourceArchive};
 use crate::{Reporter, RequiresDist};
 
 mod built_wheel_metadata;
@@ -982,9 +982,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 // Download the source distribution.
                 debug!("Downloading source distribution: {source}");
                 let entry = cache_shard.shard(revision.id()).entry(SOURCE);
-                let algorithms = http_hash_algorithms(hashes);
                 let (hashes, size) = self
-                    .download_archive(response, source, ext, entry.path(), &algorithms)
+                    .download_archive(response, source, ext, entry.path(), hashes, &[])
                     .await?;
 
                 Ok(revision
@@ -1350,9 +1349,15 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Unzip the archive to a temporary directory.
         debug!("Unpacking source distribution: {source}");
         let entry = cache_shard.shard(revision.id()).entry(SOURCE);
-        let algorithms = hashes.algorithms();
         let hashes = self
-            .persist_archive(&resource.path, resource.ext, entry.path(), &algorithms)
+            .persist_archive(
+                source,
+                &resource.path,
+                resource.ext,
+                entry.path(),
+                hashes,
+                &[],
+            )
             .await?;
 
         // Include the hashes and cache info in the revision.
@@ -1829,9 +1834,15 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Otherwise, we need to unzip the archive, or at least compute the hashes.
         debug!("Unpacking source distribution: {source}");
         let entry = cache_shard.entry(SOURCE);
-        let algorithms = hashes.algorithms();
         let hashes = self
-            .persist_archive(&install_path, resource.ext, entry.path(), &algorithms)
+            .persist_archive(
+                source,
+                &install_path,
+                resource.ext,
+                entry.path(),
+                hashes,
+                &[],
+            )
             .await?;
 
         // Persist the revision.
@@ -2708,25 +2719,16 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     ) -> Result<Revision, Error> {
         warn!("Re-extracting missing source distribution: {source}");
 
-        // Take the union of the requested and existing hash algorithms.
-        let algorithms = {
-            let mut algorithms = hashes.algorithms();
-            for digest in revision.hashes() {
-                algorithms.push(digest.algorithm());
-            }
-            algorithms.sort();
-            algorithms.dedup();
-            algorithms
-        };
-
         let hashes = self
-            .persist_archive(&resource.path, resource.ext, entry.path(), &algorithms)
+            .persist_archive(
+                source,
+                &resource.path,
+                resource.ext,
+                entry.path(),
+                hashes,
+                revision.hashes(),
+            )
             .await?;
-        for existing in revision.hashes() {
-            if !hashes.contains(existing) {
-                return Err(Error::CacheHeal(source.to_string(), existing.algorithm()));
-            }
-        }
         Ok(revision.with_hashes(HashDigests::from(hashes)))
     }
 
@@ -2767,25 +2769,16 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         let download = |response| {
             async {
-                // Take the union of the requested and existing hash algorithms.
-                let algorithms = {
-                    let mut algorithms = http_hash_algorithms(hashes);
-                    for digest in revision.hashes() {
-                        algorithms.push(digest.algorithm());
-                    }
-                    algorithms.sort();
-                    algorithms.dedup();
-                    algorithms
-                };
-
                 let (hashes, size) = self
-                    .download_archive(response, source, ext, entry.path(), &algorithms)
+                    .download_archive(
+                        response,
+                        source,
+                        ext,
+                        entry.path(),
+                        hashes,
+                        revision.hashes(),
+                    )
                     .await?;
-                for existing in revision.hashes() {
-                    if !hashes.contains(existing) {
-                        return Err(Error::CacheHeal(source.to_string(), existing.algorithm()));
-                    }
-                }
                 Ok(revision
                     .clone()
                     .with_hashes(HashDigests::from(hashes))
@@ -2820,15 +2813,34 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         ext: SourceDistExtension,
         target: &Path,
-        algorithms: &[HashAlgorithm],
+        hash_policy: HashPolicy<'_>,
+        existing_hashes: &[HashDigest],
     ) -> Result<(Vec<HashDigest>, u64), Error> {
-        let archive = ValidatedSourceArchive::extract_http(
-            response,
+        let reader = response
+            .bytes_stream()
+            .map_err(std::io::Error::other)
+            .into_async_read();
+        let expected_size = match source {
+            BuildableSource::Dist(SourceDist::Registry(dist)) if dist.size_is_authoritative => {
+                dist.size()
+            }
+            BuildableSource::Dist(SourceDist::DirectUrl(dist)) => dist.size(),
+            _ => None,
+        };
+
+        let archive = ValidatedSourceArchive::extract(
+            reader.compat(),
             source,
             ext,
             self.build_context.cache(),
-            algorithms,
+            ArchiveValidation {
+                extra_algorithms: &[HashAlgorithm::Sha256],
+                hash_policy,
+                existing_hashes,
+                expected_size,
+            },
         )
+        .instrument(info_span!("download_source_dist", source_dist = %source))
         .await?;
         let metadata = archive.persist(target).await?;
         Ok((metadata.hashes, metadata.size))
@@ -2837,16 +2849,28 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     /// Extract, validate, and persist a local source archive into the cache.
     async fn persist_archive(
         &self,
+        source: &BuildableSource<'_>,
         path: &Path,
         ext: SourceDistExtension,
         target: &Path,
-        algorithms: &[HashAlgorithm],
+        hash_policy: HashPolicy<'_>,
+        existing_hashes: &[HashDigest],
     ) -> Result<Vec<HashDigest>, Error> {
-        let archive = ValidatedSourceArchive::extract_local(
-            path,
+        debug!("Unpacking for build: {}", path.display());
+        let reader = fs_err::tokio::File::open(path)
+            .await
+            .map_err(Error::CacheRead)?;
+        let archive = ValidatedSourceArchive::extract(
+            reader,
+            source,
             ext,
             self.build_context.cache(),
-            algorithms,
+            ArchiveValidation {
+                extra_algorithms: &[],
+                hash_policy,
+                existing_hashes,
+                expected_size: None,
+            },
         )
         .await?;
         Ok(archive.persist(target).await?.hashes)

--- a/crates/uv-distribution/src/source/validated_archive.rs
+++ b/crates/uv-distribution/src/source/validated_archive.rs
@@ -1,31 +1,38 @@
 use std::io::ErrorKind;
 use std::path::Path;
 
-use futures::TryStreamExt;
-use reqwest::Response;
 use tempfile::TempDir;
 use tokio::io::AsyncRead;
-use tokio_util::compat::FuturesAsyncReadCompatExt;
-use tracing::{Span, debug, info_span, warn};
+use tracing::warn;
 
 use uv_cache::{Cache, CacheBucket};
 use uv_distribution_filename::SourceDistExtension;
-use uv_distribution_types::{BuildableSource, RemoteSource, SourceDist};
+use uv_distribution_types::{BuildableSource, HashPolicy};
 use uv_extract::hash::{HashReader, Hasher};
 use uv_fs::rename_with_retry;
 use uv_pypi_types::{HashAlgorithm, HashDigest};
 
 use crate::error::Error;
 
-/// An extracted source archive that satisfies the checks requested during extraction.
+/// The checks required before an extracted source archive can be persisted to the cache.
+pub(super) struct ArchiveValidation<'a> {
+    /// Additional hashes to generate beyond those required for validation.
+    pub(super) extra_algorithms: &'a [HashAlgorithm],
+    /// The caller's trusted hash policy.
+    pub(super) hash_policy: HashPolicy<'a>,
+    /// Every digest from a cache revision being repaired must remain unchanged.
+    pub(super) existing_hashes: &'a [HashDigest],
+    pub(super) expected_size: Option<u64>,
+}
+
+/// An extracted source archive that satisfies its requested size and hash checks.
 ///
 /// The staging directory and fields are private to this module. Callers can only obtain this type
-/// through extraction, so only a validated archive can be persisted. Persisting consumes the value
-/// and returns the metadata computed during extraction.
+/// through [`Self::extract`], so only a validated archive can be persisted. Persisting consumes the
+/// value, while dropping it removes the staged files.
 pub(super) struct ValidatedSourceArchive {
     staging_dir: TempDir,
     metadata: SourceArchiveMetadata,
-    origin: ArchiveOrigin,
 }
 
 /// Metadata computed while consuming a source archive.
@@ -34,93 +41,24 @@ pub(super) struct SourceArchiveMetadata {
     pub(super) size: u64,
 }
 
-/// Controls cache-rename collisions and cleanup of non-singular archives.
-///
-/// HTTP archives accept [`ErrorKind::AlreadyExists`] and use [`TempDir::keep`] when the archive
-/// contains multiple top-level entries. Local archives accept [`ErrorKind::DirectoryNotEmpty`] and
-/// retain automatic temporary-directory cleanup.
-enum ArchiveOrigin {
-    Http,
-    Local,
-}
-
 impl ValidatedSourceArchive {
-    /// Download and extract a source distribution, computing its hashes and checking its size.
-    pub(super) async fn extract_http(
-        response: Response,
+    /// Extract into a fresh temporary directory and validate the complete archive before returning.
+    pub(super) async fn extract(
+        reader: impl AsyncRead + Unpin,
         source: &BuildableSource<'_>,
         ext: SourceDistExtension,
         cache: &Cache,
-        algorithms: &[HashAlgorithm],
+        validation: ArchiveValidation<'_>,
     ) -> Result<Self, Error> {
-        let temp_dir = tempfile::tempdir_in(cache.bucket(CacheBucket::SourceDistributions))
+        let staging_dir = tempfile::tempdir_in(cache.bucket(CacheBucket::SourceDistributions))
             .map_err(Error::CacheWrite)?;
 
-        let reader = response
-            .bytes_stream()
-            .map_err(std::io::Error::other)
-            .into_async_read();
-
-        let expected_size = match source {
-            BuildableSource::Dist(SourceDist::Registry(dist)) if dist.size_is_authoritative => {
-                dist.size()
-            }
-            BuildableSource::Dist(SourceDist::DirectUrl(dist)) => dist.size(),
-            _ => None,
-        };
-        Self::extract(
-            reader.compat(),
-            ext,
-            temp_dir,
-            algorithms,
-            ArchiveOrigin::Http,
-            expected_size,
-            source.to_string(),
-            || Some(info_span!("download_source_dist", source_dist = %source)),
-        )
-        .await
-    }
-
-    /// Extract a local source archive and compute its requested hashes.
-    pub(super) async fn extract_local(
-        path: &Path,
-        ext: SourceDistExtension,
-        cache: &Cache,
-        algorithms: &[HashAlgorithm],
-    ) -> Result<Self, Error> {
-        debug!("Unpacking for build: {}", path.display());
-
-        let temp_dir = tempfile::tempdir_in(cache.bucket(CacheBucket::SourceDistributions))
-            .map_err(Error::CacheWrite)?;
-        let reader = fs_err::tokio::File::open(&path)
-            .await
-            .map_err(Error::CacheRead)?;
-        let error_context = temp_dir.path().to_string_lossy().into_owned();
-        Self::extract(
-            reader,
-            ext,
-            temp_dir,
-            algorithms,
-            ArchiveOrigin::Local,
-            None,
-            error_context,
-            || None,
-        )
-        .await
-    }
-
-    /// Extract into private staging and complete the requested checks before constructing a value.
-    async fn extract(
-        reader: impl AsyncRead + Unpin,
-        ext: SourceDistExtension,
-        staging_dir: TempDir,
-        algorithms: &[HashAlgorithm],
-        origin: ArchiveOrigin,
-        expected_size: Option<u64>,
-        error_context: String,
-        make_span: impl FnOnce() -> Option<Span>,
-    ) -> Result<Self, Error> {
-        // Create a hasher for each hash algorithm.
+        // Include every algorithm needed to validate the caller's policy or repair an old revision.
+        let mut algorithms = validation.hash_policy.algorithms();
+        algorithms.extend_from_slice(validation.extra_algorithms);
+        algorithms.extend(validation.existing_hashes.iter().map(HashDigest::algorithm));
+        algorithms.sort();
+        algorithms.dedup();
         let mut hashers = algorithms
             .iter()
             .copied()
@@ -128,111 +66,138 @@ impl ValidatedSourceArchive {
             .collect::<Vec<_>>();
         let mut hasher = HashReader::new(reader, &mut hashers);
 
-        let span = make_span();
-        if let Err(err) = uv_extract::stream::archive(&mut hasher, ext, staging_dir.path()).await {
-            return Err(Error::Extract(error_context, err));
-        }
-        drop(span);
+        uv_extract::stream::archive(&mut hasher, ext, staging_dir.path())
+            .await
+            .map_err(|err| Error::Extract(source.to_string(), err))?;
 
-        // If necessary, exhaust the reader to compute hashes or validate the archive size.
-        if !algorithms.is_empty() || expected_size.is_some() {
+        if !algorithms.is_empty() || validation.expected_size.is_some() {
             hasher.finish().await.map_err(Error::HashExhaustion)?;
         }
-        if let Some(expected) = expected_size
-            && hasher.bytes_read() != expected
+        let size = hasher.bytes_read();
+        if let Some(expected) = validation.expected_size
+            && size != expected
         {
             return Err(Error::MismatchedSize {
-                distribution: error_context,
+                distribution: source.to_string(),
                 expected,
-                actual: hasher.bytes_read(),
+                actual: size,
             });
         }
 
-        let size = hasher.bytes_read();
-        let hashes = hashers.into_iter().map(HashDigest::from).collect();
-
+        let hashes = hashers
+            .into_iter()
+            .map(HashDigest::from)
+            .collect::<Vec<_>>();
+        if validation.hash_policy.requires_validation() && !validation.hash_policy.matches(&hashes)
+        {
+            return Err(Error::hash_mismatch(
+                source.to_string(),
+                validation.hash_policy.digests(),
+                &hashes,
+            ));
+        }
+        for existing in validation.existing_hashes {
+            if !hashes.contains(existing) {
+                return Err(Error::CacheHeal(source.to_string(), existing.algorithm()));
+            }
+        }
         Ok(Self {
             staging_dir,
             metadata: SourceArchiveMetadata { hashes, size },
-            origin,
         })
     }
 
     /// Persist the validated source tree and return metadata computed during extraction.
     pub(super) async fn persist(self, target: &Path) -> Result<SourceArchiveMetadata, Error> {
-        let Self {
-            staging_dir: temp_dir,
-            metadata,
-            origin,
-        } = self;
-        let existing_directory = match origin {
-            ArchiveOrigin::Http => ErrorKind::AlreadyExists,
-            ArchiveOrigin::Local => ErrorKind::DirectoryNotEmpty,
-        };
-
-        // Extract the top-level directory.
-        let extracted = match uv_extract::strip_component(temp_dir.path()) {
+        let extracted = match uv_extract::strip_component(self.staging_dir.path()) {
             Ok(top_level) => top_level,
-            Err(uv_extract::Error::NonSingularArchive(_)) => match origin {
-                ArchiveOrigin::Http => temp_dir.keep(),
-                ArchiveOrigin::Local => temp_dir.path().to_path_buf(),
-            },
+            Err(uv_extract::Error::NonSingularArchive(_)) => self.staging_dir.path().to_path_buf(),
             Err(err) => {
                 return Err(Error::Extract(
-                    temp_dir.path().to_string_lossy().into_owned(),
+                    self.staging_dir.path().to_string_lossy().into_owned(),
                     err,
                 ));
             }
         };
 
-        // Persist it to the cache.
         fs_err::tokio::create_dir_all(target.parent().expect("Cache entry to have parent"))
             .await
             .map_err(Error::CacheWrite)?;
         if let Err(err) = rename_with_retry(extracted, target).await {
-            // If the directory already exists, accept it.
-            if err.kind() == existing_directory {
+            // Another task may have persisted the same revision. Accept an existing directory,
+            // accounting for the different errors returned by Unix and Windows.
+            if matches!(
+                err.kind(),
+                ErrorKind::AlreadyExists | ErrorKind::DirectoryNotEmpty
+            ) && fs_err::tokio::symlink_metadata(target)
+                .await
+                .is_ok_and(|metadata| metadata.is_dir())
+            {
                 warn!("Directory already exists: {}", target.display());
             } else {
                 return Err(Error::CacheWrite(err));
             }
         }
 
-        Ok(metadata)
+        Ok(self.metadata)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::slice;
 
     use anyhow::Result;
+    use futures::TryStreamExt;
+    use tokio_util::compat::FuturesAsyncReadCompatExt;
+
+    use uv_distribution_types::{DirectSourceUrl, HashGeneration, SourceUrl};
+    use uv_redacted::DisplaySafeUrl;
 
     use super::*;
 
-    async fn extract(
-        bytes: &[u8],
-        trailing_read: &Cell<bool>,
-        algorithms: &[HashAlgorithm],
-        expected_size: Option<u64>,
-    ) -> Result<ValidatedSourceArchive, Error> {
-        let reader = futures::stream::iter([
+    const NO_VALIDATION: ArchiveValidation<'static> = ArchiveValidation {
+        extra_algorithms: &[],
+        hash_policy: HashPolicy::None,
+        existing_hashes: &[],
+        expected_size: None,
+    };
+
+    fn cache() -> Result<Cache> {
+        let cache = Cache::temp()?;
+        fs_err::create_dir_all(cache.bucket(CacheBucket::SourceDistributions))?;
+        Ok(cache)
+    }
+
+    fn reader<'a>(bytes: &'a [u8], trailing_read: &'a Cell<bool>) -> impl AsyncRead + Unpin + 'a {
+        futures::stream::iter([
             Ok(bytes),
             Err(std::io::Error::other("unexpected trailing read")),
         ])
         .inspect_err(|_| trailing_read.set(true))
         .into_async_read()
-        .compat();
-        let staging_dir = tempfile::tempdir().map_err(Error::CacheWrite)?;
+        .compat()
+    }
+
+    async fn extract(
+        cache: &Cache,
+        reader: impl AsyncRead + Unpin,
+        validation: ArchiveValidation<'_>,
+    ) -> Result<ValidatedSourceArchive, Error> {
+        let url =
+            DisplaySafeUrl::parse("https://example.com/source.tar.gz").expect("valid test URL");
+        let source = BuildableSource::Url(SourceUrl::Direct(DirectSourceUrl {
+            url: &url,
+            subdirectory: None,
+            ext: SourceDistExtension::TarGz,
+        }));
         ValidatedSourceArchive::extract(
             reader,
+            &source,
             SourceDistExtension::TarGz,
-            staging_dir,
-            algorithms,
-            ArchiveOrigin::Http,
-            expected_size,
-            "source.tar.gz".to_owned(),
-            || None,
+            cache,
+            validation,
         )
         .await
     }
@@ -244,16 +209,32 @@ mod tests {
             Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join("../../test/links/basic_package-0.1.0.tar.gz"),
         )?;
+        let cache = cache()?;
         let trailing_read = Cell::new(false);
-        extract(&bytes, &trailing_read, &[], None).await?;
+        extract(&cache, reader(&bytes, &trailing_read), NO_VALIDATION).await?;
         assert!(!trailing_read.get());
 
-        for (algorithms, size) in [
-            (&[HashAlgorithm::Sha256][..], None),
-            (&[][..], Some(bytes.len() as u64)),
+        let digest = HashDigest::from(Hasher::from(HashAlgorithm::Sha256));
+        for validation in [
+            ArchiveValidation {
+                extra_algorithms: &[HashAlgorithm::Sha256],
+                ..NO_VALIDATION
+            },
+            ArchiveValidation {
+                hash_policy: HashPolicy::Generate(HashGeneration::All),
+                ..NO_VALIDATION
+            },
+            ArchiveValidation {
+                existing_hashes: slice::from_ref(&digest),
+                ..NO_VALIDATION
+            },
+            ArchiveValidation {
+                expected_size: Some(bytes.len() as u64),
+                ..NO_VALIDATION
+            },
         ] {
             assert!(matches!(
-                extract(&bytes, &trailing_read, algorithms, size).await,
+                extract(&cache, reader(&bytes, &trailing_read), validation).await,
                 Err(Error::HashExhaustion(_))
             ));
             assert!(trailing_read.replace(false));
@@ -262,19 +243,82 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn parser_error_precedes_trailing_read() {
+    async fn parser_error_precedes_trailing_read() -> Result<()> {
         let _preview = uv_preview::test::with_features(&[]);
+        let cache = cache()?;
         let trailing_read = Cell::new(false);
         assert!(matches!(
             extract(
-                &[0xff; 512],
-                &trailing_read,
-                &[HashAlgorithm::Sha256],
-                Some(1)
+                &cache,
+                reader(&[0xff; 512], &trailing_read),
+                ArchiveValidation {
+                    extra_algorithms: &[HashAlgorithm::Sha256],
+                    expected_size: Some(1),
+                    ..NO_VALIDATION
+                },
             )
             .await,
             Err(Error::Extract(_, _))
         ));
         assert!(!trailing_read.get());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn staging_directory_is_removed_on_drop_or_failure() -> Result<()> {
+        let _preview = uv_preview::test::with_features(&[]);
+        let bytes = fs_err::read(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../test/links/basic_package-0.1.0.tar.gz"),
+        )?;
+        let cache = cache()?;
+        let wrong_hash = HashDigest::from(Hasher::from(HashAlgorithm::Sha256));
+        let result = extract(
+            &cache,
+            &bytes[..],
+            ArchiveValidation {
+                hash_policy: HashPolicy::All(&[wrong_hash]),
+                ..NO_VALIDATION
+            },
+        )
+        .await;
+        assert!(matches!(result, Err(Error::MismatchedHashes { .. })));
+        assert!(
+            fs_err::read_dir(cache.bucket(CacheBucket::SourceDistributions))?
+                .next()
+                .is_none()
+        );
+
+        let existing_hash = HashDigest {
+            algorithm: HashAlgorithm::Sha512,
+            digest: "f754f5955ce76c8fbdccdacd6e0e34977354b04d062d7f993fa84f3301309257fd225c85ebc99571b8b8ad711b37c407af65c5eae73599802ea3b4d3082d2f32".into(),
+        };
+        let archive = extract(
+            &cache,
+            &bytes[..],
+            ArchiveValidation {
+                existing_hashes: slice::from_ref(&existing_hash),
+                ..NO_VALIDATION
+            },
+        )
+        .await?;
+        assert_eq!(archive.metadata.hashes, [existing_hash]);
+        assert_eq!(archive.metadata.size, bytes.len() as u64);
+        let staging_dir = archive.staging_dir.path().to_path_buf();
+        assert!(staging_dir.is_dir());
+        drop(archive);
+        assert!(!staging_dir.exists());
+
+        let archive = extract(&cache, &bytes[..], NO_VALIDATION).await?;
+        let staging_dir = archive.staging_dir.path().to_path_buf();
+        let target = cache.root().join("persisted");
+        fs_err::write(&target, b"existing")?;
+        assert!(matches!(
+            archive.persist(&target).await,
+            Err(Error::CacheWrite(_))
+        ));
+        assert!(!staging_dir.exists());
+        assert_eq!(fs_err::read(target)?, b"existing");
+        Ok(())
     }
 }

--- a/crates/uv-distribution/src/source/validated_archive.rs
+++ b/crates/uv-distribution/src/source/validated_archive.rs
@@ -311,14 +311,16 @@ mod tests {
 
         let archive = extract(&cache, &bytes[..], NO_VALIDATION).await?;
         let staging_dir = archive.staging_dir.path().to_path_buf();
-        let target = cache.root().join("persisted");
-        fs_err::write(&target, b"existing")?;
+        // A file in place of the parent directory makes cache creation fail on every platform.
+        let parent = cache.root().join("not-a-directory");
+        fs_err::write(&parent, b"existing")?;
+        let target = parent.join("persisted");
         assert!(matches!(
             archive.persist(&target).await,
             Err(Error::CacheWrite(_))
         ));
         assert!(!staging_dir.exists());
-        assert_eq!(fs_err::read(target)?, b"existing");
+        assert_eq!(fs_err::read(parent)?, b"existing");
         Ok(())
     }
 }


### PR DESCRIPTION
Source archives can be saved to the cache before their caller-supplied hashes are checked. Cache repair can also save replacement contents before detecting a mismatch with the previous revision.

Check supplied hashes alongside the existing download-size check in `ValidatedSourceArchive::extract`, before it returns the value consumed by `persist`. Check every digest from a previous revision there too, before a repaired source tree is saved. Extraction still streams into a private temporary directory and returns parser errors immediately.

This also removes the split in persistence behavior captured by `ArchiveOrigin`. HTTP and local archives now accept `AlreadyExists` or `DirectoryNotEmpty` only when the destination is a directory, and both retain temporary-directory ownership through persistence. The HTTP path no longer calls `TempDir::keep` for archives with multiple top-level entries, so failed persistence attempts clean up those staged files too.

HTTP response handling and local file opening remain separate, and cache locations and `rename_with_retry` are unchanged. The caller still supplies the hashes and any download size to check; this PR does not read trusted hashes from `uv.lock`. #21223 supplies the hashes recorded in an existing `uv.lock`.

Based on #21247.
