### PR TITLE
Version all Azure requests

### DIFF
--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -12,7 +12,7 @@ use reqsign::aws::DefaultSigner as AwsDefaultSigner;
 use reqsign::azure::DefaultSigner as AzureDefaultSigner;
 use reqsign::google::DefaultSigner as GcsDefaultSigner;
 use reqwest::Request;
-use reqwest::header::{HeaderName, HeaderValue, InvalidHeaderValue};
+use reqwest::header::{HeaderValue, InvalidHeaderValue};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
@@ -20,8 +20,6 @@ use url::Url;
 use uv_netrc::Netrc;
 use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
-
-const AZURE_STORAGE_VERSION: &str = "2023-11-03";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Credentials {
@@ -602,10 +600,6 @@ impl Authentication {
                         source,
                     })?;
                 *http_req.headers_mut() = request.headers().clone();
-                http_req
-                    .headers_mut()
-                    .entry(HeaderName::from_static("x-ms-version"))
-                    .or_insert(HeaderValue::from_static(AZURE_STORAGE_VERSION));
 
                 // Sign the parts.
                 let (mut parts, ()) = http_req.into_parts();
@@ -823,15 +817,6 @@ mod tests {
             .expect("Authorization header should be set");
         assert_eq!(authorization.to_str().unwrap(), "Bearer token");
         assert!(request.headers().contains_key("x-ms-date"));
-        assert_eq!(
-            request
-                .headers()
-                .get("x-ms-version")
-                .expect("x-ms-version header should be set")
-                .to_str()
-                .unwrap(),
-            AZURE_STORAGE_VERSION
-        );
     }
 
     #[tokio::test]

--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -3,6 +3,7 @@ pub use credentials::{Credentials, CredentialsFromUrlError, Username};
 pub use index::{AuthPolicy, Index, Indexes};
 pub use keyring::KeyringProvider;
 pub use middleware::AuthMiddleware;
+pub use providers::AzureEndpointProvider;
 pub use realm::{Realm, RealmRef};
 pub use service::Service;
 pub use store::{AuthBackend, TextCredentialStore, TomlCredentialError};

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -326,8 +326,7 @@ impl Middleware for AuthMiddleware {
     ///
     /// - Check the cache (URL key)
     /// - Perform the request
-    /// - On 401, 403, 404, or an Azure public-access denial, check for authentication if there was
-    ///   a cache miss
+    /// - On 401, 403, or 404 check for authentication if there was a cache miss
     ///     - Check the cache (index URL or realm key) for the username and password
     ///     - Check the netrc for a username and password
     ///     - Perform the request again if found
@@ -420,11 +419,12 @@ impl Middleware for AuthMiddleware {
 
             let response = next.clone().run(request, extensions).await?;
 
-            // If we don't fail with authorization related codes or authentication policy is
-            // Never, return the response.
-            if !response_requires_authentication(&response, retry_request.url(), self.preview)
-                .map_err(Error::Middleware)?
-                || matches!(auth_policy, AuthPolicy::Never)
+            // If we don't fail with authorization related codes or
+            // authentication policy is Never, return the response.
+            if !matches!(
+                response.status(),
+                StatusCode::FORBIDDEN | StatusCode::NOT_FOUND | StatusCode::UNAUTHORIZED
+            ) || matches!(auth_policy, AuthPolicy::Never)
             {
                 return Ok(response);
             }
@@ -876,32 +876,6 @@ impl AuthMiddleware {
     }
 }
 
-/// Returns `true` when an unauthenticated response should trigger credential discovery.
-fn response_requires_authentication(
-    response: &Response,
-    url: &url::Url,
-    preview: Preview,
-) -> anyhow::Result<bool> {
-    if matches!(
-        response.status(),
-        StatusCode::FORBIDDEN | StatusCode::NOT_FOUND | StatusCode::UNAUTHORIZED
-    ) {
-        return Ok(true);
-    }
-
-    if response.status() != StatusCode::CONFLICT {
-        return Ok(false);
-    }
-
-    // Azure Storage reports an anonymous request to a private endpoint as a conflict instead of an
-    // authorization error.
-    Ok(AzureEndpointProvider::is_azure_endpoint(url, preview)?
-        && response
-            .headers()
-            .get("x-ms-error-code")
-            .is_some_and(|value| value == "PublicAccessNotPermitted"))
-}
-
 fn tracing_url(request: &Request, credentials: Option<&Authentication>) -> DisplaySafeUrl {
     let mut url = DisplaySafeUrl::from_url(request.url().clone());
     if let Some(Authentication::Credentials(creds)) = credentials {
@@ -935,51 +909,6 @@ mod tests {
     use super::*;
 
     type Error = Box<dyn std::error::Error>;
-
-    #[test]
-    fn test_response_requires_authentication() -> Result<(), Error> {
-        let url = Url::parse("https://example.com")?;
-
-        let response = Response::from(
-            http::Response::builder()
-                .status(401)
-                .body(Vec::new())
-                .unwrap(),
-        );
-        assert!(response_requires_authentication(
-            &response,
-            &url,
-            Preview::default()
-        )?);
-
-        let response = Response::from(
-            http::Response::builder()
-                .status(409)
-                .header("x-ms-error-code", "PublicAccessNotPermitted")
-                .body(Vec::new())
-                .unwrap(),
-        );
-        assert!(!response_requires_authentication(
-            &response,
-            &url,
-            Preview::default()
-        )?);
-
-        let response = Response::from(
-            http::Response::builder()
-                .status(409)
-                .header("x-ms-error-code", "ContainerBeingDeleted")
-                .body(Vec::new())
-                .unwrap(),
-        );
-        assert!(!response_requires_authentication(
-            &response,
-            &url,
-            Preview::default()
-        )?);
-
-        Ok(())
-    }
 
     async fn start_test_server(username: &'static str, password: &'static str) -> MockServer {
         let server = MockServer::start().await;

--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -155,11 +155,11 @@ static AZURE_ENDPOINT_URL: LazyLock<Result<Option<Url>, ParseError>> =
 
 /// A provider for authentication credentials for Azure endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct AzureEndpointProvider;
+pub struct AzureEndpointProvider;
 
 impl AzureEndpointProvider {
     /// Returns `true` if the URL matches the configured Azure endpoint.
-    pub(crate) fn is_azure_endpoint(url: &Url, preview: Preview) -> Result<bool> {
+    pub fn is_azure_endpoint(url: &Url, preview: Preview) -> Result<bool> {
         if let Some(azure_endpoint_url) = AZURE_ENDPOINT_URL
             .as_ref()
             .map_err(|error| *error)

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -36,7 +36,7 @@ use uv_version::version;
 use uv_warnings::warn_user_once;
 
 use crate::linehaul::LineHaul;
-use crate::middleware::OfflineMiddleware;
+use crate::middleware::{AzureStorageMiddleware, OfflineMiddleware};
 use crate::tls::{Certificates, read_identity};
 use crate::{Connectivity, RetriableError, RetryState, UvRetryableStrategy};
 
@@ -666,6 +666,10 @@ impl<'a> BaseClientBuilder<'a> {
                         client = client.with_arc(middleware.clone());
                     }
                 }
+
+                client = client.with(AzureStorageMiddleware {
+                    preview: self.preview,
+                });
 
                 // Initialize the authentication middleware to set headers.
                 match self.auth_integration {

--- a/crates/uv-client/src/middleware.rs
+++ b/crates/uv-client/src/middleware.rs
@@ -8,8 +8,6 @@ use reqwest::header::HeaderValue;
 use reqwest::{Request, Response};
 use reqwest_middleware::{Middleware, Next};
 
-const AZURE_STORAGE_VERSION: &str = "2023-11-03";
-
 pub(crate) struct AzureStorageMiddleware {
     pub(crate) preview: Preview,
 }
@@ -23,10 +21,17 @@ impl Middleware for AzureStorageMiddleware {
         next: Next<'_>,
     ) -> reqwest_middleware::Result<Response> {
         if AzureEndpointProvider::is_azure_endpoint(request.url(), self.preview)? {
+            // Anonymous requests need 2019-12-12 or later to return a 401
+            // bearer challenge instead of 409 when account-level public access
+            // is disabled. Use the earliest such version supported by Azure
+            // Stack Hub (2301 and later).
+            //
+            // https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory#bearer-challenge
+            // https://learn.microsoft.com/en-us/azure-stack/user/azure-stack-acs-differences#api-version
             request
                 .headers_mut()
                 .entry("x-ms-version")
-                .or_insert(HeaderValue::from_static(AZURE_STORAGE_VERSION));
+                .or_insert(HeaderValue::from_static("2020-10-02"));
         }
 
         next.run(request, extensions).await

--- a/crates/uv-client/src/middleware.rs
+++ b/crates/uv-client/src/middleware.rs
@@ -1,9 +1,37 @@
 use http::Extensions;
 use std::fmt::Debug;
+use uv_auth::AzureEndpointProvider;
+use uv_preview::Preview;
 use uv_redacted::DisplaySafeUrl;
 
+use reqwest::header::HeaderValue;
 use reqwest::{Request, Response};
 use reqwest_middleware::{Middleware, Next};
+
+const AZURE_STORAGE_VERSION: &str = "2023-11-03";
+
+pub(crate) struct AzureStorageMiddleware {
+    pub(crate) preview: Preview,
+}
+
+#[async_trait::async_trait]
+impl Middleware for AzureStorageMiddleware {
+    async fn handle(
+        &self,
+        mut request: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        if AzureEndpointProvider::is_azure_endpoint(request.url(), self.preview)? {
+            request
+                .headers_mut()
+                .entry("x-ms-version")
+                .or_insert(HeaderValue::from_static(AZURE_STORAGE_VERSION));
+        }
+
+        next.run(request, extensions).await
+    }
+}
 
 /// A custom error type for the offline middleware.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Anonymous requests to an Azure storage account with public access disabled can return 409 before uv attempts credentials. With uv 0.12.7 and a matching UV_AZURE_ENDPOINT_URL, a wheel download failed: its anonymous HEAD response had no x-ms-error-code header. The special case added in 17b195bd714 retries only 409 responses whose error header is PublicAccessNotPermitted, so it missed this response.

The API version explains the difference. uv previously added x-ms-version: 2023-11-03 only when signing an authenticated request. Without that header, an anonymous request uses the account's DefaultServiceVersion, or a legacy version if that property is unset [1]. Anonymous HEAD requests to the same affected blob returned:

| x-ms-version | HTTP status | x-ms-error-code |
| --- | --- | --- |
| Omitted | 409 | Absent |
| 2019-07-07 | 409 | PublicAccessNotPermitted |
| 2019-12-12 | 401 | NoAuthenticationInformation |
| 2020-10-02 | 401 | NoAuthenticationInformation |

Add x-ms-version before authentication for requests matching the configured Azure endpoint, preserving explicitly supplied versions. Bearer authorization requires 2017-11-09, and anonymous 401 bearer challenges require 2019-12-12 [2]. The earliest version meeting both requirements that Azure Stack Hub 2301 and later supports is 2020-10-02; its next older supported version is 2019-07-07 [3]. The existing 401 handling can then discover credentials and retry with authentication, so revert the Azure-specific 409 handling from 17b195bd714.

Pinning the request version makes this behavior independent of the account default. An account owner could change DefaultServiceVersion instead, but that affects other unversioned clients too [4]. Compatible endpoints must accept the requested version. The shared API-version requirement is therefore 2020-10-02, rather than the 2023-11-03 previously used for signed requests.

To reproduce, use a blob in an account with anonymous public access disabled. The unversioned result depends on the account default; the explicitly versioned requests isolate the 409-to-401 change:

```sh
blob_url='https://<account>.blob.core.windows.net/<container>/<blob>'
curl -q -sSI --max-time 30 "$blob_url"
curl -q -sSI --max-time 30 -H 'x-ms-version: 2019-07-07' "$blob_url"
curl -q -sSI --max-time 30 -H 'x-ms-version: 2019-12-12' "$blob_url"
curl -q -sSI --max-time 30 -H 'x-ms-version: 2020-10-02' "$blob_url"
```

[1]: https://learn.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#requests-via-anonymous-access
[2]: https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory#bearer-challenge
[3]: https://learn.microsoft.com/en-us/azure-stack/user/azure-stack-acs-differences#api-version
[4]: https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-service-properties
