### PR TITLE
bench: remove CODSPEED_TOKEN

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -66,6 +66,8 @@ jobs:
     runs-on: codspeed-macro
     needs: benchmarks-walltime-build
     timeout-minutes: 20
+    permissions:
+      id-token: write # for codspeed authentication
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -93,13 +95,14 @@ jobs:
         with:
           run: cargo codspeed run
           mode: walltime
-          token: ${{ secrets.CODSPEED_TOKEN }}
 
   benchmarks-simulated:
     name: "simulated"
     runs-on: depot-ubuntu-24.04-4
     if: ${{ github.repository == 'astral-sh/uv' }}
     timeout-minutes: 30
+    permissions:
+      id-token: write # for codspeed authentication
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -135,4 +138,3 @@ jobs:
         with:
           run: cargo codspeed run
           mode: simulation
-          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,8 @@ jobs:
     secrets: inherit
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
+    permissions:
+      id-token: write
 
   # This job cannot be moved into a reusable workflow because it includes coverage for uploading
   # attestations and PyPI does not support attestations in reusable workflows.


### PR DESCRIPTION
## Summary

CodSpeed supports OIDC auth.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

NFC, CI only.

<!-- How was it tested? -->
