### PR TITLE
Pipeline file cache publication for streamed wheels

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -941,8 +941,13 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 let target = temp_dir.path().to_owned();
                 let file = file.into_std().await;
+                let cache = self.build_context.cache().clone();
                 let mut extracted = tokio::task::spawn_blocking(move || {
-                    ExtractedWheel::extract_seekable(file, &target, content_addressed_cache)
+                    ExtractedWheel::extract_seekable(
+                        file,
+                        &target,
+                        content_addressed_cache.then_some(&cache),
+                    )
                 })
                 .await?
                 .map_err(|err| Error::Extract(filename.to_string(), err))?;
@@ -1195,15 +1200,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let (temp_dir, mut extracted) = tokio::task::spawn_blocking({
             let path = path.to_owned();
-            let root = self.build_context.cache().root().to_path_buf();
+            let cache = self.build_context.cache().clone();
             move || -> Result<_, Error> {
                 // Unzip the wheel into a temporary directory.
-                let temp_dir = tempfile::tempdir_in(root).map_err(Error::CacheWrite)?;
+                let temp_dir = tempfile::tempdir_in(cache.root()).map_err(Error::CacheWrite)?;
                 let reader = fs_err::File::open(&path).map_err(Error::CacheWrite)?;
                 let extracted = ExtractedWheel::extract_seekable(
                     reader,
                     temp_dir.path(),
-                    content_addressed_cache,
+                    content_addressed_cache.then_some(&cache),
                 )
                 .map_err(|err| Error::Extract(path.to_string_lossy().into_owned(), err))?;
                 Ok((temp_dir, extracted))
@@ -1233,12 +1238,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         hashed_wheel: Option<HashedWheel>,
     ) -> Result<ArchiveId, Error> {
         let cache = self.build_context.cache();
-        let (temp_dir, id) = if let Some(HashedWheel {
-            files,
-            tree,
-            files_persisted,
-        }) = hashed_wheel
-        {
+        let (temp_dir, id) = if let Some(HashedWheel { files, tree }) = hashed_wheel {
             let manifest = ArchiveManifest::new(
                 files
                     .iter()
@@ -1249,17 +1249,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             let digest = DirectoryDigest::with_metadata(tree.hash(), &contents);
             let id = ArchiveId::from_digest(digest.into());
             let manifest_entry = cache.entry(CacheBucket::Manifest, &id, "manifest.json");
-            let cache = cache.clone();
             let temp_dir = tokio::task::spawn_blocking(move || {
-                if !files_persisted {
-                    persist_archive_files(
-                        &cache,
-                        temp_dir.path(),
-                        &files,
-                        &mut FxHashSet::default(),
-                    )
-                    .map_err(Error::CacheWrite)?;
-                }
                 fs_err::create_dir_all(manifest_entry.dir()).map_err(Error::CacheWrite)?;
                 uv_fs::write_atomic_sync(manifest_entry.path(), contents)
                     .map_err(Error::CacheWrite)?;
@@ -1300,10 +1290,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 }
 
 /// Per-file digests and the hash tree of an extracted wheel.
+///
+/// All files except `RECORD` have been published to the file store.
 struct HashedWheel {
     files: Vec<HashedFile>,
     tree: DirhashTree,
-    files_persisted: bool,
 }
 
 /// Files extracted from a wheel, with or without content-addressing metadata.
@@ -1353,13 +1344,12 @@ impl ExtractedWheel {
                 Ok::<_, io::Error>(())
             };
             let extraction = async move {
-                let result =
-                    uv_extract::stream::unzip_and_hash_with_callback(reader, &target, |file| {
-                        sender
-                            .send(file)
-                            .map_err(|_| io::Error::other("file cache publisher stopped"))
-                    })
-                    .await;
+                let result = uv_extract::stream::unzip_and_hash(reader, &target, |file| {
+                    sender
+                        .send(file)
+                        .map_err(|_| io::Error::other("file cache publisher stopped"))
+                })
+                .await;
                 drop(sender);
                 result
             };
@@ -1372,33 +1362,25 @@ impl ExtractedWheel {
             let temp_dir = Arc::try_unwrap(temp_dir).map_err(|_| {
                 uv_extract::Error::Io(io::Error::other("file cache publisher retained archive"))
             })?;
-            Ok((
-                temp_dir,
-                Self::Hashed(HashedWheel {
-                    files,
-                    tree,
-                    files_persisted: true,
-                }),
-            ))
+            Ok((temp_dir, Self::Hashed(HashedWheel { files, tree })))
         } else {
             let files = uv_extract::stream::unzip(reader, temp_dir.path()).await?;
             Ok((temp_dir, Self::Unhashed(files)))
         }
     }
 
-    /// Extract a wheel from a seekable file, optionally retaining its per-file digests.
+    /// Extract a wheel from a seekable file, optionally retaining its per-file digests and
+    /// publishing its files to the file store.
     fn extract_seekable(
         reader: fs_err::File,
         target: &Path,
-        content_addressed: bool,
+        cache: Option<&Cache>,
     ) -> Result<Self, uv_extract::Error> {
-        if content_addressed {
+        if let Some(cache) = cache {
             let (files, tree) = uv_extract::unzip_and_hash(reader, target)?;
-            Ok(Self::Hashed(HashedWheel {
-                files,
-                tree,
-                files_persisted: false,
-            }))
+            persist_archive_files(cache, target, &files, &mut FxHashSet::default())
+                .map_err(uv_extract::Error::Io)?;
+            Ok(Self::Hashed(HashedWheel { files, tree }))
         } else {
             let files = uv_extract::unzip(reader, target)?;
             Ok(Self::Unhashed(files))

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -2,18 +2,18 @@ use std::cmp::Reverse;
 use std::fmt::Display;
 use std::future::Future;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use either::Either;
-use futures::{FutureExt, TryStreamExt};
+use futures::{FutureExt, TryFutureExt, TryStreamExt};
 use rayon::in_place_scope;
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, mpsc};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{Instrument, info_span, instrument, warn};
 use url::Url;
@@ -709,21 +709,23 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let temp_dir = tempfile::tempdir_in(self.build_context.cache().root())
                     .map_err(Error::CacheWrite)?;
 
-                let mut extracted = match progress {
+                let (temp_dir, mut extracted) = match progress {
                     Some((reporter, progress)) => {
                         let mut reader = ProgressReader::new(&mut hasher, progress, &**reporter);
                         ExtractedWheel::extract_streaming(
                             &mut reader,
-                            temp_dir.path(),
-                            self.content_addressed_cache,
+                            temp_dir,
+                            self.content_addressed_cache
+                                .then_some(self.build_context.cache()),
                         )
                         .await
                         .map_err(|err| Error::Extract(filename.to_string(), err))?
                     }
                     None => ExtractedWheel::extract_streaming(
                         &mut hasher,
-                        temp_dir.path(),
-                        self.content_addressed_cache,
+                        temp_dir,
+                        self.content_addressed_cache
+                            .then_some(self.build_context.cache()),
                     )
                     .await
                     .map_err(|err| Error::Extract(filename.to_string(), err))?,
@@ -1134,10 +1136,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             let mut hasher = uv_extract::hash::HashReader::new(file, &mut hashers);
 
             // Unzip the wheel to a temporary directory.
-            let mut extracted = ExtractedWheel::extract_streaming(
+            let (temp_dir, mut extracted) = ExtractedWheel::extract_streaming(
                 &mut hasher,
-                temp_dir.path(),
-                self.content_addressed_cache,
+                temp_dir,
+                self.content_addressed_cache
+                    .then_some(self.build_context.cache()),
             )
             .await
             .map_err(|err| Error::Extract(filename.to_string(), err))?;
@@ -1230,7 +1233,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         hashed_wheel: Option<HashedWheel>,
     ) -> Result<ArchiveId, Error> {
         let cache = self.build_context.cache();
-        let (temp_dir, id) = if let Some(HashedWheel { files, tree }) = hashed_wheel {
+        let (temp_dir, id) = if let Some(HashedWheel {
+            files,
+            tree,
+            files_persisted,
+        }) = hashed_wheel
+        {
             let manifest = ArchiveManifest::new(
                 files
                     .iter()
@@ -1243,8 +1251,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             let manifest_entry = cache.entry(CacheBucket::Manifest, &id, "manifest.json");
             let cache = cache.clone();
             let temp_dir = tokio::task::spawn_blocking(move || {
-                persist_archive_files(&cache, temp_dir.path(), &files)
+                if !files_persisted {
+                    persist_archive_files(
+                        &cache,
+                        temp_dir.path(),
+                        &files,
+                        &mut FxHashSet::default(),
+                    )
                     .map_err(Error::CacheWrite)?;
+                }
                 fs_err::create_dir_all(manifest_entry.dir()).map_err(Error::CacheWrite)?;
                 uv_fs::write_atomic_sync(manifest_entry.path(), contents)
                     .map_err(Error::CacheWrite)?;
@@ -1288,6 +1303,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 struct HashedWheel {
     files: Vec<HashedFile>,
     tree: DirhashTree,
+    files_persisted: bool,
 }
 
 /// Files extracted from a wheel, with or without content-addressing metadata.
@@ -1297,21 +1313,76 @@ enum ExtractedWheel {
 }
 
 impl ExtractedWheel {
-    /// Extract a wheel from a streaming reader, optionally retaining its per-file digests.
+    /// Extract a wheel from a streaming reader, optionally publishing completed file objects while
+    /// the remaining payloads are downloaded and extracted.
     async fn extract_streaming<R>(
         reader: R,
-        target: &Path,
-        content_addressed: bool,
-    ) -> Result<Self, uv_extract::Error>
+        temp_dir: tempfile::TempDir,
+        cache: Option<&Cache>,
+    ) -> Result<(tempfile::TempDir, Self), uv_extract::Error>
     where
         R: AsyncRead + Unpin,
     {
-        if content_addressed {
-            let (files, tree) = uv_extract::stream::unzip_and_hash(reader, target).await?;
-            Ok(Self::Hashed(HashedWheel { files, tree }))
+        if let Some(cache) = cache {
+            const BATCH_SIZE: usize = 256;
+
+            let target = temp_dir.path().to_path_buf();
+            let temp_dir = Arc::new(temp_dir);
+            let archive = Arc::clone(&temp_dir);
+            let cache = cache.clone();
+            let (sender, mut receiver) = mpsc::channel(BATCH_SIZE);
+            let publisher = async move {
+                let mut files = Vec::with_capacity(BATCH_SIZE);
+                let mut shards = FxHashSet::default();
+                while receiver.recv_many(&mut files, BATCH_SIZE).await != 0 {
+                    let archive = Arc::clone(&archive);
+                    let cache = cache.clone();
+                    // Keep the private archive alive if extraction is cancelled during this batch.
+                    let (batch, created_shards, result) = tokio::task::spawn_blocking(move || {
+                        let result =
+                            persist_archive_files(&cache, archive.path(), &files, &mut shards);
+                        (files, shards, result)
+                    })
+                    .await
+                    .map_err(io::Error::other)?;
+                    files = batch;
+                    shards = created_shards;
+                    result?;
+                    files.clear();
+                }
+                Ok::<_, io::Error>(())
+            };
+            let extraction = async move {
+                let result =
+                    uv_extract::stream::unzip_and_hash_with_callback(reader, &target, |file| {
+                        sender
+                            .send(file)
+                            .map_err(|_| io::Error::other("file cache publisher stopped"))
+                    })
+                    .await;
+                drop(sender);
+                result
+            };
+
+            // Always join the publisher, including after an extraction error. Report its original
+            // error rather than the channel closure observed by the extraction callback.
+            let (extracted, published) = tokio::join!(extraction, publisher);
+            published.map_err(uv_extract::Error::Io)?;
+            let (files, tree) = extracted?;
+            let temp_dir = Arc::try_unwrap(temp_dir).map_err(|_| {
+                uv_extract::Error::Io(io::Error::other("file cache publisher retained archive"))
+            })?;
+            Ok((
+                temp_dir,
+                Self::Hashed(HashedWheel {
+                    files,
+                    tree,
+                    files_persisted: true,
+                }),
+            ))
         } else {
-            let files = uv_extract::stream::unzip(reader, target).await?;
-            Ok(Self::Unhashed(files))
+            let files = uv_extract::stream::unzip(reader, temp_dir.path()).await?;
+            Ok((temp_dir, Self::Unhashed(files)))
         }
     }
 
@@ -1323,7 +1394,11 @@ impl ExtractedWheel {
     ) -> Result<Self, uv_extract::Error> {
         if content_addressed {
             let (files, tree) = uv_extract::unzip_and_hash(reader, target)?;
-            Ok(Self::Hashed(HashedWheel { files, tree }))
+            Ok(Self::Hashed(HashedWheel {
+                files,
+                tree,
+                files_persisted: false,
+            }))
         } else {
             let files = uv_extract::unzip(reader, target)?;
             Ok(Self::Unhashed(files))
@@ -1372,7 +1447,12 @@ impl ExtractedWheel {
 }
 
 /// Share extracted files other than `RECORD` while keeping the unpublished archive complete.
-fn persist_archive_files(cache: &Cache, archive: &Path, files: &[HashedFile]) -> io::Result<()> {
+fn persist_archive_files(
+    cache: &Cache,
+    archive: &Path,
+    files: &[HashedFile],
+    created_shards: &mut FxHashSet<PathBuf>,
+) -> io::Result<()> {
     initialize_rayon_once();
     let targets = files
         .par_iter()
@@ -1408,7 +1488,9 @@ fn persist_archive_files(cache: &Cache, archive: &Path, files: &[HashedFile]) ->
     // thread, while workers link files in the shards that are already available.
     in_place_scope(|scope| -> io::Result<()> {
         for (parent, files, result) in &mut shards {
-            fs_err::create_dir_all(parent)?;
+            if created_shards.insert(parent.to_path_buf()) {
+                fs_err::create_dir_all(parent)?;
+            }
             scope.spawn(move |_| {
                 *result = files
                     .iter()

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -1,3 +1,5 @@
+use std::future::{Future, ready};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
@@ -65,7 +67,9 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
 ) -> Result<Vec<UnhashedFile>, Error> {
-    let UnzipOutput::Unhashed(files) = Box::pin(unzip_inner(reader, target, false)).await? else {
+    let UnzipOutput::Unhashed(files) =
+        Box::pin(unzip_inner(reader, target, false, |_| ready(Ok(())))).await?
+    else {
         return Err(Error::Io(std::io::Error::other(
             "streaming ZIP hash tree was unexpectedly computed",
         )));
@@ -85,7 +89,24 @@ pub async fn unzip_and_hash<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
 ) -> Result<(Vec<HashedFile>, DirhashTree), Error> {
-    let UnzipOutput::Hashed { files, tree } = Box::pin(unzip_inner(reader, target, true)).await?
+    unzip_and_hash_with_callback(reader, target, |_| ready(Ok(()))).await
+}
+
+/// Like [`unzip_and_hash`], but report each completed file after validating its local header and
+/// data descriptor. Files are non-executable; their intended executable status is only known in
+/// the returned metadata after validating the central directory. The remaining ZIP can still fail.
+pub async fn unzip_and_hash_with_callback<R, F, Fut>(
+    reader: R,
+    target: impl AsRef<Path>,
+    on_file: F,
+) -> Result<(Vec<HashedFile>, DirhashTree), Error>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    F: FnMut(HashedFile) -> Fut,
+    Fut: Future<Output = io::Result<()>>,
+{
+    let UnzipOutput::Hashed { files, tree } =
+        Box::pin(unzip_inner(reader, target, true, on_file)).await?
     else {
         return Err(Error::Io(std::io::Error::other(
             "streaming ZIP hash tree was not computed",
@@ -94,11 +115,17 @@ pub async fn unzip_and_hash<R: tokio::io::AsyncRead + Unpin>(
     Ok((files, tree))
 }
 
-async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
+async fn unzip_inner<R, F, Fut>(
     reader: R,
     target: impl AsRef<Path>,
     hash_contents: bool,
-) -> Result<UnzipOutput, Error> {
+    mut on_file: F,
+) -> Result<UnzipOutput, Error>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    F: FnMut(HashedFile) -> Fut,
+    Fut: Future<Output = io::Result<()>>,
+{
     // Determine whether ZIP validation is disabled.
     let skip_validation = insecure_no_validate();
 
@@ -378,6 +405,17 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                     });
                 }
             }
+        }
+
+        if let Some(digest) = computed.digest {
+            on_file(HashedFile::new(
+                relpath.clone(),
+                computed.uncompressed_size,
+                digest,
+                false,
+            ))
+            .await
+            .map_err(Error::Io)?;
         }
 
         // Store the offset, for validation, and error if we see a duplicate file.
@@ -893,5 +931,76 @@ pub async fn archive<R: tokio::io::AsyncRead + Unpin>(
             untar_zst(reader, target).await
         }
         SourceDistExtension::Legacy(_) => Err(Error::UnsupportedCompression),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::ready;
+    use std::io;
+    use std::path::Path;
+    use std::time::Duration;
+
+    use async_zip::base::write::ZipFileWriter;
+    use async_zip::{Compression, ZipEntryBuilder};
+    use tokio::io::AsyncWriteExt;
+    use tokio::sync::oneshot;
+
+    #[tokio::test]
+    async fn reports_completed_file_before_next_payload() -> anyhow::Result<()> {
+        let mut archive = ZipFileWriter::new(Vec::new());
+        archive
+            .write_entry_whole(
+                ZipEntryBuilder::new("first".into(), Compression::Deflate).unix_permissions(0o755),
+                b"first payload",
+            )
+            .await?;
+        let boundary = archive.inner_mut().len();
+        archive
+            .write_entry_whole(
+                ZipEntryBuilder::new("second".into(), Compression::Deflate),
+                b"second payload",
+            )
+            .await?;
+        let contents = archive.close().await?;
+        let target = tempfile::tempdir()?;
+        let (reader, mut writer) = tokio::io::duplex(64);
+        let (sender, receiver) = oneshot::channel();
+        let mut sender = Some(sender);
+        let download = async {
+            writer.write_all(&contents[..boundary]).await?;
+            // Do not send the next entry until extraction reports the first completed file.
+            receiver.await.map_err(io::Error::other)?;
+            writer.write_all(&contents[boundary..]).await?;
+            writer.shutdown().await?;
+            Ok::<_, io::Error>(())
+        };
+        let extraction = super::unzip_and_hash_with_callback(reader, target.path(), |file| {
+            assert!(!file.is_executable());
+            if file.path() == Path::new("first")
+                && let Some(sender) = sender.take()
+            {
+                assert!(!target.path().join("second").exists());
+                let _ = sender.send(());
+            }
+            ready(Ok(()))
+        });
+        let (download, extraction) = tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(download, extraction)
+        })
+        .await?;
+        download?;
+        let (files, _) = extraction?;
+        assert_eq!(files.len(), 2);
+        assert!(
+            files
+                .iter()
+                .any(|file| file.path() == Path::new("first") && file.is_executable())
+        );
+        assert_eq!(
+            fs_err::read(target.path().join("second"))?,
+            b"second payload"
+        );
+        Ok(())
     }
 }

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -85,17 +85,11 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
 ///
 /// See [`unzip`] for details.
 /// Executable permissions are recorded in the returned files instead of being applied on disk.
-pub async fn unzip_and_hash<R: tokio::io::AsyncRead + Unpin>(
-    reader: R,
-    target: impl AsRef<Path>,
-) -> Result<(Vec<HashedFile>, DirhashTree), Error> {
-    unzip_and_hash_with_callback(reader, target, |_| ready(Ok(()))).await
-}
-
-/// Like [`unzip_and_hash`], but report each completed file after validating its local header and
+///
+/// Reports each completed file to `on_file` after validating its local header and
 /// data descriptor. Files are non-executable; their intended executable status is only known in
 /// the returned metadata after validating the central directory. The remaining ZIP can still fail.
-pub async fn unzip_and_hash_with_callback<R, F, Fut>(
+pub async fn unzip_and_hash<R, F, Fut>(
     reader: R,
     target: impl AsRef<Path>,
     on_file: F,
@@ -975,7 +969,7 @@ mod tests {
             writer.shutdown().await?;
             Ok::<_, io::Error>(())
         };
-        let extraction = super::unzip_and_hash_with_callback(reader, target.path(), |file| {
+        let extraction = super::unzip_and_hash(reader, target.path(), |file| {
             assert!(!file.is_executable());
             if file.path() == Path::new("first")
                 && let Some(sender) = sender.take()

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -16744,6 +16744,52 @@ async fn all_files_except_record_use_archive_file_store() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn streamed_file_objects_survive_invalid_zip_until_pruned() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_file_counts()
+        .with_filtered_sizes_and_units()
+        .with_filter((r"http://127\.0\.0\.1:\d+", "http://[LOCALHOST]"));
+    let server = MockServer::start().await;
+    let wheel = binary_payload_wheel(&context)?;
+    let mut contents = fs_err::read(wheel)?;
+    // Reject the ZIP after all central-directory entries have been processed.
+    contents.extend_from_slice(b"invalid trailing data");
+    Mock::given(method("GET"))
+        .and(path("/binary_payload-0.1.0-py3-none-any.whl"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(contents))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .args(["--preview-features", "content-addressed-cache"])
+        .arg(format!("{}/binary_payload-0.1.0-py3-none-any.whl", server.uri())), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+      × Failed to download `binary-payload @ http://[LOCALHOST]/binary_payload-0.1.0-py3-none-any.whl`
+      ├─▶ Failed to extract archive: binary_payload-0.1.0-py3-none-any.whl
+      ╰─▶ ZIP file contains trailing contents after the end-of-central-directory record
+    ");
+
+    assert_eq!(
+        cache_files(context.cache_dir.child("files-v0").path())?.len(),
+        6
+    );
+    assert!(!context.cache_dir.child("archive-v0").exists());
+    assert!(!context.cache_dir.child("manifest-v0").exists());
+    assert!(!context.site_packages().join("binary_payload").exists());
+
+    uv_snapshot!(context.filters(), context.prune(), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Pruning cache at: [CACHE_DIR]/
+    Removed [N] files ([SIZE])
+    ");
+    assert!(cache_files(context.cache_dir.child("files-v0").path())?.is_empty());
+    Ok(())
+}
+
 #[test]
 fn executable_manifests_distinguish_identical_wheel_contents() -> Result<()> {
     let context = uv_test::test_context!("3.12")


### PR DESCRIPTION
## Summary

We currently finish streaming extraction before publishing the extracted files to `files-v0`. This PR publishes each completed file after checking its local header and data descriptor, so cache linking overlaps downloading and extracting the remaining payloads. A bounded queue feeds batches to blocking workers, retaining the existing grouping by cache shard.

We still keep `RECORD` private and wait for extraction and file publication to finish before persisting the executable manifest and exposing the wheel in `archive-v0`. A rejected or interrupted ZIP can leave completed file objects behind; cache pruning removes those unreferenced objects. The temporary archive stays alive while any blocking publication work is running, including when extraction is cancelled.

This uses the existing streaming download without additional requests. Executable status still comes from the central directory and is stored in the manifest; the published file objects remain non-executable.
