### PR TITLE
Use integer indices when traversing locked dependencies

### DIFF
--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -408,10 +408,10 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     continue;
                 }
 
-                let dep_dist = &self.lock().packages[dep.package_index.0];
+                let dep_dist = &self.lock().packages[dep.index.0];
 
                 // Add the package to the graph.
-                let dep_index = match inverse[dep.package_index.0] {
+                let dep_index = match inverse[dep.index.0] {
                     None => {
                         let index = petgraph.add_node(self.package_to_node(
                             dep_dist,
@@ -420,7 +420,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                             install_options,
                             marker_env,
                         )?);
-                        inverse[dep.package_index.0] = Some(index);
+                        inverse[dep.index.0] = Some(index);
                         index
                     }
                     Some(index) => {
@@ -462,20 +462,20 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 // Push its dependencies on the queue.
                 add_reachability(
                     &mut conflict_reachability,
-                    (dep.package_index, None),
+                    (dep.index, None),
                     dep.complexified_marker,
                 );
-                if seen.insert((dep.package_index, None)) {
-                    queue.push_back((dep.package_index, None));
+                if seen.insert((dep.index, None)) {
+                    queue.push_back((dep.index, None));
                 }
                 for extra in &dep.extra {
                     add_reachability(
                         &mut conflict_reachability,
-                        (dep.package_index, Some(extra)),
+                        (dep.index, Some(extra)),
                         dep.complexified_marker,
                     );
-                    if seen.insert((dep.package_index, Some(extra))) {
-                        queue.push_back((dep.package_index, Some(extra)));
+                    if seen.insert((dep.index, Some(extra))) {
+                        queue.push_back((dep.index, Some(extra)));
                     }
                 }
             }
@@ -699,20 +699,16 @@ trait InstallableExt<'lock>: Installable<'lock> {
                         activated_extras.push(key);
                     }
                     // Push its dependencies on the queue.
-                    if add_reachability(
-                        &mut reachability,
-                        (dep.package_index, None),
-                        dep_reachability,
-                    ) {
-                        queue.push_back((dep.package_index, None));
+                    if add_reachability(&mut reachability, (dep.index, None), dep_reachability) {
+                        queue.push_back((dep.index, None));
                     }
                     for extra in &dep.extra {
                         if add_reachability(
                             &mut reachability,
-                            (dep.package_index, Some(extra)),
+                            (dep.index, Some(extra)),
                             dep_reachability,
                         ) {
-                            queue.push_back((dep.package_index, Some(extra)));
+                            queue.push_back((dep.index, Some(extra)));
                         }
                     }
                 }
@@ -766,10 +762,10 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     continue;
                 }
 
-                let dep_dist = &self.lock().packages[dep.package_index.0];
+                let dep_dist = &self.lock().packages[dep.index.0];
 
                 // Add the dependency to the graph.
-                let dep_index = match inverse[dep.package_index.0] {
+                let dep_index = match inverse[dep.index.0] {
                     None => {
                         let index = petgraph.add_node(self.package_to_node(
                             dep_dist,
@@ -778,7 +774,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                             install_options,
                             marker_env,
                         )?);
-                        inverse[dep.package_index.0] = Some(index);
+                        inverse[dep.index.0] = Some(index);
                         index
                     }
                     Some(index) => {
@@ -808,12 +804,12 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((dep.package_index, None)) {
-                    queue.push_back((dep.package_index, None));
+                if seen.insert((dep.index, None)) {
+                    queue.push_back((dep.index, None));
                 }
                 for extra in &dep.extra {
-                    if seen.insert((dep.package_index, Some(extra))) {
-                        queue.push_back((dep.package_index, Some(extra)));
+                    if seen.insert((dep.index, Some(extra))) {
+                        queue.push_back((dep.index, Some(extra)));
                     }
                 }
             }

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use either::Either;
 use itertools::Itertools;
 use petgraph::Graph;
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use uv_configuration::{
     BuildOptions, DependencyGroupsWithDefaults, ExtrasSpecification,
@@ -19,8 +19,8 @@ use uv_platform_tags::Tags;
 use uv_pypi_types::{ConflictKind, ConflictSet, ResolverMarkerEnvironment};
 
 use crate::lock::{
-    Dependency, DependencySelectionContext, HashedDist, LockErrorKind, Package, PackageId,
-    SelectedDependency, TagPolicy,
+    Dependency, DependencySelectionContext, HashedDist, LockErrorKind, Package, SelectedDependency,
+    TagPolicy,
 };
 use crate::universal_marker::ActivatedConflictItems;
 use crate::{Lock, LockError, UniversalMarker};
@@ -42,8 +42,8 @@ fn newly_activated_extras<'lock>(
 ///
 /// Returns `true` when the combined reachability changed.
 fn add_reachability<'lock>(
-    reachability: &mut FxHashMap<(&'lock PackageId, Option<&'lock ExtraName>), UniversalMarker>,
-    key: (&'lock PackageId, Option<&'lock ExtraName>),
+    reachability: &mut FxHashMap<(usize, Option<&'lock ExtraName>), UniversalMarker>,
+    key: (usize, Option<&'lock ExtraName>),
     marker: UniversalMarker,
 ) -> bool {
     match reachability.entry(key) {
@@ -265,9 +265,9 @@ trait InstallableExt<'lock>: Installable<'lock> {
     ) -> Result<Resolution, LockError> {
         let size_guess = self.lock().packages.len();
         let mut petgraph = Graph::with_capacity(size_guess, size_guess);
-        let mut inverse = FxHashMap::with_capacity_and_hasher(size_guess, FxBuildHasher);
+        let mut inverse = vec![None; size_guess];
 
-        let mut queue: VecDeque<(&Package, Option<&ExtraName>)> = VecDeque::new();
+        let mut queue: VecDeque<(usize, Option<&ExtraName>)> = VecDeque::new();
         let mut seen = FxHashSet::default();
         let mut conflict_reachability = FxHashMap::default();
         let mut activated_projects: Vec<&PackageName> = vec![];
@@ -342,6 +342,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
             .chain(group_root.map(|dist| (dist, InstallableRootKind::DependencyGroups)))
         {
             // Add the workspace package to the graph.
+            let package_index = self.lock().by_id[&dist.id];
             let index = petgraph.add_node(
                 if root_kind == InstallableRootKind::Production && groups.prod() {
                     self.package_to_node(dist, tags, build_options, install_options, marker_env)?
@@ -349,30 +350,30 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     self.non_installable_node(dist, tags, marker_env)?
                 },
             );
-            inverse.insert(&dist.id, index);
+            inverse[package_index] = Some(index);
 
             // Add an edge from the root.
             petgraph.add_edge(root, index, Edge::Prod);
 
             // Push the package onto the queue.
-            initialized_roots.push((dist, index, root_kind));
+            initialized_roots.push((dist, package_index, index, root_kind));
         }
 
         // Add the workspace dependencies to the queue.
-        for (dist, index, root_kind) in initialized_roots {
+        for (dist, package_index, index, root_kind) in initialized_roots {
             if root_kind == InstallableRootKind::Production && groups.prod() {
                 // Push its dependencies onto the queue.
-                queue.push_back((dist, None));
+                queue.push_back((package_index, None));
                 add_reachability(
                     &mut conflict_reachability,
-                    (&dist.id, None),
+                    (package_index, None),
                     UniversalMarker::TRUE,
                 );
                 for extra in extras.extra_names(dist.optional_dependencies.keys()) {
-                    queue.push_back((dist, Some(extra)));
+                    queue.push_back((package_index, Some(extra)));
                     add_reachability(
                         &mut conflict_reachability,
-                        (&dist.id, Some(extra)),
+                        (package_index, Some(extra)),
                         UniversalMarker::TRUE,
                     );
                 }
@@ -407,11 +408,11 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     continue;
                 }
 
-                let dep_dist = self.lock().find_by_id(&dep.package_id);
+                let dep_dist = &self.lock().packages[dep.package_index];
 
                 // Add the package to the graph.
-                let dep_index = match inverse.entry(&dep.package_id) {
-                    Entry::Vacant(entry) => {
+                let dep_index = match inverse[dep.package_index] {
+                    None => {
                         let index = petgraph.add_node(self.package_to_node(
                             dep_dist,
                             tags,
@@ -419,14 +420,13 @@ trait InstallableExt<'lock>: Installable<'lock> {
                             install_options,
                             marker_env,
                         )?);
-                        entry.insert(index);
+                        inverse[dep.package_index] = Some(index);
                         index
                     }
-                    Entry::Occupied(entry) => {
+                    Some(index) => {
                         // Critically, if the package is already in the graph, then it's a workspace
                         // member. If it was omitted due to, e.g., `--only-dev`, but is itself
                         // referenced as a development dependency, then we need to re-enable it.
-                        let index = *entry.get();
                         let node = &mut petgraph[index];
                         if !groups.prod() || matches!(node, Node::Dist { install: false, .. }) {
                             *node = self.package_to_node(
@@ -462,20 +462,20 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 // Push its dependencies on the queue.
                 add_reachability(
                     &mut conflict_reachability,
-                    (&dep.package_id, None),
+                    (dep.package_index, None),
                     dep.complexified_marker,
                 );
-                if seen.insert((&dep.package_id, None)) {
-                    queue.push_back((dep_dist, None));
+                if seen.insert((dep.package_index, None)) {
+                    queue.push_back((dep.package_index, None));
                 }
                 for extra in &dep.extra {
                     add_reachability(
                         &mut conflict_reachability,
-                        (&dep.package_id, Some(extra)),
+                        (dep.package_index, Some(extra)),
                         dep.complexified_marker,
                     );
-                    if seen.insert((&dep.package_id, Some(extra))) {
-                        queue.push_back((dep_dist, Some(extra)));
+                    if seen.insert((dep.package_index, Some(extra))) {
+                        queue.push_back((dep.package_index, Some(extra)));
                     }
                 }
             }
@@ -501,12 +501,13 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     })?;
 
                 // Add the package to the graph.
+                let package_index = self.lock().by_id[&dist.id];
                 let index = petgraph.add_node(if groups.prod() {
                     self.package_to_node(dist, tags, build_options, install_options, marker_env)?
                 } else {
                     self.non_installable_node(dist, tags, marker_env)?
                 });
-                inverse.insert(&dist.id, index);
+                inverse[package_index] = Some(index);
 
                 // Add the edge.
                 petgraph.add_edge(root, index, Edge::Prod);
@@ -514,20 +515,20 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 // Push its dependencies on the queue.
                 add_reachability(
                     &mut conflict_reachability,
-                    (&dist.id, None),
+                    (package_index, None),
                     UniversalMarker::TRUE,
                 );
-                if seen.insert((&dist.id, None)) {
-                    queue.push_back((dist, None));
+                if seen.insert((package_index, None)) {
+                    queue.push_back((package_index, None));
                 }
                 for extra in &dependency.extras {
                     add_reachability(
                         &mut conflict_reachability,
-                        (&dist.id, Some(extra)),
+                        (package_index, Some(extra)),
                         UniversalMarker::TRUE,
                     );
-                    if seen.insert((&dist.id, Some(extra))) {
-                        queue.push_back((dist, Some(extra)));
+                    if seen.insert((package_index, Some(extra))) {
+                        queue.push_back((package_index, Some(extra)));
                     }
                 }
             }
@@ -563,8 +564,9 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     })?;
 
                 // Add the package to the graph.
-                let index = match inverse.entry(&dist.id) {
-                    Entry::Vacant(entry) => {
+                let package_index = self.lock().by_id[&dist.id];
+                let index = match inverse[package_index] {
+                    None => {
                         let index = petgraph.add_node(self.package_to_node(
                             dist,
                             tags,
@@ -572,14 +574,13 @@ trait InstallableExt<'lock>: Installable<'lock> {
                             install_options,
                             marker_env,
                         )?);
-                        entry.insert(index);
+                        inverse[package_index] = Some(index);
                         index
                     }
-                    Entry::Occupied(entry) => {
+                    Some(index) => {
                         // Critically, if the package is already in the graph, then it's a workspace
                         // member. If it was omitted due to, e.g., `--only-dev`, but is itself
                         // referenced as a development dependency, then we need to re-enable it.
-                        let index = *entry.get();
                         let node = &mut petgraph[index];
                         if !groups.prod() {
                             *node = self.package_to_node(
@@ -611,20 +612,20 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 // Push its dependencies on the queue.
                 add_reachability(
                     &mut conflict_reachability,
-                    (&dist.id, None),
+                    (package_index, None),
                     UniversalMarker::TRUE,
                 );
-                if seen.insert((&dist.id, None)) {
-                    queue.push_back((dist, None));
+                if seen.insert((package_index, None)) {
+                    queue.push_back((package_index, None));
                 }
                 for extra in &dependency.extras {
                     add_reachability(
                         &mut conflict_reachability,
-                        (&dist.id, Some(extra)),
+                        (package_index, Some(extra)),
                         UniversalMarker::TRUE,
                     );
-                    if seen.insert((&dist.id, Some(extra))) {
-                        queue.push_back((dist, Some(extra)));
+                    if seen.insert((package_index, Some(extra))) {
+                        queue.push_back((package_index, Some(extra)));
                     }
                 }
             }
@@ -663,8 +664,9 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 activated_extras.iter().copied().collect();
             let mut queue = queue.clone();
             let mut reachability = conflict_reachability;
-            while let Some((package, extra)) = queue.pop_front() {
-                let Some(parent_reachability) = reachability.get(&(&package.id, extra)).copied()
+            while let Some((package_index, extra)) = queue.pop_front() {
+                let package = &self.lock().packages[package_index];
+                let Some(parent_reachability) = reachability.get(&(package_index, extra)).copied()
                 else {
                     continue;
                 };
@@ -696,22 +698,21 @@ trait InstallableExt<'lock>: Installable<'lock> {
                         activated_extras_set.insert(key);
                         activated_extras.push(key);
                     }
-                    let dep_dist = self.lock().find_by_id(&dep.package_id);
                     // Push its dependencies on the queue.
                     if add_reachability(
                         &mut reachability,
-                        (&dep.package_id, None),
+                        (dep.package_index, None),
                         dep_reachability,
                     ) {
-                        queue.push_back((dep_dist, None));
+                        queue.push_back((dep.package_index, None));
                     }
                     for extra in &dep.extra {
                         if add_reachability(
                             &mut reachability,
-                            (&dep.package_id, Some(extra)),
+                            (dep.package_index, Some(extra)),
                             dep_reachability,
                         ) {
-                            queue.push_back((dep_dist, Some(extra)));
+                            queue.push_back((dep.package_index, Some(extra)));
                         }
                     }
                 }
@@ -752,7 +753,8 @@ trait InstallableExt<'lock>: Installable<'lock> {
             activated_groups.iter().copied(),
         );
 
-        while let Some((package, extra)) = queue.pop_front() {
+        while let Some((package_index, extra)) = queue.pop_front() {
+            let package = &self.lock().packages[package_index];
             for dep in package_dependencies(package, extra) {
                 if validate_conflicts && dep.complexified_marker.has_conflict_marker() {
                     dependencies_for_conflict_validation.push((package, dep));
@@ -764,11 +766,11 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     continue;
                 }
 
-                let dep_dist = self.lock().find_by_id(&dep.package_id);
+                let dep_dist = &self.lock().packages[dep.package_index];
 
                 // Add the dependency to the graph.
-                let dep_index = match inverse.entry(&dep.package_id) {
-                    Entry::Vacant(entry) => {
+                let dep_index = match inverse[dep.package_index] {
+                    None => {
                         let index = petgraph.add_node(self.package_to_node(
                             dep_dist,
                             tags,
@@ -776,11 +778,10 @@ trait InstallableExt<'lock>: Installable<'lock> {
                             install_options,
                             marker_env,
                         )?);
-                        entry.insert(index);
+                        inverse[dep.package_index] = Some(index);
                         index
                     }
-                    Entry::Occupied(entry) => {
-                        let index = *entry.get();
+                    Some(index) => {
                         if matches!(&petgraph[index], Node::Dist { install: false, .. }) {
                             petgraph[index] = self.package_to_node(
                                 dep_dist,
@@ -795,7 +796,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 };
 
                 // Add the edge.
-                let index = inverse[&package.id];
+                let index = inverse[package_index].expect("queued package has a graph node");
                 petgraph.add_edge(
                     index,
                     dep_index,
@@ -807,12 +808,12 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((&dep.package_id, None)) {
-                    queue.push_back((dep_dist, None));
+                if seen.insert((dep.package_index, None)) {
+                    queue.push_back((dep.package_index, None));
                 }
                 for extra in &dep.extra {
-                    if seen.insert((&dep.package_id, Some(extra))) {
-                        queue.push_back((dep_dist, Some(extra)));
+                    if seen.insert((dep.package_index, Some(extra))) {
+                        queue.push_back((dep.package_index, Some(extra)));
                     }
                 }
             }
@@ -822,8 +823,11 @@ trait InstallableExt<'lock>: Installable<'lock> {
         // them. Reject markers that still depend on conflict items outside the resulting subgraph.
         if !dependencies_for_conflict_validation.is_empty() {
             let subgraph_packages = inverse
-                .keys()
-                .map(|package_id| &package_id.name)
+                .iter()
+                .enumerate()
+                .filter_map(|(package_index, index)| {
+                    index.map(|_| &self.lock().packages[package_index].id.name)
+                })
                 .collect::<FxHashSet<_>>();
             let selection_context_package = selection_context.package();
 
@@ -1023,6 +1027,7 @@ impl Lock {
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::cmp::Ordering;
     use std::str::FromStr;
     use std::sync::LazyLock;
 
@@ -1382,6 +1387,34 @@ provides-extras = ["cli"]
             &InstallOptions::default(),
         )
         .expect("valid resolution")
+    }
+
+    #[test]
+    fn unrelated_packages_do_not_change_dependency_identity() {
+        let original = lock();
+        let input = format!(
+            "{}\n{}",
+            original.to_toml().expect("valid lock TOML"),
+            r#"
+[[package]]
+name = "aaa-unrelated"
+version = "1.0.0"
+source = { registry = "https://example.com/simple" }
+"#
+        );
+        let extended = Lock::from_toml(&input).expect("valid extended lock");
+        let original_root = package(&original, "root-a", "1.0.0");
+        let extended_root = package(&extended, "root-a", "1.0.0");
+
+        assert_eq!(original_root, extended_root);
+        assert_eq!(
+            original_root.dependencies.cmp(&extended_root.dependencies),
+            Ordering::Equal,
+        );
+        assert_eq!(
+            graph_snapshot(&materialize(&original, &[original_root], &DARWIN_MARKERS)),
+            graph_snapshot(&materialize(&extended, &[extended_root], &DARWIN_MARKERS)),
+        );
     }
 
     struct OverridingInstallable<'lock> {

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -19,8 +19,8 @@ use uv_platform_tags::Tags;
 use uv_pypi_types::{ConflictKind, ConflictSet, ResolverMarkerEnvironment};
 
 use crate::lock::{
-    Dependency, DependencySelectionContext, HashedDist, LockErrorKind, Package, SelectedDependency,
-    TagPolicy,
+    Dependency, DependencySelectionContext, HashedDist, LockErrorKind, Package, PackageIndex,
+    SelectedDependency, TagPolicy,
 };
 use crate::universal_marker::ActivatedConflictItems;
 use crate::{Lock, LockError, UniversalMarker};
@@ -42,8 +42,8 @@ fn newly_activated_extras<'lock>(
 ///
 /// Returns `true` when the combined reachability changed.
 fn add_reachability<'lock>(
-    reachability: &mut FxHashMap<(usize, Option<&'lock ExtraName>), UniversalMarker>,
-    key: (usize, Option<&'lock ExtraName>),
+    reachability: &mut FxHashMap<(PackageIndex, Option<&'lock ExtraName>), UniversalMarker>,
+    key: (PackageIndex, Option<&'lock ExtraName>),
     marker: UniversalMarker,
 ) -> bool {
     match reachability.entry(key) {
@@ -267,7 +267,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
         let mut petgraph = Graph::with_capacity(size_guess, size_guess);
         let mut inverse = vec![None; size_guess];
 
-        let mut queue: VecDeque<(usize, Option<&ExtraName>)> = VecDeque::new();
+        let mut queue: VecDeque<(PackageIndex, Option<&ExtraName>)> = VecDeque::new();
         let mut seen = FxHashSet::default();
         let mut conflict_reachability = FxHashMap::default();
         let mut activated_projects: Vec<&PackageName> = vec![];
@@ -350,7 +350,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     self.non_installable_node(dist, tags, marker_env)?
                 },
             );
-            inverse[package_index] = Some(index);
+            inverse[package_index.0] = Some(index);
 
             // Add an edge from the root.
             petgraph.add_edge(root, index, Edge::Prod);
@@ -408,10 +408,10 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     continue;
                 }
 
-                let dep_dist = &self.lock().packages[dep.package_index];
+                let dep_dist = &self.lock().packages[dep.package_index.0];
 
                 // Add the package to the graph.
-                let dep_index = match inverse[dep.package_index] {
+                let dep_index = match inverse[dep.package_index.0] {
                     None => {
                         let index = petgraph.add_node(self.package_to_node(
                             dep_dist,
@@ -420,7 +420,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                             install_options,
                             marker_env,
                         )?);
-                        inverse[dep.package_index] = Some(index);
+                        inverse[dep.package_index.0] = Some(index);
                         index
                     }
                     Some(index) => {
@@ -507,7 +507,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 } else {
                     self.non_installable_node(dist, tags, marker_env)?
                 });
-                inverse[package_index] = Some(index);
+                inverse[package_index.0] = Some(index);
 
                 // Add the edge.
                 petgraph.add_edge(root, index, Edge::Prod);
@@ -565,7 +565,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
 
                 // Add the package to the graph.
                 let package_index = self.lock().by_id[&dist.id];
-                let index = match inverse[package_index] {
+                let index = match inverse[package_index.0] {
                     None => {
                         let index = petgraph.add_node(self.package_to_node(
                             dist,
@@ -574,7 +574,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                             install_options,
                             marker_env,
                         )?);
-                        inverse[package_index] = Some(index);
+                        inverse[package_index.0] = Some(index);
                         index
                     }
                     Some(index) => {
@@ -665,7 +665,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
             let mut queue = queue.clone();
             let mut reachability = conflict_reachability;
             while let Some((package_index, extra)) = queue.pop_front() {
-                let package = &self.lock().packages[package_index];
+                let package = &self.lock().packages[package_index.0];
                 let Some(parent_reachability) = reachability.get(&(package_index, extra)).copied()
                 else {
                     continue;
@@ -754,7 +754,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
         );
 
         while let Some((package_index, extra)) = queue.pop_front() {
-            let package = &self.lock().packages[package_index];
+            let package = &self.lock().packages[package_index.0];
             for dep in package_dependencies(package, extra) {
                 if validate_conflicts && dep.complexified_marker.has_conflict_marker() {
                     dependencies_for_conflict_validation.push((package, dep));
@@ -766,10 +766,10 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     continue;
                 }
 
-                let dep_dist = &self.lock().packages[dep.package_index];
+                let dep_dist = &self.lock().packages[dep.package_index.0];
 
                 // Add the dependency to the graph.
-                let dep_index = match inverse[dep.package_index] {
+                let dep_index = match inverse[dep.package_index.0] {
                     None => {
                         let index = petgraph.add_node(self.package_to_node(
                             dep_dist,
@@ -778,7 +778,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                             install_options,
                             marker_env,
                         )?);
-                        inverse[dep.package_index] = Some(index);
+                        inverse[dep.package_index.0] = Some(index);
                         index
                     }
                     Some(index) => {
@@ -796,7 +796,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 };
 
                 // Add the edge.
-                let index = inverse[package_index].expect("queued package has a graph node");
+                let index = inverse[package_index.0].expect("queued package has a graph node");
                 petgraph.add_edge(
                     index,
                     dep_index,
@@ -929,7 +929,7 @@ impl Lock {
             }
             .into());
         };
-        let Some(package) = self.packages.get(*index) else {
+        let Some(package) = self.packages.get(index.0) else {
             return Err(LockErrorKind::RootPackageMissingFromLock {
                 id: selected_package.id.clone(),
             }
@@ -994,7 +994,7 @@ impl Lock {
                 .into());
             };
             if seen.insert(&root.id) {
-                let Some(root) = self.packages.get(*index) else {
+                let Some(root) = self.packages.get(index.0) else {
                     return Err(LockErrorKind::RootPackageMissingFromLock {
                         id: root.id.clone(),
                     }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -332,7 +332,7 @@ pub struct Lock {
     /// this map, and that every dependency for every package has an ID
     /// that exists in this map. That is, there are no dependencies that don't
     /// have a corresponding locked package entry in the same lockfile.
-    by_id: FxHashMap<PackageId, usize>,
+    by_id: FxHashMap<PackageId, PackageIndex>,
     /// The input requirements to the resolution.
     manifest: ResolverManifest,
 }
@@ -1201,8 +1201,8 @@ impl Lock {
         // Check for duplicate package IDs and also build up the map for
         // packages keyed by their ID.
         let mut by_id = FxHashMap::default();
-        for (i, dist) in packages.iter().enumerate() {
-            if by_id.insert(dist.id.clone(), i).is_some() {
+        for (index, dist) in packages.iter().enumerate() {
+            if by_id.insert(dist.id.clone(), PackageIndex(index)).is_some() {
                 return Err(LockErrorKind::DuplicatePackage {
                     id: dist.id.clone(),
                 }
@@ -2072,7 +2072,7 @@ impl Lock {
     fn find_by_id(&self, id: &PackageId) -> &Package {
         let index = *self.by_id.get(id).expect("locked package for ID");
 
-        (self.packages.get(index).expect("valid index for package")) as _
+        (self.packages.get(index.0).expect("valid index for package")) as _
     }
 
     /// Return a [`SatisfiesResult`] if the given extras do not match the [`Package`] metadata.
@@ -6289,6 +6289,10 @@ impl TryFrom<WheelWire> for Wheel {
     }
 }
 
+/// The position of a package in [`Lock::packages`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct PackageIndex(usize);
+
 /// A single dependency of a package in a lockfile.
 #[derive(Clone, Debug, Eq)]
 pub struct Dependency {
@@ -6296,7 +6300,7 @@ pub struct Dependency {
     /// The target's position in [`Lock::packages`], initialized by [`Lock::new`].
     /// This cache is excluded from equality and ordering, since the position can differ between
     /// locks that contain the same dependency.
-    package_index: usize,
+    package_index: PackageIndex,
     extra: BTreeSet<ExtraName>,
     /// A marker simplified from the PEP 508 marker in `complexified_marker`
     /// by assuming `requires-python` and the PEP 508 portion of the parent package's reachability
@@ -6335,7 +6339,7 @@ impl Dependency {
         let complexified_marker = simplified_marker.into_marker(requires_python);
         Self {
             package_id,
-            package_index: 0,
+            package_index: PackageIndex(0),
             extra,
             simplified_marker,
             complexified_marker: UniversalMarker::from_combined(complexified_marker),
@@ -6439,7 +6443,7 @@ impl DependencyWire {
             };
         Ok(Dependency {
             package_id: self.package_id.unwire(unambiguous_package_ids)?,
-            package_index: 0,
+            package_index: PackageIndex(0),
             extra: self.extra,
             simplified_marker,
             complexified_marker,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
@@ -1239,15 +1240,21 @@ impl Lock {
         // Check that every dependency has an entry in `by_id`. If any don't,
         // it implies we somehow have a dependency with no corresponding locked
         // package.
-        for dist in &packages {
-            for dependency in dist.all_dependencies() {
-                if !by_id.contains_key(&dependency.package_id) {
+        for dist in &mut packages {
+            for dependency in dist
+                .dependencies
+                .iter_mut()
+                .chain(dist.optional_dependencies.values_mut().flatten())
+                .chain(dist.dependency_groups.values_mut().flatten())
+            {
+                let Some(&index) = by_id.get(&dependency.package_id) else {
                     return Err(LockErrorKind::UnrecognizedDependency {
                         id: dist.id.clone(),
                         dependency: dependency.clone(),
                     }
                     .into());
-                }
+                };
+                dependency.package_index = index;
             }
 
             // Also check that our sources are consistent with whether we have
@@ -6283,9 +6290,13 @@ impl TryFrom<WheelWire> for Wheel {
 }
 
 /// A single dependency of a package in a lockfile.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq)]
 pub struct Dependency {
     package_id: PackageId,
+    /// The target's position in [`Lock::packages`], initialized by [`Lock::new`].
+    /// This cache is excluded from equality and ordering, since the position can differ between
+    /// locks that contain the same dependency.
+    package_index: usize,
     extra: BTreeSet<ExtraName>,
     /// A marker simplified from the PEP 508 marker in `complexified_marker`
     /// by assuming `requires-python` and the PEP 508 portion of the parent package's reachability
@@ -6324,6 +6335,7 @@ impl Dependency {
         let complexified_marker = simplified_marker.into_marker(requires_python);
         Self {
             package_id,
+            package_index: 0,
             extra,
             simplified_marker,
             complexified_marker: UniversalMarker::from_combined(complexified_marker),
@@ -6338,6 +6350,38 @@ impl Dependency {
     /// Returns the extras specified on this dependency.
     pub fn extra(&self) -> &BTreeSet<ExtraName> {
         &self.extra
+    }
+}
+
+impl PartialEq for Dependency {
+    fn eq(&self, other: &Self) -> bool {
+        self.package_id == other.package_id
+            && self.extra == other.extra
+            && self.simplified_marker == other.simplified_marker
+            && self.complexified_marker == other.complexified_marker
+    }
+}
+
+impl PartialOrd for Dependency {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Dependency {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (
+            &self.package_id,
+            &self.extra,
+            &self.simplified_marker,
+            &self.complexified_marker,
+        )
+            .cmp(&(
+                &other.package_id,
+                &other.extra,
+                &other.simplified_marker,
+                &other.complexified_marker,
+            ))
     }
 }
 
@@ -6395,6 +6439,7 @@ impl DependencyWire {
             };
         Ok(Dependency {
             package_id: self.package_id.unwire(unambiguous_package_ids)?,
+            package_index: 0,
             extra: self.extra,
             simplified_marker,
             complexified_marker,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1254,7 +1254,7 @@ impl Lock {
                     }
                     .into());
                 };
-                dependency.package_index = index;
+                dependency.index = index;
             }
 
             // Also check that our sources are consistent with whether we have
@@ -6300,7 +6300,7 @@ pub struct Dependency {
     /// The target's position in [`Lock::packages`], initialized by [`Lock::new`].
     /// This cache is excluded from equality and ordering, since the position can differ between
     /// locks that contain the same dependency.
-    package_index: PackageIndex,
+    index: PackageIndex,
     extra: BTreeSet<ExtraName>,
     /// A marker simplified from the PEP 508 marker in `complexified_marker`
     /// by assuming `requires-python` and the PEP 508 portion of the parent package's reachability
@@ -6339,7 +6339,7 @@ impl Dependency {
         let complexified_marker = simplified_marker.into_marker(requires_python);
         Self {
             package_id,
-            package_index: PackageIndex(0),
+            index: PackageIndex(0),
             extra,
             simplified_marker,
             complexified_marker: UniversalMarker::from_combined(complexified_marker),
@@ -6443,7 +6443,7 @@ impl DependencyWire {
             };
         Ok(Dependency {
             package_id: self.package_id.unwire(unambiguous_package_ids)?,
-            package_index: PackageIndex(0),
+            index: PackageIndex(0),
             extra: self.extra,
             simplified_marker,
             complexified_marker,

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -120,7 +120,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
@@ -127,7 +127,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_required_present.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_required_present.snap
@@ -119,7 +119,9 @@ Ok(
                 source: Path(
                     "file:///foo/bar",
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -153,7 +153,9 @@ Ok(
                                 ),
                             ),
                         },
-                        package_index: 0,
+                        package_index: PackageIndex(
+                            0,
+                        ),
                         extra: {},
                         simplified_marker: SimplifiedMarkerTree(
                             true,
@@ -185,7 +187,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
             PackageId {
                 name: PackageName(
                     "b",
@@ -200,7 +204,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 1,
+            }: PackageIndex(
+                1,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -153,6 +153,7 @@ Ok(
                                 ),
                             ),
                         },
+                        package_index: 0,
                         extra: {},
                         simplified_marker: SimplifiedMarkerTree(
                             true,

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -153,7 +153,7 @@ Ok(
                                 ),
                             ),
                         },
-                        package_index: PackageIndex(
+                        index: PackageIndex(
                             0,
                         ),
                         extra: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -153,7 +153,9 @@ Ok(
                                 ),
                             ),
                         },
-                        package_index: 0,
+                        package_index: PackageIndex(
+                            0,
+                        ),
                         extra: {},
                         simplified_marker: SimplifiedMarkerTree(
                             true,
@@ -185,7 +187,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
             PackageId {
                 name: PackageName(
                     "b",
@@ -200,7 +204,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 1,
+            }: PackageIndex(
+                1,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -153,6 +153,7 @@ Ok(
                                 ),
                             ),
                         },
+                        package_index: 0,
                         extra: {},
                         simplified_marker: SimplifiedMarkerTree(
                             true,

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -153,7 +153,7 @@ Ok(
                                 ),
                             ),
                         },
-                        package_index: PackageIndex(
+                        index: PackageIndex(
                             0,
                         ),
                         extra: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_dynamic.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_dynamic.snap
@@ -169,7 +169,7 @@ Ok(
                                 "path/to/a",
                             ),
                         },
-                        package_index: PackageIndex(
+                        index: PackageIndex(
                             0,
                         ),
                         extra: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_dynamic.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_dynamic.snap
@@ -169,7 +169,9 @@ Ok(
                                 "path/to/a",
                             ),
                         },
-                        package_index: 0,
+                        package_index: PackageIndex(
+                            0,
+                        ),
                         extra: {},
                         simplified_marker: SimplifiedMarkerTree(
                             true,
@@ -195,7 +197,9 @@ Ok(
                 source: Editable(
                     "path/to/a",
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
             PackageId {
                 name: PackageName(
                     "a",
@@ -210,7 +214,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 1,
+            }: PackageIndex(
+                1,
+            ),
             PackageId {
                 name: PackageName(
                     "b",
@@ -225,7 +231,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 2,
+            }: PackageIndex(
+                2,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_dynamic.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_dynamic.snap
@@ -169,6 +169,7 @@ Ok(
                                 "path/to/a",
                             ),
                         },
+                        package_index: 0,
                         extra: {},
                         simplified_marker: SimplifiedMarkerTree(
                             true,

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -153,7 +153,9 @@ Ok(
                                 ),
                             ),
                         },
-                        package_index: 0,
+                        package_index: PackageIndex(
+                            0,
+                        ),
                         extra: {},
                         simplified_marker: SimplifiedMarkerTree(
                             true,
@@ -185,7 +187,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
             PackageId {
                 name: PackageName(
                     "b",
@@ -200,7 +204,9 @@ Ok(
                         ),
                     ),
                 ),
-            }: 1,
+            }: PackageIndex(
+                1,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -153,6 +153,7 @@ Ok(
                                 ),
                             ),
                         },
+                        package_index: 0,
                         extra: {},
                         simplified_marker: SimplifiedMarkerTree(
                             true,

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -153,7 +153,7 @@ Ok(
                                 ),
                             ),
                         },
-                        package_index: PackageIndex(
+                        index: PackageIndex(
                             0,
                         ),
                         extra: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
@@ -99,7 +99,9 @@ Ok(
                         ),
                     },
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
@@ -95,7 +95,9 @@ Ok(
                         subdirectory: None,
                     },
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_directory.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_directory.snap
@@ -85,7 +85,9 @@ Ok(
                 source: Directory(
                     "path/to/dir",
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
         },
         manifest: ResolverManifest {
             members: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_editable.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_editable.snap
@@ -85,7 +85,9 @@ Ok(
                 source: Editable(
                     "path/to/dir",
                 ),
-            }: 0,
+            }: PackageIndex(
+                0,
+            ),
         },
         manifest: ResolverManifest {
             members: {},


### PR DESCRIPTION
## Summary

When constructing a resolution from a lockfile, we repeatedly hash package IDs to find dependency targets and graph nodes. Cache each dependency's target index during existing lock validation, then use integer indices in traversal queues and graph lookups. The cached index is excluded from dependency equality and ordering, so identical dependencies still compare equally across lockfiles. The lockfile format is unchanged.

The following graph-conversion measurements compare this patch with `7896d580c`, with parsing outside the timer. They use Linux/ext4, optimized `profiling` builds without LTO, Rust 1.98 (Ohm 1.98.0-2), and eight samples per variant in alternating ABBA/BAAB blocks. Canonical graph signatures matched across every sample.

| Lock                        |  Baseline |   This PR | Time reduction |
| --------------------------- | --------: | --------: | -------------: |
| Jupyter                     |  0.316 ms |  0.272 ms |          13.9% |
| Synthetic 1,000-package DAG |  3.381 ms |  2.452 ms |          27.5% |
| Synthetic 5,000-package DAG | 41.601 ms | 36.624 ms |          12.0% |

Graph conversion improved in every block. Including parsing, the reductions were 3.2%, 9.2%, and 4.8%, respectively. Whole no-op sync changed much less: Jupyter went from 33.86 to 32.90 ms, the 1,000-package case from 95.41 to 91.31 ms, and the 5,000-package case was effectively flat. The change adds one cached `usize` per dependency; observed process RSS was roughly unchanged.

Larger-project measurements compare `7c1d80ed0` with `8f0f824f7` on an AMD EPYC 9V74 devbox, using the same optimized profiling configuration and 16 samples per variant in eight alternating ABBA/BAAB blocks. These graph-conversion times also exclude parsing:

| Project | Lock entries | Baseline | This PR | Time reduction |
| --- | ---: | ---: | ---: | ---: |
| Airflow 2.9.3, all extras | 585 | 1.741 ms | 1.374 ms | 21.1% |
| Home Assistant 2025.1.4, all integrations | 1,456 | 5.017 ms | 4.149 ms | 17.3% |

Graph conversion improved in every block for both projects. Including parsing, the reductions were 7.5% and 5.5%, respectively; parsing alone was roughly unchanged. Whole-command `sync --frozen --offline --dry-run --no-dev` against empty virtual environments was effectively flat: 92.1 → 91.5 ms for Airflow and 208.8 → 208.2 ms for Home Assistant. These are dry-run planning measurements. Canonical graphs and complete sync plans matched between binaries, and the locks and environments remained unchanged.

Airflow used Python 3.11.15 with an August 8, 2024 cutoff. Home Assistant used Python 3.12.14 with a February 1, 2025 cutoff and its [official 2025.1.4 requirements](https://github.com/home-assistant/core/blob/6145ea232367ad2364b40eddd687a11943298803/requirements_all.txt), preserving all integration/core requirements and upstream constraints. The older checked-in fixture could not resolve because `pyunifiprotect==4.20.0` is unavailable on PyPI.
