### PR TITLE
fix PR labeler automation

### DIFF
--- a/agents/schemas/pull-request-labels.json
+++ b/agents/schemas/pull-request-labels.json
@@ -5,8 +5,7 @@
     "labels": {
       "type": "array",
       "items": { "type": "string" },
-      "maxItems": 3,
-      "uniqueItems": true
+      "maxItems": 3
     },
     "summary": { "type": "string" }
   },


### PR DESCRIPTION
[https://github.com/astral-sh/uv/pull/21143/changes#diff-a9cda8a194bead3baaee81d5817d0b3ee64161cb3c3fa33583a7e29c5dccc79bR9](https://github.com/astral-sh/uv/pull/21143/changes#diff-a9cda8a194bead3baaee81d5817d0b3ee64161cb3c3fa33583a7e29c5dccc79bR9) introduced an unsupported (by the codex action) `uniqueItems` key to the output schema for the labeler.