### PR TITLE
fix: Allow commas as python_version string separators

### DIFF
--- a/crates/uv-pep508/src/marker/parse.rs
+++ b/crates/uv-pep508/src/marker/parse.rs
@@ -385,7 +385,8 @@ pub(crate) fn parse_marker_key_op_value<T: Pep508Url>(
 /// [not] in '<version> [additional versions]'
 /// ```
 ///
-/// where the version is PEP 440 compliant. Arbitrary whitespace is allowed between versions.
+/// where the version is PEP 440 compliant. Versions may be separated by any combination of
+/// whitespace and commas (e.g., `3.8 3.9`, `3.8,3.9`, `3.8, 3.9`, or even `3.8,,,3.9`).
 ///
 /// Returns `None` if the [`MarkerOperator`] is not relevant.
 /// Reports a warning if an invalid version is encountered, and returns `None`.
@@ -402,10 +403,10 @@ fn parse_version_in_expr(
 
     // Parse all of the values in the list as versions
     loop {
-        // Allow arbitrary whitespace between versions
-        cursor.eat_whitespace();
+        // Allow arbitrary runs of whitespace and commas between versions.
+        cursor.take_while(|c| c.is_whitespace() || c == ',');
 
-        let (start, len) = cursor.take_while(|c| !c.is_whitespace());
+        let (start, len) = cursor.take_while(|c| !c.is_whitespace() && c != ',');
         if len == 0 {
             break;
         }

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -2515,10 +2515,22 @@ mod test {
         assert_true("python_version in 'foo'");
         // e.g., including `*` versions, which would require tracking a version specifier
         assert_true("python_version in '3.9.*'");
-        // e.g., when non-whitespace separators are present
-        assert_true("python_version in '3.9, 3.10'");
-        assert_true("python_version in '3.9,3.10'");
+        // e.g., when non-whitespace, non-comma separators are present
         assert_true("python_version in '3.9 or 3.10'");
+        // versions may also be separated by commas, with or without whitespace, including
+        // repeated separators
+        assert_simplifies(
+            "python_version in '3.9, 3.10'",
+            "python_full_version >= '3.9' and python_full_version < '3.11'",
+        );
+        assert_simplifies(
+            "python_version in '3.9,3.10'",
+            "python_full_version >= '3.9' and python_full_version < '3.11'",
+        );
+        assert_simplifies(
+            "python_version in '3.9,,,3.10'",
+            "python_full_version >= '3.9' and python_full_version < '3.11'",
+        );
 
         // This is an edge case that happens to be supported, but is not critical to support.
         assert_simplifies(


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

uv properly parses `python_version in "3.8 3.9 3.10"` (space separated) but not comma separated `python_version in "3.8,3.9,3.10"`

This allows comma to be a separating character

Fixes #21310

## Test Plan

<!-- How was it tested? -->
Unit tests