### PR TITLE
Fix conflicting flag diagnostics for pairs without a `no-` prefix

### DIFF
--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -39,6 +39,20 @@ pub fn flag(yes: bool, no: bool, name: &str) -> anyhow::Result<Option<bool>> {
         "flag names must not include the `no-` prefix"
     );
 
+    flag_with_names(yes, no, name, format_args!("no-{name}"))
+}
+
+/// Given a boolean flag pair whose negative flag is not spelled `--no-{yes_name}` (like `--exact`
+/// and `--inexact`, or `--allow-python-downloads` and `--no-python-downloads`), resolve the value
+/// of the flag.
+///
+/// Prefer [`flag`] for the common case.
+pub fn flag_with_names(
+    yes: bool,
+    no: bool,
+    yes_name: impl fmt::Display,
+    no_name: impl fmt::Display,
+) -> anyhow::Result<Option<bool>> {
     match (yes, no) {
         (true, false) => Ok(Some(true)),
         (false, true) => Ok(Some(false)),
@@ -48,8 +62,8 @@ pub fn flag(yes: bool, no: bool, name: &str) -> anyhow::Result<Option<bool>> {
                 "`{}` and `{}` cannot be used together. \
                 Boolean flags on different levels are currently not supported \
                 (https://github.com/clap-rs/clap/issues/6049)",
-                format!("--{name}").green(),
-                format!("--no-{name}").green(),
+                format!("--{yes_name}").green(),
+                format!("--{no_name}").green(),
             )));
         }
     }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -28,8 +28,8 @@ use uv_cli::{
     HashCheckingArgs, PackageExcludeNewerArgs, PublishArgs, PythonDirArgs, RegistryClientArgs,
     ResolverArgs, ResolverInstallerArgs, ToolUpgradeArgs,
     options::{
-        Flag, FlagSource, IntoPipOptions, check_conflicts, flag, resolve_flag, resolve_flag_pair,
-        resolver_installer_options, resolver_options,
+        Flag, FlagSource, IntoPipOptions, check_conflicts, flag, flag_with_names, resolve_flag,
+        resolve_flag_pair, resolver_installer_options, resolver_options,
     },
 };
 use uv_client::{Certificates, Connectivity};
@@ -139,10 +139,11 @@ impl GlobalSettings {
             show_settings: args.show_settings,
             preview: resolve_preview(args, workspace, environment)?,
             python_preference,
-            python_downloads: flag(
+            python_downloads: flag_with_names(
                 args.allow_python_downloads,
                 args.no_python_downloads,
-                "python-downloads",
+                "allow-python-downloads",
+                "no-python-downloads",
             )?
             .map(PythonDownloads::from)
             .combine(env(env::UV_PYTHON_DOWNLOADS))
@@ -516,7 +517,7 @@ impl InitSettings {
         let package = flag(
             package || build_backend.is_some(),
             no_package || r#virtual,
-            "virtual",
+            "package",
         )?;
 
         let kind = if script {
@@ -810,7 +811,8 @@ impl RunSettings {
                 flag(editable.into(), no_editable.into(), "editable")?,
                 no_editable_package,
             ),
-            modifications: if flag(exact, inexact, "inexact")?.unwrap_or(false) {
+            modifications: if flag_with_names(exact, inexact, "exact", "inexact")?.unwrap_or(false)
+            {
                 Modifications::Exact
             } else {
                 Modifications::Sufficient
@@ -2026,7 +2028,7 @@ impl SyncSettings {
                 no_install_package,
                 only_install_package,
             ),
-            modifications: if flag(exact, inexact, "inexact")?.unwrap_or(true) {
+            modifications: if flag_with_names(exact, inexact, "exact", "inexact")?.unwrap_or(true) {
                 Modifications::Exact
             } else {
                 Modifications::Sufficient
@@ -3785,7 +3787,8 @@ impl PipInstallSettings {
             overrides_from_workspace,
             excludes_from_workspace,
             build_constraints_from_workspace,
-            modifications: if flag(exact, inexact, "inexact")?.unwrap_or(false) {
+            modifications: if flag_with_names(exact, inexact, "exact", "inexact")?.unwrap_or(false)
+            {
                 Modifications::Exact
             } else {
                 Modifications::Sufficient
@@ -3974,7 +3977,7 @@ impl PipListSettings {
         } = args;
 
         Ok(Self {
-            editable: flag(editable, exclude_editable, "exclude-editable")?,
+            editable: flag_with_names(editable, exclude_editable, "editable", "exclude-editable")?,
             exclude: exclude.into_iter().collect(),
             format,
             outdated: flag(outdated, no_outdated, "outdated")?.unwrap_or(false),

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -14384,6 +14384,25 @@ fn conflicting_flags_clap_bug() {
     );
 }
 
+/// Test that we name the flags the user actually passed when the negative flag is not spelled
+/// `--no-{name}`.
+#[test]
+fn conflicting_flags_clap_bug_mismatched_names() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.command()
+        .arg("pip")
+        .arg("--allow-python-downloads")
+        .arg("install")
+        .arg("--no-python-downloads")
+        .arg("tqdm"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: `--allow-python-downloads` and `--no-python-downloads` cannot be used together. Boolean flags on different levels are currently not supported (https://github.com/clap-rs/clap/issues/6049)
+    "
+    );
+}
+
 /// Test that conflicting global arguments retain their color styling.
 #[test]
 fn conflicting_flags_clap_bug_color() -> Result<()> {


### PR DESCRIPTION
Summary

Fixes #20841 by correcting misleading flag conflict error messages.

- Added support for explicitly naming mismatched flag pairs.
- Fixed three mismatched flag pairs and related error messages.
- Existing flag behavior remains unchanged.




<img width="1726" height="428" alt="image" src="https://github.com/user-attachments/assets/fa091083-bb1e-43f6-aea5-6e78762031b3" />

