### PR TITLE
Prototype age-based cache pruning

### DIFF
--- a/crates/uv-cache/src/gc.rs
+++ b/crates/uv-cache/src/gc.rs
@@ -1,0 +1,175 @@
+use std::io;
+use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use rustc_hash::FxHashSet;
+use tracing::debug;
+
+use crate::usage::{UPDATE_INTERVAL, last_used, marker_path, touch};
+use crate::{Cache, CacheBucket};
+
+impl Cache {
+    /// Remove unpacked wheels whose recorded use is older than `max_age`.
+    ///
+    /// The caller must hold the exclusive cache lock. Cached environments, source trees, compressed
+    /// built wheels, and metadata are retained. The update interval is added to the retention period
+    /// because usage markers can lag the last use by that amount.
+    ///
+    /// Returns the archive paths removed, or that would be removed during a dry run. A dry run does
+    /// not update usage records. Otherwise, archives without records receive a fresh timestamp.
+    pub fn prune_unused(&self, max_age: Duration, dry_run: bool) -> io::Result<Vec<PathBuf>> {
+        if !self.supports_age_pruning()? {
+            return Ok(Vec::new());
+        }
+
+        let archive_root = fs_err::canonicalize(self.root())?.join(CacheBucket::Archive.to_str());
+        let protected = self.environment_archives(&archive_root)?;
+        let references = self.find_archive_references()?;
+        let max_age = max_age.saturating_add(UPDATE_INTERVAL);
+        let now = SystemTime::now();
+        let mut expired = Vec::new();
+
+        // Discover deletion targets from known wheel references, never from marker filenames.
+        // Archives without such references may belong to another cache user and are left alone.
+        for (archive, references) in references {
+            if archive.parent() != Some(archive_root.as_path()) || protected.contains(&archive) {
+                continue;
+            }
+            let Some(name) = archive.file_name() else {
+                continue;
+            };
+            let marker = marker_path(self.root(), name);
+            let Some(last_used) = last_used(&marker)? else {
+                if !dry_run {
+                    touch(self.root(), name)?;
+                }
+                continue;
+            };
+            if !now
+                .duration_since(last_used)
+                .is_ok_and(|elapsed| elapsed > max_age)
+            {
+                continue;
+            }
+
+            if !dry_run {
+                for reference in references {
+                    // URL and local-wheel cache hits can trust these pointers without checking
+                    // that the payload still exists. Remove pointers before unlinking the archive.
+                    if reference.starts_with(self.bucket(CacheBucket::Wheels))
+                        && let Some(filename) = reference.file_name()
+                    {
+                        for extension in [".http", ".rev"] {
+                            let mut pointer = filename.to_os_string();
+                            pointer.push(extension);
+                            self.remove_path(reference.with_file_name(pointer))?;
+                        }
+                    }
+                    self.remove_path(reference)?;
+                }
+                self.remove_path(&archive)?;
+                fs_err::remove_file(marker)?;
+            }
+            expired.push(archive);
+        }
+        expired.sort_unstable();
+        Ok(expired)
+    }
+
+    /// Avoid collecting archives whose references may use an unknown bucket format.
+    fn supports_age_pruning(&self) -> io::Result<bool> {
+        let buckets = [
+            ("wheels-v", CacheBucket::Wheels),
+            ("sdists-v", CacheBucket::SourceDistributions),
+            ("environments-v", CacheBucket::Environments),
+            ("archive-v", CacheBucket::Archive),
+        ];
+        for entry in fs_err::read_dir(self.root())? {
+            let entry = entry?;
+            let name = entry.file_name();
+            for (prefix, bucket) in buckets {
+                if name
+                    .to_str()
+                    .is_some_and(|name| name.starts_with(prefix) && name != bucket.to_str())
+                {
+                    debug!("Skipping age-based pruning with unknown cache bucket: {name:?}");
+                    return Ok(false);
+                }
+                if name == bucket.to_str() && entry.file_type()?.is_symlink() {
+                    debug!("Skipping age-based pruning with linked cache bucket: {name:?}");
+                    return Ok(false);
+                }
+            }
+        }
+        for path in [
+            self.bucket(CacheBucket::Usage),
+            self.bucket(CacheBucket::Usage)
+                .join(CacheBucket::Archive.to_str()),
+        ] {
+            match fs_err::symlink_metadata(&path) {
+                Ok(metadata) if metadata.is_dir() => {}
+                Ok(_) => {
+                    debug!(
+                        "Skipping age-based pruning with invalid usage directory: {}",
+                        path.display()
+                    );
+                    return Ok(false);
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(true)
+    }
+
+    /// Find archives owned by retained environments, including symlinked wheel dependencies.
+    fn environment_archives(&self, archive_root: &Path) -> io::Result<FxHashSet<PathBuf>> {
+        let environments = self.bucket(CacheBucket::Environments);
+        let mut pending = vec![environments.clone()];
+        let mut protected = FxHashSet::default();
+        while let Some(root) = pending.pop() {
+            for entry in walkdir::WalkDir::new(&root).follow_root_links(false) {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(err)
+                        if err
+                            .io_error()
+                            .is_some_and(|err| err.kind() == io::ErrorKind::NotFound) =>
+                    {
+                        continue;
+                    }
+                    Err(err) => return Err(err.into()),
+                };
+                let target = if entry.file_type().is_symlink() {
+                    fs_err::canonicalize(entry.path())
+                } else if cfg!(windows)
+                    && root == environments
+                    && entry.depth() == 2
+                    && entry.file_type().is_file()
+                {
+                    // Windows represents cached-environment links using structured files at
+                    // environments/<interpreter>/<resolution>, rather than filesystem symlinks.
+                    self.resolve_link(entry.path())
+                } else {
+                    continue;
+                };
+                let target = match target {
+                    Ok(target) => target,
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                    // Files such as pyvenv.cfg can occupy the same depth as a Windows link.
+                    Err(err) if err.kind() == io::ErrorKind::InvalidData => continue,
+                    Err(err) => return Err(err),
+                };
+                if let Ok(relative) = target.strip_prefix(archive_root)
+                    && let Some(Component::Normal(name)) = relative.components().next()
+                {
+                    let archive = archive_root.join(name);
+                    if protected.insert(archive.clone()) {
+                        pending.push(archive);
+                    }
+                }
+            }
+        }
+        Ok(protected)
+    }
+}

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -19,6 +19,7 @@ pub use crate::by_timestamp::CachedByTimestamp;
 pub use crate::cli::CacheArgs;
 use crate::removal::Remover;
 pub use crate::removal::{Removal, RemovalAccounting};
+use crate::usage::CacheUsage;
 pub use crate::wheel::WheelCache;
 use crate::wheel::WheelCacheKind;
 pub use archive::ArchiveId;
@@ -27,7 +28,9 @@ mod archive;
 mod by_timestamp;
 #[cfg(feature = "clap")]
 mod cli;
+mod gc;
 mod removal;
+mod usage;
 mod wheel;
 
 /// The version of the archive bucket.
@@ -174,6 +177,8 @@ pub struct Cache {
     /// Ensure that `uv cache` operations don't remove items from the cache that are used by another
     /// uv process.
     lock_file: Option<Arc<LockedFile>>,
+    /// Deferred last-use records, retaining the shared lock until they have been flushed.
+    usage: Option<Arc<CacheUsage>>,
     /// The storage accounting used when removing cache entries.
     removal_accounting: RemovalAccounting,
 }
@@ -186,6 +191,7 @@ impl Cache {
             refresh: Refresh::None(Timestamp::now()),
             temp_dir: None,
             lock_file: None,
+            usage: None,
             removal_accounting: RemovalAccounting::Coarse,
         }
     }
@@ -198,6 +204,7 @@ impl Cache {
             refresh: Refresh::None(Timestamp::now()),
             temp_dir: Some(Arc::new(temp_dir)),
             lock_file: None,
+            usage: None,
             removal_accounting: RemovalAccounting::Coarse,
         })
     }
@@ -237,8 +244,12 @@ impl Cache {
             refresh,
             temp_dir,
             lock_file,
+            usage,
             removal_accounting,
         } = self;
+
+        // Flush usage while the shared lock is still held.
+        drop(usage);
 
         // Release the existing lock, avoid deadlocks from a cloned cache.
         if let Some(lock_file) = lock_file {
@@ -260,6 +271,7 @@ impl Cache {
             refresh,
             temp_dir,
             lock_file: Some(Arc::new(lock_file)),
+            usage: None,
             removal_accounting,
         })
     }
@@ -273,6 +285,7 @@ impl Cache {
             refresh,
             temp_dir,
             lock_file,
+            usage,
             removal_accounting,
         } = self;
 
@@ -286,6 +299,7 @@ impl Cache {
                 refresh,
                 temp_dir,
                 lock_file: Some(Arc::new(lock_file)),
+                usage,
                 removal_accounting,
             }),
             None => Err(Self {
@@ -293,6 +307,7 @@ impl Cache {
                 refresh,
                 temp_dir,
                 lock_file,
+                usage,
                 removal_accounting,
             }),
         }
@@ -326,6 +341,16 @@ impl Cache {
     /// Return the path to an archive in the cache.
     pub fn archive(&self, id: &ArchiveId) -> PathBuf {
         self.bucket(CacheBucket::Archive).join(id)
+    }
+
+    /// Record use of a selected or newly prepared unpacked wheel.
+    ///
+    /// Updates are deduplicated and flushed before the last shared cache lock is released.
+    /// Paths outside the archive store are ignored, as are temporary and uninitialized caches.
+    pub fn record_archive_use(&self, path: impl AsRef<Path>) {
+        if let Some(usage) = &self.usage {
+            usage.record(path.as_ref());
+        }
     }
 
     /// Create a temporary directory to be used as a Python virtual environment.
@@ -420,6 +445,8 @@ impl Cache {
         fs_err::create_dir_all(path.as_ref().parent().expect("Cache entry to have parent"))?;
         self.create_link(&id, path.as_ref())?;
 
+        self.record_archive_use(&archive_entry);
+
         Ok(id)
     }
 
@@ -445,6 +472,8 @@ impl Cache {
         // Create a symlink to the directory store.
         fs_err::create_dir_all(path.as_ref().parent().expect("Cache entry to have parent"))?;
         self.create_link(&id, path.as_ref())?;
+
+        self.record_archive_use(&archive_entry);
 
         Ok(id)
     }
@@ -546,9 +575,18 @@ impl Cache {
             Err(err) => return Err(err.into()),
         };
 
+        let root = std::path::absolute(root).map_err(Error::Absolute)?;
+        let usage = if self.is_temporary() {
+            None
+        } else {
+            lock_file
+                .as_ref()
+                .map(|lock| Arc::new(CacheUsage::new(root.clone(), Arc::clone(lock))))
+        };
         Ok(Self {
-            root: std::path::absolute(root).map_err(Error::Absolute)?,
+            root,
             lock_file,
+            usage,
             ..self
         })
     }
@@ -567,15 +605,22 @@ impl Cache {
         ) else {
             return Ok(None);
         };
+        let root = std::path::absolute(root).map_err(Error::Absolute)?;
+        let lock_file = Arc::new(lock_file);
+        let usage = (!self.is_temporary())
+            .then(|| Arc::new(CacheUsage::new(root.clone(), Arc::clone(&lock_file))));
         Ok(Some(Self {
-            root: std::path::absolute(root).map_err(Error::Absolute)?,
-            lock_file: Some(Arc::new(lock_file)),
+            root,
+            lock_file: Some(lock_file),
+            usage,
             ..self
         }))
     }
 
     /// Clear the cache, removing all entries.
-    pub fn clear(self, reporter: Box<dyn CleanReporter>) -> Result<Removal, io::Error> {
+    pub fn clear(mut self, reporter: Box<dyn CleanReporter>) -> Result<Removal, io::Error> {
+        // Do not recreate usage markers after clearing the cache.
+        self.usage.take();
         // Remove everything but `.lock`, Windows does not allow removal of a locked file
         let mut removal = Remover::new(reporter)
             .with_removal_accounting(self.removal_accounting)
@@ -1253,6 +1298,8 @@ pub enum CacheBucket {
     /// Cache structure:
     ///  * `osv-v0/vulnerability/<vuln_id>.msgpack` — cached full vulnerability records
     Osv,
+    /// Explicit last-use timestamps for cached artifacts.
+    Usage,
 }
 
 impl CacheBucket {
@@ -1280,6 +1327,7 @@ impl CacheBucket {
             Self::Python => "python-v0",
             Self::Binaries => "binaries-v0",
             Self::Osv => "osv-v0",
+            Self::Usage => "usage-v0",
         }
     }
 
@@ -1388,7 +1436,8 @@ impl CacheBucket {
             | Self::Environments
             | Self::Python
             | Self::Binaries
-            | Self::Osv => {
+            | Self::Osv
+            | Self::Usage => {
                 // Nothing to do.
             }
         }
@@ -1410,6 +1459,7 @@ impl CacheBucket {
             Self::Python,
             Self::Binaries,
             Self::Osv,
+            Self::Usage,
         ]
         .iter()
         .copied()

--- a/crates/uv-cache/src/usage.rs
+++ b/crates/uv-cache/src/usage.rs
@@ -1,0 +1,143 @@
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use fs_err::OpenOptions;
+use rustc_hash::FxHashSet;
+use tracing::debug;
+use uv_fs::LockedFile;
+
+use crate::CacheBucket;
+
+/// The interval used to coalesce repeated last-use updates.
+pub(crate) const UPDATE_INTERVAL: Duration = Duration::from_hours(24);
+
+/// Deferred archive use, flushed while its shared cache lock is still held.
+#[derive(Debug)]
+pub(crate) struct CacheUsage {
+    root: PathBuf,
+    archive_root: PathBuf,
+    canonical_archive_root: PathBuf,
+    archives: Mutex<FxHashSet<OsString>>,
+    // Retain the lock through `Drop`, even if the owning `Cache` releases its guard first.
+    _lock_file: Arc<LockedFile>,
+}
+
+impl CacheUsage {
+    pub(crate) fn new(root: PathBuf, lock_file: Arc<LockedFile>) -> Self {
+        let canonical_root = fs_err::canonicalize(&root).unwrap_or_else(|_| root.clone());
+        Self {
+            archive_root: root.join(CacheBucket::Archive.to_str()),
+            canonical_archive_root: canonical_root.join(CacheBucket::Archive.to_str()),
+            root,
+            archives: Mutex::default(),
+            _lock_file: lock_file,
+        }
+    }
+
+    /// Queue the use of an archive, accepting both lexical and canonical cache paths.
+    pub(crate) fn record(&self, path: &Path) {
+        if path.parent().is_some_and(|parent| {
+            parent == self.archive_root || parent == self.canonical_archive_root
+        }) && let Some(name) = path.file_name()
+            && let Ok(mut archives) = self.archives.lock()
+        {
+            archives.insert(name.to_os_string());
+        }
+    }
+}
+
+impl Drop for CacheUsage {
+    fn drop(&mut self) {
+        let Ok(archives) = self.archives.get_mut() else {
+            debug!("Skipping cache usage updates after a poisoned lock");
+            return;
+        };
+        for archive in archives.iter() {
+            if let Err(err) = touch(&self.root, archive) {
+                debug!("Failed to record cache archive use for {archive:?}: {err}");
+            }
+        }
+    }
+}
+
+/// Return the usage marker for an archive directly inside the archive bucket.
+pub(crate) fn marker_path(root: &Path, archive: &OsStr) -> PathBuf {
+    root.join(CacheBucket::Usage.to_str())
+        .join(CacheBucket::Archive.to_str())
+        .join(archive)
+}
+
+/// Read an explicit last-use timestamp without following a marker symlink.
+pub(crate) fn last_used(marker: &Path) -> io::Result<Option<SystemTime>> {
+    match fs_err::symlink_metadata(marker) {
+        Ok(metadata) if metadata.is_file() => metadata.modified().map(Some),
+        Ok(_) => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Cache usage marker is not a regular file: {}",
+                marker.display()
+            ),
+        )),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+/// Record use at flush time, limiting writes to approximately one per archive per day.
+pub(crate) fn touch(root: &Path, archive: &OsStr) -> io::Result<()> {
+    let marker = marker_path(root, archive);
+    if let Some(last_used) = last_used(&marker)?
+        && !SystemTime::now()
+            .duration_since(last_used)
+            .is_ok_and(|elapsed| elapsed >= UPDATE_INTERVAL)
+    {
+        // Future timestamps are preserved if the system clock moves backwards.
+        return Ok(());
+    }
+
+    let usage_root = root.join(CacheBucket::Usage.to_str());
+    ensure_directory(&usage_root)?;
+    ensure_directory(&usage_root.join(CacheBucket::Archive.to_str()))?;
+
+    let file = match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&marker)
+    {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+            // Another reader may have created or refreshed this marker while we were flushing.
+            if let Some(last_used) = last_used(&marker)?
+                && !SystemTime::now()
+                    .duration_since(last_used)
+                    .is_ok_and(|elapsed| elapsed >= UPDATE_INTERVAL)
+            {
+                return Ok(());
+            }
+            OpenOptions::new().write(true).open(&marker)?
+        }
+        Err(err) => return Err(err),
+    };
+    file.set_modified(SystemTime::now())
+}
+
+/// Create a marker directory, rejecting existing links or other non-directory entries.
+fn ensure_directory(path: &Path) -> io::Result<()> {
+    match fs_err::create_dir(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+            if fs_err::symlink_metadata(path)?.is_dir() {
+                Ok(())
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Cache usage path is not a directory: {}", path.display()),
+                ))
+            }
+        }
+        Err(err) => Err(err),
+    }
+}

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1,8 +1,10 @@
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
+use std::num::NonZeroU64;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::Duration;
 
 use anyhow::{Result, anyhow};
 use clap::builder::styling::{AnsiColor, Effects, Style};
@@ -979,6 +981,37 @@ pub struct PruneArgs {
     /// `--force` is used, `uv cache prune` will proceed without taking a lock.
     #[arg(long)]
     pub force: bool,
+
+    /// Remove unpacked wheels that have not been used for the given number of days.
+    ///
+    /// This experimental mode retains source distributions, compressed wheels built from source,
+    /// metadata, and cached environments. Wheels without usage records receive a full retention
+    /// period on the first prune.
+    ///
+    /// The number of days must be a positive integer. Cannot be combined with `--ci` or `--force`.
+    #[arg(
+        long,
+        value_name = "DAYS",
+        value_parser = parse_max_age,
+        conflicts_with_all = ["ci", "force"]
+    )]
+    pub max_age: Option<Duration>,
+
+    /// Show which unpacked wheels would be removed without changing the cache.
+    #[arg(long, requires = "max_age")]
+    pub dry_run: bool,
+}
+
+/// Parse a positive number of days into a [`Duration`].
+fn parse_max_age(input: &str) -> Result<Duration, String> {
+    let days = input
+        .parse::<NonZeroU64>()
+        .map_err(|_| "expected a positive integer number of days".to_string())?;
+    let seconds = days
+        .get()
+        .checked_mul(24 * 60 * 60)
+        .ok_or_else(|| "number of days is too large".to_string())?;
+    Ok(Duration::from_secs(seconds))
 }
 
 #[derive(Args, Debug)]

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -130,10 +130,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         tags: &Tags,
         hashes: HashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
-        match dist {
+        let wheel = match dist {
             Dist::Built(built) => self.get_wheel(built, hashes).await,
             Dist::Source(source) => self.build_wheel(source, tags, hashes).await,
-        }
+        }?;
+        self.build_context
+            .cache()
+            .record_archive_use(&wheel.archive);
+        Ok(wheel)
     }
 
     /// Either fetch the only wheel metadata (directly from the index or with range requests) or
@@ -539,6 +543,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // TODO(charlie): Request the hashes via a separate method, to reduce the coupling in this API.
         if hashes.is_generate(dist) {
             let wheel = self.get_wheel(dist, hashes).await?;
+            self.build_context
+                .cache()
+                .record_archive_use(&wheel.archive);
             // If the metadata was provided by the user directly, prefer it.
             let metadata = if let Some(metadata) = self
                 .build_context
@@ -592,6 +599,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 // If the request failed due to an error that could be resolved by
                 // downloading the wheel directly, try that.
                 let wheel = self.get_wheel(dist, hashes).await?;
+                self.build_context
+                    .cache()
+                    .record_archive_use(&wheel.archive);
                 let metadata = wheel.metadata()?;
                 let hashes = wheel.hashes;
                 Ok(ArchiveMetadata {

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -762,6 +762,10 @@ impl<'a> Planner<'a> {
             }
         }
 
+        for dist in &cached {
+            cache.record_archive_use(dist.path());
+        }
+
         Ok(Plan {
             cached,
             remote,

--- a/crates/uv/src/commands/cache_prune.rs
+++ b/crates/uv/src/commands/cache_prune.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
@@ -15,6 +16,8 @@ use crate::printer::Printer;
 pub(crate) async fn cache_prune(
     ci: bool,
     force: bool,
+    max_age: Option<Duration>,
+    dry_run: bool,
     cache: Cache,
     printer: Printer,
     preview: Preview,
@@ -30,18 +33,40 @@ pub(crate) async fn cache_prune(
 
     let cache = match cache.with_exclusive_lock_no_wait() {
         Ok(cache) => cache,
-        Err(cache) if force => {
+        Err(cache) if force && max_age.is_none() => {
             debug!("Cache is currently in use, proceeding due to `--force`");
             cache
         }
         Err(cache) => {
-            writeln!(
-                printer.stderr(),
-                "Cache is currently in-use, waiting for other uv processes to finish (use `--force` to override)"
-            )?;
+            if max_age.is_some() {
+                writeln!(
+                    printer.stderr(),
+                    "Cache is currently in-use, waiting for other uv processes to finish"
+                )?;
+            } else {
+                writeln!(
+                    printer.stderr(),
+                    "Cache is currently in-use, waiting for other uv processes to finish (use `--force` to override)"
+                )?;
+            }
             cache.with_exclusive_lock().await?
         }
     };
+
+    if let Some(max_age) = max_age {
+        let paths = cache.prune_unused(max_age, dry_run).with_context(|| {
+            format!("Failed to prune cache at: {}", cache.root().user_display())
+        })?;
+        let action = if dry_run { "Would remove" } else { "Removed" };
+        let wheels = if paths.len() == 1 { "wheel" } else { "wheels" };
+        writeln!(printer.stderr(), "{action} {} unused {wheels}", paths.len())?;
+        if dry_run {
+            for path in paths {
+                writeln!(printer.stderr(), "  {}", path.user_display())?;
+            }
+        }
+        return Ok(ExitStatus::Success);
+    }
 
     let removal_accounting = if preview.is_enabled(PreviewFeature::CachePhysicalSpace) {
         RemovalAccounting::Fine

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1288,7 +1288,16 @@ async fn run_with_workspace_cache(
             command: CacheCommand::Prune(args),
         }) => {
             show_settings!(args);
-            commands::cache_prune(args.ci, args.force, cache, printer, globals.preview).await
+            commands::cache_prune(
+                args.ci,
+                args.force,
+                args.max_age,
+                args.dry_run,
+                cache,
+                printer,
+                globals.preview,
+            )
+            .await
         }
         Commands::Cache(CacheNamespace {
             command: CacheCommand::Dir,

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -1,8 +1,14 @@
-use anyhow::Result;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result};
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
+use filetime::FileTime;
 use indoc::indoc;
+use insta::allow_duplicates;
 
+use uv_cache::{ArchiveId, Cache};
 use uv_static::EnvVars;
 
 use uv_test::uv_snapshot;
@@ -570,4 +576,512 @@ fn prune_stale_revision_content_addressed_cache() -> Result<()> {
     ");
 
     Ok(())
+}
+
+/// Age pruning removes unused wheels and their pointers, preserving source build inputs.
+#[tokio::test]
+async fn prune_unused_wheels() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_filter((
+        r"\[CACHE_DIR\](\\|/)archive-v0(\\|/)[^\r\n]+",
+        "[CACHE_DIR]/archive-v0/[ARCHIVE]",
+    ));
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+    let unused_entry = context
+        .cache_dir
+        .child("wheels-v6/pypi/demo/1.0.0-py3-none-any");
+    let (unused_archive, unused_marker) = persist_archive(&cache, &unused_entry).await?;
+    let (fresh_archive, fresh_marker) = persist_archive(
+        &cache,
+        &context
+            .cache_dir
+            .child("wheels-v6/pypi/demo/2.0.0-py3-none-any"),
+    )
+    .await?;
+    let (recent_archive, recent_marker) = persist_archive(
+        &cache,
+        &context
+            .cache_dir
+            .child("wheels-v6/pypi/demo/3.0.0-py3-none-any"),
+    )
+    .await?;
+    let source = context
+        .cache_dir
+        .child("sdists-v9/pypi/demo/1.0.0/revision");
+    let built_entry = source.child("demo-1.0.0-py3-none-any");
+    let (built_archive, built_marker) = persist_archive(&cache, &built_entry).await?;
+    drop(cache);
+
+    let http_pointer = unused_entry.with_file_name("1.0.0-py3-none-any.http");
+    let local_pointer = unused_entry.with_file_name("1.0.0-py3-none-any.rev");
+    fs_err::write(&http_pointer, "HTTP archive pointer")?;
+    fs_err::write(&local_pointer, "local archive pointer")?;
+    source
+        .child("demo-1.0.0-py3-none-any.whl")
+        .write_str("compressed wheel")?;
+    source.child("metadata.msgpack").write_str("metadata")?;
+    source.child("src/pyproject.toml").write_str("source")?;
+
+    let old = FileTime::from_unix_time(1_700_000_000, 0);
+    filetime::set_file_mtime(&unused_marker, old)?;
+    filetime::set_file_mtime(&built_marker, old)?;
+    let future = FileTime::from_unix_time(FileTime::now().unix_seconds() + 86_400, 0);
+    filetime::set_file_mtime(&fresh_marker, future)?;
+    // A daily timestamp update can understate actual use by up to a day.
+    filetime::set_file_mtime(
+        &recent_marker,
+        FileTime::from_system_time(SystemTime::now() - Duration::from_hours(30 * 24 + 12)),
+    )?;
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30", "--dry-run"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would remove 2 unused wheels
+      [CACHE_DIR]/archive-v0/[ARCHIVE]
+      [CACHE_DIR]/archive-v0/[ARCHIVE]
+    ");
+
+    assert!(unused_archive.is_dir());
+    assert!(built_archive.is_dir());
+    assert!(unused_entry.exists());
+    assert!(http_pointer.is_file());
+    assert!(local_pointer.is_file());
+    assert_eq!(
+        FileTime::from_last_modification_time(&fs_err::metadata(&unused_marker)?),
+        old
+    );
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 2 unused wheels
+    ");
+
+    assert!(!unused_archive.exists());
+    assert!(!built_archive.exists());
+    assert!(fs_err::symlink_metadata(&unused_entry).is_err());
+    assert!(fs_err::symlink_metadata(&built_entry).is_err());
+    assert!(!http_pointer.exists());
+    assert!(!local_pointer.exists());
+    assert!(!unused_marker.exists());
+    assert!(!built_marker.exists());
+    assert!(fresh_archive.is_dir());
+    assert!(fresh_marker.is_file());
+    assert_eq!(
+        FileTime::from_last_modification_time(&fs_err::metadata(&fresh_marker)?),
+        future
+    );
+    assert!(recent_archive.is_dir());
+    assert!(source.child("demo-1.0.0-py3-none-any.whl").is_file());
+    assert!(source.child("metadata.msgpack").is_file());
+    assert!(source.child("src/pyproject.toml").is_file());
+
+    Ok(())
+}
+
+/// Existing cache entries receive a grace period, without mutating the cache during a dry run.
+#[tokio::test]
+async fn prune_unused_missing_markers() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+    let (archive, marker) = persist_archive(
+        &cache,
+        &context
+            .cache_dir
+            .child("wheels-v6/pypi/demo/1.0.0-py3-none-any"),
+    )
+    .await?;
+    drop(cache);
+    fs_err::remove_file(&marker)?;
+    filetime::set_file_mtime(&archive, FileTime::from_unix_time(1_700_000_000, 0))?;
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30", "--dry-run"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would remove 0 unused wheels
+    ");
+    assert!(!marker.exists());
+    assert!(archive.is_dir());
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 0 unused wheels
+    ");
+    assert!(marker.is_file());
+    assert!(archive.is_dir());
+
+    filetime::set_file_mtime(&marker, FileTime::from_unix_time(1_700_000_000, 0))?;
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 1 unused wheel
+    ");
+    assert!(!archive.exists());
+
+    Ok(())
+}
+
+/// Reusing a wheel refreshes its usage record, without keeping every cached version alive.
+#[test]
+fn prune_unused_reinstall() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let links = context.workspace_root.join("test/links");
+    for requirement in ["ok==1.0.0", "ok==2.0.0"] {
+        context
+            .pip_install()
+            .arg(requirement)
+            .args(["--offline", "--no-index", "--find-links"])
+            .arg(&links)
+            .assert()
+            .success();
+    }
+
+    let archives = fs_err::read_dir(context.cache_dir.child("archive-v0").path())?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    let unused_archive = archives
+        .iter()
+        .find(|path| path.join("ok-1.0.0.dist-info").is_dir())
+        .context("missing cached ok==1.0.0")?;
+    let selected_archive = archives
+        .iter()
+        .find(|path| path.join("ok-2.0.0.dist-info").is_dir())
+        .context("missing cached ok==2.0.0")?;
+    let usage = context.cache_dir.child("usage-v0/archive-v0");
+    let unused_marker = usage.child(unused_archive.file_name().context("missing archive name")?);
+    let selected_marker = usage.child(
+        selected_archive
+            .file_name()
+            .context("missing archive name")?,
+    );
+    let old = FileTime::from_unix_time(1_700_000_000, 0);
+    filetime::set_file_mtime(&unused_marker, old)?;
+    filetime::set_file_mtime(&selected_marker, old)?;
+    let metadata = selected_archive.join("ok-2.0.0.dist-info/METADATA");
+    let metadata_modified = fs_err::metadata(&metadata)?.modified()?;
+
+    context.pip_uninstall().arg("ok").assert().success();
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("ok==2.0.0")
+        .args(["--offline", "--no-index", "--find-links"])
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==2.0.0
+    ");
+
+    assert_eq!(
+        FileTime::from_last_modification_time(&fs_err::metadata(&unused_marker)?),
+        old
+    );
+    assert!(FileTime::from_last_modification_time(&fs_err::metadata(&selected_marker)?) > old);
+    assert_eq!(fs_err::metadata(&metadata)?.modified()?, metadata_modified);
+
+    // Repeated uses within a day do not cause another timestamp write.
+    let recent = FileTime::from_unix_time(FileTime::now().unix_seconds() - 3600, 0);
+    filetime::set_file_mtime(&selected_marker, recent)?;
+    context.pip_uninstall().arg("ok").assert().success();
+    context
+        .pip_install()
+        .arg("ok==2.0.0")
+        .args(["--offline", "--no-index", "--find-links"])
+        .arg(&links)
+        .assert()
+        .success();
+    assert_eq!(
+        FileTime::from_last_modification_time(&fs_err::metadata(&selected_marker)?),
+        recent
+    );
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 1 unused wheel
+    ");
+    assert!(!unused_archive.exists());
+    assert!(selected_archive.is_dir());
+
+    // The local wheel can be unpacked again after its stale archive and pointer are removed.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("ok==1.0.0")
+        .args(["--offline", "--no-index", "--find-links"])
+        .arg(&links), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - ok==2.0.0
+     + ok==1.0.0
+    ");
+
+    Ok(())
+}
+
+/// Cached environments retain both their backing archive and wheels installed with symlinks.
+#[cfg(unix)]
+#[tokio::test]
+async fn prune_unused_cached_environments() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+    let (needed_archive, needed_marker) = persist_archive(
+        &cache,
+        &context
+            .cache_dir
+            .child("wheels-v6/pypi/demo/1.0.0-py3-none-any"),
+    )
+    .await?;
+    let (unused_archive, unused_marker) = persist_archive(
+        &cache,
+        &context
+            .cache_dir
+            .child("wheels-v6/pypi/demo/2.0.0-py3-none-any"),
+    )
+    .await?;
+    let environment = context.cache_dir.child("environments-v2/tool");
+    let (environment_archive, environment_marker) = persist_archive(&cache, &environment).await?;
+    fs_err::os::unix::fs::symlink(
+        needed_archive.join("payload.py"),
+        environment_archive.join("installed.py"),
+    )?;
+    drop(cache);
+    for marker in [&needed_marker, &unused_marker, &environment_marker] {
+        filetime::set_file_mtime(marker, FileTime::from_unix_time(1_700_000_000, 0))?;
+    }
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 1 unused wheel
+    ");
+
+    assert!(!unused_archive.exists());
+    assert!(needed_archive.is_dir());
+    assert!(environment.exists());
+    assert!(environment_archive.is_dir());
+    assert_eq!(
+        fs_err::read_to_string(environment.join("installed.py"))?,
+        "payload"
+    );
+
+    Ok(())
+}
+
+/// Unknown cache generations may contain references that this version cannot safely interpret.
+#[tokio::test]
+async fn prune_unused_unknown_buckets() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+    let (archive, marker) = persist_archive(
+        &cache,
+        &context
+            .cache_dir
+            .child("wheels-v6/pypi/demo/1.0.0-py3-none-any"),
+    )
+    .await?;
+    drop(cache);
+    filetime::set_file_mtime(&marker, FileTime::from_unix_time(1_700_000_000, 0))?;
+
+    for bucket in [
+        "wheels-v999",
+        "sdists-v999",
+        "archive-v999",
+        "environments-v999",
+    ] {
+        let unknown = context.cache_dir.child(bucket);
+        unknown.child("payload").write_str("unknown cache data")?;
+
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Removed 0 unused wheels
+            ");
+        }
+        assert!(archive.is_dir());
+        assert!(unknown.child("payload").is_file());
+        fs_err::remove_dir_all(&unknown)?;
+    }
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 1 unused wheel
+    ");
+    assert!(!archive.exists());
+
+    Ok(())
+}
+
+/// Usage directories that link outside the cache must not be used to expire or rewrite entries.
+#[cfg(unix)]
+#[tokio::test]
+async fn prune_unused_linked_usage_directories() -> Result<()> {
+    for usage_path in ["usage-v0", "usage-v0/archive-v0"] {
+        let context = uv_test::test_context!("3.12");
+        let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+        let entry = context
+            .cache_dir
+            .child("wheels-v6/pypi/demo/1.0.0-py3-none-any");
+        let (archive, marker) = persist_archive(&cache, &entry).await?;
+        drop(cache);
+
+        let usage = context.cache_dir.child(usage_path);
+        let outside = context.temp_dir.child("outside-usage");
+        let outside_marker = outside.join(marker.strip_prefix(&usage)?);
+        fs_err::rename(&usage, &outside)?;
+        fs_err::os::unix::fs::symlink(&outside, &usage)?;
+        fs_err::write(&outside_marker, "outside marker data")?;
+        let old = FileTime::from_unix_time(1_700_000_000, 0);
+        filetime::set_file_mtime(&outside_marker, old)?;
+
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30", "--dry-run"]), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Would remove 0 unused wheels
+            ");
+
+            uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Removed 0 unused wheels
+            ");
+        }
+
+        assert!(archive.is_dir());
+        assert!(entry.exists());
+        assert!(fs_err::symlink_metadata(&usage)?.is_symlink());
+        assert_eq!(
+            fs_err::read_to_string(&outside_marker)?,
+            "outside marker data"
+        );
+        assert_eq!(
+            FileTime::from_last_modification_time(&fs_err::metadata(&outside_marker)?),
+            old
+        );
+    }
+
+    Ok(())
+}
+
+/// Age pruning cannot remove a wheel while another command holds a shared cache lock.
+#[tokio::test]
+async fn prune_unused_locked_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+    let (archive, marker) = persist_archive(
+        &cache,
+        &context
+            .cache_dir
+            .child("wheels-v6/pypi/demo/1.0.0-py3-none-any"),
+    )
+    .await?;
+    drop(cache);
+    filetime::set_file_mtime(&marker, FileTime::from_unix_time(1_700_000_000, 0))?;
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+
+    uv_snapshot!(context.filters(), context.prune()
+        .args(["--max-age", "30"])
+        .env(EnvVars::UV_LOCK_TIMEOUT, "1"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Cache is currently in-use, waiting for other uv processes to finish
+    error: Timeout ([TIME]) when waiting for lock on `[CACHE_DIR]/` at `[CACHE_DIR]/.lock`, is another uv process running? You can set `UV_LOCK_TIMEOUT` to increase the timeout.
+    ");
+    assert!(archive.is_dir());
+    drop(cache);
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 1 unused wheel
+    ");
+    assert!(!archive.exists());
+
+    Ok(())
+}
+
+/// Shared archive IDs refresh one usage record and remove every reference when the payload expires.
+#[tokio::test]
+async fn prune_unused_shared_archive() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_filter((
+        r"\[CACHE_DIR\](\\|/)archive-v0(\\|/)[^\r\n]+",
+        "[CACHE_DIR]/archive-v0/[ARCHIVE]",
+    ));
+    let first_entry = context
+        .cache_dir
+        .child("wheels-v6/pypi/demo/1.0.0-py3-none-any");
+    let second_entry = context
+        .cache_dir
+        .child("wheels-v6/index/other/demo/1.0.0-py3-none-any");
+    let id = ArchiveId::default();
+    let archive = context.cache_dir.child("archive-v0").join(&id);
+    let marker = context.cache_dir.child("usage-v0/archive-v0").join(&id);
+    let old = FileTime::from_unix_time(1_700_000_000, 0);
+    let mut pointers = Vec::new();
+
+    for reference in [&first_entry, &second_entry] {
+        let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+        let directory = tempfile::tempdir_in(cache.root())?;
+        fs_err::write(directory.path().join("payload.py"), "payload")?;
+        cache
+            .persist_with_id(directory, reference, id.clone())
+            .await?;
+        drop(cache);
+
+        // The second publication reuses the archive and must refresh its aged marker.
+        assert!(FileTime::from_last_modification_time(&fs_err::metadata(&marker)?) > old);
+        filetime::set_file_mtime(&marker, old)?;
+
+        for extension in ["http", "rev"] {
+            let pointer = reference.with_file_name(format!("1.0.0-py3-none-any.{extension}"));
+            fs_err::write(&pointer, "archive pointer")?;
+            pointers.push(pointer);
+        }
+    }
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30", "--dry-run"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would remove 1 unused wheel
+      [CACHE_DIR]/archive-v0/[ARCHIVE]
+    ");
+
+    assert!(archive.is_dir());
+    assert!(first_entry.exists());
+    assert!(second_entry.exists());
+    assert!(pointers.iter().all(|pointer| pointer.is_file()));
+    assert_eq!(
+        FileTime::from_last_modification_time(&fs_err::metadata(&marker)?),
+        old
+    );
+
+    uv_snapshot!(context.filters(), context.prune().args(["--max-age", "30"]), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Removed 1 unused wheel
+    ");
+
+    assert!(!archive.exists());
+    assert!(!marker.exists());
+    assert!(fs_err::symlink_metadata(&first_entry).is_err());
+    assert!(fs_err::symlink_metadata(&second_entry).is_err());
+    assert!(pointers.iter().all(|pointer| !pointer.exists()));
+
+    Ok(())
+}
+
+/// Persist a synthetic archive through the same layout as an unpacked wheel or environment.
+async fn persist_archive(cache: &Cache, reference: &Path) -> Result<(PathBuf, PathBuf)> {
+    let directory = tempfile::tempdir_in(cache.root())?;
+    fs_err::write(directory.path().join("payload.py"), "payload")?;
+    let id = cache.persist(directory.keep(), reference).await?;
+    Ok((
+        cache.archive(&id),
+        cache.root().join("usage-v0/archive-v0").join(id),
+    ))
 }

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -163,6 +163,33 @@ deadlocks. This timeout can be changed with
 [`UV_LOCK_TIMEOUT`](../reference/environment.md#uv_lock_timeout). In cases where it is known that no
 other uv processes are reading or writing from the cache, `--force` can be used to ignore the lock.
 
+### Removing old wheels
+
+The experimental `--max-age` option removes unpacked wheels that have not been used for a given
+number of days. Preview the removals before running the command:
+
+```console
+$ uv cache prune --max-age 90 --dry-run
+$ uv cache prune --max-age 90
+```
+
+This mode removes unpacked wheel payloads and their cache pointers, while retaining source
+distributions, compressed wheels built from source, separate metadata entries, and cached
+environments. Usage is recorded in separate files with timestamp updates coalesced over a day.
+Cleanup includes an extra day of retention to account for this approximate tracking. Wheels without
+a usage record receive a full retention period on the first prune; a dry run does not create usage
+records or change the cache.
+
+This prototype skips age-based cleanup if it finds an unrecognized wheel, source distribution,
+archive, or environment bucket version, since those buckets may contain references it cannot read.
+
+Age-based cleanup is manual; uv does not run it automatically. It waits for other uv commands to
+finish and cannot be combined with `--ci` or `--force`. `--max-age` requires a positive integer
+number of days, and `--dry-run` requires `--max-age`.
+
+As with other cache cleanup commands, removing wheels can break external environments installed with
+`--link-mode symlink`.
+
 ## Caching in continuous integration
 
 It's common to cache package installation artifacts in continuous integration environments (like


### PR DESCRIPTION
Prototype age-based pruning for wheel payloads that are no longer used. We add `uv cache prune --max-age 90` and `--dry-run`, using filesystem last-use markers with updates coalesced over a day.

Pruning holds the exclusive cache lock and removes expired payloads and their pointers. Cached environments, source trees, compressed built wheels, and metadata remain cached. Entries without usage records get a fresh retention period, and unknown cache layouts are skipped. Cleanup is manual in this draft.
