### PR TITLE
Warm the interpreter cache when syncing workspace metadata

### DIFF
--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -32,6 +32,7 @@ use uv_static::EnvVars;
 use crate::implementation::LenientImplementationName;
 use crate::managed::ManagedPythonInstallations;
 use crate::pointer_size::PointerSize;
+use crate::virtualenv::virtualenv_python_executable;
 use crate::{
     Prefix, PyVenvConfiguration, PythonInstallationKey, PythonVariant, PythonVersion, Target,
     VersionRequest, VirtualEnvironment,
@@ -106,7 +107,7 @@ impl Interpreter {
     pub fn clear_cache(executable: impl AsRef<Path>, cache: &Cache) -> Result<(), Error> {
         let absolute = std::path::absolute(executable.as_ref())?;
         let canonical = canonicalize_executable(&absolute)?;
-        let cache_entry = InterpreterInfo::cache_entry(&absolute, &canonical, cache);
+        let cache_entry = InterpreterInfo::cache_entry(&absolute, &canonical, cache)?;
 
         match fs::remove_file(cache_entry.path()) {
             Ok(()) => Ok(()),
@@ -115,9 +116,54 @@ impl Interpreter {
         }
     }
 
+    /// Cache the metadata for this environment's Python without querying it.
+    ///
+    /// Uses the executable selected by virtual environment discovery, which may be a different
+    /// alias from the executable used to create the environment.
+    pub fn cache_virtualenv(&self, cache: &Cache) -> Result<(), Error> {
+        // Launcher overrides can change `sys.executable` and `sys.prefix`, while
+        // `sys._base_executable` isn't affected. Instead of trying to stitch together this edge
+        // case, query the actual metadata on the next run.
+        if env::var_os(EnvVars::PYTHONEXECUTABLE).is_some()
+            || env::var_os(EnvVars::PYVENV_LAUNCHER).is_some()
+        {
+            return Ok(());
+        }
+
+        let info = InterpreterInfo::from_virtualenv(self)?;
+        info.cache(cache)
+    }
+
     /// Return a new [`Interpreter`] with the given virtual environment root.
     #[must_use]
     pub fn with_virtualenv(self, virtualenv: VirtualEnvironment) -> Self {
+        // Match `site.getsitepackages()` for the new environment instead of retaining the
+        // parent interpreter's site-packages paths.
+        // Note: This is not `sys.path`, but a distinct list.
+        let mut site_packages = if self.markers.os_name() == "nt" {
+            vec![virtualenv.root.clone(), virtualenv.scheme.purelib.clone()]
+        } else if virtualenv.scheme.platlib == virtualenv.scheme.purelib {
+            vec![virtualenv.scheme.purelib.clone()]
+        } else {
+            vec![
+                virtualenv.scheme.platlib.clone(),
+                virtualenv.scheme.purelib.clone(),
+            ]
+        };
+        if self.markers.os_name() != "nt" {
+            // Some distributions add import paths that are not part of the installation scheme,
+            // e.g., Debian's `dist-packages`. Build those paths as relative to the new environment,
+            // excluding paths outside the parent's prefix (such as an existing venv's system site
+            // packages).
+            for path in &self.site_packages {
+                if let Ok(relative) = path.strip_prefix(&self.sys_prefix) {
+                    let path = virtualenv.root.join(relative);
+                    if !site_packages.contains(&path) {
+                        site_packages.push(path);
+                    }
+                }
+            }
+        }
         Self {
             scheme: virtualenv.scheme,
             sys_base_executable: Some(virtualenv.base_executable),
@@ -125,7 +171,7 @@ impl Interpreter {
             sys_prefix: virtualenv.root,
             target: None,
             prefix: None,
-            site_packages: vec![],
+            site_packages,
             ..self
         }
     }
@@ -972,6 +1018,57 @@ struct InterpreterInfo {
 }
 
 impl InterpreterInfo {
+    /// Build metadata for virtual environment discovery without querying Python or using the cache.
+    fn from_virtualenv(interpreter: &Interpreter) -> Result<Self, Error> {
+        let executable = virtualenv_python_executable(interpreter.sys_prefix());
+        let mut scheme = interpreter.scheme.clone();
+        // Joining the empty relative data path adds a trailing separator that sysconfig omits.
+        scheme.data = scheme.data.components().collect();
+        Ok(Self {
+            platform: interpreter.platform.clone(),
+            markers: (*interpreter.markers).clone(),
+            scheme,
+            virtualenv: interpreter.virtualenv.clone(),
+            manylinux_compatible: interpreter.manylinux_compatible,
+            sys_prefix: interpreter.sys_prefix.clone(),
+            // These fields are unused by `Interpreter`, but retained in the cache format.
+            sys_base_exec_prefix: PathBuf::new(),
+            sys_path: Vec::new(),
+            sys_base_prefix: interpreter.sys_base_prefix.clone(),
+            sys_base_executable: interpreter.sys_base_executable.clone(),
+            sys_executable: std::path::absolute(executable)?,
+            site_packages: interpreter.site_packages.clone(),
+            stdlib: interpreter.stdlib.clone(),
+            extension_suffixes: interpreter.extension_suffixes.clone(),
+            standalone: interpreter.standalone,
+            pointer_size: interpreter.pointer_size,
+            gil_disabled: interpreter.gil_disabled,
+            debug_enabled: interpreter.debug_enabled,
+        })
+    }
+
+    /// Cache already prepared metadata for this executable.
+    fn cache(&self, cache: &Cache) -> Result<(), Error> {
+        let absolute = std::path::absolute(&self.sys_executable)?;
+        let canonical = canonicalize_executable(&absolute)?;
+        let cache_entry = Self::cache_entry(&absolute, &canonical, cache)?;
+        let modified = Timestamp::from_path(&canonical)?;
+        self.write_cache(&cache_entry, modified)
+    }
+
+    /// Write interpreter metadata using the same format for queried and inferred interpreters.
+    fn write_cache(&self, cache_entry: &CacheEntry, modified: Timestamp) -> Result<(), Error> {
+        fs::create_dir_all(cache_entry.dir())?;
+        write_atomic_sync(
+            cache_entry.path(),
+            rmp_serde::to_vec(&CachedByTimestamp {
+                timestamp: modified,
+                data: self,
+            })?,
+        )?;
+        Ok(())
+    }
+
     /// Return the resolved [`InterpreterInfo`] for the given Python executable.
     fn query(interpreter: &Path, cache: &Cache) -> Result<Self, Error> {
         let tempdir = tempfile::tempdir_in(cache.root())?;
@@ -1093,7 +1190,11 @@ impl InterpreterInfo {
                 err,
                 path: interpreter.to_path_buf(),
             }),
-            InterpreterInfoResult::Success(data) => Ok(*data),
+            InterpreterInfoResult::Success(mut data) => {
+                // CPython can report a relative executable when a launcher override is relative.
+                data.sys_executable = std::path::absolute(&data.sys_executable)?;
+                Ok(*data)
+            }
         }
     }
 
@@ -1132,11 +1233,24 @@ impl InterpreterInfo {
     }
 
     /// Return the cache entry for an interpreter's absolute and canonical executable paths.
-    fn cache_entry(absolute: &Path, canonical: &Path, cache: &Cache) -> CacheEntry {
+    fn cache_entry(absolute: &Path, canonical: &Path, cache: &Cache) -> Result<CacheEntry, Error> {
         let python_executable = env::var_os(EnvVars::PYTHONEXECUTABLE).map(PathBuf::from);
         let pyvenv_launcher = env::var_os(EnvVars::PYVENV_LAUNCHER).map(PathBuf::from);
+        let key = cache_digest(&(absolute, canonical, &python_executable, &pyvenv_launcher));
+        // Keep the original values: relative and absolute overrides can behave differently in
+        // CPython. Relative overrides also depend on the working directory, including an empty
+        // `__PYVENV_LAUNCHER__` consumed by `site.py` on older macOS Pythons.
+        let key = if python_executable
+            .iter()
+            .chain(pyvenv_launcher.iter())
+            .any(|path| path.is_relative())
+        {
+            cache_digest(&(key, env::current_dir()?))
+        } else {
+            key
+        };
 
-        cache.entry(
+        let entry = cache.entry(
             CacheBucket::Interpreter,
             // Shard interpreter metadata by host architecture, operating system, and version, to
             // invalidate the cache (e.g.) on OS upgrades.
@@ -1159,11 +1273,9 @@ impl InterpreterInfo {
             //
             // Launcher overrides can also change the reported executable and virtual environment
             // without changing either executable path.
-            format!(
-                "{}.msgpack",
-                cache_digest(&(absolute, canonical, &python_executable, &pyvenv_launcher))
-            ),
-        )
+            format!("{key}.msgpack"),
+        );
+        Ok(entry)
     }
 
     /// A wrapper around [`markers::query_interpreter_info`] to cache the computed markers.
@@ -1199,7 +1311,7 @@ impl InterpreterInfo {
         };
 
         let canonical = canonicalize_executable(&absolute).map_err(handle_io_error)?;
-        let cache_entry = Self::cache_entry(&absolute, &canonical, cache);
+        let cache_entry = Self::cache_entry(&absolute, &canonical, cache)?;
 
         // We check the timestamp of the canonicalized executable to check if an underlying
         // interpreter has been modified.
@@ -1248,14 +1360,7 @@ impl InterpreterInfo {
         // If `executable` is a pyenv shim, a bash script that redirects to the activated
         // python executable at another path, we're not allowed to cache the interpreter info.
         if is_same_file(executable, &info.sys_executable).unwrap_or(false) {
-            fs::create_dir_all(cache_entry.dir())?;
-            write_atomic_sync(
-                cache_entry.path(),
-                rmp_serde::to_vec(&CachedByTimestamp {
-                    timestamp: modified,
-                    data: &info,
-                })?,
-            )?;
+            info.write_cache(&cache_entry, modified)?;
         }
 
         Ok(info)

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -1187,11 +1187,7 @@ impl InterpreterInfo {
                 err,
                 path: interpreter.to_path_buf(),
             }),
-            InterpreterInfoResult::Success(mut data) => {
-                // CPython can report a relative executable when a launcher override is relative.
-                data.sys_executable = std::path::absolute(&data.sys_executable)?;
-                Ok(*data)
-            }
+            InterpreterInfoResult::Success(data) => Ok(*data),
         }
     }
 

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -107,7 +107,7 @@ impl Interpreter {
     pub fn clear_cache(executable: impl AsRef<Path>, cache: &Cache) -> Result<(), Error> {
         let absolute = std::path::absolute(executable.as_ref())?;
         let canonical = canonicalize_executable(&absolute)?;
-        let cache_entry = InterpreterInfo::cache_entry(&absolute, &canonical, cache)?;
+        let cache_entry = InterpreterInfo::cache_entry(&absolute, &canonical, cache);
 
         match fs::remove_file(cache_entry.path()) {
             Ok(()) => Ok(()),
@@ -1051,7 +1051,7 @@ impl InterpreterInfo {
     fn cache(&self, cache: &Cache) -> Result<(), Error> {
         let absolute = std::path::absolute(&self.sys_executable)?;
         let canonical = canonicalize_executable(&absolute)?;
-        let cache_entry = Self::cache_entry(&absolute, &canonical, cache)?;
+        let cache_entry = Self::cache_entry(&absolute, &canonical, cache);
         let modified = Timestamp::from_path(&canonical)?;
         self.write_cache(&cache_entry, modified)
     }
@@ -1233,24 +1233,21 @@ impl InterpreterInfo {
     }
 
     /// Return the cache entry for an interpreter's absolute and canonical executable paths.
-    fn cache_entry(absolute: &Path, canonical: &Path, cache: &Cache) -> Result<CacheEntry, Error> {
+    fn cache_entry(absolute: &Path, canonical: &Path, cache: &Cache) -> CacheEntry {
         let python_executable = env::var_os(EnvVars::PYTHONEXECUTABLE).map(PathBuf::from);
         let pyvenv_launcher = env::var_os(EnvVars::PYVENV_LAUNCHER).map(PathBuf::from);
-        let key = cache_digest(&(absolute, canonical, &python_executable, &pyvenv_launcher));
-        // Keep the original values: relative and absolute overrides can behave differently in
-        // CPython. Relative overrides also depend on the working directory, including an empty
-        // `__PYVENV_LAUNCHER__` consumed by `site.py` on older macOS Pythons.
-        let key = if python_executable
-            .iter()
-            .chain(pyvenv_launcher.iter())
-            .any(|path| path.is_relative())
-        {
-            cache_digest(&(key, env::current_dir()?))
-        } else {
-            key
-        };
-
-        let entry = cache.entry(
+        // We use the absolute path for the cache entry to avoid cache collisions for relative
+        // paths. But we don't want to query the executable with symbolic links resolved because
+        // that can change reported values, e.g., `sys.executable`. We include the canonical
+        // path in the cache entry as well, otherwise we can have cache collisions if an
+        // absolute path refers to different interpreters with matching ctimes, e.g., if you
+        // have a `.venv/bin/python` pointing to both Python 3.12 and Python 3.13 that were
+        // modified at the same time.
+        //
+        // Launcher overrides can also change the reported executable and virtual environment
+        // without changing either executable path.
+        let file_stem = cache_digest(&(absolute, canonical, &python_executable, &pyvenv_launcher));
+        cache.entry(
             CacheBucket::Interpreter,
             // Shard interpreter metadata by host architecture, operating system, and version, to
             // invalidate the cache (e.g.) on OS upgrades.
@@ -1263,19 +1260,8 @@ impl InterpreterInfo {
                     .map(|os_release| os_release.to_string())
                     .unwrap_or_default(),
             )),
-            // We use the absolute path for the cache entry to avoid cache collisions for relative
-            // paths. But we don't want to query the executable with symbolic links resolved because
-            // that can change reported values, e.g., `sys.executable`. We include the canonical
-            // path in the cache entry as well, otherwise we can have cache collisions if an
-            // absolute path refers to different interpreters with matching ctimes, e.g., if you
-            // have a `.venv/bin/python` pointing to both Python 3.12 and Python 3.13 that were
-            // modified at the same time.
-            //
-            // Launcher overrides can also change the reported executable and virtual environment
-            // without changing either executable path.
-            format!("{key}.msgpack"),
-        );
-        Ok(entry)
+            format!("{file_stem}.msgpack"),
+        )
     }
 
     /// A wrapper around [`markers::query_interpreter_info`] to cache the computed markers.
@@ -1311,7 +1297,7 @@ impl InterpreterInfo {
         };
 
         let canonical = canonicalize_executable(&absolute).map_err(handle_io_error)?;
-        let cache_entry = Self::cache_entry(&absolute, &canonical, cache)?;
+        let cache_entry = Self::cache_entry(&absolute, &canonical, cache);
 
         // We check the timestamp of the canonicalized executable to check if an underlying
         // interpreter has been modified.

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -32,7 +32,6 @@ use uv_static::EnvVars;
 use crate::implementation::LenientImplementationName;
 use crate::managed::ManagedPythonInstallations;
 use crate::pointer_size::PointerSize;
-use crate::virtualenv::virtualenv_python_executable;
 use crate::{
     Prefix, PyVenvConfiguration, PythonInstallationKey, PythonVariant, PythonVersion, Target,
     VersionRequest, VirtualEnvironment,
@@ -118,8 +117,7 @@ impl Interpreter {
 
     /// Cache the metadata for this environment's Python without querying it.
     ///
-    /// Uses the executable selected by virtual environment discovery, which may be a different
-    /// alias from the executable used to create the environment.
+    /// The executable created for this environment is also used by virtual environment discovery.
     pub fn cache_virtualenv(&self, cache: &Cache) -> Result<(), Error> {
         // Launcher overrides can change `sys.executable` and `sys.prefix`, while
         // `sys._base_executable` isn't affected. Instead of trying to stitch together this edge
@@ -1020,7 +1018,6 @@ struct InterpreterInfo {
 impl InterpreterInfo {
     /// Build metadata for virtual environment discovery without querying Python or using the cache.
     fn from_virtualenv(interpreter: &Interpreter) -> Result<Self, Error> {
-        let executable = virtualenv_python_executable(interpreter.sys_prefix());
         let mut scheme = interpreter.scheme.clone();
         // Joining the empty relative data path adds a trailing separator that sysconfig omits.
         scheme.data = scheme.data.components().collect();
@@ -1036,7 +1033,7 @@ impl InterpreterInfo {
             sys_path: Vec::new(),
             sys_base_prefix: interpreter.sys_base_prefix.clone(),
             sys_base_executable: interpreter.sys_base_executable.clone(),
-            sys_executable: std::path::absolute(executable)?,
+            sys_executable: std::path::absolute(interpreter.sys_executable())?,
             site_packages: interpreter.site_packages.clone(),
             stdlib: interpreter.stdlib.clone(),
             extension_suffixes: interpreter.extension_suffixes.clone(),

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -245,6 +245,11 @@ pub(crate) async fn metadata(
                 )
                 .await
                 .context("Failed to collect module owners")?;
+                if sync.is_some() {
+                    // Prime the interpreter cache so we don't have to query on the next uv
+                    // invocation.
+                    environment.interpreter().cache_virtualenv(cache)?;
+                }
                 export = export
                     .with_environment(&environment)
                     .with_module_owners(module_owners);

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -174,52 +174,73 @@ pub(crate) async fn metadata(
                 },
             };
             let mut export = metadata_for_target(install_target)?;
-            let environment = if sync.is_some() {
-                Some(match target {
-                    LockTarget::Workspace(workspace) => ProjectEnvironment::get_or_init(
-                        workspace,
-                        &groups,
-                        python.as_deref().map(PythonRequest::parse),
-                        &install_mirrors,
-                        &client_builder,
-                        python_preference,
-                        python_downloads,
-                        false,
-                        config_discovery,
-                        active,
-                        cache,
-                        DryRun::Disabled,
-                        LinkErrorReporting::User,
-                        printer,
-                    )
-                    .await?
-                    .into_environment()?,
-                    LockTarget::Script(script) => ScriptEnvironment::get_or_init(
-                        script.into(),
-                        python.as_deref().map(PythonRequest::parse),
-                        &client_builder,
-                        python_preference,
-                        python_downloads,
-                        &install_mirrors,
-                        false,
-                        config_discovery,
-                        active,
-                        cache,
-                        DryRun::Disabled,
-                        printer,
-                    )
-                    .await?
-                    .into_environment()?,
-                })
+            let (environment, environment_created) = if sync.is_some() {
+                let (environment, environment_created) = match target {
+                    LockTarget::Workspace(workspace) => {
+                        let environment = ProjectEnvironment::get_or_init(
+                            workspace,
+                            &groups,
+                            python.as_deref().map(PythonRequest::parse),
+                            &install_mirrors,
+                            &client_builder,
+                            python_preference,
+                            python_downloads,
+                            false,
+                            config_discovery,
+                            active,
+                            cache,
+                            DryRun::Disabled,
+                            LinkErrorReporting::User,
+                            printer,
+                        )
+                        .await?;
+                        let environment_created = match environment {
+                            ProjectEnvironment::Existing(_) => false,
+                            ProjectEnvironment::Replaced(_) | ProjectEnvironment::Created(_) => {
+                                true
+                            }
+                            ProjectEnvironment::WouldReplace(_, _, _)
+                            | ProjectEnvironment::WouldCreate(_, _, _) => false,
+                        };
+                        (environment.into_environment()?, environment_created)
+                    }
+                    LockTarget::Script(script) => {
+                        let environment = ScriptEnvironment::get_or_init(
+                            script.into(),
+                            python.as_deref().map(PythonRequest::parse),
+                            &client_builder,
+                            python_preference,
+                            python_downloads,
+                            &install_mirrors,
+                            false,
+                            config_discovery,
+                            active,
+                            cache,
+                            DryRun::Disabled,
+                            printer,
+                        )
+                        .await?;
+                        let environment_created = match environment {
+                            ScriptEnvironment::Existing(_) => false,
+                            ScriptEnvironment::Replaced(_) | ScriptEnvironment::Created(_) => true,
+                            ScriptEnvironment::WouldReplace(_, _, _)
+                            | ScriptEnvironment::WouldCreate(_, _, _) => false,
+                        };
+                        (environment.into_environment()?, environment_created)
+                    }
+                };
+                (Some(environment), environment_created)
             } else {
-                match target {
+                let environment = match target {
                     LockTarget::Workspace(workspace) => {
                         ProjectInterpreter::discover_existing(workspace, active, cache)?
                     }
                     LockTarget::Script(script) => {
                         ScriptInterpreter::discover_existing(script.into(), active, cache)
                     }
-                }
+                };
+                // The environment is always discovered, never created.
+                (environment, false)
             };
 
             if let Some(environment) = environment {
@@ -245,7 +266,7 @@ pub(crate) async fn metadata(
                 )
                 .await
                 .context("Failed to collect module owners")?;
-                if sync.is_some() {
+                if environment_created {
                     // Prime the interpreter cache so we don't have to query on the next uv
                     // invocation.
                     environment.interpreter().cache_virtualenv(cache)?;

--- a/crates/uv/tests/workspace/workspace_metadata.rs
+++ b/crates/uv/tests/workspace/workspace_metadata.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 use async_zip::base::write::ZipFileWriter;
@@ -9,8 +9,12 @@ use futures::executor::block_on;
 use indoc::{formatdoc, indoc};
 use url::Url;
 
+use uv_cache::Cache;
+use uv_python::PythonEnvironment;
 use uv_static::EnvVars;
-use uv_test::{copy_dir_ignore, uv_snapshot};
+#[cfg(target_os = "macos")]
+use uv_test::venv_bin_path;
+use uv_test::{copy_dir_ignore, site_packages_path, uv_snapshot};
 
 fn write_wheel(
     path: &Path,
@@ -456,6 +460,109 @@ fn workspace_metadata_script_includes_existing_environment() -> Result<()> {
         }
         "#);
     });
+
+    Ok(())
+}
+
+#[test]
+fn workspace_metadata_script_sync_caches_interpreter() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+    let wheel = context
+        .temp_dir
+        .child("startup_probe-0.1.0-py3-none-any.whl");
+    write_wheel(
+        wheel.path(),
+        "startup-probe",
+        "startup_probe-0.1.0",
+        &[(
+            "sitecustomize.py",
+            indoc! {r#"
+                from pathlib import Path
+
+                Path(__file__).with_name("interpreter-started").touch()
+            "#},
+        )],
+    )?;
+    let script = context.temp_dir.child("script.py");
+    script.write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["startup-probe"]
+        # [tool.uv.sources]
+        # startup-probe = { path = "startup_probe-0.1.0-py3-none-any.whl" }
+        # ///
+        "#
+    })?;
+
+    let prepared = context
+        .workspace_metadata()
+        .arg("--script")
+        .arg(script.path())
+        .arg("--sync")
+        .assert()
+        .success();
+    let metadata: serde_json::Value = serde_json::from_slice(&prepared.get_output().stdout)?;
+    let root = metadata["environment"]["root"]
+        .as_str()
+        .context("Missing environment root")?;
+    let startup_marker =
+        site_packages_path(Path::new(root), "python3.12").join("interpreter-started");
+
+    // Priming the cache must not run the newly prepared interpreter.
+    assert!(!startup_marker.exists());
+
+    // Compare all inferred interpreter metadata with a query of the actual venv Python.
+    let cache = Cache::from_path(context.cache_dir.path().to_path_buf())
+        .init_no_wait()?
+        .context("Interpreter cache is locked")?;
+    let fresh_cache = Cache::temp()?
+        .init_no_wait()?
+        .context("Fresh interpreter cache is locked")?;
+    let cached = PythonEnvironment::from_root(root, &cache)?;
+    assert!(!startup_marker.exists());
+    let queried = PythonEnvironment::from_root(root, &fresh_cache)?;
+    assert!(startup_marker.is_file());
+    assert_eq!(format!("{cached:?}"), format!("{queried:?}"));
+
+    Ok(())
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn workspace_metadata_script_sync_launcher_override() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let override_python = venv_bin_path(&context.venv).join("python3");
+    let script = context.temp_dir.child("script.py");
+    script.write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = []
+        # ///
+        "#
+    })?;
+
+    let prepared = context
+        .workspace_metadata()
+        .arg("--script")
+        .arg(script.path())
+        .arg("--sync")
+        .env(EnvVars::PYTHONEXECUTABLE, &override_python)
+        .assert()
+        .success();
+    let metadata: serde_json::Value = serde_json::from_slice(&prepared.get_output().stdout)?;
+    let root = metadata["environment"]["root"]
+        .as_str()
+        .context("Missing environment root")?;
+    assert_ne!(Path::new(root), context.venv.path());
+
+    // Inferred metadata for the script environment must not hide the launcher override.
+    uv_snapshot!(context.filters(), context.python_find()
+        .arg(root)
+        .env(EnvVars::PYTHONEXECUTABLE, &override_python), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [VENV]/bin/python3
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
`uv workspace metadata --sync` currently creates environments without caching their interpreter metadata, so the next metadata invocation still has to query Python. We can cache in the first run using the parent interpreter and inferring the rest (we know where the interpreter will be, we can infer `site.getsitepackages()`), so starting from the second run its fast.