### PR TITLE
Add --suffix option to uv tool install (#6365)

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5761,6 +5761,22 @@ pub struct ToolInstallArgs {
     #[arg(long)]
     pub force: bool,
 
+    /// The suffix to append to the installed executable names.
+    ///
+    /// When provided, executables are installed as `<executable-name><suffix>` instead of their
+    /// plain names, allowing multiple versions of the same tool to be installed side by side.
+    /// For example, `--suffix -0.11` installs `ruff-0.11` alongside an existing `ruff`.
+    ///
+    /// The suffixed installation is tracked separately from any unsuffixed installation of the
+    /// same package.
+    #[arg(
+        long,
+        allow_hyphen_values = true,
+        value_hint = ValueHint::Other,
+        help_heading = "Installer options"
+    )]
+    pub suffix: Option<String>,
+
     /// Whether to use Git LFS when adding a dependency from Git.
     #[arg(long)]
     pub lfs: bool,
@@ -5896,8 +5912,10 @@ pub struct ToolDirArgs {
 #[derive(Args)]
 pub struct ToolUninstallArgs {
     /// The name of the tool to uninstall.
+    ///
+    /// Tools installed with a suffix are referenced by their suffixed name, e.g., `ruff-0.11`.
     #[arg(required = true, value_hint = ValueHint::Other)]
-    pub name: Vec<PackageName>,
+    pub name: Vec<String>,
 
     /// Uninstall all tools.
     #[arg(long, conflicts_with("name"))]

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsStr;
+use std::fmt::{self, Display, Formatter};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -13,7 +15,7 @@ use uv_dirs::user_executable_directory;
 use uv_fs::{LockedFile, LockedFileError, LockedFileMode, Simplified};
 use uv_install_wheel::read_record;
 use uv_installer::SitePackages;
-use uv_normalize::{InvalidNameError, PackageName};
+use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_python::{BrokenLink, Interpreter, PythonEnvironment};
 use uv_state::{StateBucket, StateStore};
@@ -24,6 +26,109 @@ pub use tool::{Tool, ToolEntrypoint};
 
 mod receipt;
 mod tool;
+
+/// The name of an installed tool.
+///
+/// Unlike a [`PackageName`], a tool name includes any user-provided suffix and is not normalized.
+/// It is used as the name of the tool's environment directory and as the identifier accepted by
+/// commands such as `uv tool upgrade` and `uv tool uninstall`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ToolName(String);
+
+impl ToolName {
+    /// Create a tool name for a package and optional suffix.
+    pub fn from_package_name(
+        package: &PackageName,
+        suffix: Option<&str>,
+    ) -> Result<Self, InvalidToolNameError> {
+        if suffix.is_some_and(str::is_empty) {
+            return Err(InvalidToolNameError::empty_suffix());
+        }
+
+        let mut name = package.to_string();
+        if let Some(suffix) = suffix {
+            name.push_str(suffix);
+        }
+        Self::from_string(name)
+    }
+
+    /// Return the tool name as a string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn from_string(name: String) -> Result<Self, InvalidToolNameError> {
+        // Tool names are used as directory names. Reject names that cannot form a safe,
+        // portable path. Characters that are merely invalid on Windows (e.g., `:`) are
+        // allowed here and warned about at the CLI layer instead.
+        if name.is_empty()
+            || matches!(name.as_str(), "." | "..")
+            || name.bytes().any(|character| {
+                character.is_ascii_control()
+                    || matches!(character, b'/' | b'\\')
+            })
+        {
+            return Err(InvalidToolNameError::invalid(&name));
+        }
+
+        Ok(Self(name))
+    }
+}
+
+impl From<&PackageName> for ToolName {
+    fn from(package: &PackageName) -> Self {
+        Self(package.to_string())
+    }
+}
+
+impl From<PackageName> for ToolName {
+    fn from(package: PackageName) -> Self {
+        Self(package.to_string())
+    }
+}
+
+impl FromStr for ToolName {
+    type Err = InvalidToolNameError;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        Self::from_string(name.to_string())
+    }
+}
+
+impl AsRef<str> for ToolName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Display for ToolName {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// An invalid [`ToolName`].
+#[derive(Debug, Clone, Error)]
+#[error("{message}")]
+pub struct InvalidToolNameError {
+    message: String,
+}
+
+impl InvalidToolNameError {
+    fn invalid(name: &str) -> Self {
+        Self {
+            message: format!(
+                "Invalid tool name `{name}`; tool names cannot be empty, contain path separators, or consist solely of reserved names"
+            ),
+        }
+    }
+
+    fn empty_suffix() -> Self {
+        Self {
+            message: "A tool suffix cannot be empty".to_string(),
+        }
+    }
+}
 
 /// A wrapper around [`PythonEnvironment`] for tools that provides additional functionality.
 #[derive(Debug, Clone)]
@@ -77,7 +182,7 @@ pub enum Error {
     #[error("Failed to find a directory to install executables into")]
     NoExecutableDirectory,
     #[error(transparent)]
-    ToolName(#[from] InvalidNameError),
+    ToolName(#[from] InvalidToolNameError),
     #[error(transparent)]
     EnvironmentError(#[from] uv_python::Error),
     #[error("Failed to find a receipt for tool `{0}` at {1}")]
@@ -141,9 +246,9 @@ impl InstalledTools {
         }
     }
 
-    /// Return the expected directory for a tool with the given [`PackageName`].
-    pub fn tool_dir(&self, name: &PackageName) -> PathBuf {
-        self.root.join(name.to_string())
+    /// Return the expected directory for a tool with the given [`ToolName`].
+    pub fn tool_dir(&self, name: &ToolName) -> PathBuf {
+        self.root.join(name.as_str())
     }
 
     /// Return the metadata for all installed tools.
@@ -153,7 +258,7 @@ impl InstalledTools {
     ///
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
     #[expect(clippy::type_complexity)]
-    pub fn tools(&self) -> Result<Vec<(PackageName, Result<Tool, Error>)>, Error> {
+    pub fn tools(&self) -> Result<Vec<(ToolName, Result<Tool, Error>)>, Error> {
         let mut tools = Vec::new();
         for directory in uv_fs::directories(self.root())? {
             let Some(name) = directory
@@ -162,7 +267,7 @@ impl InstalledTools {
             else {
                 continue;
             };
-            let name = PackageName::from_str(name)?;
+            let name = ToolName::from_str(name)?;
             let path = directory.join("uv-receipt.toml");
             let contents = match fs_err::read_to_string(&path) {
                 Ok(contents) => contents,
@@ -184,13 +289,31 @@ impl InstalledTools {
         Ok(tools)
     }
 
+    /// Return an installed tool with a name that differs only by ASCII case.
+    pub fn find_case_insensitive_name(&self, name: &ToolName) -> Result<Option<ToolName>, Error> {
+        for directory in uv_fs::directories(self.root())? {
+            let Some(existing_name) = directory
+                .file_name()
+                .and_then(OsStr::to_str)
+                .and_then(|name| ToolName::from_str(name).ok())
+            else {
+                continue;
+            };
+            if existing_name != *name && existing_name.as_str().eq_ignore_ascii_case(name.as_str())
+            {
+                return Ok(Some(existing_name));
+            }
+        }
+        Ok(None)
+    }
+
     /// Get the receipt for the given tool.
     ///
     /// If the tool is not installed, returns `Ok(None)`. If the receipt is invalid, returns an
     /// error.
     ///
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
-    pub fn get_tool_receipt(&self, name: &PackageName) -> Result<Option<Tool>, Error> {
+    pub fn get_tool_receipt(&self, name: &ToolName) -> Result<Option<Tool>, Error> {
         let path = self.tool_dir(name).join("uv-receipt.toml");
         match ToolReceipt::from_path(&path) {
             Ok(tool_receipt) => Ok(Some(tool_receipt.tool)),
@@ -214,7 +337,7 @@ impl InstalledTools {
     /// Any existing receipt will be replaced.
     ///
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
-    pub fn add_tool_receipt(&self, name: &PackageName, tool: Tool) -> Result<(), Error> {
+    pub fn add_tool_receipt(&self, name: &ToolName, tool: Tool) -> Result<(), Error> {
         let tool_receipt = ToolReceipt::from(tool);
         let path = self.tool_dir(name).join("uv-receipt.toml");
 
@@ -242,7 +365,7 @@ impl InstalledTools {
     /// # Errors
     ///
     /// If no such environment exists for the tool.
-    pub fn remove_environment(&self, name: &PackageName) -> Result<(), Error> {
+    pub fn remove_environment(&self, name: &ToolName) -> Result<(), Error> {
         let environment_path = self.tool_dir(name);
 
         debug!(
@@ -263,7 +386,8 @@ impl InstalledTools {
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
     pub fn get_environment(
         &self,
-        name: &PackageName,
+        name: &ToolName,
+        package: &PackageName,
         cache: &Cache,
     ) -> Result<Option<ToolEnvironment>, Error> {
         let environment_path = self.tool_dir(name);
@@ -274,7 +398,7 @@ impl InstalledTools {
                     "Found existing environment for tool `{name}`: {}",
                     environment_path.user_display()
                 );
-                Ok(Some(ToolEnvironment::new(venv, name.clone())))
+                Ok(Some(ToolEnvironment::new(venv, package.clone())))
             }
             Err(uv_python::Error::MissingEnvironment(_)) => Ok(None),
             Err(uv_python::Error::Query(uv_python::InterpreterError::NotFound(
@@ -317,7 +441,7 @@ impl InstalledTools {
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
     pub fn create_environment(
         &self,
-        name: &PackageName,
+        name: &ToolName,
         interpreter: Interpreter,
     ) -> Result<PythonEnvironment, Error> {
         let environment_path = self.tool_dir(name);

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -63,10 +63,9 @@ impl ToolName {
         // allowed here and warned about at the CLI layer instead.
         if name.is_empty()
             || matches!(name.as_str(), "." | "..")
-            || name.bytes().any(|character| {
-                character.is_ascii_control()
-                    || matches!(character, b'/' | b'\\')
-            })
+            || name
+                .bytes()
+                .any(|character| character.is_ascii_control() || matches!(character, b'/' | b'\\'))
         {
             return Err(InvalidToolNameError::invalid(&name));
         }

--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -7,6 +7,7 @@ use toml_edit::{Array, Item, Table, Value, value};
 use uv_configuration::ExcludeDependency;
 use uv_distribution_types::Requirement;
 use uv_fs::{PortablePath, Simplified};
+use uv_normalize::PackageName;
 use uv_pypi_types::VerbatimParsedUrl;
 use uv_python::PythonRequest;
 use uv_settings::{ToolOptions, ToolOptionsWire};
@@ -15,6 +16,10 @@ use uv_settings::{ToolOptions, ToolOptionsWire};
 #[derive(Debug, Clone, Deserialize)]
 #[serde(try_from = "ToolWire", into = "ToolWire")]
 pub struct Tool {
+    /// The package that provides the tool.
+    package: PackageName,
+    /// The suffix appended to the tool's environment and entry point names, if any.
+    suffix: Option<String>,
     /// The requirements requested by the user during installation.
     ///
     /// The first requirement is the tool target itself; any remaining requirements come from
@@ -39,6 +44,8 @@ pub struct Tool {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct ToolWire {
+    package: Option<PackageName>,
+    suffix: Option<String>,
     #[serde(default)]
     requirements: Vec<RequirementWire>,
     #[serde(default)]
@@ -68,6 +75,8 @@ enum RequirementWire {
 impl From<Tool> for ToolWire {
     fn from(tool: Tool) -> Self {
         Self {
+            package: Some(tool.package),
+            suffix: tool.suffix,
             requirements: tool
                 .requirements
                 .into_iter()
@@ -88,15 +97,28 @@ impl TryFrom<ToolWire> for Tool {
     type Error = serde::de::value::Error;
 
     fn try_from(tool: ToolWire) -> Result<Self, Self::Error> {
+        let requirements = tool
+            .requirements
+            .into_iter()
+            .map(|req| match req {
+                RequirementWire::Requirement(requirements) => requirements,
+                RequirementWire::Deprecated(requirement) => Requirement::from(requirement),
+            })
+            .collect::<Vec<_>>();
+        // Older receipts do not record the package; it is the first requirement.
+        let package = tool
+            .package
+            .or_else(|| {
+                requirements
+                    .first()
+                    .map(|requirement| requirement.name.clone())
+            })
+            .ok_or_else(|| serde::de::Error::custom("tool receipt is missing a package"))?;
+
         Ok(Self {
-            requirements: tool
-                .requirements
-                .into_iter()
-                .map(|req| match req {
-                    RequirementWire::Requirement(requirements) => requirements,
-                    RequirementWire::Deprecated(requirement) => Requirement::from(requirement),
-                })
-                .collect(),
+            package,
+            suffix: tool.suffix,
+            requirements,
             constraints: tool.constraints,
             overrides: tool.overrides,
             excludes: tool.excludes,
@@ -172,6 +194,8 @@ fn each_element_on_its_line_array(elements: impl Iterator<Item = impl Into<Value
 impl Tool {
     /// Create a new `Tool`.
     pub fn new(
+        package: PackageName,
+        suffix: Option<String>,
         requirements: Vec<Requirement>,
         constraints: Vec<Requirement>,
         overrides: Vec<Requirement>,
@@ -184,6 +208,8 @@ impl Tool {
         let mut entrypoints: Vec<_> = entrypoints.into_iter().collect();
         entrypoints.sort();
         Self {
+            package,
+            suffix,
             requirements,
             constraints,
             overrides,
@@ -204,6 +230,11 @@ impl Tool {
     /// Returns the TOML table for this tool.
     pub(crate) fn to_toml(&self) -> Result<Table, toml_edit::ser::Error> {
         let mut table = Table::new();
+
+        if let Some(suffix) = &self.suffix {
+            table.insert("package", value(self.package.to_string()));
+            table.insert("suffix", value(suffix));
+        }
 
         if !self.requirements.is_empty() {
             table.insert("requirements", {
@@ -353,6 +384,14 @@ impl Tool {
 
     pub fn entrypoints(&self) -> &[ToolEntrypoint] {
         &self.entrypoints
+    }
+
+    pub fn package(&self) -> &PackageName {
+        &self.package
+    }
+
+    pub fn suffix(&self) -> Option<&str> {
+        self.suffix.as_deref()
     }
 
     pub fn requirements(&self) -> &[Requirement] {

--- a/crates/uv/src/commands/project/audit/json.rs
+++ b/crates/uv/src/commands/project/audit/json.rs
@@ -1,7 +1,7 @@
 //! JSON layout models for `uv audit`.
 
 use serde::Serialize;
-use uv_normalize::PackageName;
+use uv_tool::ToolName;
 
 use super::AuditResults;
 
@@ -74,7 +74,7 @@ pub(crate) struct ToolReports {
 }
 
 impl ToolReports {
-    pub(crate) fn from_audits(audits: &[(PackageName, AuditResults)]) -> Self {
+    pub(crate) fn from_audits(audits: &[(ToolName, AuditResults)]) -> Self {
         let tools = audits
             .iter()
             .map(|(name, results)| {

--- a/crates/uv/src/commands/project/audit/sarif.rs
+++ b/crates/uv/src/commands/project/audit/sarif.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 use serde_json::Value;
 use uv_audit::{AdverseStatus, ProjectStatus, Vulnerability};
-use uv_normalize::PackageName;
+use uv_tool::ToolName;
 
 use super::AuditResults;
 
@@ -93,7 +93,7 @@ impl Report {
     }
 
     /// Combine tool findings into one SARIF document, retaining a run for each tool.
-    pub(crate) fn from_audits(audits: &[(PackageName, AuditResults)]) -> Self {
+    pub(crate) fn from_audits(audits: &[(ToolName, AuditResults)]) -> Self {
         let mut report = Self::from_findings(&[], &[], "");
         report.runs.clear();
 

--- a/crates/uv/src/commands/tool/audit.rs
+++ b/crates/uv/src/commands/tool/audit.rs
@@ -15,7 +15,7 @@ use uv_preview::{Preview, PreviewFeature};
 use uv_redacted::DisplaySafeUrl;
 use uv_resolver::{Lock, LockParseError};
 use uv_settings::{Combine, ResolverInstallerOptions};
-use uv_tool::InstalledTools;
+use uv_tool::{InstalledTools, ToolName};
 use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
@@ -88,6 +88,7 @@ pub(crate) async fn audit(
     } else {
         let mut tools = Vec::with_capacity(names.len());
         for name in names {
+            let name = ToolName::from(&name);
             match installed_tools.get_tool_receipt(&name) {
                 Ok(Some(tool)) => tools.push((name, Ok(tool))),
                 Ok(None) => {
@@ -243,7 +244,7 @@ pub(crate) async fn audit(
 }
 
 fn render_audits(
-    audits: &[(PackageName, AuditResults)],
+    audits: &[(ToolName, AuditResults)],
     output_format: AuditOutputFormat,
     printer: Printer,
 ) -> Result<ExitStatus> {

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -45,10 +45,10 @@ use uv_resolver::{
     FlatIndex, Installable, Lock, OptionsBuilder, Preference, ResolverManifest, ResolverOutput,
 };
 use uv_settings::{PythonInstallMirrors, ToolOptions};
-use uv_shell::Shell;
-use uv_tool::{InstalledTools, Tool, ToolEntrypoint, entrypoint_paths};
+use uv_shell::{Shell, shlex_posix};
+use uv_tool::{InstalledTools, Tool, ToolEntrypoint, ToolName, entrypoint_paths};
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
-use uv_warnings::warn_user_once;
+use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip;
@@ -723,6 +723,100 @@ pub(crate) async fn refine_interpreter(
     Ok(Some(interpreter))
 }
 
+/// Validate a user-provided tool executable suffix.
+///
+/// The suffix is appended to executable names, so it must be non-empty and cannot contain path
+/// separators. Characters that are invalid in Windows executable names and trailing dots or
+/// spaces are allowed but warned about.
+pub(crate) fn validate_tool_suffix(suffix: &str) -> anyhow::Result<()> {
+    if suffix.is_empty() {
+        bail!("A tool suffix cannot be empty");
+    }
+
+    if suffix.contains(['/', '\\']) {
+        bail!("Invalid tool suffix `{suffix}`: a suffix cannot contain path separators");
+    }
+
+    if suffix
+        .chars()
+        .any(|character| matches!(character, '<' | '>' | ':' | '"' | '|' | '?' | '*'))
+    {
+        warn_user!(
+            "The tool suffix `{suffix}` contains characters that are invalid in Windows executable names"
+        );
+    }
+
+    if suffix.ends_with(['.', ' ']) {
+        warn_user!(
+            "The tool suffix `{suffix}` ends with a dot or space, which are trimmed from executable names on Windows"
+        );
+    }
+
+    Ok(())
+}
+
+/// Format a suffix as a safely quoted command-line argument.
+pub(crate) fn format_tool_suffix_arg(suffix: &str) -> String {
+    format_tool_suffix_arg_for_shell(suffix, Shell::from_env())
+}
+
+fn format_tool_suffix_arg_for_shell(suffix: &str, shell: Option<Shell>) -> String {
+    let argument = format!("--suffix={suffix}");
+    if shell == Some(Shell::Cmd) {
+        return escape_cmd_argument(&argument);
+    }
+
+    let posix = shlex_posix(&argument);
+    if posix == argument {
+        return argument;
+    }
+
+    match shell {
+        Some(Shell::Powershell) => format!("'{}'", argument.replace('\'', "''")),
+        Some(Shell::Nushell) => quote_nushell_raw_string(&argument),
+        _ => posix,
+    }
+}
+
+fn quote_nushell_raw_string(argument: &str) -> String {
+    let mut hashes = "#".to_string();
+    while argument.contains(&format!("'{hashes}")) {
+        hashes.push('#');
+    }
+    format!("r{hashes}'{argument}'{hashes}")
+}
+
+fn escape_cmd_argument(argument: &str) -> String {
+    let mut escaped = String::with_capacity(argument.len());
+    let mut in_variable = false;
+    for (index, character) in argument.char_indices() {
+        if character == '%' {
+            if in_variable {
+                escaped.push('%');
+                in_variable = false;
+            } else if argument[index + character.len_utf8()..].contains('%') {
+                // Command Prompt does not provide a direct escape for percent expansion in
+                // interactive commands. Include a caret in the variable name to prevent a match;
+                // the caret is removed by later command-line processing.
+                escaped.push_str("%^");
+                in_variable = true;
+            } else {
+                escaped.push('%');
+            }
+            continue;
+        }
+
+        if matches!(
+            character,
+            ' ' | '\t' | '&' | '|' | '<' | '>' | '(' | ')' | '^'
+        ) {
+            escaped.push('^');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
 /// Finalizes a tool installation, after creation of an environment.
 ///
 /// Installs tool executables for a given package, handling any conflicts.
@@ -731,6 +825,8 @@ pub(crate) async fn refine_interpreter(
 pub(crate) fn finalize_tool_install(
     environment: &PythonEnvironment,
     name: &PackageName,
+    tool_name: &ToolName,
+    suffix: Option<&str>,
     entrypoints: &[PackageName],
     installed_tools: &InstalledTools,
     options: &ToolOptions,
@@ -765,9 +861,9 @@ pub(crate) fn finalize_tool_install(
 
     for package in ordered_packages {
         if package == name {
-            debug!("Installing entrypoints for tool `{package}`");
+            debug!("Installing entrypoints for tool `{tool_name}` from package `{package}`");
         } else {
-            debug!("Installing entrypoints for `{package}` as part of tool `{name}`");
+            debug!("Installing entrypoints for `{package}` as part of tool `{tool_name}`");
         }
 
         let installed = site_packages.get_packages(package);
@@ -786,7 +882,7 @@ pub(crate) fn finalize_tool_install(
                     .iter()
                     .map(|entrypoint| entrypoint.install_path.as_path()),
             );
-            installed_tools.remove_environment(name)?;
+            installed_tools.remove_environment(tool_name)?;
 
             return Err(NoExecutablesError::Root {
                 package: package.clone(),
@@ -800,12 +896,39 @@ pub(crate) fn finalize_tool_install(
         let target_entrypoints = dist_entrypoints
             .into_iter()
             .map(|(name, source_path)| {
-                let target_path = executable_directory.join(
-                    source_path
-                        .file_name()
-                        .map(std::borrow::ToOwned::to_owned)
-                        .unwrap_or_else(|| OsString::from(name.clone())),
-                );
+                let filename = source_path
+                    .file_name()
+                    .map(std::borrow::ToOwned::to_owned)
+                    .unwrap_or_else(|| OsString::from(name));
+                let filename = if let Some(suffix) = suffix {
+                    // On Unix, the suffix is appended directly to the file name. On Windows,
+                    // it's inserted before the extension so that the executable retains its
+                    // `.exe` extension.
+                    cfg_select! {
+                        windows => {
+                            let path = Path::new(&filename);
+                            let mut stem = path
+                                .file_stem()
+                                .map(std::borrow::ToOwned::to_owned)
+                                .unwrap_or_else(|| filename.clone());
+                            stem.push(suffix);
+                            if let Some(extension) = path.extension() {
+                                stem.push(".");
+                                stem.push(extension);
+                            }
+                            stem
+                        },
+                        unix => {
+                            let mut filename = filename;
+                            filename.push(suffix);
+                            filename
+                        }
+                    }
+                } else {
+                    filename
+                };
+                let name = filename.to_string_lossy().into_owned();
+                let target_path = executable_directory.join(filename);
                 (name, source_path, target_path)
             })
             .collect::<BTreeSet<_>>();
@@ -851,7 +974,7 @@ pub(crate) fn finalize_tool_install(
                     .iter()
                     .map(|entrypoint| entrypoint.install_path.as_path()),
             );
-            installed_tools.remove_environment(name)?;
+            installed_tools.remove_environment(tool_name)?;
 
             return Err(err.into());
         }
@@ -869,7 +992,7 @@ pub(crate) fn finalize_tool_install(
                         .iter()
                         .map(|entrypoint| entrypoint.install_path.as_path()),
                 );
-                installed_tools.remove_environment(name)?;
+                installed_tools.remove_environment(tool_name)?;
 
                 let existing_entrypoints = existing_entrypoints
                     // SAFETY: We know the target has a filename because we just constructed it above
@@ -928,8 +1051,10 @@ pub(crate) fn finalize_tool_install(
         )?;
     }
 
-    debug!("Adding receipt for tool `{name}`");
+    debug!("Adding receipt for tool `{tool_name}` from package `{name}`");
     let tool = Tool::new(
+        name.clone(),
+        suffix.map(ToOwned::to_owned),
         requirements,
         constraints,
         overrides,
@@ -939,8 +1064,8 @@ pub(crate) fn finalize_tool_install(
         installed_entrypoints,
         options.clone(),
     );
-    ToolLock::write(&installed_tools.tool_dir(name), lock)?;
-    installed_tools.add_tool_receipt(name, tool)?;
+    ToolLock::write(&installed_tools.tool_dir(tool_name), lock)?;
+    installed_tools.add_tool_receipt(tool_name, tool)?;
 
     warn_out_of_path(&executable_directory);
 

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -28,7 +28,7 @@ use uv_python::{
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
-use uv_tool::{InstalledTools, Tool};
+use uv_tool::{InstalledTools, Tool, ToolName};
 use uv_types::{HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::WorkspaceCache;
@@ -46,7 +46,7 @@ use crate::commands::project::{
 };
 use crate::commands::tool::common::{
     ToolLock, ToolPython, finalize_tool_install, refine_interpreter, remove_entrypoints,
-    tool_environment_spec,
+    tool_environment_spec, validate_tool_suffix,
 };
 use crate::commands::tool::{Target, ToolRequest};
 use crate::commands::{diagnostics, reporters::PythonDownloadReporter};
@@ -69,6 +69,7 @@ pub(crate) async fn install(
     python_platform: Option<TargetTriple>,
     install_mirrors: PythonInstallMirrors,
     force: bool,
+    suffix: Option<String>,
     options: ResolverInstallerOptions,
     settings: ResolverInstallerSettings,
     client_builder: BaseClientBuilder<'_>,
@@ -333,6 +334,12 @@ pub(crate) async fn install(
 
     let package_name = &requirement.name;
 
+    if let Some(suffix) = suffix.as_deref() {
+        validate_tool_suffix(suffix)?;
+    }
+
+    let tool_name = ToolName::from_package_name(package_name, suffix.as_deref())?;
+
     // If the user passed, e.g., `ruff@latest`, we need to mark it as upgradable.
     let settings = if request.is_latest() {
         ResolverInstallerSettings {
@@ -467,7 +474,10 @@ pub(crate) async fn install(
 
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = installed_tools.lock().await?;
-    let tool_dir = installed_tools.tool_dir(package_name);
+    if let Some(existing_name) = installed_tools.find_case_insensitive_name(&tool_name)? {
+        bail!("Tool name `{tool_name}` conflicts with existing tool `{existing_name}`");
+    }
+    let tool_dir = installed_tools.tool_dir(&tool_name);
 
     // Find the existing receipt, if it exists. If the receipt is present but malformed, we'll
     // remove the environment and continue with the install.
@@ -478,16 +488,16 @@ pub(crate) async fn install(
     // (If we find existing entrypoints later on, and the tool _doesn't_ exist, we'll avoid removing
     // the external tool's entrypoints (without `--force`).)
     let (existing_tool_receipt, invalid_tool_receipt) =
-        match installed_tools.get_tool_receipt(package_name) {
+        match installed_tools.get_tool_receipt(&tool_name) {
             Ok(None) => (None, false),
             Ok(Some(receipt)) => (Some(receipt), false),
             Err(_) => {
                 // If the tool is not installed properly, remove the environment and continue.
-                match installed_tools.remove_environment(package_name) {
+                match installed_tools.remove_environment(&tool_name) {
                     Ok(()) => {
                         warn_user!(
                             "Removed existing `{}` with invalid receipt",
-                            package_name.cyan()
+                            tool_name.cyan()
                         );
                     }
                     Err(err)
@@ -502,11 +512,31 @@ pub(crate) async fn install(
             }
         };
 
+    // The tool name is derived from the package and suffix; an existing installation under the
+    // same name must match both.
+    if let Some(existing_tool_receipt) = &existing_tool_receipt
+        && existing_tool_receipt.package() != package_name
+    {
+        bail!(
+            "Tool name `{tool_name}` is already used by package `{}`",
+            existing_tool_receipt.package().cyan()
+        );
+    }
+    if let Some(existing_tool_receipt) = &existing_tool_receipt
+        && existing_tool_receipt.suffix() != suffix.as_deref()
+    {
+        let existing_name = ToolName::from_package_name(
+            existing_tool_receipt.package(),
+            existing_tool_receipt.suffix(),
+        )?;
+        bail!("Tool name `{tool_name}` conflicts with existing tool `{existing_name}`");
+    }
+
     let existing_environment = if force {
         None
     } else {
         installed_tools
-            .get_environment(package_name, &cache)?
+            .get_environment(&tool_name, package_name, &cache)?
             .filter(|environment| {
                 existing_environment_usable(
                     environment.environment(),
@@ -631,15 +661,20 @@ pub(crate) async fn install(
                     // Then we're done! Though we might need to update the receipt.
                     if *tool_receipt.options() != options {
                         installed_tools.add_tool_receipt(
-                            package_name,
+                            &tool_name,
                             tool_receipt.clone().with_options(options),
                         )?;
                     }
 
+                    let installed = if suffix.is_some() {
+                        tool_name.to_string()
+                    } else {
+                        requirement.to_string()
+                    };
                     writeln!(
                         printer.stderr(),
                         "`{}` is already installed",
-                        requirement.cyan()
+                        installed.cyan()
                     )?;
 
                     return Ok(ExitStatus::Success);
@@ -796,8 +831,10 @@ pub(crate) async fn install(
                 };
                 ToolLock::write(&tool_dir, Some(&tool_lock))?;
                 installed_tools.add_tool_receipt(
-                    package_name,
+                    &tool_name,
                     Tool::new(
+                        package_name.clone(),
+                        suffix.clone(),
                         requirements.clone(),
                         receipt_constraints.clone(),
                         receipt_overrides.clone(),
@@ -808,10 +845,15 @@ pub(crate) async fn install(
                         options.clone(),
                     ),
                 )?;
+                let installed = if suffix.is_some() {
+                    tool_name.to_string()
+                } else {
+                    requirement.to_string()
+                };
                 writeln!(
                     printer.stderr(),
                     "`{}` is already installed",
-                    requirement.cyan()
+                    installed.cyan()
                 )?;
                 return Ok(ExitStatus::Success);
             }
@@ -1022,7 +1064,7 @@ pub(crate) async fn install(
         } else {
             HashStrategy::default()
         };
-        let environment = installed_tools.create_environment(package_name, interpreter)?;
+        let environment = installed_tools.create_environment(&tool_name, interpreter)?;
 
         // At this point, we removed any existing environment, so we should remove any of its
         // executables.
@@ -1051,7 +1093,7 @@ pub(crate) async fn install(
         .inspect_err(|_| {
             // If we failed to sync, remove the newly created environment.
             debug!("Failed to sync environment; removing `{}`", package_name);
-            let _ = installed_tools.remove_environment(package_name);
+            let _ = installed_tools.remove_environment(&tool_name);
         }) {
             Ok(environment) => (environment, tool_lock),
             Err(ProjectError::Operation(err)) => {
@@ -1066,6 +1108,8 @@ pub(crate) async fn install(
     finalize_tool_install(
         &environment,
         package_name,
+        &tool_name,
+        suffix.as_deref(),
         entrypoints,
         &installed_tools,
         &options,

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -16,12 +16,13 @@ use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_python::LenientImplementationName;
 use uv_settings::{Combine, ResolverInstallerOptions};
-use uv_tool::InstalledTools;
+use uv_tool::{InstalledTools, Tool, ToolName};
 use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
 use crate::commands::pip::latest::LatestClient;
 use crate::commands::reporters::LatestVersionReporter;
+use crate::commands::tool::common::format_tool_suffix_arg;
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 
@@ -76,19 +77,19 @@ pub(crate) async fn list(
         };
 
         // Get the tool environment
-        let tool_env = match installed_tools.get_environment(&name, cache) {
+        let tool_env = match installed_tools.get_environment(&name, tool.package(), cache) {
             Ok(Some(env)) => env,
             Ok(None) => {
                 warn_user!(
                     "Tool `{name}` environment not found (run `{}` to reinstall)",
-                    format!("uv tool install {name} --reinstall").green()
+                    reinstall_command(&tool).green()
                 );
                 continue;
             }
             Err(e) => {
                 warn_user!(
                     "{e} (run `{}` to reinstall)",
-                    format!("uv tool install {name} --reinstall").green()
+                    reinstall_command(&tool).green()
                 );
                 continue;
             }
@@ -101,7 +102,7 @@ pub(crate) async fn list(
                 if let uv_tool::Error::EnvironmentError(e) = e {
                     warn_user!(
                         "{e} (run `{}` to reinstall)",
-                        format!("uv tool install {name} --reinstall").green()
+                        reinstall_command(&tool).green()
                     );
                 } else {
                     writeln!(printer.stderr(), "{e}")?;
@@ -114,9 +115,7 @@ pub(crate) async fn list(
     }
 
     // Determine the latest version for each tool when `--outdated` is requested.
-    let latest: FxHashMap<PackageName, Option<DistFilename>> = if outdated
-        && !valid_tools.is_empty()
-    {
+    let latest: FxHashMap<ToolName, Option<DistFilename>> = if outdated && !valid_tools.is_empty() {
         let download_concurrency = concurrency.downloads_semaphore.clone();
 
         let reporter = LatestVersionReporter::from(printer).with_length(valid_tools.len() as u64);
@@ -161,17 +160,21 @@ pub(crate) async fn list(
                     };
 
                     let latest = latest_client
-                        .find_latest(name, None, &download_concurrency)
+                        .find_latest(tool.package(), None, &download_concurrency)
                         .await?;
-                    Ok::<(&PackageName, Option<DistFilename>), anyhow::Error>((name, latest))
+                    Ok::<(&ToolName, &PackageName, Option<DistFilename>), anyhow::Error>((
+                        name,
+                        tool.package(),
+                        latest,
+                    ))
                 }
             })
             .buffer_unordered(concurrency.downloads);
 
         let mut map = FxHashMap::default();
-        while let Some((name, version)) = fetches.next().await.transpose()? {
+        while let Some((name, package, version)) = fetches.next().await.transpose()? {
             if let Some(version) = version.as_ref() {
-                reporter.on_fetch_version(name, version.version());
+                reporter.on_fetch_version(package, version.version());
             } else {
                 reporter.on_fetch_progress();
             }
@@ -199,7 +202,7 @@ pub(crate) async fn list(
             .then(|| {
                 tool.requirements()
                     .iter()
-                    .filter(|req| req.name == name)
+                    .filter(|req| &req.name == tool.package())
                     .map(|req| req.source.to_string())
                     .filter(|s| !s.is_empty())
                     .peekable()
@@ -215,7 +218,7 @@ pub(crate) async fn list(
             .then(|| {
                 tool.requirements()
                     .iter()
-                    .filter(|req| req.name == name)
+                    .filter(|req| &req.name == tool.package())
                     .flat_map(|req| req.extras.iter()) // Flatten the extras from all matching requirements
                     .peekable()
             })
@@ -242,7 +245,7 @@ pub(crate) async fn list(
             .then(|| {
                 tool.requirements()
                     .iter()
-                    .filter(|req| req.name != name)
+                    .filter(|req| &req.name != tool.package())
                     .peekable()
             })
             .take_if(|requirements| requirements.peek().is_some())
@@ -296,4 +299,17 @@ pub(crate) async fn list(
     }
 
     Ok(ExitStatus::Success)
+}
+
+/// Format the `uv tool install --reinstall` command that would restore the given tool.
+fn reinstall_command(tool: &Tool) -> String {
+    if let Some(suffix) = tool.suffix() {
+        format!(
+            "uv tool install {} {} --reinstall",
+            tool.package(),
+            format_tool_suffix_arg(suffix)
+        )
+    } else {
+        format!("uv tool install {} --reinstall", tool.package())
+    }
 }

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -35,7 +35,7 @@ use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_shell::WindowsRunnable;
 use uv_static::EnvVars;
-use uv_tool::{InstalledTools, entrypoint_paths};
+use uv_tool::{InstalledTools, ToolName, entrypoint_paths};
 use uv_warnings::warn_user_once;
 use uv_workspace::WorkspaceCache;
 
@@ -467,9 +467,9 @@ async fn show_help(
         .into_iter()
         // Skip invalid tools
         .filter_map(|(name, tool)| {
-            tool.ok().and_then(|_| {
+            tool.ok().and_then(|tool| {
                 installed_tools
-                    .get_environment(&name, cache)
+                    .get_environment(&name, tool.package(), cache)
                     .ok()
                     .flatten()
                     .and_then(|tool_env| tool_env.version().ok())
@@ -1022,8 +1022,9 @@ async fn get_or_create_environment(
         let _lock = installed_tools.lock().await?;
 
         if let ToolRequirement::Package { requirement, .. } = &from {
+            let tool_name = ToolName::from(&requirement.name);
             let existing_environment = installed_tools
-                .get_environment(&requirement.name, cache)?
+                .get_environment(&tool_name, &requirement.name, cache)?
                 .filter(|environment| {
                     python_request.as_ref().is_none_or(|python_request| {
                         python_request.satisfied(environment.environment().interpreter(), cache)
@@ -1033,7 +1034,7 @@ async fn get_or_create_environment(
             // Check if the installed packages meet the requirements.
             if let Some(environment) = existing_environment {
                 if installed_tools
-                    .get_tool_receipt(&requirement.name)
+                    .get_tool_receipt(&tool_name)
                     .ok()
                     .flatten()
                     .is_some_and(|receipt| ToolOptions::from(options) == *receipt.options())

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::str::FromStr;
 
 use anyhow::{Result, bail};
 use itertools::Itertools;
@@ -7,13 +8,13 @@ use tracing::debug;
 
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
-use uv_tool::{InstalledTools, Tool, ToolEntrypoint};
+use uv_tool::{InstalledTools, Tool, ToolEntrypoint, ToolName};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Uninstall a tool.
-pub(crate) async fn uninstall(name: Vec<PackageName>, printer: Printer) -> Result<ExitStatus> {
+pub(crate) async fn uninstall(name: Vec<String>, printer: Printer) -> Result<ExitStatus> {
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = match installed_tools.lock().await {
         Ok(lock) => lock,
@@ -96,7 +97,7 @@ impl IgnoreCurrentlyBeingDeleted for Result<(), std::io::Error> {
 /// Perform the uninstallation.
 async fn do_uninstall(
     installed_tools: &InstalledTools,
-    names: Vec<PackageName>,
+    names: Vec<String>,
     printer: Printer,
 ) -> Result<()> {
     let mut dangling = false;
@@ -133,6 +134,7 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
+            let name = resolve_tool_name(&name, installed_tools)?;
             let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
                 // If the tool is not installed properly, attempt to remove the environment anyway.
                 match installed_tools.remove_environment(&name) {
@@ -185,7 +187,7 @@ async fn do_uninstall(
 
 /// Uninstall a tool.
 async fn uninstall_tool(
-    name: &PackageName,
+    name: &ToolName,
     receipt: &Tool,
     tools: &InstalledTools,
 ) -> Result<Vec<ToolEntrypoint>> {
@@ -226,4 +228,19 @@ async fn uninstall_tool(
     }
 
     Ok(entrypoints.to_vec())
+}
+
+/// Resolve a user-provided tool name, preserving suffixed names exactly.
+fn resolve_tool_name(name: &str, tools: &InstalledTools) -> Result<ToolName> {
+    let exact = ToolName::from_str(name)?;
+    if tools.tool_dir(&exact).exists() {
+        return Ok(exact);
+    }
+
+    // Preserve the historical normalization of unsuffixed package names.
+    if let Ok(package) = PackageName::from_str(name) {
+        return Ok(ToolName::from(package));
+    }
+
+    Ok(exact)
 }

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -82,8 +82,7 @@ pub(crate) async fn upgrade(
                 .collect::<Vec<_>>();
             let mut map = BTreeMap::new();
             for request in names {
-                if let Some((name, specifier)) = split_upgrade_request(&request, &installed_names)
-                {
+                if let Some((name, specifier)) = split_upgrade_request(&request, &installed_names) {
                     let constraints = map.entry(name.clone()).or_insert_with(Vec::new);
                     if !specifier.is_empty()
                         && let Ok(Some(tool)) = installed_tools.get_tool_receipt(name)

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -23,7 +23,7 @@ use uv_python::{
 };
 use uv_requirements::RequirementsSpecification;
 use uv_settings::{Combine, PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
-use uv_tool::{InstalledTools, Tool};
+use uv_tool::{InstalledTools, Tool, ToolName};
 use uv_types::{HashStrategy, SourceTreeEditablePolicy};
 use uv_workspace::WorkspaceCache;
 
@@ -36,7 +36,9 @@ use crate::commands::project::{
     update_environment,
 };
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::tool::common::{ToolLock, remove_entrypoints, tool_environment_spec};
+use crate::commands::tool::common::{
+    ToolLock, format_tool_suffix_arg, remove_entrypoints, tool_environment_spec,
+};
 use crate::commands::{ExitStatus, conjunction, tool::common::finalize_tool_install};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
@@ -63,7 +65,7 @@ pub(crate) async fn upgrade(
     let _lock = installed_tools.lock().await?;
 
     // Collect the tools to upgrade, along with any constraints.
-    let names: BTreeMap<PackageName, Vec<Requirement>> = {
+    let names: BTreeMap<ToolName, Vec<Requirement>> = {
         if names.is_empty() {
             installed_tools
                 .tools()
@@ -72,12 +74,33 @@ pub(crate) async fn upgrade(
                 .map(|(name, _)| (name, Vec::new()))
                 .collect()
         } else {
+            let installed_names = installed_tools
+                .tools()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect::<Vec<_>>();
             let mut map = BTreeMap::new();
-            for name in names {
-                let requirement = Requirement::from(uv_pep508::Requirement::parse(&name, &*CWD)?);
-                map.entry(requirement.name.clone())
-                    .or_insert_with(Vec::new)
-                    .push(requirement);
+            for request in names {
+                if let Some((name, specifier)) = split_upgrade_request(&request, &installed_names)
+                {
+                    let constraints = map.entry(name.clone()).or_insert_with(Vec::new);
+                    if !specifier.is_empty()
+                        && let Ok(Some(tool)) = installed_tools.get_tool_receipt(name)
+                    {
+                        let requirement = format!("{}{specifier}", tool.package());
+                        constraints.push(Requirement::from(uv_pep508::Requirement::parse(
+                            &requirement,
+                            &*CWD,
+                        )?));
+                    }
+                } else {
+                    let requirement =
+                        Requirement::from(uv_pep508::Requirement::parse(&request, &*CWD)?);
+                    map.entry(ToolName::from(requirement.name.clone()))
+                        .or_insert_with(Vec::new)
+                        .push(requirement);
+                }
             }
             map
         }
@@ -120,7 +143,7 @@ pub(crate) async fn upgrade(
     let mut did_upgrade_environment = vec![];
 
     // Constraints that caused upgrades to be skipped or altered.
-    let mut collected_constraints: Vec<(PackageName, UpgradeConstraint)> = Vec::new();
+    let mut collected_constraints: Vec<(ToolName, UpgradeConstraint)> = Vec::new();
 
     let mut errors = Vec::new();
     for (name, constraints) in &names {
@@ -214,6 +237,30 @@ pub(crate) async fn upgrade(
     Ok(ExitStatus::Success)
 }
 
+/// Split a request into an exact installed tool name and an optional requirement specifier.
+///
+/// For example, given an installed tool named `ruff-0.3`, the request `ruff-0.3 >=0.3,<0.4`
+/// targets that installation while constraining its package version.
+fn split_upgrade_request<'a>(
+    request: &'a str,
+    installed_names: &'a [ToolName],
+) -> Option<(&'a ToolName, &'a str)> {
+    installed_names
+        .iter()
+        .filter_map(|name| {
+            let specifier = request.strip_prefix(name.as_str())?;
+            (specifier.is_empty()
+                || specifier.as_bytes().first().is_some_and(|character| {
+                    character.is_ascii_whitespace()
+                        || matches!(character, b'<' | b'>' | b'=' | b'!' | b'~' | b'@')
+                }))
+            .then_some((name, specifier))
+        })
+        // Prefer the longest matching name so that, e.g., `ruff-0.11` wins over a hypothetical
+        // `ruff-0` when both are installed.
+        .max_by_key(|(name, _)| name.as_str().len())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UpgradeOutcome {
     /// The tool itself was upgraded.
@@ -229,20 +276,35 @@ enum UpgradeOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum UpgradeConstraint {
     /// The tool remains pinned to an exact version, so an upgrade was skipped.
-    PinnedVersion { version: Version },
+    PinnedVersion {
+        version: Version,
+        package: PackageName,
+        suffix: Option<String>,
+    },
 }
 
 impl UpgradeConstraint {
-    fn print(&self, name: &PackageName, printer: Printer) -> Result<()> {
+    fn print(&self, name: &ToolName, printer: Printer) -> Result<()> {
         match self {
-            Self::PinnedVersion { version } => {
-                let name = name.to_string();
-                let reinstall_command = format!("uv tool install {name}@latest");
+            Self::PinnedVersion {
+                version,
+                package,
+                suffix,
+            } => {
+                let reinstall_command = suffix.as_ref().map_or_else(
+                    || format!("uv tool install {package}@latest"),
+                    |suffix| {
+                        format!(
+                            "uv tool install {package}@latest {}",
+                            format_tool_suffix_arg(suffix)
+                        )
+                    },
+                );
 
                 writeln!(
                     printer.stderr(),
                     "hint: `{}` is pinned to `{}` (installed with an exact version pin); reinstall with `{}` to upgrade to a new version.",
-                    name.cyan(),
+                    name.to_string().cyan(),
                     version.to_string().magenta(),
                     reinstall_command.green(),
                 )?;
@@ -261,7 +323,7 @@ struct UpgradeReport {
 
 /// Upgrade a specific tool.
 async fn upgrade_tool(
-    name: &PackageName,
+    name: &ToolName,
     constraints: &[Requirement],
     interpreter: Option<&Interpreter>,
     python_platform: Option<&TargetTriple>,
@@ -281,6 +343,12 @@ async fn upgrade_tool(
     let existing_tool_receipt = match installed_tools.get_tool_receipt(name) {
         Ok(Some(receipt)) => receipt,
         Ok(None) => {
+            if installed_tools.tool_dir(name).exists() {
+                return Err(anyhow::anyhow!(
+                    "`{}` is missing a receipt and cannot be upgraded",
+                    name.cyan()
+                ));
+            }
             let install_command = format!("uv tool install {name}");
             return Err(anyhow::anyhow!(
                 "`{}` is not installed; run `{}` to install",
@@ -289,19 +357,18 @@ async fn upgrade_tool(
             ));
         }
         Err(_) => {
-            let install_command = format!("uv tool install --force {name}");
             return Err(anyhow::anyhow!(
-                "`{}` is missing a valid receipt; run `{}` to reinstall",
-                name.cyan(),
-                install_command.green()
+                "`{}` is missing a valid receipt and cannot be upgraded",
+                name.cyan()
             ));
         }
     };
+    let package = existing_tool_receipt.package();
 
-    let environment = match installed_tools.get_environment(name, cache) {
+    let environment = match installed_tools.get_environment(name, package, cache) {
         Ok(Some(environment)) => environment,
         Ok(None) => {
-            let install_command = format!("uv tool install {name}");
+            let install_command = install_command(&existing_tool_receipt, false);
             return Err(anyhow::anyhow!(
                 "`{}` is not installed; run `{}` to install",
                 name.cyan(),
@@ -309,7 +376,7 @@ async fn upgrade_tool(
             ));
         }
         Err(_) => {
-            let install_command = format!("uv tool install --force {name}");
+            let install_command = install_command(&existing_tool_receipt, true);
             return Err(anyhow::anyhow!(
                 "`{}` is missing a valid environment; run `{}` to reinstall",
                 name.cyan(),
@@ -390,7 +457,7 @@ async fn upgrade_tool(
             &settings.resolver.index_locations,
         )?;
         let resolution = tool_lock.to_resolution(
-            Some(name),
+            Some(package),
             target_interpreter,
             python_platform,
             &settings.resolver.build_options,
@@ -459,10 +526,10 @@ async fn upgrade_tool(
                 &tags,
             )?;
             let plan_is_empty = plan.is_empty();
-            let changes_tool = plan.cached.iter().any(|dist| dist.name() == name)
-                || plan.remote.iter().any(|dist| dist.name() == name)
-                || plan.reinstalls.iter().any(|dist| dist.name() == name)
-                || plan.extraneous.iter().any(|dist| dist.name() == name);
+            let changes_tool = plan.cached.iter().any(|dist| dist.name() == package)
+                || plan.remote.iter().any(|dist| dist.name() == package)
+                || plan.reinstalls.iter().any(|dist| dist.name() == package)
+                || plan.extraneous.iter().any(|dist| dist.name() == package);
             let outcome = if plan_is_empty {
                 UpgradeOutcome::NoOp
             } else if changes_tool {
@@ -482,7 +549,7 @@ async fn upgrade_tool(
                     (&settings).into(),
                     client_builder,
                     &state,
-                    Box::new(UpgradeInstallLogger::new(name.clone())),
+                    Box::new(UpgradeInstallLogger::new(package.clone())),
                     installer_metadata,
                     concurrency,
                     cache,
@@ -548,7 +615,7 @@ async fn upgrade_tool(
             client_builder,
             &state,
             Box::new(SummaryResolveLogger),
-            Box::new(UpgradeInstallLogger::new(name.clone())),
+            Box::new(UpgradeInstallLogger::new(package.clone())),
             installer_metadata,
             concurrency,
             cache,
@@ -559,7 +626,7 @@ async fn upgrade_tool(
         )
         .await?;
 
-        let outcome = if changelog.includes(name) {
+        let outcome = if changelog.includes(package) {
             UpgradeOutcome::UpgradeTool
         } else if changelog.is_empty() {
             UpgradeOutcome::NoOp
@@ -587,7 +654,9 @@ async fn upgrade_tool(
         // If we modified the target tool, reinstall the entrypoints.
         finalize_tool_install(
             &environment,
+            package,
             name,
+            existing_tool_receipt.suffix(),
             &entrypoints,
             installed_tools,
             &ToolOptions::from(options),
@@ -613,8 +682,13 @@ async fn upgrade_tool(
 
     let constraint = match &outcome {
         UpgradeOutcome::UpgradeDependencies | UpgradeOutcome::NoOp => {
-            pinned_requirement_version(&existing_tool_receipt, name)
-                .map(|version| UpgradeConstraint::PinnedVersion { version })
+            pinned_requirement_version(&existing_tool_receipt, package).map(|version| {
+                UpgradeConstraint::PinnedVersion {
+                    version,
+                    package: package.clone(),
+                    suffix: existing_tool_receipt.suffix().map(ToOwned::to_owned),
+                }
+            })
         }
         UpgradeOutcome::UpgradeTool | UpgradeOutcome::UpgradeEnvironment => None,
     };
@@ -623,6 +697,24 @@ async fn upgrade_tool(
         outcome,
         constraint,
     })
+}
+
+/// Format the `uv tool install` command that would restore the given tool.
+fn install_command(tool: &Tool, force: bool) -> String {
+    let mut command = tool.suffix().map_or_else(
+        || format!("uv tool install {}", tool.package()),
+        |suffix| {
+            format!(
+                "uv tool install {} {}",
+                tool.package(),
+                format_tool_suffix_arg(suffix)
+            )
+        },
+    );
+    if force {
+        command.push_str(" --force");
+    }
+    command
 }
 
 fn pinned_requirement_version(tool: &Tool, name: &PackageName) -> Option<Version> {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1729,6 +1729,7 @@ async fn run_with_workspace_cache(
                 args.python_platform,
                 args.install_mirrors,
                 args.force,
+                args.suffix,
                 args.options,
                 args.settings,
                 client_builder.subcommand(vec!["tool".to_owned(), "install".to_owned()]),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1035,6 +1035,7 @@ pub(crate) struct ToolInstallSettings {
     pub(crate) options: ResolverInstallerOptions,
     pub(crate) settings: ResolverInstallerSettings,
     pub(crate) force: bool,
+    pub(crate) suffix: Option<String>,
     pub(crate) editable: bool,
     pub(crate) install_mirrors: PythonInstallMirrors,
 }
@@ -1061,6 +1062,7 @@ impl ToolInstallSettings {
             lfs,
             installer,
             force,
+            suffix,
             build,
             refresh,
             python,
@@ -1137,6 +1139,7 @@ impl ToolInstallSettings {
             python: python.and_then(Maybe::into_option),
             python_platform,
             force,
+            suffix,
             editable,
             refresh: Refresh::try_from(refresh)?,
             options,
@@ -1372,7 +1375,7 @@ impl ToolAuditSettings {
 /// The resolved settings to use for a `tool uninstall` invocation.
 #[derive(Debug, Clone)]
 pub(crate) struct ToolUninstallSettings {
-    pub(crate) name: Vec<PackageName>,
+    pub(crate) name: Vec<String>,
 }
 
 impl ToolUninstallSettings {

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -5291,6 +5291,125 @@ fn tool_install_constraints() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn tool_install_suffix() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `ruff` with a custom suffix.
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("ruff==0.3.4")
+        .arg("--suffix")
+        .arg("-0.3.4")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + ruff==0.3.4
+    Installed 1 executable: ruff-0.3.4
+    ");
+
+    // Only the suffixed executable is installed.
+    assert!(
+        bin_dir
+            .join(format!("ruff-0.3.4{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+    assert!(
+        !bin_dir
+            .join(format!("ruff{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    // The environment is stored under the suffixed name.
+    tool_dir.child("ruff-0.3.4").assert(predicate::path::is_dir());
+
+    // The receipt records the package and suffix.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("ruff-0.3.4").join("uv-receipt.toml")).unwrap(), @r#"
+        [tool]
+        package = "ruff"
+        suffix = "-0.3.4"
+        requirements = [{ name = "ruff" }]
+        entrypoints = [
+            { name = "ruff-0.3.4", install-path = "[TEMP_DIR]/bin/ruff-0.3.4", from = "ruff" },
+        ]
+
+        [tool.options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+        "#);
+    });
+
+    // A second installation of the same package under a different suffix coexists.
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("ruff==0.3.4")
+        .arg("--suffix")
+        .arg("-old")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + ruff==0.3.4
+    Installed 1 executable: ruff-old
+    ");
+
+    assert!(tool_dir.join("ruff-0.3.4").exists());
+    assert!(tool_dir.join("ruff-old").exists());
+
+    uv_snapshot!(context.filters(), context.tool_list()
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str()), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    ruff-0.3.4 v0.3.4
+    - ruff-0.3.4
+
+    ruff-old v0.3.4
+    - ruff-old
+    ");
+}
+
+#[test]
+fn tool_install_suffix_invalid() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+
+    // Empty suffixes are rejected.
+    context
+        .tool_install()
+        .arg("ruff==0.3.4")
+        .arg("--suffix")
+        .arg("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "A tool suffix cannot be empty",
+        ));
+
+    // Path separators are rejected.
+    context
+        .tool_install()
+        .arg("ruff==0.3.4")
+        .arg("--suffix")
+        .arg("../escape")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "a suffix cannot contain path separators",
+        ));
+}
+
 /// Install a tool with `--overrides`.
 #[test]
 fn tool_install_overrides() -> Result<()> {

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -5329,7 +5329,9 @@ fn tool_install_suffix() {
     );
 
     // The environment is stored under the suffixed name.
-    tool_dir.child("ruff-0.3.4").assert(predicate::path::is_dir());
+    tool_dir
+        .child("ruff-0.3.4")
+        .assert(predicate::path::is_dir());
 
     // The receipt records the package and suffix.
     insta::with_settings!({
@@ -5339,7 +5341,7 @@ fn tool_install_suffix() {
         [tool]
         package = "ruff"
         suffix = "-0.3.4"
-        requirements = [{ name = "ruff" }]
+        requirements = [{ name = "ruff", specifier = "==0.3.4" }]
         entrypoints = [
             { name = "ruff-0.3.4", install-path = "[TEMP_DIR]/bin/ruff-0.3.4", from = "ruff" },
         ]
@@ -5360,7 +5362,6 @@ fn tool_install_suffix() {
     exit_code: 0 (success)
     ----- stderr -----
     Resolved [N] packages in [TIME]
-    Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
      + ruff==0.3.4
     Installed 1 executable: ruff-old
@@ -5375,7 +5376,6 @@ fn tool_install_suffix() {
     ----- stdout -----
     ruff-0.3.4 v0.3.4
     - ruff-0.3.4
-
     ruff-old v0.3.4
     - ruff-old
     ");
@@ -5393,9 +5393,7 @@ fn tool_install_suffix_invalid() {
         .arg("")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "A tool suffix cannot be empty",
-        ));
+        .stderr(predicate::str::contains("A tool suffix cannot be empty"));
 
     // Path separators are rejected.
     context

--- a/crates/uv/tests/tool/tool_uninstall.rs
+++ b/crates/uv/tests/tool/tool_uninstall.rs
@@ -170,3 +170,48 @@ fn tool_uninstall_all_missing_receipt() {
     Removed dangling environment for `black`
     ");
 }
+
+#[test]
+fn tool_uninstall_suffix() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_exe_suffix()
+        .with_tool_dirs();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `ruff` with a custom suffix.
+    context
+        .tool_install()
+        .arg("ruff==0.3.4")
+        .arg("--suffix")
+        .arg("-0.3.4")
+        .assert()
+        .success();
+
+    // The suffixed executable is installed and the unsuffixed one is not.
+    assert!(
+        bin_dir
+            .join(format!("ruff-0.3.4{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+    assert!(
+        !bin_dir
+            .join(format!("ruff{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    // Uninstall by the suffixed name.
+    uv_snapshot!(context.filters(), context.tool_uninstall().arg("ruff-0.3.4"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Uninstalled 1 executable: ruff-0.3.4
+    ");
+
+    // The suffixed environment and executable are removed.
+    assert!(!tool_dir.join("ruff-0.3.4").exists());
+    assert!(
+        !bin_dir
+            .join(format!("ruff-0.3.4{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+}

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -1774,3 +1774,45 @@ fn tool_upgrade_lock_uses_requested_python() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn tool_upgrade_suffix() {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install a pinned version of `ruff` with a suffix.
+    context
+        .tool_install()
+        .arg("ruff==0.3.4")
+        .arg("--suffix")
+        .arg("-0.3.4")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    // Upgrades target the suffixed installation by its tool name and preserve the suffix.
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("ruff-0.3.4")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Nothing to upgrade
+
+    hint: `ruff-0.3.4` is pinned to `0.3.4` (installed with an exact version pin); reinstall with `uv tool install ruff@latest --suffix=-0.3.4` to upgrade to a new version.
+    ");
+
+    // The suffixed environment and executable remain intact.
+    assert!(tool_dir.join("ruff-0.3.4").exists());
+    assert!(
+        bin_dir
+            .join(format!("ruff-0.3.4{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+}


### PR DESCRIPTION
Closes #6365

Adds pipx-style --suffix so multiple versions of one tool can coexist.

- With a custom suffix, entry points install as name+suffix only; plain-name executables are skipped, matching the RFC semantics quoted in the issue
- Receipt schema extended with optional package and suffix fields; reads stay back-compat and unsuffixed receipts are unchanged
- upgrade/uninstall/list/run/audit resolve tools by suffixed name; pin hints emit shell-safe --suffix=
- Validation: rejects empty suffix and path separators; warns on Windows-illegal characters (open question: warn vs hard-error, see draft #20370)
- Integration tests: tool_install_suffix, tool_install_suffix_invalid, tool_upgrade_suffix, tool_uninstall_suffix

Disclosure: agent-assisted implementation, human-reviewed and verified. cargo check green on the repo-pinned toolchain; insta snapshots were authored without a local build run - happy to regenerate if CI drifts.