### PR TITLE
Respect `CONDA_PREFIX` for `--active` in project commands

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3867,8 +3867,8 @@ pub struct SyncArgs {
     /// Sync dependencies to the active virtual environment.
     ///
     /// Instead of creating or updating the virtual environment for the project or script, the
-    /// active virtual environment will be preferred, if the `VIRTUAL_ENV` environment variable is
-    /// set.
+    /// active environment will be preferred, if the `VIRTUAL_ENV` environment variable is
+    /// set, or if a non-base Conda environment is active via `CONDA_PREFIX`.
     #[arg(long, overrides_with = "no_active")]
     pub active: bool,
 
@@ -7906,8 +7906,8 @@ pub struct MetadataArgs {
     /// Sync dependencies to the active virtual environment.
     ///
     /// Instead of creating or updating the virtual environment for the project or script, the
-    /// active virtual environment will be preferred, if the `VIRTUAL_ENV` environment variable is
-    /// set.
+    /// active environment will be preferred, if the `VIRTUAL_ENV` environment variable is
+    /// set, or if a non-base Conda environment is active via `CONDA_PREFIX`.
     #[arg(long)]
     pub active: bool,
 

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -28,7 +28,10 @@ pub use crate::version_files::{
     FilePreference as VersionFilePreference, PYTHON_VERSION_FILENAME, PYTHON_VERSIONS_FILENAME,
     PythonVersionFile,
 };
-pub use crate::virtualenv::{Error as VirtualEnvError, PyVenvConfiguration, VirtualEnvironment};
+pub use crate::virtualenv::{
+    CondaEnvironmentKind, Error as VirtualEnvError, PyVenvConfiguration, VirtualEnvironment,
+    conda_environment_from_env,
+};
 
 mod discovery;
 pub mod downloads;

--- a/crates/uv-python/src/virtualenv.rs
+++ b/crates/uv-python/src/virtualenv.rs
@@ -71,7 +71,7 @@ pub(crate) fn virtualenv_from_env() -> Option<PathBuf> {
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub(crate) enum CondaEnvironmentKind {
+pub enum CondaEnvironmentKind {
     /// The base Conda environment; treated like a system Python environment.
     Base,
     /// Any other Conda environment; treated like a virtual environment.
@@ -136,7 +136,7 @@ fn is_pixi_environment(path: &Path) -> bool {
 ///
 /// If `base` is true, the active environment must be the base environment or `None` is returned,
 /// and vice-versa.
-pub(crate) fn conda_environment_from_env(kind: CondaEnvironmentKind) -> Option<PathBuf> {
+pub fn conda_environment_from_env(kind: CondaEnvironmentKind) -> Option<PathBuf> {
     let dir = env::var_os(EnvVars::CONDA_PREFIX).filter(|value| !value.is_empty())?;
     let path = PathBuf::from(dir);
 

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -900,7 +900,18 @@ impl Workspace {
     /// If `active` is [`ActiveEnvironment::Prefer`], the `VIRTUAL_ENV` variable will be preferred.
     /// If it is [`ActiveEnvironment::Ignore`], warnings about mismatches between the active
     /// environment and the project environment will be silenced.
-    pub fn environment_selection(&self, active: ActiveEnvironment) -> ProjectEnvironmentSelection {
+    ///
+    /// If `VIRTUAL_ENV` is unset and `active` is [`ActiveEnvironment::Prefer`], the
+    /// `conda_env_path` argument is used instead, matching the order of `uv pip`. Callers to this
+    /// function must pass a non-base conda environment (see `uv_python::CondaEnvironmentKind`), as
+    /// base conda environments are treated as system installations, and shouldn't be used as
+    /// project environments. `conda_env_path` is ignored unless `active` is
+    /// [`ActiveEnvironment::Prefer`].
+    pub fn environment_selection(
+        &self,
+        active: ActiveEnvironment,
+        conda_env_path: Option<PathBuf>,
+    ) -> ProjectEnvironmentSelection {
         /// Resolve the `UV_PROJECT_ENVIRONMENT` value, if any.
         fn from_project_environment_variable(workspace: &Workspace) -> Option<PathBuf> {
             let value = std::env::var_os(EnvVars::UV_PROJECT_ENVIRONMENT)?;
@@ -975,6 +986,17 @@ impl Workspace {
                     "Use of the active virtual environment was requested, but `VIRTUAL_ENV` is not set"
                 );
             }
+        }
+
+        if active == ActiveEnvironment::Prefer
+            && let Some(conda_env_path) = conda_env_path
+        {
+            debug!(
+                "Using active conda environment `{}` instead of project environment `{}`",
+                conda_env_path.user_display(),
+                project_environment_path.user_display()
+            );
+            return ProjectEnvironmentSelection::Active(conda_env_path);
         }
 
         selection

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -35,10 +35,10 @@ use uv_preview::{Preview, PreviewFeature};
 use uv_pypi_types::{ConflictItem, ConflictKind, ConflictSet, Conflicts};
 use uv_python::managed::{ManagedPythonInstallation, PythonMinorVersionLink};
 use uv_python::{
-    BrokenLink, ConfigDiscovery, EnvironmentPreference, Interpreter, InvalidEnvironmentKind,
-    LenientImplementationName, PythonDownloads, PythonEnvironment, PythonInstallation,
-    PythonPreference, PythonRequest, PythonSource, PythonVariant, PythonVersionFile,
-    VersionFileDiscoveryOptions, VersionRequest,
+    BrokenLink, CondaEnvironmentKind, ConfigDiscovery, EnvironmentPreference, Interpreter,
+    InvalidEnvironmentKind, LenientImplementationName, PythonDownloads, PythonEnvironment,
+    PythonInstallation, PythonPreference, PythonRequest, PythonSource, PythonVariant,
+    PythonVersionFile, VersionFileDiscoveryOptions, VersionRequest, conda_environment_from_env,
 };
 use uv_requirements::{
     LockedRequirements, NamedRequirementsResolver, RequirementsSpecification,
@@ -1386,7 +1386,8 @@ impl ProjectInterpreter {
         active: ActiveEnvironment,
         cache: &Cache,
     ) -> Result<Option<PythonEnvironment>, ProjectError> {
-        let selection = workspace.environment_selection(active);
+        let conda_env_path = conda_environment_from_env(CondaEnvironmentKind::Child);
+        let selection = workspace.environment_selection(active, conda_env_path);
         let root = selection
             .explicit_path()
             .map_or_else(|| workspace.install_path().join(".venv"), Path::to_path_buf);
@@ -1426,8 +1427,8 @@ impl ProjectInterpreter {
             python_request,
             requires_python,
         } = workspace_python;
-
-        let environment_selection = workspace.environment_selection(active);
+        let conda_env_path = conda_environment_from_env(CondaEnvironmentKind::Child);
+        let environment_selection = workspace.environment_selection(active, conda_env_path);
         let centralized = centralized_environments_enabled(&environment_selection, cache);
         let upgradeable = python_request
             .as_ref()
@@ -1845,7 +1846,8 @@ impl ProjectEnvironment {
         link_error_reporting: LinkErrorReporting,
         printer: Printer,
     ) -> Result<Self, ProjectError> {
-        let environment_selection = workspace.environment_selection(active);
+        let conda_env_path = conda_environment_from_env(CondaEnvironmentKind::Child);
+        let environment_selection = workspace.environment_selection(active, conda_env_path);
         let centralized = centralized_environments_enabled(&environment_selection, cache);
 
         // Lock the project environment to avoid synchronization issues.

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -131,7 +131,7 @@ pub(crate) async fn venv(
         .map(|workspace| {
             (
                 workspace,
-                workspace.environment_selection(ActiveEnvironment::Ignore),
+                workspace.environment_selection(ActiveEnvironment::Ignore, None),
             )
         });
 

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -7057,6 +7057,120 @@ fn sync_active_project_environment() -> Result<()> {
 }
 
 #[test]
+fn sync_active_conda_project_environment() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12"])
+        .with_filtered_virtualenv_bin()
+        .with_filtered_python_names();
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.11"
+        dependencies = ["iniconfig"]
+        "#,
+    )?;
+
+    // An active conda environment should be ignored without `--active`, and unlike
+    // `VIRTUAL_ENV`, no warning is emitted. Conda users typically have an environment
+    // active at all times.
+    uv_snapshot!(context.filters(), context.sync()
+    .env(EnvVars::CONDA_PREFIX, "envs/conda-env")
+    .env(EnvVars::CONDA_DEFAULT_ENV, "conda-env"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.11.[X] interpreter at: [PYTHON-3.11]
+    Creating virtual environment at: .venv
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    context
+        .temp_dir
+        .child(".venv")
+        .assert(predicate::path::is_dir());
+
+    context
+        .temp_dir
+        .child("envs/conda-env")
+        .assert(predicate::path::missing());
+
+    // Using `--active` should use the conda environment
+    uv_snapshot!(context.filters(), context.sync()
+    .arg("--active")
+    .env(EnvVars::CONDA_PREFIX, "envs/conda-env")
+    .env(EnvVars::CONDA_DEFAULT_ENV, "conda-env"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.11.[X] interpreter at: [PYTHON-3.11]
+    Creating virtual environment at: envs/conda-env
+    Resolved 2 packages in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    context
+        .temp_dir
+        .child("envs/conda-env")
+        .assert(predicate::path::is_dir());
+
+    // `--no-active` still prefers the project environment
+    uv_snapshot!(context.filters(), context.sync()
+    .arg("--no-active")
+    .env(EnvVars::CONDA_PREFIX, "envs/conda-env")
+    .env(EnvVars::CONDA_DEFAULT_ENV, "conda-env"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Checked 1 package in [TIME]
+    ");
+
+    // A conda base environment is treated as a system installation, so it is
+    // never used, even with `--active`. `CONDA_DEFAULT_ENV` doesn't match the
+    // prefix directory name, which marks it as a base environment.
+    uv_snapshot!(context.filters(), context.sync()
+    .arg("--active")
+    .env(EnvVars::CONDA_PREFIX, "envs/base-env")
+    .env(EnvVars::CONDA_DEFAULT_ENV, "base"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Checked 1 package in [TIME]
+    ");
+
+    context
+        .temp_dir
+        .child("envs/base-env")
+        .assert(predicate::path::missing());
+
+    // `VIRTUAL_ENV` should take precedence over `CONDA_PREFIX`
+    uv_snapshot!(context.filters(), context.sync()
+    .arg("--active")
+    .env(EnvVars::VIRTUAL_ENV, "foo")
+    .env(EnvVars::CONDA_PREFIX, "envs/conda-env")
+    .env(EnvVars::CONDA_DEFAULT_ENV, "conda-env"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.11.[X] interpreter at: [PYTHON-3.11]
+    Creating virtual environment at: foo
+    Resolved 2 packages in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    context
+        .temp_dir
+        .child("foo")
+        .assert(predicate::path::is_dir());
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "test-python-managed")]
 fn sync_active_project_environment_with_relative_managed_python_dir() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[])

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -195,6 +195,11 @@ To target this environment, you'd export `UV_PROJECT_ENVIRONMENT=/usr/local`.
     environment. The `--active` flag can be used to opt-in to respecting `VIRTUAL_ENV`. The
     `--no-active` flag can be used to silence the warning.
 
+    The `--active` flag respects an active Conda environment, via the `CONDA_PREFIX` environment
+    variable. If both are set, `VIRTUAL_ENV` takes precedence. Base Conda environments are treated
+    as system installations and are ignored. Unlike `VIRTUAL_ENV`, no warning is displayed when
+    `CONDA_PREFIX` does not match the project's environment.
+
 ## Build isolation
 
 By default, uv builds all packages in isolated virtual environments alongside their declared build


### PR DESCRIPTION
## Summary
This PR is related to issue #11315

The `uv pip` interface already does discovery for an active conda environment, through `$CONDA_PREFIX`, however the project interface does not, so the `--active` flag only checks for `$VIRTUAL_ENV`. This PR brings the two in line.

Previously, conda users would have had to fiddle with environment variables to have `uv` manage their environment, for example 
```
VIRTUAL_ENV=$CONDA_PREFIX uv sync --active
```
This PR makes it so they can use it transparently with just:
```
uv sync --active
```
Also, that workaround doesn't protect the base environment, which is the default for most conda installs, and so it will prune the conda installation itself. This change excludes the base environment, matching the behavior of `uv pip`.

Unlike with a `$VIRTUAL_ENV` that differs from the `uv` environment, I made the decision to not warn the user when their conda environment is different from the project environment, as conda users usually have an environment active and the warning could get noisy. This can easily be changed so it has the same behavior as `$VIRTUAL_ENV` though, if you'd prefer to preserve that symmetry.

To make this change I had to get the information about the conda environment to the `environment_selection` function. There were already helper functions in `uv-python` that provide this, so rather than adding a dependency from `uv-workspace` to `uv-python` I decided to make them public and have the callers in `uv` pass the `PathBuf`. This meant changing the signature and updating the callers, which was the biggest architectural change in this PR.

Also, I made the decision to make `VIRTUAL_ENV` take precedence over a conda environment following the convention in `uv-python`.

Finally, this PR only changes the project interface, but the script interface is still incomplete.
The changes made here rely on `uv` refusing to delete and recreate directories that are not virtual environments (identified by having lacking a `pyvenv.cfg`). However, the script side doesn't do this check. In fact, I found a bug where you can wipe the contents of any non-environment directory by pointing `$VIRTUAL_ENV` at it and running `uv run --active --script`, provided the directory is not a usable Python environment. I opened a separate issue at #21364. 
Because of this, the Conda support for scripts should wait until that's fixed.

Additionally, I didn't touch the error message. When a conda environment is incompatible, uv reports that it "cannot be recreated because it is not a virtual environment", which is not the real issue, which would be a Python version mismatch. That seemed like a separate change.

## Test Plan

I added tests that check:
- The active conda environment being ignored when not using `--active`.
- The active conda environment being picked up when using `--active`.
- The active conda environment being ignored when using `--no-active`.
- `--active` not picking up the base conda environment.
- `$VIRTUAL_ENV` having precedence over the active conda environment.

I also verified the behavior manually with a miniforge installation. A child environment is used with `--active`, the base environment is ignored, `VIRTUAL_ENV` takes precedence when both are set and an incompatible conda environment produces an error instead of being deleted.