### PR TITLE
automations: skip workflow failure diagnosis on successfully retried re-runs

### DIFF
--- a/.github/workflows/diagnose-workflow-failure.yml
+++ b/.github/workflows/diagnose-workflow-failure.yml
@@ -37,6 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: "Collect workflow failure context"
+        id: context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ inputs.head_sha }}
@@ -77,8 +78,8 @@ jobs:
           fi
           if ! jq --exit-status '.conclusion | IN("failure", "timed_out", "startup_failure")' \
             .workflow-failure-event.json > /dev/null; then
-            echo "The workflow run did not fail; refusing to diagnose it." >&2
-            exit 1
+            echo "The workflow run is no longer failed; skipping diagnosis."
+            exit 0
           fi
 
           # Fetch jobs separately to avoid gh's limit of 25 per-job log fallbacks.
@@ -102,8 +103,11 @@ jobs:
             cat agents/prompts/diagnose-workflow-failure.md
           } > "$RUNNER_TEMP/diagnose-workflow-failure-prompt.md"
 
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
       - name: "Diagnose workflow failure"
         id: diagnose
+        if: steps.context.outputs.ready == 'true'
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -120,7 +124,7 @@ jobs:
           output-schema-file: "agents/schemas/workflow-failure.json"
 
       - name: "Upload Codex thread"
-        if: always()
+        if: always() && steps.context.outputs.ready == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codex-thread-workflow-failure-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
seeing some failures of the diagnose workflow failure automation when a user manually re-runs the job before the automation runs. if a human intervened to re-run and it was successful, assume that it was a known or exceptional flake.