### PR TITLE
Disable cycle estimation for simulated benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -135,4 +135,5 @@ jobs:
         with:
           run: cargo codspeed run
           mode: simulation
+          cycle-estimation: "false"
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -135,5 +135,6 @@ jobs:
         with:
           run: cargo codspeed run
           mode: simulation
+          # Sampling marker: 2/5
           cycle-estimation: "false"
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -135,6 +135,5 @@ jobs:
         with:
           run: cargo codspeed run
           mode: simulation
-          # Sampling marker: 2/5
           cycle-estimation: "false"
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
CodSpeed v5 enabled cycle estimation by default. The uv benchmark history shows an immediate measurement discontinuity at that upgrade, and filesystem-heavy benchmarks such as `unzip_wheel_many_files` became substantially noisier while CPU-only benchmarks remained stable. Disable cycle estimation for the simulation job so its measurements use the previous model again; wall-time measurements remain unchanged.