### PR TITLE
Test public package registries

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -951,6 +951,38 @@ jobs:
           # Check that we don't fail on `pyenv-win` shims
           ./uv python list -v
 
+  integration-test-public-registries:
+    name: "public registries"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: 3.12
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-linux-libc-${{ inputs.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Run public registry tests"
+        run: ./uv run --locked --python "${PYTHON_VERSION}" --no-build --script scripts/registries-test.py --uv ./uv --color always
+        env:
+          UV_TEST_MICROSOFT_PKG: typing-extensions
+          UV_TEST_MICROSOFT_PUBLIC: "true"
+          # TODO: Enable when https://github.com/astral-sh/uv/issues/21349 is fixed.
+          # UV_TEST_MICROSOFT_REQUIRE_METADATA_RANGE_REQUESTS: "true"
+          UV_TEST_MICROSOFT_URL: https://packagefeedproxy.microsoft.io/pypi/simple
+
   integration-test-registries:
     name: "registries"
     timeout-minutes: 10

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -977,11 +977,22 @@ jobs:
       - name: "Run public registry tests"
         run: ./uv run --locked --python "${PYTHON_VERSION}" --no-build --script scripts/registries-test.py --uv ./uv --color always
         env:
+          UV_TEST_ASTRAL_PKG: transformer-engine
+          UV_TEST_ASTRAL_PUBLIC: "true"
+          UV_TEST_ASTRAL_URL: https://wheels.astral.sh/simple/cu128/
           UV_TEST_MICROSOFT_PKG: typing-extensions
           UV_TEST_MICROSOFT_PUBLIC: "true"
           # TODO: Enable when https://github.com/astral-sh/uv/issues/21349 is fixed.
           # UV_TEST_MICROSOFT_REQUIRE_METADATA_RANGE_REQUESTS: "true"
           UV_TEST_MICROSOFT_URL: https://packagefeedproxy.microsoft.io/pypi/simple
+          UV_TEST_NVIDIA_PKG: nvidia-nvtx-cu12
+          UV_TEST_NVIDIA_PUBLIC: "true"
+          UV_TEST_NVIDIA_REQUIRE_METADATA_RANGE_REQUESTS: "true"
+          UV_TEST_NVIDIA_URL: https://pypi.nvidia.com/
+          UV_TEST_PYTORCH_PKG: colorama
+          UV_TEST_PYTORCH_PUBLIC: "true"
+          UV_TEST_PYTORCH_REQUIRE_METADATA_RANGE_REQUESTS: "true"
+          UV_TEST_PYTORCH_URL: https://download.pytorch.org/whl/cpu
 
   integration-test-registries:
     name: "registries"

--- a/scripts/registries-test.py
+++ b/scripts/registries-test.py
@@ -8,6 +8,10 @@ To configure a registry, set the following environment variables:
     `UV_TEST_<registry_name>_URL`         URL for the registry
     `UV_TEST_<registry_name>_TOKEN`       authentication token
 
+For public registries that do not require authentication, set:
+
+    `UV_TEST_<registry_name>_PUBLIC`      `true`
+
 To fail instead of streaming the entire wheel when metadata range requests are unsupported, set:
 
     `UV_TEST_<registry_name>_REQUIRE_METADATA_RANGE_REQUESTS`  `true`
@@ -180,7 +184,7 @@ def run_test(
     registry_url: str,
     package: str,
     username: str,
-    token: str,
+    token: str | None,
     verbosity: int,
     timeout: int,
     requires_python: str,
@@ -189,19 +193,22 @@ def run_test(
 ) -> bool:
     print(uv)
     """Attempt to install a package from this registry."""
-    print(
-        f"{registry_name} -- Running test for {registry_url} with username {username}"
-    )
+    if token:
+        print(
+            f"{registry_name} -- Running test for {registry_url} with username {username}"
+        )
+    else:
+        print(f"{registry_name} -- Running public test for {registry_url}")
     if package == DEFAULT_PKG_NAME:
         print(
             f"** Using default test package name: {package}. To choose a different package, set UV_TEST_{registry_name.upper()}_PKG"
         )
     print(f"\nAttempting to install {package}")
 
-    if auth_method == "env":
+    if token and auth_method == "env":
         env[f"UV_INDEX_{registry_name.upper()}_USERNAME"] = username
         env[f"UV_INDEX_{registry_name.upper()}_PASSWORD"] = token
-    elif auth_method == "text-store":
+    elif token and auth_method == "text-store":
         # Use uv's text store for authentication
         subprocess.check_call(
             [
@@ -216,7 +223,7 @@ def run_test(
             ],
             env=env,
         )
-    else:
+    elif token:
         raise ValueError(f"Unknown authentication method: {auth_method}")
 
     with tempfile.TemporaryDirectory() as project_dir:
@@ -373,7 +380,10 @@ def main() -> None:
         print("----------------")
 
         token = env.get(f"UV_TEST_{registry_name.upper()}_TOKEN")
-        if not token:
+        public = (
+            env.get(f"UV_TEST_{registry_name.upper()}_PUBLIC", "").lower() == "true"
+        )
+        if not token and not public:
             if args.all:
                 print(
                     f"{Fore.RED}{registry_name}: UV_TEST_{registry_name.upper()}_TOKEN contained no token. Required by --all"
@@ -412,7 +422,7 @@ def main() -> None:
         else:
             failed.append(registry_name)
 
-        untested_registries.remove(registry_name)
+        untested_registries.discard(registry_name)
 
     total = len(passed) + len(failed)
 
@@ -445,6 +455,7 @@ def main() -> None:
         print("\nNo tests were run - have you defined at least one registry?")
         print("     * UV_TEST_<registry_name>_URL")
         print("     * UV_TEST_<registry_name>_TOKEN")
+        print("     * UV_TEST_<registry_name>_PUBLIC=true (for public registries)")
         print(
             "     * UV_TEST_<registry_name>_PKG (the private package to test installing)"
         )


### PR DESCRIPTION
The registry integration tests currently require credentials, leaving public package indexes without dedicated coverage. Add an unprivileged job that installs small packages from Microsoft's public feed, PyTorch, NVIDIA, and Astral's GPU index. Require working metadata range requests for PyTorch and NVIDIA; Astral exercises PEP 658 metadata. Keep the Microsoft range assertion disabled until #21349 is fixed.
