### PR TITLE
Improve basic space accounting when reporting cache clean space savings

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -18,7 +18,7 @@ pub use crate::by_timestamp::CachedByTimestamp;
 #[cfg(feature = "clap")]
 pub use crate::cli::CacheArgs;
 use crate::removal::Remover;
-pub use crate::removal::{Removal, RemovalMode};
+pub use crate::removal::{Removal, RemovalAccounting};
 pub use crate::wheel::WheelCache;
 use crate::wheel::WheelCacheKind;
 pub use archive::ArchiveId;
@@ -175,7 +175,7 @@ pub struct Cache {
     /// uv process.
     lock_file: Option<Arc<LockedFile>>,
     /// The storage accounting used when removing cache entries.
-    removal_mode: RemovalMode,
+    removal_accounting: RemovalAccounting,
 }
 
 impl Cache {
@@ -186,7 +186,7 @@ impl Cache {
             refresh: Refresh::None(Timestamp::now()),
             temp_dir: None,
             lock_file: None,
-            removal_mode: RemovalMode::Logical,
+            removal_accounting: RemovalAccounting::Coarse,
         }
     }
 
@@ -198,7 +198,7 @@ impl Cache {
             refresh: Refresh::None(Timestamp::now()),
             temp_dir: Some(Arc::new(temp_dir)),
             lock_file: None,
-            removal_mode: RemovalMode::Logical,
+            removal_accounting: RemovalAccounting::Coarse,
         })
     }
 
@@ -210,22 +210,24 @@ impl Cache {
 
     /// Set the storage accounting used when removing cache entries.
     ///
-    /// Falls back to logical accounting when physical accounting is unsupported.
+    /// Falls back to [`RemovalAccounting::Coarse`] when fine-grained accounting is unsupported.
     #[must_use]
-    pub fn with_removal_mode(self, removal_mode: RemovalMode) -> Self {
-        let removal_mode = match removal_mode {
-            RemovalMode::Physical if !uv_fs::supports_physical_space() => RemovalMode::Logical,
-            removal_mode => removal_mode,
+    pub fn with_removal_accounting(self, removal_accounting: RemovalAccounting) -> Self {
+        let removal_accounting = match removal_accounting {
+            RemovalAccounting::Fine if !uv_fs::supports_fine_grained_accounting() => {
+                RemovalAccounting::Coarse
+            }
+            removal_accounting => removal_accounting,
         };
         Self {
-            removal_mode,
+            removal_accounting,
             ..self
         }
     }
 
-    /// Create an empty removal summary using the cache's configured accounting mode.
+    /// Create an empty removal summary using the cache's configured accounting.
     pub fn removal(&self) -> Removal {
-        Removal::new(self.removal_mode)
+        Removal::new(self.removal_accounting)
     }
 
     /// Acquire a lock that allows removing entries from the cache.
@@ -235,7 +237,7 @@ impl Cache {
             refresh,
             temp_dir,
             lock_file,
-            removal_mode,
+            removal_accounting,
         } = self;
 
         // Release the existing lock, avoid deadlocks from a cloned cache.
@@ -258,7 +260,7 @@ impl Cache {
             refresh,
             temp_dir,
             lock_file: Some(Arc::new(lock_file)),
-            removal_mode,
+            removal_accounting,
         })
     }
 
@@ -271,7 +273,7 @@ impl Cache {
             refresh,
             temp_dir,
             lock_file,
-            removal_mode,
+            removal_accounting,
         } = self;
 
         match LockedFile::acquire_no_wait(
@@ -284,14 +286,14 @@ impl Cache {
                 refresh,
                 temp_dir,
                 lock_file: Some(Arc::new(lock_file)),
-                removal_mode,
+                removal_accounting,
             }),
             None => Err(Self {
                 root,
                 refresh,
                 temp_dir,
                 lock_file,
-                removal_mode,
+                removal_accounting,
             }),
         }
     }
@@ -551,7 +553,7 @@ impl Cache {
     pub fn clear(self, reporter: Box<dyn CleanReporter>) -> Result<Removal, io::Error> {
         // Remove everything but `.lock`, Windows does not allow removal of a locked file
         let mut removal = Remover::new(reporter)
-            .with_removal_mode(self.removal_mode)
+            .with_removal_accounting(self.removal_accounting)
             .rm_rf(&self.root, true)?;
         let Self {
             root, lock_file, ..
@@ -745,7 +747,7 @@ impl Cache {
     /// Remove a cache path using the cache's configured storage accounting.
     pub fn remove_path(&self, path: impl AsRef<Path>) -> io::Result<Removal> {
         Remover::default()
-            .with_removal_mode(self.removal_mode)
+            .with_removal_accounting(self.removal_accounting)
             .rm_rf(path, false)
     }
 

--- a/crates/uv-cache/src/removal.rs
+++ b/crates/uv-cache/src/removal.rs
@@ -61,7 +61,11 @@ impl Remover {
 /// Estimate the storage reclaimed by removing a non-directory entry.
 #[cfg(unix)]
 fn file_size(metadata: &Metadata) -> u64 {
-    metadata.blocks().saturating_mul(512)
+    if metadata.nlink() == 1 {
+        metadata.blocks().saturating_mul(512)
+    } else {
+        0
+    }
 }
 
 /// Estimate the storage reclaimed by removing a non-directory entry.

--- a/crates/uv-cache/src/removal.rs
+++ b/crates/uv-cache/src/removal.rs
@@ -10,21 +10,21 @@ use uv_fs::PhysicalSpaceError;
 
 use crate::CleanReporter;
 
-/// The storage accounting used when removing cache entries.
+/// How to estimate reclaimed storage when removing cache entries.
 #[derive(Debug, Clone, Copy, Default)]
-pub enum RemovalMode {
-    /// Report the logical size of the removed files.
+pub enum RemovalAccounting {
+    /// Estimate reclaimed storage from ordinary filesystem metadata.
     #[default]
-    Logical,
-    /// Report the exclusively owned physical storage reclaimed by the removed files.
-    Physical,
+    Coarse,
+    /// Inspect filesystem allocation and sharing where supported.
+    Fine,
 }
 
 /// A builder for a [`Remover`] that can remove files and directories.
 #[derive(Default)]
 pub(crate) struct Remover {
     reporter: Option<Box<dyn CleanReporter>>,
-    removal_mode: RemovalMode,
+    removal_accounting: RemovalAccounting,
 }
 
 impl Remover {
@@ -37,8 +37,8 @@ impl Remover {
     }
 
     /// Set the storage accounting used before each file is removed.
-    pub(crate) fn with_removal_mode(mut self, removal_mode: RemovalMode) -> Self {
-        self.removal_mode = removal_mode;
+    pub(crate) fn with_removal_accounting(mut self, removal_accounting: RemovalAccounting) -> Self {
+        self.removal_accounting = removal_accounting;
         self
     }
 
@@ -49,7 +49,7 @@ impl Remover {
         path: impl AsRef<Path>,
         skip_locked_file: bool,
     ) -> io::Result<Removal> {
-        let mut removal = Removal::new(self.removal_mode);
+        let mut removal = Removal::new(self.removal_accounting);
         removal.rm_rf(path.as_ref(), self.reporter.as_deref(), skip_locked_file)?;
         Ok(removal)
     }
@@ -62,24 +62,21 @@ pub struct Removal {
     pub num_files: u64,
     /// The number of directories removed.
     pub num_dirs: u64,
-    /// The logical number of bytes removed.
-    ///
-    /// Note: this will both over-count bytes removed for hard-linked files, and under-count
-    /// bytes in general since it's a measure of the exact byte size (as opposed to the block size).
-    pub logical_bytes: u64,
-    /// The exclusively owned physical file data reclaimed by the removal, when available.
-    pub physical_bytes: Option<u64>,
-    /// Whether any removed entries could not be measured, making the physical count a lower bound.
-    pub physical_bytes_incomplete: bool,
+    /// The coarse estimate of the number of bytes occupied by the removed files.
+    pub coarse_bytes: u64,
+    /// The fine-grained estimate of reclaimed physical file data, when available.
+    pub fine_bytes: Option<u64>,
+    /// Whether any removed entries could not be measured, making the fine-grained count a lower bound.
+    pub fine_bytes_incomplete: bool,
 }
 
 impl Removal {
     /// Create an empty removal summary with the requested storage accounting.
-    pub(crate) fn new(removal_mode: RemovalMode) -> Self {
+    pub(crate) fn new(removal_accounting: RemovalAccounting) -> Self {
         Self {
-            physical_bytes: match removal_mode {
-                RemovalMode::Logical => None,
-                RemovalMode::Physical => Some(0),
+            fine_bytes: match removal_accounting {
+                RemovalAccounting::Coarse => None,
+                RemovalAccounting::Fine => Some(0),
             },
             ..Self::default()
         }
@@ -87,27 +84,27 @@ impl Removal {
 
     /// Account for a file while its current sharing state can still be inspected.
     fn add_file(&mut self, path: &Path, metadata: &std::fs::Metadata) {
-        self.logical_bytes += metadata.len();
+        self.coarse_bytes += metadata.len();
 
-        if let Some(physical_bytes) = self.physical_bytes {
+        if let Some(fine_bytes) = self.fine_bytes {
             match uv_fs::physical_space(path, metadata) {
-                Ok(physical) => {
-                    self.physical_bytes = Some(physical_bytes.saturating_add(physical));
+                Ok(bytes) => {
+                    self.fine_bytes = Some(fine_bytes.saturating_add(bytes));
                 }
                 Err(PhysicalSpaceError::UnsupportedFilesystem) => {
                     debug!(
-                        "Physical space accounting is unsupported for {}; falling back to logical space",
+                        "Fine-grained space accounting is unsupported for {}; falling back to coarse accounting",
                         path.display()
                     );
-                    self.physical_bytes = None;
-                    self.physical_bytes_incomplete = false;
+                    self.fine_bytes = None;
+                    self.fine_bytes_incomplete = false;
                 }
                 Err(PhysicalSpaceError::UnmeasurableFile(error)) => {
                     debug!(
                         "Failed to measure physical space for {}: {error}",
                         path.display()
                     );
-                    self.physical_bytes_incomplete = true;
+                    self.fine_bytes_incomplete = true;
                 }
             }
         }
@@ -218,8 +215,8 @@ impl Removal {
                 // Remove the file.
                 if let Ok(metadata) = entry.metadata() {
                     self.add_file(entry.path(), &metadata);
-                } else if self.physical_bytes.is_some() {
-                    self.physical_bytes_incomplete = true;
+                } else if self.fine_bytes.is_some() {
+                    self.fine_bytes_incomplete = true;
                 }
                 remove_file(entry.path())?;
             }
@@ -237,13 +234,13 @@ impl std::ops::AddAssign for Removal {
     fn add_assign(&mut self, other: Self) {
         self.num_files += other.num_files;
         self.num_dirs += other.num_dirs;
-        self.logical_bytes += other.logical_bytes;
-        self.physical_bytes = self
-            .physical_bytes
-            .zip(other.physical_bytes)
+        self.coarse_bytes += other.coarse_bytes;
+        self.fine_bytes = self
+            .fine_bytes
+            .zip(other.fine_bytes)
             .map(|(left, right)| left.saturating_add(right));
-        self.physical_bytes_incomplete = self.physical_bytes.is_some()
-            && (self.physical_bytes_incomplete || other.physical_bytes_incomplete);
+        self.fine_bytes_incomplete = self.fine_bytes.is_some()
+            && (self.fine_bytes_incomplete || other.fine_bytes_incomplete);
     }
 }
 

--- a/crates/uv-cache/src/removal.rs
+++ b/crates/uv-cache/src/removal.rs
@@ -2,7 +2,10 @@
 //! Cargo is dual-licensed under either Apache 2.0 or MIT, at the user's choice.
 //! Source: <https://github.com/rust-lang/cargo/blob/e1ebce1035f9b53bb46a55bd4b0ecf51e24c6458/src/cargo/ops/cargo_clean.rs#L324>
 
+use std::fs::Metadata;
 use std::io;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 use tracing::debug;
@@ -55,6 +58,18 @@ impl Remover {
     }
 }
 
+/// Estimate the storage reclaimed by removing a non-directory entry.
+#[cfg(unix)]
+fn file_size(metadata: &Metadata) -> u64 {
+    metadata.blocks().saturating_mul(512)
+}
+
+/// Estimate the storage reclaimed by removing a non-directory entry.
+#[cfg(not(unix))]
+fn file_size(metadata: &Metadata) -> u64 {
+    metadata.len()
+}
+
 /// A removal operation with statistics on the number of files and directories removed.
 #[derive(Debug, Default)]
 pub struct Removal {
@@ -83,8 +98,8 @@ impl Removal {
     }
 
     /// Account for a file while its current sharing state can still be inspected.
-    fn add_file(&mut self, path: &Path, metadata: &std::fs::Metadata) {
-        self.coarse_bytes += metadata.len();
+    fn add_file(&mut self, path: &Path, metadata: &Metadata) {
+        self.coarse_bytes += file_size(metadata);
 
         if let Some(fine_bytes) = self.fine_bytes {
             match uv_fs::physical_space(path, metadata) {

--- a/crates/uv-cache/tests/removal.rs
+++ b/crates/uv-cache/tests/removal.rs
@@ -65,3 +65,53 @@ fn prune_sparse_file() -> io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn remove_path_retained_hardlink() -> io::Result<()> {
+    let root = tempfile::tempdir()?;
+    let cache = Cache::from_path(root.path().join("cache"));
+    fs_err::create_dir(cache.root())?;
+
+    let retained = root.path().join("retained.bin");
+    fs_err::write(&retained, vec![0; 1024 * 1024])?;
+    assert!(synced_metadata(&retained)?.blocks() > 0);
+    let cached = cache.root().join("cached.bin");
+    fs_err::hard_link(&retained, &cached)?;
+
+    // Ignoring the remaining hardlink would report the file's allocated bytes instead of zero.
+    let summary = cache.remove_path(&cached)?;
+    assert_eq!(summary.num_files, 1);
+    assert_eq!(summary.coarse_bytes, 0);
+    assert!(!cached.exists());
+    assert!(retained.is_file());
+
+    Ok(())
+}
+
+#[test]
+fn prune_hardlinks_once() -> io::Result<()> {
+    let cache = Cache::temp()?;
+    let first = cache.root().join("stale-v0");
+    let second = cache.root().join("stale-v1");
+    fs_err::create_dir(&first)?;
+    fs_err::create_dir(&second)?;
+
+    let original = first.join("cached.bin");
+    fs_err::write(&original, vec![0; 1024 * 1024])?;
+    let metadata = synced_metadata(&original)?;
+    // Filesystems that compress the file cannot satisfy the uncompressed size bounds.
+    if metadata.blocks() < metadata.len() / 512 {
+        return Ok(());
+    }
+    fs_err::hard_link(&original, second.join("cached.bin"))?;
+
+    // Counting each path separately would report at least 2 MiB.
+    let summary = cache.prune(false)?;
+    assert_eq!(summary.num_files, 2);
+    assert_eq!(summary.num_dirs, 2);
+    assert!((1024 * 1024..2 * 1024 * 1024).contains(&summary.coarse_bytes));
+    assert!(!first.exists());
+    assert!(!second.exists());
+
+    Ok(())
+}

--- a/crates/uv-cache/tests/removal.rs
+++ b/crates/uv-cache/tests/removal.rs
@@ -1,0 +1,67 @@
+#![cfg(unix)]
+
+use std::fs::Metadata;
+use std::io;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use fs_err::{File, OpenOptions};
+use uv_cache::Cache;
+
+/// Return the file's metadata after syncing its allocated blocks.
+fn synced_metadata(path: &Path) -> io::Result<Metadata> {
+    let file = OpenOptions::new().write(true).open(path)?;
+    // Sync the file so the reported block count is accurate.
+    file.sync_all()?;
+    file.metadata()
+}
+
+#[test]
+fn remove_path_allocated_blocks() -> io::Result<()> {
+    let cache = Cache::temp()?;
+    let path = cache.root().join("cached.bin");
+    fs_err::write(&path, [0])?;
+    // Some filesystems store small files inline without allocating a block.
+    if synced_metadata(&path)?.blocks() == 0 {
+        return Ok(());
+    }
+
+    let summary = cache.remove_path(&path)?;
+    assert_eq!(summary.num_files, 1);
+    // File-length accounting would report one byte instead.
+    assert!(summary.coarse_bytes >= 512);
+    assert!(!path.exists());
+
+    Ok(())
+}
+
+#[test]
+fn prune_sparse_file() -> io::Result<()> {
+    let cache = Cache::temp()?;
+    // Prune treats unknown top-level directories as stale cache buckets.
+    let stale = cache.root().join("stale-v0");
+    let nested = stale.join("nested");
+    fs_err::create_dir_all(&nested)?;
+
+    let cached = stale.join("cached.bin");
+    fs_err::write(&cached, [0])?;
+    synced_metadata(&cached)?;
+
+    let sparse = nested.join("sparse.bin");
+    File::create(&sparse)?.set_len(1024 * 1024)?;
+    let sparse_metadata = synced_metadata(&sparse)?;
+    // Some filesystems, including HFS+, allocate the entire extended file.
+    if sparse_metadata.blocks() >= sparse_metadata.len() / 512 {
+        return Ok(());
+    }
+
+    // File-length accounting would include the hole and report 1 MiB plus one byte.
+    let summary = cache.prune(false)?;
+    assert_eq!(summary.num_files, 2);
+    assert_eq!(summary.num_dirs, 2);
+    assert!(summary.coarse_bytes < 1024 * 1024);
+    assert!(!stale.exists());
+    assert!(cache.root().is_dir());
+
+    Ok(())
+}

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -18,7 +18,7 @@ use tracing::{debug, warn};
 pub use crate::locked_file::*;
 pub use crate::path::*;
 pub use crate::read::ValidatedReader;
-pub use crate::space::{PhysicalSpaceError, physical_space, supports_physical_space};
+pub use crate::space::{PhysicalSpaceError, physical_space, supports_fine_grained_accounting};
 
 pub mod cachedir;
 pub mod link;

--- a/crates/uv-fs/src/space.rs
+++ b/crates/uv-fs/src/space.rs
@@ -28,8 +28,8 @@ pub enum PhysicalSpaceError {
     UnmeasurableFile(#[from] io::Error),
 }
 
-/// Return whether the current platform can identify individual files' physical storage.
-pub const fn supports_physical_space() -> bool {
+/// Return whether the current platform supports fine-grained space accounting.
+pub const fn supports_fine_grained_accounting() -> bool {
     cfg!(any(
         target_os = "linux",
         target_os = "macos",

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -101,7 +101,7 @@ pub(crate) async fn cache_clean(
 
     // If any, report the physical space, falling back to the logical removed size.
     let reported_bytes = summary.physical_bytes.unwrap_or(summary.logical_bytes);
-    if summary.logical_bytes > 0 || reported_bytes > 0 {
+    if summary.num_files > 0 || summary.num_dirs > 0 {
         let bytes = human_readable_bytes(reported_bytes);
         if summary.physical_bytes_incomplete {
             write!(printer.stderr(), " (at least {:.1})", bytes.green())?;

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
 use tracing::debug;
 
-use uv_cache::{Cache, RemovalMode};
+use uv_cache::{Cache, RemovalAccounting};
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_preview::{Preview, PreviewFeature};
@@ -45,12 +45,12 @@ pub(crate) async fn cache_clean(
         }
     };
 
-    let removal_mode = if preview.is_enabled(PreviewFeature::CachePhysicalSpace) {
-        RemovalMode::Physical
+    let removal_accounting = if preview.is_enabled(PreviewFeature::CachePhysicalSpace) {
+        RemovalAccounting::Fine
     } else {
-        RemovalMode::Logical
+        RemovalAccounting::Coarse
     };
-    let cache = cache.with_removal_mode(removal_mode);
+    let cache = cache.with_removal_accounting(removal_accounting);
 
     let summary = if packages.is_empty() {
         writeln!(
@@ -99,11 +99,11 @@ pub(crate) async fn cache_clean(
         }
     }
 
-    // If any, report the physical space, falling back to the logical removed size.
-    let reported_bytes = summary.physical_bytes.unwrap_or(summary.logical_bytes);
+    // Prefer the fine-grained estimate, falling back to coarse accounting.
+    let reported_bytes = summary.fine_bytes.unwrap_or(summary.coarse_bytes);
     if summary.num_files > 0 || summary.num_dirs > 0 {
         let bytes = human_readable_bytes(reported_bytes);
-        if summary.physical_bytes_incomplete {
+        if summary.fine_bytes_incomplete {
             write!(printer.stderr(), " (at least {:.1})", bytes.green())?;
         } else {
             write!(printer.stderr(), " ({:.1})", bytes.green())?;

--- a/crates/uv/src/commands/cache_prune.rs
+++ b/crates/uv/src/commands/cache_prune.rs
@@ -88,7 +88,7 @@ pub(crate) async fn cache_prune(
 
     // If any, report the physical space, falling back to the logical removed size.
     let reported_bytes = summary.physical_bytes.unwrap_or(summary.logical_bytes);
-    if summary.logical_bytes > 0 || reported_bytes > 0 {
+    if summary.num_files > 0 || summary.num_dirs > 0 {
         let bytes = human_readable_bytes(reported_bytes);
         if summary.physical_bytes_incomplete {
             write!(printer.stderr(), " (at least {:.1})", bytes.green())?;

--- a/crates/uv/src/commands/cache_prune.rs
+++ b/crates/uv/src/commands/cache_prune.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
 use tracing::debug;
 
-use uv_cache::{Cache, RemovalMode};
+use uv_cache::{Cache, RemovalAccounting};
 use uv_fs::Simplified;
 use uv_preview::{Preview, PreviewFeature};
 
@@ -43,12 +43,12 @@ pub(crate) async fn cache_prune(
         }
     };
 
-    let removal_mode = if preview.is_enabled(PreviewFeature::CachePhysicalSpace) {
-        RemovalMode::Physical
+    let removal_accounting = if preview.is_enabled(PreviewFeature::CachePhysicalSpace) {
+        RemovalAccounting::Fine
     } else {
-        RemovalMode::Logical
+        RemovalAccounting::Coarse
     };
-    let cache = cache.with_removal_mode(removal_mode);
+    let cache = cache.with_removal_accounting(removal_accounting);
 
     writeln!(
         printer.stderr(),
@@ -86,11 +86,11 @@ pub(crate) async fn cache_prune(
         }
     }
 
-    // If any, report the physical space, falling back to the logical removed size.
-    let reported_bytes = summary.physical_bytes.unwrap_or(summary.logical_bytes);
+    // Prefer the fine-grained estimate, falling back to coarse accounting.
+    let reported_bytes = summary.fine_bytes.unwrap_or(summary.coarse_bytes);
     if summary.num_files > 0 || summary.num_dirs > 0 {
         let bytes = human_readable_bytes(reported_bytes);
-        if summary.physical_bytes_incomplete {
+        if summary.fine_bytes_incomplete {
             write!(printer.stderr(), " (at least {:.1})", bytes.green())?;
         } else {
             write!(printer.stderr(), " ({:.1})", bytes.green())?;

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -523,7 +523,7 @@ fn clean_handles_verbatim_paths() -> Result<()> {
     DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
-    Removed 2 files
+    Removed 2 files (0B)
     ");
 
     Ok(())

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -41,11 +41,15 @@ fn clean_all() -> Result<()> {
     Ok(())
 }
 
-/// `cache clean` should report physical space for hardlinks only when the preview is enabled.
+/// Cache cleanup should count hardlinked storage only when its final link is removed.
 #[cfg(unix)]
 #[test]
 fn clean_all_hardlinked_file() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_counts();
+
+    // Remove unrelated cache entries so the retained hardlink is the only cached data.
+    context.clean().assert().success();
+    context.cache_dir.create_dir_all()?;
 
     // Keep the retained hardlink beside the cache so both entries share a filesystem.
     let retained = context.cache_dir.path().with_file_name("retained.bin");
@@ -58,11 +62,12 @@ fn clean_all_hardlinked_file() -> Result<()> {
     let cached = context.cache_dir.child("hardlinked.bin");
     fs_err::hard_link(&retained, &cached)?;
 
+    // Counting the externally retained hardlink would incorrectly report 1.0MiB.
     uv_snapshot!(context.filters(), context.clean(), @"
     exit_code: 0 (success)
     ----- stderr -----
     Clearing cache at: [CACHE_DIR]/
-    Removed [N] files (1.0MiB)
+    Removed [N] files (0B)
     ");
 
     context.cache_dir.create_dir_all()?;
@@ -85,6 +90,7 @@ fn clean_all_hardlinked_file() -> Result<()> {
         .sync_all()?;
     fs_err::hard_link(&cached, context.cache_dir.child("second-hardlink.bin"))?;
 
+    // Counting each hardlink separately would incorrectly report 2.0MiB.
     uv_snapshot!(context.filters(), context.clean().arg("--preview-features").arg("cache-physical-space"), @"
     exit_code: 0 (success)
     ----- stderr -----

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -34,7 +34,7 @@ fn prune_no_op() -> Result<()> {
     Ok(())
 }
 
-/// `cache prune` should report physical space for hardlinks only when the preview is enabled.
+/// Cache pruning should not count storage retained by another hardlink.
 #[cfg(unix)]
 #[test]
 fn prune_hardlinked_file() -> Result<()> {
@@ -52,11 +52,12 @@ fn prune_hardlinked_file() -> Result<()> {
     stale.create_dir_all()?;
     fs_err::hard_link(&retained, stale.child("hardlinked.bin"))?;
 
+    // Counting the externally retained hardlink would incorrectly report 1.0MiB.
     uv_snapshot!(context.filters(), context.prune(), @"
     exit_code: 0 (success)
     ----- stderr -----
     Pruning cache at: [CACHE_DIR]/
-    Removed 1 file (1.0MiB)
+    Removed 1 file (0B)
     ");
 
     stale.create_dir_all()?;

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -124,7 +124,7 @@ fn prune_stale_directory() -> Result<()> {
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache bucket: [CACHE_DIR]/simple-v4
-    Removed 1 directory
+    Removed 1 directory (0B)
     ");
 
     Ok(())
@@ -282,7 +282,7 @@ async fn prune_force() -> Result<()> {
     DEBUG Cache is currently in use, proceeding due to `--force`
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache bucket: [CACHE_DIR]/simple-v4
-    Removed 1 directory
+    Removed 1 directory (0B)
     ");
 
     Ok(())

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -144,9 +144,9 @@ uv provides a few different mechanisms for removing entries from the cache:
   longer necessary and can be safely removed. Centralized project environments are recreated as
   needed. `uv cache prune` is safe to run periodically, to keep the cache directory clean.
 
-By default, cache cleanup reports the logical size of removed entries. Enable the
-`cache-physical-space` [preview feature](./preview.md) to instead report the physical disk space
-reclaimed, accounting for hardlinks and copy-on-write clones:
+By default, cache cleanup estimates the disk space reclaimed. Enable the `cache-physical-space`
+[preview feature](./preview.md) for a more accurate estimate that accounts for hardlinks and
+copy-on-write clones:
 
 ```console
 $ uv cache clean --preview-features cache-physical-space
@@ -154,7 +154,8 @@ $ uv cache clean --preview-features cache-physical-space
 
 If an entry's allocated size cannot be measured, such as a compressed extent on Btrfs, uv reports a
 lower bound for the space reclaimed from the remaining entries. The preview feature is currently
-supported on macOS and Linux; other platforms continue reporting the logical removed size.
+supported on macOS and Linux; other platforms continue reporting a coarser estimate of the space
+reclaimed.
 
 uv blocks cache-modifying operations while other uv commands are running. By default, those
 `uv cache` commands have a 5 min timeout waiting for other uv processes to terminate to avoid


### PR DESCRIPTION
## Summary

While looking at Charlie's new preview space accounting PR which utilises special APIs to count extents I noticed we have some areas where small changes could improve accounting accuracy.

This PR uses block counts instead of file sizes to determine file space savings and additionally uses hardlink counts to avoid double-counting space when hardlinks are in use.

Notably the PR changes a small detail about our output format, it now reports the number of bytes recovered (even if it's zero) whenever any files or directories were deleted.

Previously we had some quirky logic where we'd only do this if we had "logical" or "physical" counts, regardless of which one we'd then print. I think the intent is to report 0 when things were deleted but nothing got saved so I picked that as a simpler condition.

## Test Plan

Adjustments to existing tests and some new tests. Unit tests avoid some of the potential uncertainty when doing accounting.