### PR TITLE
Clarify distribution hash policy

### DIFF
--- a/crates/uv-distribution-types/src/hash.rs
+++ b/crates/uv-distribution-types/src/hash.rs
@@ -1,11 +1,12 @@
 use uv_pypi_types::{HashAlgorithm, HashDigest};
 
+/// The normalized hash policy for a single distribution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HashPolicy<'a> {
+pub enum DistHashPolicy<'a> {
     /// No hash policy is specified.
     None,
-    /// Hashes should be generated (specifically, a SHA-256 hash), but not validated.
-    Generate(HashGeneration),
+    /// A hash should be included, but not validated.
+    Include,
     /// Hashes should be validated against a pre-defined list of hashes, and any matching digest is
     /// sufficient. If necessary, hashes should be generated so as to ensure that the archive is
     /// valid.
@@ -15,7 +16,7 @@ pub enum HashPolicy<'a> {
     All(&'a [HashDigest]),
 }
 
-impl HashPolicy<'_> {
+impl DistHashPolicy<'_> {
     /// Returns `true` if the hash policy is `None`.
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
@@ -26,24 +27,16 @@ impl HashPolicy<'_> {
         matches!(self, Self::Any(_) | Self::All(_))
     }
 
-    /// Returns `true` if the hash policy indicates that hashes should be generated.
-    pub fn is_generate(&self, dist: &crate::BuiltDist) -> bool {
-        match self {
-            Self::Generate(HashGeneration::Url) => dist.file().is_none(),
-            Self::Generate(HashGeneration::All) => {
-                dist.file().is_none_or(|file| file.hashes.is_empty())
-            }
-            Self::Any(_) => false,
-            Self::All(_) => false,
-            Self::None => false,
-        }
+    /// Returns `true` if a hash needs to be supplied for the distribution.
+    pub fn needs_inclusion(&self, dist: &crate::BuiltDist) -> bool {
+        matches!(self, Self::Include) && dist.file().is_none_or(|file| file.hashes.is_empty())
     }
 
     /// Return the algorithms used in the hash policy.
     pub fn algorithms(&self) -> Vec<HashAlgorithm> {
         match self {
             Self::None => vec![],
-            Self::Generate(_) => vec![HashAlgorithm::Sha256],
+            Self::Include => vec![HashAlgorithm::Sha256],
             Self::Any(hashes) | Self::All(hashes) => {
                 let mut algorithms = hashes.iter().map(HashDigest::algorithm).collect::<Vec<_>>();
                 algorithms.sort();
@@ -57,7 +50,7 @@ impl HashPolicy<'_> {
     pub fn digests(&self) -> &[HashDigest] {
         match self {
             Self::None => &[],
-            Self::Generate(_) => &[],
+            Self::Include => &[],
             Self::Any(hashes) | Self::All(hashes) => hashes,
         }
     }
@@ -66,7 +59,7 @@ impl HashPolicy<'_> {
     pub fn matches(&self, hashes: &[HashDigest]) -> bool {
         match self {
             Self::None => true,
-            Self::Generate(_) => hashes
+            Self::Include => hashes
                 .iter()
                 .any(|hash| hash.algorithm == HashAlgorithm::Sha256),
             Self::Any(required) => {
@@ -82,7 +75,7 @@ impl HashPolicy<'_> {
     fn has_required_algorithms(&self, hashes: &[HashDigest]) -> bool {
         match self {
             Self::None => true,
-            Self::Generate(_) => hashes
+            Self::Include => hashes
                 .iter()
                 .any(|hash| hash.algorithm == HashAlgorithm::Sha256),
             Self::Any(required) => {
@@ -103,14 +96,31 @@ impl HashPolicy<'_> {
     }
 }
 
-/// The context in which hashes should be generated.
+/// How to include distribution hashes in a resolution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HashGeneration {
-    /// Generate hashes for direct URL distributions.
-    Url,
-    /// Generate hashes for direct URL distributions, along with any distributions that are hosted
-    /// on a registry that does _not_ provide hashes.
-    All,
+pub struct HashInclusion {
+    missing_registry: MissingRegistryHash,
+}
+
+impl HashInclusion {
+    /// Create a hash inclusion policy with the given behavior for missing registry hashes.
+    pub const fn new(missing_registry: MissingRegistryHash) -> Self {
+        Self { missing_registry }
+    }
+
+    /// Return the behavior for missing registry hashes.
+    pub const fn missing_registry(self) -> MissingRegistryHash {
+        self.missing_registry
+    }
+}
+
+/// How to handle a registry distribution when its index metadata does not provide a hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissingRegistryHash {
+    /// Do not download the distribution solely to compute a hash.
+    Skip,
+    /// Download the distribution and compute a hash.
+    Compute,
 }
 
 pub trait Hashed {
@@ -118,12 +128,12 @@ pub trait Hashed {
     fn hashes(&self) -> &[HashDigest];
 
     /// Returns `true` if the archive satisfies the given hash policy.
-    fn satisfies(&self, hashes: HashPolicy) -> bool {
+    fn satisfies(&self, hashes: DistHashPolicy) -> bool {
         hashes.matches(self.hashes())
     }
 
     /// Returns `true` if the archive includes the algorithms required by the given hash policy.
-    fn has_digests(&self, hashes: HashPolicy) -> bool {
+    fn has_digests(&self, hashes: DistHashPolicy) -> bool {
         hashes.has_required_algorithms(self.hashes())
     }
 }
@@ -146,7 +156,7 @@ mod tests {
 
     use uv_pypi_types::HashDigest;
 
-    use super::HashPolicy;
+    use super::DistHashPolicy;
 
     #[test]
     fn validate_all_requires_every_digest() {
@@ -163,7 +173,7 @@ mod tests {
         )
         .unwrap();
 
-        let policy = HashPolicy::All(&[sha256.clone(), sha512.clone()]);
+        let policy = DistHashPolicy::All(&[sha256.clone(), sha512.clone()]);
         assert!(policy.matches(&[sha256.clone(), sha512]));
         assert!(!policy.matches(std::slice::from_ref(&sha256)));
         assert!(!policy.matches(&[sha256, wrong_sha512]));
@@ -184,7 +194,7 @@ mod tests {
         )
         .unwrap();
 
-        let policy = HashPolicy::Any(&[sha256.clone(), sha512]);
+        let policy = DistHashPolicy::Any(&[sha256.clone(), sha512]);
         assert!(policy.matches(&[sha256]));
         assert!(!policy.matches(&[wrong_sha512]));
     }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -19,7 +19,7 @@ use uv_client::{
 };
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
-    BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, File, HashPolicy, Hashed, IndexUrl,
+    BuildInfo, BuildableSource, BuiltDist, Dist, DistHashPolicy, DistRef, File, Hashed, IndexUrl,
     InstalledDist, Name, SourceDist, ToUrlError,
 };
 use uv_extract::hash::Hasher;
@@ -118,7 +118,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         &self,
         dist: &Dist,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         match dist {
             Dist::Built(built) => self.get_wheel(built, hashes).await,
@@ -161,7 +161,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     pub async fn get_or_build_wheel_metadata(
         &self,
         dist: &Dist,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         match dist {
             Dist::Built(built) => self.get_wheel_metadata(built, hashes).await,
@@ -179,7 +179,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     async fn get_wheel(
         &self,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         match dist {
             BuiltDist::Registry(wheels) => {
@@ -434,7 +434,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         &self,
         dist: &SourceDist,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         let built_wheel = self
             .builder
@@ -533,23 +533,24 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     async fn get_wheel_metadata(
         &self,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
-        // If hash generation is enabled, and the distribution isn't hosted on a registry, get the
-        // entire wheel to ensure that the hashes are included in the response. If the distribution
-        // is hosted on an index, the hashes will be included in the simple metadata response.
+        // If hashes are requested during resolution, and the distribution isn't hosted on a
+        // registry, get the entire wheel to ensure that hashes are included in the response. If
+        // the distribution is hosted on an index, hashes are included in the simple metadata
+        // response.
         // For hash _validation_, callers are expected to enforce the policy when retrieving the
         // wheel.
         //
         // Historically, for `uv pip compile --universal`, we also generate hashes for
         // registry-based distributions when the relevant registry doesn't provide them. This was
-        // motivated by `--find-links`. We continue that behavior (under `HashGeneration::All`) for
-        // backwards compatibility, but it's a little dubious, since we're only hashing _one_
+        // motivated by `--find-links`. We continue that behavior when missing registry hashes are
+        // computed for backwards compatibility, but it's a little dubious, since we're hashing one
         // distribution here (as opposed to hashing all distributions for the version), and it may
         // not even be a compatible distribution!
         //
         // TODO(charlie): Request the hashes via a separate method, to reduce the coupling in this API.
-        if hashes.is_generate(dist) {
+        if hashes.needs_inclusion(dist) {
             let wheel = self.get_wheel(dist, hashes).await?;
             // If the metadata was provided by the user directly, prefer it.
             let metadata = if let Some(metadata) = self
@@ -622,7 +623,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     pub async fn build_wheel_metadata(
         &self,
         source: &BuildableSource<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         // If the metadata was provided by the user directly, prefer it.
         if let Some(dist) = source.as_dist() {
@@ -673,7 +674,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<Archive, Error> {
         let expected_size = match dist {
             BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
@@ -875,7 +876,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<Archive, Error> {
         let expected_size = match dist {
             BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
@@ -1084,7 +1085,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         extension: WheelExtension,
         wheel_entry: CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         #[cfg(windows)]
         let _lock = {

--- a/crates/uv-distribution/src/hash.rs
+++ b/crates/uv-distribution/src/hash.rs
@@ -1,8 +1,8 @@
-use uv_distribution_types::HashPolicy;
+use uv_distribution_types::DistHashPolicy;
 use uv_pypi_types::HashAlgorithm;
 
 /// Return the algorithms to compute for an HTTP distribution.
-pub(crate) fn http_hash_algorithms(hashes: HashPolicy<'_>) -> Vec<HashAlgorithm> {
+pub(crate) fn http_hash_algorithms(hashes: DistHashPolicy<'_>) -> Vec<HashAlgorithm> {
     let mut algorithms = hashes.algorithms();
     algorithms.push(HashAlgorithm::Sha256);
     algorithms.sort();

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -30,8 +30,8 @@ use uv_client::{
 use uv_configuration::{BuildKind, BuildOutput, NoSources};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::{
-    BuildInfo, BuildVariables, BuildableSource, ConfigSettings, DirectorySourceUrl,
-    ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, HashPolicy, Hashed, IndexUrl,
+    BuildInfo, BuildVariables, BuildableSource, ConfigSettings, DirectorySourceUrl, DistHashPolicy,
+    ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, Hashed, IndexUrl,
     PathSourceUrl, RemoteSource, RequirementSource, RequiresPython, SourceDist, SourceUrl,
 };
 use uv_fs::{Simplified, rename_with_retry, write_atomic};
@@ -261,7 +261,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let built_wheel_metadata = match &source {
@@ -425,7 +425,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     pub(crate) async fn download_and_build_metadata(
         &self,
         source: &BuildableSource<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let metadata = match &source {
@@ -631,7 +631,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         subdirectory: Option<&'data Path>,
         ext: SourceDistExtension,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
@@ -764,7 +764,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         cache_shard: &CacheShard,
         subdirectory: Option<&'data Path>,
         ext: SourceDistExtension,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
@@ -948,7 +948,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         url: &DisplaySafeUrl,
         index: Option<&IndexUrl>,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<Revision, Error> {
         let cache_entry = cache_shard.entry(HTTP_REVISION);
@@ -1058,7 +1058,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
@@ -1166,7 +1166,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
@@ -1321,7 +1321,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<LocalRevisionPointer, Error> {
         // Verify that the archive exists.
         if !resource.path.is_file() {
@@ -1375,7 +1375,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &DirectorySourceUrl<'_>,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Before running the build, check that the hashes match.
         if hashes.requires_validation() {
@@ -1481,7 +1481,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &DirectorySourceUrl<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         credentials_cache: &CredentialsCache,
     ) -> Result<ArchiveMetadata, Error> {
         // Before running the build, check that the hashes match.
@@ -1793,7 +1793,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &GitPathSourceUrl<'_>,
         fetch: &Fetch,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<RevisionHashes, Error> {
         // Validate that LFS artifacts were fully initialized.
         if resource.git.lfs().enabled() && !fetch.lfs_ready() {
@@ -1847,7 +1847,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &GitPathSourceUrl<'_>,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Fetch the Git repository.
@@ -1957,7 +1957,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &GitPathSourceUrl<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         // Fetch the Git repository.
@@ -2120,7 +2120,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &GitDirectorySourceUrl<'_>,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Before running the build, check that the hashes match.
@@ -2228,7 +2228,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &GitDirectorySourceUrl<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
         credentials_cache: &CredentialsCache,
     ) -> Result<ArchiveMetadata, Error> {
@@ -2704,7 +2704,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &PathSourceUrl<'_>,
         entry: &CacheEntry,
         revision: Revision,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
     ) -> Result<Revision, Error> {
         warn!("Re-extracting missing source distribution: {source}");
 
@@ -2739,7 +2739,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         index: Option<&IndexUrl>,
         entry: &CacheEntry,
         revision: Revision,
-        hashes: HashPolicy<'_>,
+        hashes: DistHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<Revision, Error> {
         warn!("Re-downloading missing source distribution: {source}");

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -10,7 +10,7 @@ use uv_configuration::ExtrasSpecification;
 use uv_distribution::{DistributionDatabase, FlatRequiresDist, Reporter, RequiresDist};
 use uv_distribution_types::Requirement;
 use uv_distribution_types::{
-    BuildableSource, DirectorySourceUrl, HashGeneration, HashPolicy, Identifier, SourceUrl,
+    BuildableSource, DirectorySourceUrl, DistHashPolicy, Identifier, SourceUrl,
 };
 use uv_fs::Simplified;
 use uv_normalize::{ExtraName, PackageName};
@@ -212,13 +212,11 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
                     path.user_display()
                 ));
             }
-            HashVerification::IfPresent(_) => {
-                HashPolicy::Generate(self.hasher.generation().unwrap_or(HashGeneration::All))
-            }
+            HashVerification::IfPresent(_) => DistHashPolicy::Include,
             HashVerification::None => self
                 .hasher
-                .generation()
-                .map_or(HashPolicy::None, HashPolicy::Generate),
+                .inclusion()
+                .map_or(DistHashPolicy::None, |_| DistHashPolicy::Include),
         };
 
         // Fetch the metadata for the distribution.

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -7,21 +7,21 @@ use rustc_hash::FxHashMap;
 
 use uv_configuration::HashCheckingMode;
 use uv_distribution_types::{
-    DistributionMetadata, HashGeneration, HashPolicy, Name, Requirement, RequirementSource,
-    Resolution, UnresolvedRequirement, VersionId,
+    DistHashPolicy, DistributionMetadata, HashInclusion, MissingRegistryHash, Name, Requirement,
+    RequirementSource, Resolution, UnresolvedRequirement, VersionId,
 };
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, HashError, ResolverMarkerEnvironment};
 use uv_redacted::DisplaySafeUrl;
 
-/// Hash generation and verification policies for a resolution.
+/// Hash inclusion and verification policies for a resolution.
 ///
-/// Verification takes precedence for distributions with trusted hashes. The generation policy
+/// Verification takes precedence for distributions with trusted hashes. The inclusion policy
 /// applies to the remaining distributions.
 #[derive(Debug, Default, Clone)]
 pub struct HashStrategy {
-    generation: Option<HashGeneration>,
+    inclusion: Option<HashInclusion>,
     verification: HashVerification,
 }
 
@@ -38,10 +38,10 @@ pub enum HashVerification {
 }
 
 impl HashStrategy {
-    /// Generate hashes according to the given policy.
-    pub fn generate(generation: HashGeneration) -> Self {
+    /// Include hashes in the resolution according to the given policy.
+    pub fn include(inclusion: HashInclusion) -> Self {
         Self {
-            generation: Some(generation),
+            inclusion: Some(inclusion),
             ..Self::default()
         }
     }
@@ -56,16 +56,16 @@ impl HashStrategy {
         Self::default().with_verification(HashVerification::Required(hashes))
     }
 
-    /// Set verification independently of hash generation.
+    /// Set verification independently of hash inclusion.
     #[must_use]
     fn with_verification(mut self, verification: HashVerification) -> Self {
         self.verification = verification;
         self
     }
 
-    /// Return the hash generation policy.
-    pub fn generation(&self) -> Option<HashGeneration> {
-        self.generation
+    /// Return the hash inclusion policy.
+    pub fn inclusion(&self) -> Option<HashInclusion> {
+        self.inclusion
     }
 
     /// Return the hash verification policy.
@@ -73,40 +73,60 @@ impl HashStrategy {
         &self.verification
     }
 
-    /// Return the [`HashPolicy`] for the given distribution.
-    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> HashPolicy<'_> {
+    /// Return the [`DistHashPolicy`] for the given distribution.
+    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> DistHashPolicy<'_> {
         self.get_id(|| distribution.version_id())
     }
 
-    /// Return the [`HashPolicy`] for the given registry-based package.
-    pub fn get_package(&self, name: &PackageName, version: &Version) -> HashPolicy<'_> {
+    /// Return the [`DistHashPolicy`] for the given registry-based package.
+    pub fn get_package(&self, name: &PackageName, version: &Version) -> DistHashPolicy<'_> {
         self.get_id(|| VersionId::from_registry(name.clone(), version.clone()))
     }
 
-    /// Return the [`HashPolicy`] for the given direct URL package.
+    /// Return the [`DistHashPolicy`] for the given direct URL package.
     ///
     /// A direct URL identifies a single concrete artifact, so every provided digest must match.
-    pub fn get_url(&self, url: &DisplaySafeUrl) -> HashPolicy<'_> {
+    pub fn get_url(&self, url: &DisplaySafeUrl) -> DistHashPolicy<'_> {
         self.get_id(|| VersionId::from_url(url))
     }
 
-    /// Construct an identity only when verification requires a lookup.
-    fn get_id(&self, id: impl FnOnce() -> VersionId) -> HashPolicy<'_> {
+    /// Construct an identity only when verification or inclusion requires a lookup.
+    fn get_id(&self, id: impl FnOnce() -> VersionId) -> DistHashPolicy<'_> {
         match &self.verification {
             HashVerification::IfPresent(hashes) => {
                 let id = id();
                 if let Some(hashes) = hashes.get(&id) {
-                    return hash_policy(&id, hashes);
+                    return dist_hash_policy(&id, hashes);
                 }
+                return self.inclusion_policy(|| id);
             }
             HashVerification::Required(hashes) => {
                 let id = id();
-                return hash_policy(&id, hashes.get(&id).map(Vec::as_slice).unwrap_or_default());
+                return dist_hash_policy(
+                    &id,
+                    hashes.get(&id).map(Vec::as_slice).unwrap_or_default(),
+                );
             }
             HashVerification::None => {}
         }
-        self.generation
-            .map_or(HashPolicy::None, HashPolicy::Generate)
+        self.inclusion_policy(id)
+    }
+
+    fn inclusion_policy(&self, id: impl FnOnce() -> VersionId) -> DistHashPolicy<'static> {
+        match self.inclusion {
+            None => DistHashPolicy::None,
+            Some(inclusion) => match inclusion.missing_registry() {
+                MissingRegistryHash::Compute => DistHashPolicy::Include,
+                MissingRegistryHash::Skip => match id() {
+                    VersionId::NameVersion { .. } => DistHashPolicy::None,
+                    VersionId::ArchiveUrl { .. }
+                    | VersionId::Git { .. }
+                    | VersionId::Path { .. }
+                    | VersionId::Directory { .. }
+                    | VersionId::Unknown { .. } => DistHashPolicy::Include,
+                },
+            },
+        }
     }
 
     /// Returns `true` if the given registry-based package is allowed.
@@ -421,14 +441,14 @@ impl HashStrategy {
     }
 }
 
-fn hash_policy<'a>(id: &VersionId, digests: &'a [HashDigest]) -> HashPolicy<'a> {
+fn dist_hash_policy<'a>(id: &VersionId, digests: &'a [HashDigest]) -> DistHashPolicy<'a> {
     match id {
-        VersionId::NameVersion { .. } => HashPolicy::Any(digests),
+        VersionId::NameVersion { .. } => DistHashPolicy::Any(digests),
         VersionId::ArchiveUrl { .. }
         | VersionId::Git { .. }
         | VersionId::Path { .. }
         | VersionId::Directory { .. }
-        | VersionId::Unknown { .. } => HashPolicy::All(digests),
+        | VersionId::Unknown { .. } => DistHashPolicy::All(digests),
     }
 }
 
@@ -521,8 +541,8 @@ mod tests {
     use uv_configuration::HashCheckingMode;
     use uv_distribution_filename::DistExtension;
     use uv_distribution_types::{
-        HashGeneration, HashPolicy, Requirement, RequirementSource, UnresolvedRequirement,
-        VersionId,
+        DistHashPolicy, HashInclusion, MissingRegistryHash, Requirement, RequirementSource,
+        UnresolvedRequirement, VersionId,
     };
     use uv_normalize::PackageName;
     use uv_pep440::Version;
@@ -585,12 +605,15 @@ mod tests {
             let RequirementSource::Url { url, .. } = &requirement.source else {
                 panic!("expected direct URL requirement");
             };
-            assert_eq!(hasher.get_url(url), HashPolicy::All(expected.as_slice()));
+            assert_eq!(
+                hasher.get_url(url),
+                DistHashPolicy::All(expected.as_slice())
+            );
         }
     }
 
     #[test]
-    fn generate_and_verify_validates_known_hashes_and_generates_unknown_hashes()
+    fn include_and_verify_validates_known_hashes_and_includes_unknown_hashes()
     -> Result<(), Box<dyn std::error::Error>> {
         let url: DisplaySafeUrl = "https://example.com/anyio-4.0.0.tar.gz".parse()?;
         let unknown_url: DisplaySafeUrl = "https://example.com/anyio-4.1.0.tar.gz".parse()?;
@@ -607,39 +630,51 @@ mod tests {
                 vec![digest.clone()],
             ),
         ]);
-        let strategy = HashStrategy::generate(HashGeneration::All)
+        let strategy = HashStrategy::include(HashInclusion::new(MissingRegistryHash::Compute))
             .with_verification(HashVerification::IfPresent(Arc::new(hashes)));
 
         assert_eq!(
             strategy.get_url(&url),
-            HashPolicy::All(slice::from_ref(&digest))
+            DistHashPolicy::All(slice::from_ref(&digest))
         );
-        assert_eq!(
-            strategy.get_url(&unknown_url),
-            HashPolicy::Generate(HashGeneration::All)
-        );
+        assert_eq!(strategy.get_url(&unknown_url), DistHashPolicy::Include);
         assert_eq!(
             strategy.get_package(&name, &version),
-            HashPolicy::Any(slice::from_ref(&digest))
+            DistHashPolicy::Any(slice::from_ref(&digest))
         );
         assert_eq!(
             strategy.get_package(&name, &unknown_version),
-            HashPolicy::Generate(HashGeneration::All)
+            DistHashPolicy::Include
         );
 
         Ok(())
     }
 
     #[test]
-    fn required_hashes_take_precedence_over_generation() -> Result<(), Box<dyn std::error::Error>> {
+    fn skip_missing_registry_hashes() -> Result<(), Box<dyn std::error::Error>> {
         let url: DisplaySafeUrl = "https://example.com/anyio-4.0.0.tar.gz".parse()?;
         let name: PackageName = "anyio".parse()?;
         let version: Version = "4.0.0".parse()?;
-        let strategy = HashStrategy::generate(HashGeneration::All)
+        let strategy = HashStrategy::include(HashInclusion::new(MissingRegistryHash::Skip));
+
+        assert_eq!(strategy.get_url(&url), DistHashPolicy::Include);
+        assert_eq!(strategy.get_package(&name, &version), DistHashPolicy::None);
+        Ok(())
+    }
+
+    #[test]
+    fn required_hashes_take_precedence_over_inclusion() -> Result<(), Box<dyn std::error::Error>> {
+        let url: DisplaySafeUrl = "https://example.com/anyio-4.0.0.tar.gz".parse()?;
+        let name: PackageName = "anyio".parse()?;
+        let version: Version = "4.0.0".parse()?;
+        let strategy = HashStrategy::include(HashInclusion::new(MissingRegistryHash::Compute))
             .with_verification(HashVerification::Required(Arc::default()));
 
-        assert_eq!(strategy.get_url(&url), HashPolicy::All(&[]));
-        assert_eq!(strategy.get_package(&name, &version), HashPolicy::Any(&[]));
+        assert_eq!(strategy.get_url(&url), DistHashPolicy::All(&[]));
+        assert_eq!(
+            strategy.get_package(&name, &version),
+            DistHashPolicy::Any(&[])
+        );
         assert!(!strategy.allows_url(&url));
         assert!(!strategy.allows_package(&name, &version));
         Ok(())

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -21,9 +21,9 @@ use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::LoweredExtraBuildDependencies;
 use uv_distribution_types::{
-    ConfigSettings, DependencyMetadata, ExtraBuildVariables, HashGeneration, Index, IndexLocations,
-    NameRequirementSpecification, Origin, PackageConfigSettings, Requirement, RequiresPython,
-    Verbatim,
+    ConfigSettings, DependencyMetadata, ExtraBuildVariables, HashInclusion, Index, IndexLocations,
+    MissingRegistryHash, NameRequirementSpecification, Origin, PackageConfigSettings, Requirement,
+    RequiresPython, Verbatim,
 };
 use uv_fs::{CWD, Simplified};
 use uv_git::ResolvedRepositoryReference;
@@ -411,10 +411,10 @@ pub(crate) async fn pip_compile(
         (Some(tags), ResolverEnvironment::specific(marker_env))
     };
 
-    // Generate, but don't enforce hashes for the requirements. PEP 751 _requires_ a hash to be
+    // Include, but don't enforce hashes for the requirements. PEP 751 _requires_ a hash to be
     // present, but otherwise, we omit them by default.
     let hasher = if generate_hashes || matches!(format, PipCompileFormat::PylockToml) {
-        HashStrategy::generate(HashGeneration::All)
+        HashStrategy::include(HashInclusion::new(MissingRegistryHash::Compute))
     } else {
         HashStrategy::default()
     };

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -18,8 +18,8 @@ use uv_configuration::{
 use uv_dispatch::BuildDispatch;
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies};
 use uv_distribution_types::{
-    DependencyMetadata, HashGeneration, Index, IndexLocations, NameRequirementSpecification,
-    Requirement, RequiresPython, UnresolvedRequirementSpecification,
+    DependencyMetadata, HashInclusion, Index, IndexLocations, MissingRegistryHash,
+    NameRequirementSpecification, Requirement, RequiresPython, UnresolvedRequirementSpecification,
 };
 use uv_git::ResolvedRepositoryReference;
 use uv_git_types::GitOid;
@@ -835,7 +835,7 @@ async fn do_lock(
         .build_options(build_options.clone())
         .artifact_environments(artifact_environments.clone())
         .build();
-    let hasher = HashStrategy::generate(HashGeneration::Url);
+    let hasher = HashStrategy::include(HashInclusion::new(MissingRegistryHash::Skip));
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them
     // optional on the downstream APIs.

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -20,9 +20,9 @@ use uv_configuration::{
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies, LoweredRequirement};
 use uv_distribution_types::{
-    ExtraBuildRequirement, ExtraBuildRequires, HashGeneration, Index, IndexCredentialsError,
-    IndexUrlError, Requirement, RequiresPython, Resolution, UnresolvedRequirement,
-    UnresolvedRequirementSpecification,
+    ExtraBuildRequirement, ExtraBuildRequires, HashInclusion, Index, IndexCredentialsError,
+    IndexUrlError, MissingRegistryHash, Requirement, RequiresPython, Resolution,
+    UnresolvedRequirement, UnresolvedRequirementSpecification,
 };
 use uv_fs::{CWD, LockedFile, LockedFileError, LockedFileMode, Simplified, verbatim_path};
 use uv_git::ResolvedRepositoryReference;
@@ -2657,7 +2657,9 @@ pub(crate) async fn resolve_environment(
     let groups = BTreeMap::new();
     let hasher = match resolution_scope {
         EnvironmentResolution::Specific => HashStrategy::default(),
-        EnvironmentResolution::Universal => HashStrategy::generate(HashGeneration::Url),
+        EnvironmentResolution::Universal => {
+            HashStrategy::include(HashInclusion::new(MissingRegistryHash::Skip))
+        }
     };
     let build_hasher = HashStrategy::default();
 

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -22,8 +22,8 @@ use uv_distribution::{
     DistributionDatabase, LoweredExtraBuildDependencies, StaticMetadataDatabase,
 };
 use uv_distribution_types::{
-    DependencyMetadata, HashGeneration, Index, IndexLocations, InstalledDist, Name, Requirement,
-    RequiresPython, Resolution, UnresolvedRequirement,
+    DependencyMetadata, HashInclusion, Index, IndexLocations, InstalledDist, MissingRegistryHash,
+    Name, Requirement, RequiresPython, Resolution, UnresolvedRequirement,
 };
 use uv_errors::{ErrorWithHints, Hint, Hints};
 #[cfg(unix)]
@@ -463,7 +463,7 @@ impl ToolLock {
             .index_strategy(*index_strategy)
             .build_options(build_options.clone())
             .build();
-        let hasher = HashStrategy::generate(HashGeneration::Url);
+        let hasher = HashStrategy::include(HashInclusion::new(MissingRegistryHash::Skip));
         let build_hasher = HashStrategy::default();
 
         let flat_index = {


### PR DESCRIPTION
`HashStrategy` combines hash inclusion with verification, then normalizes them into a policy for each distribution. The existing generation policy conflates the requirement to include a hash with the fallback mechanism used to obtain one.

Represent inclusion explicitly: `DistHashPolicy::Include` means that a concrete distribution should supply a hash, while `HashInclusion` only configures whether a missing registry hash is skipped or computed. Keep the verification precedence introduced in #21247 unchanged, so trusted hashes satisfy inclusion and required hashes cannot fall back to unverified inclusion. This makes the boundary explicit for #21279, which can reuse declared URL hashes instead of computing them.