### PR TITLE
Share downloaded URL wheels across hash fragments

### DIFF
--- a/crates/uv-cache-key/src/canonical_url.rs
+++ b/crates/uv-cache-key/src/canonical_url.rs
@@ -8,14 +8,14 @@ use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 
 use crate::cache_key::{CacheKey, CacheKeyHasher};
 
-/// A wrapper around `Url` which represents a "canonical" version of an original URL.
+/// A normalized URL for comparing package sources.
 ///
 /// A "canonical" url is only intended for internal comparison purposes. It's to help paper over
 /// mistakes such as depending on `github.com/foo/bar` vs. `github.com/foo/bar.git`.
 ///
-/// This is **only** for internal purposes and provides no means to actually read the underlying
-/// string value of the `Url` it contains. This is intentional, because all fetching should still
-/// happen within the context of the original URL.
+/// Known hash fragments are omitted from source identity. All other fragments are preserved,
+/// including unknown fields that may acquire meaning in the future. Fetching and hash validation
+/// must use the original URL; equal canonical URLs do not imply equal archive contents.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct CanonicalUrl(DisplaySafeUrl);
 
@@ -24,6 +24,22 @@ impl CanonicalUrl {
         // If the URL cannot be a base, then it's not a valid URL anyway.
         if url.cannot_be_a_base() {
             return Self(url);
+        }
+
+        // Match the hash fields recognized by `uv_pypi_types::Hashes::parse_fragment`, without
+        // interpreting other fragments. In particular, malformed or unknown fields are retained.
+        if let Some(fragment) = url.fragment() {
+            let fragments = fragment
+                .split('&')
+                .filter(|fragment| {
+                    !fragment.split_once('=').is_some_and(|(name, value)| {
+                        matches!(name, "md5" | "sha256" | "sha384" | "sha512" | "blake2b")
+                            && !value.contains('=')
+                    })
+                })
+                .collect::<Vec<_>>();
+            let fragment = (!fragments.is_empty()).then(|| fragments.join("&"));
+            url.set_fragment(fragment.as_deref());
         }
 
         // Strip credentials.
@@ -225,6 +241,56 @@ impl std::fmt::Display for RepositoryUrl {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_url_ignores_known_hash_fragments() -> Result<(), DisplaySafeUrlError> {
+        for algorithm in ["md5", "sha256", "sha384", "sha512", "blake2b"] {
+            assert_eq!(
+                CanonicalUrl::parse(&format!("https://example.com/pkg.whl#{algorithm}=abc"))?,
+                CanonicalUrl::parse("https://example.com/pkg.whl")?,
+            );
+            assert_eq!(
+                CanonicalUrl::parse(&format!(
+                    "https://example.com/pkg.tar.gz#subdirectory=src&{algorithm}=abc&unknown=value"
+                ))?,
+                CanonicalUrl::parse(
+                    "https://example.com/pkg.tar.gz#subdirectory=src&unknown=value"
+                )?,
+            );
+        }
+        assert_eq!(
+            CanonicalUrl::parse("https://example.com/pkg.whl#sha256=abc&sha512=def")?,
+            CanonicalUrl::parse("https://example.com/pkg.whl")?,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_url_preserves_other_fragments() -> Result<(), DisplaySafeUrlError> {
+        for fragment in [
+            "subdirectory=src",
+            "path=dist/pkg.whl",
+            "lfs=true",
+            "egg=pkg",
+            "unknown=value",
+            "sha3_256=abc",
+            "SHA256=abc",
+            "sha256",
+            "sha256=abc=def",
+            "0123456789012345678901234567890123456789",
+        ] {
+            let url = DisplaySafeUrl::parse(&format!("https://example.com/pkg#{fragment}"))?;
+            assert_eq!(DisplaySafeUrl::from(CanonicalUrl::new(url.clone())), url);
+        }
+        // Preserve duplicate fields and their order, matching the source parsers.
+        assert_eq!(
+            CanonicalUrl::parse(
+                "https://example.com/pkg#subdirectory=first&sha256=abc&subdirectory=second"
+            )?,
+            CanonicalUrl::parse("https://example.com/pkg#subdirectory=first&subdirectory=second")?,
+        );
+        Ok(())
+    }
 
     #[test]
     fn user_credential_does_not_affect_cache_key() -> Result<(), DisplaySafeUrlError> {

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -421,9 +421,7 @@ impl Cache {
         fs_err::create_dir_all(archive_entry.dir())?;
         uv_fs::rename_with_retry(temp_dir.as_ref(), archive_entry.path()).await?;
 
-        // Create a symlink to the directory store.
-        fs_err::create_dir_all(path.as_ref().parent().expect("Cache entry to have parent"))?;
-        self.create_link(&id, path.as_ref())?;
+        self.link(&id, path)?;
 
         Ok(id)
     }
@@ -452,6 +450,12 @@ impl Cache {
         self.create_link(&id, path.as_ref())?;
 
         Ok(id)
+    }
+
+    /// Link an existing archive into a cache entry, retaining it when the cache is pruned.
+    pub fn link(&self, id: &ArchiveId, path: impl AsRef<Path>) -> io::Result<()> {
+        fs_err::create_dir_all(path.as_ref().parent().expect("Cache entry to have parent"))?;
+        self.create_link(id, path)
     }
 
     /// Returns `true` if the [`Cache`] is temporary.

--- a/crates/uv-cache/src/wheel.rs
+++ b/crates/uv-cache/src/wheel.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use uv_cache_key::{CanonicalUrl, cache_digest};
 use uv_distribution_types::IndexUrl;
+use uv_pypi_types::HashDigest;
 use uv_redacted::DisplaySafeUrl;
 
 /// Cache wheels and their metadata, both from remote wheels and built from source distributions.
@@ -29,45 +30,47 @@ impl WheelCache<'_> {
             Self::Index(IndexUrl::Pypi(_)) => WheelCacheKind::Pypi.root(),
             Self::Index(url) => WheelCacheKind::Index
                 .root()
-                .join(cache_digest(&CanonicalUrl::new(url.url().clone()))),
-            Self::Url(url) => WheelCacheKind::Url
-                .root()
-                .join(cache_digest(&CanonicalUrl::new((*url).clone()))),
-            Self::Path(url) => WheelCacheKind::Path
-                .root()
-                .join(cache_digest(&CanonicalUrl::new((*url).clone()))),
-            Self::Editable(url) => WheelCacheKind::Editable
-                .root()
-                .join(cache_digest(&CanonicalUrl::new((*url).clone()))),
+                .join(revision_digest(url.url())),
+            Self::Url(url) => WheelCacheKind::Url.root().join(revision_digest(url)),
+            Self::Path(url) => WheelCacheKind::Path.root().join(revision_digest(url)),
+            Self::Editable(url) => WheelCacheKind::Editable.root().join(revision_digest(url)),
             Self::Git(url, sha) => WheelCacheKind::Git
                 .root()
-                .join(cache_digest(&CanonicalUrl::new((*url).clone())))
+                .join(revision_digest(url))
                 .join(sha),
         }
     }
 
-    /// A subdirectory for downloaded wheels belonging to a specific package.
-    ///
-    /// URL fragments do not identify different wheel bytes. Expected hashes are checked against
-    /// the computed hashes in the cached archive, rather than being part of its location.
+    /// A subdirectory for wheels and metadata belonging to a specific package and URL revision.
     pub fn wheel_dir(&self, package_name: impl AsRef<Path>) -> PathBuf {
-        match self {
-            Self::Url(url) => {
-                let mut url = (*url).clone();
-                url.set_fragment(None);
-                WheelCache::Url(&url).root().join(package_name)
-            }
-            _ => self.root().join(package_name),
-        }
-    }
-
-    /// A subdirectory for wheel metadata belonging to a specific package.
-    ///
-    /// Unlike downloaded archives, metadata cannot be checked against an archive's hash. Retain
-    /// the URL fragment so a changed hash cannot reuse metadata for a previous artifact.
-    pub fn metadata_dir(&self, package_name: impl AsRef<Path>) -> PathBuf {
         self.root().join(package_name)
     }
+
+    /// A shared cache location for a URL wheel with a computed hash.
+    ///
+    /// Unlike HTTP responses, downloaded archives can be shared across hash declarations by
+    /// checking their computed digests. Keep unknown and source-selecting fragments in the key.
+    pub fn url_hash_dir(
+        url: &DisplaySafeUrl,
+        package_name: impl AsRef<Path>,
+        hash: &HashDigest,
+    ) -> PathBuf {
+        WheelCacheKind::Url
+            .root()
+            .join(cache_digest(&CanonicalUrl::new(url.clone())))
+            .join(package_name)
+            .join("hashes")
+            .join(cache_digest(&hash.to_string()))
+    }
+}
+
+/// Identify a URL revision, retaining hash declarations that cannot be checked against metadata.
+fn revision_digest(url: &DisplaySafeUrl) -> String {
+    // Metadata and source builds are not interchangeable across expected hashes. Keep a separate
+    // revision for each declaration, preserving the existing on-disk keys.
+    let mut revision = DisplaySafeUrl::from(CanonicalUrl::new(url.clone()));
+    revision.set_fragment(url.fragment());
+    cache_digest(&revision.as_str())
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -111,21 +114,28 @@ impl AsRef<Path> for WheelCacheKind {
 
 #[cfg(test)]
 mod tests {
+    use uv_cache_key::cache_digest;
+    use uv_pypi_types::{HashAlgorithm, HashDigest};
     use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 
-    use super::WheelCache;
+    use super::{WheelCache, revision_digest};
 
     #[test]
     fn archive_and_metadata_url_identity() -> Result<(), DisplaySafeUrlError> {
         let plain = DisplaySafeUrl::parse("https://example.org/pkg.whl")?;
         let hashed = DisplaySafeUrl::parse("https://example.org/pkg.whl#sha256=abc")?;
-        assert_eq!(
+        assert_ne!(
             WheelCache::Url(&plain).wheel_dir("pkg"),
             WheelCache::Url(&hashed).wheel_dir("pkg"),
         );
-        assert_ne!(
-            WheelCache::Url(&plain).metadata_dir("pkg"),
-            WheelCache::Url(&hashed).metadata_dir("pkg"),
+        assert_eq!(revision_digest(&hashed), cache_digest(&hashed.as_str()));
+        let hash = HashDigest {
+            algorithm: HashAlgorithm::Sha256,
+            digest: "abc".into(),
+        };
+        assert_eq!(
+            WheelCache::url_hash_dir(&plain, "pkg", &hash),
+            WheelCache::url_hash_dir(&hashed, "pkg", &hash),
         );
 
         let first = DisplaySafeUrl::parse("https://example.org/pkg.tar.gz#subdirectory=first")?;

--- a/crates/uv-cache/src/wheel.rs
+++ b/crates/uv-cache/src/wheel.rs
@@ -46,8 +46,26 @@ impl WheelCache<'_> {
         }
     }
 
-    /// A subdirectory in a bucket for wheels for a specific package.
+    /// A subdirectory for downloaded wheels belonging to a specific package.
+    ///
+    /// URL fragments do not identify different wheel bytes. Expected hashes are checked against
+    /// the computed hashes in the cached archive, rather than being part of its location.
     pub fn wheel_dir(&self, package_name: impl AsRef<Path>) -> PathBuf {
+        match self {
+            Self::Url(url) => {
+                let mut url = (*url).clone();
+                url.set_fragment(None);
+                WheelCache::Url(&url).root().join(package_name)
+            }
+            _ => self.root().join(package_name),
+        }
+    }
+
+    /// A subdirectory for wheel metadata belonging to a specific package.
+    ///
+    /// Unlike downloaded archives, metadata cannot be checked against an archive's hash. Retain
+    /// the URL fragment so a changed hash cannot reuse metadata for a previous artifact.
+    pub fn metadata_dir(&self, package_name: impl AsRef<Path>) -> PathBuf {
         self.root().join(package_name)
     }
 }
@@ -88,5 +106,34 @@ impl WheelCacheKind {
 impl AsRef<Path> for WheelCacheKind {
     fn as_ref(&self) -> &Path {
         self.to_str().as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
+
+    use super::WheelCache;
+
+    #[test]
+    fn archive_and_metadata_url_identity() -> Result<(), DisplaySafeUrlError> {
+        let plain = DisplaySafeUrl::parse("https://example.org/pkg.whl")?;
+        let hashed = DisplaySafeUrl::parse("https://example.org/pkg.whl#sha256=abc")?;
+        assert_eq!(
+            WheelCache::Url(&plain).wheel_dir("pkg"),
+            WheelCache::Url(&hashed).wheel_dir("pkg"),
+        );
+        assert_ne!(
+            WheelCache::Url(&plain).metadata_dir("pkg"),
+            WheelCache::Url(&hashed).metadata_dir("pkg"),
+        );
+
+        let first = DisplaySafeUrl::parse("https://example.org/pkg.tar.gz#subdirectory=first")?;
+        let second = DisplaySafeUrl::parse("https://example.org/pkg.tar.gz#subdirectory=second")?;
+        assert_ne!(
+            WheelCache::Url(&first).root(),
+            WheelCache::Url(&second).root()
+        );
+        Ok(())
     }
 }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1033,7 +1033,7 @@ impl RegistryClient {
 
             let cache_entry = self.cache.entry(
                 CacheBucket::Wheels,
-                WheelCache::Index(index).metadata_dir(filename.name.as_ref()),
+                WheelCache::Index(index).wheel_dir(filename.name.as_ref()),
                 format!("{}.msgpack", filename.cache_key()),
             );
             let cache_control = match self.connectivity {
@@ -1123,7 +1123,7 @@ impl RegistryClient {
     ) -> Result<ResolutionMetadata, Error> {
         let cache_entry = self.cache.entry(
             CacheBucket::Wheels,
-            cache_shard.metadata_dir(filename.name.as_ref()),
+            cache_shard.wheel_dir(filename.name.as_ref()),
             format!("{}.msgpack", filename.cache_key()),
         );
         let cache_control = match self.connectivity {

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1033,7 +1033,7 @@ impl RegistryClient {
 
             let cache_entry = self.cache.entry(
                 CacheBucket::Wheels,
-                WheelCache::Index(index).wheel_dir(filename.name.as_ref()),
+                WheelCache::Index(index).metadata_dir(filename.name.as_ref()),
                 format!("{}.msgpack", filename.cache_key()),
             );
             let cache_control = match self.connectivity {
@@ -1123,7 +1123,7 @@ impl RegistryClient {
     ) -> Result<ResolutionMetadata, Error> {
         let cache_entry = self.cache.entry(
             CacheBucket::Wheels,
-            cache_shard.wheel_dir(filename.name.as_ref()),
+            cache_shard.metadata_dir(filename.name.as_ref()),
             format!("{}.msgpack", filename.cache_key()),
         );
         let cache_control = match self.connectivity {

--- a/crates/uv-distribution-types/src/id.rs
+++ b/crates/uv-distribution-types/src/id.rs
@@ -204,7 +204,9 @@ impl Display for VersionId {
 /// the URL would also be sufficient).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DistributionId {
-    Url(CanonicalUrl),
+    /// The source location and original fragment, including its expected hashes. In-flight
+    /// downloads must not conflate different content expectations at the same canonical URL.
+    Url(CanonicalUrl, Option<String>),
     PathBuf(PathBuf),
     Digest(HashDigest),
     AbsoluteUrl(String),
@@ -250,6 +252,7 @@ mod tests {
     use fs_err as fs;
 
     use super::VersionId;
+    use crate::Identifier;
     use uv_redacted::DisplaySafeUrl;
 
     #[test]
@@ -264,6 +267,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(VersionId::from_url(&first), VersionId::from_url(&second));
+        assert_ne!(first.distribution_id(), second.distribution_id());
     }
 
     #[test]

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -49,6 +49,7 @@ use std::str::FromStr;
 use memchr::memchr3;
 use url::Url;
 
+use uv_cache_key::{CanonicalUrl, RepositoryUrl};
 use uv_distribution_filename::{
     DistExtension, SourceDistExtension, SourceDistFilename, WheelFilename,
 };
@@ -1457,11 +1458,14 @@ impl RemoteSource for Dist {
 
 impl Identifier for DisplaySafeUrl {
     fn distribution_id(&self) -> DistributionId {
-        DistributionId::Url(uv_cache_key::CanonicalUrl::new(self.clone()))
+        DistributionId::Url(
+            CanonicalUrl::new(self.clone()),
+            self.fragment().map(str::to_owned),
+        )
     }
 
     fn resource_id(&self) -> ResourceId {
-        ResourceId::Url(uv_cache_key::RepositoryUrl::new(self.clone()))
+        ResourceId::Url(RepositoryUrl::new(self.clone()))
     }
 }
 

--- a/crates/uv-distribution/src/archive.rs
+++ b/crates/uv-distribution/src/archive.rs
@@ -1,7 +1,7 @@
 use serde::ser::SerializeMap;
 use uv_cache::{ARCHIVE_VERSION, ArchiveId, Cache};
 use uv_distribution_filename::WheelFilename;
-use uv_distribution_types::Hashed;
+use uv_distribution_types::{ArchiveHashPolicy, Hashed};
 use uv_pypi_types::{HashDigest, HashDigests};
 
 /// An archive (unzipped wheel) that exists in the local cache.
@@ -57,6 +57,20 @@ impl Archive {
     /// Returns `true` if the archive exists in the cache.
     pub(crate) fn exists(&self, cache: &Cache) -> bool {
         self.version == ARCHIVE_VERSION && cache.archive(&self.id).exists()
+    }
+
+    /// Return whether these cached contents satisfy the requested wheel's integrity constraints.
+    pub(crate) fn is_usable(
+        &self,
+        cache: &Cache,
+        filename: &WheelFilename,
+        hashes: ArchiveHashPolicy<'_>,
+        size: Option<u64>,
+    ) -> bool {
+        self.filename == *filename
+            && self.satisfies(hashes)
+            && self.exists(cache)
+            && size.is_none_or(|size| self.size == Some(size))
     }
 }
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -622,8 +622,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             let cache_hash_policy = declared_hashes.as_ref().map_or(hash_policy, |hashes| {
                 ArchiveHashPolicy::All(hashes.as_slice())
             });
-            let cached_wheel = if let Some(pointer) =
-                HttpArchivePointer::read_from_direct_url(cache, wheel, cache_hash_policy)
+            // Only a matching expected hash can bypass HTTP revalidation.
+            let cached_wheel = if cache_hash_policy.requires_validation()
+                && let Some(pointer) =
+                    HttpArchivePointer::read_from_direct_url(cache, wheel, cache_hash_policy)
             {
                 Some(pointer.into_wheel(cache, dist))
             } else {
@@ -633,9 +635,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     format!("{}.http", wheel.filename.cache_key()),
                 );
                 if http_entry.path().try_exists().map_err(Error::CacheRead)? {
-                    // The cached pointer is corrupt or its archive no longer satisfies this
-                    // request. Recover it before resolving dependencies, not only when the
-                    // installer retrieves the wheel.
+                    // Revalidate mutable URL responses and recover unusable archives before
+                    // resolving dependencies, so installation uses the same contents.
                     Some(
                         self.get_wheel(dist, cache_hash_policy)
                             .boxed_local()
@@ -655,7 +656,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 }
                 return Ok(ArchiveMetadata {
                     metadata: Metadata::from_metadata23(wheel.metadata()?),
-                    hashes: wheel.hashes,
+                    hashes: match hashes.collection {
+                        HashCollection::None => HashDigests::empty(),
+                        HashCollection::Url | HashCollection::All => wheel.hashes,
+                    },
                 });
             }
         }
@@ -688,7 +692,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 // downloading the wheel directly, try that.
                 let wheel = self.get_wheel(dist, hash_policy).boxed_local().await?;
                 let metadata = wheel.metadata()?;
-                let hashes = wheel.hashes;
+                let hashes = match hashes.collection {
+                    HashCollection::None => HashDigests::empty(),
+                    HashCollection::Url | HashCollection::All => wheel.hashes,
+                };
                 Ok(ArchiveMetadata {
                     metadata: Metadata::from_metadata23(metadata),
                     hashes,
@@ -1567,7 +1574,7 @@ impl HttpArchivePointer {
     }
 
     /// Read an [`HttpArchivePointer`] from the cache.
-    pub fn read_from(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
+    pub(crate) fn read_from(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
         match fs_err::File::open(path.as_ref()) {
             Ok(file) => {
                 let data = DataWithCachePolicy::from_reader(file)?.data;
@@ -1584,7 +1591,7 @@ impl HttpArchivePointer {
     /// Only computed hashes populate this index. HTTP metadata and mutable URL responses are not
     /// shared, and a matching index key alone is not sufficient to accept an archive. Unreadable
     /// entries are ignored so that other cached archives or a fresh download can be used instead.
-    pub fn read_from_hashes(
+    fn read_from_hashes(
         cache: &Cache,
         url: &DisplaySafeUrl,
         filename: &WheelFilename,

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashMap;
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
 use tokio::sync::Semaphore;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
-use tracing::{Instrument, info_span, instrument, warn};
+use tracing::{Instrument, debug, info_span, instrument, warn};
 use url::Url;
 
 use uv_cache::{ArchiveFileId, ArchiveId, Cache, CacheBucket, CacheEntry, WheelCache};
@@ -25,9 +25,9 @@ use uv_client::{
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
-    ArchiveHashPolicy, BuildInfo, BuildableSource, BuiltDist, DirectUrlBuiltDist, Dist, DistRef, HashCollection,
-    HashValidation, Hashed, IndexUrl, InstalledDist, MetadataHashPolicy, Name, SourceDist,
-    SourceUrl, parse_url_hashes,
+    ArchiveHashPolicy, BuildInfo, BuildableSource, BuiltDist, DirectUrlBuiltDist, Dist, DistRef,
+    HashCollection, HashValidation, Hashed, IndexUrl, InstalledDist, MetadataHashPolicy, Name,
+    SourceDist, SourceUrl, parse_url_hashes,
 };
 use uv_extract::dirhash::{DirectoryDigest, HashedFile};
 use uv_extract::hash::Hasher;
@@ -224,7 +224,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // When generating hashes, compute the URL's declared algorithms too, so the downloaded
         // archive can be reused by those digests. Validation remains the caller's responsibility.
         let declared_hashes = match (hashes, dist) {
-            (ArchiveHashPolicy::Generate, BuiltDist::DirectUrl(dist)) => parse_url_hashes(&dist.url),
+            (ArchiveHashPolicy::Generate, BuiltDist::DirectUrl(dist)) => {
+                parse_url_hashes(&dist.url)
+            }
             _ => None,
         };
         let hashes = declared_hashes
@@ -333,7 +335,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         &wheel.filename,
                         hashes,
                         wheel.size,
-                    )?
+                    )
                 {
                     return Ok(pointer.into_wheel(cache, dist));
                 }
@@ -617,11 +619,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 || self.client.unmanaged.connectivity() == Connectivity::Offline)
         {
             let cache = self.build_context.cache();
-            let cache_hash_policy = declared_hashes
-                .as_ref()
-                .map_or(hash_policy, |hashes| ArchiveHashPolicy::All(hashes.as_slice()));
+            let cache_hash_policy = declared_hashes.as_ref().map_or(hash_policy, |hashes| {
+                ArchiveHashPolicy::All(hashes.as_slice())
+            });
             let cached_wheel = if let Some(pointer) =
-                HttpArchivePointer::read_from_direct_url(cache, wheel, cache_hash_policy)?
+                HttpArchivePointer::read_from_direct_url(cache, wheel, cache_hash_policy)
             {
                 Some(pointer.into_wheel(cache, dist))
             } else {
@@ -630,9 +632,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
                     format!("{}.http", wheel.filename.cache_key()),
                 );
-                if HttpArchivePointer::read_from(&http_entry)?.is_some() {
-                    // The cached archive no longer satisfies this request. Refresh it before
-                    // resolving dependencies, not only when the installer retrieves the wheel.
+                if http_entry.path().try_exists().map_err(Error::CacheRead)? {
+                    // The cached pointer is corrupt or its archive no longer satisfies this
+                    // request. Recover it before resolving dependencies, not only when the
+                    // installer retrieves the wheel.
                     Some(
                         self.get_wheel(dist, cache_hash_policy)
                             .boxed_local()
@@ -1579,55 +1582,76 @@ impl HttpArchivePointer {
     /// Find downloaded URL wheel contents that satisfy the complete hash policy.
     ///
     /// Only computed hashes populate this index. HTTP metadata and mutable URL responses are not
-    /// shared, and a matching index key alone is not sufficient to accept an archive.
+    /// shared, and a matching index key alone is not sufficient to accept an archive. Unreadable
+    /// entries are ignored so that other cached archives or a fresh download can be used instead.
     pub fn read_from_hashes(
         cache: &Cache,
         url: &DisplaySafeUrl,
         filename: &WheelFilename,
         hashes: ArchiveHashPolicy<'_>,
         size: Option<u64>,
-    ) -> Result<Option<Self>, Error> {
+    ) -> Option<Self> {
         for hash in hashes.digests() {
             let entry = cache.entry(
                 CacheBucket::Wheels,
                 WheelCache::url_hash_dir(url, filename.name.as_ref(), hash),
                 format!("{}.msgpack", filename.cache_key()),
             );
-            let archive = match fs_err::read(entry.path()) {
-                Ok(data) => rmp_serde::from_slice::<Archive>(&data)?,
-                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
-                Err(err) => return Err(Error::CacheRead(err)),
+            let archive = match fs_err::read(entry.path())
+                .map_err(Error::CacheRead)
+                .and_then(|data| {
+                    rmp_serde::from_slice::<Archive>(&data).map_err(Error::CacheDecode)
+                }) {
+                Ok(archive) => archive,
+                Err(Error::CacheRead(err)) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => {
+                    debug!(
+                        "Failed to read cached URL wheel at {}: {err}",
+                        entry.path().display()
+                    );
+                    continue;
+                }
             };
             if archive.is_usable(cache, filename, hashes, size) {
-                return Ok(Some(Self { archive }));
+                return Some(Self { archive });
             }
         }
-        Ok(None)
+        None
     }
 
     /// Find a URL wheel whose hashes, size, filename, and archive are valid for this request.
     ///
     /// Prefer the shared hash index, then check the URL's HTTP response with the same constraints.
+    /// Unreadable entries are treated as cache misses, allowing the HTTP client to recover them.
     pub fn read_from_direct_url(
         cache: &Cache,
         wheel: &DirectUrlBuiltDist,
         hashes: ArchiveHashPolicy<'_>,
-    ) -> Result<Option<Self>, Error> {
+    ) -> Option<Self> {
         if let Some(pointer) =
-            Self::read_from_hashes(cache, &wheel.url, &wheel.filename, hashes, wheel.size)?
+            Self::read_from_hashes(cache, &wheel.url, &wheel.filename, hashes, wheel.size)
         {
-            return Ok(Some(pointer));
+            return Some(pointer);
         }
         let entry = cache.entry(
             CacheBucket::Wheels,
             WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
             format!("{}.http", wheel.filename.cache_key()),
         );
-        Ok(Self::read_from(&entry)?.filter(|pointer| {
-            pointer
-                .archive
-                .is_usable(cache, &wheel.filename, hashes, wheel.size)
-        }))
+        match Self::read_from(&entry) {
+            Ok(pointer) => pointer.filter(|pointer| {
+                pointer
+                    .archive
+                    .is_usable(cache, &wheel.filename, hashes, wheel.size)
+            }),
+            Err(err) => {
+                debug!(
+                    "Failed to read cached URL wheel at {}: {err}",
+                    entry.path().display()
+                );
+                None
+            }
+        }
     }
 
     /// Index an archive by its computed digests without replacing any URL response or metadata.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -4,7 +4,6 @@ use std::io;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
@@ -221,9 +220,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         dist: &BuiltDist,
         hashes: ArchiveHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
-        // When generating hashes, compute the URL's declared algorithms too, and refresh cached
-        // archives that do not match the declaration. Validation of downloaded bytes is still
-        // the caller's responsibility.
+        // When generating hashes, compute the URL's declared algorithms too, so the downloaded
+        // archive can be reused by those digests. Validation remains the caller's responsibility.
         let declared_hashes = match (hashes, dist) {
             (ArchiveHashPolicy::Generate, BuiltDist::DirectUrl(dist)) => parse_url_hashes(&dist.url),
             _ => None,
@@ -323,15 +321,27 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             }
 
             BuiltDist::DirectUrl(wheel) => {
-                // Create a cache entry for the wheel.
-                let wheel_entry = self.build_context.cache().entry(
+                let cache = self.build_context.cache();
+                // A matching computed hash identifies immutable contents, even when the URL's
+                // declaration differs (or was moved into the lockfile).
+                if (!cache.must_revalidate_package(wheel.name())
+                    || self.client.unmanaged.connectivity() == Connectivity::Offline)
+                    && let Some(pointer) = HttpArchivePointer::read_from_hashes(
+                        cache,
+                        &wheel.url,
+                        &wheel.filename,
+                        hashes,
+                        wheel.size,
+                    )?
+                {
+                    return Ok(pointer.into_wheel(cache, dist));
+                }
+                let wheel_entry = cache.entry(
                     CacheBucket::Wheels,
                     WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
                     wheel.filename.cache_key(),
                 );
-
-                // Download and unzip.
-                match self
+                let archive = match self
                     .stream_wheel(
                         wheel.url.raw().clone(),
                         None,
@@ -343,18 +353,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     )
                     .await
                 {
-                    Ok(archive) => Ok(LocalWheel {
-                        dist: Dist::Built(dist.clone()),
-                        archive: self
-                            .build_context
-                            .cache()
-                            .archive(&archive.id)
-                            .into_boxed_path(),
-                        hashes: archive.hashes,
-                        filename: wheel.filename.clone(),
-                        cache: CacheInfo::default(),
-                        build: None,
-                    }),
+                    Ok(archive) => archive,
                     Err(Error::Extract(name, err)) => {
                         if err.is_http_streaming_unsupported() {
                             warn!(
@@ -365,35 +364,25 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         } else {
                             return Err(Error::Extract(name, err));
                         }
-
-                        // If the request failed because streaming was unsupported or failed,
-                        // download the wheel directly.
-                        let archive = self
-                            .download_wheel(
-                                wheel.url.raw().clone(),
-                                None,
-                                &wheel.filename,
-                                wheel.size,
-                                &wheel_entry,
-                                dist,
-                                hashes,
-                            )
-                            .await?;
-                        Ok(LocalWheel {
-                            dist: Dist::Built(dist.clone()),
-                            archive: self
-                                .build_context
-                                .cache()
-                                .archive(&archive.id)
-                                .into_boxed_path(),
-                            hashes: archive.hashes,
-                            filename: wheel.filename.clone(),
-                            cache: CacheInfo::default(),
-                            build: None,
-                        })
+                        self.download_wheel(
+                            wheel.url.raw().clone(),
+                            None,
+                            &wheel.filename,
+                            wheel.size,
+                            &wheel_entry,
+                            dist,
+                            hashes,
+                        )
+                        .await?
                     }
-                    Err(err) => Err(err),
-                }
+                    Err(err) => return Err(err),
+                };
+                let pointer = HttpArchivePointer { archive };
+                pointer
+                    .write_hashes(cache, &wheel.url)
+                    .boxed_local()
+                    .await?;
+                Ok(pointer.into_wheel(cache, dist))
             }
 
             BuiltDist::GitPath(wheel) => {
@@ -555,6 +544,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         dist: &BuiltDist,
         hashes: MetadataHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
+        let declared_hashes = if hashes.validation == HashValidation::None
+            && hashes.collection != HashCollection::None
+            && let BuiltDist::DirectUrl(wheel) = dist
+        {
+            parse_url_hashes(&wheel.url)
+        } else {
+            None
+        };
         let hash_policy = match hashes.validation {
             HashValidation::None => {
                 let compute_hashes = match hashes.collection {
@@ -566,7 +563,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                             hashes.collection == HashCollection::All
                                 && dist.best_wheel().file.hashes.is_empty()
                         }
-                        BuiltDist::DirectUrl(dist) => parse_url_hashes(&dist.url).is_none(),
+                        BuiltDist::DirectUrl(_) => declared_hashes.is_none(),
                         BuiltDist::Path(_) | BuiltDist::GitPath(_) => true,
                     },
                 };
@@ -582,7 +579,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Fetch the entire wheel only when we need to compute a hash for resolution.
         // TODO(charlie): Request the hashes via a separate method, to reduce the coupling in this API.
         if hash_policy == ArchiveHashPolicy::Generate {
-            let wheel = self.get_wheel(dist, hash_policy).await?;
+            let wheel = self.get_wheel(dist, hash_policy).boxed_local().await?;
             // If the metadata was provided by the user directly, prefer it.
             let metadata = if let Some(metadata) = self
                 .build_context
@@ -607,6 +604,31 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .get(dist.name(), Some(dist.version()))
         {
             return Ok(ArchiveMetadata::from_metadata23(metadata));
+        }
+
+        // When installation can reuse an archive by hash, resolution must read that archive's
+        // metadata too, not metadata from another revision at the same URL.
+        if let BuiltDist::DirectUrl(wheel) = dist
+            && (!self
+                .build_context
+                .cache()
+                .must_revalidate_package(wheel.name())
+                || self.client.unmanaged.connectivity() == Connectivity::Offline)
+            && let Some(pointer) = HttpArchivePointer::read_from_hashes(
+                self.build_context.cache(),
+                &wheel.url,
+                &wheel.filename,
+                declared_hashes
+                    .as_ref()
+                    .map_or(hash_policy, |hashes| ArchiveHashPolicy::All(hashes.as_slice())),
+                wheel.size,
+            )?
+        {
+            let wheel = pointer.into_wheel(self.build_context.cache(), dist);
+            return Ok(ArchiveMetadata {
+                metadata: Metadata::from_metadata23(wheel.metadata()?),
+                hashes: wheel.hashes,
+            });
         }
 
         let result = self
@@ -635,7 +657,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 // If the request failed due to an error that could be resolved by
                 // downloading the wheel directly, try that.
-                let wheel = self.get_wheel(dist, hash_policy).await?;
+                let wheel = self.get_wheel(dist, hash_policy).boxed_local().await?;
                 let metadata = wheel.metadata()?;
                 let hashes = wheel.hashes;
                 Ok(ArchiveMetadata {
@@ -738,10 +760,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
 
-        let downloaded = AtomicBool::new(false);
         let download = |response: reqwest::Response| {
             async {
-                downloaded.store(true, Ordering::Relaxed);
                 let progress_size = size.or_else(|| content_length(&response));
 
                 let progress = self.reporter.as_ref().map(|reporter| {
@@ -856,15 +876,19 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
-        // Refresh incomplete or missing archives, and cached URL wheels that do not match the
-        // expected hashes. Fresh downloads are validated by the caller, without another retry.
+        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
+            && expected != actual
+        {
+            return Err(Error::MismatchedSize {
+                distribution: dist.to_string(),
+                expected,
+                actual,
+            });
+        }
+
+        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
         let archive = Some(archive)
             .filter(|archive| archive.has_digests(hashes))
-            .filter(|archive| {
-                !matches!(dist, BuiltDist::DirectUrl(_))
-                    || downloaded.load(Ordering::Relaxed)
-                    || archive.satisfies(hashes)
-            })
             .filter(|archive| archive.exists(self.build_context.cache()))
             .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
@@ -889,16 +913,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 })
                 .await?
         };
-
-        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
-            && expected != actual
-        {
-            return Err(Error::MismatchedSize {
-                distribution: dist.to_string(),
-                expected,
-                actual,
-            });
-        }
 
         Ok(archive)
     }
@@ -928,10 +942,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
 
-        let downloaded = AtomicBool::new(false);
         let download = |response: reqwest::Response| {
             async {
-                downloaded.store(true, Ordering::Relaxed);
                 let progress_size = size.or_else(|| content_length(&response));
 
                 let progress = self.reporter.as_ref().map(|reporter| {
@@ -1064,15 +1076,19 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
-        // Refresh incomplete or missing archives, and cached URL wheels that do not match the
-        // expected hashes. Fresh downloads are validated by the caller, without another retry.
+        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
+            && expected != actual
+        {
+            return Err(Error::MismatchedSize {
+                distribution: dist.to_string(),
+                expected,
+                actual,
+            });
+        }
+
+        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
         let archive = Some(archive)
             .filter(|archive| archive.has_digests(hashes))
-            .filter(|archive| {
-                !matches!(dist, BuiltDist::DirectUrl(_))
-                    || downloaded.load(Ordering::Relaxed)
-                    || archive.satisfies(hashes)
-            })
             .filter(|archive| archive.exists(self.build_context.cache()))
             .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
@@ -1097,16 +1113,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 })
                 .await?
         };
-
-        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
-            && expected != actual
-        {
-            return Err(Error::MismatchedSize {
-                distribution: dist.to_string(),
-                expected,
-                actual,
-            });
-        }
 
         Ok(archive)
     }
@@ -1306,10 +1312,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     }
 
     /// Returns a GET [`reqwest::Request`] for the given URL.
-    fn request(&self, mut url: DisplaySafeUrl) -> Result<reqwest::Request, reqwest::Error> {
-        // Match the fragment-free archive cache key. Fragments are not sent to the server, and
-        // must not cause the HTTP cache policy to reject an otherwise identical request.
-        url.set_fragment(None);
+    fn request(&self, url: DisplaySafeUrl) -> Result<reqwest::Request, reqwest::Error> {
         self.client
             .unmanaged
             .uncached_client(&url)
@@ -1487,15 +1490,27 @@ where
     }
 }
 
-/// A pointer to an archive in the cache, fetched from an HTTP archive.
+/// A pointer to a downloaded HTTP archive in the cache.
 ///
-/// Encoded with `MsgPack`, and represented on disk by a `.http` file.
+/// Stored with its HTTP policy in a `.http` file, or indexed by computed hashes as `MsgPack`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct HttpArchivePointer {
     archive: Archive,
 }
 
 impl HttpArchivePointer {
+    /// Attach a cached archive to the requested distribution without changing its contents.
+    fn into_wheel(self, cache: &Cache, dist: &BuiltDist) -> LocalWheel {
+        LocalWheel {
+            dist: Dist::Built(dist.clone()),
+            archive: cache.archive(&self.archive.id).into_boxed_path(),
+            hashes: self.archive.hashes,
+            filename: self.archive.filename,
+            cache: CacheInfo::default(),
+            build: None,
+        }
+    }
+
     /// Read an [`HttpArchivePointer`] from the cache.
     pub fn read_from(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
         match fs_err::File::open(path.as_ref()) {
@@ -1507,6 +1522,67 @@ impl HttpArchivePointer {
             Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
             Err(err) => Err(Error::CacheRead(err)),
         }
+    }
+
+    /// Find downloaded URL wheel contents that satisfy the complete hash policy.
+    ///
+    /// Only computed hashes populate this index. HTTP metadata and mutable URL responses are not
+    /// shared, and a matching index key alone is not sufficient to accept an archive.
+    pub fn read_from_hashes(
+        cache: &Cache,
+        url: &DisplaySafeUrl,
+        filename: &WheelFilename,
+        hashes: ArchiveHashPolicy<'_>,
+        size: Option<u64>,
+    ) -> Result<Option<Self>, Error> {
+        for hash in hashes.digests() {
+            let entry = cache.entry(
+                CacheBucket::Wheels,
+                WheelCache::url_hash_dir(url, filename.name.as_ref(), hash),
+                format!("{}.msgpack", filename.cache_key()),
+            );
+            let archive = match fs_err::read(entry.path()) {
+                Ok(data) => rmp_serde::from_slice::<Archive>(&data)?,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(Error::CacheRead(err)),
+            };
+            if archive.filename == *filename
+                && archive.satisfies(hashes)
+                && archive.exists(cache)
+                && size.is_none_or(|size| archive.size == Some(size))
+            {
+                return Ok(Some(Self { archive }));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Index an archive by its computed digests without replacing any URL response or metadata.
+    async fn write_hashes(&self, cache: &Cache, url: &DisplaySafeUrl) -> Result<(), Error> {
+        let data = rmp_serde::to_vec(&self.archive)?;
+        for hash in self.archive.hashes.iter() {
+            let entry = cache.entry(
+                CacheBucket::Wheels,
+                WheelCache::url_hash_dir(url, self.archive.filename.name.as_ref(), hash),
+                self.archive.filename.cache_key(),
+            );
+            // Keep the archive reference and pointer consistent when different declarations
+            // download the same contents concurrently.
+            let lock_entry = entry.with_file(format!("{}.lock", self.archive.filename.cache_key()));
+            let _lock = lock_entry.lock().await.map_err(Error::CacheLock)?;
+            cache
+                .link(&self.archive.id, entry.path())
+                .map_err(Error::CacheWrite)?;
+            write_atomic(
+                entry
+                    .with_file(format!("{}.msgpack", self.archive.filename.cache_key()))
+                    .path(),
+                &data,
+            )
+            .await
+            .map_err(Error::CacheWrite)?;
+        }
+        Ok(())
     }
 
     /// Return the [`Archive`] from the pointer.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
@@ -151,8 +152,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     ///
     /// Returns a wheel that's compliant with the given platform tags.
     ///
-    /// While hashes will be generated in some cases, hash-checking is only enforced for source
-    /// distributions, and should be enforced by the caller for wheels.
+    /// Hash-checking is enforced for source distributions. Callers must still validate wheels
+    /// before installation, since their metadata may be fetched without the archive.
     #[instrument(skip_all, fields(%dist))]
     pub async fn get_or_build_wheel(
         &self,
@@ -537,8 +538,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
     /// Fetch wheel metadata, along with any hashes requested for resolution.
     ///
-    /// Wheel archive hash validation is deferred to installation. Metadata sidecar hashes are
-    /// checked by the client when downloading sidecars with index-provided hashes.
+    /// Callers must validate wheel archive hashes before installation. Metadata sidecar hashes
+    /// are checked by the client when downloading sidecars with index-provided hashes.
     async fn get_wheel_metadata(
         &self,
         dist: &BuiltDist,
@@ -606,29 +607,54 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             return Ok(ArchiveMetadata::from_metadata23(metadata));
         }
 
-        // When installation can reuse an archive by hash, resolution must read that archive's
-        // metadata too, not metadata from another revision at the same URL.
+        // When installation can reuse an archive, resolution must read that archive's metadata
+        // too, not metadata from another revision at the same URL.
         if let BuiltDist::DirectUrl(wheel) = dist
             && (!self
                 .build_context
                 .cache()
                 .must_revalidate_package(wheel.name())
                 || self.client.unmanaged.connectivity() == Connectivity::Offline)
-            && let Some(pointer) = HttpArchivePointer::read_from_hashes(
-                self.build_context.cache(),
-                &wheel.url,
-                &wheel.filename,
-                declared_hashes
-                    .as_ref()
-                    .map_or(hash_policy, |hashes| ArchiveHashPolicy::All(hashes.as_slice())),
-                wheel.size,
-            )?
         {
-            let wheel = pointer.into_wheel(self.build_context.cache(), dist);
-            return Ok(ArchiveMetadata {
-                metadata: Metadata::from_metadata23(wheel.metadata()?),
-                hashes: wheel.hashes,
-            });
+            let cache = self.build_context.cache();
+            let cache_hash_policy = declared_hashes
+                .as_ref()
+                .map_or(hash_policy, |hashes| ArchiveHashPolicy::All(hashes.as_slice()));
+            let cached_wheel = if let Some(pointer) =
+                HttpArchivePointer::read_from_direct_url(cache, wheel, cache_hash_policy)?
+            {
+                Some(pointer.into_wheel(cache, dist))
+            } else {
+                let http_entry = cache.entry(
+                    CacheBucket::Wheels,
+                    WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
+                    format!("{}.http", wheel.filename.cache_key()),
+                );
+                if HttpArchivePointer::read_from(&http_entry)?.is_some() {
+                    // The cached archive no longer satisfies this request. Refresh it before
+                    // resolving dependencies, not only when the installer retrieves the wheel.
+                    Some(
+                        self.get_wheel(dist, cache_hash_policy)
+                            .boxed_local()
+                            .await?,
+                    )
+                } else {
+                    None
+                }
+            };
+            if let Some(wheel) = cached_wheel {
+                if !wheel.satisfies(cache_hash_policy) {
+                    return Err(Error::hash_mismatch(
+                        dist.to_string(),
+                        cache_hash_policy.digests(),
+                        wheel.hashes(),
+                    ));
+                }
+                return Ok(ArchiveMetadata {
+                    metadata: Metadata::from_metadata23(wheel.metadata()?),
+                    hashes: wheel.hashes,
+                });
+            }
         }
 
         let result = self
@@ -760,6 +786,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
 
+        let downloaded = AtomicBool::new(false);
         let download = |response: reqwest::Response| {
             async {
                 let progress_size = size.or_else(|| content_length(&response));
@@ -827,6 +854,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
+                downloaded.store(true, Ordering::Relaxed);
                 Ok(Archive::new(
                     id,
                     hashers.into_iter().map(HashDigest::from).collect(),
@@ -876,8 +904,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
+        // A cached direct URL response can be HTTP-fresh but refer to older contents. When
+        // online, refresh it if the integrity constraints changed. Do not retry a fresh download
+        // that fails validation, or turn an offline integrity error into a network request.
+        let refresh_mismatched = matches!(dist, BuiltDist::DirectUrl(_))
+            && self.client.unmanaged.connectivity() == Connectivity::Online
+            && !downloaded.load(Ordering::Relaxed);
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
+            && !refresh_mismatched
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
@@ -886,11 +921,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             });
         }
 
-        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
-        let archive = Some(archive)
-            .filter(|archive| archive.has_digests(hashes))
-            .filter(|archive| archive.exists(self.build_context.cache()))
-            .filter(|archive| expected_size.is_none() || archive.size.is_some());
+        let archive = Some(archive).filter(|archive| {
+            if refresh_mismatched {
+                archive.is_usable(self.build_context.cache(), filename, hashes, expected_size)
+            } else {
+                archive.has_digests(hashes)
+                    && archive.exists(self.build_context.cache())
+                    && (expected_size.is_none() || archive.size.is_some())
+            }
+        });
 
         let archive = if let Some(archive) = archive {
             archive
@@ -942,6 +981,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
 
+        let downloaded = AtomicBool::new(false);
         let download = |response: reqwest::Response| {
             async {
                 let progress_size = size.or_else(|| content_length(&response));
@@ -1027,6 +1067,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
+                downloaded.store(true, Ordering::Relaxed);
                 Ok(Archive::new(
                     id,
                     hashes,
@@ -1076,8 +1117,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
+        // A cached direct URL response can be HTTP-fresh but refer to older contents. When
+        // online, refresh it if the integrity constraints changed. Do not retry a fresh download
+        // that fails validation, or turn an offline integrity error into a network request.
+        let refresh_mismatched = matches!(dist, BuiltDist::DirectUrl(_))
+            && self.client.unmanaged.connectivity() == Connectivity::Online
+            && !downloaded.load(Ordering::Relaxed);
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
+            && !refresh_mismatched
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
@@ -1086,11 +1134,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             });
         }
 
-        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
-        let archive = Some(archive)
-            .filter(|archive| archive.has_digests(hashes))
-            .filter(|archive| archive.exists(self.build_context.cache()))
-            .filter(|archive| expected_size.is_none() || archive.size.is_some());
+        let archive = Some(archive).filter(|archive| {
+            if refresh_mismatched {
+                archive.is_usable(self.build_context.cache(), filename, hashes, expected_size)
+            } else {
+                archive.has_digests(hashes)
+                    && archive.exists(self.build_context.cache())
+                    && (expected_size.is_none() || archive.size.is_some())
+            }
+        });
 
         let archive = if let Some(archive) = archive {
             archive

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
@@ -220,6 +221,17 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         dist: &BuiltDist,
         hashes: ArchiveHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
+        // When generating hashes, compute the URL's declared algorithms too, and refresh cached
+        // archives that do not match the declaration. Validation of downloaded bytes is still
+        // the caller's responsibility.
+        let declared_hashes = match (hashes, dist) {
+            (ArchiveHashPolicy::Generate, BuiltDist::DirectUrl(dist)) => parse_url_hashes(&dist.url),
+            _ => None,
+        };
+        let hashes = declared_hashes
+            .as_ref()
+            .map_or(hashes, |hashes| ArchiveHashPolicy::All(hashes.as_slice()));
+
         match dist {
             BuiltDist::Registry(wheels) => {
                 let wheel = wheels.best_wheel();
@@ -726,8 +738,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
 
+        let downloaded = AtomicBool::new(false);
         let download = |response: reqwest::Response| {
             async {
+                downloaded.store(true, Ordering::Relaxed);
                 let progress_size = size.or_else(|| content_length(&response));
 
                 let progress = self.reporter.as_ref().map(|reporter| {
@@ -842,19 +856,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
-        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
-            && expected != actual
-        {
-            return Err(Error::MismatchedSize {
-                distribution: dist.to_string(),
-                expected,
-                actual,
-            });
-        }
-
-        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
+        // Refresh incomplete or missing archives, and cached URL wheels that do not match the
+        // expected hashes. Fresh downloads are validated by the caller, without another retry.
         let archive = Some(archive)
             .filter(|archive| archive.has_digests(hashes))
+            .filter(|archive| {
+                !matches!(dist, BuiltDist::DirectUrl(_))
+                    || downloaded.load(Ordering::Relaxed)
+                    || archive.satisfies(hashes)
+            })
             .filter(|archive| archive.exists(self.build_context.cache()))
             .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
@@ -879,6 +889,16 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 })
                 .await?
         };
+
+        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
+            && expected != actual
+        {
+            return Err(Error::MismatchedSize {
+                distribution: dist.to_string(),
+                expected,
+                actual,
+            });
+        }
 
         Ok(archive)
     }
@@ -908,8 +928,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
 
+        let downloaded = AtomicBool::new(false);
         let download = |response: reqwest::Response| {
             async {
+                downloaded.store(true, Ordering::Relaxed);
                 let progress_size = size.or_else(|| content_length(&response));
 
                 let progress = self.reporter.as_ref().map(|reporter| {
@@ -1042,19 +1064,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 CachedClientError::Client(err) => Error::Client(err),
             })?;
 
-        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
-            && expected != actual
-        {
-            return Err(Error::MismatchedSize {
-                distribution: dist.to_string(),
-                expected,
-                actual,
-            });
-        }
-
-        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
+        // Refresh incomplete or missing archives, and cached URL wheels that do not match the
+        // expected hashes. Fresh downloads are validated by the caller, without another retry.
         let archive = Some(archive)
             .filter(|archive| archive.has_digests(hashes))
+            .filter(|archive| {
+                !matches!(dist, BuiltDist::DirectUrl(_))
+                    || downloaded.load(Ordering::Relaxed)
+                    || archive.satisfies(hashes)
+            })
             .filter(|archive| archive.exists(self.build_context.cache()))
             .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
@@ -1079,6 +1097,16 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 })
                 .await?
         };
+
+        if let (Some(expected), Some(actual)) = (expected_size, archive.size)
+            && expected != actual
+        {
+            return Err(Error::MismatchedSize {
+                distribution: dist.to_string(),
+                expected,
+                actual,
+            });
+        }
 
         Ok(archive)
     }
@@ -1278,7 +1306,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     }
 
     /// Returns a GET [`reqwest::Request`] for the given URL.
-    fn request(&self, url: DisplaySafeUrl) -> Result<reqwest::Request, reqwest::Error> {
+    fn request(&self, mut url: DisplaySafeUrl) -> Result<reqwest::Request, reqwest::Error> {
+        // Match the fragment-free archive cache key. Fragments are not sent to the server, and
+        // must not cause the HTTP cache policy to reject an otherwise identical request.
+        url.set_fragment(None);
         self.client
             .unmanaged
             .uncached_client(&url)

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -24,7 +24,7 @@ use uv_client::{
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
-    ArchiveHashPolicy, BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, HashCollection,
+    ArchiveHashPolicy, BuildInfo, BuildableSource, BuiltDist, DirectUrlBuiltDist, Dist, DistRef, HashCollection,
     HashValidation, Hashed, IndexUrl, InstalledDist, MetadataHashPolicy, Name, SourceDist,
     SourceUrl, parse_url_hashes,
 };
@@ -1546,15 +1546,36 @@ impl HttpArchivePointer {
                 Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
                 Err(err) => return Err(Error::CacheRead(err)),
             };
-            if archive.filename == *filename
-                && archive.satisfies(hashes)
-                && archive.exists(cache)
-                && size.is_none_or(|size| archive.size == Some(size))
-            {
+            if archive.is_usable(cache, filename, hashes, size) {
                 return Ok(Some(Self { archive }));
             }
         }
         Ok(None)
+    }
+
+    /// Find a URL wheel whose hashes, size, filename, and archive are valid for this request.
+    ///
+    /// Prefer the shared hash index, then check the URL's HTTP response with the same constraints.
+    pub fn read_from_direct_url(
+        cache: &Cache,
+        wheel: &DirectUrlBuiltDist,
+        hashes: ArchiveHashPolicy<'_>,
+    ) -> Result<Option<Self>, Error> {
+        if let Some(pointer) =
+            Self::read_from_hashes(cache, &wheel.url, &wheel.filename, hashes, wheel.size)?
+        {
+            return Ok(Some(pointer));
+        }
+        let entry = cache.entry(
+            CacheBucket::Wheels,
+            WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
+            format!("{}.http", wheel.filename.cache_key()),
+        );
+        Ok(Self::read_from(&entry)?.filter(|pointer| {
+            pointer
+                .archive
+                .is_usable(cache, &wheel.filename, hashes, wheel.size)
+        }))
     }
 
     /// Index an archive by its computed digests without replacing any URL response or metadata.

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -433,8 +433,23 @@ impl<'a> Planner<'a> {
                         )
                         .entry(format!("{}.http", wheel.filename.cache_key()));
 
-                    // Read the HTTP pointer.
-                    match HttpArchivePointer::read_from(&cache_entry) {
+                    // Prefer contents identified by the lockfile or URL hashes. Otherwise, use
+                    // the HTTP response for this specific URL declaration.
+                    let pointer = HttpArchivePointer::read_from_hashes(
+                        cache,
+                        &wheel.url,
+                        &wheel.filename,
+                        hasher.get(dist.as_ref()),
+                        wheel.size,
+                    )
+                    .and_then(|pointer| {
+                        if pointer.is_some() {
+                            Ok(pointer)
+                        } else {
+                            HttpArchivePointer::read_from(&cache_entry)
+                        }
+                    });
+                    match pointer {
                         Ok(Some(pointer)) => {
                             let cache_info = pointer.to_cache_info();
                             let build_info = pointer.to_build_info();

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -424,37 +424,29 @@ impl<'a> Planner<'a> {
                         );
                     }
 
-                    match HttpArchivePointer::read_from_direct_url(
+                    if let Some(pointer) = HttpArchivePointer::read_from_direct_url(
                         cache,
                         wheel,
                         hasher.archive_policy(dist.as_ref()),
                     ) {
-                        Ok(Some(pointer)) => {
-                            let cache_info = pointer.to_cache_info();
-                            let build_info = pointer.to_build_info();
-                            let archive = pointer.into_archive();
-                            let cached_dist = CachedDirectUrlDist {
-                                filename: wheel.filename.clone(),
-                                url: VerbatimParsedUrl {
-                                    parsed_url: wheel.to_parsed_url(),
-                                    verbatim: wheel.url.clone(),
-                                },
-                                hashes: archive.hashes,
-                                cache_info,
-                                build_info,
-                                path: cache.archive(&archive.id).into_boxed_path(),
-                            };
+                        let cache_info = pointer.to_cache_info();
+                        let build_info = pointer.to_build_info();
+                        let archive = pointer.into_archive();
+                        let cached_dist = CachedDirectUrlDist {
+                            filename: wheel.filename.clone(),
+                            url: VerbatimParsedUrl {
+                                parsed_url: wheel.to_parsed_url(),
+                                verbatim: wheel.url.clone(),
+                            },
+                            hashes: archive.hashes,
+                            cache_info,
+                            build_info,
+                            path: cache.archive(&archive.id).into_boxed_path(),
+                        };
 
-                            debug!("URL wheel requirement already cached: {cached_dist}");
-                            cached.push(CachedDist::Url(cached_dist));
-                            continue;
-                        }
-                        Ok(None) => {}
-                        Err(err) => {
-                            debug!(
-                                "Failed to deserialize cached URL wheel requirement for: {wheel} ({err})"
-                            );
-                        }
+                        debug!("URL wheel requirement already cached: {cached_dist}");
+                        cached.push(CachedDist::Url(cached_dist));
+                        continue;
                     }
                 }
                 Dist::Built(BuiltDist::Path(wheel)) => {

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -424,56 +424,30 @@ impl<'a> Planner<'a> {
                         );
                     }
 
-                    // Find the exact wheel from the cache, since we know the filename in
-                    // advance.
-                    let cache_entry = cache
-                        .shard(
-                            CacheBucket::Wheels,
-                            WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
-                        )
-                        .entry(format!("{}.http", wheel.filename.cache_key()));
-
-                    // Prefer contents identified by the lockfile or URL hashes. Otherwise, use
-                    // the HTTP response for this specific URL declaration.
-                    let pointer = HttpArchivePointer::read_from_hashes(
+                    match HttpArchivePointer::read_from_direct_url(
                         cache,
-                        &wheel.url,
-                        &wheel.filename,
-                        hasher.get(dist.as_ref()),
-                        wheel.size,
-                    )
-                    .and_then(|pointer| {
-                        if pointer.is_some() {
-                            Ok(pointer)
-                        } else {
-                            HttpArchivePointer::read_from(&cache_entry)
-                        }
-                    });
-                    match pointer {
+                        wheel,
+                        hasher.archive_policy(dist.as_ref()),
+                    ) {
                         Ok(Some(pointer)) => {
                             let cache_info = pointer.to_cache_info();
                             let build_info = pointer.to_build_info();
                             let archive = pointer.into_archive();
-                            if archive.satisfies(hasher.archive_policy(dist.as_ref())) {
-                                let cached_dist = CachedDirectUrlDist {
-                                    filename: wheel.filename.clone(),
-                                    url: VerbatimParsedUrl {
-                                        parsed_url: wheel.to_parsed_url(),
-                                        verbatim: wheel.url.clone(),
-                                    },
-                                    hashes: archive.hashes,
-                                    cache_info,
-                                    build_info,
-                                    path: cache.archive(&archive.id).into_boxed_path(),
-                                };
+                            let cached_dist = CachedDirectUrlDist {
+                                filename: wheel.filename.clone(),
+                                url: VerbatimParsedUrl {
+                                    parsed_url: wheel.to_parsed_url(),
+                                    verbatim: wheel.url.clone(),
+                                },
+                                hashes: archive.hashes,
+                                cache_info,
+                                build_info,
+                                path: cache.archive(&archive.id).into_boxed_path(),
+                            };
 
-                                debug!("URL wheel requirement already cached: {cached_dist}");
-                                cached.push(CachedDist::Url(cached_dist));
-                                continue;
-                            }
-                            debug!(
-                                "Cached URL wheel requirement does not match expected hash policy for: {wheel}"
-                            );
+                            debug!("URL wheel requirement already cached: {cached_dist}");
+                            cached.push(CachedDist::Url(cached_dist));
+                            continue;
                         }
                         Ok(None) => {}
                         Err(err) => {

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 #[cfg(feature = "test-universal")]
 use serde_json::json;
 #[cfg(feature = "test-universal")]
-use sha2::{Digest, Sha256};
+use sha2::{Digest, Sha256, Sha512};
 use url::Url;
 #[cfg(feature = "test-universal")]
 use walkdir::WalkDir;
@@ -1400,6 +1400,218 @@ fn lock_wheel_url() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     Checked 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Reuse a wheel downloaded during locking under the fragment-free URL in the lockfile.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_wheel_url_fragment_download() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = MockServer::start().await;
+    let filename = "ok-1.0.0-py3-none-any.whl";
+    let wheel = fs_err::read(context.workspace_root.join("test/links").join(filename))?;
+    Mock::given(method("GET"))
+        .and(path(format!("/{filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_bytes(wheel),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // MD5 cannot be reused for hash generation, so locking must download the wheel to compute
+    // SHA-256. Stronger URL hashes can avoid downloading the archive altogether.
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok @ {}/{filename}#md5=88d6d524262f256596aa7f663c88038b"]
+    "#, server.uri()})?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    Ok(())
+}
+
+/// Reuse downloaded URL wheels offline, while refreshing bytes when an expected hash changes.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_wheel_url_hash_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.13")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix();
+    let server = MockServer::start().await;
+    let ok_filename = "ok-1.0.0-py3-none-any.whl";
+    let basic_filename = "basic_package-0.1.0-py3-none-any.whl";
+    let ok_wheel = fs_err::read(context.workspace_root.join("test/links").join(ok_filename))?;
+    let mut basic_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links")
+            .join(basic_filename),
+    )?;
+    let ok_hash = hex::encode(Sha256::digest(&ok_wheel));
+    let basic_hash = hex::encode(Sha512::digest(&basic_wheel));
+
+    // Serve metadata without range requests, then cache the complete wheels during installation.
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(405))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{ok_filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_bytes(ok_wheel),
+        )
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{basic_filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_bytes(basic_wheel.clone()),
+        )
+        .expect(2)
+        .mount(&server)
+        .await;
+    let pyproject = formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = [
+            "ok @ {}/{ok_filename}#sha256={ok_hash}",
+            "basic-package @ {}/{basic_filename}#sha512={basic_hash}",
+        ]
+    "#, server.uri(), server.uri()};
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject)?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("seed")
+        .arg(format!("{}/{ok_filename}#sha256={ok_hash}", server.uri()))
+        .arg(format!("{}/{basic_filename}#sha512={basic_hash}", server.uri())), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.13.[X] interpreter at: .venv/[BIN]/[PYTHON]
+    Resolved 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl#sha512=765bde25938af485e492e25ee0e8cde262462565122c1301213a69bf9ceb2008e3997b652a604092a238c4b1a6a334e697ff3cee3c22f9a617cb14f34e26ef17)
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha256=79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f)
+    ");
+    uv_snapshot!(context.filters(), context.lock(), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Installed 2 packages in [TIME]
+     + basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl)
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+    server.verify().await;
+    server.reset().await;
+
+    // Change the wheel bytes at the same URL by adding a valid ZIP comment. The old response is
+    // still fresh according to HTTP, so the changed expected hash must force a new download.
+    let length = basic_wheel.len();
+    basic_wheel[length - 2..].copy_from_slice(&7_u16.to_le_bytes());
+    basic_wheel.extend_from_slice(b"updated");
+    let updated_hash = hex::encode(Sha512::digest(&basic_wheel));
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(405))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{basic_filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_bytes(basic_wheel),
+        )
+        .expect(4)
+        .mount(&server)
+        .await;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject.replace(&basic_hash, &updated_hash))?;
+    // Resolve without the previous lockfile's hashes, but keep the HTTP cache fresh.
+    fs_err::remove_file(context.temp_dir.join("uv.lock"))?;
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("updated")
+        .arg(format!("{}/{basic_filename}#sha512={updated_hash}", server.uri())), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.13.[X] interpreter at: .venv/[BIN]/[PYTHON]
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl#sha512=07a4dd1023f6c7ef1457ebc070ff953d070007c3538b7054823c158fbb903ed92902ef323723c9ad1460af0a29ec642e2fbd2b92f264df5edd8e4f21f7f7ec7b)
+    ");
+    uv_snapshot!(context.filters(), context.lock(), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--frozen")
+        .arg("--offline")
+        .arg("--reinstall-package")
+        .arg("basic-package"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl)
+    ");
+
+    // A new hash must still be checked against the downloaded bytes, even with a warm cache.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("rejected")
+        .arg(format!("{}/{basic_filename}#sha512={}", server.uri(), "0".repeat(128))), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Using CPython 3.13.[X] interpreter at: .venv/[BIN]/[PYTHON]
+    Resolved 1 package in [TIME]
+      × Failed to download `basic-package @ http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl#sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
+      ╰─▶ Hash mismatch for `basic-package @ http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl#sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
+
+          Expected:
+            sha512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+
+          Computed:
+            sha256:13df8f3a9de47f515fefc702c4f4ba4278608d7c61bcf64c14e361af97f4eff9
+            sha512:07a4dd1023f6c7ef1457ebc070ff953d070007c3538b7054823c158fbb903ed92902ef323723c9ad1460af0a29ec642e2fbd2b92f264df5edd8e4f21f7f7ec7b
     ");
 
     Ok(())

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1537,6 +1537,7 @@ async fn lock_wheel_url_hash_cache() -> Result<()> {
      + basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl)
      + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
     ");
+    let original_lock = fs_err::read_to_string(context.temp_dir.join("uv.lock"))?;
     server.verify().await;
     server.reset().await;
 
@@ -1582,6 +1583,25 @@ async fn lock_wheel_url_hash_cache() -> Result<()> {
     ----- stderr -----
     Resolved 3 packages in [TIME]
     ");
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--frozen")
+        .arg("--offline")
+        .arg("--reinstall-package")
+        .arg("basic-package"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl)
+    ");
+
+    // The newer wheel must not hide the older revision, including after cache pruning.
+    context.prune().assert().success();
+    context
+        .temp_dir
+        .child("uv.lock")
+        .write_str(&original_lock)?;
     uv_snapshot!(context.filters(), context.sync()
         .arg("--frozen")
         .arg("--offline")

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -6,6 +6,8 @@ use async_zip::base::write::ZipFileWriter;
 #[cfg(feature = "test-universal")]
 use async_zip::{Compression, ZipEntryBuilder};
 use indoc::{formatdoc, indoc};
+#[cfg(feature = "test-universal")]
+use insta::allow_duplicates;
 use insta::assert_snapshot;
 #[cfg(feature = "test-universal")]
 use serde_json::json;
@@ -1450,190 +1452,81 @@ async fn lock_wheel_url_fragment_download() -> Result<()> {
     Ok(())
 }
 
-/// Reuse downloaded URL wheels offline, while refreshing bytes when an expected hash changes.
+/// Both revisions of a URL wheel remain available offline, including after pruning.
 #[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_wheel_url_hash_cache() -> Result<()> {
-    let context = uv_test::test_context!("3.13")
-        .with_filtered_python_names()
-        .with_filtered_virtualenv_bin()
-        .with_filtered_exe_suffix();
+    let context = uv_test::test_context!("3.12");
     let server = MockServer::start().await;
-    let ok_filename = "ok-1.0.0-py3-none-any.whl";
-    let basic_filename = "basic_package-0.1.0-py3-none-any.whl";
-    let ok_wheel = fs_err::read(context.workspace_root.join("test/links").join(ok_filename))?;
-    let mut basic_wheel = fs_err::read(
+    let filename = "ok-1.0.0-py3-none-any.whl";
+    let original = fs_err::read(context.workspace_root.join("test/links").join(filename))?;
+    let mut updated = original.clone();
+    // Change the bytes without changing the package by adding a valid ZIP comment.
+    let length = updated.len();
+    updated[length - 2..].copy_from_slice(&7_u16.to_le_bytes());
+    updated.extend_from_slice(b"updated");
+
+    let mut locks = Vec::new();
+    for (revision, wheel) in [("original", original), ("updated", updated)] {
+        let hash = hex::encode(Sha512::digest(&wheel));
+        let url = format!("{}/{filename}#sha512={hash}", server.uri());
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(405))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{filename}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("cache-control", "max-age=3600")
+                    .set_body_bytes(wheel),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        // Seed the fragment-bearing cache entry, then lock using the cached archive's metadata.
         context
-            .workspace_root
-            .join("test/links")
-            .join(basic_filename),
-    )?;
-    let ok_hash = hex::encode(Sha256::digest(&ok_wheel));
-    let basic_hash = hex::encode(Sha512::digest(&basic_wheel));
+            .pip_install()
+            .arg("--target")
+            .arg(revision)
+            .arg(&url)
+            .assert()
+            .success();
+        context
+            .temp_dir
+            .child("pyproject.toml")
+            .write_str(&formatdoc! {r#"
+                [project]
+                name = "project"
+                version = "0.1.0"
+                requires-python = ">=3.12"
+                dependencies = ["ok @ {url}"]
+            "#})?;
+        context.lock().assert().success();
+        locks.push(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?);
+        // Do not carry the previous lockfile's hashes into the next resolution.
+        fs_err::remove_file(context.temp_dir.join("uv.lock"))?;
+        server.verify().await;
+        server.reset().await;
+    }
 
-    // Serve metadata without range requests, then cache the complete wheels during installation.
-    Mock::given(method("HEAD"))
-        .respond_with(ResponseTemplate::new(405))
-        .expect(2)
-        .mount(&server)
-        .await;
-    Mock::given(method("GET"))
-        .and(path(format!("/{ok_filename}")))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("cache-control", "max-age=3600")
-                .set_body_bytes(ok_wheel),
-        )
-        .expect(2)
-        .mount(&server)
-        .await;
-    Mock::given(method("GET"))
-        .and(path(format!("/{basic_filename}")))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("cache-control", "max-age=3600")
-                .set_body_bytes(basic_wheel.clone()),
-        )
-        .expect(2)
-        .mount(&server)
-        .await;
-    let pyproject = formatdoc! {r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.13"
-        dependencies = [
-            "ok @ {}/{ok_filename}#sha256={ok_hash}",
-            "basic-package @ {}/{basic_filename}#sha512={basic_hash}",
-        ]
-    "#, server.uri(), server.uri()};
-    context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(&pyproject)?;
-
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg("--target").arg("seed")
-        .arg(format!("{}/{ok_filename}#sha256={ok_hash}", server.uri()))
-        .arg(format!("{}/{basic_filename}#sha512={basic_hash}", server.uri())), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Using CPython 3.13.[X] interpreter at: .venv/[BIN]/[PYTHON]
-    Resolved 2 packages in [TIME]
-    Prepared 2 packages in [TIME]
-    Installed 2 packages in [TIME]
-     + basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl#sha512=765bde25938af485e492e25ee0e8cde262462565122c1301213a69bf9ceb2008e3997b652a604092a238c4b1a6a334e697ff3cee3c22f9a617cb14f34e26ef17)
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha256=79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f)
-    ");
-    uv_snapshot!(context.filters(), context.lock(), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 3 packages in [TIME]
-    ");
-    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--offline"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Installed 2 packages in [TIME]
-     + basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl)
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-    let original_lock = fs_err::read_to_string(context.temp_dir.join("uv.lock"))?;
-    server.verify().await;
-    server.reset().await;
-
-    // Change the wheel bytes at the same URL by adding a valid ZIP comment. The old response is
-    // still fresh according to HTTP, so the changed expected hash must force a new download.
-    let length = basic_wheel.len();
-    basic_wheel[length - 2..].copy_from_slice(&7_u16.to_le_bytes());
-    basic_wheel.extend_from_slice(b"updated");
-    let updated_hash = hex::encode(Sha512::digest(&basic_wheel));
-    Mock::given(method("HEAD"))
-        .respond_with(ResponseTemplate::new(405))
-        .mount(&server)
-        .await;
-    Mock::given(method("GET"))
-        .and(path(format!("/{basic_filename}")))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("cache-control", "max-age=3600")
-                .set_body_bytes(basic_wheel),
-        )
-        .expect(4)
-        .mount(&server)
-        .await;
-    context
-        .temp_dir
-        .child("pyproject.toml")
-        .write_str(&pyproject.replace(&basic_hash, &updated_hash))?;
-    // Resolve without the previous lockfile's hashes, but keep the HTTP cache fresh.
-    fs_err::remove_file(context.temp_dir.join("uv.lock"))?;
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg("--target").arg("updated")
-        .arg(format!("{}/{basic_filename}#sha512={updated_hash}", server.uri())), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Using CPython 3.13.[X] interpreter at: .venv/[BIN]/[PYTHON]
-    Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl#sha512=07a4dd1023f6c7ef1457ebc070ff953d070007c3538b7054823c158fbb903ed92902ef323723c9ad1460af0a29ec642e2fbd2b92f264df5edd8e4f21f7f7ec7b)
-    ");
-    uv_snapshot!(context.filters(), context.lock(), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 3 packages in [TIME]
-    ");
-    uv_snapshot!(context.filters(), context.sync()
-        .arg("--frozen")
-        .arg("--offline")
-        .arg("--reinstall-package")
-        .arg("basic-package"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Prepared 1 package in [TIME]
-    Uninstalled 1 package in [TIME]
-    Installed 1 package in [TIME]
-     ~ basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl)
-    ");
-
-    // The newer wheel must not hide the older revision, including after cache pruning.
     context.prune().assert().success();
-    context
-        .temp_dir
-        .child("uv.lock")
-        .write_str(&original_lock)?;
-    uv_snapshot!(context.filters(), context.sync()
-        .arg("--frozen")
-        .arg("--offline")
-        .arg("--reinstall-package")
-        .arg("basic-package"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Prepared 1 package in [TIME]
-    Uninstalled 1 package in [TIME]
-    Installed 1 package in [TIME]
-     ~ basic-package==0.1.0 (from http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl)
-    ");
-
-    // A new hash must still be checked against the downloaded bytes, even with a warm cache.
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg("--target").arg("rejected")
-        .arg(format!("{}/{basic_filename}#sha512={}", server.uri(), "0".repeat(128))), @"
-    exit_code: 1 (failure)
-    ----- stderr -----
-    Using CPython 3.13.[X] interpreter at: .venv/[BIN]/[PYTHON]
-    Resolved 1 package in [TIME]
-      × Failed to download `basic-package @ http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl#sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
-      ╰─▶ Hash mismatch for `basic-package @ http://[LOCALHOST]/basic_package-0.1.0-py3-none-any.whl#sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
-
-          Expected:
-            sha512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-
-          Computed:
-            sha256:13df8f3a9de47f515fefc702c4f4ba4278608d7c61bcf64c14e361af97f4eff9
-            sha512:07a4dd1023f6c7ef1457ebc070ff953d070007c3538b7054823c158fbb903ed92902ef323723c9ad1460af0a29ec642e2fbd2b92f264df5edd8e4f21f7f7ec7b
-    ");
-
+    // Each lockfile stores the fragment-free URL. Clear the installed package between revisions
+    // so both requests must select and validate a cached archive.
+    for lock in locks {
+        context.temp_dir.child("uv.lock").write_str(&lock)?;
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--offline"), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Installed 1 package in [TIME]
+             + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+            ");
+        }
+        context.pip_uninstall().arg("ok").assert().success();
+    }
     Ok(())
 }
 

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -11,6 +11,7 @@ use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+use uv_cache::{Cache, CacheBucket};
 use uv_fs::{Simplified, copy_dir_all};
 use uv_static::EnvVars;
 use uv_test::find_links::FindLinksServer;
@@ -5807,6 +5808,54 @@ fn pep_751_validates_cached_remote_archive_size() -> Result<()> {
       × Failed to download `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`
       ╰─▶ Size mismatch for `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`: expected 1 bytes, but downloaded 921 bytes
     "#);
+
+    // A normal cache hit must enforce the same size check, without bypassing the planner via
+    // `--reinstall`.
+    context.pip_uninstall().arg("a").assert().success();
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("pylock.toml"), @r#"
+    exit_code: 1 (failure)
+    ----- stderr -----
+      × Failed to download `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`
+      ╰─▶ Size mismatch for `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`: expected 1 bytes, but downloaded 921 bytes
+    "#);
+
+    Ok(())
+}
+
+/// A dangling HTTP pointer is a cache miss, not an installable wheel.
+#[test]
+fn direct_url_missing_cached_archive() -> Result<()> {
+    let server = PackseServer::new("simple/single-package.toml");
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("requirements.txt")
+        .write_str(&format!(
+            "a @ {}",
+            server.file_url("a-1.0.0-py3-none-any.whl"),
+        ))?;
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .assert()
+        .success();
+    context.pip_uninstall().arg("a").assert().success();
+
+    // Keep both the HTTP pointer and hash index, but remove the referenced archive.
+    let cache = Cache::from_path(context.cache_dir.path());
+    fs::remove_dir_all(cache.bucket(CacheBucket::Archive))?;
+
+    uv_snapshot!(context.filters(), context.pip_sync().arg("requirements.txt"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + a==1.0.0 (from http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl)
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -5841,45 +5841,52 @@ async fn direct_url_wheel_cache_refresh() -> Result<()> {
         let context = uv_test::test_context!("3.12");
         let server = MockServer::start().await;
         let url = format!("{}/{filename}", server.uri());
-        let mut writer = ZipFileWriter::new(Vec::new());
-        for (name, contents) in [
-            ("ok/__init__.py", ""),
-            (
-                "ok-1.0.0.dist-info/METADATA",
-                "Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\n",
-            ),
-            (
-                "ok-1.0.0.dist-info/WHEEL",
-                "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
-            ),
-            (
-                "ok-1.0.0.dist-info/RECORD",
-                "ok/__init__.py,,\nok-1.0.0.dist-info/METADATA,,\nok-1.0.0.dist-info/WHEEL,,\nok-1.0.0.dist-info/RECORD,,\n",
-            ),
-        ] {
-            let entry = ZipEntryBuilder::new(name.into(), Compression::Stored);
-            if streaming_supported {
-                writer.write_entry_whole(entry, contents.as_bytes()).await?;
-            } else {
-                // Stored entries with data descriptors require the full-download fallback.
-                let mut entry_writer = writer.write_entry_stream(entry).await?;
-                entry_writer.write_all(contents.as_bytes()).await?;
-                entry_writer.close().await?;
+        let wheel = async |comment: &str| -> Result<Vec<u8>> {
+            let mut writer = ZipFileWriter::new(Vec::new());
+            writer.comment(comment.to_owned());
+            for (name, contents) in [
+                ("ok/__init__.py", ""),
+                (
+                    "ok-1.0.0.dist-info/METADATA",
+                    "Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\n",
+                ),
+                (
+                    "ok-1.0.0.dist-info/WHEEL",
+                    "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+                ),
+                (
+                    "ok-1.0.0.dist-info/RECORD",
+                    "ok/__init__.py,,\nok-1.0.0.dist-info/METADATA,,\nok-1.0.0.dist-info/WHEEL,,\nok-1.0.0.dist-info/RECORD,,\n",
+                ),
+            ] {
+                let entry = ZipEntryBuilder::new(name.into(), Compression::Stored);
+                if streaming_supported {
+                    writer.write_entry_whole(entry, contents.as_bytes()).await?;
+                } else {
+                    // Stored entries with data descriptors require the full-download fallback.
+                    let mut entry_writer = writer.write_entry_stream(entry).await?;
+                    entry_writer.write_all(contents.as_bytes()).await?;
+                    entry_writer.close().await?;
+                }
             }
-        }
-        let original = writer.close().await?;
-        let expected_requests = if streaming_supported { 1 } else { 2 };
-        let original_hash = hex::encode(Sha256::digest(&original));
-
-        // Adding a ZIP comment changes both the hash and size without changing the wheel contents.
-        let Some(prefix) = original.strip_suffix(&[0, 0]) else {
-            anyhow::bail!("Expected a wheel without a ZIP comment");
+            Ok(writer.close().await?)
         };
-        let mut changed = prefix.to_vec();
-        let comment = b"Updated wheel";
-        changed.extend_from_slice(&u16::try_from(comment.len())?.to_le_bytes());
-        changed.extend_from_slice(comment);
+        // ZIP comments change the hash and size without changing the installed contents.
+        let original = wheel("").await?;
+        let changed = wheel("Updated wheel").await?;
+        let original_hash = hex::encode(Sha256::digest(&original));
         let changed_hash = hex::encode(Sha256::digest(&changed));
+        let expected_requests = if streaming_supported { 1 } else { 2 };
+        let serve = |wheel| {
+            Mock::given(method("GET"))
+                .and(path(format!("/{filename}")))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header("cache-control", "max-age=3600")
+                        .set_body_bytes(wheel),
+                )
+                .expect(expected_requests)
+        };
 
         let pylock = context.temp_dir.child("pylock.toml");
         let write_lock = |hash: &str, size: usize| {
@@ -5907,32 +5914,14 @@ async fn direct_url_wheel_cache_refresh() -> Result<()> {
             command
         };
         write_lock(&original_hash, original.len())?;
-        Mock::given(method("GET"))
-            .and(path(format!("/{filename}")))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("cache-control", "max-age=3600")
-                    .set_body_bytes(original),
-            )
-            .expect(expected_requests)
-            .mount(&server)
-            .await;
+        serve(original).mount(&server).await;
         sync().assert().success();
         context.pip_uninstall().arg("ok").assert().success();
         server.verify().await;
         server.reset().await;
 
         write_lock(&changed_hash, changed.len())?;
-        Mock::given(method("GET"))
-            .and(path(format!("/{filename}")))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("cache-control", "max-age=3600")
-                    .set_body_bytes(changed.clone()),
-            )
-            .expect(expected_requests)
-            .mount(&server)
-            .await;
+        serve(changed.clone()).mount(&server).await;
 
         // Offline mode cannot fetch the new revision. Online mode must refresh it, falling back
         // to a full download when streaming is unsupported.
@@ -5952,12 +5941,7 @@ async fn direct_url_wheel_cache_refresh() -> Result<()> {
 
         // Fresh integrity mismatches must not retry beyond the streaming fallback, if needed.
         write_lock(&"0".repeat(64), changed.len() + 1)?;
-        Mock::given(method("GET"))
-            .and(path(format!("/{filename}")))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(changed))
-            .expect(expected_requests)
-            .mount(&server)
-            .await;
+        serve(changed).mount(&server).await;
         sync().arg("--no-cache").assert().failure();
     }
     Ok(())

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -16,8 +16,9 @@ use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use uv_cache::{Cache, CacheBucket};
+use uv_cache::{Cache, CacheBucket, WheelCache};
 use uv_fs::{Simplified, copy_dir_all};
+use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 use uv_test::find_links::FindLinksServer;
 use uv_test::packse::PackseServer;
@@ -5947,36 +5948,47 @@ async fn direct_url_wheel_cache_refresh() -> Result<()> {
     Ok(())
 }
 
-/// A dangling HTTP pointer is a cache miss, not an installable wheel.
+/// Missing archives and corrupt HTTP pointers should recover through a fresh download.
 #[test]
-fn direct_url_missing_cached_archive() -> Result<()> {
+fn direct_url_invalid_cache() -> Result<()> {
     let server = PackseServer::new("simple/single-package.toml");
     let context = uv_test::test_context!("3.12");
+    let url = DisplaySafeUrl::parse(&server.file_url("a-1.0.0-py3-none-any.whl"))?;
     context
         .temp_dir
         .child("requirements.txt")
-        .write_str(&format!(
-            "a @ {}",
-            server.file_url("a-1.0.0-py3-none-any.whl"),
-        ))?;
+        .write_str(&format!("a @ {url}"))?;
     context
         .pip_sync()
         .arg("requirements.txt")
         .assert()
         .success();
-    context.pip_uninstall().arg("a").assert().success();
-
-    // Keep both the HTTP pointer and hash index, but remove the referenced archive.
     let cache = Cache::from_path(context.cache_dir.path());
-    fs::remove_dir_all(cache.bucket(CacheBucket::Archive))?;
+    let http_entry = cache.entry(
+        CacheBucket::Wheels,
+        WheelCache::Url(&url).wheel_dir("a"),
+        "1.0.0-py3-none-any.http",
+    );
 
-    uv_snapshot!(context.filters(), context.pip_sync().arg("requirements.txt"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + a==1.0.0 (from http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl)
-    ");
+    for corrupt_pointer in [false, true] {
+        context.pip_uninstall().arg("a").assert().success();
+        if corrupt_pointer {
+            assert!(http_entry.path().is_file());
+            fs::write(http_entry.path(), b"truncated")?;
+        } else {
+            // Keep the pointers, but remove the referenced archive.
+            fs::remove_dir_all(cache.bucket(CacheBucket::Archive))?;
+        }
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), context.pip_sync().arg("requirements.txt"), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Resolved 1 package in [TIME]
+            Installed 1 package in [TIME]
+             + a==1.0.0 (from http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl)
+            ");
+        }
+    }
 
     Ok(())
 }

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -4,9 +4,14 @@ use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
+use async_zip::base::write::ZipFileWriter;
+use async_zip::{Compression, ZipEntryBuilder};
 use fs_err as fs;
+use futures::io::AsyncWriteExt;
 use indoc::{formatdoc, indoc};
+use insta::allow_duplicates;
 use predicates::Predicate;
+use sha2::{Digest, Sha256};
 use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -5825,6 +5830,139 @@ fn pep_751_validates_cached_remote_archive_size() -> Result<()> {
     Ok(())
 }
 
+/// Changed integrity constraints refresh an otherwise fresh HTTP response, but never retry a
+/// freshly downloaded wheel that fails validation.
+#[tokio::test]
+async fn direct_url_wheel_cache_refresh() -> Result<()> {
+    let filename = "ok-1.0.0-py3-none-any.whl";
+    for (validate_hashes, streaming_supported) in
+        [(true, true), (false, true), (true, false), (false, false)]
+    {
+        let context = uv_test::test_context!("3.12");
+        let server = MockServer::start().await;
+        let url = format!("{}/{filename}", server.uri());
+        let mut writer = ZipFileWriter::new(Vec::new());
+        for (name, contents) in [
+            ("ok/__init__.py", ""),
+            (
+                "ok-1.0.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\n",
+            ),
+            (
+                "ok-1.0.0.dist-info/WHEEL",
+                "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+            ),
+            (
+                "ok-1.0.0.dist-info/RECORD",
+                "ok/__init__.py,,\nok-1.0.0.dist-info/METADATA,,\nok-1.0.0.dist-info/WHEEL,,\nok-1.0.0.dist-info/RECORD,,\n",
+            ),
+        ] {
+            let entry = ZipEntryBuilder::new(name.into(), Compression::Stored);
+            if streaming_supported {
+                writer.write_entry_whole(entry, contents.as_bytes()).await?;
+            } else {
+                // Stored entries with data descriptors require the full-download fallback.
+                let mut entry_writer = writer.write_entry_stream(entry).await?;
+                entry_writer.write_all(contents.as_bytes()).await?;
+                entry_writer.close().await?;
+            }
+        }
+        let original = writer.close().await?;
+        let expected_requests = if streaming_supported { 1 } else { 2 };
+        let original_hash = hex::encode(Sha256::digest(&original));
+
+        // Adding a ZIP comment changes both the hash and size without changing the wheel contents.
+        let Some(prefix) = original.strip_suffix(&[0, 0]) else {
+            anyhow::bail!("Expected a wheel without a ZIP comment");
+        };
+        let mut changed = prefix.to_vec();
+        let comment = b"Updated wheel";
+        changed.extend_from_slice(&u16::try_from(comment.len())?.to_le_bytes());
+        changed.extend_from_slice(comment);
+        let changed_hash = hex::encode(Sha256::digest(&changed));
+
+        let pylock = context.temp_dir.child("pylock.toml");
+        let write_lock = |hash: &str, size: usize| {
+            let size = if validate_hashes {
+                String::new()
+            } else {
+                format!("size = {size}, ")
+            };
+            pylock.write_str(&formatdoc! {r#"
+                lock-version = "1.0"
+                created-by = "uv"
+
+                [[packages]]
+                name = "ok"
+                version = "1.0.0"
+                archive = {{ url = "{url}", {size}hashes = {{ sha256 = "{hash}" }} }}
+            "#})
+        };
+        let sync = || {
+            let mut command = context.pip_sync();
+            command.arg("--preview").arg("pylock.toml");
+            if !validate_hashes {
+                command.arg("--no-verify-hashes");
+            }
+            command
+        };
+        write_lock(&original_hash, original.len())?;
+        Mock::given(method("GET"))
+            .and(path(format!("/{filename}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("cache-control", "max-age=3600")
+                    .set_body_bytes(original),
+            )
+            .expect(expected_requests)
+            .mount(&server)
+            .await;
+        sync().assert().success();
+        context.pip_uninstall().arg("ok").assert().success();
+        server.verify().await;
+        server.reset().await;
+
+        write_lock(&changed_hash, changed.len())?;
+        Mock::given(method("GET"))
+            .and(path(format!("/{filename}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("cache-control", "max-age=3600")
+                    .set_body_bytes(changed.clone()),
+            )
+            .expect(expected_requests)
+            .mount(&server)
+            .await;
+
+        // Offline mode cannot fetch the new revision. Online mode must refresh it, falling back
+        // to a full download when streaming is unsupported.
+        sync().arg("--offline").assert().failure();
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), sync(), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Prepared 1 package in [TIME]
+            Installed 1 package in [TIME]
+             + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+            ");
+        }
+        context.pip_uninstall().arg("ok").assert().success();
+        server.verify().await;
+        server.reset().await;
+
+        // Fresh integrity mismatches must not retry beyond the streaming fallback, if needed.
+        write_lock(&"0".repeat(64), changed.len() + 1)?;
+        Mock::given(method("GET"))
+            .and(path(format!("/{filename}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(changed))
+            .expect(expected_requests)
+            .mount(&server)
+            .await;
+        sync().arg("--no-cache").assert().failure();
+    }
+    Ok(())
+}
+
 /// A dangling HTTP pointer is a cache miss, not an installable wheel.
 #[test]
 fn direct_url_missing_cached_archive() -> Result<()> {
@@ -5852,7 +5990,6 @@ fn direct_url_missing_cached_archive() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + a==1.0.0 (from http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl)
     ");

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -11122,7 +11122,7 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("cache-control", "max-age=3600")
-                .set_body_bytes(changed),
+                .set_body_bytes(changed.clone()),
         )
         .mount(&server)
         .await;
@@ -11169,6 +11169,59 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
         .arg("--target").arg("constrained")
         .arg("--offline").arg("--require-hashes")
         .arg("-r").arg("requirements.txt"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because cache-missing-dependency was not found in the cache and ok==1.0.0 depends on cache-missing-dependency==1.0, we can conclude that ok==1.0.0 cannot be used.
+          And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
+
+    hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
+    ");
+
+    // A third revision is not cached under any hash. Refresh it before resolving dependencies,
+    // rather than resolving the original metadata and only refreshing during installation.
+    let Some(prefix) = changed.strip_suffix(&[0, 0]) else {
+        anyhow::bail!("Expected a wheel without a ZIP comment");
+    };
+    let mut refreshed = prefix.to_vec();
+    let comment = b"Third revision";
+    refreshed.extend_from_slice(&u16::try_from(comment.len())?.to_le_bytes());
+    refreshed.extend_from_slice(comment);
+    let hash = hex::encode(Sha256::digest(&refreshed));
+    server.reset().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_bytes(refreshed),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    context
+        .temp_dir
+        .child("requirements.txt")
+        .write_str(&format!("ok @ {url} --hash=sha256:{hash}"))?;
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("refreshed")
+        .arg("--no-index").arg("--require-hashes")
+        .arg("-r").arg("requirements.txt"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because cache-missing-dependency was not found in the provided package locations and ok==1.0.0 depends on cache-missing-dependency==1.0, we can conclude that ok==1.0.0 cannot be used.
+          And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
+
+    hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
+    ");
+
+    // The refreshed HTTP archive also determines metadata for subsequent unconstrained requests.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("refreshed-again")
+        .arg("--offline").arg(&url), @"
     exit_code: 1 (failure)
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -11069,19 +11069,20 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
     let filename = "ok-1.0.0-py3-none-any.whl";
     let url = format!("{}/{filename}", server.uri());
     let original = fs_err::read(context.workspace_root.join("test/links").join(filename))?;
+    let serve = |wheel| {
+        Mock::given(method("GET"))
+            .and(path(format!("/{filename}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("cache-control", "max-age=3600")
+                    .set_body_bytes(wheel),
+            )
+    };
     Mock::given(method("HEAD"))
         .respond_with(ResponseTemplate::new(405))
         .mount(&server)
         .await;
-    Mock::given(method("GET"))
-        .and(path(format!("/{filename}")))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("cache-control", "max-age=3600")
-                .set_body_bytes(original),
-        )
-        .mount(&server)
-        .await;
+    serve(original).mount(&server).await;
     context
         .pip_install()
         .arg("--target")
@@ -11092,40 +11093,24 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
     server.reset().await;
 
     // Publish different metadata at the same wheel URL, selected by a new hash.
-    let mut writer = ZipFileWriter::new(Vec::new());
-    for (name, contents) in [
-        ("ok/__init__.py", ""),
-        (
-            "ok-1.0.0.dist-info/METADATA",
-            "Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\nRequires-Dist: cache-missing-dependency==1.0\n",
-        ),
-        (
-            "ok-1.0.0.dist-info/WHEEL",
-            "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
-        ),
-        (
-            "ok-1.0.0.dist-info/RECORD",
-            "ok/__init__.py,,\nok-1.0.0.dist-info/METADATA,,\nok-1.0.0.dist-info/WHEEL,,\nok-1.0.0.dist-info/RECORD,,\n",
-        ),
-    ] {
-        let entry = ZipEntryBuilder::new(name.into(), Compression::Stored);
-        writer.write_entry_whole(entry, contents.as_bytes()).await?;
-    }
-    let changed = writer.close().await?;
+    let wheel_with_dependency = |dependency: &str| -> Result<Vec<u8>> {
+        let (_, wheel) = generate_wheel(
+            &"ok".parse()?,
+            &"1.0.0".parse()?,
+            &[dependency.parse()?],
+            &BTreeMap::new(),
+            None,
+            "py3-none-any",
+        );
+        Ok(wheel)
+    };
+    let changed = wheel_with_dependency("cache-missing-dependency==1.0")?;
     let hash = hex::encode(Sha256::digest(&changed));
     Mock::given(method("HEAD"))
         .respond_with(ResponseTemplate::new(405))
         .mount(&server)
         .await;
-    Mock::given(method("GET"))
-        .and(path(format!("/{filename}")))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("cache-control", "max-age=3600")
-                .set_body_bytes(changed.clone()),
-        )
-        .mount(&server)
-        .await;
+    serve(changed).mount(&server).await;
     context
         .pip_install()
         .arg("--target")
@@ -11147,17 +11132,10 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
     Installed 1 package in [TIME]
      + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
     ");
+    let metadata = "ok-1.0.0.dist-info/METADATA";
     assert_eq!(
-        fs_err::read(
-            context
-                .temp_dir
-                .join("original/ok-1.0.0.dist-info/METADATA")
-        )?,
-        fs_err::read(
-            context
-                .temp_dir
-                .join("original-again/ok-1.0.0.dist-info/METADATA")
-        )?,
+        fs_err::read(context.temp_dir.join("original").join(metadata))?,
+        fs_err::read(context.temp_dir.join("original-again").join(metadata))?,
     );
 
     // A hash constraint without a fragment selects the new archive AND its new metadata.
@@ -11181,25 +11159,10 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
 
     // A third revision is not cached under any hash. Refresh it before resolving dependencies,
     // rather than resolving the original metadata and only refreshing during installation.
-    let Some(prefix) = changed.strip_suffix(&[0, 0]) else {
-        anyhow::bail!("Expected a wheel without a ZIP comment");
-    };
-    let mut refreshed = prefix.to_vec();
-    let comment = b"Third revision";
-    refreshed.extend_from_slice(&u16::try_from(comment.len())?.to_le_bytes());
-    refreshed.extend_from_slice(comment);
+    let refreshed = wheel_with_dependency("cache-missing-dependency==2.0")?;
     let hash = hex::encode(Sha256::digest(&refreshed));
     server.reset().await;
-    Mock::given(method("GET"))
-        .and(path(format!("/{filename}")))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("cache-control", "max-age=3600")
-                .set_body_bytes(refreshed),
-        )
-        .expect(1)
-        .mount(&server)
-        .await;
+    serve(refreshed).expect(1).mount(&server).await;
     context
         .temp_dir
         .child("requirements.txt")
@@ -11212,7 +11175,7 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
       × No solution found when resolving dependencies:
-      ╰─▶ Because cache-missing-dependency was not found in the provided package locations and ok==1.0.0 depends on cache-missing-dependency==1.0, we can conclude that ok==1.0.0 cannot be used.
+      ╰─▶ Because cache-missing-dependency was not found in the provided package locations and ok==1.0.0 depends on cache-missing-dependency==2.0, we can conclude that ok==1.0.0 cannot be used.
           And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
@@ -11226,7 +11189,7 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
       × No solution found when resolving dependencies:
-      ╰─▶ Because cache-missing-dependency was not found in the cache and ok==1.0.0 depends on cache-missing-dependency==1.0, we can conclude that ok==1.0.0 cannot be used.
+      ╰─▶ Because cache-missing-dependency was not found in the cache and ok==1.0.0 depends on cache-missing-dependency==2.0, we can conclude that ok==1.0.0 cannot be used.
           And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -11058,6 +11058,129 @@ fn static_metadata_source_tree() -> Result<()> {
     Ok(())
 }
 
+/// Cached metadata and wheel contents must come from the same URL revision.
+#[tokio::test]
+async fn direct_url_hash_cache_metadata() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix();
+    let server = MockServer::start().await;
+    let filename = "ok-1.0.0-py3-none-any.whl";
+    let url = format!("{}/{filename}", server.uri());
+    let original = fs_err::read(context.workspace_root.join("test/links").join(filename))?;
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(405))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_bytes(original),
+        )
+        .mount(&server)
+        .await;
+    context
+        .pip_install()
+        .arg("--target")
+        .arg("original")
+        .arg(&url)
+        .assert()
+        .success();
+    server.reset().await;
+
+    // Publish different metadata at the same wheel URL, selected by a new hash.
+    let mut writer = ZipFileWriter::new(Vec::new());
+    for (name, contents) in [
+        ("ok/__init__.py", ""),
+        (
+            "ok-1.0.0.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\nRequires-Dist: cache-missing-dependency==1.0\n",
+        ),
+        (
+            "ok-1.0.0.dist-info/WHEEL",
+            "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+        ),
+        (
+            "ok-1.0.0.dist-info/RECORD",
+            "ok/__init__.py,,\nok-1.0.0.dist-info/METADATA,,\nok-1.0.0.dist-info/WHEEL,,\nok-1.0.0.dist-info/RECORD,,\n",
+        ),
+    ] {
+        let entry = ZipEntryBuilder::new(name.into(), Compression::Stored);
+        writer.write_entry_whole(entry, contents.as_bytes()).await?;
+    }
+    let changed = writer.close().await?;
+    let hash = hex::encode(Sha256::digest(&changed));
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(405))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_bytes(changed),
+        )
+        .mount(&server)
+        .await;
+    context
+        .pip_install()
+        .arg("--target")
+        .arg("changed")
+        .arg("--no-deps")
+        .arg(format!("{url}#sha256={hash}"))
+        .assert()
+        .success();
+
+    // The unconstrained URL still resolves and installs the original wheel, not the new bytes
+    // with their additional dependency silently omitted.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("original-again")
+        .arg("--offline").arg(&url), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+    Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+    assert_eq!(
+        fs_err::read(
+            context
+                .temp_dir
+                .join("original/ok-1.0.0.dist-info/METADATA")
+        )?,
+        fs_err::read(
+            context
+                .temp_dir
+                .join("original-again/ok-1.0.0.dist-info/METADATA")
+        )?,
+    );
+
+    // A hash constraint without a fragment selects the new archive AND its new metadata.
+    context
+        .temp_dir
+        .child("requirements.txt")
+        .write_str(&format!("ok @ {url} --hash=sha256:{hash}"))?;
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("constrained")
+        .arg("--offline").arg("--require-hashes")
+        .arg("-r").arg("requirements.txt"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because cache-missing-dependency was not found in the cache and ok==1.0.0 depends on cache-missing-dependency==1.0, we can conclude that ok==1.0.0 cannot be used.
+          And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
+
+    hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
+    ");
+    Ok(())
+}
+
 /// Regression test for: <https://github.com/astral-sh/uv/issues/18778>
 #[test]
 fn direct_url_hash_source_tree_dependency() -> Result<()> {

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -11079,7 +11079,7 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
             .and(path(format!("/{filename}")))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .insert_header("cache-control", "max-age=3600")
+                    .insert_header("cache-control", "max-age=0, must-revalidate")
                     .set_body_bytes(wheel),
             )
     };
@@ -11186,6 +11186,20 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
           And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
+    ");
+
+    // An expired URL without an expected hash must revalidate before resolving dependencies.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("unpinned")
+        .arg("--no-index").arg(&url), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because cache-missing-dependency was not found in the provided package locations and ok==1.0.0 depends on cache-missing-dependency==1.0, we can conclude that ok==1.0.0 cannot be used.
+          And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
+
+    hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     ");
 
     // A third revision is not cached under any hash. Refresh it before resolving dependencies,

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -24,9 +24,12 @@ use wiremock::{
     matchers::{basic_auth, method, path},
 };
 
+use uv_cache::{Cache, CacheBucket, WheelCache};
 use uv_extract::dirhash::{DirectoryDigest, dirhash_path};
 use uv_fs::{PortablePath, Simplified};
 use uv_install_wheel::validate_and_heal_record;
+use uv_pypi_types::HashDigest;
+use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 use uv_test::archive::write_tar_gz;
 #[cfg(feature = "test-git")]
@@ -11069,6 +11072,8 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
     let filename = "ok-1.0.0-py3-none-any.whl";
     let url = format!("{}/{filename}", server.uri());
     let original = fs_err::read(context.workspace_root.join("test/links").join(filename))?;
+    let original_hash =
+        format!("sha256:{}", hex::encode(Sha256::digest(&original))).parse::<HashDigest>()?;
     let serve = |wheel| {
         Mock::given(method("GET"))
             .and(path(format!("/{filename}")))
@@ -11090,6 +11095,32 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
         .arg(&url)
         .assert()
         .success();
+
+    // A corrupt hash-index entry must not hide a valid HTTP archive, even offline.
+    let cache = Cache::from_path(context.cache_dir.path());
+    let cache_url = DisplaySafeUrl::parse(&url)?;
+    let hash_entry = cache.entry(
+        CacheBucket::Wheels,
+        WheelCache::url_hash_dir(&cache_url, "ok", &original_hash),
+        "1.0.0-py3-none-any.msgpack",
+    );
+    assert!(hash_entry.path().is_file());
+    fs_err::write(hash_entry.path(), b"truncated")?;
+    context
+        .temp_dir
+        .child("requirements.txt")
+        .write_str(&format!("ok @ {url} --hash={original_hash}"))?;
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("recovered")
+        .arg("--offline").arg("--require-hashes")
+        .arg("-r").arg("requirements.txt"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+    Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
     server.reset().await;
 
     // Publish different metadata at the same wheel URL, selected by a new hash.
@@ -11159,6 +11190,14 @@ async fn direct_url_hash_cache_metadata() -> Result<()> {
 
     // A third revision is not cached under any hash. Refresh it before resolving dependencies,
     // rather than resolving the original metadata and only refreshing during installation.
+    // A broken HTTP pointer must take the same recovery path, without reusing stale metadata.
+    let http_entry = cache.entry(
+        CacheBucket::Wheels,
+        WheelCache::Url(&cache_url).wheel_dir("ok"),
+        "1.0.0-py3-none-any.http",
+    );
+    assert!(http_entry.path().is_file());
+    fs_err::write(http_entry.path(), b"truncated")?;
     let refreshed = wheel_with_dependency("cache-missing-dependency==2.0")?;
     let hash = hex::encode(Sha256::digest(&refreshed));
     server.reset().await;


### PR DESCRIPTION
## Summary

We omit known hash fields from `CanonicalUrl`, preserving source selectors and unknown fragments, and index downloaded URL wheels by their canonical URL and computed hashes. This lets `uv sync --offline` reuse a wheel downloaded from a fragment-hashed URL when the lockfile stores its URL and hashes separately.

Keep HTTP metadata, source builds, and in-flight downloads scoped to their original hash declarations. Sharing checks the complete hash policy and reads metadata from the selected archive, so a newer revision cannot hide an older cached wheel or pair new wheel bytes with old metadata. Existing cache keys remain valid, and references to older revisions survive cache pruning.

Apply the same filename, hash, size, and archive-existence checks to every cached URL wheel candidate. When online, refresh cached contents that no longer match the requested hashes or size before resolving dependencies. Fresh integrity failures are rejected without an extra retry, including in the full-download fallback.

Follows #21279, which added URL hash reuse during resolution.
