### PR TITLE
Format lock snapshot command chains

### DIFF
--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -3603,7 +3603,10 @@ fn lock_conflicting_project_basic1() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock_without_metadata.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("package-conflicts,lock-without-metadata").arg("--locked"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -3617,7 +3620,10 @@ fn lock_conflicting_project_basic1() -> Result<()> {
         .child("uv.lock")
         .write_str(&missing_conflict_marker)?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("package-conflicts,lock-without-metadata").arg("--locked"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked"), @"
     exit_code: 1 (failure)
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -4059,7 +4065,11 @@ fn lock_conflicting_workspace_members_depends_direct_extra() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("package-conflicts,lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 4 packages in [TIME]
@@ -4372,7 +4382,11 @@ fn lock_conflicting_workspace_members_depends_transitive_extra() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("package-conflicts,lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 5 packages in [TIME]
@@ -4750,7 +4764,11 @@ fn lock_conflicting_mixed() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -5285,7 +5303,11 @@ fn lock_check_refresh_workspace_conflicts() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 4 packages in [TIME]
@@ -17897,7 +17919,10 @@ fn lock_writes_without_package_metadata() -> Result<()> {
         dev = []
         "#})?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
@@ -17918,7 +17943,11 @@ fn lock_writes_without_package_metadata() -> Result<()> {
     source = { virtual = "." }
     "#);
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--check").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--check")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
@@ -17941,14 +17970,21 @@ fn lock_writes_without_package_metadata() -> Result<()> {
             .all(|package| package.get("metadata").is_some())
     );
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--check").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--check")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
     ");
     assert_eq!(context.read("uv.lock"), standard_lock);
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
@@ -18045,7 +18081,11 @@ fn lock_metadata_free_many_conflicts() -> Result<()> {
         dependencies = [{{ name = "dep" }}]
         "#})?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("package-conflicts,lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("package-conflicts,lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -18213,7 +18253,11 @@ fn lock_regenerates_dependencies_without_metadata() -> Result<()> {
         exclude-dependencies = ["urllib3"]
         "#})?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 10 packages in [TIME]
@@ -18254,7 +18298,12 @@ fn lock_regenerates_dependencies_without_metadata() -> Result<()> {
     hint: To update the lockfile, run `uv lock`.
     ");
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 10 packages in [TIME]
@@ -18263,7 +18312,12 @@ fn lock_regenerates_dependencies_without_metadata() -> Result<()> {
     // Compatible declarations generate the same resolved dependency edges.
     // That is a change from lockfiles with metadata, which would (unnecessarily) error here.
     pyproject_toml.write_str(&original_pyproject.replace("tqdm>1", "tqdm>0"))?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 10 packages in [TIME]
@@ -18271,7 +18325,12 @@ fn lock_regenerates_dependencies_without_metadata() -> Result<()> {
 
     // Removing production requirements must not retain optional or group edges.
     pyproject_toml.write_str(&original_pyproject.replace("    \"httpx\",\n", ""))?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 1 (failure)
     ----- stderr -----
     Resolved 10 packages in [TIME]
@@ -18341,7 +18400,8 @@ fn lock_regenerates_incompatible_self_requirement() -> Result<()> {
     "#};
     pyproject_toml.write_str(original_pyproject)?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
@@ -18357,7 +18417,11 @@ fn lock_regenerates_incompatible_self_requirement() -> Result<()> {
         {original_pyproject}
         dependencies = ["project>=0.1.0"]
         "#})?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
@@ -18367,7 +18431,11 @@ fn lock_regenerates_incompatible_self_requirement() -> Result<()> {
         {original_pyproject}
         dependencies = ["project>=2.0.0 ; python_version < '3.0'"]
         "#})?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
@@ -18377,7 +18445,11 @@ fn lock_regenerates_incompatible_self_requirement() -> Result<()> {
         {original_pyproject}
         dependencies = ["project>=2.0.0"]
         "#})?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
@@ -18392,7 +18464,11 @@ fn lock_regenerates_incompatible_self_requirement() -> Result<()> {
         [project.optional-dependencies]
         feature = ["project>=2.0.0"]
         "#})?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 1 (failure)
     ----- stderr -----
       × No solution found when resolving dependencies:
@@ -18489,7 +18565,11 @@ fn lock_regenerates_activated_empty_extra() -> Result<()> {
         leaf = { path = "../leaf" }
         "#})?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 1 (failure)
     ----- stderr -----
     Resolved 4 packages in [TIME]
@@ -18531,7 +18611,8 @@ fn lock_metadata_free_frozen_filtered_dependency_selections() -> Result<()> {
         exclude-dependencies = ["excluded-dependency"]
         "#})?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
@@ -18628,7 +18709,10 @@ fn lock_metadata_free_frozen_preserves_recorded_selections() -> Result<()> {
 
     pyproject_toml.write_str(&original_pyproject.replace("original =", "added ="))?;
 
-    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--extra").arg("original"), @"
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--frozen")
+        .arg("--extra")
+        .arg("original"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Prepared 1 package in [TIME]
@@ -18713,7 +18797,11 @@ fn lock_regenerates_marker_specific_local_extra() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -18773,7 +18861,11 @@ fn lock_regenerates_scoped_workspace_overrides() -> Result<()> {
         requires-python = ">=3.10"
         dependencies = ["anyio==4.3.0 ; sys_platform != 'win32'"]
         "#})?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 8 packages in [TIME]
@@ -18789,7 +18881,12 @@ fn lock_regenerates_scoped_workspace_overrides() -> Result<()> {
             .all(|package| package.get("metadata").is_none())
     );
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 8 packages in [TIME]
@@ -19574,7 +19671,11 @@ fn lock_regenerates_marker_specific_requested_extras() -> Result<()> {
             "httpx ; sys_platform == 'win32'",
         ]
         "#})?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -19590,7 +19691,12 @@ fn lock_regenerates_marker_specific_requested_extras() -> Result<()> {
             .all(|package| package.get("metadata").is_none())
     );
     let lockfile = context.temp_dir.child("uv.lock");
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -19615,7 +19721,12 @@ fn lock_regenerates_marker_specific_requested_extras() -> Result<()> {
     dependency.insert("marker", toml_edit::Value::from("sys_platform == 'linux'"));
     lockfile.write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--index-url").arg(server.index_url()), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--index-url")
+        .arg(server.index_url()), @"
     exit_code: 1 (failure)
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -27195,7 +27306,11 @@ fn lock_extra_marker_preserves_production_platform() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -27795,7 +27910,11 @@ fn lock_group_include() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 11 packages in [TIME]
@@ -27923,7 +28042,11 @@ fn lock_group_requires_python() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 5 packages in [TIME]
@@ -28083,7 +28206,11 @@ fn lock_group_includes_requires_python() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 5 packages in [TIME]
@@ -29246,7 +29373,11 @@ fn lock_dynamic_version_no_build() -> Result<()> {
             [package.dev-dependencies]
             dev = [{{ name = "project" }}]
             "#})?;
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
@@ -29760,7 +29891,11 @@ fn lock_dynamic_version_self_extra_hatchling() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 5 packages in [TIME]
@@ -29924,7 +30059,11 @@ fn lock_dynamic_version_self_extra_setuptools() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 5 packages in [TIME]
@@ -31111,7 +31250,11 @@ fn lock_recursive_extra() -> Result<()> {
         .child("uv.lock")
         .write_str(&lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--offline"), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--offline"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -36741,7 +36884,13 @@ async fn lock_path_dependency_explicit_index() -> Result<()> {
     let lock = lock_without_package_metadata(&fs_err::read_to_string(pkg_b.join("uv.lock"))?)?;
     fs_err::write(pkg_b.join("uv.lock"), lock.to_string())?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--preview-features").arg("lock-without-metadata").arg("--locked").arg("--default-index").arg("https://example.invalid/simple").current_dir(&pkg_b), @"
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--preview-features")
+        .arg("lock-without-metadata")
+        .arg("--locked")
+        .arg("--default-index")
+        .arg("https://example.invalid/simple")
+        .current_dir(&pkg_b), @"
     exit_code: 0 (success)
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]


### PR DESCRIPTION
Format existing lock-test snapshot command chains over multiple lines for readability. The command arguments and inline snapshots are unchanged.

Broken out of https://github.com/astral-sh/uv/pull/21163, it's only churning those tests.