### PR TITLE
Use bundled LLD for the ARM64 manylinux PGO build

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -589,6 +589,11 @@ jobs:
             scripts/install-cargo-extensions.sh
 
             if [[ "${{ matrix.platform.pgo }}" == "true" ]]; then
+                # GNU ld cannot resolve long-range calls in the instrumented ARM64 binary.
+                bundled_lld_dir="$(rustc --print sysroot)/lib/rustlib/${{ matrix.platform.target }}/bin/gcc-ld"
+                test -x "${bundled_lld_dir}/ld.lld"
+                export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-C link-arg=-B${bundled_lld_dir} -C link-arg=-fuse-ld=lld"
+
                 rustup component add llvm-tools-preview
                 python${{ env.PYTHON_VERSION }} scripts/build_uv_pgo.py \
                     --target "${{ matrix.platform.target }}" \


### PR DESCRIPTION
## Summary

- The ARM64 `manylinux_2_28` image uses GCC Toolset 14's GNU ld (binutils 2.41), which has an AArch64 branch-veneer placement bug when `--fix-cortex-a53-843419` is enabled.
- Rust 1.98 enables that Cortex-A53 mitigation by default, and PGO instrumentation makes uv large enough to expose the old manylinux linker's bug.
- Use Rust's bundled LLD for the ARM64 manylinux PGO build, preserving the Cortex-A53 mitigation and leaving other release targets unchanged.
- GNU ld fixed the bug upstream in [binutils-gdb commit `d3af401`](https://sourceware.org/pipermail/binutils/2026-January/146938.html).

Closes https://github.com/astral-sh/uv-dev/issues/834.
