### PR TITLE
Upgrade Hawk to 0.1.13

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -17,7 +17,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   # renovate: datasource=github-releases depName=astral-sh/hawk
-  HAWK_VERSION: 0.1.11
+  HAWK_VERSION: 0.1.13
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
@@ -168,13 +168,13 @@ jobs:
           cache-workspace-crates: "false"
           save-if: ${{ inputs.save-rust-cache == 'true' }}
       - name: "Install Rust toolchain"
-        run: rustup toolchain install 1.97.1
+        run: rustup toolchain install 1.98.0
       - name: "Install Hawk"
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
       - name: "Hawk"
-        run: cargo +1.97.1 hawk check --target-dir target/hawk -D warnings
+        run: cargo +1.98.0 hawk check --target-dir target/hawk -D warnings
 
   shear:
     name: "cargo shear"


### PR DESCRIPTION
## Summary

- Upgrade Hawk from 0.1.11 to 0.1.13.
- Run the Hawk lint job with Rust 1.98.0 to match Hawk's embedded compiler and the workspace toolchain.
