### PR TITLE
docs: clarify tool.uv.pip index intereaction with global indexes

### DIFF
--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -371,3 +371,7 @@ follow the same prioritization rules:
 In effect, `--index-url` and `--extra-index-url` can be thought of as unnamed `[[tool.uv.index]]`
 entries, with `default = true` enabled for the former. In that context, `--index-url` maps to
 `--default-index`, and `--extra-index-url` maps to `--index`.
+
+!!! note "Interaction with `tool.uv.pip` configuration"
+
+    Configuring `index-url` or `extra-index-url` inside the `[tool.uv.pip]` section of `pyproject.toml` (or via `uv pip` CLI flags) does not remove or override globally defined `[[tool.uv.index]]` entries. Global indexes defined in `pyproject.toml` remain active during `uv pip` operations.


### PR DESCRIPTION
## Summary

Clarifies in `docs/concepts/indexes.md` that configuring `index-url` or `extra-index-url` inside the `[tool.uv.pip]` table (or via CLI flags) does not disable or override global `[[tool.uv.index]]` definitions, ensuring users understand both index sources remain active during `uv pip` operations.

Closes #18547

## Test Plan

Inspected the markdown syntax and formatting changes in `docs/concepts/indexes.md` to ensure correct rendering of the  note.