### PR TITLE
Allow frozen exports without workspace member manifests

### DIFF
--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -15,7 +15,7 @@ use uv_configuration::{
     Concurrency, DependencyGroups, EditableMode, ExportFormat, ExtrasSpecification, InstallOptions,
 };
 use uv_distribution_types::Verbatim;
-use uv_normalize::{DefaultExtras, DefaultGroups, PackageName};
+use uv_normalize::{DEV_DEPENDENCIES, DefaultExtras, DefaultGroups, PackageName};
 use uv_preview::Preview;
 use uv_python::{ConfigDiscovery, PythonDownloads, PythonPreference, PythonRequest};
 use uv_requirements::is_pylock_toml;
@@ -105,18 +105,8 @@ pub(crate) async fn export(
                 ..DiscoveryOptions::default()
             };
 
-            if let [name] = package.as_slice() {
-                VirtualProject::discover_with_package(
-                    project_dir,
-                    &options,
-                    cache,
-                    workspace_cache,
-                    name.clone(),
-                )
-                .await?
-            } else {
-                VirtualProject::discover(project_dir, &options, cache, workspace_cache).await?
-            }
+            // A selected member may only exist in the lockfile during a frozen export.
+            VirtualProject::discover(project_dir, &options, cache, workspace_cache).await?
         } else if let [name] = package.as_slice() {
             VirtualProject::discover_with_package(
                 project_dir,
@@ -148,7 +138,18 @@ pub(crate) async fn export(
 
     // Determine the default groups to include.
     let default_groups = match &target {
-        ExportTarget::Project(project) => default_dependency_groups(project.pyproject_toml())?,
+        ExportTarget::Project(project) => match package.as_slice() {
+            // Read the selected member's defaults if its manifest is available. Otherwise, use
+            // the standard defaults rather than inheriting the workspace root's defaults.
+            [name] => project
+                .workspace()
+                .packages()
+                .get(name)
+                .map(|member| default_dependency_groups(member.pyproject_toml()))
+                .transpose()?
+                .unwrap_or_else(|| DefaultGroups::List(vec![DEV_DEPENDENCIES.clone()])),
+            _ => default_dependency_groups(project.pyproject_toml())?,
+        },
         ExportTarget::Script(_) => DefaultGroups::default(),
     };
 

--- a/crates/uv/src/commands/project/install_target.rs
+++ b/crates/uv/src/commands/project/install_target.rs
@@ -141,7 +141,9 @@ impl<'lock> Installable<'lock> for InstallTarget<'lock> {
         }
 
         let Self::Project {
-            workspace, name, ..
+            workspace,
+            name,
+            lock,
         } = self
         else {
             return true;
@@ -157,7 +159,7 @@ impl<'lock> Installable<'lock> for InstallTarget<'lock> {
             return false;
         }
 
-        !workspace.packages().get(*name).is_some_and(|member| {
+        let member_defines_group = if let Some(member) = workspace.packages().get(*name) {
             let pyproject = member.pyproject_toml();
             pyproject
                 .dependency_groups
@@ -172,7 +174,18 @@ impl<'lock> Installable<'lock> for InstallTarget<'lock> {
                         .and_then(|tool| tool.uv.as_ref())
                         .and_then(|uv| uv.dev_dependencies.as_ref())
                         .is_some()
-        })
+        } else {
+            // Frozen exports can omit member manifests, so check the lockfile for groups that
+            // take precedence over the workspace root's groups.
+            lock.find_by_name(name)
+                .ok()
+                .flatten()
+                .is_some_and(|package| {
+                    package.dependency_groups().contains_key(group)
+                        || package.resolved_dependency_groups().contains_key(group)
+                })
+        };
+        !member_defines_group
     }
 
     fn project_name(&self) -> Option<&PackageName> {

--- a/crates/uv/tests/project/export.rs
+++ b/crates/uv/tests/project/export.rs
@@ -1165,6 +1165,134 @@ fn requirements_txt_frozen_workspace_member_group_precedence() -> Result<()> {
     Ok(())
 }
 
+/// Frozen exports can select a member from the lockfile without its manifest.
+#[cfg(feature = "test-universal")]
+#[test]
+fn requirements_txt_frozen_workspace_missing_member() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [project]
+            name = "root"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+
+            [dependency-groups]
+            dev = ["packaging"]
+
+            [tool.uv]
+            default-groups = "all"
+
+            [tool.uv.workspace]
+            members = ["child"]
+        "#})?;
+
+    let child = context.temp_dir.child("child");
+    child.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["typing-extensions"]
+
+        [project.optional-dependencies]
+        optional = ["sniffio"]
+
+        [dependency-groups]
+        dev = ["iniconfig"]
+        tools = ["idna"]
+
+        [tool.uv]
+        default-groups = ["tools"]
+    "#})?;
+
+    context.lock().assert().success();
+
+    // Use the member's configured defaults while its manifest is available.
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--no-header")
+        .arg("--no-hashes")
+        .arg("--no-annotate")
+        .arg("--package").arg("child"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    idna==3.6
+    typing-extensions==4.10.0
+    ");
+
+    fs_err::remove_dir_all(child.path())?;
+
+    // Without a member manifest, use the standard defaults, not the root's defaults.
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--no-header")
+        .arg("--no-hashes")
+        .arg("--no-annotate")
+        .arg("--package").arg("child"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    iniconfig==2.0.0
+    typing-extensions==4.10.0
+    ");
+
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--no-header")
+        .arg("--no-hashes")
+        .arg("--no-annotate")
+        .arg("--package").arg("child")
+        .arg("--no-default-groups"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    typing-extensions==4.10.0
+    ");
+
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--no-header")
+        .arg("--no-hashes")
+        .arg("--no-annotate")
+        .arg("--package").arg("child")
+        .arg("--no-default-groups")
+        .arg("--extra").arg("optional"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    sniffio==1.3.1
+    typing-extensions==4.10.0
+    ");
+
+    // The member's locked group still takes precedence over the root's group.
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--no-header")
+        .arg("--no-hashes")
+        .arg("--no-annotate")
+        .arg("--package").arg("child")
+        .arg("--only-group").arg("dev"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    iniconfig==2.0.0
+    ");
+
+    uv_snapshot!(context.filters(), context.export()
+        .arg("--frozen")
+        .arg("--no-header")
+        .arg("--no-hashes")
+        .arg("--no-annotate")
+        .arg("--package").arg("child")
+        .arg("--only-group").arg("tools"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    idna==3.6
+    ");
+
+    Ok(())
+}
+
 #[cfg(feature = "test-universal")]
 #[test]
 fn allrequirements_txt_() -> Result<()> {


### PR DESCRIPTION
`uv export --frozen --package <member>` fails if the member's `pyproject.toml` is missing, even when the member is present in `uv.lock`. This regressed in #20930 and breaks exports that only copy the workspace root manifest and lockfile.

Discover existing members without requiring the selected member on disk. Use its manifest for default groups when available; otherwise, default to `dev` without inheriting the root's settings. When the member manifest is absent, consult its locked groups so they still take precedence over matching workspace-root groups.
