### PR TITLE
Preserve macOS cache cleanup without directory search permission

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -675,6 +675,8 @@ impl Cache {
                 directories.push(entry.into_path());
             }
         }
+        // The walk visits parents first so the bulk path can skip their contents.
+        // Remove directories in reverse order so children are removed before parents.
         for directory in directories.into_iter().rev() {
             match fs_err::remove_dir(directory) {
                 Ok(()) => {

--- a/crates/uv-fs/src/hardlink_macos.rs
+++ b/crates/uv-fs/src/hardlink_macos.rs
@@ -76,7 +76,7 @@ pub(super) fn files_with_one_hardlink(path: &Path) -> io::Result<Option<Vec<Path
                 // but an empty directory can still be read and removed without it. The ordinary
                 // walk will propagate permission errors for inaccessible entries.
                 Some(libc::ENOTSUP | libc::ENOSYS | libc::EINVAL | libc::EACCES) => {
-                    debug!(%error, "Falling back to individual hardlink counts");
+                    debug!("Falling back to individual hardlink counts: {error}");
                     Ok(None)
                 }
                 _ => Err(error),

--- a/crates/uv-fs/src/hardlink_macos.rs
+++ b/crates/uv-fs/src/hardlink_macos.rs
@@ -71,10 +71,11 @@ pub(super) fn files_with_one_hardlink(path: &Path) -> io::Result<Option<Vec<Path
             let error = io::Error::last_os_error();
             return match error.raw_os_error() {
                 // ENOTSUP/ENOSYS mean bulk reads are unavailable. EINVAL means this attribute
-                // request was rejected; the ordinary scan remains valid. Log the fallback since
-                // EINVAL can also indicate a bug in the request. Propagate other errors, such as
-                // permission or I/O failures, instead of hiding them behind the fallback.
-                Some(libc::ENOTSUP | libc::ENOSYS | libc::EINVAL) => {
+                // request was rejected; log the fallback since it can also indicate a bug.
+                // EACCES can require a fallback too: bulk link counts need search permission,
+                // but an empty directory can still be read and removed without it. The ordinary
+                // walk will propagate permission errors for inaccessible entries.
+                Some(libc::ENOTSUP | libc::ENOSYS | libc::EINVAL | libc::EACCES) => {
                     debug!(%error, "Falling back to individual hardlink counts");
                     Ok(None)
                 }

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -476,10 +476,18 @@ fn clean_package_does_not_follow_symlinks() -> Result<()> {
     fs_err::os::unix::fs::symlink(&victim_dir, files.child("escape"))?;
     fs_err::os::unix::fs::symlink(&victim_dir, shard.child("escape"))?;
 
+    // Keep this shard flat so macOS can prune it with bulk metadata reads.
+    let flat_shard = files.child("flat");
+    flat_shard.child("orphan").write_str("orphan")?;
+    let retained = context.cache_dir.path().with_file_name("retained.bin");
+    fs_err::write(&retained, "retained")?;
+    fs_err::hard_link(&retained, flat_shard.child("retained"))?;
+    fs_err::os::unix::fs::symlink(&victim_dir, flat_shard.child("escape"))?;
+
     uv_snapshot!(context.filters(), context.clean().args(["demo", "other"]), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Removed 5 files ([SIZE])
+    Removed 6 files ([SIZE])
     ");
 
     assert!(victim_dir.is_dir());
@@ -490,6 +498,10 @@ fn clean_package_does_not_follow_symlinks() -> Result<()> {
     assert!(!shard.child("nested").exists());
     assert!(fs_err::symlink_metadata(files.child("escape"))?.is_symlink());
     assert!(fs_err::symlink_metadata(shard.child("escape"))?.is_symlink());
+    assert!(!flat_shard.child("orphan").exists());
+    assert!(retained.is_file());
+    assert!(flat_shard.child("retained").is_file());
+    assert!(fs_err::symlink_metadata(flat_shard.child("escape"))?.is_symlink());
 
     Ok(())
 }

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -1,3 +1,8 @@
+#[cfg(target_os = "macos")]
+use std::fs::Permissions;
+#[cfg(target_os = "macos")]
+use std::os::unix::fs::PermissionsExt;
+
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
@@ -485,6 +490,26 @@ fn clean_package_does_not_follow_symlinks() -> Result<()> {
     assert!(!shard.child("nested").exists());
     assert!(fs_err::symlink_metadata(files.child("escape"))?.is_symlink());
     assert!(fs_err::symlink_metadata(shard.child("escape"))?.is_symlink());
+
+    Ok(())
+}
+
+/// Empty file-cache shards can be removed without search permission.
+#[cfg(target_os = "macos")]
+#[test]
+fn clean_package_empty_shard_without_search_permission() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let shard = context.cache_dir.child("files-v0").child("shard");
+    shard.create_dir_all()?;
+    fs_err::set_permissions(&shard, Permissions::from_mode(0o600))?;
+
+    uv_snapshot!(context.filters(), context.clean().arg("demo"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 1 directory (0B)
+    ");
+
+    assert!(!shard.exists());
 
     Ok(())
 }


### PR DESCRIPTION
Stacked on #21344.

`uv cache clean <package>` fails on macOS when an empty file-cache shard is readable but lacks search permission: `getattrlistbulk` requires that permission even though the ordinary directory walk can enumerate and remove the shard. Fall back on `EACCES` to preserve existing cleanup behavior while retaining errors from the ordinary walk.

Also align the fallback log with nearby diagnostics and explain why directory removal is deferred.
