### PR TITLE
Reuse cached small files during wheel extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6704,6 +6704,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uv-cache",
  "uv-configuration",
  "uv-distribution-filename",
  "uv-preview",

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -716,6 +716,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                             &mut reader,
                             temp_dir.path(),
                             self.content_addressed_cache,
+                            self.build_context.cache(),
                         )
                         .await
                         .map_err(|err| Error::Extract(filename.to_string(), err))?
@@ -724,6 +725,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         &mut hasher,
                         temp_dir.path(),
                         self.content_addressed_cache,
+                        self.build_context.cache(),
                     )
                     .await
                     .map_err(|err| Error::Extract(filename.to_string(), err))?,
@@ -939,8 +941,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 let target = temp_dir.path().to_owned();
                 let file = file.into_std().await;
+                let cache = self.build_context.cache().clone();
                 let mut extracted = tokio::task::spawn_blocking(move || {
-                    ExtractedWheel::extract_seekable(file, &target, content_addressed_cache)
+                    ExtractedWheel::extract_seekable(file, &target, content_addressed_cache, &cache)
                 })
                 .await?
                 .map_err(|err| Error::Extract(filename.to_string(), err))?;
@@ -1138,6 +1141,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 &mut hasher,
                 temp_dir.path(),
                 self.content_addressed_cache,
+                self.build_context.cache(),
             )
             .await
             .map_err(|err| Error::Extract(filename.to_string(), err))?;
@@ -1193,6 +1197,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         let (temp_dir, mut extracted) = tokio::task::spawn_blocking({
             let path = path.to_owned();
             let root = self.build_context.cache().root().to_path_buf();
+            let cache = self.build_context.cache().clone();
             move || -> Result<_, Error> {
                 // Unzip the wheel into a temporary directory.
                 let temp_dir = tempfile::tempdir_in(root).map_err(Error::CacheWrite)?;
@@ -1201,6 +1206,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reader,
                     temp_dir.path(),
                     content_addressed_cache,
+                    &cache,
                 )
                 .map_err(|err| Error::Extract(path.to_string_lossy().into_owned(), err))?;
                 Ok((temp_dir, extracted))
@@ -1291,12 +1297,14 @@ impl ExtractedWheel {
         reader: R,
         target: &Path,
         content_addressed: bool,
+        cache: &Cache,
     ) -> Result<Self, uv_extract::Error>
     where
         R: AsyncRead + Unpin,
     {
         if content_addressed {
-            let (files, tree) = uv_extract::stream::unzip_and_hash(reader, target).await?;
+            let cache = cache.bucket(CacheBucket::Files).is_dir().then_some(cache);
+            let (files, tree) = uv_extract::stream::unzip_and_hash(reader, target, cache).await?;
             Ok(Self::Hashed(HashedWheel { files, tree }))
         } else {
             let files = uv_extract::stream::unzip(reader, target).await?;
@@ -1309,9 +1317,11 @@ impl ExtractedWheel {
         reader: fs_err::File,
         target: &Path,
         content_addressed: bool,
+        cache: &Cache,
     ) -> Result<Self, uv_extract::Error> {
         if content_addressed {
-            let (files, tree) = uv_extract::unzip_and_hash(reader, target)?;
+            let cache = cache.bucket(CacheBucket::Files).is_dir().then_some(cache);
+            let (files, tree) = uv_extract::unzip_and_hash(reader, target, cache)?;
             Ok(Self::Hashed(HashedWheel { files, tree }))
         } else {
             let files = uv_extract::unzip(reader, target)?;
@@ -1366,7 +1376,7 @@ fn persist_archive_files(cache: &Cache, archive: &Path, files: &[HashedFile]) ->
     let targets = files
         .par_iter()
         // Keep RECORD private, since it may have been healed after hashing.
-        .filter(|file| !file.path().ends_with("RECORD"))
+        .filter(|file| !file.is_reused() && !file.path().ends_with("RECORD"))
         .map(|file| {
             let id = ArchiveFileId::from_digest(&file.object_digest_hex());
             (archive.join(file.path()), cache.archive_file(&id))

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 workspace = true
 
 [dependencies]
+uv-cache = { workspace = true }
 uv-configuration = { workspace = true }
 uv-distribution-filename = { workspace = true }
 uv-pypi-types = { workspace = true }

--- a/crates/uv-extract/src/dirhash.rs
+++ b/crates/uv-extract/src/dirhash.rs
@@ -74,6 +74,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 mod archive;
 mod seek;
 
+pub(crate) use archive::MAX_BUFFERED_FILE_SIZE;
 pub(crate) use archive::UnzipOutput;
 pub(crate) use archive::directory_tree_from_extracted;
 pub use archive::{DirectoryDigest, HashedFile, UnhashedFile};

--- a/crates/uv-extract/src/dirhash/archive.rs
+++ b/crates/uv-extract/src/dirhash/archive.rs
@@ -2,12 +2,17 @@
 
 use std::path::{Path, PathBuf};
 
+use uv_cache::{ArchiveFileId, Cache};
+
 use super::{DirhashError, DirhashTree};
 use crate::archive_path::SanitizedArchivePath;
 
 const DIRECTORY_DIGEST_LENGTH: usize = 24;
 const BASE36_ALPHABET: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
 const BASE36_RADIX: u16 = 36;
+
+/// Maximum uncompressed file size retained to look up an existing cache object before writing.
+pub(crate) const MAX_BUFFERED_FILE_SIZE: usize = 64 * 1024;
 
 /// Files extracted with or without content hashes.
 pub(crate) enum UnzipOutput {
@@ -78,6 +83,7 @@ pub struct HashedFile {
     size: u64,
     digest: blake3::Hash,
     executable: bool,
+    pub(crate) reused: bool,
 }
 
 impl HashedFile {
@@ -98,6 +104,7 @@ impl HashedFile {
             size,
             digest,
             executable,
+            reused: false,
         }
     }
 
@@ -125,6 +132,16 @@ impl HashedFile {
     /// Return the size of the extracted file in bytes.
     pub fn size(&self) -> u64 {
         self.size
+    }
+
+    /// Whether extraction linked this file directly from an existing cache object.
+    pub fn is_reused(&self) -> bool {
+        self.reused
+    }
+
+    /// Resolve this file's content and executable status in the shared file store.
+    pub(crate) fn cache_path(&self, cache: &Cache) -> PathBuf {
+        cache.archive_file(&ArchiveFileId::from_digest(&self.object_digest_hex()))
     }
 }
 

--- a/crates/uv-extract/src/dirhash/seek.rs
+++ b/crates/uv-extract/src/dirhash/seek.rs
@@ -1,5 +1,6 @@
 //! Directory hashing while extracting seekable ZIP archives.
 
+use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::pin;
 use std::sync::Mutex;
@@ -15,10 +16,12 @@ use rayon::prelude::*;
 use rustc_hash::FxHashSet;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use tracing::warn;
+use uv_cache::Cache;
 use uv_configuration::initialize_rayon_once;
 
 use super::{
-    DirhashTree, HashedFile, UnhashedFile, UnzipOutput, blake3_copy, directory_tree_from_extracted,
+    DirhashTree, HashedFile, MAX_BUFFERED_FILE_SIZE, UnhashedFile, UnzipOutput, blake3_copy,
+    directory_tree_from_extracted,
 };
 use crate::archive_path::SanitizedArchivePath;
 
@@ -29,13 +32,14 @@ enum ExtractedEntry {
         size: u64,
         digest: Option<blake3::Hash>,
         executable: bool,
+        reused: bool,
     },
     Directory(SanitizedArchivePath),
 }
 
 /// Unzip a `.zip` archive into the target directory.
 pub(crate) fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<UnhashedFile>, Error> {
-    let UnzipOutput::Unhashed(files) = unzip_inner(reader, target, false)? else {
+    let UnzipOutput::Unhashed(files) = unzip_inner(reader, target, false, None)? else {
         return Err(Error::Io(std::io::Error::other(
             "seekable ZIP hash tree was unexpectedly computed",
         )));
@@ -51,8 +55,9 @@ pub(crate) fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<UnhashedF
 pub(crate) fn unzip_and_hash(
     reader: fs_err::File,
     target: &Path,
+    cache: Option<&Cache>,
 ) -> Result<(Vec<HashedFile>, DirhashTree), Error> {
-    let UnzipOutput::Hashed { files, tree } = unzip_inner(reader, target, true)? else {
+    let UnzipOutput::Hashed { files, tree } = unzip_inner(reader, target, true, cache)? else {
         return Err(Error::Io(std::io::Error::other(
             "seekable ZIP hash tree was not computed",
         )));
@@ -64,6 +69,7 @@ fn unzip_inner(
     reader: fs_err::File,
     target: &Path,
     hash_contents: bool,
+    cache: Option<&Cache>,
 ) -> Result<UnzipOutput, Error> {
     let (reader, _) = reader.into_parts();
 
@@ -90,6 +96,7 @@ fn unzip_inner(
             &directories,
             skip_validation,
             hash_contents,
+            cache,
         )
     };
 
@@ -124,9 +131,12 @@ fn unzip_inner(
                 size,
                 digest,
                 executable,
+                reused,
             } => {
                 if let Some(digest) = digest {
-                    hashed_files.push(HashedFile::new(path, size, digest, executable));
+                    let mut file = HashedFile::new(path, size, digest, executable);
+                    file.reused = reused;
+                    hashed_files.push(file);
                 }
             }
             ExtractedEntry::Directory(path) => {
@@ -168,6 +178,7 @@ fn extract_entry<R>(
     directories: &Mutex<FxHashSet<PathBuf>>,
     skip_validation: bool,
     hash_contents: bool,
+    cache: Option<&Cache>,
 ) -> Result<Option<ExtractedEntry>, Error>
 where
     R: std::io::BufRead + std::io::Seek + Unpin,
@@ -205,6 +216,7 @@ where
         &path,
         skip_validation,
         hash_contents,
+        cache,
     )
     .map(Some)
 }
@@ -271,10 +283,66 @@ fn extract_file_entry<R>(
     path: &Path,
     skip_validation: bool,
     hash_contents: bool,
+    cache: Option<&Cache>,
 ) -> Result<ExtractedEntry, Error>
 where
     R: std::io::BufRead + std::io::Seek + Unpin,
 {
+    let size = entry.uncompressed_size();
+    if let Some(cache) = cache
+        && !skip_validation
+        && let Ok(capacity) = usize::try_from(size)
+        && capacity <= MAX_BUFFERED_FILE_SIZE
+        && !enclosed_name.as_path().ends_with("RECORD")
+    {
+        let buffered = block_on(pin!(async {
+            let mut reader = archive.reader_with_entry(file_number).await?;
+            let mut contents = Vec::with_capacity(capacity);
+            (&mut reader)
+                .take(MAX_BUFFERED_FILE_SIZE as u64 + 1)
+                .read_to_end(&mut contents)
+                .await
+                .map_err(Error::io_or_zip)?;
+            Ok::<_, Error>((contents, reader.compute_hash()))
+        }))?;
+        let (contents, computed_crc32) = buffered;
+        // A dishonest size must not turn this into an unbounded allocation. Reopen oversized
+        // entries through the normal streaming path, which validates their actual size.
+        if contents.len() <= MAX_BUFFERED_FILE_SIZE {
+            validate_file_entry(
+                enclosed_name.as_path(),
+                contents.len() as u64,
+                size,
+                computed_crc32,
+                entry.crc32(),
+                skip_validation,
+            )?;
+            let digest = blake3::hash(&contents);
+            let file = HashedFile::new(
+                enclosed_name.clone(),
+                size,
+                digest,
+                entry
+                    .unix_permissions()
+                    .is_some_and(|mode| mode & 0o111 != 0),
+            );
+            let reused = fs_err::hard_link(file.cache_path(cache), path).is_ok();
+            if !reused {
+                let mut output = fs_err::File::create_new(path).map_err(Error::Io)?;
+                io::Write::write_all(&mut output, &contents).map_err(Error::Io)?;
+                #[cfg(unix)]
+                preserve_executable_bit(path, entry.unix_permissions())?;
+            }
+            return Ok(ExtractedEntry::File {
+                path: enclosed_name,
+                size,
+                digest: Some(digest),
+                executable: file.is_executable(),
+                reused,
+            });
+        }
+    }
+
     let outfile = if hash_contents {
         fs_err::OpenOptions::new()
             .write(true)
@@ -284,7 +352,6 @@ where
         fs_err::File::create(path)
     }
     .map_err(Error::Io)?;
-    let size = entry.uncompressed_size();
     let writer = buffered_file_writer(outfile, size);
 
     // Keep the hashing state out of ordinary extraction, and pin both futures here to avoid
@@ -315,6 +382,7 @@ where
         executable: entry
             .unix_permissions()
             .is_some_and(|mode| mode & 0o111 != 0),
+        reused: false,
     })
 }
 

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -13,17 +13,22 @@ use tar_codec::{
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tracing::{debug, warn};
 
+use uv_cache::Cache;
 use uv_distribution_filename::{LegacySourceDistExtension, SourceDistExtension};
 use uv_preview::PreviewFeature;
 
 use crate::archive_path::SanitizedArchivePath;
 use crate::dirhash::{
-    DirhashTree, HashedFile, UnhashedFile, UnzipOutput, blake3_copy_with_buffer,
-    directory_tree_from_extracted,
+    DirhashTree, HashedFile, MAX_BUFFERED_FILE_SIZE, UnhashedFile, UnzipOutput,
+    blake3_copy_with_buffer, directory_tree_from_extracted,
 };
 use crate::{Error, insecure_no_validate};
 
 const DEFAULT_BUF_SIZE: usize = 128 * 1024;
+// Streaming ZIPs reveal executable permissions in the central directory. Bound both the bytes
+// and number of files retained until then; later entries continue through ordinary extraction.
+const MAX_BUFFERED_WHEEL_SIZE: usize = 1024 * 1024;
+const MAX_BUFFERED_FILES: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LocalHeaderEntry {
@@ -41,6 +46,7 @@ struct LocalHeaderEntry {
     data_descriptor: bool,
     /// The digest of the extracted file contents.
     digest: Option<blake3::Hash>,
+    contents: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,7 +72,8 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
 ) -> Result<Vec<UnhashedFile>, Error> {
-    let UnzipOutput::Unhashed(files) = Box::pin(unzip_inner(reader, target, false)).await? else {
+    let UnzipOutput::Unhashed(files) = Box::pin(unzip_inner(reader, target, false, None)).await?
+    else {
         return Err(Error::Io(std::io::Error::other(
             "streaming ZIP hash tree was unexpectedly computed",
         )));
@@ -81,11 +88,15 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
 /// followed as symlinks; non-directory entries are materialized and hashed as regular files.
 ///
 /// See [`unzip`] for details.
+/// When a cache is provided, a bounded set of small files is retained until the central directory
+/// supplies their executable status, then linked directly from existing file objects when possible.
 pub async fn unzip_and_hash<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
+    cache: Option<&Cache>,
 ) -> Result<(Vec<HashedFile>, DirhashTree), Error> {
-    let UnzipOutput::Hashed { files, tree } = Box::pin(unzip_inner(reader, target, true)).await?
+    let UnzipOutput::Hashed { files, tree } =
+        Box::pin(unzip_inner(reader, target, true, cache)).await?
     else {
         return Err(Error::Io(std::io::Error::other(
             "streaming ZIP hash tree was not computed",
@@ -98,9 +109,11 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
     hash_contents: bool,
+    cache: Option<&Cache>,
 ) -> Result<UnzipOutput, Error> {
     // Determine whether ZIP validation is disabled.
     let skip_validation = insecure_no_validate();
+    let cache = cache.filter(|_| !skip_validation);
 
     let target = target.as_ref();
     let mut reader = futures::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader.compat());
@@ -113,6 +126,8 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
     let mut hashed_files = Vec::new();
     let mut digest_directories = FxHashSet::default();
     let mut hash_buffer = Vec::new();
+    let mut buffered_size = 0;
+    let mut buffered_files = 0;
     let mut offset = 0;
 
     while let Some(mut entry) = zip.next_with_entry().await? {
@@ -157,6 +172,7 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
         // Either create the directory or write the file to disk.
         let path = target.join(relpath.as_path());
         let is_dir = zip_entry.dir()?;
+        let mut contents = None;
         let computed = if is_dir {
             if directories.insert(path.clone()) {
                 fs_err::tokio::create_dir_all(path)
@@ -201,12 +217,40 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                 }
             }
 
+            // Retain only small entries until their executable status is known. Read one extra
+            // byte so an incorrect local-header size cannot grow the buffer without bound.
+            let mut prefix = Vec::new();
+            if cache.is_some()
+                && expected_uncompressed_size <= MAX_BUFFERED_FILE_SIZE as u64
+                && buffered_size <= MAX_BUFFERED_WHEEL_SIZE - MAX_BUFFERED_FILE_SIZE
+                && buffered_files < MAX_BUFFERED_FILES
+                && !relpath.as_path().ends_with("RECORD")
+            {
+                entry
+                    .reader_mut()
+                    .take(MAX_BUFFERED_FILE_SIZE as u64 + 1)
+                    .read_to_end(&mut prefix)
+                    .await
+                    .map_err(Error::io_or_zip)?;
+                if prefix.len() <= MAX_BUFFERED_FILE_SIZE {
+                    buffered_size += prefix.len();
+                    buffered_files += 1;
+                    contents = Some(std::mem::take(&mut prefix));
+                }
+            }
+
             // We don't know the file permissions here, because we haven't seen the central directory yet.
-            let (actual_uncompressed_size, digest, reader) =
+            let (actual_uncompressed_size, digest, reader) = if let Some(contents) = &contents {
+                (
+                    contents.len() as u64,
+                    Some(blake3::hash(contents)),
+                    entry.reader_mut(),
+                )
+            } else {
                 match fs_err::tokio::File::create_new(&path).await {
                     Ok(file) => {
                         // Write the file to disk.
-                        let size = zip_entry.uncompressed_size();
+                        let size = expected_uncompressed_size;
                         let mut writer = if let Ok(size) = usize::try_from(size) {
                             tokio::io::BufWriter::with_capacity(
                                 std::cmp::min(size, 1024 * 1024),
@@ -217,10 +261,13 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                         };
                         let mut reader = entry.reader_mut().compat();
                         let (bytes_read, digest) = if hash_contents {
-                            let (bytes_read, digest) =
-                                blake3_copy_with_buffer(&mut reader, &mut writer, &mut hash_buffer)
-                                    .await
-                                    .map_err(Error::io_or_zip)?;
+                            let (bytes_read, digest) = blake3_copy_with_buffer(
+                                tokio::io::AsyncReadExt::chain(prefix.as_slice(), &mut reader),
+                                &mut writer,
+                                &mut hash_buffer,
+                            )
+                            .await
+                            .map_err(Error::io_or_zip)?;
                             (bytes_read, Some(digest))
                         } else {
                             let mut bytes_read = 0;
@@ -277,7 +324,8 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                         (bytes_read as u64, digest, entry_reader)
                     }
                     Err(err) => return Err(Error::Io(err)),
-                };
+                }
+            };
 
             // Validate the uncompressed size.
             if actual_uncompressed_size != expected_uncompressed_size {
@@ -393,6 +441,7 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                     compressed_size: expected_compressed_size,
                     data_descriptor: expected_data_descriptor,
                     digest: computed.digest,
+                    contents,
                 });
             }
             std::collections::hash_map::Entry::Occupied(..) => {
@@ -447,6 +496,7 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                     continue;
                 };
                 let is_dir = entry.dir()?;
+                let mut reused = false;
 
                 // Validate that various fields are consistent between the local file header and the
                 // central directory entry.
@@ -506,14 +556,36 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                                 digest_directories.insert(relpath.clone());
                             }
                         } else if let Some(digest) = local_header.digest {
-                            hashed_files.push(HashedFile::new(
+                            let mut file = HashedFile::new(
                                 relpath.clone(),
                                 local_header.uncompressed_size,
                                 digest,
                                 entry
                                     .unix_permissions()
                                     .is_some_and(|mode| mode & 0o111 != 0),
-                            ));
+                            );
+                            if let Some(contents) = local_header.contents {
+                                let path = target.join(relpath.as_path());
+                                if let Some(cache) = cache {
+                                    reused =
+                                        fs_err::tokio::hard_link(file.cache_path(cache), &path)
+                                            .await
+                                            .is_ok();
+                                }
+                                if !reused {
+                                    let mut output = fs_err::tokio::File::create_new(&path)
+                                        .await
+                                        .map_err(Error::Io)?;
+                                    tokio::io::AsyncWriteExt::write_all(&mut output, &contents)
+                                        .await
+                                        .map_err(Error::Io)?;
+                                    tokio::io::AsyncWriteExt::flush(&mut output)
+                                        .await
+                                        .map_err(Error::Io)?;
+                                }
+                            }
+                            file.reused = reused;
+                            hashed_files.push(file);
                         } else {
                             files.push(UnhashedFile::new(
                                 relpath.to_path_buf(),
@@ -539,7 +611,7 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                     use std::fs::Permissions;
                     use std::os::unix::fs::PermissionsExt;
 
-                    if is_dir {
+                    if is_dir || reused {
                         continue;
                     }
 

--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use uv_cache::Cache;
+
 use crate::Error;
 use crate::dirhash::{DirhashTree, HashedFile, UnhashedFile};
 
@@ -18,11 +20,13 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<UnhashedFile>, E
 /// regular files.
 ///
 /// Returns the list of unpacked files and their sizes, along with the hash tree.
+/// When a cache is provided, small files can reuse existing file objects without writing a copy.
 pub fn unzip_and_hash(
     reader: fs_err::File,
     target: &Path,
+    cache: Option<&Cache>,
 ) -> Result<(Vec<HashedFile>, DirhashTree), Error> {
-    crate::dirhash::unzip_and_hash(reader, target)
+    crate::dirhash::unzip_and_hash(reader, target, cache)
 }
 
 /// Extract the top-level directory from an unpacked archive.

--- a/crates/uv/tests/build/cache.rs
+++ b/crates/uv/tests/build/cache.rs
@@ -6,15 +6,19 @@ use anyhow::{Context, Result};
 use assert_fs::prelude::*;
 use async_zip::base::write::ZipFileWriter;
 use async_zip::{Compression, ZipEntryBuilder};
+use fs_err as fs;
+use fs_err::File;
+use futures::AsyncWriteExt;
 use futures::executor::block_on;
-use insta::{allow_duplicates, assert_snapshot};
+use insta::{allow_duplicates, assert_debug_snapshot, assert_snapshot};
 use predicates::prelude::predicate;
 use wiremock::{
     Mock, MockServer, ResponseTemplate,
     matchers::{method, path},
 };
 
-use uv_cache::CacheBucket;
+use uv_cache::{ArchiveFileId, Cache, CacheBucket};
+use uv_extract::dirhash::dirhash_path;
 use uv_fs::PortablePath;
 #[cfg(unix)]
 use uv_fs::create_symlink;
@@ -622,6 +626,181 @@ fn binary_payload_copy_fallback_uses_archive_file_store() -> Result<()> {
         BINARY_PAYLOAD_CONTENTS,
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn small_files_reuse_cached_objects_during_extraction() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel = binary_payload_wheel(&context)?;
+    uv_snapshot!(context.filters(), context.pip_install()
+        .args(["--preview-features", "content-addressed-cache"])
+        .arg(&wheel), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + binary-payload==0.1.0 (from file://[TEMP_DIR]/binary_payload-0.1.0-py3-none-any.whl)
+    ");
+
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+    for streaming in [false, true] {
+        let target = context.temp_dir.child(format!("extracted-{streaming}"));
+        target.create_dir_all()?;
+        let (mut files, tree) = if streaming {
+            uv_extract::stream::unzip_and_hash(
+                fs::read(&wheel)?.as_slice(),
+                target.path(),
+                Some(&cache),
+            )
+            .await?
+        } else {
+            uv_extract::unzip_and_hash(File::open(&wheel)?, target.path(), Some(&cache))?
+        };
+        assert_eq!(tree.hash(), dirhash_path(target.path())?);
+        files.sort_by(|left, right| left.path().cmp(right.path()));
+        let mut snapshot = String::new();
+        for file in files {
+            let object = cache.archive_file(&ArchiveFileId::from_digest(&file.object_digest_hex()));
+            let shared =
+                uv_fs::is_same_file_allow_missing(&target.join(file.path()), &object) == Some(true);
+            assert_eq!(file.is_reused(), shared);
+            writeln!(
+                snapshot,
+                "{}: shared={shared}",
+                PortablePath::from(file.path())
+            )?;
+        }
+        allow_duplicates! {
+            assert_snapshot!(snapshot, @"
+            binary_payload/__init__.py: shared=true
+            binary_payload/large.dat: shared=false
+            binary_payload/module.py: shared=true
+            binary_payload/native.DLL: shared=true
+            binary_payload/native.dylib: shared=true
+            binary_payload/native.pyd: shared=true
+            binary_payload/native.so: shared=true
+            binary_payload/plain.so: shared=true
+            binary_payload/tool: shared=true
+            binary_payload/versioned.so.1: shared=true
+            binary_payload/versioned.so.1.2: shared=true
+            binary_payload-0.1.0.dist-info/METADATA: shared=true
+            binary_payload-0.1.0.dist-info/RECORD: shared=false
+            binary_payload-0.1.0.dist-info/WHEEL: shared=true
+            binary_payload-0.1.0.dist-info/ignored.so: shared=true
+            ");
+        }
+    }
+    // Corrupt the first file's CRC in both ZIP headers. An existing object with identical
+    // contents must not bypass validation of the archive being extracted.
+    let mut contents = fs::read(&wheel)?;
+    let central_directory = contents
+        .windows(4)
+        .position(|bytes| bytes == b"PK\x01\x02")
+        .context("missing central directory")?;
+    contents[14] ^= 1;
+    contents[central_directory + 16] ^= 1;
+    fs::write(&wheel, &contents)?;
+    for streaming in [false, true] {
+        let target = context.temp_dir.child(format!("invalid-{streaming}"));
+        target.create_dir_all()?;
+        let result = if streaming {
+            uv_extract::stream::unzip_and_hash(contents.as_slice(), target.path(), Some(&cache))
+                .await
+        } else {
+            uv_extract::unzip_and_hash(File::open(&wheel)?, target.path(), Some(&cache))
+        };
+        allow_duplicates! {
+            assert_debug_snapshot!(result.map(|_| ()), @r#"
+            Err(
+                BadCrc32 {
+                    path: "binary_payload/__init__.py",
+                    computed: 0,
+                    expected: 1,
+                },
+            )
+            "#);
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn cached_streaming_extraction_limits_buffered_files() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+    let wheel = context.temp_dir.child("many-files.zip");
+    let mut writer = ZipFileWriter::new(Vec::new());
+    for index in 0..1100 {
+        let entry = ZipEntryBuilder::new(format!("module_{index}.py").into(), Compression::Stored);
+        writer.write_entry_whole(entry, b"VALUE = 1\n").await?;
+    }
+    fs::write(wheel.path(), writer.close().await?)?;
+    let source = context.temp_dir.child("source");
+    source.create_dir_all()?;
+    let (files, expected_tree) =
+        uv_extract::unzip_and_hash(File::open(wheel.path())?, source.path(), None)?;
+    let file = files.first().context("missing extracted file")?;
+    let object = cache.archive_file(&ArchiveFileId::from_digest(&file.object_digest_hex()));
+    fs::create_dir_all(object.parent().context("missing cache shard")?)?;
+    fs::hard_link(source.join(file.path()), &object)?;
+
+    let target = context.temp_dir.child("target");
+    target.create_dir_all()?;
+    let (files, tree) = uv_extract::stream::unzip_and_hash(
+        fs::read(wheel.path())?.as_slice(),
+        target.path(),
+        Some(&cache),
+    )
+    .await?;
+    assert_eq!(tree.hash(), expected_tree.hash());
+    assert_eq!(tree.hash(), dirhash_path(target.path())?);
+    assert_snapshot!(format!("files={}, reused={}", files.len(), files.iter().filter(|file| file.is_reused()).count()), @"files=1100, reused=1024");
+    Ok(())
+}
+
+#[tokio::test]
+async fn cached_streaming_extraction_limits_buffered_bytes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let cache = Cache::from_path(context.cache_dir.path()).init().await?;
+    let wheel = context.temp_dir.child("buffered.zip");
+    let mut writer = ZipFileWriter::new(Vec::new());
+    for index in 0..20 {
+        let entry = ZipEntryBuilder::new(format!("payload_{index}").into(), Compression::Deflate);
+        // Streaming entries omit sizes in the local header. The first entry exceeds the
+        // per-file limit; the remaining entries exceed the aggregate buffering limit.
+        let mut entry = writer.write_entry_stream(entry).await?;
+        entry
+            .write_all(&vec![42; 64 * 1024 + usize::from(index == 0)])
+            .await?;
+        entry.close().await?;
+    }
+    fs::write(wheel.path(), writer.close().await?)?;
+
+    let source = context.temp_dir.child("source");
+    source.create_dir_all()?;
+    let (files, expected_tree) =
+        uv_extract::unzip_and_hash(File::open(wheel.path())?, source.path(), None)?;
+    for file in files {
+        let object = cache.archive_file(&ArchiveFileId::from_digest(&file.object_digest_hex()));
+        if !object.exists() {
+            fs::create_dir_all(object.parent().context("missing cache shard")?)?;
+            fs::hard_link(source.join(file.path()), &object)?;
+        }
+    }
+
+    let target = context.temp_dir.child("target");
+    target.create_dir_all()?;
+    let (files, tree) = uv_extract::stream::unzip_and_hash(
+        fs::read(wheel.path())?.as_slice(),
+        target.path(),
+        Some(&cache),
+    )
+    .await?;
+    assert_eq!(tree.hash(), expected_tree.hash());
+    assert_eq!(tree.hash(), dirhash_path(target.path())?);
+    assert_snapshot!(format!("files={}, reused={}", files.len(), files.iter().filter(|file| file.is_reused()).count()), @"files=20, reused=16");
     Ok(())
 }
 

--- a/crates/uv/tests/build/cache.rs
+++ b/crates/uv/tests/build/cache.rs
@@ -732,19 +732,23 @@ async fn cached_streaming_extraction_limits_buffered_files() -> Result<()> {
     let cache = Cache::from_path(context.cache_dir.path()).init().await?;
     let wheel = context.temp_dir.child("many-files.zip");
     let mut writer = ZipFileWriter::new(Vec::new());
+    // Distinct payloads exercise the buffering limit without reaching Windows' hardlink limit.
     for index in 0..1100 {
         let entry = ZipEntryBuilder::new(format!("module_{index}.py").into(), Compression::Stored);
-        writer.write_entry_whole(entry, b"VALUE = 1\n").await?;
+        writer
+            .write_entry_whole(entry, format!("VALUE = {index}\n").as_bytes())
+            .await?;
     }
     fs::write(wheel.path(), writer.close().await?)?;
     let source = context.temp_dir.child("source");
     source.create_dir_all()?;
     let (files, expected_tree) =
         uv_extract::unzip_and_hash(File::open(wheel.path())?, source.path(), None)?;
-    let file = files.first().context("missing extracted file")?;
-    let object = cache.archive_file(&ArchiveFileId::from_digest(&file.object_digest_hex()));
-    fs::create_dir_all(object.parent().context("missing cache shard")?)?;
-    fs::hard_link(source.join(file.path()), &object)?;
+    for file in files {
+        let object = cache.archive_file(&ArchiveFileId::from_digest(&file.object_digest_hex()));
+        fs::create_dir_all(object.parent().context("missing cache shard")?)?;
+        fs::hard_link(source.join(file.path()), &object)?;
+    }
 
     let target = context.temp_dir.child("target");
     target.create_dir_all()?;

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -16428,7 +16428,7 @@ fn handle_record_mismatches() -> Result<()> {
     // Healing changes the extracted tree, so the archive ID must reflect the repaired RECORD.
     let extracted = context.temp_dir.join("foo-extracted");
     let (hashed_files, unhealed_tree) =
-        uv_extract::unzip_and_hash(File::open(&repacked_wheel)?, &extracted)?;
+        uv_extract::unzip_and_hash(File::open(&repacked_wheel)?, &extracted, None)?;
     let unhealed_digest = DirectoryDigest::from(unhealed_tree.hash());
     assert!(
         validate_and_heal_record(


### PR DESCRIPTION
When a small wheel file already exists in the content-addressed cache, we currently write out another copy during extraction, delete it, and replace it with a hardlink. This prototype buffers files up to 64 KiB and links existing objects directly into the extracted archive, avoiding the redundant write.

Streaming extraction retains at most 1 MiB of file contents and 1,024 files until the central directory supplies executable permissions. Larger files and exhausted budgets keep streaming; cache misses and failed hardlinks write a private copy. `RECORD` stays private, and ZIP checksums and sizes are still validated.

We compared against #21327 on Linux/ext4 using optimized builds, preselected wheels, and localhost HTTP. Each cell is the median of eight runs per binary in alternating ABBA/BAAB blocks, with baseline → prototype wall time. Installed paths, contents, and permissions matched across all 192 runs.

| Workload | Input | Empty cache | Existing file objects |
| --- | --- | --- | --- |
| 100 small synthetic wheels | Local | 0.599 → 0.611 s (+2.1%) | 0.612 → 0.524 s (-14.5%) |
| 100 small synthetic wheels | HTTP | 0.763 → 0.530 s (-30.5%) | 0.684 → 0.534 s (-22.0%) |
| AnyIO, NumPy, SymPy | Local | 0.495 → 0.435 s (-12.1%) | 0.498 → 0.434 s (-12.8%) |
| AnyIO, NumPy, SymPy | HTTP | 0.913 → 0.922 s (+0.9%) | 0.923 → 0.890 s (-3.6%) |
| Jupyter (96 wheels) | Local | 2.354 → 2.431 s (+3.2%) | 3.437 → 2.808 s (-18.3%) |
| Jupyter (96 wheels) | HTTP | 3.837 → 4.187 s (+9.1%) | 3.722 → 3.837 s (+3.1%) |

The existing-object case retains only `files-v0` and forces wheel extraction again, isolating the reuse opportunity. Ordinary warm installs can reuse the unpacked archive directly. These are exploratory timings with substantial variation in several cases, especially the synthetic HTTP workload.

The clearest gain was local Jupyter extraction with existing objects: 18% lower median time, improvement in all four paired blocks, and 42% fewer reported filesystem output blocks. HTTP Jupyter was slower both with an empty cache and with existing objects, so this remains a draft while we evaluate the streaming tradeoff.
