### PR TITLE
Portable Environments

### DIFF
--- a/crates/uv-dev/src/generate_preview_features_reference.rs
+++ b/crates/uv-dev/src/generate_preview_features_reference.rs
@@ -139,6 +139,7 @@ mod tests {
         - `package-conflicts`: Allows defining workspace conflicts at the package level.
         - `packaged-init`: Makes `uv init` create a packaged application with a `src/` layout, build system, and script
           entry point by default.
+        - `portable-envs`: Creates self-contained environments by bundling managed Python installations.
         - `project-directory-must-exist`: Rejects an invalid `--project` path instead of warning and continuing. Except for `uv init`,
           the path must already exist as a directory or point to a `pyproject.toml` file. This feature
           takes effect before configuration is loaded.

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -136,6 +136,9 @@ pub struct LinkOptions<'a, F = fn(&Path) -> bool> {
     /// Predicate that returns `true` for files that need a mutable (safe to
     /// write) copy. Only applied in [`LinkMode::Hardlink`] and [`LinkMode::Symlink`] modes.
     needs_mutable_copy: F,
+    /// Predicate that returns `true` for paths that should be included.
+    /// Excluding a directory also excludes its entire subtree.
+    filter: Option<fn(&Path) -> bool>,
     /// Optional locks for synchronized copying during concurrent operations.
     copy_locks: Option<&'a CopyLocks>,
     /// What to do when the destination directory already exists.
@@ -148,6 +151,7 @@ impl LinkOptions<'static> {
         Self {
             mode,
             needs_mutable_copy: |_| false,
+            filter: None,
             copy_locks: None,
             on_existing_directory: OnExistingDirectory::default(),
         }
@@ -172,8 +176,21 @@ impl<'a, F> LinkOptions<'a, F> {
         LinkOptions {
             mode: self.mode,
             needs_mutable_copy: f,
+            filter: self.filter,
             copy_locks: self.copy_locks,
             on_existing_directory: self.on_existing_directory,
+        }
+    }
+
+    /// Set a predicate for paths that should be included during linking.
+    ///
+    /// Paths for which the predicate returns `false` are skipped. When a directory is skipped,
+    /// its entire subtree is excluded.
+    #[must_use]
+    pub fn with_filter(self, filter: fn(&Path) -> bool) -> Self {
+        Self {
+            filter: Some(filter),
+            ..self
         }
     }
 
@@ -186,6 +203,7 @@ impl<'a, F> LinkOptions<'a, F> {
         LinkOptions {
             mode: self.mode,
             needs_mutable_copy: self.needs_mutable_copy,
+            filter: self.filter,
             copy_locks: Some(locks),
             on_existing_directory: self.on_existing_directory,
         }
@@ -197,6 +215,7 @@ impl<'a, F> LinkOptions<'a, F> {
         LinkOptions {
             mode: self.mode,
             needs_mutable_copy: self.needs_mutable_copy,
+            filter: self.filter,
             copy_locks: self.copy_locks,
             on_existing_directory,
         }
@@ -330,7 +349,7 @@ where
 {
     // On macOS, try to clone the entire directory in one syscall.
     #[cfg(target_os = "macos")]
-    {
+    if options.filter.is_none() {
         match try_clone_dir_recursive(src, dst, options) {
             Ok(()) => return Ok(LinkMode::Clone),
             Err(e) => {
@@ -362,7 +381,12 @@ where
 {
     let mut state = LinkState::new(mode);
 
-    for entry in WalkDir::new(src) {
+    for entry in WalkDir::new(src).into_iter().filter_entry(|entry| {
+        options
+            .filter
+            .as_ref()
+            .is_none_or(|filter| filter(entry.path()))
+    }) {
         let entry = entry.map_err(|err| LinkError::WalkDir {
             path: src.to_path_buf(),
             err,
@@ -981,6 +1005,34 @@ mod tests {
 
         assert_eq!(result, LinkMode::Copy);
         verify_test_tree(dst_dir.path());
+    }
+
+    #[test]
+    fn test_link_dir_filter() {
+        let src_dir = test_tempdir();
+        create_test_tree(src_dir.path());
+
+        for mode in [
+            LinkMode::Copy,
+            LinkMode::Hardlink,
+            LinkMode::Clone,
+            LinkMode::Symlink,
+        ] {
+            let dst_dir = test_tempdir();
+            // An existing destination would force macOS's whole-directory clone to fall back,
+            // hiding regressions where that fast path ignores the filter.
+            let destination = dst_dir.path().join("filtered");
+            let options = LinkOptions::new(mode).with_filter(|path: &Path| {
+                !path.ends_with("file2.txt") && !path.ends_with("subdir")
+            });
+
+            link_dir(src_dir.path(), &destination, &options)
+                .expect("directory linking should succeed");
+
+            assert!(destination.join("file1.txt").is_file());
+            assert!(!destination.join("file2.txt").exists());
+            assert!(!destination.join("subdir").exists());
+        }
     }
 
     #[test]

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -281,6 +281,8 @@ pub enum PreviewFeature {
     AdjustUlimit,
     /// Stops treating Conda environments named `base` or `root` as special.
     SpecialCondaEnvNames,
+    /// Creates self-contained environments by bundling managed Python installations.
+    PortableEnvs,
     /// Creates relocatable virtual environments by default.
     RelocatableEnvsDefault,
     /// Requires normalized distribution filenames when publishing, skipping files whose names are

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -30,7 +30,9 @@ use crate::implementation::ImplementationName;
 use crate::installation::{PythonInstallation, PythonInstallationKey};
 use crate::interpreter::Error as InterpreterError;
 use crate::interpreter::{StatusCodeError, UnexpectedResponseError};
-use crate::managed::{ManagedPythonInstallations, PythonMinorVersionLink};
+use crate::managed::{
+    ManagedPythonInstallation, ManagedPythonInstallations, PythonMinorVersionLink,
+};
 #[cfg(windows)]
 use crate::microsoft_store::find_microsoft_store_pythons;
 use crate::python_version::python_build_versions_from_env;
@@ -2187,6 +2189,42 @@ impl PythonRequest {
             path1 == path2 || is_same_file(path1, path2).unwrap_or(false)
         }
 
+        /// Returns `true` if a portable environment copied the requested managed installation.
+        fn is_same_portable_installation(
+            interpreter: &Interpreter,
+            requested_interpreter: impl FnOnce() -> Result<Interpreter, InterpreterError>,
+        ) -> bool {
+            if interpreter.sys_prefix() != interpreter.sys_base_prefix()
+                || !interpreter.is_virtualenv()
+                || !interpreter.is_managed()
+            {
+                return false;
+            }
+
+            let Ok(requested_interpreter) = requested_interpreter() else {
+                return false;
+            };
+            if requested_interpreter.is_virtualenv()
+                || interpreter.key() != requested_interpreter.key()
+            {
+                return false;
+            }
+            let Some(installation) =
+                ManagedPythonInstallation::try_from_interpreter(&requested_interpreter)
+            else {
+                return false;
+            };
+
+            match (
+                installation.build(),
+                fs_err::read_to_string(interpreter.sys_prefix().join("BUILD")),
+            ) {
+                (Some(build), Ok(portable_build)) => portable_build.trim() == build,
+                (None, Err(error)) => error.kind() == io::ErrorKind::NotFound,
+                _ => false,
+            }
+        }
+
         match self {
             Self::Default | Self::Any => true,
             Self::Version(version_request) => version_request.matches_interpreter(interpreter),
@@ -2197,6 +2235,10 @@ impl PythonRequest {
                         virtualenv_python_executable(directory).as_path(),
                         interpreter.sys_executable(),
                     )
+                    || is_same_portable_installation(interpreter, || {
+                        python_installation_from_directory(directory, cache)
+                            .map(PythonInstallation::into_interpreter)
+                    })
             }
             Self::File(file) => {
                 // The interpreter satisfies the request both if it is the venv...
@@ -2228,7 +2270,7 @@ impl PythonRequest {
                         }
                     }
                 }
-                false
+                is_same_portable_installation(interpreter, || Interpreter::query(file, cache))
             }
             Self::ExecutableName(name) => {
                 // First, see if we have a match in the venv ...

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -310,7 +310,7 @@ impl Interpreter {
     /// Returns `true` if this interpreter is managed by uv.
     ///
     /// Returns `false` if we cannot determine the path of the uv managed Python interpreters.
-    pub(crate) fn is_managed(&self) -> bool {
+    pub fn is_managed(&self) -> bool {
         if let Ok(test_managed) =
             std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_PYTHON_MANAGED)
         {

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -117,7 +117,18 @@ impl Interpreter {
 
     /// Return a new [`Interpreter`] with the given virtual environment root.
     #[must_use]
-    pub fn with_virtualenv(self, virtualenv: VirtualEnvironment) -> Self {
+    pub fn with_virtualenv(mut self, virtualenv: VirtualEnvironment) -> Self {
+        if virtualenv.portable {
+            self.stdlib = virtualenv
+                .scheme
+                .purelib
+                .parent()
+                .unwrap_or(&virtualenv.root)
+                .to_path_buf();
+            self.sys_base_prefix.clone_from(&virtualenv.root);
+            self.real_executable.clone_from(&virtualenv.executable);
+        }
+
         Self {
             scheme: virtualenv.scheme,
             sys_base_executable: Some(virtualenv.base_executable),
@@ -283,7 +294,7 @@ impl Interpreter {
     /// See: <https://github.com/pypa/pip/blob/0ad4c94be74cc24874c6feb5bb3c2152c398a18e/src/pip/_internal/utils/virtualenv.py#L14>
     pub fn is_virtualenv(&self) -> bool {
         // Maybe this should return `false` if it's a target?
-        self.sys_prefix != self.sys_base_prefix
+        self.sys_prefix != self.sys_base_prefix || uv_fs::is_virtualenv_base(&self.sys_prefix)
     }
 
     /// Returns `true` if the environment is a `--target` environment.
@@ -328,7 +339,13 @@ impl Interpreter {
         let root = dunce::canonicalize(&root).unwrap_or(root);
 
         let Ok(suffix) = sys_base_prefix.strip_prefix(&root) else {
-            return false;
+            return PyVenvConfiguration::parse(sys_base_prefix.join("pyvenv.cfg")).is_ok_and(
+                |configuration| {
+                    configuration.home.is_none()
+                        && configuration.is_uv()
+                        && configuration.is_relocatable()
+                },
+            );
         };
 
         let Some(first_component) = suffix.components().next() else {
@@ -1370,8 +1387,9 @@ mod tests {
     use uv_cache::{Cache, CacheBucket};
     use uv_cache_info::Timestamp;
     use uv_pep440::Version;
+    use uv_pypi_types::Scheme;
 
-    use crate::Interpreter;
+    use crate::{Interpreter, VirtualEnvironment};
 
     fn mocked_interpreter_response() -> &'static str {
         indoc! {r##"
@@ -1432,6 +1450,55 @@ mod tests {
             "debug_enabled": false
         }
     "##}
+    }
+
+    #[tokio::test]
+    async fn portable_virtualenv_relocates_interpreter_metadata() -> Result<()> {
+        let directory = tempdir()?;
+        let source_executable = directory.path().join("python");
+        let response = mocked_interpreter_response()
+            .replace("{sys_executable}", &source_executable.display().to_string());
+        fs::write(
+            &source_executable,
+            formatdoc! {r"
+                #!/bin/sh
+                echo '{response}'
+            "},
+        )?;
+        fs::set_permissions(
+            &source_executable,
+            std::os::unix::fs::PermissionsExt::from_mode(0o770),
+        )?;
+
+        let cache = Cache::temp()?.init().await?;
+        let root = directory.path().join("portable");
+        let executable = root.join("bin").join("python");
+        let site_packages = root.join("lib").join("python3.12").join("site-packages");
+        // Creation returns an interpreter without querying the copied executable, so its metadata
+        // must already refer to the portable environment instead of the original installation.
+        let portable =
+            Interpreter::query(&source_executable, &cache)?.with_virtualenv(VirtualEnvironment {
+                root: root.clone(),
+                executable: executable.clone(),
+                base_executable: executable.clone(),
+                portable: true,
+                scheme: Scheme {
+                    purelib: site_packages.clone(),
+                    platlib: site_packages,
+                    scripts: root.join("bin"),
+                    data: root.clone(),
+                    include: root.join("include"),
+                },
+            });
+
+        assert_eq!(portable.sys_prefix(), root);
+        assert_eq!(portable.sys_base_prefix(), root);
+        assert_eq!(portable.sys_executable(), executable);
+        assert_eq!(portable.to_base_python()?, executable);
+        assert_eq!(portable.real_executable(), executable);
+        assert_eq!(portable.stdlib(), root.join("lib").join("python3.12"));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/uv-python/src/macos_dylib.rs
+++ b/crates/uv-python/src/macos_dylib.rs
@@ -1,15 +1,18 @@
-use std::{io::ErrorKind, path::PathBuf};
+use std::{
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
 
 use uv_fs::Simplified as _;
 use uv_warnings::warn_user;
 
 use crate::managed::ManagedPythonInstallation;
 
-pub(crate) fn patch_dylib_install_name(dylib: PathBuf) -> Result<(), Error> {
+pub(crate) fn patch_dylib_install_name(dylib: &Path, install_name: &Path) -> Result<(), Error> {
     let output = match std::process::Command::new("install_name_tool")
         .arg("-id")
-        .arg(&dylib)
-        .arg(&dylib)
+        .arg(install_name)
+        .arg(dylib)
         .output()
     {
         Ok(output) => output,
@@ -25,7 +28,10 @@ pub(crate) fn patch_dylib_install_name(dylib: PathBuf) -> Result<(), Error> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-        return Err(Error::RenameError { dylib, stderr });
+        return Err(Error::RenameError {
+            dylib: dylib.to_path_buf(),
+            stderr,
+        });
     }
 
     Ok(())

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -609,7 +609,7 @@ impl ManagedPythonInstallation {
                         self.key.variant().executable_suffix(),
                         std::env::consts::DLL_SUFFIX
                     ));
-                    macos_dylib::patch_dylib_install_name(dylib_path)?;
+                    macos_dylib::patch_dylib_install_name(&dylib_path, &dylib_path)?;
                 }
             }
         }

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -15,6 +15,7 @@ use tracing::{debug, warn};
 #[cfg(windows)]
 use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
 
+use uv_fs::link::{LinkError, LinkMode, LinkOptions, OnExistingDirectory, link_dir};
 use uv_fs::{
     LockedFile, LockedFileError, LockedFileMode, Simplified, normalize_absolute_path,
     replace_symlink, symlink_or_copy_file, verbatim_path,
@@ -881,6 +882,110 @@ fn executable_path_from_base(
         // On Unix, the executable is in `bin/`
         base.join("bin").join(executable_name)
     }
+}
+
+/// Return whether a linked Python installation file must remain independently writable.
+fn needs_mutable_copy(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(OsStr::to_str) else {
+        return false;
+    };
+    let extension = path.extension().and_then(OsStr::to_str);
+
+    if file_name.starts_with("_sysconfigdata_")
+        && extension.is_some_and(|extension| extension.eq_ignore_ascii_case("py"))
+    {
+        return true;
+    }
+
+    #[cfg(target_os = "macos")]
+    if file_name.starts_with("libpython")
+        && extension.is_some_and(|extension| extension.eq_ignore_ascii_case("dylib"))
+    {
+        return true;
+    }
+
+    false
+}
+
+/// Link a Python installation into `destination`, copying files that must subsequently be patched.
+///
+/// Omit installed packages and the externally-managed marker so the destination can be used as an
+/// independent environment.
+pub fn link_python_installation(
+    source: &Path,
+    destination: &Path,
+    allow_existing: bool,
+) -> Result<(), LinkError> {
+    let on_existing_directory = if allow_existing {
+        OnExistingDirectory::Merge
+    } else {
+        OnExistingDirectory::Fail
+    };
+    let options = LinkOptions::new(LinkMode::default())
+        .with_mutable_copy_filter(needs_mutable_copy)
+        .with_filter(|path| {
+            let file_name = path.file_name().and_then(OsStr::to_str);
+            if matches!(file_name, Some("site-packages" | "EXTERNALLY-MANAGED")) {
+                return false;
+            }
+
+            let parent = path
+                .parent()
+                .and_then(Path::file_name)
+                .and_then(OsStr::to_str);
+            !(matches!(parent, Some("bin" | "Scripts"))
+                && file_name.is_some_and(|file_name| file_name.starts_with("pip")))
+        })
+        .with_on_existing_directory(on_existing_directory);
+
+    link_dir(source, destination, &options)?;
+    Ok(())
+}
+
+/// Patch embedded paths in a copied Python installation.
+pub fn patch_python_installation(path: &Path, interpreter: &Interpreter) -> Result<(), Error> {
+    if cfg!(unix) && interpreter.implementation_name() == "cpython" {
+        sysconfig::make_sysconfig_relocatable(
+            path,
+            interpreter.python_major(),
+            interpreter.python_minor(),
+            interpreter.variant().lib_suffix(),
+        )?;
+    }
+
+    #[cfg(target_os = "macos")]
+    if interpreter.implementation_name() == "cpython" {
+        let dylib_name = format!(
+            "{}python{}.{}{}{}",
+            std::env::consts::DLL_PREFIX,
+            interpreter.python_major(),
+            interpreter.python_minor(),
+            interpreter.variant().executable_suffix(),
+            std::env::consts::DLL_SUFFIX,
+        );
+        let dylib_path = path.join("lib").join(&dylib_name);
+
+        // An executable-relative install name keeps env/bin executables and extension modules
+        // portable, but cannot support PyO3/Cargo embedders outside env/bin. Ordinary managed
+        // installations use an absolute install name to support those external embedders.
+        let install_name = Path::new("@executable_path/../lib").join(dylib_name);
+        if dylib_path.exists()
+            && let Err(error) = macos_dylib::patch_dylib_install_name(&dylib_path, &install_name)
+        {
+            let detail = if tracing::enabled!(tracing::Level::DEBUG) {
+                format!("\nUnderlying error: {error}")
+            } else {
+                String::new()
+            };
+            uv_warnings::warn_user!(
+                "Failed to patch the install name of the dynamic library for `{}`. \
+                 This may cause issues when building Python native extensions.{detail}",
+                dylib_path.simplified_display(),
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// A Python executable and its window mode.

--- a/crates/uv-python/src/sysconfig/mod.rs
+++ b/crates/uv-python/src/sysconfig/mod.rs
@@ -40,6 +40,8 @@ mod generated_mappings;
 mod parser;
 mod replacements;
 
+const RELOCATABLE_PREFIX: &str = "__UV_PYTHON_INSTALL_PREFIX__";
+
 /// Update the `sysconfig` data in a Python installation.
 pub(crate) fn update_sysconfig(
     install_root: &Path,
@@ -88,6 +90,59 @@ pub(crate) fn update_sysconfig(
             file.sync_data()?;
         }
     }
+
+    Ok(())
+}
+
+/// Make a Python installation's `sysconfig` data follow its location.
+pub(crate) fn make_sysconfig_relocatable(
+    install_root: &Path,
+    major: u8,
+    minor: u8,
+    suffix: &str,
+) -> Result<(), Error> {
+    let install_root = std::path::absolute(install_root)?;
+    let sysconfigdata = find_sysconfigdata(&install_root, major, minor, suffix)?;
+    trace!(
+        "Making `sysconfig` data relocatable at: {}",
+        sysconfigdata.display()
+    );
+
+    let contents = fs_err::read_to_string(&sysconfigdata)?;
+    let mut data = SysconfigData::from_str(&contents)?;
+    let Some((_, Value::String(previous_prefix))) =
+        data.iter_mut().find(|(key, _)| key.as_str() == "prefix")
+    else {
+        return Err(Error::MissingSysconfigPrefix);
+    };
+    let previous_prefix = std::mem::replace(previous_prefix, RELOCATABLE_PREFIX.to_string());
+
+    for (_, value) in data.iter_mut() {
+        if let Value::String(value) = value {
+            *value = value.replace(&previous_prefix, RELOCATABLE_PREFIX);
+        }
+    }
+
+    let mut file = fs_err::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&sysconfigdata)?;
+    file.write_all(data.to_string_pretty()?.as_bytes())?;
+    file.write_all(
+        br#"
+_uv_path = __import__("os").path
+_uv_previous_prefix = build_time_vars["prefix"]
+_uv_current_prefix = _uv_path.dirname(
+    _uv_path.dirname(_uv_path.dirname(_uv_path.abspath(__file__)))
+)
+for _uv_key, _uv_value in build_time_vars.items():
+    if isinstance(_uv_value, str):
+        build_time_vars[_uv_key] = _uv_value.replace(
+            _uv_previous_prefix, _uv_current_prefix
+        )
+"#,
+    )?;
+    file.sync_data()?;
 
     Ok(())
 }
@@ -274,6 +329,8 @@ pub enum Error {
     MissingLib(PathBuf),
     #[error("Python installation is missing a `_sysconfigdata_` file")]
     MissingSysconfigdata,
+    #[error("Python installation's `_sysconfigdata_` is missing its installation prefix")]
+    MissingSysconfigPrefix,
     #[error(transparent)]
     Parse(#[from] ParseError),
     #[error(transparent)]
@@ -317,6 +374,44 @@ mod tests {
             "base": "/real/prefix/base",
             "exec_prefix": "/real/prefix/exec_prefix",
             "prefix": "/real/prefix/prefix"
+        }
+        "#);
+
+        Ok(())
+    }
+
+    #[test]
+    fn relocate_sysconfig_preserves_install_paths() -> Result<(), Error> {
+        let root = tempfile::tempdir()?;
+        let lib = root.path().join("lib/python3.12");
+        fs_err::create_dir_all(&lib)?;
+        let sysconfigdata = lib.join("_sysconfigdata_test.py");
+        fs_err::write(
+            &sysconfigdata,
+            indoc! {r#"
+                # system configuration generated and used by the sysconfig module
+                build_time_vars = {
+                    "BINDIR": "/source/python/bin",
+                    "CONFIG_ARGS": "--prefix=/install",
+                    "INSTALL": "/usr/bin/install -c",
+                    "WASM_ASSETS_DIR": "./install",
+                    "prefix": "/source/python"
+                }
+            "#},
+        )?;
+
+        make_sysconfig_relocatable(root.path(), 3, 12, "")?;
+
+        let contents = fs_err::read_to_string(&sysconfigdata)?;
+        let data = SysconfigData::from_str(&contents)?;
+        insta::assert_snapshot!(data.to_string_pretty()?, @r#"
+        # system configuration generated and used by the sysconfig module
+        build_time_vars = {
+            "BINDIR": "__UV_PYTHON_INSTALL_PREFIX__/bin",
+            "CONFIG_ARGS": "--prefix=/install",
+            "INSTALL": "/usr/bin/install -c",
+            "WASM_ASSETS_DIR": "./install",
+            "prefix": "__UV_PYTHON_INSTALL_PREFIX__"
         }
         "#);
 

--- a/crates/uv-python/src/virtualenv.rs
+++ b/crates/uv-python/src/virtualenv.rs
@@ -23,8 +23,11 @@ pub struct VirtualEnvironment {
     /// (Unix, Python 3.11).
     pub executable: PathBuf,
 
-    /// The path to the base executable for the environment, within the `home` directory.
+    /// The path to the base executable, either within `home` or the portable environment.
     pub base_executable: PathBuf,
+
+    /// Whether the environment contains its own portable base Python installation.
+    pub portable: bool,
 
     /// The [`Scheme`] paths for the virtualenv, as returned by (e.g.) `sysconfig.get_paths()`.
     pub scheme: Scheme,

--- a/crates/uv-virtualenv/src/lib.rs
+++ b/crates/uv-virtualenv/src/lib.rs
@@ -20,6 +20,8 @@ pub enum Error {
     NotFound(String),
     #[error(transparent)]
     Python(#[from] uv_python::managed::Error),
+    #[error(transparent)]
+    LinkDir(#[from] uv_fs::link::LinkError),
     #[error("A {name} already exists at: {}", path.user_display())]
     Exists {
         /// The type of environment (e.g., "virtual environment" or "directory").

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -633,6 +633,7 @@ pub(crate) fn create(
         root: location,
         executable,
         base_executable: base_python,
+        portable: false,
     })
 }
 

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -20,7 +20,8 @@ use uv_platform_tags::Os;
 use uv_preview::PreviewFeature;
 use uv_pypi_types::Scheme;
 use uv_python::managed::{
-    ManagedPythonInstallation, PythonExecutable, PythonMinorVersionLink, replace_link_to_executable,
+    ManagedPythonInstallation, PythonExecutable, PythonMinorVersionLink, link_python_installation,
+    patch_python_installation, replace_link_to_executable,
 };
 use uv_python::{Interpreter, VirtualEnvironment};
 use uv_shell::escape_posix_for_single_quotes;
@@ -195,6 +196,29 @@ pub(crate) fn create(
 
     // Use the absolute path for all further operations.
     let location = absolute;
+    let portable_environment = relocatable
+        && !matches!(
+            on_existing,
+            OnExisting::Remove(RemovalReason::TemporaryEnvironment)
+        )
+        && !system_site_packages
+        && ManagedPythonInstallation::try_from_interpreter(interpreter).is_some()
+        && interpreter.implementation_name() == "cpython"
+        && uv_preview::is_enabled(PreviewFeature::PortableEnvs);
+
+    if portable_environment {
+        let python_root = fs_err::canonicalize(interpreter.sys_base_prefix())?;
+        debug!(
+            "Creating portable environment by linking Python installation from `{}`",
+            python_root.display()
+        );
+        link_python_installation(
+            &python_root,
+            &location,
+            matches!(on_existing, OnExisting::Allow),
+        )?;
+        patch_python_installation(&location, interpreter)?;
+    }
 
     let bin_name = if cfg!(unix) {
         "bin"
@@ -212,7 +236,7 @@ pub(crate) fn create(
     fs_err::write(location.join(".gitignore"), "*")?;
 
     let mut using_minor_version_link = false;
-    let executable_target = if upgradeable {
+    let executable_target = if upgradeable && !portable_environment {
         if let Some(minor_version_link) =
             ManagedPythonInstallation::try_from_interpreter(interpreter)
                 .and_then(|installation| PythonMinorVersionLink::from_installation(&installation))
@@ -262,28 +286,42 @@ pub(crate) fn create(
 
     #[cfg(unix)]
     {
-        uv_fs::replace_symlink(&executable_target, &executable)?;
+        if portable_environment {
+            uv_fs::replace_symlink(
+                format!(
+                    "python{}.{}{}",
+                    interpreter.python_major(),
+                    interpreter.python_minor(),
+                    interpreter.variant().executable_suffix(),
+                ),
+                &executable,
+            )?;
+        } else {
+            uv_fs::replace_symlink(&executable_target, &executable)?;
+        }
         uv_fs::replace_symlink(
             "python",
             scripts.join(format!("python{}", interpreter.python_major())),
         )?;
-        uv_fs::replace_symlink(
-            "python",
-            scripts.join(format!(
-                "python{}.{}",
-                interpreter.python_major(),
-                interpreter.python_minor(),
-            )),
-        )?;
-        if interpreter.gil_disabled() {
+        if !portable_environment {
             uv_fs::replace_symlink(
                 "python",
                 scripts.join(format!(
-                    "python{}.{}t",
+                    "python{}.{}",
                     interpreter.python_major(),
                     interpreter.python_minor(),
                 )),
             )?;
+            if interpreter.gil_disabled() {
+                uv_fs::replace_symlink(
+                    "python",
+                    scripts.join(format!(
+                        "python{}.{}t",
+                        interpreter.python_major(),
+                        interpreter.python_minor(),
+                    )),
+                )?;
+            }
         }
 
         if interpreter.markers().implementation_name() == "pypy" {
@@ -303,7 +341,54 @@ pub(crate) fn create(
     // interpreters, this target path includes a minor version junction to enable
     // transparent upgrades.
     if cfg!(windows) {
-        if using_minor_version_link {
+        if portable_environment {
+            let root_python = location.join("python.exe");
+            let root_python = if root_python.exists() {
+                root_python
+            } else {
+                let executable_name = base_python.file_name().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "The Python interpreter needs to have a file name",
+                    )
+                })?;
+                location.join(executable_name)
+            };
+            fs_err::copy(&root_python, &executable)?;
+
+            if interpreter.gil_disabled() {
+                let executable_name = WindowsExecutable::PythonMajorMinort.exe(interpreter);
+                fs_err::copy(&root_python, scripts.join(executable_name))?;
+            }
+
+            let root_pythonw = location.join("pythonw.exe");
+            let root_pythonw = if root_pythonw.exists() {
+                Some(root_pythonw)
+            } else if interpreter.gil_disabled() {
+                let executable_name = WindowsExecutable::PythonwMajorMinort.exe(interpreter);
+                let root_pythonw = location.join(executable_name);
+                root_pythonw.exists().then_some(root_pythonw)
+            } else {
+                None
+            };
+            if let Some(root_pythonw) = root_pythonw {
+                let scripts_pythonw = scripts.join("pythonw.exe");
+                fs_err::copy(&root_pythonw, &scripts_pythonw)?;
+
+                if interpreter.gil_disabled() {
+                    let executable_name = WindowsExecutable::PythonwMajorMinort.exe(interpreter);
+                    fs_err::copy(&root_pythonw, scripts.join(executable_name))?;
+                }
+            }
+
+            for entry in fs_err::read_dir(&location)? {
+                let entry = entry?;
+                let name = entry.file_name();
+                if name.to_string_lossy().ends_with(".dll") {
+                    fs_err::copy(entry.path(), scripts.join(name))?;
+                }
+            }
+        } else if using_minor_version_link {
             let target = scripts.join(WindowsExecutable::Python.exe(interpreter));
             replace_link_to_executable(
                 target.as_path(),
@@ -539,11 +624,14 @@ pub(crate) fn create(
         fs_err::write(scripts.join(name), activator)?;
     }
 
-    let mut pyvenv_cfg_data: Vec<(String, String)> = vec![
-        (
+    let mut pyvenv_cfg_data: Vec<(String, String)> = Vec::new();
+    if !portable_environment {
+        pyvenv_cfg_data.push((
             "home".to_string(),
             python_home.simplified_display().to_string(),
-        ),
+        ));
+    }
+    pyvenv_cfg_data.extend([
         (
             "implementation".to_string(),
             interpreter
@@ -568,7 +656,7 @@ pub(crate) fn create(
                 "false".to_string()
             },
         ),
-    ];
+    ]);
 
     if relocatable {
         pyvenv_cfg_data.push(("relocatable".to_string(), "true".to_string()));
@@ -622,6 +710,12 @@ pub(crate) fn create(
         fs_err::write(site_packages.join("_virtualenv.pth"), "import _virtualenv")?;
     }
 
+    let base_executable = if portable_environment {
+        executable.clone()
+    } else {
+        base_python
+    };
+
     Ok(VirtualEnvironment {
         scheme: Scheme {
             purelib: location.join(&interpreter.virtualenv().purelib),
@@ -632,8 +726,8 @@ pub(crate) fn create(
         },
         root: location,
         executable,
-        base_executable: base_python,
-        portable: false,
+        base_executable,
+        portable: portable_environment,
     })
 }
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1266,8 +1266,16 @@ pub(crate) fn is_centralized_environment_reference(path: &Path, cache: &Cache) -
 }
 
 /// Return whether a project environment can follow managed Python patch upgrades.
-pub(crate) fn project_environment_upgradeable(python_request: Option<&PythonRequest>) -> bool {
+///
+/// An explicit relocatability override takes precedence over the preview-controlled default.
+pub(crate) fn project_environment_upgradeable(
+    python_request: Option<&PythonRequest>,
+    relocatable_override: Option<bool>,
+) -> bool {
+    let relocatable = relocatable_override
+        .unwrap_or_else(|| uv_preview::is_enabled(PreviewFeature::RelocatableEnvsDefault));
     python_request.is_none_or(|request| !request.includes_patch())
+        && !(relocatable && uv_preview::is_enabled(PreviewFeature::PortableEnvs))
 }
 
 /// Return the centralized environment path for a given workspace and interpreter.
@@ -1459,7 +1467,7 @@ impl ProjectInterpreter {
 
         let environment_selection = workspace.environment_selection(active);
         let centralized = centralized_environments_enabled(&environment_selection, cache);
-        let upgradeable = project_environment_upgradeable(python_request.as_ref());
+        let upgradeable = project_environment_upgradeable(python_request.as_ref(), None);
 
         // Prefer `.venv`'s interpreter to keep its compatible cached environment selected; derive
         // the cache root instead of trusting the link target.
@@ -1893,7 +1901,9 @@ impl ProjectEnvironment {
             config_discovery,
         )
         .await?;
-        let upgradeable = project_environment_upgradeable(workspace_python.python_request.as_ref());
+        let upgradeable =
+            project_environment_upgradeable(workspace_python.python_request.as_ref(), None);
+        let relocatable = uv_preview::is_enabled(PreviewFeature::RelocatableEnvsDefault);
 
         match ProjectInterpreter::discover(
             workspace,
@@ -2001,7 +2011,7 @@ impl ProjectEnvironment {
                         uv_virtualenv::OnExisting::Remove(
                             uv_virtualenv::RemovalReason::ManagedEnvironment,
                         ),
-                        uv_preview::is_enabled(PreviewFeature::RelocatableEnvsDefault),
+                        relocatable,
                         uv_virtualenv::Seed::Disabled,
                         upgradeable,
                     )?;
@@ -2062,7 +2072,7 @@ impl ProjectEnvironment {
                     uv_virtualenv::OnExisting::Remove(
                         uv_virtualenv::RemovalReason::ManagedEnvironment,
                     ),
-                    uv_preview::is_enabled(PreviewFeature::RelocatableEnvsDefault),
+                    relocatable,
                     uv_virtualenv::Seed::Disabled,
                     upgradeable,
                 )?;

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1265,6 +1265,11 @@ pub(crate) fn is_centralized_environment_reference(path: &Path, cache: &Cache) -
             .is_some_and(|target| is_centralized_environment_path(&target, cache))
 }
 
+/// Return whether a project environment can follow managed Python patch upgrades.
+pub(crate) fn project_environment_upgradeable(python_request: Option<&PythonRequest>) -> bool {
+    python_request.is_none_or(|request| !request.includes_patch())
+}
+
 /// Return the centralized environment path for a given workspace and interpreter.
 pub(crate) fn centralized_environment_root(
     workspace: &Workspace,
@@ -1454,9 +1459,7 @@ impl ProjectInterpreter {
 
         let environment_selection = workspace.environment_selection(active);
         let centralized = centralized_environments_enabled(&environment_selection, cache);
-        let upgradeable = python_request
-            .as_ref()
-            .is_none_or(|request| !request.includes_patch());
+        let upgradeable = project_environment_upgradeable(python_request.as_ref());
 
         // Prefer `.venv`'s interpreter to keep its compatible cached environment selected; derive
         // the cache root instead of trusting the link target.
@@ -1890,10 +1893,7 @@ impl ProjectEnvironment {
             config_discovery,
         )
         .await?;
-        let upgradeable = workspace_python
-            .python_request
-            .as_ref()
-            .is_none_or(|request| !request.includes_patch());
+        let upgradeable = project_environment_upgradeable(workspace_python.python_request.as_ref());
 
         match ProjectInterpreter::discover(
             workspace,

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -43,7 +43,8 @@ use crate::commands::pip::operations::{Changelog, report_interpreter};
 use crate::commands::project::{
     LinkErrorReporting, WorkspacePython, centralized_environment_root,
     centralized_environments_enabled, is_centralized_environment_reference,
-    lock_project_environment, update_project_environment_link, validate_project_requires_python,
+    lock_project_environment, project_environment_upgradeable, update_project_environment_link,
+    validate_project_requires_python,
 };
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::printer::Printer;
@@ -179,9 +180,7 @@ pub(crate) async fn venv(
         python.into_interpreter()
     };
 
-    let upgradeable = python_request
-        .as_ref()
-        .is_none_or(|request| !request.includes_patch());
+    let upgradeable = project_environment_upgradeable(python_request.as_ref());
 
     // Determine the default path.
     let path = if let Some(workspace) = centralized_workspace {

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -22,7 +22,7 @@ use uv_distribution_types::{
 use uv_fs::Simplified;
 use uv_install_wheel::LinkMode;
 use uv_normalize::DefaultGroups;
-use uv_preview::Preview;
+use uv_preview::{Preview, PreviewFeature};
 use uv_python::{
     ConfigDiscovery, EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference,
     PythonRequest,
@@ -180,7 +180,21 @@ pub(crate) async fn venv(
         python.into_interpreter()
     };
 
-    let upgradeable = project_environment_upgradeable(python_request.as_ref());
+    if system_site_packages
+        && relocatable
+        && interpreter.is_managed()
+        && interpreter.implementation_name() == "cpython"
+        && preview.is_enabled(PreviewFeature::PortableEnvs)
+    {
+        warn_user!(
+            "The `portable-envs` preview feature is ignored when using `--system-site-packages`"
+        );
+    }
+
+    let upgradeable = project_environment_upgradeable(
+        python_request.as_ref(),
+        Some(relocatable && !system_site_packages),
+    );
 
     // Determine the default path.
     let path = if let Some(workspace) = centralized_workspace {

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1,10 +1,12 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use indoc::indoc;
 use predicates::prelude::*;
+use uv_cache::ARCHIVE_VERSION;
 use uv_cache_key::cache_digest;
 use uv_fs::{LockedFile, LockedFileMode};
 use uv_python::{PYTHON_VERSION_FILENAME, PYTHON_VERSIONS_FILENAME};
@@ -17,7 +19,7 @@ use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 #[cfg(windows)]
 use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
-use uv_test::{site_packages_path, uv_snapshot};
+use uv_test::{site_packages_path, uv_snapshot, venv_bin_path};
 
 #[test]
 fn create_venv() {
@@ -1739,6 +1741,410 @@ fn verify_pyvenv_cfg_relocatable() {
     activate_xsh.assert(predicates::str::contains(
         r#"self.embedded_virtual_prompt = b"r\xc3\xa9sum\xc3\xa9 \"quoted\"\\path\n".decode("utf-8")"#,
     ));
+}
+
+#[test]
+fn relocatable_portable_environment() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_filtered_latest_python_versions()
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+
+    context.python_install().arg("3.12").assert().success();
+    let pyvenv_cfg = context.venv.child("pyvenv.cfg");
+    uv_snapshot!(context.filters(), context
+        .venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.12")
+        .arg("--relocatable")
+        .arg("--system-site-packages")
+        .arg("--preview-features")
+        .arg("portable-envs"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[LATEST]
+    warning: The `portable-envs` preview feature is ignored when using `--system-site-packages`
+    Creating virtual environment at: .venv
+    Activate with: source .venv/[BIN]/activate
+    ");
+
+    pyvenv_cfg.assert(predicates::str::contains("home = "));
+    pyvenv_cfg.assert(predicates::str::contains(
+        "include-system-site-packages = true",
+    ));
+
+    context
+        .venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.12")
+        .arg("--relocatable")
+        .arg("--clear")
+        .arg("--preview-features")
+        .arg("portable-envs")
+        .assert()
+        .success();
+
+    pyvenv_cfg.assert(predicates::str::contains("relocatable = true"));
+    pyvenv_cfg.assert(predicates::str::contains("home = ").not());
+    pyvenv_cfg.assert(predicates::str::contains(
+        "include-system-site-packages = false",
+    ));
+
+    let stdlib = if cfg!(windows) {
+        context.venv.child("Lib")
+    } else {
+        context.venv.child("lib").child("python3.12")
+    };
+    stdlib.child("os.py").assert(predicates::path::is_file());
+    stdlib
+        .child("EXTERNALLY-MANAGED")
+        .assert(predicates::path::missing());
+
+    let scripts = venv_bin_path(&context.venv);
+    let pip = scripts.join(format!("pip{}", std::env::consts::EXE_SUFFIX));
+    assert!(!pip.exists());
+
+    context
+        .pip_install()
+        .arg("iniconfig")
+        .arg("wheel")
+        .assert()
+        .success();
+
+    #[cfg(windows)]
+    for name in ["python.exe", "pythonw.exe", "python3.dll", "python312.dll"] {
+        let destination = context.venv.child("Scripts").child(name);
+        if destination.path().is_file() {
+            destination.write_str("outdated")?;
+        }
+    }
+
+    context
+        .venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.12")
+        .arg("--relocatable")
+        .arg("--allow-existing")
+        .arg("--seed")
+        .arg("--preview-features")
+        .arg("portable-envs")
+        .assert()
+        .success();
+
+    assert!(pip.is_file());
+
+    #[cfg(windows)]
+    for name in ["python.exe", "pythonw.exe", "python3.dll", "python312.dll"] {
+        let source = context.venv.child(name);
+        if source.path().is_file() {
+            let destination = context.venv.child("Scripts").child(name);
+            assert_eq!(
+                fs_err::read(source.path())?,
+                fs_err::read(destination.path())?
+            );
+        }
+    }
+
+    let nested = context.temp_dir.child("nested");
+    context
+        .venv()
+        .arg(nested.path())
+        .arg("--python")
+        .arg(context.interpreter())
+        .arg("--relocatable")
+        .arg("--preview-features")
+        .arg("portable-envs")
+        .assert()
+        .success();
+    nested
+        .child("pyvenv.cfg")
+        .assert(predicates::str::contains("home = "));
+    assert!(
+        !venv_bin_path(nested.path())
+            .join(format!("wheel{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    let relocated = context.temp_dir.child("relocated");
+    fs_err::rename(context.venv.path(), relocated.path())?;
+    fs_err::remove_dir_all(context.temp_dir.child("managed"))?;
+
+    let portable_environment_command = |environment: &Path| {
+        let python =
+            venv_bin_path(environment).join(format!("python{}", std::env::consts::EXE_SUFFIX));
+
+        let mut command = Command::new(python);
+        command.arg("-c").arg(indoc! {r##"
+            import iniconfig
+            import os
+            import shlex
+            import subprocess
+            import sys
+            import sysconfig
+
+            if os.name == "posix":
+                assert sysconfig.get_config_var("prefix") == sys.prefix
+                install = shlex.split(sysconfig.get_config_var("INSTALL"))[0]
+                assert os.path.basename(install) == "install", install
+                wasm_assets = sysconfig.get_config_var("WASM_ASSETS_DIR")
+                if wasm_assets is not None:
+                    assert wasm_assets == "./install", wasm_assets
+                for key in ("BINDIR", "LIBDIR", "INCLUDEPY", "LIBPL"):
+                    path = sysconfig.get_config_var(key)
+                    assert path.startswith(sys.prefix + os.sep), (key, path)
+                    assert os.path.exists(path), (key, path)
+
+                site_packages = sysconfig.get_path("platlib")
+                extension = os.path.join(
+                    site_packages,
+                    "_portable_extension" + sysconfig.get_config_var("EXT_SUFFIX"),
+                )
+                if not os.path.exists(extension):
+                    source = os.path.join(site_packages, "_portable_extension.c")
+                    with open(source, "w", encoding="utf-8") as file:
+                        file.write(
+                            "#include <Python.h>\n"
+                            "static PyModuleDef module = {"
+                            'PyModuleDef_HEAD_INIT, "_portable_extension", NULL, -1, NULL};\n'
+                            "PyMODINIT_FUNC PyInit__portable_extension(void) {"
+                            "return PyModule_Create(&module);}\n"
+                        )
+                    subprocess.run(
+                        [
+                            *shlex.split(sysconfig.get_config_var("LDSHARED")),
+                            "-I",
+                            sysconfig.get_path("include"),
+                            source,
+                            "-o",
+                            extension,
+                        ],
+                        check=True,
+                    )
+                __import__("_portable_extension")
+
+            if sys.platform == "darwin":
+                dylib = os.path.join(sys.prefix, "lib", "libpython3.12.dylib")
+                install_name = subprocess.check_output(
+                    ("otool", "-D", dylib), text=True
+                ).splitlines()[-1]
+                assert install_name == "@executable_path/../lib/libpython3.12.dylib"
+
+            scripts = os.path.dirname(sys.executable)
+            suffix = ".exe" if os.name == "nt" else ""
+            subprocess.run(
+                (os.path.join(scripts, f"pip{suffix}"), "--version"),
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+            subprocess.run(
+                (os.path.join(scripts, f"wheel{suffix}"), "version"),
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+
+            print("ok")
+        "##});
+        command
+    };
+
+    portable_environment_command(relocated.path())
+        .assert()
+        .success();
+
+    let archive = context.temp_dir.child("portable.tar");
+    let unpacked = context.temp_dir.child("unpacked");
+    let python =
+        venv_bin_path(relocated.path()).join(format!("python{}", std::env::consts::EXE_SUFFIX));
+    Command::new(python)
+        .arg("-c")
+        .arg(indoc! {r#"
+            import sys
+            import tarfile
+
+            with tarfile.open(sys.argv[1], "w") as archive:
+                archive.add(sys.argv[2], arcname="portable")
+            with tarfile.open(sys.argv[1]) as archive:
+                archive.extractall(sys.argv[3], filter="data")
+        "#})
+        .arg(archive.path())
+        .arg(relocated.path())
+        .arg(unpacked.path())
+        .assert()
+        .success();
+    fs_err::remove_dir_all(relocated.path())?;
+
+    uv_snapshot!(context.filters(), portable_environment_command(unpacked.child("portable").path()), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    ok
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn relocatable_portable_environment_sync_python314() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+
+    context.python_install().arg("3.14").assert().success();
+    let managed_python = context.python_find().arg("3.14").output()?;
+    assert!(managed_python.status.success());
+    let managed_python = std::str::from_utf8(&managed_python.stdout)?.trim();
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [project]
+            name = "project"
+            version = "0.1.0"
+            requires-python = ">=3.14"
+            dependencies = ["iniconfig"]
+        "#})?;
+    context
+        .venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.14")
+        .arg("--relocatable")
+        .arg("--preview-features")
+        .arg("portable-envs")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.sync(), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    let marker = context.venv.child("portable-marker");
+    marker.write_str("")?;
+    // The copied interpreter is outside the managed installation directory. Its home-less
+    // pyvenv.cfg must preserve managed provenance so --managed-python reuses the environment.
+    context.sync().arg("--managed-python").assert().success();
+    marker.assert(predicates::path::is_file());
+
+    context
+        .sync()
+        .arg("--python")
+        .arg(managed_python)
+        .assert()
+        .success();
+    marker.assert(predicates::path::is_file());
+
+    let managed_build = Path::new(managed_python)
+        .ancestors()
+        .map(|parent| parent.join("BUILD"))
+        .find(|path| path.is_file())
+        .ok_or_else(|| anyhow::anyhow!("managed Python installation does not have a BUILD file"))?;
+    let managed_installation = managed_build
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("managed Python installation does not have a parent"))?;
+    fs_err::remove_file(&managed_build)?;
+    fs_err::remove_file(context.venv.join("BUILD"))?;
+    context
+        .sync()
+        .arg("--python")
+        .arg(managed_installation)
+        .assert()
+        .success();
+    marker.assert(predicates::path::is_file());
+
+    context
+        .run()
+        .env_remove(EnvVars::VIRTUAL_ENV)
+        .arg("--no-project")
+        .arg("--python")
+        .arg(managed_python)
+        .arg("--with")
+        .arg("iniconfig")
+        .arg("--preview-features")
+        .arg("portable-envs")
+        .arg("python")
+        .arg("-c")
+        .arg("import iniconfig")
+        .assert()
+        .success();
+
+    let archives = context
+        .cache_dir
+        .child(format!("archive-v{ARCHIVE_VERSION}"));
+    let mut found_cached_environment = false;
+    for entry in fs_err::read_dir(archives.path())? {
+        let root = entry?.path();
+        if root.join("pyvenv.cfg").is_file() {
+            let stdlib = if cfg!(windows) {
+                root.join("Lib")
+            } else {
+                root.join("lib").join("python3.14")
+            };
+            assert!(!stdlib.join("os.py").exists());
+            found_cached_environment = true;
+        }
+    }
+    assert!(found_cached_environment);
+
+    #[cfg(windows)]
+    {
+        context.python_install().arg("3.13t").assert().success();
+        let managed_freethreaded = context.python_find().arg("3.13t").output()?;
+        assert!(managed_freethreaded.status.success());
+        let managed_freethreaded =
+            PathBuf::from(std::str::from_utf8(&managed_freethreaded.stdout)?.trim());
+
+        for (standard, versioned) in [
+            ("python.exe", "python3.13t.exe"),
+            ("pythonw.exe", "pythonw3.13t.exe"),
+        ] {
+            let standard = managed_freethreaded.with_file_name(standard);
+            let versioned = managed_freethreaded.with_file_name(versioned);
+            if standard.is_file() && versioned.is_file() {
+                fs_err::remove_file(standard)?;
+            }
+        }
+
+        let freethreaded = context.temp_dir.child("portable-freethreaded");
+        context
+            .venv()
+            .arg(freethreaded.path())
+            .arg("--python")
+            .arg("3.13t")
+            .arg("--relocatable")
+            .arg("--preview-features")
+            .arg("portable-envs")
+            .assert()
+            .success();
+
+        let scripts = freethreaded.child("Scripts");
+        for name in [
+            "python.exe",
+            "pythonw.exe",
+            "python3.13t.exe",
+            "pythonw3.13t.exe",
+        ] {
+            scripts.child(name).assert(predicates::path::is_file());
+        }
+        Command::new(scripts.child("python.exe").path())
+            .arg("--version")
+            .assert()
+            .success();
+    }
+
+    Ok(())
 }
 
 /// With `UV_VENV_RELOCATABLE=1`, the virtual environment is relocatable.

--- a/crates/uv/tests/sync/centralized_project_envs.rs
+++ b/crates/uv/tests/sync/centralized_project_envs.rs
@@ -220,6 +220,77 @@ fn sync_centralized_env_survives_python_patch_upgrade() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "test-python-managed")]
+fn sync_centralized_portable_env_is_not_upgradeable() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_managed_python_dirs()
+        .with_python_download_cache()
+        .with_filtered_centralized_environment_hashes();
+    context.python_install().arg("3.12.9").assert().success();
+    write_project(&context, ">=3.12", &[])?;
+
+    let previews = "centralized-project-envs,portable-envs,relocatable-envs-default";
+    context
+        .sync()
+        .arg("--python")
+        .arg("3.12")
+        .arg("--managed-python")
+        .arg("--preview-features")
+        .arg(previews)
+        .assert()
+        .success();
+
+    let link = context.temp_dir.child(".venv");
+    let environment = fs_err::read_link(link.path())?;
+    insta::with_settings!({ filters => context.filters() }, {
+        assert_snapshot!(environment.portable_display(), @"[CACHE_DIR]/environments-v2/project-cp3.12.9-[HASH]");
+    });
+
+    // An explicit relocatable `uv venv` uses the same non-upgradeable identity without relying on
+    // relocatable environments being enabled by default.
+    context
+        .venv()
+        .arg("--python")
+        .arg("3.12")
+        .arg("--relocatable")
+        .arg("--preview-features")
+        .arg("centralized-project-envs,portable-envs")
+        .assert()
+        .success();
+    assert_eq!(fs_err::read_link(link.path())?, environment);
+
+    let marker = environment.join("portable-marker");
+    fs_err::write(&marker, "")?;
+
+    context.python_install().arg("3.12.11").assert().success();
+    let python = uv_test::venv_bin_path(&environment)
+        .join(format!("python{}", std::env::consts::EXE_SUFFIX));
+    uv_snapshot!(context.filters(), Command::new(&python).arg("--version"), @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    Python 3.12.9
+    "#);
+
+    fs_err::remove_dir_all(context.temp_dir.child("managed").path())?;
+
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--offline")
+        .arg("--python")
+        .arg("3.12")
+        .arg("--managed-python")
+        .arg("--preview-features")
+        .arg(previews), @r#"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    "#);
+    assert!(marker.is_file());
+
+    Ok(())
+}
+
+#[test]
 fn sync_centralized_env_avoids_project_name_collisions() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.12"]);
     let project_a = context.temp_dir.child("project-a");

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3764,6 +3764,7 @@ fn preview_features() {
     +            GcsEndpoint,
     +            AdjustUlimit,
     +            SpecialCondaEnvNames,
+    +            PortableEnvs,
     +            RelocatableEnvsDefault,
     +            PublishRequireNormalized,
     +            AuditCommand,

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1807,6 +1807,7 @@
             "gcs-endpoint",
             "adjust-ulimit",
             "special-conda-env-names",
+            "portable-envs",
             "relocatable-envs-default",
             "publish-require-normalized",
             "audit-command",


### PR DESCRIPTION
## Summary

Add `--preview portable-envs` which makes relocatable environments backed by uv-managed Pythons "portable" or "real" environments which contain their own Python interpreter and can be moved between compatible machines.

## Notes

Global `--preview` will enable this feature for all eligible environments. I think this might be a bit too much, but wasn't sure how to gate it. I am open for suggestions.

This patches `libpython.dylib` to be relative to `@executable_path`. This means executables linking against `libpython` will work once they're in the virtual environment's `bin` directory, and will work when moved around. But executables not in the `bin` directory will _not_ work because `@executable_path` won't be in the right place. There's not much that can be done to fix this, AIUI... See also: #10598

This patches `_sysconfigdata_*.py` to make it portable. But it does it only for portable environments. I think it might be safe-ish to just do it always? Not sure.

## Test Plan

A bunch of new tests covering corner cases nobody could have even imagined.