### PR TITLE
Update Rust to 1.98 and MSRV to 1.96

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 homepage = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"
 authors = ["uv"]

--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -635,6 +635,8 @@ impl Authentication {
 
 #[cfg(test)]
 mod tests {
+    use std::future::{self, Future};
+
     use insta::{assert_debug_snapshot, assert_snapshot};
     use reqsign::aws::Credential as AwsCredential;
     use reqsign::azure::Credential as AzureCredential;
@@ -648,11 +650,11 @@ mod tests {
     impl ProvideCredential for EmptyAwsCredentialProvider {
         type Credential = AwsCredential;
 
-        async fn provide_credential(
+        fn provide_credential(
             &self,
             _ctx: &Context,
-        ) -> reqsign::Result<Option<Self::Credential>> {
-            Ok(None)
+        ) -> impl Future<Output = reqsign::Result<Option<Self::Credential>>> {
+            future::ready(Ok(None))
         }
     }
 
@@ -662,11 +664,11 @@ mod tests {
     impl ProvideCredential for EmptyAzureCredentialProvider {
         type Credential = AzureCredential;
 
-        async fn provide_credential(
+        fn provide_credential(
             &self,
             _ctx: &Context,
-        ) -> reqsign::Result<Option<Self::Credential>> {
-            Ok(None)
+        ) -> impl Future<Output = reqsign::Result<Option<Self::Credential>>> {
+            future::ready(Ok(None))
         }
     }
 

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -3,6 +3,7 @@
 //! implementing [`BuildContext`].
 
 use std::ffi::{OsStr, OsString};
+use std::future::{self, Future};
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -209,8 +210,8 @@ impl<'a> BuildDispatch<'a> {
 impl BuildContext for BuildDispatch<'_> {
     type SourceDistBuilder = SourceBuild;
 
-    async fn interpreter(&self) -> &Interpreter {
-        self.interpreter
+    fn interpreter(&self) -> impl Future<Output = &Interpreter> + '_ {
+        future::ready(self.interpreter)
     }
 
     fn cache(&self) -> &Cache {

--- a/crates/uv-publish/src/trusted_publishing.rs
+++ b/crates/uv-publish/src/trusted_publishing.rs
@@ -38,7 +38,7 @@ pub enum TrustedPublishingError {
     #[error(
         "Server returned error code {0}, is trusted publishing correctly configured?\nResponse: {1}\nToken claims, which must match the publisher configuration: {2:#?}"
     )]
-    TokenRejected(StatusCode, String, OidcTokenClaims),
+    TokenRejected(StatusCode, String, Box<OidcTokenClaims>),
     /// When trusted publishing is misconfigured, the error above should occur, not this one.
     #[error(
         "Server returned error code {0}, and the OIDC has an unexpected format.\nResponse: {1}"

--- a/crates/uv-publish/src/trusted_publishing/pypi.rs
+++ b/crates/uv-publish/src/trusted_publishing/pypi.rs
@@ -110,7 +110,7 @@ impl TrustedPublishingService for PyPIPublishingService<'_> {
                     Err(TrustedPublishingError::TokenRejected(
                         status,
                         String::from_utf8_lossy(&body).to_string(),
-                        claims,
+                        Box::new(claims),
                     ))
                 }
                 None => {

--- a/crates/uv-publish/src/trusted_publishing/pyx.rs
+++ b/crates/uv-publish/src/trusted_publishing/pyx.rs
@@ -136,7 +136,7 @@ impl TrustedPublishingService for PyxPublishingService<'_> {
                     Err(TrustedPublishingError::TokenRejected(
                         status,
                         String::from_utf8_lossy(&body).to_string(),
-                        claims,
+                        Box::new(claims),
                     ))
                 }
                 None => {

--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -240,7 +240,7 @@ impl RequirementsTxt {
         )
         .await
         .map_err(|err| RequirementsTxtFileError {
-            file: requirements_txt.to_path_buf(),
+            file: requirements_txt.into(),
             error: err,
         })
     }
@@ -268,7 +268,7 @@ impl RequirementsTxt {
             #[cfg(not(feature = "http"))]
             {
                 return Err(RequirementsTxtFileError {
-                    file: requirements_txt.to_path_buf(),
+                    file: requirements_txt.into(),
                     error: RequirementsTxtParserError::Io(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         "Remote file not supported without `http` feature",
@@ -280,7 +280,7 @@ impl RequirementsTxt {
             {
                 let url = requirements_txt.display().to_string();
                 let url = DisplaySafeUrl::parse(&url).map_err(|err| RequirementsTxtFileError {
-                    file: requirements_txt.to_path_buf(),
+                    file: requirements_txt.into(),
                     error: RequirementsTxtParserError::InvalidUrl(
                         requirements_txt.display().to_string(),
                         err,
@@ -290,7 +290,7 @@ impl RequirementsTxt {
                 // Avoid constructing a client if network is disabled already
                 if client_builder.is_offline() {
                     return Err(RequirementsTxtFileError {
-                        file: requirements_txt.to_path_buf(),
+                        file: requirements_txt.into(),
                         error: RequirementsTxtParserError::Io(io::Error::new(
                             io::ErrorKind::InvalidInput,
                             format!(
@@ -302,13 +302,13 @@ impl RequirementsTxt {
                 let client = client_builder
                     .build()
                     .map_err(|err| RequirementsTxtFileError {
-                        file: requirements_txt.to_path_buf(),
+                        file: requirements_txt.into(),
                         error: RequirementsTxtParserError::ClientBuild(url.clone(), Box::new(err)),
                     })?;
                 let content = read_url_to_string(&requirements_txt, client)
                     .await
                     .map_err(|err| RequirementsTxtFileError {
-                        file: requirements_txt.to_path_buf(),
+                        file: requirements_txt.into(),
                         error: err,
                     })?;
                 cache.insert(requirements_txt.to_path_buf(), content.clone());
@@ -319,7 +319,7 @@ impl RequirementsTxt {
             let content = uv_fs::read_to_string_transcode(&requirements_txt)
                 .await
                 .map_err(|err| RequirementsTxtFileError {
-                    file: requirements_txt.to_path_buf(),
+                    file: requirements_txt.into(),
                     error: RequirementsTxtParserError::Io(err),
                 })?;
             cache.insert(requirements_txt.to_path_buf(), content.clone());
@@ -338,7 +338,7 @@ impl RequirementsTxt {
         )
         .await
         .map_err(|err| RequirementsTxtFileError {
-            file: requirements_txt.to_path_buf(),
+            file: requirements_txt.into(),
             error: err,
         })?;
 
@@ -1141,7 +1141,7 @@ async fn read_url_to_string(
 /// Error parsing requirements.txt, wrapper with filename
 #[derive(Debug)]
 pub struct RequirementsTxtFileError {
-    file: PathBuf,
+    file: Box<Path>,
     error: RequirementsTxtParserError,
 }
 

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -78,7 +78,7 @@ pub(crate) enum Error {
     #[error(transparent)]
     BuildFrontend(#[from] uv_build_frontend::Error),
     #[error(transparent)]
-    Project(#[from] ProjectError),
+    Project(#[from] Box<ProjectError>),
     #[error("Failed to write message")]
     Fmt(#[from] fmt::Error),
     #[error("Can't use `--force-pep517` with `--list`")]
@@ -100,6 +100,12 @@ pub(crate) enum Error {
     NameMismatch(PackageName, PackageName),
     #[error("The source distribution declares version {0}, but the wheel declares version {1}")]
     VersionMismatch(Version, Version),
+}
+
+impl From<ProjectError> for Error {
+    fn from(error: ProjectError) -> Self {
+        Self::Project(Box::new(error))
+    }
 }
 
 impl Hint for Error {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1261,8 +1261,7 @@ fn read_environment_path_file(path: &Path) -> io::Result<PathBuf> {
 pub(crate) fn is_centralized_environment_reference(path: &Path, cache: &Cache) -> bool {
     is_centralized_environment_link(path, cache)
         || read_environment_path_file(path)
-            .ok()
-            .is_some_and(|target| is_centralized_environment_path(&target, cache))
+            .is_ok_and(|target| is_centralized_environment_path(&target, cache))
 }
 
 /// Return the centralized environment path for a given workspace and interpreter.
@@ -1495,8 +1494,7 @@ impl ProjectInterpreter {
             // A centralized path file is not a local environment; let initialization replace it.
             if !(environment_selection.is_default()
                 && read_environment_path_file(&project_environment_path)
-                    .ok()
-                    .is_some_and(|target| is_centralized_environment_path(&target, cache)))
+                    .is_ok_and(|target| is_centralized_environment_path(&target, cache)))
                 && let Some(environment) = discover_project_environment(
                     &project_environment_path,
                     python_request.as_ref(),

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -517,7 +517,7 @@ async fn execute_official_installer(
     modify_path: bool,
     target_version: &Pep440Version,
     astral_mirror_url: Option<&str>,
-) -> Result<(), AxoupdateError> {
+) -> Result<()> {
     let mut command = if cfg!(windows) {
         let mut command = Command::new("powershell");
         command.arg("-ExecutionPolicy").arg("ByPass");
@@ -577,7 +577,8 @@ async fn execute_official_installer(
         status: output.status.code(),
         stdout,
         stderr,
-    })
+    }
+    .into())
 }
 
 /// Read whether the existing standalone install opted out of PATH modification.
@@ -1168,16 +1169,16 @@ mod tests {
         )
         .await
         .expect_err("failing installer should return an error");
-        let AxoupdateError::InstallFailed {
+        let Some(AxoupdateError::InstallFailed {
             status,
             stdout,
             stderr,
-        } = err
+        }) = err.downcast_ref::<AxoupdateError>()
         else {
             panic!("expected InstallFailed error");
         };
 
-        assert_eq!(status, Some(23));
+        assert_eq!(*status, Some(23));
         assert_eq!(stdout.as_deref(), Some("hello from stdout\n"));
         assert_eq!(stderr.as_deref(), Some("hello from stderr\n"));
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"


### PR DESCRIPTION
## Summary

- Update the Rust toolchain to 1.98.0 and raise the MSRV to 1.96.0 under our N-2 support policy.
- Address new Rust 1.98 Clippy warnings by shrinking oversized errors, returning ready futures where appropriate, and simplifying `Result` checks.
