### PR TITLE
Read file-cache link counts in bulk on macOS

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -670,7 +670,7 @@ impl Cache {
                     Err(err) => return Err(err),
                 }
             } else if entry.file_type().is_dir() {
-                if let Some(files) = uv_fs::single_link_files(entry.path())? {
+                if let Some(files) = uv_fs::files_with_one_hardlink(entry.path())? {
                     entries.skip_current_dir();
                     for file in files {
                         summary += self.remove_path(file)?;

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -679,6 +679,8 @@ impl Cache {
                 directories.push(entry.into_path());
             }
         }
+        // The walk visits parents first so the bulk path can skip their contents.
+        // Remove directories in reverse order so children are removed before parents.
         for directory in directories.into_iter().rev() {
             match fs_err::remove_dir(directory) {
                 Ok(()) => {

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -658,10 +658,9 @@ impl Cache {
         }
 
         let mut summary = self.removal();
-        for entry in walkdir::WalkDir::new(&root)
-            .min_depth(1)
-            .contents_first(true)
-        {
+        let mut directories = Vec::new();
+        let mut entries = walkdir::WalkDir::new(&root).min_depth(1).into_iter();
+        while let Some(entry) = entries.next() {
             let entry = entry?;
             if entry.file_type().is_file() {
                 match uv_fs::hardlink_count(entry.path()) {
@@ -671,17 +670,26 @@ impl Cache {
                     Err(err) => return Err(err),
                 }
             } else if entry.file_type().is_dir() {
-                match fs_err::remove_dir(entry.path()) {
-                    Ok(()) => {
-                        summary.num_dirs += 1;
+                directories.push(entry.path().to_path_buf());
+                if let Some(files) = uv_fs::single_link_files(entry.path())? {
+                    entries.skip_current_dir();
+                    for file in files {
+                        summary += self.remove_path(file)?;
                     }
-                    Err(err)
-                        if matches!(
-                            err.kind(),
-                            io::ErrorKind::DirectoryNotEmpty | io::ErrorKind::NotFound
-                        ) => {}
-                    Err(err) => return Err(err),
                 }
+            }
+        }
+        for directory in directories.into_iter().rev() {
+            match fs_err::remove_dir(directory) {
+                Ok(()) => {
+                    summary.num_dirs += 1;
+                }
+                Err(err)
+                    if matches!(
+                        err.kind(),
+                        io::ErrorKind::DirectoryNotEmpty | io::ErrorKind::NotFound
+                    ) => {}
+                Err(err) => return Err(err),
             }
         }
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -670,13 +670,13 @@ impl Cache {
                     Err(err) => return Err(err),
                 }
             } else if entry.file_type().is_dir() {
-                directories.push(entry.path().to_path_buf());
                 if let Some(files) = uv_fs::single_link_files(entry.path())? {
                     entries.skip_current_dir();
                     for file in files {
                         summary += self.remove_path(file)?;
                     }
                 }
+                directories.push(entry.into_path());
             }
         }
         for directory in directories.into_iter().rev() {

--- a/crates/uv-fs/src/hardlink_macos.rs
+++ b/crates/uv-fs/src/hardlink_macos.rs
@@ -1,10 +1,12 @@
 use std::ffi::{CStr, OsStr};
 use std::io;
+use std::mem::{offset_of, size_of};
 use std::os::fd::AsRawFd;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 use fs_err::os::unix::fs::OpenOptionsExt;
+use tracing::debug;
 
 // Constants from sys/attr.h and sys/vnode.h that libc does not expose.
 const ATTR_CMN_ERROR: u32 = 0x2000_0000;
@@ -15,9 +17,26 @@ const VDIR: u32 = 2;
 #[repr(align(8))]
 struct AttributeBuffer([u8; 64 * 1024]);
 
-/// Collect pruning candidates with `getattrlistbulk`, avoiding a metadata call for every file.
+/// Fixed attributes requested for regular files, in Darwin's packing order.
+///
+/// This describes the layout only: records are read with checked byte slices, never cast to this
+/// type. File-only fields must not be read until the object type and returned attributes are checked.
+#[repr(C)]
+struct FileAttributes {
+    length: u32,
+    returned: libc::attribute_set_t,
+    error: u32,
+    name: libc::attrreference_t,
+    object_type: u32,
+    hardlink_count: u32,
+}
+
+/// Collect regular files whose only hardlink is their directory entry in `path`.
+///
+/// These are candidates for cache pruning. `getattrlistbulk` avoids a metadata call for every file;
+/// neither `nix` nor `rustix` provides a wrapper, so the native call and checked decoding stay here.
 #[expect(unsafe_code)]
-pub(super) fn single_link_files(path: &Path) -> io::Result<Option<Vec<PathBuf>>> {
+pub(super) fn files_with_one_hardlink(path: &Path) -> io::Result<Option<Vec<PathBuf>>> {
     let directory = fs_err::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
@@ -51,44 +70,48 @@ pub(super) fn single_link_files(path: &Path) -> io::Result<Option<Vec<PathBuf>>>
         let Ok(count) = usize::try_from(count) else {
             let error = io::Error::last_os_error();
             return match error.raw_os_error() {
-                Some(libc::ENOTSUP | libc::ENOSYS | libc::EINVAL) => Ok(None),
+                // ENOTSUP/ENOSYS mean bulk reads are unavailable. EINVAL means this attribute
+                // request was rejected; the ordinary scan remains valid. Log the fallback since
+                // EINVAL can also indicate a bug in the request. Propagate other errors, such as
+                // permission or I/O failures, instead of hiding them behind the fallback.
+                Some(libc::ENOTSUP | libc::ENOSYS | libc::EINVAL) => {
+                    debug!(%error, "Falling back to individual hardlink counts");
+                    Ok(None)
+                }
                 _ => Err(error),
             };
         };
         if count == 0 {
             return Ok(Some(files));
         }
-        let Some(batch) = single_link_files_from_buffer(path, &buffer.0, count)? else {
+        let Some(batch) = files_with_one_hardlink_from_buffer(path, &buffer.0, count)? else {
             return Ok(None);
         };
         files.extend(batch);
     }
 }
 
-/// Decode a batch using the attribute request in [`single_link_files`].
+/// Decode a batch using the attribute request in [`files_with_one_hardlink`].
 ///
 /// Offsets assume `FSOPT_PACK_INVAL_ATTRS`; returned attribute bits still determine which values
 /// are valid. A subdirectory or missing required attribute discards the batch's candidates and
 /// returns `None` so the caller can walk the directory normally.
-fn single_link_files_from_buffer(
+fn files_with_one_hardlink_from_buffer(
     directory: &Path,
     mut buffer: &[u8],
     count: usize,
 ) -> io::Result<Option<Vec<PathBuf>>> {
-    // length, returned attribute sets, error, name reference, object type, and link count.
-    const HEADER_SIZE: usize = 44;
-    const NAME_REFERENCE_OFFSET: usize = 28;
     let mut files = Vec::new();
     for _ in 0..count {
-        let length = read_u32(buffer, 0)? as usize;
+        let length = read_u32(buffer, offset_of!(FileAttributes, length))? as usize;
         let record = buffer
             .get(..length)
-            .filter(|record| record.len() >= HEADER_SIZE)
+            .filter(|record| record.len() >= size_of::<FileAttributes>())
             .ok_or_else(invalid_attributes)?;
         buffer = &buffer[length..];
 
-        let common = read_u32(record, 4)?;
-        let error = read_u32(record, 24)?;
+        let common = read_u32(record, offset_of!(FileAttributes, returned.commonattr))?;
+        let error = read_u32(record, offset_of!(FileAttributes, error))?;
         if common & ATTR_CMN_ERROR != 0 && error != 0 {
             let error = io::Error::from_raw_os_error(
                 i32::try_from(error).map_err(|_| invalid_attributes())?,
@@ -103,42 +126,54 @@ fn single_link_files_from_buffer(
         {
             return Ok(None);
         }
-        match read_u32(record, 36)? {
+        match read_u32(record, offset_of!(FileAttributes, object_type))? {
             VDIR => return Ok(None),
             VREG => {}
             _ => continue,
         }
-        if read_u32(record, 16)? & libc::ATTR_FILE_LINKCOUNT == 0 {
+        let file_attributes = read_u32(record, offset_of!(FileAttributes, returned.fileattr))?;
+        if file_attributes & libc::ATTR_FILE_LINKCOUNT == 0 {
             return Ok(None);
         }
-        if read_u32(record, 40)? != 1 {
+        if read_u32(record, offset_of!(FileAttributes, hardlink_count))? != 1 {
             continue;
         }
 
-        let name_offset = read_u32(record, NAME_REFERENCE_OFFSET)?.cast_signed();
-        let name_start = NAME_REFERENCE_OFFSET
-            .checked_add_signed(name_offset as isize)
-            .ok_or_else(invalid_attributes)?;
-        let name_end = name_start
-            .checked_add(read_u32(record, 32)? as usize)
-            .ok_or_else(invalid_attributes)?;
-        let name = record
-            .get(name_start..name_end)
-            .ok_or_else(invalid_attributes)?;
-        let name = CStr::from_bytes_with_nul(name)
-            .map_err(|_| invalid_attributes())?
-            .to_bytes();
-        if name.is_empty() || name == b"." || name == b".." || name.contains(&b'/') {
-            return Err(invalid_attributes());
-        }
-        files.push(directory.join(OsStr::from_bytes(name)));
+        files.push(directory.join(read_file_name(record)?));
     }
     Ok(Some(files))
 }
 
+/// Resolve a returned name reference to a single path component, preserving non-UTF-8 bytes.
+///
+/// The offset is relative to the [`libc::attrreference_t`], not the record. Check both the reference
+/// and its target against the record bounds, and reject names that could escape the directory.
+/// The caller must first check that `ATTR_CMN_NAME` was returned.
+fn read_file_name(record: &[u8]) -> io::Result<&OsStr> {
+    let name_offset =
+        read_u32(record, offset_of!(FileAttributes, name.attr_dataoffset))?.cast_signed();
+    let name_length = read_u32(record, offset_of!(FileAttributes, name.attr_length))? as usize;
+    let name_start = offset_of!(FileAttributes, name)
+        .checked_add_signed(name_offset as isize)
+        .ok_or_else(invalid_attributes)?;
+    let name_end = name_start
+        .checked_add(name_length)
+        .ok_or_else(invalid_attributes)?;
+    let name = record
+        .get(name_start..name_end)
+        .ok_or_else(invalid_attributes)?;
+    let name = CStr::from_bytes_with_nul(name)
+        .map_err(|_| invalid_attributes())?
+        .to_bytes();
+    if name.is_empty() || name == b"." || name == b".." || name.contains(&b'/') {
+        return Err(invalid_attributes());
+    }
+    Ok(OsStr::from_bytes(name))
+}
+
 fn read_u32(buffer: &[u8], offset: usize) -> io::Result<u32> {
     buffer
-        .get(offset..offset + 4)
+        .get(offset..offset + size_of::<u32>())
         .and_then(|bytes| bytes.try_into().ok())
         .map(u32::from_ne_bytes)
         .ok_or_else(invalid_attributes)
@@ -155,7 +190,9 @@ mod tests {
     use std::os::unix::ffi::OsStrExt;
     use std::path::Path;
 
-    use super::{ATTR_CMN_ERROR, VREG, single_link_files, single_link_files_from_buffer};
+    use super::{
+        ATTR_CMN_ERROR, VREG, files_with_one_hardlink, files_with_one_hardlink_from_buffer,
+    };
 
     #[test]
     fn reads_multiple_batches_without_following_links() -> io::Result<()> {
@@ -176,7 +213,7 @@ mod tests {
         fs_err::hard_link(&retained, directory.join("shared"))?;
         fs_err::os::unix::fs::symlink(&retained, directory.join("symlink"))?;
 
-        let mut actual = single_link_files(&directory)?;
+        let mut actual = files_with_one_hardlink(&directory)?;
         if let Some(files) = &mut actual {
             files.sort();
         }
@@ -184,10 +221,11 @@ mod tests {
         assert_eq!(actual, Some(expected));
 
         fs_err::create_dir(directory.join("nested"))?;
-        assert!(single_link_files(&directory)?.is_none());
+        assert!(files_with_one_hardlink(&directory)?.is_none());
         Ok(())
     }
 
+    /// Encode Darwin's layout independently of the production layout declaration.
     fn record(name: &[u8]) -> Vec<u8> {
         let length = (44 + name.len() + 1).next_multiple_of(8);
         let fields = [
@@ -219,7 +257,7 @@ mod tests {
     fn preserves_non_utf8_names() -> io::Result<()> {
         let name = OsStr::from_bytes(b"file-\xff");
         assert_eq!(
-            single_link_files_from_buffer(Path::new("files"), &record(name.as_bytes()), 1)?,
+            files_with_one_hardlink_from_buffer(Path::new("files"), &record(name.as_bytes()), 1)?,
             Some(vec![Path::new("files").join(name)]),
         );
         Ok(())
@@ -229,7 +267,7 @@ mod tests {
     fn falls_back_when_link_counts_are_unavailable() -> io::Result<()> {
         let mut attributes = record(b"file");
         attributes[16..20].copy_from_slice(&0_u32.to_ne_bytes());
-        assert!(single_link_files_from_buffer(Path::new("files"), &attributes, 1)?.is_none());
+        assert!(files_with_one_hardlink_from_buffer(Path::new("files"), &attributes, 1)?.is_none());
         Ok(())
     }
 
@@ -238,7 +276,7 @@ mod tests {
         let attributes = record(b"file");
         for length in 0..attributes.len() {
             assert!(
-                single_link_files_from_buffer(Path::new("files"), &attributes[..length], 1)
+                files_with_one_hardlink_from_buffer(Path::new("files"), &attributes[..length], 1)
                     .is_err()
             );
         }
@@ -250,10 +288,23 @@ mod tests {
             b"",
             b"file\0suffix",
         ] {
-            assert!(single_link_files_from_buffer(Path::new("files"), &record(name), 1).is_err());
+            assert!(
+                files_with_one_hardlink_from_buffer(Path::new("files"), &record(name), 1).is_err()
+            );
         }
-        let mut attributes = record(b"file");
-        attributes[28..32].copy_from_slice(&i32::MIN.to_ne_bytes());
-        assert!(single_link_files_from_buffer(Path::new("files"), &attributes, 1).is_err());
+        for offset in [i32::MIN, i32::MAX] {
+            let mut attributes = record(b"file");
+            attributes[28..32].copy_from_slice(&offset.to_ne_bytes());
+            assert!(
+                files_with_one_hardlink_from_buffer(Path::new("files"), &attributes, 1).is_err()
+            );
+        }
+        for length in [0_u32, u32::MAX] {
+            let mut attributes = record(b"file");
+            attributes[32..36].copy_from_slice(&length.to_ne_bytes());
+            assert!(
+                files_with_one_hardlink_from_buffer(Path::new("files"), &attributes, 1).is_err()
+            );
+        }
     }
 }

--- a/crates/uv-fs/src/hardlink_macos.rs
+++ b/crates/uv-fs/src/hardlink_macos.rs
@@ -71,11 +71,12 @@ pub(super) fn files_with_one_hardlink(path: &Path) -> io::Result<Option<Vec<Path
             let error = io::Error::last_os_error();
             return match error.raw_os_error() {
                 // ENOTSUP/ENOSYS mean bulk reads are unavailable. EINVAL means this attribute
-                // request was rejected; the ordinary scan remains valid. Log the fallback since
-                // EINVAL can also indicate a bug in the request. Propagate other errors, such as
-                // permission or I/O failures, instead of hiding them behind the fallback.
-                Some(libc::ENOTSUP | libc::ENOSYS | libc::EINVAL) => {
-                    debug!(%error, "Falling back to individual hardlink counts");
+                // request was rejected; log the fallback since it can also indicate a bug.
+                // EACCES can require a fallback too: bulk link counts need search permission,
+                // but an empty directory can still be read and removed without it. The ordinary
+                // walk will propagate permission errors for inaccessible entries.
+                Some(libc::ENOTSUP | libc::ENOSYS | libc::EINVAL | libc::EACCES) => {
+                    debug!("Falling back to individual hardlink counts: {error}");
                     Ok(None)
                 }
                 _ => Err(error),

--- a/crates/uv-fs/src/hardlink_macos.rs
+++ b/crates/uv-fs/src/hardlink_macos.rs
@@ -15,7 +15,7 @@ const VDIR: u32 = 2;
 #[repr(align(8))]
 struct AttributeBuffer([u8; 64 * 1024]);
 
-/// Read single-link files in batches, falling back if any entries need a regular directory walk.
+/// Collect pruning candidates with `getattrlistbulk`, avoiding a metadata call for every file.
 #[expect(unsafe_code)]
 pub(super) fn single_link_files(path: &Path) -> io::Result<Option<Vec<PathBuf>>> {
     let directory = fs_err::OpenOptions::new()
@@ -65,7 +65,11 @@ pub(super) fn single_link_files(path: &Path) -> io::Result<Option<Vec<PathBuf>>>
     }
 }
 
-/// Decode the fixed attributes and record-relative names returned with `FSOPT_PACK_INVAL_ATTRS`.
+/// Decode a batch using the attribute request in [`single_link_files`].
+///
+/// Offsets assume `FSOPT_PACK_INVAL_ATTRS`; returned attribute bits still determine which values
+/// are valid. A subdirectory or missing required attribute discards the batch's candidates and
+/// returns `None` so the caller can walk the directory normally.
 fn single_link_files_from_buffer(
     directory: &Path,
     mut buffer: &[u8],
@@ -118,13 +122,12 @@ fn single_link_files_from_buffer(
         let name_end = name_start
             .checked_add(read_u32(record, 32)? as usize)
             .ok_or_else(invalid_attributes)?;
-        let name = CStr::from_bytes_with_nul(
-            record
-                .get(name_start..name_end)
-                .ok_or_else(invalid_attributes)?,
-        )
-        .map_err(|_| invalid_attributes())?
-        .to_bytes();
+        let name = record
+            .get(name_start..name_end)
+            .ok_or_else(invalid_attributes)?;
+        let name = CStr::from_bytes_with_nul(name)
+            .map_err(|_| invalid_attributes())?
+            .to_bytes();
         if name.is_empty() || name == b"." || name == b".." || name.contains(&b'/') {
             return Err(invalid_attributes());
         }

--- a/crates/uv-fs/src/hardlink_macos.rs
+++ b/crates/uv-fs/src/hardlink_macos.rs
@@ -1,0 +1,256 @@
+use std::ffi::{CStr, OsStr};
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+
+use fs_err::os::unix::fs::OpenOptionsExt;
+
+// Constants from sys/attr.h and sys/vnode.h that libc does not expose.
+const ATTR_CMN_ERROR: u32 = 0x2000_0000;
+const VREG: u32 = 1;
+const VDIR: u32 = 2;
+
+// getattrlistbulk returns an eight-byte-aligned sequence of variable-length records.
+#[repr(align(8))]
+struct AttributeBuffer([u8; 64 * 1024]);
+
+/// Read single-link files in batches, falling back if any entries need a regular directory walk.
+#[expect(unsafe_code)]
+pub(super) fn single_link_files(path: &Path) -> io::Result<Option<Vec<PathBuf>>> {
+    let directory = fs_err::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(path)?;
+    let mut attributes = libc::attrlist {
+        bitmapcount: libc::ATTR_BIT_MAP_COUNT,
+        reserved: 0,
+        commonattr: libc::ATTR_CMN_RETURNED_ATTRS
+            | ATTR_CMN_ERROR
+            | libc::ATTR_CMN_NAME
+            | libc::ATTR_CMN_OBJTYPE,
+        volattr: 0,
+        dirattr: 0,
+        fileattr: libc::ATTR_FILE_LINKCOUNT,
+        forkattr: 0,
+    };
+    let mut buffer = AttributeBuffer([0; 64 * 1024]);
+    let mut files = Vec::new();
+    loop {
+        // SAFETY: The descriptor remains open and refers to a directory. `attributes` is a valid
+        // request, and `buffer` is writable, eight-byte aligned, and has the supplied length.
+        let count = unsafe {
+            libc::getattrlistbulk(
+                directory.as_raw_fd(),
+                (&raw mut attributes).cast(),
+                buffer.0.as_mut_ptr().cast(),
+                buffer.0.len(),
+                u64::from(libc::FSOPT_PACK_INVAL_ATTRS),
+            )
+        };
+        let Ok(count) = usize::try_from(count) else {
+            let error = io::Error::last_os_error();
+            return match error.raw_os_error() {
+                Some(libc::ENOTSUP | libc::ENOSYS | libc::EINVAL) => Ok(None),
+                _ => Err(error),
+            };
+        };
+        if count == 0 {
+            return Ok(Some(files));
+        }
+        let Some(batch) = single_link_files_from_buffer(path, &buffer.0, count)? else {
+            return Ok(None);
+        };
+        files.extend(batch);
+    }
+}
+
+/// Decode the fixed attributes and record-relative names returned with `FSOPT_PACK_INVAL_ATTRS`.
+fn single_link_files_from_buffer(
+    directory: &Path,
+    mut buffer: &[u8],
+    count: usize,
+) -> io::Result<Option<Vec<PathBuf>>> {
+    // length, returned attribute sets, error, name reference, object type, and link count.
+    const HEADER_SIZE: usize = 44;
+    const NAME_REFERENCE_OFFSET: usize = 28;
+    let mut files = Vec::new();
+    for _ in 0..count {
+        let length = read_u32(buffer, 0)? as usize;
+        let record = buffer
+            .get(..length)
+            .filter(|record| record.len() >= HEADER_SIZE)
+            .ok_or_else(invalid_attributes)?;
+        buffer = &buffer[length..];
+
+        let common = read_u32(record, 4)?;
+        let error = read_u32(record, 24)?;
+        if common & ATTR_CMN_ERROR != 0 && error != 0 {
+            let error = io::Error::from_raw_os_error(
+                i32::try_from(error).map_err(|_| invalid_attributes())?,
+            );
+            if error.kind() == io::ErrorKind::NotFound {
+                continue;
+            }
+            return Err(error);
+        }
+        if common & (libc::ATTR_CMN_NAME | libc::ATTR_CMN_OBJTYPE)
+            != libc::ATTR_CMN_NAME | libc::ATTR_CMN_OBJTYPE
+        {
+            return Ok(None);
+        }
+        match read_u32(record, 36)? {
+            VDIR => return Ok(None),
+            VREG => {}
+            _ => continue,
+        }
+        if read_u32(record, 16)? & libc::ATTR_FILE_LINKCOUNT == 0 {
+            return Ok(None);
+        }
+        if read_u32(record, 40)? != 1 {
+            continue;
+        }
+
+        let name_offset = read_u32(record, NAME_REFERENCE_OFFSET)?.cast_signed();
+        let name_start = NAME_REFERENCE_OFFSET
+            .checked_add_signed(name_offset as isize)
+            .ok_or_else(invalid_attributes)?;
+        let name_end = name_start
+            .checked_add(read_u32(record, 32)? as usize)
+            .ok_or_else(invalid_attributes)?;
+        let name = CStr::from_bytes_with_nul(
+            record
+                .get(name_start..name_end)
+                .ok_or_else(invalid_attributes)?,
+        )
+        .map_err(|_| invalid_attributes())?
+        .to_bytes();
+        if name.is_empty() || name == b"." || name == b".." || name.contains(&b'/') {
+            return Err(invalid_attributes());
+        }
+        files.push(directory.join(OsStr::from_bytes(name)));
+    }
+    Ok(Some(files))
+}
+
+fn read_u32(buffer: &[u8], offset: usize) -> io::Result<u32> {
+    buffer
+        .get(offset..offset + 4)
+        .and_then(|bytes| bytes.try_into().ok())
+        .map(u32::from_ne_bytes)
+        .ok_or_else(invalid_attributes)
+}
+
+fn invalid_attributes() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "invalid bulk file attributes")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::io;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+
+    use super::{ATTR_CMN_ERROR, VREG, single_link_files, single_link_files_from_buffer};
+
+    #[test]
+    fn reads_multiple_batches_without_following_links() -> io::Result<()> {
+        let root = tempfile::tempdir()?;
+        let directory = root.path().join("files");
+        fs_err::create_dir(&directory)?;
+        let mut expected = Vec::new();
+        for index in 0..1500 {
+            let path = directory.join(format!("{index:064x}"));
+            fs_err::write(&path, [])?;
+            expected.push(path);
+        }
+        let unicode = directory.join("file-λ");
+        fs_err::write(&unicode, [])?;
+        expected.push(unicode);
+        let retained = root.path().join("retained");
+        fs_err::write(&retained, [])?;
+        fs_err::hard_link(&retained, directory.join("shared"))?;
+        fs_err::os::unix::fs::symlink(&retained, directory.join("symlink"))?;
+
+        let mut actual = single_link_files(&directory)?;
+        if let Some(files) = &mut actual {
+            files.sort();
+        }
+        expected.sort();
+        assert_eq!(actual, Some(expected));
+
+        fs_err::create_dir(directory.join("nested"))?;
+        assert!(single_link_files(&directory)?.is_none());
+        Ok(())
+    }
+
+    fn record(name: &[u8]) -> Vec<u8> {
+        let length = (44 + name.len() + 1).next_multiple_of(8);
+        let fields = [
+            u32::try_from(length).expect("test attribute record fits in u32"),
+            libc::ATTR_CMN_RETURNED_ATTRS
+                | ATTR_CMN_ERROR
+                | libc::ATTR_CMN_NAME
+                | libc::ATTR_CMN_OBJTYPE,
+            0,
+            0,
+            libc::ATTR_FILE_LINKCOUNT,
+            0,
+            0,
+            16,
+            u32::try_from(name.len()).expect("test file name fits in u32") + 1,
+            VREG,
+            1,
+        ];
+        let mut record = fields
+            .into_iter()
+            .flat_map(u32::to_ne_bytes)
+            .collect::<Vec<_>>();
+        record.extend_from_slice(name);
+        record.resize(length, 0);
+        record
+    }
+
+    #[test]
+    fn preserves_non_utf8_names() -> io::Result<()> {
+        let name = OsStr::from_bytes(b"file-\xff");
+        assert_eq!(
+            single_link_files_from_buffer(Path::new("files"), &record(name.as_bytes()), 1)?,
+            Some(vec![Path::new("files").join(name)]),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn falls_back_when_link_counts_are_unavailable() -> io::Result<()> {
+        let mut attributes = record(b"file");
+        attributes[16..20].copy_from_slice(&0_u32.to_ne_bytes());
+        assert!(single_link_files_from_buffer(Path::new("files"), &attributes, 1)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_truncated_records_and_names_outside_the_directory() {
+        let attributes = record(b"file");
+        for length in 0..attributes.len() {
+            assert!(
+                single_link_files_from_buffer(Path::new("files"), &attributes[..length], 1)
+                    .is_err()
+            );
+        }
+        for name in [
+            b"../outside".as_slice(),
+            b"/outside",
+            b".",
+            b"..",
+            b"",
+            b"file\0suffix",
+        ] {
+            assert!(single_link_files_from_buffer(Path::new("files"), &record(name), 1).is_err());
+        }
+        let mut attributes = record(b"file");
+        attributes[28..32].copy_from_slice(&i32::MIN.to_ne_bytes());
+        assert!(single_link_files_from_buffer(Path::new("files"), &attributes, 1).is_err());
+    }
+}

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -66,18 +66,18 @@ pub fn hardlink_count(_path: &Path) -> io::Result<u64> {
     ))
 }
 
-/// Collect regular files with a single hardlink from a flat directory, ignoring symlink entries.
+/// Collect regular files whose only hardlink is their entry in this directory.
 ///
-/// Uses bulk metadata reads on macOS. Returns `None` when the fast path is unavailable, required
-/// attributes are missing, or the directory contains subdirectories that need a recursive walk.
+/// Ignores symlink entries and uses bulk metadata reads on macOS. Returns `None` when the fast path
+/// is unavailable, required attributes are missing, or subdirectories need a recursive walk.
 /// No candidates are returned unless the entire directory can use the fast path.
 ///
 /// Callers deleting these files must prevent concurrent changes to the directory and hardlink
 /// counts throughout both the scan and deletion.
-pub fn single_link_files(path: &Path) -> io::Result<Option<Vec<PathBuf>>> {
+pub fn files_with_one_hardlink(path: &Path) -> io::Result<Option<Vec<PathBuf>>> {
     #[cfg(target_os = "macos")]
     {
-        hardlink_macos::single_link_files(path)
+        hardlink_macos::files_with_one_hardlink(path)
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -66,10 +66,14 @@ pub fn hardlink_count(_path: &Path) -> io::Result<u64> {
     ))
 }
 
-/// Return regular files with a single hardlink from a flat directory, without following symlinks.
+/// Collect regular files with a single hardlink from a flat directory, ignoring symlink entries.
 ///
 /// Uses bulk metadata reads on macOS. Returns `None` when the fast path is unavailable, required
 /// attributes are missing, or the directory contains subdirectories that need a recursive walk.
+/// No candidates are returned unless the entire directory can use the fast path.
+///
+/// Callers deleting these files must prevent concurrent changes to the directory and hardlink
+/// counts throughout both the scan and deletion.
 pub fn single_link_files(path: &Path) -> io::Result<Option<Vec<PathBuf>>> {
     #[cfg(target_os = "macos")]
     {

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -30,6 +30,8 @@ pub use crate::read::ValidatedReader;
 pub use crate::space::{PhysicalSpaceError, physical_space, supports_fine_grained_accounting};
 
 pub mod cachedir;
+#[cfg(target_os = "macos")]
+mod hardlink_macos;
 pub mod link;
 mod locked_file;
 mod path;
@@ -62,6 +64,22 @@ pub fn hardlink_count(_path: &Path) -> io::Result<u64> {
         io::ErrorKind::Unsupported,
         "hardlink counts are not supported on this platform",
     ))
+}
+
+/// Return regular files with a single hardlink from a flat directory, without following symlinks.
+///
+/// Uses bulk metadata reads on macOS. Returns `None` when the fast path is unavailable, required
+/// attributes are missing, or the directory contains subdirectories that need a recursive walk.
+pub fn single_link_files(path: &Path) -> io::Result<Option<Vec<PathBuf>>> {
+    #[cfg(target_os = "macos")]
+    {
+        hardlink_macos::single_link_files(path)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = path;
+        Ok(None)
+    }
 }
 
 /// Return a path's creation time, including on Linux targets where [`std::fs::Metadata::created`]

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -461,16 +461,30 @@ fn clean_package_does_not_follow_symlinks() -> Result<()> {
     fs_err::os::unix::fs::symlink(&victim_dir, package_entry.join("escape"))?;
     fs_err::os::unix::fs::symlink(&archive_entry, package_entry.join("archive"))?;
 
-    uv_snapshot!(context.filters(), context.clean().arg("demo"), @"
+    let files = context.cache_dir.child("files-v0");
+    let shard = files.child("shard");
+    shard.child("orphan").write_str("orphan")?;
+    shard
+        .child("nested")
+        .child("orphan")
+        .write_str("nested orphan")?;
+    fs_err::os::unix::fs::symlink(&victim_dir, files.child("escape"))?;
+    fs_err::os::unix::fs::symlink(&victim_dir, shard.child("escape"))?;
+
+    uv_snapshot!(context.filters(), context.clean().args(["demo", "other"]), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Removed 3 files ([SIZE])
+    Removed 5 files ([SIZE])
     ");
 
     assert!(victim_dir.is_dir());
     assert!(victim_dir.child("payload.txt").is_file());
     assert!(fs_err::symlink_metadata(package_entry).is_err());
     assert!(fs_err::symlink_metadata(archive_entry).is_err());
+    assert!(!shard.child("orphan").exists());
+    assert!(!shard.child("nested").exists());
+    assert!(fs_err::symlink_metadata(files.child("escape"))?.is_symlink());
+    assert!(fs_err::symlink_metadata(shard.child("escape"))?.is_symlink());
 
     Ok(())
 }

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -1,3 +1,8 @@
+#[cfg(target_os = "macos")]
+use std::fs::Permissions;
+#[cfg(target_os = "macos")]
+use std::os::unix::fs::PermissionsExt;
+
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
@@ -471,10 +476,18 @@ fn clean_package_does_not_follow_symlinks() -> Result<()> {
     fs_err::os::unix::fs::symlink(&victim_dir, files.child("escape"))?;
     fs_err::os::unix::fs::symlink(&victim_dir, shard.child("escape"))?;
 
+    // Keep this shard flat so macOS can prune it with bulk metadata reads.
+    let flat_shard = files.child("flat");
+    flat_shard.child("orphan").write_str("orphan")?;
+    let retained = context.cache_dir.path().with_file_name("retained.bin");
+    fs_err::write(&retained, "retained")?;
+    fs_err::hard_link(&retained, flat_shard.child("retained"))?;
+    fs_err::os::unix::fs::symlink(&victim_dir, flat_shard.child("escape"))?;
+
     uv_snapshot!(context.filters(), context.clean().args(["demo", "other"]), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Removed 5 files ([SIZE])
+    Removed 6 files ([SIZE])
     ");
 
     assert!(victim_dir.is_dir());
@@ -485,6 +498,30 @@ fn clean_package_does_not_follow_symlinks() -> Result<()> {
     assert!(!shard.child("nested").exists());
     assert!(fs_err::symlink_metadata(files.child("escape"))?.is_symlink());
     assert!(fs_err::symlink_metadata(shard.child("escape"))?.is_symlink());
+    assert!(!flat_shard.child("orphan").exists());
+    assert!(retained.is_file());
+    assert!(flat_shard.child("retained").is_file());
+    assert!(fs_err::symlink_metadata(flat_shard.child("escape"))?.is_symlink());
+
+    Ok(())
+}
+
+/// Empty file-cache shards can be removed without search permission.
+#[cfg(target_os = "macos")]
+#[test]
+fn clean_package_empty_shard_without_search_permission() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let shard = context.cache_dir.child("files-v0").child("shard");
+    shard.create_dir_all()?;
+    fs_err::set_permissions(&shard, Permissions::from_mode(0o600))?;
+
+    uv_snapshot!(context.filters(), context.clean().arg("demo"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 1 directory (0B)
+    ");
+
+    assert!(!shard.exists());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Follow-up to #21327.

Cache cleanup currently reads the hardlink count of every `files-v0` object separately. On macOS, we can request names, file types, and link counts in batches with `getattrlistbulk`, allocating paths only for files with a single link.

Use this fast path for flat cache shards. We keep the existing walk on other platforms, when bulk reads or required attributes aren't available, and for nested directories. We don't follow symlinks, and file removal still uses the existing storage accounting.

On macOS, with 87,129 distinct empty file objects across 256 shards and two hardlinks per object, median full-command times across eight paired warm-cache runs were:

| Command                        | Before |  After |
| ------------------------------ | -----: | -----: |
| `uv cache clean <package>`     | 386 ms | 105 ms |
| `uv cache clean <10 packages>` | 389 ms | 104 ms |
| `uv cache prune`               | 386 ms | 101 ms |

These runs retain every object, so they measure scan cost rather than deletion throughput. The scan is still single-threaded.
