### PR TITLE
Stop copying `bot:promote` to promoted PRs

### DIFF
--- a/.github/workflows/promote-pull-request.yml
+++ b/.github/workflows/promote-pull-request.yml
@@ -625,8 +625,10 @@ jobs:
 
           upstream_number=$(jq --exit-status --raw-output '.number | select(type == "number")' <<< "$upstream_pull_request")
 
-          if jq --exit-status '.labels | length > 0' <<< "$source_pull_request" > /dev/null; then
-            jq '{labels: [.labels[].name]}' <<< "$source_pull_request" |
+          if jq --exit-status --arg label "$UV_SECURITY_PUBLISH_LABEL" \
+            '.labels | any(.name != $label)' <<< "$source_pull_request" > /dev/null; then
+            jq --arg label "$UV_SECURITY_PUBLISH_LABEL" \
+              '{labels: [.labels[].name | select(. != $label)]}' <<< "$source_pull_request" |
               gh api \
                 --method POST \
                 "repos/astral-sh/uv/issues/$upstream_number/labels" \

--- a/.github/workflows/promote-pull-request.yml
+++ b/.github/workflows/promote-pull-request.yml
@@ -625,10 +625,8 @@ jobs:
 
           upstream_number=$(jq --exit-status --raw-output '.number | select(type == "number")' <<< "$upstream_pull_request")
 
-          if jq --exit-status --arg label "$UV_SECURITY_PUBLISH_LABEL" \
-            '.labels | any(.name != $label)' <<< "$source_pull_request" > /dev/null; then
-            jq --arg label "$UV_SECURITY_PUBLISH_LABEL" \
-              '{labels: [.labels[].name | select(. != $label)]}' <<< "$source_pull_request" |
+          if jq --exit-status '.labels | any(.name | startswith("bot:") | not)' <<< "$source_pull_request" > /dev/null; then
+            jq '{labels: [.labels[].name | select(startswith("bot:") | not)]}' <<< "$source_pull_request" |
               gh api \
                 --method POST \
                 "repos/astral-sh/uv/issues/$upstream_number/labels" \


### PR DESCRIPTION
The promotion workflow currently copies `bot:promote` to the public PR. Exclude it from the copied labels and skip the label request when no other labels remain. Leave labels already on reused target PRs alone.

## Test Plan (on top of CI)

Exercised the promotion step in 24 scenarios with mocked GitHub responses.
