### PR TITLE
fix(project): skip VIRTUAL_ENV mismatch warn on --no-sync

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -282,6 +282,14 @@ pub(crate) async fn add(
 
         if frozen.is_some() || no_sync {
             // Discover the interpreter.
+            // `--no-sync` does not touch the project environment. If the user did not pass
+            // `--active`/`--no-active`, treat a mismatched `VIRTUAL_ENV` as ignored without
+            // warning (see astral-sh/uv#7073).
+            let active = if no_sync {
+                active.or(Some(false))
+            } else {
+                active
+            };
             let workspace_python = WorkspacePython::from_request(
                 python.as_deref().map(PythonRequest::parse),
                 Some(project.workspace()),

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -226,6 +226,10 @@ pub(crate) async fn remove(
         RemoveTarget::Project(project) => {
             if no_sync {
                 // Discover the interpreter.
+                // `--no-sync` does not touch the project environment. If the user did not pass
+                // `--active`/`--no-active`, treat a mismatched `VIRTUAL_ENV` as ignored without
+                // warning (see astral-sh/uv#7073).
+                let active = active.or(Some(false));
                 let workspace_python = WorkspacePython::from_request(
                     python.as_deref().map(PythonRequest::parse),
                     Some(project.workspace()),

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -4384,6 +4384,35 @@ fn add_no_sync() -> Result<()> {
     Ok(())
 }
 
+/// `--no-sync` should not warn about a mismatched `VIRTUAL_ENV` (astral-sh/uv#7073).
+#[test]
+fn add_no_sync_ignores_virtual_env_warning() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    fs_err::remove_dir_all(&context.venv)?;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add()
+        .arg("anyio==3.7.0")
+        .arg("--no-sync")
+        .env(EnvVars::VIRTUAL_ENV, "foo"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn add_reject_multiple_git_ref_flags() {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
add/remove --no-sync only need an interpreter and do not update the project environment, so a mismatched VIRTUAL_ENV warning is noise.

When --active/--no-active is unset, treat it as --no-active for interpreter discovery.

Refs: astral-sh/uv#7073

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
