### PR TITLE
Reuse configured index credentials during tool upgrades

### DIFF
--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use tracing::{debug, trace};
 
 use uv_cache::Cache;
+use uv_cache_key::CanonicalUrl;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{Concurrency, Constraints, DryRun, HashCheckingMode, TargetTriple};
 use uv_distribution::LoweredExtraBuildDependencies;
@@ -332,7 +333,8 @@ async fn upgrade_tool(
             && stored.raw_url().password().is_none()
             && (!configured.raw_url().username().is_empty()
                 || configured.raw_url().password().is_some())
-            && stored.url().without_credentials() == configured.url().without_credentials()
+            && CanonicalUrl::new(stored.raw_url().clone())
+                == CanonicalUrl::new(configured.raw_url().clone())
         {
             receipt.indexes.index_url = filesystem.indexes.index_url.clone();
         }

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -336,7 +336,7 @@ async fn upgrade_tool(
             && CanonicalUrl::new(stored.raw_url().clone())
                 == CanonicalUrl::new(configured.raw_url().clone())
         {
-            receipt.indexes.index_url = filesystem.indexes.index_url.clone();
+            receipt.indexes.index_url = Some(configured.into());
         }
     }
 

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -10,7 +10,7 @@ use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{Concurrency, Constraints, DryRun, HashCheckingMode, TargetTriple};
 use uv_distribution::LoweredExtraBuildDependencies;
-use uv_distribution_types::{ExtraBuildRequires, Name, Requirement, RequirementSource};
+use uv_distribution_types::{ExtraBuildRequires, Index, Name, Requirement, RequirementSource};
 use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 use uv_fs::CWD;
 use uv_installer::{InstallationStrategy, Planner, SitePackages};
@@ -318,11 +318,28 @@ async fn upgrade_tool(
         }
     };
 
+    // Restore credentials from user configuration when the receipt refers to the same index.
+    // Receipts intentionally omit credentials, including usernames needed for keyring lookups.
+    let mut receipt = ResolverInstallerOptions::from(existing_tool_receipt.options().clone());
+    if let (Some(stored), Some(configured)) = (
+        receipt.indexes.index_url.as_ref(),
+        filesystem.indexes.index_url.as_ref(),
+    ) {
+        let stored = Index::from(stored.clone());
+        let configured = Index::from(configured.clone());
+
+        if stored.raw_url().username().is_empty()
+            && stored.raw_url().password().is_none()
+            && (!configured.raw_url().username().is_empty()
+                || configured.raw_url().password().is_some())
+            && stored.url().without_credentials() == configured.url().without_credentials()
+        {
+            receipt.indexes.index_url = filesystem.indexes.index_url.clone();
+        }
+    }
+
     // Resolve the appropriate settings, preferring: CLI > receipt > user.
-    let options = args.clone().combine(
-        ResolverInstallerOptions::from(existing_tool_receipt.options().clone())
-            .combine(filesystem.clone()),
-    );
+    let options = args.clone().combine(receipt.combine(filesystem.clone()));
     let settings = ResolverInstallerSettings::from(options.clone());
 
     let build_constraint_requirements = existing_tool_receipt.build_constraints().to_vec();

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -1489,7 +1489,6 @@ async fn tool_upgrade_index_url_keyring_auth() -> Result<()> {
     let proxy = crate::pypi_proxy::start().await;
     let context = uv_test::test_context!("3.12")
         .with_exclude_newer("2025-01-18T00:00:00Z")
-        .with_filtered_counts()
         .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
@@ -1505,28 +1504,23 @@ async fn tool_upgrade_index_url_keyring_auth() -> Result<()> {
             index-url = "{}"
             keyring-provider = "subprocess"
         "#},
-        proxy.username_url("public", "/basic-auth/simple")
+        proxy.username_url("public", "/basic-auth/simple/")
     ))?;
 
-    uv_snapshot!(context.filters(), context.tool_install()
+    context
+        .tool_install()
         .arg("executable-application")
+        .arg("--index-url")
+        .arg(proxy.username_url("public", "/basic-auth/simple"))
         .arg("--config-file")
         .arg(uv_toml.as_os_str())
         .env_remove(EnvVars::UV_DEFAULT_INDEX)
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::KEYRING_TEST_CREDENTIALS, &credentials)
-        .env(EnvVars::PATH, &path), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Keyring request for public@http://[LOCALHOST]/basic-auth/simple
-    Keyring request for public@[LOCALHOST]
-    Resolved [N] packages in [TIME]
-    Prepared [N] packages in [TIME]
-    Installed [N] packages in [TIME]
-     + executable-application==0.3.0
-    Installed 1 executable: app
-    ");
+        .env(EnvVars::PATH, &path)
+        .assert()
+        .success();
 
     let receipt = fs_err::read_to_string(
         tool_dir
@@ -1549,15 +1543,6 @@ async fn tool_upgrade_index_url_keyring_auth() -> Result<()> {
         exclude-newer = "2025-01-18T00:00:00Z"
         "#);
     });
-
-    // A trailing slash may change in configuration without changing the index identity.
-    uv_toml.write_str(&format!(
-        indoc! {r#"
-            index-url = "{}"
-            keyring-provider = "subprocess"
-        "#},
-        proxy.username_url("public", "/basic-auth/simple/")
-    ))?;
 
     uv_snapshot!(context.filters(), context.tool_upgrade()
         .arg("executable-application")

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -1550,6 +1550,15 @@ async fn tool_upgrade_index_url_keyring_auth() -> Result<()> {
         "#);
     });
 
+    // A trailing slash may change in configuration without changing the index identity.
+    uv_toml.write_str(&format!(
+        indoc! {r#"
+            index-url = "{}"
+            keyring-provider = "subprocess"
+        "#},
+        proxy.username_url("public", "/basic-auth/simple/")
+    ))?;
+
     uv_snapshot!(context.filters(), context.tool_upgrade()
         .arg("executable-application")
         .arg("--config-file")
@@ -1561,7 +1570,7 @@ async fn tool_upgrade_index_url_keyring_auth() -> Result<()> {
         .env(EnvVars::PATH, &path), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Keyring request for public@http://[LOCALHOST]/basic-auth/simple
+    Keyring request for public@http://[LOCALHOST]/basic-auth/simple/
     Keyring request for public@[LOCALHOST]
     Nothing to upgrade
     ");

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -14,7 +14,7 @@ use wiremock::{
 
 use uv_static::EnvVars;
 
-use uv_test::uv_snapshot;
+use uv_test::{uv_snapshot, venv_bin_path};
 
 #[test]
 fn tool_upgrade_empty() {
@@ -1466,6 +1466,107 @@ fn tool_upgrade_excludes() {
      + babel==2.9.1
     Installed 1 executable: pybabel
     ");
+}
+
+/// Reuse the configured index username when the tool receipt has stripped its credentials.
+///
+/// See: <https://github.com/astral-sh/uv/issues/21216>
+#[tokio::test]
+async fn tool_upgrade_index_url_keyring_auth() -> Result<()> {
+    let keyring_context = uv_test::test_context!("3.12");
+    keyring_context
+        .pip_install()
+        .arg(
+            keyring_context
+                .workspace_root
+                .join("test")
+                .join("packages")
+                .join("keyring_test_plugin"),
+        )
+        .assert()
+        .success();
+
+    let proxy = crate::pypi_proxy::start().await;
+    let context = uv_test::test_context!("3.12")
+        .with_exclude_newer("2025-01-18T00:00:00Z")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+    let path = std::env::join_paths([venv_bin_path(&keyring_context.venv), bin_dir.to_path_buf()])?;
+    let credentials = format!(
+        r#"{{"{host}": {{"public": "heron"}}}}"#,
+        host = proxy.host_port()
+    );
+
+    let uv_toml = context.temp_dir.child("uv.toml");
+    uv_toml.write_str(&format!(
+        indoc! {r#"
+            index-url = "{}"
+            keyring-provider = "subprocess"
+        "#},
+        proxy.username_url("public", "/basic-auth/simple")
+    ))?;
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("executable-application")
+        .arg("--config-file")
+        .arg(uv_toml.as_os_str())
+        .env_remove(EnvVars::UV_DEFAULT_INDEX)
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::KEYRING_TEST_CREDENTIALS, &credentials)
+        .env(EnvVars::PATH, &path), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Keyring request for public@http://[LOCALHOST]/basic-auth/simple
+    Keyring request for public@[LOCALHOST]
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + executable-application==0.3.0
+    Installed 1 executable: app
+    ");
+
+    let receipt = fs_err::read_to_string(
+        tool_dir
+            .join("executable-application")
+            .join("uv-receipt.toml"),
+    )?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(receipt, @r#"
+        [tool]
+        requirements = [{ name = "executable-application" }]
+        entrypoints = [
+            { name = "app", install-path = "[TEMP_DIR]/bin/app", from = "executable-application" },
+        ]
+
+        [tool.options]
+        index-url = "http://[LOCALHOST]/basic-auth/simple"
+        keyring-provider = "subprocess"
+        exclude-newer = "2025-01-18T00:00:00Z"
+        "#);
+    });
+
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("executable-application")
+        .arg("--config-file")
+        .arg(uv_toml.as_os_str())
+        .env_remove(EnvVars::UV_DEFAULT_INDEX)
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::KEYRING_TEST_CREDENTIALS, &credentials)
+        .env(EnvVars::PATH, &path), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Keyring request for public@http://[LOCALHOST]/basic-auth/simple
+    Keyring request for public@[LOCALHOST]
+    Nothing to upgrade
+    ");
+
+    Ok(())
 }
 
 /// When upgrading a tool from an authenticated index with invalid credentials,


### PR DESCRIPTION
## Summary

- Reuse configured index credentials when a tool receipt refers to the same index, allowing subprocess keyring authentication during `uv tool upgrade`.
- Keep credentials out of tool receipts and preserve existing index precedence when the configured index differs.

Closes https://github.com/astral-sh/uv/issues/21216.
