### PR TITLE
normalize paths to avoid traversing symlinks when writing console scripts

### DIFF
--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -47,7 +47,8 @@ pub fn uninstall_wheel(
     // Uninstall the files, keeping track of any directories that are left empty.
     let mut visited = BTreeSet::new();
     for entry in &record {
-        let path = site_packages.join(&entry.path);
+        // Normalize `..` lexically instead of letting the system resolve to avoid traversing symlinks.
+        let path = normalize_path(&site_packages.join(&entry.path));
 
         if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
             continue;

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -14,7 +14,10 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, instrument, trace, warn};
 use walkdir::WalkDir;
 
-use uv_fs::{PortablePath, Simplified, normalize_path_under, persist_with_retry_sync, relative_to};
+use uv_fs::{
+    PortablePath, Simplified, normalize_path, normalize_path_under, persist_with_retry_sync,
+    relative_to,
+};
 use uv_normalize::PackageName;
 use uv_pypi_types::DirectUrl;
 use uv_shell::escape_posix_for_single_quotes;
@@ -854,7 +857,11 @@ fn write_file_recorded(
         relative_path.display()
     );
 
-    uv_fs::write_atomic_sync(site_packages.join(relative_path), content.as_ref())?;
+    // Normalize `..` lexically instead of letting the system resolve to avoid traversing symlinks.
+    uv_fs::write_atomic_sync(
+        normalize_path(site_packages.join(relative_path)),
+        content.as_ref(),
+    )?;
 
     let hash = Sha256::new().chain_update(content.as_ref()).finalize();
     let encoded_hash = format!("sha256={}", BASE64URL_NOPAD.encode(&hash));


### PR DESCRIPTION
Fixes #21255 

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Normalize the path lexically (collapsing .. without resolving symlinks, via uv_fs::normalize_path) before writing, so destination to write console scripts resolves correctly and is consistent with the subsequent metadata check that uses the absolute path: https://github.com/astral-sh/uv/blob/5715fe31cefec52d651cafde383130bf401979d9/crates/uv-install-wheel/src/wheel.rs#L373. This is a no-op for paths that stay within site-packages, so all other callers (write_installer_metadata, regular wheel files) are unaffected.

The same site_packages.join(entry.path) expression is used to remove files on uninstall, so uninstall is normalized too.

## Test Plan

Minimal reproduction as mentioned in #21255
```sh
V=$(mktemp -d)/venv
mkdir -p "$V/usr/lib" "$V/usr/bin"
ln -s usr/lib "$V/lib"                      # merged-/usr layout
uv venv --allow-existing --python python3.12 "$V"
VIRTUAL_ENV="$V" uv pip install idna        # idna ships a `idna` console script
ls "$V/bin/idna"                            # before: fails / script in usr/bin; after: present
VIRTUAL_ENV="$V" uv pip uninstall idna
ls "$V/bin/idna"                            # after: correctly removed
```

- Before: install aborts with failed to query metadata of file .../bin/idna, launcher written to usr/bin/idna.
- After: launcher installed to bin/idna; uninstall removes it cleanly; nothing left in usr/bin.
- Removing the lib symlink (normal venv) is unchanged in both cases.
