### PR TITLE
Fix release binary workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,8 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+    permissions:
+      "contents": "read"
 
   build-docker:
     needs:


### PR DESCRIPTION
The release workflow currently fails validation before any jobs start because `release.yml` withholds `contents` access from `build-release-binaries`, while the reusable workflow now requires `contents: read`. Grant the call read-only repository access so GitHub can instantiate the reusable workflow without broadening permissions for the rest of the release.