### PR TITLE
Preserve source encoding declarations in wheel scripts

### DIFF
--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
 use std::io;
-use std::io::{BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 use data_encoding::BASE64URL_NOPAD;
@@ -139,6 +139,77 @@ fn format_shebang(executable: impl AsRef<Path>, os_name: &str, relocatable: bool
     }
 
     format!("#!{executable}")
+}
+
+/// Return whether a line contains a Python source encoding declaration as defined by PEP 263.
+fn is_python_source_encoding(line: &[u8]) -> bool {
+    let line = line
+        .iter()
+        .position(|byte| !matches!(byte, b' ' | b'\t' | 0x0c))
+        .map_or(&[][..], |index| &line[index..]);
+    if !line.starts_with(b"#") {
+        return false;
+    }
+
+    line.windows(b"coding".len())
+        .enumerate()
+        .any(|(index, window)| {
+            if window != b"coding" {
+                return false;
+            }
+            let Some(delimiter) = line.get(index + b"coding".len()) else {
+                return false;
+            };
+            if !matches!(delimiter, b':' | b'=') {
+                return false;
+            }
+            line[index + b"coding".len() + 1..]
+                .iter()
+                .find(|byte| !matches!(byte, b' ' | b'\t'))
+                .is_some_and(|byte| {
+                    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+                })
+        })
+}
+
+/// Ensure that a Python source encoding declaration is also a POSIX shell comment.
+fn make_python_source_encoding_shell_safe(line: &mut Vec<u8>) {
+    if line
+        .iter()
+        .take_while(|byte| matches!(byte, b' ' | b'\t' | 0x0c))
+        .any(|byte| *byte == 0x0c)
+    {
+        line.insert(0, b'#');
+    }
+}
+
+/// Read one line without decoding it, preserving LF, CRLF, and CR line endings.
+fn read_line_bytes(reader: &mut impl BufRead, line: &mut Vec<u8>) -> io::Result<()> {
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(());
+        }
+
+        if let Some(index) = available
+            .iter()
+            .position(|byte| matches!(byte, b'\n' | b'\r'))
+        {
+            let terminator = available[index];
+            line.extend_from_slice(&available[..=index]);
+            reader.consume(index + 1);
+
+            if terminator == b'\r' && reader.fill_buf()?.first() == Some(&b'\n') {
+                line.push(b'\n');
+                reader.consume(1);
+            }
+            return Ok(());
+        }
+
+        let length = available.len();
+        line.extend_from_slice(available);
+        reader.consume(length);
+    }
 }
 
 /// Returns a [`PathBuf`] to `python[w].exe` for script execution.
@@ -551,7 +622,7 @@ fn install_script(
         })?;
 
     let path = file.path();
-    let mut script = File::open(&path)?;
+    let mut script = BufReader::new(File::open(&path)?);
 
     // https://sphinx-locales.github.io/peps/pep-0427/#recommended-installer-features
     // > In wheel, scripts are packaged in {distribution}-{version}.data/scripts/.
@@ -579,6 +650,9 @@ fn install_script(
             match script.read_exact(&mut byte) {
                 Ok(()) => {
                     if byte[0] == b'\n' || byte[0] == b'\r' {
+                        if byte[0] == b'\r' && script.fill_buf()?.first() == Some(&b'\n') {
+                            script.consume(1);
+                        }
                         break;
                     }
 
@@ -598,6 +672,21 @@ fn install_script(
         let mut start = format_shebang(&executable, &layout.os_name, relocatable)
             .as_bytes()
             .to_vec();
+        let mut following_line = Vec::new();
+
+        // PEP 263 requires source encoding declarations to appear on the first or second line.
+        // Keep a declaration from the original second line directly after the `#!/bin/sh` line.
+        if start.starts_with(b"#!/bin/sh\n") {
+            read_line_bytes(&mut script, &mut following_line)?;
+            if is_python_source_encoding(&following_line) {
+                make_python_source_encoding_shell_safe(&mut following_line);
+                if !following_line.ends_with(b"\n") {
+                    following_line.push(b'\n');
+                }
+                let insert_at = b"#!/bin/sh\n".len();
+                start.splice(insert_at..insert_at, following_line.drain(..));
+            }
+        }
 
         // Use appropriate line ending for the platform.
         if layout.os_name == "nt" {
@@ -605,6 +694,7 @@ fn install_script(
         } else {
             start.push(b'\n');
         }
+        start.extend_from_slice(&following_line);
 
         let mut target = uv_fs::tempfile_in(&layout.scheme.scripts)?;
         let size_and_encoded_hash = copy_and_hash(&mut start.chain(script), &mut target)?;
@@ -1220,7 +1310,7 @@ impl RenameOrCopy {
 #[cfg(test)]
 mod test {
     use std::assert_matches;
-    use std::io::{Cursor, ErrorKind};
+    use std::io::{BufReader, Cursor, ErrorKind, Read};
     use std::path::Path;
 
     use anyhow::Result;
@@ -1229,7 +1319,9 @@ mod test {
 
     use super::{
         Error, RecordEntry, Script, WheelFile, format_shebang, get_script_executable,
-        parse_email_message_file, parse_scripts, read_record, write_installer_metadata,
+        is_python_source_encoding, make_python_source_encoding_shell_safe,
+        parse_email_message_file, parse_scripts, read_line_bytes, read_record,
+        write_installer_metadata,
     };
 
     #[test]
@@ -1444,6 +1536,87 @@ mod test {
             format_shebang(executable, os_name, false),
             "#!/bin/sh\n'''exec' '/usr/bin/path/to/a/very/long/executable/executable/executable/executable/executable/executable/executable/executable/name/python3' \"$0\" \"$@\"\n' '''"
         );
+    }
+
+    #[test]
+    fn test_python_source_encoding() {
+        for line in [
+            b"# coding=windows-1252\n".as_slice(),
+            b"# -*- coding: utf-8 -*-\r\n".as_slice(),
+            b" \t\x0c# comment; coding: latin-1\r".as_slice(),
+            b"# coding: cp1252\nprint(\"\x80\")".as_slice(),
+        ] {
+            assert!(is_python_source_encoding(line), "{line:?}");
+        }
+
+        for line in [
+            b"coding=utf-8\n".as_slice(),
+            b"# Coding=utf-8\n".as_slice(),
+            b"# coding = utf-8\n".as_slice(),
+            b"# coding:\n".as_slice(),
+            b"print('# coding=utf-8')\n".as_slice(),
+        ] {
+            assert!(!is_python_source_encoding(line), "{line:?}");
+        }
+    }
+
+    #[test]
+    fn test_make_python_source_encoding_shell_safe() {
+        for (input, expected) in [
+            (
+                b"\x0c# coding=windows-1252\n".as_slice(),
+                b"#\x0c# coding=windows-1252\n".as_slice(),
+            ),
+            (
+                b" \t\x0c# coding=windows-1252\r\n".as_slice(),
+                b"# \t\x0c# coding=windows-1252\r\n".as_slice(),
+            ),
+            (
+                b" # coding=windows-1252\n".as_slice(),
+                b" # coding=windows-1252\n".as_slice(),
+            ),
+            (
+                b"\t# coding=windows-1252\r".as_slice(),
+                b"\t# coding=windows-1252\r".as_slice(),
+            ),
+        ] {
+            let mut line = input.to_vec();
+            make_python_source_encoding_shell_safe(&mut line);
+            assert_eq!(line, expected);
+        }
+    }
+
+    #[test]
+    fn test_read_line_bytes() -> Result<()> {
+        for (input, expected_line, expected_rest) in [
+            (
+                b"line\nrest".as_slice(),
+                b"line\n".as_slice(),
+                b"rest".as_slice(),
+            ),
+            (
+                b"line\r\nrest".as_slice(),
+                b"line\r\n".as_slice(),
+                b"rest".as_slice(),
+            ),
+            (
+                b"line\rrest".as_slice(),
+                b"line\r".as_slice(),
+                b"rest".as_slice(),
+            ),
+            (b"line".as_slice(), b"line".as_slice(), b"".as_slice()),
+            (b"".as_slice(), b"".as_slice(), b"".as_slice()),
+        ] {
+            let mut reader = BufReader::with_capacity(1, Cursor::new(input));
+            let mut line = Vec::new();
+            read_line_bytes(&mut reader, &mut line)?;
+            assert_eq!(line, expected_line);
+
+            let mut rest = Vec::new();
+            reader.read_to_end(&mut rest)?;
+            assert_eq!(rest, expected_rest);
+        }
+        Ok(())
     }
 
     #[test]

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -79,6 +79,48 @@ fn write_many_files_wheel(path: &Path, source_files: usize) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn write_data_scripts_wheel(path: &Path, scripts: &[(&str, &[u8])]) -> Result<()> {
+    let mut writer = ZipFileWriter::new(Vec::new());
+    let mut record = String::new();
+
+    for (name, contents) in scripts {
+        let name = format!("source_encoding_test-0.1.0.data/scripts/{name}");
+        let entry = ZipEntryBuilder::new(name.clone().into(), Compression::Stored);
+        block_on(writer.write_entry_whole(entry, contents))?;
+        writeln!(record, "{name},,")?;
+    }
+
+    let metadata = indoc! {"
+        Metadata-Version: 2.1
+        Name: source-encoding-test
+        Version: 0.1.0
+    "};
+    let wheel = indoc! {"
+        Wheel-Version: 1.0
+        Generator: uv-test
+        Root-Is-Purelib: true
+        Tag: py3-none-any
+    "};
+    for (name, contents) in [
+        ("source_encoding_test-0.1.0.dist-info/METADATA", metadata),
+        ("source_encoding_test-0.1.0.dist-info/WHEEL", wheel),
+    ] {
+        let entry = ZipEntryBuilder::new(name.into(), Compression::Stored);
+        block_on(writer.write_entry_whole(entry, contents.as_bytes()))?;
+        writeln!(record, "{name},,")?;
+    }
+    record.push_str("source_encoding_test-0.1.0.dist-info/RECORD,,\n");
+    let entry = ZipEntryBuilder::new(
+        "source_encoding_test-0.1.0.dist-info/RECORD".into(),
+        Compression::Stored,
+    );
+    block_on(writer.write_entry_whole(entry, record.as_bytes()))?;
+
+    fs_err::write(path, block_on(writer.close())?)?;
+    Ok(())
+}
+
 #[test]
 fn install_wheel_cache_incompatible_with_older_uv() -> Result<()> {
     allow_duplicates! {
@@ -14542,6 +14584,97 @@ fn strip_shebang_arguments() -> Result<()> {
         print(f"Hello from GUI script: {sys.executable}")
         "#);
     });
+
+    Ok(())
+}
+
+/// PEP 263 requires source encoding declarations to appear on the first or second line.
+#[test]
+#[cfg(unix)]
+fn preserve_data_script_source_encoding_with_sh_redirector() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel = context
+        .temp_dir
+        .child("source_encoding_test-0.1.0-py3-none-any.whl");
+    write_data_scripts_wheel(
+        wheel.path(),
+        &[
+            (
+                "form-feed-lf",
+                b"#!python\n \t\x0c# coding=windows-1252\nprint(\"\x80\x99\")\n",
+            ),
+            (
+                "form-feed-crlf",
+                b"#!python\r\n\x0c# coding=windows-1252\r\nprint(\"\x80\x99\")\r\n",
+            ),
+            (
+                "form-feed-cr",
+                b"#!python\r\x0c# coding=windows-1252\rprint(\"\x80\x99\")\r",
+            ),
+            (
+                "space-lf",
+                b"#!python\n # coding=windows-1252\nprint(\"\x80\x99\")\n",
+            ),
+            (
+                "tab-crlf",
+                b"#!python\r\n\t# coding=windows-1252\r\nprint(\"\x80\x99\")\r\n",
+            ),
+        ],
+    )?;
+
+    // A space in the virtual environment path forces uv to use the `#!/bin/sh` redirector.
+    let venv = context.temp_dir.child("venv with space");
+    context
+        .command()
+        .arg("venv")
+        .arg(venv.path())
+        .assert()
+        .success();
+    context
+        .command()
+        .arg("pip")
+        .arg("install")
+        .arg("--python")
+        .arg(venv_bin_path(&venv).join("python"))
+        .arg(wheel.path())
+        .assert()
+        .success();
+
+    for (name, expected_prefix) in [
+        (
+            "form-feed-lf",
+            b"#!/bin/sh\n# \t\x0c# coding=windows-1252\n'''exec' ".as_slice(),
+        ),
+        (
+            "form-feed-crlf",
+            b"#!/bin/sh\n#\x0c# coding=windows-1252\r\n'''exec' ".as_slice(),
+        ),
+        (
+            "form-feed-cr",
+            b"#!/bin/sh\n#\x0c# coding=windows-1252\r\n'''exec' ".as_slice(),
+        ),
+        (
+            "space-lf",
+            b"#!/bin/sh\n # coding=windows-1252\n'''exec' ".as_slice(),
+        ),
+        (
+            "tab-crlf",
+            b"#!/bin/sh\n\t# coding=windows-1252\r\n'''exec' ".as_slice(),
+        ),
+    ] {
+        let installed_script = venv_bin_path(&venv).join(name);
+        let contents = fs::read(&installed_script)?;
+        assert!(
+            contents.starts_with(expected_prefix),
+            "encoding declaration must remain shell-safe on line 2 for {name}: {}",
+            String::from_utf8_lossy(&contents)
+        );
+        Command::new(installed_script)
+            .assert()
+            .success()
+            .stdout("€™\n")
+            .stderr("");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Wheel data scripts use `#!python` as a placeholder for the interpreter selected during installation. A script can also declare a non-UTF-8 source encoding on its second physical line:

```python
#!python
# coding=windows-1252
print("\x80\x99")
```

When the selected POSIX interpreter path contains a space, is too long, or is relocatable, uv cannot use a direct shebang. It replaces `#!python` with a three-line shell redirector:

```sh
#!/bin/sh
'''exec' '/path with space/python' "$0" "$@"
' '''
```

The previous installer placed that complete redirector before the remaining script body. The encoding declaration therefore moved from line two to line four:

```text
1  #!/bin/sh
2  '''exec' ...
3  ' '''
4  # coding=windows-1252
5  print("\x80\x99")
```

PEP 263 only recognizes source encodings on the first or second physical line. Python consequently decodes the installed script as UTF-8 and exits with `SyntaxError: Non-UTF-8 code ... but no encoding declared` before the script can run.

Keep a valid declaration from the original second line immediately after the generated `#!/bin/sh` line, before the rest of the redirector. The installer reads and writes this path as bytes rather than a Rust string, preserving non-UTF-8 contents and LF, CRLF, or CR physical line boundaries. It consumes the complete original shebang terminator so CRLF does not leave a false empty line in front of the declaration.

PEP 263 permits form feed before the comment marker, but a POSIX shell does not treat form feed as shell whitespace. A declaration such as `\x0c# coding=windows-1252` would still run as a shell command after being moved to line two. For that case only, prefix the original line with a column-zero `#`; ordinary space- and tab-indented declarations remain byte-for-byte unchanged. Direct shebangs and second lines that are not encoding declarations keep the existing order.

Related work in Pex preserves the declaration when Pex later rewrites installed launchers, but it does not modify uv's wheel installer or prevent this earlier rewrite.

Fixes #21276.

## Test Plan

The integration test builds wheel data scripts containing Windows-1252 bytes and installs them into a virtual environment whose path contains a space, which deterministically selects the shell redirector. On the previous implementation, the structural assertion shows the declaration on line four and the separately installed script exits with the non-UTF-8 `SyntaxError` above.

The final test executes the installed LF, CRLF, and CR variants and checks their exact generated prefixes, output, and empty stderr. It covers form-feed, space, and tab indentation; the form-feed case specifically fails against the initial declaration-moving implementation with `\x0c#: not found`, so success alone is not sufficient. Unit coverage also exercises declaration recognition and byte-line reading at one-byte buffer boundaries.

The `uv-install-wheel` package suite passes with 25 tests. The targeted `pip_install` regression and its adjacent controls pass, and package-level Linux and Windows cross-compiled checks are clean. The full workspace suite and native Windows and macOS execution were not run locally; the behavior change itself is restricted to the POSIX redirector branch.
