### PR TITLE
astral-tl 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tl"
-version = "0.7.11"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90933ffb0f97e2fc2e0de21da9d3f20597b804012d199843a6fe7c2810d28f3"
+checksum = "04d4bb5df351abb6758a04240b0193794ddaf34a7c0b9452fab3c25dcce39e88"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ tempfile = { version = "3.14.0" }
 terminal_size = { version = "0.4.2" }
 textwrap = { version = "0.16.1" }
 thiserror = { version = "2.0.0" }
-astral-tl = { version = "0.7.11" }
+astral-tl = { version = "0.8.0" }
 tokio = { version = "1.40.0", features = [
   "fs",
   "io-util",


### PR DESCRIPTION
## Summary

Bumps our own astral-tl crate.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

NFC; this is a breaking change in astral-tl's APIs but not in terms of uv's usage.

<!-- How was it tested? -->
