### PR TITLE
Lift cargo-shear into our dev toolchain

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -32,7 +32,7 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.5"
-      - run: uv run --only-group=check ruff check .
+      - run: uv run --only-group check ruff check .
 
   ty:
     timeout-minutes: 10
@@ -46,7 +46,7 @@ jobs:
         with:
           version: "0.12.5"
       # `uv check` checks the entire repository; keep this scoped to the Python package.
-      - run: uv run --only-group=check ty check python/uv
+      - run: uv run --only-group check ty check python/uv
       - name: "Check scrolls"
         env:
           # TODO: Remove once ty infers Python versions from script environments instead of the root project.
@@ -188,7 +188,7 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.5"
-      - run: uv run --only-group=check cargo-shear --deny-warnings
+      - run: uv run --only-group check cargo-shear --deny-warnings
 
   typos:
     name: "check for typos"
@@ -201,4 +201,4 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.5"
-      - run: uv run --only-group=check typos
+      - run: uv run --only-group check typos

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -179,7 +179,9 @@ jobs:
   shear:
     name: "cargo shear"
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    # NOTE: `cargo shear` needs `cargo metadata`, so we don't use `ubuntu-slim` here
+    # as it doesn't include the Rust toolchain.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -179,21 +179,26 @@ jobs:
   shear:
     name: "cargo shear"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: "Install cargo shear"
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with:
-          tool: cargo-shear@1.12.4
-      - run: cargo shear --deny-warnings
-
-  typos:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.5"
+      - run: uv run --only-group=check cargo-shear --deny-warnings
+
+  typos:
+    name: "check for typos"
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.5"
+      - run: uv run --only-group=check typos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,8 @@ docker run --rm -v .:/src/ -w /src/ node:alpine npx prettier@3.9.0 --write .
 ## Linting
 
 Linting requires [shellcheck](https://github.com/koalaman/shellcheck) to be installed separately.
-Validating `pyproject.toml` against the checked-in uv schema also requires [jq](https://jqlang.org/).
+Validating `pyproject.toml` against the checked-in uv schema also requires
+[jq](https://jqlang.org/).
 
 ```shell
 # Rust

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,9 +156,8 @@ docker run --rm -v .:/src/ -w /src/ node:alpine npx prettier@3.9.0 --write .
 
 ## Linting
 
-Linting requires [shellcheck](https://github.com/koalaman/shellcheck) and
-[cargo-shear](https://github.com/Boshen/cargo-shear) to be installed separately. Validating
-`pyproject.toml` against the checked-in uv schema also requires [jq](https://jqlang.org/).
+Linting requires [shellcheck](https://github.com/koalaman/shellcheck) to be installed separately.
+Validating `pyproject.toml` against the checked-in uv schema also requires [jq](https://jqlang.org/).
 
 ```shell
 # Rust
@@ -183,7 +182,7 @@ shellcheck <script>
 uv run --only-group=check typos
 
 # Unused Rust dependencies
-cargo shear
+uv run --only-group=check cargo-shear
 ```
 
 ### Compiling for Windows from Unix

--- a/agents/hooks/post-edit-format.py.lock
+++ b/agents/hooks/post-edit-format.py.lock
@@ -7,4 +7,4 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"

--- a/agents/hooks/post-edit-format.py.lock
+++ b/agents/hooks/post-edit-format.py.lock
@@ -5,3 +5,6 @@ requires-python = ">=3.12"
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false

--- a/agents/scripts/agent-review-to-github-comments.py.lock
+++ b/agents/scripts/agent-review-to-github-comments.py.lock
@@ -7,4 +7,4 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"

--- a/agents/scripts/agent-review-to-github-comments.py.lock
+++ b/agents/scripts/agent-review-to-github-comments.py.lock
@@ -5,3 +5,6 @@ requires-python = ">=3.12"
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false

--- a/crates/uv-extract/test_vectors/dirhash.py.lock
+++ b/crates/uv-extract/test_vectors/dirhash.py.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.14"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [manifest]
 requirements = [{ name = "blake3", specifier = ">=1.0.9" }]
 

--- a/crates/uv-extract/test_vectors/dirhash.py.lock
+++ b/crates/uv-extract/test_vectors/dirhash.py.lock
@@ -7,7 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [manifest]
 requirements = [{ name = "blake3", specifier = ">=1.0.9" }]

--- a/crates/uv-python/fetch-download-metadata.py.lock
+++ b/crates/uv-python/fetch-download-metadata.py.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.12"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [manifest]
 requirements = [{ name = "httpx", specifier = "<1" }]
 

--- a/crates/uv-python/fetch-download-metadata.py.lock
+++ b/crates/uv-python/fetch-download-metadata.py.lock
@@ -7,7 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [manifest]
 requirements = [{ name = "httpx", specifier = "<1" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ cache-keys = [
 exclude-newer = "P7D"
 
 [tool.uv.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = "2026-08-26"
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [tool.uv.dependency-groups]
 docs = { requires-python = ">=3.12" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ cache-keys = [
 exclude-newer = "P7D"
 
 [tool.uv.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-26"
 
 [tool.uv.dependency-groups]
 docs = { requires-python = ">=3.12" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ release = [
   "rooster==0.1.1",
 ]
 check = [
+    "astral-dev-toolchain-cargo-shear>=1.13.4",
     "ruff>=0.16.2",
     "ty>=0.0.69",
     "typos>=1.49.0",
@@ -127,7 +128,6 @@ check = [
 
 [tool.uv]
 no-build = true
-exclude-newer = "P7D"
 cache-keys = [
     { file = "pyproject.toml" },
     { file = "Cargo.toml" },
@@ -135,6 +135,10 @@ cache-keys = [
     { file = "crates/**/*.rs" },
     { file = "crates/**/Cargo.toml" },
 ]
+exclude-newer = "P7D"
+
+[tool.uv.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
 
 [tool.uv.dependency-groups]
 docs = { requires-python = ">=3.12" }

--- a/scripts/build_uv_pgo.py.lock
+++ b/scripts/build_uv_pgo.py.lock
@@ -7,4 +7,4 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"

--- a/scripts/build_uv_pgo.py.lock
+++ b/scripts/build_uv_pgo.py.lock
@@ -5,3 +5,6 @@ requires-python = ">=3.11"
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false

--- a/scripts/bump-workspace-crate-versions.py.lock
+++ b/scripts/bump-workspace-crate-versions.py.lock
@@ -7,4 +7,4 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"

--- a/scripts/bump-workspace-crate-versions.py.lock
+++ b/scripts/bump-workspace-crate-versions.py.lock
@@ -5,3 +5,6 @@ requires-python = ">=3.13"
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false

--- a/scripts/check-trampoline-version-consistency.py.lock
+++ b/scripts/check-trampoline-version-consistency.py.lock
@@ -7,4 +7,4 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"

--- a/scripts/check-trampoline-version-consistency.py.lock
+++ b/scripts/check-trampoline-version-consistency.py.lock
@@ -5,3 +5,6 @@ requires-python = ">=3.12"
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false

--- a/scripts/create-python-mirror.py.lock
+++ b/scripts/create-python-mirror.py.lock
@@ -11,6 +11,9 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [manifest]
 requirements = [
     { name = "gitpython" },

--- a/scripts/create-python-mirror.py.lock
+++ b/scripts/create-python-mirror.py.lock
@@ -12,7 +12,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [manifest]
 requirements = [

--- a/scripts/generate-crate-readmes.py.lock
+++ b/scripts/generate-crate-readmes.py.lock
@@ -7,4 +7,4 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"

--- a/scripts/generate-crate-readmes.py.lock
+++ b/scripts/generate-crate-readmes.py.lock
@@ -5,3 +5,6 @@ requires-python = ">=3.13"
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false

--- a/scripts/generate-known-stdlib.py.lock
+++ b/scripts/generate-known-stdlib.py.lock
@@ -7,7 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [manifest]
 requirements = [{ name = "stdlibs" }]

--- a/scripts/generate-known-stdlib.py.lock
+++ b/scripts/generate-known-stdlib.py.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.12"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [manifest]
 requirements = [{ name = "stdlibs" }]
 

--- a/scripts/publish/test_publish.py.lock
+++ b/scripts/publish/test_publish.py.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.12"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [manifest]
 requirements = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1,<0.29" },

--- a/scripts/publish/test_publish.py.lock
+++ b/scripts/publish/test_publish.py.lock
@@ -7,7 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [manifest]
 requirements = [

--- a/scripts/registries-test.py.lock
+++ b/scripts/registries-test.py.lock
@@ -7,7 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [manifest]
 requirements = [{ name = "colorama", specifier = ">=0.4.6" }]

--- a/scripts/registries-test.py.lock
+++ b/scripts/registries-test.py.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.12"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [manifest]
 requirements = [{ name = "colorama", specifier = ">=0.4.6" }]
 

--- a/scripts/sync-python-version-constants.py.lock
+++ b/scripts/sync-python-version-constants.py.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.12"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [manifest]
 requirements = [{ name = "packaging" }]
 

--- a/scripts/sync-python-version-constants.py.lock
+++ b/scripts/sync-python-version-constants.py.lock
@@ -7,7 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [manifest]
 requirements = [{ name = "packaging" }]

--- a/scripts/update-latest-changelog-section.py.lock
+++ b/scripts/update-latest-changelog-section.py.lock
@@ -7,4 +7,4 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"

--- a/scripts/update-latest-changelog-section.py.lock
+++ b/scripts/update-latest-changelog-section.py.lock
@@ -5,3 +5,6 @@ requires-python = ">=3.12"
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false

--- a/scripts/uv-run-remote-script-test.py.lock
+++ b/scripts/uv-run-remote-script-test.py.lock
@@ -7,7 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [manifest]
 requirements = [{ name = "rich", specifier = "==13.7.1" }]

--- a/scripts/uv-run-remote-script-test.py.lock
+++ b/scripts/uv-run-remote-script-test.py.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.11"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [manifest]
 requirements = [{ name = "rich", specifier = "==13.7.1" }]
 

--- a/scripts/vendor-packaging.py.lock
+++ b/scripts/vendor-packaging.py.lock
@@ -7,4 +7,4 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"

--- a/scripts/vendor-packaging.py.lock
+++ b/scripts/vendor-packaging.py.lock
@@ -5,3 +5,6 @@ requires-python = ">=3.12"
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-astral-dev-toolchain-cargo-shear = false
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
 
 [[package]]
 name = "annotated-doc"

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,9 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = false
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -53,6 +56,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4b/cd5d66b9f87e773bc71344a368b9472987e33514e6627e28342b9c3e7c43/anysqlite-0.0.5.tar.gz", hash = "sha256:9dfcf87baf6b93426ad1d9118088c41dbf24ef01b445eea4a5d486bac2755cce", size = 3432, upload-time = "2023-10-02T13:49:25.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/31/349eae2bc9d9331dd8951684cf94528d91efaa71129dc30822ac111dfc66/anysqlite-0.0.5-py3-none-any.whl", hash = "sha256:cb345dc4f76f6b37f768d7a0b3e9cf5c700dfcb7a6356af8ab46a11f666edbe7", size = 3907, upload-time = "2023-10-02T13:49:26.943Z" },
+]
+
+[[package]]
+name = "astral-dev-toolchain-cargo-shear"
+version = "1.13.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/7d/6f44e9e1d0e29b9cd2903eeee8e9cc7612241cd195c7628841f3f9034409/astral_dev_toolchain_cargo_shear-1.13.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2142f359d3aa21a1e996ca6f89683f5b990fa568ec24e60036761c225300c35d", size = 1480556, upload-time = "2026-08-25T21:13:01.403Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/da/cbf7407c2c9391a986ebd8a05fe2c4aa72c0228723650062928e68f376e9/astral_dev_toolchain_cargo_shear-1.13.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:359e17bbfb1b388633dc87277dd6ed13f99d987923c40a574377e44b7449b3d7", size = 1342579, upload-time = "2026-08-25T21:13:02.992Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7d/1b7e465833026658ffad9f7a504b5f2d6e2b0977000f06faa14192acce3d/astral_dev_toolchain_cargo_shear-1.13.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97e9e5ca2854a3b12e511e4f30f47c49fa36aafae79c65c2badf14c4caf47998", size = 1466122, upload-time = "2026-08-25T21:13:04.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/4f/bc9865a14140f5a990f9bbb7ff5b36e2e0f9151d819570fedb516c26fdd6/astral_dev_toolchain_cargo_shear-1.13.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb239c6e9f4abe609b02dbf2933113378bdce845bcaa5ee0000bc7d04750a5ad", size = 1572315, upload-time = "2026-08-25T21:13:05.851Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f5/db879c8c71810df57b290af915fd4e4cd588d4b8161267d593d45100d7a1/astral_dev_toolchain_cargo_shear-1.13.4-py3-none-win_amd64.whl", hash = "sha256:b682608009b22130ff3b99ab782ce7ee3555711989c2a84ed627be1a016643d6", size = 1476915, upload-time = "2026-08-25T21:13:07.366Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7e/62dc9d09eec545a555030fbe8fdb117006ad5684ebe8da4dad8c81a6a251/astral_dev_toolchain_cargo_shear-1.13.4-py3-none-win_arm64.whl", hash = "sha256:91874654b0dcb2b0333a615f81e3cde3f9c10d3148b180254764fce606930af0", size = 1370034, upload-time = "2026-08-25T21:13:08.764Z" },
 ]
 
 [[package]]
@@ -1724,6 +1740,7 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 check = [
+    { name = "astral-dev-toolchain-cargo-shear" },
     { name = "ruff" },
     { name = "ty" },
     { name = "typos" },
@@ -1751,6 +1768,7 @@ release = [
 
 [package.metadata.requires-dev]
 check = [
+    { name = "astral-dev-toolchain-cargo-shear", specifier = ">=1.13.4" },
     { name = "ruff", specifier = ">=0.16.2" },
     { name = "ty", specifier = ">=0.0.69" },
     { name = "typos", specifier = ">=1.49.0" },


### PR DESCRIPTION
## Summary

This lifts cargo-shear into our dependency groups via `astral-dev-toolchain`.

## Test Plan

NFC, internal.