### PR TITLE
Use Rust 1.96 pattern assertions and update remaining toolchains

### DIFF
--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -635,6 +635,7 @@ impl Authentication {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::future::{self, Future};
 
     use insta::{assert_debug_snapshot, assert_snapshot};
@@ -675,7 +676,7 @@ mod tests {
     #[test]
     fn from_url_no_credentials() {
         let url = &Url::parse("https://example.com/simple/first/").unwrap();
-        assert!(matches!(Credentials::from_url(url), Ok(None)));
+        assert_matches!(Credentials::from_url(url), Ok(None));
     }
 
     #[test]

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -985,6 +985,7 @@ fn tracing_url(request: &Request, credentials: Option<&Authentication>) -> Displ
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::io::Write;
 
     use http::Method;
@@ -1504,11 +1505,9 @@ mod tests {
 
         let mut url = base_url.clone();
         url.set_username("other_user").unwrap();
-        assert!(
-            matches!(
-                client.get(url).send().await,
-                Err(reqwest_middleware::Error::Middleware(_))
-            ),
+        assert_matches!(
+            client.get(url).send().await,
+            Err(reqwest_middleware::Error::Middleware(_)),
             "If the username does not match, a password should not be fetched, and the middleware should fail eagerly since `authenticate = always` is not satisfied"
         );
 
@@ -2421,10 +2420,10 @@ mod tests {
             .build();
 
         // Unauthenticated requests are not allowed.
-        assert!(matches!(
+        assert_matches!(
             client.get(server.uri()).send().await,
             Err(reqwest_middleware::Error::Middleware(_))
-        ));
+        );
 
         Ok(())
     }

--- a/crates/uv-bin-install/src/lib.rs
+++ b/crates/uv-bin-install/src/lib.rs
@@ -922,6 +922,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use serde_json::json;
     use std::io::Write;
     use uv_client::{BaseClientBuilder, fetch_with_url_fallback, retryable_on_request_failure};
@@ -1316,7 +1318,7 @@ mod tests {
                 .await
                 .expect_err("no matching version should not fall back to canonical manifest");
 
-        assert!(matches!(err, Error::NoMatchingVersion { .. }));
+        assert_matches!(err, Error::NoMatchingVersion { .. });
         assert_eq!(mirror_server.received_requests().await.unwrap().len(), 1);
         assert_eq!(canonical_server.received_requests().await.unwrap().len(), 0);
     }

--- a/crates/uv-build-frontend/src/error.rs
+++ b/crates/uv-build-frontend/src/error.rs
@@ -450,6 +450,8 @@ impl Error {
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches;
+
     use crate::{Error, PythonRunnerOutput};
     use indoc::indoc;
     use std::process::ExitStatus;
@@ -504,7 +506,7 @@ mod test {
             Some("pygraphviz-1.11"),
         );
 
-        assert!(matches!(err, Error::MissingHeader { .. }));
+        assert_matches!(err, Error::MissingHeader { .. });
         let formatted = format_error_with_hints(&err);
         insta::assert_snapshot!(formatted, @r#"
         Failed building wheel through setup.py (exit code: 0)
@@ -557,7 +559,7 @@ mod test {
             None,
             Some("pygraphviz-1.11"),
         );
-        assert!(matches!(err, Error::MissingHeader { .. }));
+        assert_matches!(err, Error::MissingHeader { .. });
         let formatted = format_error_with_hints(&err);
         insta::assert_snapshot!(formatted, @"
         Failed building wheel through setup.py (exit code: 0)
@@ -600,7 +602,7 @@ mod test {
             None,
             Some("pygraphviz-1.11"),
         );
-        assert!(matches!(err, Error::MissingHeader { .. }));
+        assert_matches!(err, Error::MissingHeader { .. });
         let formatted = format_error_with_hints(&err);
         insta::assert_snapshot!(formatted, @r#"
         Failed building wheel through setup.py (exit code: 0)
@@ -646,7 +648,7 @@ mod test {
             Some(&Version::new([1, 11])),
             Some("pygraphviz-1.11"),
         );
-        assert!(matches!(err, Error::MissingHeader { .. }));
+        assert_matches!(err, Error::MissingHeader { .. });
         let formatted = format_error_with_hints(&err);
         insta::assert_snapshot!(formatted, @"
         Failed building wheel through setup.py (exit code: 0)

--- a/crates/uv-build/rust-toolchain.toml
+++ b/crates/uv-build/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -1416,6 +1416,7 @@ fn parse_seconds(value: &[u8]) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::time::Duration;
 
     use super::*;
@@ -1485,10 +1486,10 @@ mod tests {
             .insert(http::header::ACCEPT, "text/html".parse().unwrap());
 
         assert!(archived.matches_stale_request(&request));
-        assert!(matches!(
+        assert_matches!(
             archived.before_request(&mut request),
             BeforeRequest::Stale(_)
-        ));
+        );
 
         let request = http_request(http::Method::HEAD, "https://example.com/");
         assert!(archived.matches_stale_request(&request));

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1932,6 +1932,7 @@ impl Connectivity {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::str::FromStr;
 
     use tokio::sync::Semaphore;
@@ -1996,10 +1997,10 @@ mod tests {
             .await
             .expect_err("index lookup should be disabled");
 
-        assert!(matches!(
+        assert_matches!(
             error.kind(),
             crate::ErrorKind::NoIndex(error_package) if error_package == package
-        ));
+        );
         Ok(())
     }
 

--- a/crates/uv-client/tests/it/cached_client.rs
+++ b/crates/uv-client/tests/it/cached_client.rs
@@ -1,8 +1,9 @@
+use std::assert_matches;
 use uv_client::{DataWithCachePolicy, ErrorKind};
 
 #[test]
 fn reject_overflowing_cache_policy_length() {
     let error = DataWithCachePolicy::from_reader(&[u8::MAX; 8][..]).unwrap_err();
 
-    assert!(matches!(error.kind(), ErrorKind::ArchiveRead(_)));
+    assert_matches!(error.kind(), ErrorKind::ArchiveRead(_));
 }

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -324,8 +325,9 @@ impl TestClient {
     /// valid client certificate was presented.
     async fn expect_mtls_connect_fails(&self, cert: &TestCertificate) {
         self.expect_mtls_connect_fails_with_server_tls_error(cert, |server_tls_err| {
-            assert!(
-                matches!(server_tls_err, rustls::Error::NoCertificatesPresented),
+            assert_matches!(
+                server_tls_err,
+                rustls::Error::NoCertificatesPresented,
                 "expected NoCertificatesPresented, got: {server_tls_err}"
             );
         })
@@ -859,13 +861,11 @@ async fn test_mtls_with_wrong_client_cert() -> Result<()> {
         .ssl_cert_file(&server_cert.trust_path)
         .ssl_client_cert(&other_cert.client_cert_path)
         .expect_mtls_connect_fails_with_server_tls_error(&server_cert, |server_tls_err| {
-            assert!(
-                matches!(
-                    server_tls_err,
-                    rustls::Error::InvalidCertificate(
-                        rustls::CertificateError::BadSignature
-                            | rustls::CertificateError::UnknownIssuer
-                    )
+            assert_matches!(
+                server_tls_err,
+                rustls::Error::InvalidCertificate(
+                    rustls::CertificateError::BadSignature
+                        | rustls::CertificateError::UnknownIssuer
                 ),
                 "expected InvalidCertificate(BadSignature | UnknownIssuer), got: {server_tls_err}"
             );

--- a/crates/uv-configuration/src/proxy_url.rs
+++ b/crates/uv-configuration/src/proxy_url.rs
@@ -139,6 +139,8 @@ impl schemars::JsonSchema for ProxyUrl {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -199,7 +201,7 @@ mod tests {
     #[test]
     fn parse_invalid_proxy_urls() {
         let result = "ftp://proxy.example.com:8080".parse::<ProxyUrl>();
-        assert!(matches!(result, Err(ProxyUrlError::InvalidScheme { .. })));
+        assert_matches!(result, Err(ProxyUrlError::InvalidScheme { .. }));
         insta::assert_snapshot!(
             result.unwrap_err().to_string(),
             @"invalid proxy URL scheme `ftp` in `ftp://proxy.example.com:8080/`: expected http, https, socks5, or socks5h"
@@ -207,7 +209,7 @@ mod tests {
 
         // Invalid URL (spaces are not allowed)
         let result = "not a url".parse::<ProxyUrl>();
-        assert!(matches!(result, Err(ProxyUrlError::InvalidUrl(_))));
+        assert_matches!(result, Err(ProxyUrlError::InvalidUrl(_)));
         insta::assert_snapshot!(
             result.unwrap_err().to_string(),
             @"invalid proxy URL: invalid international domain name"
@@ -215,14 +217,14 @@ mod tests {
 
         // Empty string
         let result = "".parse::<ProxyUrl>();
-        assert!(matches!(result, Err(ProxyUrlError::InvalidUrl(_))));
+        assert_matches!(result, Err(ProxyUrlError::InvalidUrl(_)));
         insta::assert_snapshot!(
             result.unwrap_err().to_string(),
             @"invalid proxy URL: empty host"
         );
 
         let result = "file:///path/to/file".parse::<ProxyUrl>();
-        assert!(matches!(result, Err(ProxyUrlError::InvalidScheme { .. })));
+        assert_matches!(result, Err(ProxyUrlError::InvalidScheme { .. }));
         insta::assert_snapshot!(
             result.unwrap_err().to_string(),
             @"invalid proxy URL scheme `file` in `file:///path/to/file`: expected http, https, socks5, or socks5h"

--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -144,6 +144,7 @@ pub enum DistFilenameError {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::str::FromStr;
 
     use uv_normalize::PackageName;
@@ -161,8 +162,9 @@ mod tests {
         // is rejected because it has no recognized distribution extension.
         let name = PackageName::from_str("my-package").unwrap();
         let err = DistFilename::try_from_filename_with_reason("0.1.0", &name).unwrap_err();
-        assert!(
-            matches!(err, DistFilenameError::NoRecognizedExtension(_)),
+        assert_matches!(
+            err,
+            DistFilenameError::NoRecognizedExtension(_),
             "unexpected error variant: {err:?}"
         );
         let rendered = err.to_string();
@@ -178,8 +180,9 @@ mod tests {
         // similarly rejected with the no-extension reason rather than silently swallowing it.
         let name = PackageName::from_str("my-package").unwrap();
         let err = DistFilename::try_from_filename_with_reason("", &name).unwrap_err();
-        assert!(
-            matches!(err, DistFilenameError::NoRecognizedExtension(_)),
+        assert_matches!(
+            err,
+            DistFilenameError::NoRecognizedExtension(_),
             "unexpected error variant: {err:?}"
         );
     }
@@ -191,8 +194,9 @@ mod tests {
         let name = PackageName::from_str("my-package").unwrap();
         let err =
             DistFilename::try_from_filename_with_reason("not-a-wheel.whl", &name).unwrap_err();
-        assert!(
-            matches!(err, DistFilenameError::InvalidWheel(_)),
+        assert_matches!(
+            err,
+            DistFilenameError::InvalidWheel(_),
             "unexpected error variant: {err:?}"
         );
     }

--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -319,6 +319,8 @@ pub struct Zstd {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -355,7 +357,7 @@ mod tests {
         // Borrows a URL without a fragment
         let url = UrlString("https://example.com/path".into());
         assert_eq!(&*url.without_fragment(), &url);
-        assert!(matches!(url.without_fragment(), Cow::Borrowed(_)));
+        assert_matches!(url.without_fragment(), Cow::Borrowed(_));
 
         // Removes the fragment if present on the URL
         let url = UrlString("https://example.com/path?query#fragment".into());
@@ -363,6 +365,6 @@ mod tests {
             &*url.without_fragment(),
             &UrlString("https://example.com/path?query".into())
         );
-        assert!(matches!(url.without_fragment(), Cow::Owned(_)));
+        assert_matches!(url.without_fragment(), Cow::Owned(_));
     }
 }

--- a/crates/uv-distribution-types/src/id.rs
+++ b/crates/uv-distribution-types/src/id.rs
@@ -238,6 +238,7 @@ impl From<&Self> for ResourceId {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use fs_err as fs;
@@ -320,11 +321,8 @@ mod tests {
         let file_url = DisplaySafeUrl::from_file_path(&file).unwrap();
         let directory_url = DisplaySafeUrl::from_file_path(&directory).unwrap();
 
-        assert!(matches!(VersionId::from_url(&file_url), VersionId::Path(_)));
-        assert!(matches!(
-            VersionId::from_url(&directory_url),
-            VersionId::Directory(_)
-        ));
+        assert_matches!(VersionId::from_url(&file_url), VersionId::Path(_));
+        assert_matches!(VersionId::from_url(&directory_url), VersionId::Directory(_));
 
         fs::remove_file(file).unwrap();
         fs::remove_dir_all(root).unwrap();
@@ -335,6 +333,6 @@ mod tests {
         let url =
             DisplaySafeUrl::parse("git+ftp://example.com/pkg.git@main#subdirectory=foo").unwrap();
 
-        assert!(matches!(VersionId::from_url(&url), VersionId::Unknown(_)));
+        assert_matches!(VersionId::from_url(&url), VersionId::Unknown(_));
     }
 }

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -803,6 +803,8 @@ pub enum IndexSourceError {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use http::HeaderValue;
 
@@ -918,9 +920,6 @@ mod tests {
 
         let index: Index = toml::from_str(toml_str).unwrap();
         assert_eq!(index.name.as_ref().unwrap().as_ref(), "internal");
-        assert!(matches!(
-            index.exclude_newer,
-            Some(ExcludeNewerOverride::Enabled(_))
-        ));
+        assert_matches!(index.exclude_newer, Some(ExcludeNewerOverride::Enabled(_)));
     }
 }

--- a/crates/uv-extract/src/dirhash.rs
+++ b/crates/uv-extract/src/dirhash.rs
@@ -493,6 +493,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::assert_matches;
+
     use super::*;
     use std::cmp;
     use std::process::Command;
@@ -650,7 +653,7 @@ mod tests {
         fs_err::create_dir(root.join("dir2/inner"))?;
         symlink("../../dir1", root.join("dir2/inner/dir_link"))?;
         let error = super::dirhash_path(root).unwrap_err();
-        std::assert_matches!(error, super::DirhashError::SymlinkCycle { .. });
+        assert_matches!(error, super::DirhashError::SymlinkCycle { .. });
         Ok(())
     }
 

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -332,6 +332,7 @@ pub fn remove_symlink(path: impl AsRef<Path>) -> io::Result<()> {
 
 #[cfg(all(test, windows))]
 mod windows_tests {
+    use std::assert_matches;
     use std::os::windows::ffi::OsStrExt;
 
     use super::*;
@@ -385,10 +386,10 @@ mod windows_tests {
 
         let err = create_junction(&target, &link).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidFilename);
-        assert!(matches!(
+        assert_matches!(
             fs_err::symlink_metadata(&link),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound
-        ));
+        );
         Ok(())
     }
 }
@@ -984,6 +985,8 @@ pub fn clear_virtualenv(location: &Path) -> io::Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -997,10 +1000,10 @@ mod tests {
         create_symlink(&target, &link)?;
         remove_symlink(&link)?;
 
-        assert!(matches!(
+        assert_matches!(
             fs_err::symlink_metadata(&link),
             Err(err) if err.kind() == io::ErrorKind::NotFound
-        ));
+        );
         assert_eq!(fs_err::read_to_string(target.join("file"))?, "content");
         Ok(())
     }
@@ -1017,10 +1020,10 @@ mod tests {
 
         remove_virtualenv(&environment)?;
 
-        assert!(matches!(
+        assert_matches!(
             fs_err::symlink_metadata(environment),
             Err(err) if err.kind() == io::ErrorKind::NotFound
-        ));
+        );
         assert!(marker.is_file());
         Ok(())
     }

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -907,6 +907,8 @@ fn create_symlink(original: &Path, link: &Path) -> io::Result<()> {
 #[cfg(test)]
 #[expect(clippy::print_stderr)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use tempfile::TempDir;
 
@@ -1316,10 +1318,10 @@ mod tests {
         let result = link_dir(src_dir.path(), dst_dir.path(), &options).unwrap();
 
         // Should succeed with one of the valid modes
-        assert!(matches!(
+        assert_matches!(
             result,
             LinkMode::Clone | LinkMode::Hardlink | LinkMode::Copy
-        ));
+        );
         verify_test_tree(dst_dir.path());
     }
 

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -660,6 +660,8 @@ impl AsRef<Path> for PortablePathBuf {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -809,8 +811,9 @@ mod tests {
         // Verify the fast path: already-normalized inputs are returned borrowed.
         for already_normalized in ["foo/bar", "/a/b/c", "foo", "/", ""] {
             let path = Path::new(already_normalized);
-            assert!(
-                matches!(normalize_path(path), Cow::Borrowed(_)),
+            assert_matches!(
+                normalize_path(path),
+                Cow::Borrowed(_),
                 "expected borrowed for {already_normalized:?}"
             );
         }

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -1219,6 +1219,7 @@ impl RenameOrCopy {
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches;
     use std::io::{Cursor, ErrorKind};
     use std::path::Path;
 
@@ -1317,10 +1318,10 @@ mod test {
             .err()
             .ok_or_else(|| anyhow::anyhow!("invalid UTF-8 should fail to parse"))?;
 
-        assert!(matches!(
+        assert_matches!(
             error,
             Error::Io(err) if err.kind() == ErrorKind::InvalidData
-        ));
+        );
 
         Ok(())
     }

--- a/crates/uv-keyring/src/lib.rs
+++ b/crates/uv-keyring/src/lib.rs
@@ -354,6 +354,8 @@ impl Entry {
 /// Instead, it contains generics that each keystore invokes in their tests,
 /// passing their store-specific parameters for the generic ones.
 mod tests {
+    use std::assert_matches;
+
     use super::{Entry, Error};
     #[cfg(feature = "native-auth")]
     use super::{Result, credential::CredentialApi};
@@ -397,8 +399,9 @@ mod tests {
             .await
             .unwrap_or_else(|err| panic!("Can't delete password for {case}: {err:?}"));
         let password = entry.get_password().await;
-        assert!(
-            matches!(password, Err(Error::NoEntry)),
+        assert_matches!(
+            password,
+            Err(Error::NoEntry),
             "Read deleted password for {case}",
         );
     }
@@ -422,8 +425,9 @@ mod tests {
             .await
             .unwrap_or_else(|err| panic!("Can't delete password for {case}: {err:?}"));
         let password = entry.get_secret().await;
-        assert!(
-            matches!(password, Err(Error::NoEntry)),
+        assert_matches!(
+            password,
+            Err(Error::NoEntry),
             "Read deleted password for {case}",
         );
     }
@@ -455,8 +459,9 @@ mod tests {
     {
         let name = generate_random_string();
         let entry = f(&name, &name);
-        assert!(
-            matches!(entry.get_password().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_password().await,
+            Err(Error::NoEntry),
             "Missing entry has password"
         );
     }
@@ -519,14 +524,16 @@ mod tests {
     {
         let name = generate_random_string();
         let entry = f(&name, &name);
-        assert!(
-            matches!(entry.get_attributes().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_attributes().await,
+            Err(Error::NoEntry),
             "Read missing credential in attribute test",
         );
         let mut map: HashMap<&str, &str> = HashMap::new();
         map.insert("test attribute name", "test attribute value");
-        assert!(
-            matches!(entry.update_attributes(&map).await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.update_attributes(&map).await,
+            Err(Error::NoEntry),
             "Updated missing credential in attribute test",
         );
         // create the credential and test again
@@ -539,8 +546,9 @@ mod tests {
             Ok(attrs) if attrs.is_empty() => {}
             Ok(attrs) => panic!("Unexpected attributes: {attrs:?}"),
         }
-        assert!(
-            matches!(entry.update_attributes(&map).await, Ok(())),
+        assert_matches!(
+            entry.update_attributes(&map).await,
+            Ok(()),
             "Couldn't update attributes in attribute test",
         );
         match entry.get_attributes().await {
@@ -552,8 +560,9 @@ mod tests {
             .delete_credential()
             .await
             .unwrap_or_else(|err| panic!("Can't delete credential for attribute test: {err:?}"));
-        assert!(
-            matches!(entry.get_attributes().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_attributes().await,
+            Err(Error::NoEntry),
             "Read deleted credential in attribute test",
         );
     }

--- a/crates/uv-keyring/src/macos.rs
+++ b/crates/uv-keyring/src/macos.rs
@@ -336,6 +336,8 @@ fn decode_error(err: Error) -> ErrorCode {
 #[cfg(not(miri))]
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use crate::{Entry, Error, tests::generate_random_string};
 
     use super::MacCredential;
@@ -351,13 +353,15 @@ mod tests {
     #[test]
     fn test_invalid_parameter() {
         let credential = MacCredential::new_with_target(None, "", "user");
-        assert!(
-            matches!(credential, Err(Error::Invalid(_, _))),
+        assert_matches!(
+            credential,
+            Err(Error::Invalid(_, _)),
             "Created credential with empty service"
         );
         let credential = MacCredential::new_with_target(None, "service", "");
-        assert!(
-            matches!(credential, Err(Error::Invalid(_, _))),
+        assert_matches!(
+            credential,
+            Err(Error::Invalid(_, _)),
             "Created entry with empty user"
         );
     }
@@ -413,7 +417,7 @@ mod tests {
             .delete_credential()
             .await
             .expect("Couldn't delete after get_credential");
-        assert!(matches!(entry.get_password().await, Err(Error::NoEntry)));
+        assert_matches!(entry.get_password().await, Err(Error::NoEntry));
     }
 
     #[tokio::test]
@@ -432,8 +436,9 @@ mod tests {
                 .downcast_ref()
                 .expect("credential not a MacCredential");
             if name == "unknown" {
-                assert!(
-                    matches!(mac_cred.domain, super::MacKeychainDomain::User),
+                assert_matches!(
+                    mac_cred.domain,
+                    super::MacKeychainDomain::User,
                     "wrong domain for unknown specifier"
                 );
             }

--- a/crates/uv-keyring/src/mock.rs
+++ b/crates/uv-keyring/src/mock.rs
@@ -196,6 +196,8 @@ impl MockCredential {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::MockCredential;
     use crate::{Entry, Error, tests::generate_random_string};
 
@@ -253,11 +255,9 @@ mod tests {
             "mock error".to_string(),
             "is an error".to_string(),
         ));
-        assert!(
-            matches!(
-                entry.set_password(password).await,
-                Err(Error::Invalid(_, _))
-            ),
+        assert_matches!(
+            entry.set_password(password).await,
+            Err(Error::Invalid(_, _)),
             "set: No error"
         );
         entry
@@ -265,8 +265,9 @@ mod tests {
             .await
             .expect("set: Error not cleared");
         mock.set_error(Error::NoEntry);
-        assert!(
-            matches!(entry.get_password().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_password().await,
+            Err(Error::NoEntry),
             "get: No error"
         );
         let stored_password = entry.get_password().await.expect("get: Error not cleared");
@@ -275,16 +276,18 @@ mod tests {
             "Retrieved and set ascii passwords don't match"
         );
         mock.set_error(Error::TooLong("mock".to_string(), 3));
-        assert!(
-            matches!(entry.delete_credential().await, Err(Error::TooLong(_, 3))),
+        assert_matches!(
+            entry.delete_credential().await,
+            Err(Error::TooLong(_, 3)),
             "delete: No error"
         );
         entry
             .delete_credential()
             .await
             .expect("delete: Error not cleared");
-        assert!(
-            matches!(entry.get_password().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_password().await,
+            Err(Error::NoEntry),
             "Able to read a deleted ascii password"
         );
     }

--- a/crates/uv-keyring/src/secret_service.rs
+++ b/crates/uv-keyring/src/secret_service.rs
@@ -616,6 +616,8 @@ fn wrap(err: Error) -> Box<dyn std::error::Error + Send + Sync> {
 #[cfg(feature = "native-auth")]
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use crate::secret_service::{EncryptionType, SecretService, SsCredential};
     use crate::{Entry, Error, tests::generate_random_string};
     use std::collections::HashMap;
@@ -627,8 +629,9 @@ mod tests {
     #[test]
     fn test_invalid_parameter() {
         let credential = SsCredential::new_with_target(Some(""), "service", "user");
-        assert!(
-            matches!(credential, Err(Error::Invalid(_, _))),
+        assert_matches!(
+            credential,
+            Err(Error::Invalid(_, _)),
             "Created entry with empty target"
         );
     }
@@ -691,7 +694,7 @@ mod tests {
             .delete_credential()
             .await
             .expect("Couldn't delete get-credential");
-        assert!(matches!(entry.get_password().await, Err(Error::NoEntry)));
+        assert_matches!(entry.get_password().await, Err(Error::NoEntry));
     }
 
     #[tokio::test]
@@ -701,8 +704,9 @@ mod tests {
             .expect("Can't create credential for attribute test");
         let create_label = credential.label.clone();
         let entry = Entry::new_with_credential(Box::new(credential));
-        assert!(
-            matches!(entry.get_attributes().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_attributes().await,
+            Err(Error::NoEntry),
             "Read missing credential in attribute test",
         );
         let mut in_map: HashMap<&str, &str> = HashMap::new();
@@ -711,8 +715,9 @@ mod tests {
         in_map.insert("target", "ignored target value");
         in_map.insert("service", "ignored service value");
         in_map.insert("username", "ignored username value");
-        assert!(
-            matches!(entry.update_attributes(&in_map).await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.update_attributes(&in_map).await,
+            Err(Error::NoEntry),
             "Updated missing credential in attribute test",
         );
         // create the credential and test again
@@ -729,8 +734,9 @@ mod tests {
         assert!(!out_map.contains_key("target"));
         assert!(!out_map.contains_key("service"));
         assert!(!out_map.contains_key("username"));
-        assert!(
-            matches!(entry.update_attributes(&in_map).await, Ok(())),
+        assert_matches!(
+            entry.update_attributes(&in_map).await,
+            Ok(()),
             "Couldn't update attributes in attribute test",
         );
         let after_map = entry
@@ -744,19 +750,18 @@ mod tests {
         );
         assert_eq!(out_map["application"], "uv");
         in_map.insert("label", "");
-        assert!(
-            matches!(
-                entry.update_attributes(&in_map).await,
-                Err(Error::Invalid(_, _))
-            ),
+        assert_matches!(
+            entry.update_attributes(&in_map).await,
+            Err(Error::Invalid(_, _)),
             "Was able to set empty label in attribute test",
         );
         entry
             .delete_credential()
             .await
             .unwrap_or_else(|err| panic!("Can't delete credential for attribute test: {err:?}"));
-        assert!(
-            matches!(entry.get_attributes().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_attributes().await,
+            Err(Error::NoEntry),
             "Read deleted credential in attribute test",
         );
     }
@@ -782,7 +787,7 @@ mod tests {
             .delete_credential()
             .await
             .expect("Couldn't delete password for new collection entry");
-        assert!(matches!(entry.get_password().await, Err(Error::NoEntry)));
+        assert_matches!(entry.get_password().await, Err(Error::NoEntry));
         delete_collection(&name).await;
     }
 
@@ -832,17 +837,17 @@ mod tests {
             .delete_credential()
             .await
             .expect("Couldn't delete password for collection 1");
-        assert!(matches!(entry1.get_password().await, Err(Error::NoEntry)));
+        assert_matches!(entry1.get_password().await, Err(Error::NoEntry));
         entry2
             .delete_credential()
             .await
             .expect("Couldn't delete password for collection 2");
-        assert!(matches!(entry2.get_password().await, Err(Error::NoEntry)));
+        assert_matches!(entry2.get_password().await, Err(Error::NoEntry));
         entry3
             .delete_credential()
             .await
             .expect("Couldn't delete password for default collection");
-        assert!(matches!(entry3.get_password().await, Err(Error::NoEntry)));
+        assert_matches!(entry3.get_password().await, Err(Error::NoEntry));
         delete_collection(&name1).await;
         delete_collection(&name2).await;
     }

--- a/crates/uv-keyring/src/windows.rs
+++ b/crates/uv-keyring/src/windows.rs
@@ -522,6 +522,8 @@ impl std::error::Error for Error {
 #[cfg(feature = "native-auth")]
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     use crate::Entry;
@@ -650,8 +652,9 @@ mod tests {
     #[test]
     fn test_invalid_parameter() {
         let credential = WinCredential::new_with_target(Some(""), "service", "user");
-        assert!(
-            matches!(credential, Err(ErrorCode::Invalid(_, _))),
+        assert_matches!(
+            credential,
+            Err(ErrorCode::Invalid(_, _)),
             "Created entry with empty target"
         );
     }
@@ -692,8 +695,9 @@ mod tests {
         let cred = WinCredential::new_with_target(None, &name, &name)
             .expect("Can't create credential for attribute test");
         let entry = Entry::new_with_credential(Box::new(cred.clone()));
-        assert!(
-            matches!(entry.get_attributes().await, Err(ErrorCode::NoEntry)),
+        assert_matches!(
+            entry.get_attributes().await,
+            Err(ErrorCode::NoEntry),
             "Read missing credential in attribute test",
         );
         let mut in_map: HashMap<&str, &str> = HashMap::new();
@@ -702,11 +706,9 @@ mod tests {
         in_map.insert("target_alias", "target alias value");
         in_map.insert("comment", "comment value");
         in_map.insert("username", "username value");
-        assert!(
-            matches!(
-                entry.update_attributes(&in_map).await,
-                Err(ErrorCode::NoEntry)
-            ),
+        assert_matches!(
+            entry.update_attributes(&in_map).await,
+            Err(ErrorCode::NoEntry),
             "Updated missing credential in attribute test",
         );
         // create the credential and test again
@@ -721,8 +723,9 @@ mod tests {
         assert_eq!(out_map["target_alias"], cred.target_alias);
         assert_eq!(out_map["comment"], cred.comment);
         assert_eq!(out_map["username"], cred.username);
-        assert!(
-            matches!(entry.update_attributes(&in_map).await, Ok(())),
+        assert_matches!(
+            entry.update_attributes(&in_map).await,
+            Ok(()),
             "Couldn't update attributes in attribute test",
         );
         let after_map = entry
@@ -738,8 +741,9 @@ mod tests {
             .delete_credential()
             .await
             .unwrap_or_else(|err| panic!("Can't delete credential for attribute test: {err:?}"));
-        assert!(
-            matches!(entry.get_attributes().await, Err(ErrorCode::NoEntry)),
+        assert_matches!(
+            entry.get_attributes().await,
+            Err(ErrorCode::NoEntry),
             "Read deleted credential in attribute test",
         );
     }
@@ -778,9 +782,6 @@ mod tests {
             .delete_credential()
             .await
             .expect("Couldn't delete get-credential");
-        assert!(matches!(
-            entry.get_password().await,
-            Err(ErrorCode::NoEntry)
-        ));
+        assert_matches!(entry.get_password().await, Err(ErrorCode::NoEntry));
     }
 }

--- a/crates/uv-keyring/tests/basic.rs
+++ b/crates/uv-keyring/tests/basic.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "native-auth")]
 
 use common::{generate_random_bytes_of_len, generate_random_string, init_logger};
+use std::assert_matches;
 use uv_keyring::{Entry, Error};
 
 mod common;
@@ -11,8 +12,9 @@ async fn test_missing_entry() {
 
     let name = generate_random_string();
     let entry = Entry::new(&name, &name).expect("Can't create entry");
-    assert!(
-        matches!(entry.get_password().await, Err(Error::NoEntry)),
+    assert_matches!(
+        entry.get_password().await,
+        Err(Error::NoEntry),
         "Missing entry has password"
     );
 }
@@ -41,8 +43,9 @@ async fn test_empty_password() {
         .delete_credential()
         .await
         .expect("Can't delete password");
-    assert!(
-        matches!(entry.get_password().await, Err(Error::NoEntry)),
+    assert_matches!(
+        entry.get_password().await,
+        Err(Error::NoEntry),
         "Able to read a deleted password"
     );
 }
@@ -70,8 +73,9 @@ async fn test_round_trip_ascii_password() {
         .delete_credential()
         .await
         .expect("Can't delete ascii password");
-    assert!(
-        matches!(entry.get_password().await, Err(Error::NoEntry)),
+    assert_matches!(
+        entry.get_password().await,
+        Err(Error::NoEntry),
         "Able to read a deleted ascii password"
     );
 }
@@ -99,8 +103,9 @@ async fn test_round_trip_non_ascii_password() {
         .delete_credential()
         .await
         .expect("Can't delete non-ascii password");
-    assert!(
-        matches!(entry.get_password().await, Err(Error::NoEntry)),
+    assert_matches!(
+        entry.get_password().await,
+        Err(Error::NoEntry),
         "Able to read a deleted non-ascii password"
     );
 }
@@ -126,8 +131,9 @@ async fn test_round_trip_random_secret() {
         .delete_credential()
         .await
         .expect("Can't delete random secret");
-    assert!(
-        matches!(entry.get_password().await, Err(Error::NoEntry)),
+    assert_matches!(
+        entry.get_password().await,
+        Err(Error::NoEntry),
         "Able to read a deleted random secret"
     );
 }
@@ -168,8 +174,9 @@ async fn test_update() {
         .delete_credential()
         .await
         .expect("Can't delete updated password");
-    assert!(
-        matches!(entry.get_password().await, Err(Error::NoEntry)),
+    assert_matches!(
+        entry.get_password().await,
+        Err(Error::NoEntry),
         "Able to read a deleted updated password"
     );
 }

--- a/crates/uv-keyring/tests/threading.rs
+++ b/crates/uv-keyring/tests/threading.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "native-auth")]
 
 use common::{generate_random_string, init_logger};
+use std::assert_matches;
 use uv_keyring::{Entry, Error};
 
 mod common;
@@ -43,8 +44,9 @@ async fn test_create_then_move() {
             .delete_credential()
             .await
             .expect("Can't delete non-ascii password");
-        assert!(
-            matches!(entry.get_password().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_password().await,
+            Err(Error::NoEntry),
             "Able to read a deleted non-ascii password"
         );
     });
@@ -81,8 +83,9 @@ async fn test_simultaneous_create_then_move() {
                 .delete_credential()
                 .await
                 .expect("Can't delete ascii password");
-            assert!(
-                matches!(entry.get_password().await, Err(Error::NoEntry)),
+            assert_matches!(
+                entry.get_password().await,
+                Err(Error::NoEntry),
                 "Able to read a deleted ascii password"
             );
         });
@@ -120,8 +123,9 @@ async fn test_create_set_then_move() {
             .delete_credential()
             .await
             .expect("Can't delete ascii password");
-        assert!(
-            matches!(entry.get_password().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_password().await,
+            Err(Error::NoEntry),
             "Able to read a deleted ascii password"
         );
     });
@@ -156,8 +160,9 @@ async fn test_simultaneous_create_set_then_move() {
                 .delete_credential()
                 .await
                 .expect("Can't delete ascii password");
-            assert!(
-                matches!(entry.get_password().await, Err(Error::NoEntry)),
+            assert_matches!(
+                entry.get_password().await,
+                Err(Error::NoEntry),
                 "Able to read a deleted ascii password"
             );
         });
@@ -197,8 +202,9 @@ async fn test_simultaneous_independent_create_set() {
                 .delete_credential()
                 .await
                 .expect("Can't delete ascii password");
-            assert!(
-                matches!(entry.get_password().await, Err(Error::NoEntry)),
+            assert_matches!(
+                entry.get_password().await,
+                Err(Error::NoEntry),
                 "Able to read a deleted ascii password"
             );
         });
@@ -235,8 +241,9 @@ async fn test_multiple_create_delete_single_thread() {
             .delete_credential()
             .await
             .expect("Can't delete ascii password");
-        assert!(
-            matches!(entry.get_password().await, Err(Error::NoEntry)),
+        assert_matches!(
+            entry.get_password().await,
+            Err(Error::NoEntry),
             "Able to read a deleted ascii password"
         );
     }
@@ -273,8 +280,9 @@ async fn test_simultaneous_multiple_create_delete_single_thread() {
                     .delete_credential()
                     .await
                     .expect("Can't delete ascii password");
-                assert!(
-                    matches!(entry.get_password().await, Err(Error::NoEntry)),
+                assert_matches!(
+                    entry.get_password().await,
+                    Err(Error::NoEntry),
                     "Able to read a deleted ascii password"
                 );
             }

--- a/crates/uv-netrc/src/lib.rs
+++ b/crates/uv-netrc/src/lib.rs
@@ -108,6 +108,8 @@ impl Netrc {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -162,8 +164,7 @@ password hY5>yKqU&$vq&0
     #[test]
     fn test_from_file_failed() {
         let err = Netrc::from_file(Path::new("/netrc/file/not/exists/on/no/netrc")).unwrap_err();
-        assert!(
-            matches!(&err, Error::Io(err) if err.kind() == ErrorKind::NotFound),
+        assert_matches!(&err, Error::Io(err) if err.kind() == ErrorKind::NotFound,
             "expected NotFound I/O error, got {err}",
         );
     }

--- a/crates/uv-platform/src/host.rs
+++ b/crates/uv-platform/src/host.rs
@@ -164,6 +164,8 @@ fn unquote(s: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use insta::assert_debug_snapshot;
 
     use super::*;
@@ -228,7 +230,7 @@ VERSION_ID=40
         let os_type =
             OsType::from_env().expect("OsType should be available on supported platforms");
         cfg_select! {
-            target_os = "linux" => { assert!(matches!(os_type, OsType::Linux(_))); },
+            target_os = "linux" => { assert_matches!(os_type, OsType::Linux(_)); },
             target_os = "macos" => { assert_eq!(os_type, OsType::Darwin); },
             target_os = "windows" => { assert_eq!(os_type, OsType::Windows); },
             _ => {},
@@ -240,8 +242,8 @@ VERSION_ID=40
         let os_release =
             OsRelease::from_env().expect("OsRelease should be available on supported platforms");
         cfg_select! {
-            unix => { assert!(matches!(os_release, OsRelease::Unix(_))); },
-            windows => { assert!(matches!(os_release, OsRelease::Windows { .. })); },
+            unix => { assert_matches!(os_release, OsRelease::Unix(_)); },
+            windows => { assert_matches!(os_release, OsRelease::Windows { .. }); },
             _ => {},
         }
     }

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1583,6 +1583,7 @@ async fn handle_response(
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -1675,10 +1676,10 @@ mod tests {
 
         for features in TAR_BACKENDS {
             let _preview = uv_preview::test::with_features(features);
-            assert!(matches!(
+            assert_matches!(
                 source_dist_pkg_info(file.path()).await,
                 Err(PublishPrepareError::MissingPkgInfo)
-            ));
+            );
         }
     }
 
@@ -1692,11 +1693,11 @@ mod tests {
 
         for features in TAR_BACKENDS {
             let _preview = uv_preview::test::with_features(features);
-            assert!(matches!(
+            assert_matches!(
                 source_dist_pkg_info(file.path()).await,
                 Err(PublishPrepareError::MultiplePkgInfo(paths))
                     if paths == "example-1.0/PKG-INFO, other-1.0/PKG-INFO"
-            ));
+            );
         }
     }
 

--- a/crates/uv-pypi-types/src/metadata/metadata23.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata23.rs
@@ -404,6 +404,8 @@ impl ProjectUrls {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use crate::MetadataError;
     use insta::assert_snapshot;
@@ -412,11 +414,11 @@ mod tests {
     fn test_parse_from_str() {
         let s = "Metadata-Version: 1.0";
         let meta: Result<Metadata23, MetadataError> = s.parse();
-        assert!(matches!(meta, Err(MetadataError::FieldNotFound("Name"))));
+        assert_matches!(meta, Err(MetadataError::FieldNotFound("Name")));
 
         let s = "Metadata-Version: 1.0\nName: asdf";
         let meta = Metadata23::parse(s.as_bytes());
-        assert!(matches!(meta, Err(MetadataError::FieldNotFound("Version"))));
+        assert_matches!(meta, Err(MetadataError::FieldNotFound("Version")));
 
         let s = "Metadata-Version: 1.0\nName: asdf\nVersion: 1.0";
         let meta = Metadata23::parse(s.as_bytes()).unwrap();

--- a/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
@@ -272,6 +272,7 @@ impl ResolutionMetadata {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::str::FromStr;
 
     use uv_normalize::PackageName;
@@ -284,11 +285,11 @@ mod tests {
     fn test_parse_metadata() {
         let s = "Metadata-Version: 1.0";
         let meta = ResolutionMetadata::parse_metadata(s.as_bytes());
-        assert!(matches!(meta, Err(MetadataError::FieldNotFound("Name"))));
+        assert_matches!(meta, Err(MetadataError::FieldNotFound("Name")));
 
         let s = "Metadata-Version: 1.0\nName: asdf";
         let meta = ResolutionMetadata::parse_metadata(s.as_bytes());
-        assert!(matches!(meta, Err(MetadataError::FieldNotFound("Version"))));
+        assert_matches!(meta, Err(MetadataError::FieldNotFound("Version")));
 
         let s = "Metadata-Version: 1.0\nName: asdf\nVersion: 1.0";
         let meta = ResolutionMetadata::parse_metadata(s.as_bytes()).unwrap();
@@ -307,25 +308,22 @@ mod tests {
 
         let s = "Metadata-Version: 1.0\nName: =?utf-8?q?=C3=A4_space?= <x@y.org>\nVersion: 1.0";
         let meta = ResolutionMetadata::parse_metadata(s.as_bytes());
-        assert!(matches!(meta, Err(MetadataError::InvalidName(_))));
+        assert_matches!(meta, Err(MetadataError::InvalidName(_)));
     }
 
     #[test]
     fn test_parse_pkg_info() {
         let s = "Metadata-Version: 2.1";
         let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes());
-        assert!(matches!(
-            meta,
-            Err(MetadataError::UnsupportedMetadataVersion(_))
-        ));
+        assert_matches!(meta, Err(MetadataError::UnsupportedMetadataVersion(_)));
 
         let s = "Metadata-Version: 2.2\nName: asdf";
         let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes());
-        assert!(matches!(meta, Err(MetadataError::FieldNotFound("Version"))));
+        assert_matches!(meta, Err(MetadataError::FieldNotFound("Version")));
 
         let s = "Metadata-Version: 2.3\nName: asdf";
         let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes());
-        assert!(matches!(meta, Err(MetadataError::FieldNotFound("Version"))));
+        assert_matches!(meta, Err(MetadataError::FieldNotFound("Version")));
 
         let s = "Metadata-Version: 2.3\nName: asdf\nVersion: 1.0";
         let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes()).unwrap();
@@ -334,7 +332,7 @@ mod tests {
 
         let s = "Metadata-Version: 2.3\nName: asdf\nVersion: 1.0\nDynamic: Requires-Dist";
         let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes()).unwrap_err();
-        assert!(matches!(meta, MetadataError::DynamicField("Requires-Dist")));
+        assert_matches!(meta, MetadataError::DynamicField("Requires-Dist"));
 
         let s = "Metadata-Version: 2.3\nName: asdf\nVersion: 1.0\nRequires-Dist: foo";
         let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes()).unwrap();
@@ -351,7 +349,7 @@ mod tests {
     "#;
         let pyproject = PyProjectToml::from_toml(s, "pyproject.toml").unwrap();
         let meta = ResolutionMetadata::parse_pyproject_toml(pyproject, None);
-        assert!(matches!(meta, Err(MetadataError::FieldNotFound("version"))));
+        assert_matches!(meta, Err(MetadataError::FieldNotFound("version")));
 
         let s = r#"
         [project]
@@ -360,7 +358,7 @@ mod tests {
     "#;
         let pyproject = PyProjectToml::from_toml(s, "pyproject.toml").unwrap();
         let meta = ResolutionMetadata::parse_pyproject_toml(pyproject, None);
-        assert!(matches!(meta, Err(MetadataError::DynamicField("version"))));
+        assert_matches!(meta, Err(MetadataError::DynamicField("version")));
 
         let s = r#"
         [project]

--- a/crates/uv-pypi-types/src/metadata/pyproject_toml.rs
+++ b/crates/uv-pypi-types/src/metadata/pyproject_toml.rs
@@ -122,6 +122,8 @@ pub struct ToolPoetry {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::PyProjectToml;
     use crate::MetadataError;
 
@@ -156,9 +158,9 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             pyproject_toml.requires_python(),
             Err(MetadataError::DynamicField("requires-python"))
-        ));
+        );
     }
 }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -3837,6 +3837,7 @@ fn split_wheel_tag_release_version(version: Version) -> Version {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::{cell::Cell, io, path::PathBuf, str::FromStr};
 
     use assert_fs::{TempDir, prelude::*};
@@ -3884,11 +3885,11 @@ mod tests {
 
         sort_installations_by_key(&mut installations, |key| *key);
 
-        assert!(matches!(
+        assert_matches!(
             &installations[..],
             [Ok(2), Ok(1), Err(noncritical), Err(critical), Ok(3)]
                 if !noncritical.is_critical() && critical.is_critical()
-        ));
+        );
     }
 
     #[test]
@@ -4381,11 +4382,9 @@ mod tests {
                 PythonVariant::Default
             )
         );
-        assert!(
-            matches!(
-                VersionRequest::from_str("3rc1"),
-                Err(Error::InvalidVersionRequest(_))
-            ),
+        assert_matches!(
+            VersionRequest::from_str("3rc1"),
+            Err(Error::InvalidVersionRequest(_)),
             "Pre-release version requests require a minor version"
         );
         assert_eq!(
@@ -4415,25 +4414,19 @@ mod tests {
                 PythonVariant::Default
             )
         );
-        assert!(
-            matches!(
-                VersionRequest::from_str("3.12-dev"),
-                Err(Error::InvalidVersionRequest(_))
-            ),
+        assert_matches!(
+            VersionRequest::from_str("3.12-dev"),
+            Err(Error::InvalidVersionRequest(_)),
             "Development version segments are not allowed"
         );
-        assert!(
-            matches!(
-                VersionRequest::from_str("3.12+local"),
-                Err(Error::InvalidVersionRequest(_))
-            ),
+        assert_matches!(
+            VersionRequest::from_str("3.12+local"),
+            Err(Error::InvalidVersionRequest(_)),
             "Local version segments are not allowed"
         );
-        assert!(
-            matches!(
-                VersionRequest::from_str("3.12.post0"),
-                Err(Error::InvalidVersionRequest(_))
-            ),
+        assert_matches!(
+            VersionRequest::from_str("3.12.post0"),
+            Err(Error::InvalidVersionRequest(_)),
             "Post version segments are not allowed"
         );
         assert!(
@@ -4476,14 +4469,14 @@ mod tests {
                 PythonVariant::Freethreaded
             )
         );
-        assert!(matches!(
+        assert_matches!(
             VersionRequest::from_str("3.13tt"),
             Err(Error::InvalidVersionRequest(_))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             VersionRequest::from_str("3.12²t"),
             Err(Error::InvalidVersionRequest(_))
-        ));
+        );
 
         // `==` specifiers are parsed as concrete version requests via `from_specifiers`
         assert_eq!(
@@ -4639,22 +4632,22 @@ mod tests {
 
     #[test]
     fn test_try_split_prefix_and_version() {
-        assert!(matches!(
+        assert_matches!(
             PythonRequest::try_split_prefix_and_version("prefix", "prefix"),
             Ok(None),
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             PythonRequest::try_split_prefix_and_version("prefix", "prefix3"),
             Ok(Some(_)),
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             PythonRequest::try_split_prefix_and_version("prefix", "prefix@3"),
             Ok(Some(_)),
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             PythonRequest::try_split_prefix_and_version("prefix", "prefix3notaversion"),
             Ok(None),
-        ));
+        );
         // Version parsing errors are only raised if @ is present.
         assert!(
             PythonRequest::try_split_prefix_and_version("prefix", "prefix@3notaversion").is_err()

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1856,6 +1856,7 @@ async fn read_url(
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::collections::HashSet;
 
     use crate::PythonVariant;
@@ -2001,7 +2002,7 @@ mod tests {
     fn test_python_download_request_from_str_too_many_parts() {
         let result = PythonDownloadRequest::from_str("cpython-3.12-linux-x86_64-gnu-extra");
 
-        assert!(matches!(result, Err(Error::TooManyParts(_))));
+        assert_matches!(result, Err(Error::TooManyParts(_)));
     }
 
     /// We don't allow an empty request.
@@ -2009,7 +2010,7 @@ mod tests {
     fn test_python_download_request_from_str_empty() {
         let result = PythonDownloadRequest::from_str("");
 
-        assert!(matches!(result, Err(Error::EmptyRequest)), "{result:?}");
+        assert_matches!(result, Err(Error::EmptyRequest));
     }
 
     /// Parse a request with all "any" segments.
@@ -2052,10 +2053,7 @@ mod tests {
     fn test_python_download_request_from_str_invalid_leading_segment() {
         let result = PythonDownloadRequest::from_str("foobar-3.14-windows");
 
-        assert!(
-            matches!(result, Err(Error::ImplementationError(_))),
-            "{result:?}"
-        );
+        assert_matches!(result, Err(Error::ImplementationError(_)));
     }
 
     /// Parse a request with segments in an invalid order.
@@ -2063,10 +2061,7 @@ mod tests {
     fn test_python_download_request_from_str_out_of_order() {
         let result = PythonDownloadRequest::from_str("3.12-cpython");
 
-        assert!(
-            matches!(result, Err(Error::InvalidRequestPlatform(_))),
-            "{result:?}"
-        );
+        assert_matches!(result, Err(Error::InvalidRequestPlatform(_)));
     }
 
     /// Parse a request with too many "any" segments.
@@ -2074,7 +2069,7 @@ mod tests {
     fn test_python_download_request_from_str_too_many_any() {
         let result = PythonDownloadRequest::from_str("any-any-any-any-any-any");
 
-        assert!(matches!(result, Err(Error::TooManyParts(_))));
+        assert_matches!(result, Err(Error::TooManyParts(_)));
     }
 
     /// Test that build filtering works correctly

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -203,6 +203,7 @@ impl From<PythonNotFound> for Error {
 // TODO(zanieb): We should write a mock interpreter script that works on Windows
 #[cfg(all(test, unix))]
 mod tests {
+    use std::assert_matches;
     use std::{
         env,
         ffi::{OsStr, OsString},
@@ -675,8 +676,9 @@ mod tests {
                 &context.cache,
             )
         });
-        assert!(
-            matches!(result, Ok(Err(PythonNotFound { .. }))),
+        assert_matches!(
+            result,
+            Ok(Err(PythonNotFound { .. })),
             "With an empty path, no Python installation should be detected got {result:?}"
         );
 
@@ -689,8 +691,9 @@ mod tests {
                 &context.cache,
             )
         });
-        assert!(
-            matches!(result, Ok(Err(PythonNotFound { .. }))),
+        assert_matches!(
+            result,
+            Ok(Err(PythonNotFound { .. })),
             "With an unset path, no Python installation should be detected got {result:?}"
         );
 
@@ -713,8 +716,9 @@ mod tests {
                 &context.cache,
             )
         });
-        assert!(
-            matches!(result, Ok(Err(PythonNotFound { .. }))),
+        assert_matches!(
+            result,
+            Ok(Err(PythonNotFound { .. })),
             "With a non-executable Python, no Python installation should be detected; got {result:?}"
         );
 
@@ -734,14 +738,12 @@ mod tests {
                 &context.cache,
             )
         })??;
-        assert!(
-            matches!(
-                interpreter,
-                PythonInstallation {
-                    source: PythonSource::SearchPathFirst,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            interpreter,
+            PythonInstallation {
+                source: PythonSource::SearchPathFirst,
+                interpreter: _
+            },
             "We should find the valid executable; got {interpreter:?}"
         );
 
@@ -776,14 +778,12 @@ mod tests {
                 ))
         })?;
 
-        assert!(
-            matches!(
-                interpreter,
-                PythonInstallation {
-                    source: PythonSource::SearchPathFirst,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            interpreter,
+            PythonInstallation {
+                source: PythonSource::SearchPathFirst,
+                interpreter: _
+            },
             "We should find the local Python without reading download metadata; got {interpreter:?}"
         );
         assert_eq!(
@@ -842,14 +842,12 @@ mod tests {
                 &context.cache,
             )
         })??;
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPath,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPath,
+                interpreter: _
+            },
             "We should skip the bad executables in favor of the good one; got {python:?}"
         );
         assert_eq!(python.interpreter().sys_executable(), python_path);
@@ -1049,8 +1047,9 @@ mod tests {
             .key()
             .to_string();
         let key_request = PythonRequest::parse(&key);
-        assert!(
-            matches!(key_request, PythonRequest::Key(_)),
+        assert_matches!(
+            key_request,
+            PythonRequest::Key(_),
             "Expected an installation key request, got {key_request:?}"
         );
 
@@ -1130,8 +1129,9 @@ mod tests {
                 &context.cache,
             )
         });
-        assert!(
-            matches!(result, Err(discovery::Error::Query(..))),
+        assert_matches!(
+            result,
+            Err(discovery::Error::Query(..)),
             "If only Python 2 is available, we should report the interpreter query error; got {result:?}"
         );
 
@@ -1166,14 +1166,12 @@ mod tests {
                 &context.cache,
             )
         })??;
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPath,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPath,
+                interpreter: _
+            },
             "We should skip the Python 2 installation and find the Python 3 interpreter; got {python:?}"
         );
         assert_eq!(python.interpreter().sys_executable(), python3.path());
@@ -1291,14 +1289,12 @@ mod tests {
             )
         })??;
 
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPath,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPath,
+                interpreter: _
+            },
             "We should find a python; got {python:?}"
         );
         assert_eq!(
@@ -1324,14 +1320,12 @@ mod tests {
             )
         })??;
 
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPath,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPath,
+                interpreter: _
+            },
             "We should find a python; got {python:?}"
         );
         assert_eq!(
@@ -1356,8 +1350,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not find a python; got {result:?}"
         );
 
@@ -1377,8 +1372,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not find a python; got {result:?}"
         );
 
@@ -1424,14 +1420,12 @@ mod tests {
             )
         })?;
 
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPath,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPath,
+                interpreter: _
+            },
             "We should find a python; got {python:?}"
         );
         assert_eq!(
@@ -1457,14 +1451,12 @@ mod tests {
             )
         })?;
 
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPath,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPath,
+                interpreter: _
+            },
             "We should find a python; got {python:?}"
         );
         assert_eq!(
@@ -1492,14 +1484,12 @@ mod tests {
                     &context.cache,
                 )
             })?;
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPathFirst,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPathFirst,
+                interpreter: _
+            },
             "We should skip the active environment in favor of the requested version; got {python:?}"
         );
 
@@ -1522,14 +1512,12 @@ mod tests {
                     &context.cache,
                 )
             })?;
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::ActiveEnvironment,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::ActiveEnvironment,
+                interpreter: _
+            },
             "We should prefer the active environment after relaxing; got {python:?}"
         );
         assert_eq!(
@@ -1637,8 +1625,9 @@ mod tests {
             },
         )?;
 
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not allow the non-virtual environment; got {result:?}"
         );
 
@@ -1714,8 +1703,9 @@ mod tests {
             },
         )?;
 
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not allow the base environment when looking for virtual environments"
         );
 
@@ -1800,8 +1790,9 @@ mod tests {
             },
         )?;
 
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "Base environment detected via _CONDA_ROOT should be excluded from virtual environments; got {result:?}"
         );
 
@@ -2234,8 +2225,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not find an python; got {result:?}"
         );
 
@@ -2251,8 +2243,9 @@ mod tests {
                 )
             },
         )?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not find an python; got {result:?}"
         );
         Ok(())
@@ -2276,13 +2269,12 @@ mod tests {
                 &context.cache,
             )
         });
-        assert!(
-            matches!(
+        assert_matches!(
                 &result,
                 Err(discovery::Error::VirtualEnv(
                     crate::virtualenv::Error::MissingPyVenvCfg(path)
                 )) if path == child_venv.path()
-            ),
+            ,
             "A broken symlink at `.venv` should be eagerly rejected; got {result:?}"
         );
 
@@ -2305,12 +2297,11 @@ mod tests {
         });
         fs_err::set_permissions(&context.workdir, permissions)?;
 
-        assert!(
-            matches!(
+        assert_matches!(
                 &result,
                 Err(discovery::Error::VirtualEnv(crate::virtualenv::Error::Io(error)))
                     if error.kind() == io::ErrorKind::PermissionDenied
-            ),
+            ,
             "A virtual environment metadata error should not be ignored; got {result:?}"
         );
 
@@ -2344,8 +2335,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not find it without a specific request"
         );
 
@@ -2357,8 +2349,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not find it via a matching version request"
         );
 
@@ -2602,8 +2595,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not find the file; got {result:?}"
         );
 
@@ -2646,8 +2640,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not allow a system interpreter; got {result:?}"
         );
 
@@ -2696,8 +2691,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not find the pypy interpreter if not named `python` or requested; got {result:?}"
         );
 
@@ -2921,8 +2917,9 @@ mod tests {
                 &context.cache,
             )
         })?;
-        assert!(
-            matches!(result, Err(PythonNotFound { .. })),
+        assert_matches!(
+            result,
+            Err(PythonNotFound { .. }),
             "We should not the graalpy interpreter if not named `python` or requested; got {result:?}"
         );
 
@@ -3226,14 +3223,12 @@ mod tests {
             )
         })??;
 
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPathFirst,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPathFirst,
+                interpreter: _
+            },
             "We should find a python; got {python:?}"
         );
         assert_eq!(
@@ -3278,14 +3273,12 @@ mod tests {
             )
         })??;
 
-        assert!(
-            matches!(
-                python,
-                PythonInstallation {
-                    source: PythonSource::SearchPathFirst,
-                    interpreter: _
-                }
-            ),
+        assert_matches!(
+            python,
+            PythonInstallation {
+                source: PythonSource::SearchPathFirst,
+                interpreter: _
+            },
             "We should find a python; got {python:?}"
         );
         assert_eq!(

--- a/crates/uv-python/src/sysconfig/parser.rs
+++ b/crates/uv-python/src/sysconfig/parser.rs
@@ -269,6 +269,8 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -337,7 +339,7 @@ mod tests {
         );
 
         let result = input.parse::<SysconfigData>();
-        assert!(matches!(result, Err(Error::UnexpectedEof)));
+        assert_matches!(result, Err(Error::UnexpectedEof));
     }
 
     #[test]
@@ -352,7 +354,7 @@ mod tests {
         );
 
         let result = input.parse::<SysconfigData>();
-        assert!(matches!(result, Err(Error::UnrecognizedEscape('v'))));
+        assert_matches!(result, Err(Error::UnrecognizedEscape('v')));
     }
 
     #[test]
@@ -464,7 +466,7 @@ mod tests {
         );
 
         let result = input.parse::<SysconfigData>();
-        assert!(matches!(result, Err(Error::MissingHeader)));
+        assert_matches!(result, Err(Error::MissingHeader));
     }
 
     #[test]
@@ -479,7 +481,7 @@ mod tests {
         );
 
         let result = input.parse::<SysconfigData>();
-        assert!(matches!(result, Err(Error::MissingAssignment)));
+        assert_matches!(result, Err(Error::MissingAssignment));
     }
 
     #[test]

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1953,6 +1953,8 @@ fn simplify_range(
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use crate::resolver::UnavailableVersion;
 
@@ -2159,10 +2161,7 @@ mod tests {
             cause2: Arc::new(cause2),
         });
 
-        assert!(matches!(
-            collapse_unavailable_versions(tree),
-            ErrorTree::Derived(_)
-        ));
+        assert_matches!(collapse_unavailable_versions(tree), ErrorTree::Derived(_));
     }
 
     #[test]

--- a/crates/uv-resolver/src/lock/deserialize.rs
+++ b/crates/uv-resolver/src/lock/deserialize.rs
@@ -869,6 +869,7 @@ impl<'de> VariantAccess<'de> for InlineVariantAccess<'_, 'de> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::fmt::Write as _;
 
     use serde::Deserialize;
@@ -1032,13 +1033,13 @@ dev = [{ name = "dependency", specifier = ">=1" }]
         let input = CANONICAL_LOCK.replacen("version = 1", &format!("version = {version}"), 1);
         let error = Lock::from_toml(&input).expect_err("unsupported lock versions are rejected");
 
-        assert!(matches!(
+        assert_matches!(
             error,
             LockParseError::UnsupportedVersion {
                 supported: VERSION,
                 version: actual,
             } if actual == version
-        ));
+        );
     }
 
     #[test]
@@ -1050,14 +1051,14 @@ dev = [{ name = "dependency", specifier = ">=1" }]
         let error =
             Lock::from_toml(&input).expect_err("unparsable unsupported lock versions are rejected");
 
-        assert!(matches!(
+        assert_matches!(
             error,
             LockParseError::UnparsableVersion {
                 supported: VERSION,
                 version: actual,
                 ..
             } if actual == version
-        ));
+        );
     }
 
     #[test]
@@ -1066,16 +1067,14 @@ dev = [{ name = "dependency", specifier = ">=1" }]
             CANONICAL_LOCK.replace("requires-python = \">=3.12\"", "requires-python = '>=3.12'");
         let unsupported = from_str(&input).expect_err("literal strings require the TOML fallback");
 
-        assert!(
-            matches!(&unsupported, Error::Unsupported { offset, .. } if *offset > 0),
+        assert_matches!(&unsupported, Error::Unsupported { offset, .. } if *offset > 0,
             "unsupported syntax must retain its real byte offset: {unsupported}"
         );
 
         let input = CANONICAL_LOCK.replace("revision = 3", "revision = 03");
         let invalid = from_str(&input).expect_err("TOML rejects a leading zero");
 
-        assert!(
-            matches!(&invalid, Error::Invalid { offset, .. } if *offset > 0),
+        assert_matches!(&invalid, Error::Invalid { offset, .. } if *offset > 0,
             "invalid TOML scalars must retain their real byte offset: {invalid}"
         );
     }

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -726,6 +726,8 @@ fn serialize_metadata(metadata: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use crate::{Pep723Error, Pep723Script, ScriptTag, serialize_metadata};
     use std::str::FromStr;
 
@@ -737,10 +739,10 @@ mod tests {
         # ///
     "};
 
-        assert!(matches!(
+        assert_matches!(
             ScriptTag::parse(contents.as_bytes()),
             Err(Pep723Error::UnclosedBlock)
-        ));
+        );
     }
 
     #[test]
@@ -754,10 +756,10 @@ mod tests {
         # ]
     "};
 
-        assert!(matches!(
+        assert_matches!(
             ScriptTag::parse(contents.as_bytes()),
             Err(Pep723Error::UnclosedBlock)
-        ));
+        );
     }
 
     #[test]
@@ -765,10 +767,10 @@ mod tests {
         // Explicit string (not `indoc`) so the closing tag's trailing space is preserved.
         let contents = "# /// script\n# requires-python = '>=3.11'\n# /// \n";
 
-        assert!(matches!(
+        assert_matches!(
             ScriptTag::parse(contents.as_bytes()),
             Err(Pep723Error::UnclosedBlockTrailingContent)
-        ));
+        );
     }
 
     #[test]
@@ -779,10 +781,10 @@ mod tests {
             # /// unexpected
         "};
 
-        assert!(matches!(
+        assert_matches!(
             ScriptTag::parse(contents.as_bytes()),
             Err(Pep723Error::UnclosedBlockTrailingContent)
-        ));
+        );
     }
 
     #[test]

--- a/crates/uv-trampoline/rust-toolchain.toml
+++ b/crates/uv-trampoline/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-01-21"
+channel = "nightly-2026-03-11"

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -1,5 +1,6 @@
 //! Resolve the current [`ProjectWorkspace`] or [`Workspace`].
 
+use std::assert_matches;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -1056,10 +1057,10 @@ impl Workspace {
         if let Some(root_member) = current_project
             && !workspace_members.contains_key(&root_member.project.name)
         {
-            assert!(matches!(
+            assert_matches!(
                 options.members,
                 MemberDiscovery::None | MemberDiscovery::Ignore(_)
-            ));
+            );
             debug!(
                 "Adding current workspace member: `{}`",
                 root_member.root.simplified_display()

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -1113,6 +1113,7 @@ fn relax_requirement(
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::collections::BTreeSet;
     use std::str::FromStr;
 
@@ -1241,14 +1242,14 @@ mod tests {
         let error = propose_specifiers(&requirement, &resolved_versions(&["2.4"]))
             .expect_err("rewritten requirement must admit the resolved version");
 
-        assert!(matches!(
+        assert_matches!(
             &error,
             ProposeRequirementError::Unrepresentable {
                 package,
                 resolved_versions: actual_resolved_versions,
             } if package.as_ref() == "requests"
                 && *actual_resolved_versions == resolved_versions(&["2.4"])
-        ));
+        );
         assert_eq!(
             error.to_string(),
             "Dependency `requests` resolved to `2.4` which cannot be represented by the upgraded requirement; this is not supported yet"
@@ -1301,14 +1302,14 @@ mod tests {
         let error = propose_specifiers(&requirement, &resolved_versions(&["1.5.0", "2.4.0"]))
             .expect_err("wildcard cannot admit versions from different major lines");
 
-        assert!(matches!(
+        assert_matches!(
             &error,
             ProposeRequirementError::Unrepresentable {
                 package,
                 resolved_versions: actual_resolved_versions,
             } if package.as_ref() == "requests"
                 && *actual_resolved_versions == resolved_versions(&["1.5.0", "2.4.0"])
-        ));
+        );
         assert_eq!(
             error.to_string(),
             "Dependency `requests` resolved to `1.5.0`, `2.4.0` which cannot be represented by the upgraded requirement; this is not supported yet"


### PR DESCRIPTION
## Summary

- Use Rust 1.96's stabilized `assert_matches!` macro throughout uv so assertion failures include the actual mismatched value while preserving existing context.
- Keep the existing benchmark assertion for a value that does not implement `Debug`.
- Update the Windows trampoline nightly and nested `uv-build` toolchain to complete the Rust 1.98/MSRV 1.96 upgrade and restore trampoline CI.
