### PR TITLE
Align workspace member matching with glob expansion

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -10,7 +10,7 @@ use std::hash::BuildHasherDefault;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use glob::{GlobError, Pattern, PatternError, glob};
+use glob::{GlobError, MatchOptions, Pattern, PatternError, glob};
 use itertools::Itertools;
 use rustc_hash::{FxHashSet, FxHasher};
 use tracing::{debug, trace, warn};
@@ -2041,6 +2041,10 @@ fn is_included_in_workspace(
     workspace_root: &Path,
     workspace: &ToolUvWorkspace,
 ) -> Result<bool, WorkspaceError> {
+    let options = MatchOptions {
+        require_literal_separator: true,
+        ..MatchOptions::new()
+    };
     for member_glob in workspace.members.iter().flatten() {
         // Normalize the member glob to remove leading `./` and other relative path components
         let normalized_glob = normalize_path(Path::new(member_glob.as_str()));
@@ -2051,7 +2055,7 @@ fn is_included_in_workspace(
         let absolute_glob = absolute_glob.to_string_lossy();
         let include_pattern = glob::Pattern::new(&absolute_glob)
             .map_err(|err| WorkspaceErrorKind::Pattern(absolute_glob.to_string(), err))?;
-        if include_pattern.matches_path(project_path) {
+        if include_pattern.matches_path_with(project_path, options) {
             return Ok(true);
         }
     }

--- a/crates/uv/tests/workspace/workspace_dir.rs
+++ b/crates/uv/tests/workspace/workspace_dir.rs
@@ -71,6 +71,52 @@ fn workspace_metadata_from_member() -> Result<()> {
     Ok(())
 }
 
+/// Test workspace discovery from a nested project that is ignored by a shallower member glob.
+#[test]
+fn workspace_dir_nested_gitignored_project() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let workspace = context.temp_dir.child("workspace");
+    let project = workspace.child("packages").child("foo").child("nested");
+
+    workspace.child("pyproject.toml").write_str(
+        r#"
+        [tool.uv.workspace]
+        members = ["packages/*"]
+        "#,
+    )?;
+    workspace
+        .child(".gitignore")
+        .write_str("packages/foo/nested/\n")?;
+    project.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "nested"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    let mut filters = context.filters();
+    filters.push((r"thread 'main2' \(\d+\)", "thread 'main2'"));
+    filters.push((r"thread 'main' \(\d+\)", "thread 'main'"));
+
+    uv_snapshot!(filters, context.workspace_dir().current_dir(&project), @r#"
+    exit_code: 101 (failure)
+    ----- stderr -----
+
+    thread 'main2' panicked at crates/uv-workspace/src/workspace.rs:1060:13:
+    assertion `left matches right` failed
+      left: All
+     right: MemberDiscovery::None | MemberDiscovery::Ignore(_)
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+    thread 'main' panicked at crates/uv/src/lib.rs:3114:10:
+    Tokio executor failed, was there a panic?: Any { .. }
+    "#);
+
+    Ok(())
+}
+
 /// Test that a project inside the configured cache directory is rejected before workspace
 /// discovery.
 #[test]

--- a/crates/uv/tests/workspace/workspace_dir.rs
+++ b/crates/uv/tests/workspace/workspace_dir.rs
@@ -96,22 +96,41 @@ fn workspace_dir_nested_gitignored_project() -> Result<()> {
         "#,
     )?;
 
-    let mut filters = context.filters();
-    filters.push((r"thread 'main2' \(\d+\)", "thread 'main2'"));
-    filters.push((r"thread 'main' \(\d+\)", "thread 'main'"));
+    uv_snapshot!(context.filters(), context.workspace_dir().current_dir(&project), @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [TEMP_DIR]/workspace/packages/foo/nested
+    "#);
 
-    uv_snapshot!(filters, context.workspace_dir().current_dir(&project), @r#"
-    exit_code: 101 (failure)
-    ----- stderr -----
+    Ok(())
+}
 
-    thread 'main2' panicked at crates/uv-workspace/src/workspace.rs:1060:13:
-    assertion `left matches right` failed
-      left: All
-     right: MemberDiscovery::None | MemberDiscovery::Ignore(_)
-    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+/// Test workspace discovery from a nested project matched by a recursive member glob.
+#[test]
+fn workspace_dir_nested_recursive_member() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let workspace = context.temp_dir.child("workspace");
+    let project = workspace.child("packages").child("foo").child("nested");
 
-    thread 'main' panicked at crates/uv/src/lib.rs:3114:10:
-    Tokio executor failed, was there a panic?: Any { .. }
+    workspace.child("pyproject.toml").write_str(
+        r#"
+        [tool.uv.workspace]
+        members = ["packages/**/nested"]
+        "#,
+    )?;
+    project.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "nested"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.workspace_dir().current_dir(&project), @r#"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [TEMP_DIR]/workspace
     "#);
 
     Ok(())


### PR DESCRIPTION
Workspace discovery can claim a deeply nested project through a one-level member glob such as `packages/*`, even though member collection expands that glob to direct children only. If the direct child is skipped—for example, because it contains only gitignored files—the nested project is absent from the collected members and uv aborts instead of treating it as standalone.

Make the membership check use the same path-separator semantics as member collection. After this change, `packages/*` selects only direct children; a project at `packages/foo/nested` remains standalone unless the workspace explicitly includes that depth, for example with `packages/*/*`, `packages/**/nested`, or the exact path. Add coverage for both the standalone and recursive-member cases. This removes the workspace-discovery panic identified in #21337 without changing intentionally recursive or explicit member configurations.

Closes #21337.
