### PR TITLE
Reuse the hashing buffer across streamed wheel files

### DIFF
--- a/crates/uv-extract/src/dirhash.rs
+++ b/crates/uv-extract/src/dirhash.rs
@@ -109,10 +109,23 @@ where
     R: AsyncRead,
     W: AsyncWrite,
 {
+    blake3_copy_with_buffer(reader, writer, &mut Vec::new()).await
+}
+
+/// Copy and hash bytes with a reusable 64 KiB buffer, allocating it on the first call.
+pub(crate) async fn blake3_copy_with_buffer<R, W>(
+    reader: R,
+    writer: W,
+    buffer: &mut Vec<u8>,
+) -> io::Result<(u64, blake3::Hash)>
+where
+    R: AsyncRead,
+    W: AsyncWrite,
+{
     let mut reader = pin!(reader);
     let mut writer = pin!(writer);
     let mut hasher = blake3::Hasher::new();
-    let mut buffer = vec![0; 1 << 16]; // 64 KiB
+    buffer.resize(1 << 16, 0); // 64 KiB
     let mut total = 0u64;
     // BLAKE3 is fastest when hashing power-of-two sized buffers. That maximizes the time we spend
     // in the wide SIMD part of the implementation (which wants between 4 and 16 KiB at a time
@@ -120,7 +133,7 @@ where
     // short inputs. Hash as many full 64 KiB buffers as we can, and then one possibly-short buffer
     // when we reach EOF.
     loop {
-        let bytes_read = read_exact_or_eof(reader.as_mut(), &mut buffer).await?;
+        let bytes_read = read_exact_or_eof(reader.as_mut(), buffer).await?;
         if bytes_read == 0 {
             break; // EOF reached with no bytes. Skip unnecessary calls to `update` and `write_all`.
         }
@@ -691,6 +704,22 @@ mod tests {
         assert_eq!(big_bytes_read, big_input.len() as u64);
         assert_eq!(big_input, big_output);
         assert_eq!(big_hash, blake3::hash(&big_input));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_blake3_copy_reuses_buffer() -> io::Result<()> {
+        let mut input = vec![0; 64_000 * 3];
+        paint_input(&mut input);
+        let mut buffer = Vec::new();
+        for input in [input.as_slice(), b"hello", b""] {
+            let mut output = Vec::new();
+            let (bytes_read, hash) =
+                super::blake3_copy_with_buffer(input, &mut output, &mut buffer).await?;
+            assert_eq!(bytes_read, input.len() as u64);
+            assert_eq!(input, output);
+            assert_eq!(hash, blake3::hash(input));
+        }
         Ok(())
     }
 

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -17,7 +17,9 @@ use uv_distribution_filename::{LegacySourceDistExtension, SourceDistExtension};
 use uv_preview::PreviewFeature;
 
 use crate::archive_path::SanitizedArchivePath;
-use crate::dirhash::{DirhashTree, ExtractedFile, blake3_copy, directory_tree_from_extracted};
+use crate::dirhash::{
+    DirhashTree, ExtractedFile, blake3_copy_with_buffer, directory_tree_from_extracted,
+};
 use crate::{Error, insecure_no_validate};
 
 const DEFAULT_BUF_SIZE: usize = 128 * 1024;
@@ -109,6 +111,7 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
     let mut files = Vec::new();
     let mut extracted_files = Vec::new();
     let mut digest_directories = FxHashSet::default();
+    let mut hash_buffer = Vec::new();
     let mut offset = 0;
 
     while let Some(mut entry) = zip.next_with_entry().await? {
@@ -213,9 +216,10 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                         };
                         let mut reader = entry.reader_mut().compat();
                         let (bytes_read, digest) = if hash_contents {
-                            let (bytes_read, digest) = blake3_copy(&mut reader, &mut writer)
-                                .await
-                                .map_err(Error::io_or_zip)?;
+                            let (bytes_read, digest) =
+                                blake3_copy_with_buffer(&mut reader, &mut writer, &mut hash_buffer)
+                                    .await
+                                    .map_err(Error::io_or_zip)?;
                             (bytes_read, Some(digest))
                         } else {
                             let mut bytes_read = 0;


### PR DESCRIPTION
## Summary

When content hashing is enabled, we currently allocate and zero a new 64 KiB buffer for every file we copy and hash during streaming extraction. This PR reuses one buffer across the wheel instead. For the PyTorch wheel used in the benchmarks, that reduces buffer allocations for hashing from 11,120 to one, while keeping the buffer size at 64 KiB per active wheel.

The following measurements compare #21327 at `a188b8e833aef3c3b4b60a32ed9fafe6ac74186a` with this optimization applied on top, before moving the change onto `main`. They are not measurements against `main`. The Linux benchmarks alternate base and candidate, using pinned wheels served over local HTTP with content-addressed caching enabled:

| Cold install | #21327 | #21327 + buffer reuse | Change |
| --- | ---: | ---: | ---: |
| AnyIO | 110 ms | 107 ms | -2.6% |
| SymPy | 845 ms | 775 ms | -8.3% |
| NumPy | 627 ms | 567 ms | -9.5% |
| PyTorch CPU | 6.50 s | 5.99 s | -7.8% |
| 14-package environment, concurrency 4 | 6.95 s | 6.47 s | -7.0% |

The individual results above use 16 paired rounds; the full environment uses 12. AnyIO, SymPy, and NumPy were repeated after an initial 20-pair run: the initial AnyIO timings were noisy, while the initial SymPy and NumPy improvements were 7.8% and 6.9%. All original samples were retained. Cached installs and local-wheel controls showed no consistent change. Across the initial runs, repeats, and controls, we measured 672 installs, excluding warmups and cache priming.
