### PR TITLE
Symlink top-level package directories in symlink mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6822,9 +6822,11 @@ version = "0.0.74"
 dependencies = [
  "anyhow",
  "assert_fs",
+ "cap-primitives",
  "configparser",
  "csv",
  "data-encoding",
+ "fastrand",
  "fs-err",
  "indoc",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ blake2 = { version = "0.11.0-rc.6" }
 blake3 = { version = "1.8.5" }
 boxcar = { version = "0.2.5" }
 bytecheck = { version = "0.8.0" }
+cap-primitives = { version = "4.0.3" }
 cargo-util = { version = "0.2.14" }
 clap = { version = "4.5.17", features = [
   "derive",

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -324,6 +324,10 @@ where
                 }
             }
             materialize_symlink_dir(&target)?;
+            if state.mode == LinkMode::Clone && !target.try_exists()? {
+                // Reserve the new directory until cloning finishes, without creating it first.
+                return clone_dir(&path, &target, options).map(Some);
+            }
             fs_err::create_dir_all(&target)?;
             Ok(None)
         };
@@ -1078,6 +1082,8 @@ fn create_symlink(original: &Path, link: &Path) -> io::Result<()> {
 #[expect(clippy::print_stderr)]
 mod tests {
     use std::assert_matches;
+    #[cfg(target_os = "macos")]
+    use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
     use super::*;
     use tempfile::TempDir;
@@ -1898,20 +1904,31 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn test_macos_clone_directory_recursive() {
+    fn test_macos_clone_directory_recursive() -> io::Result<()> {
         // Test the macOS-specific directory cloning via clonefile
         let src_dir = test_tempdir();
         let dst_dir = test_tempdir();
 
         create_test_tree(src_dir.path());
+        fs_err::set_permissions(src_dir.path().join("subdir"), Permissions::from_mode(0o700))?;
 
         // On macOS with APFS, this should use clonefile for entire directories
         let options = LinkOptions::new(LinkMode::Clone);
-        let result = link_dir(src_dir.path(), dst_dir.path(), &options).unwrap();
+        let result =
+            link_dir(src_dir.path(), dst_dir.path(), &options).map_err(io::Error::other)?;
 
         // On APFS, should succeed with Clone mode
         assert_eq!(result, LinkMode::Clone);
         verify_test_tree(dst_dir.path());
+        // Cloning the entire directory preserves its permissions.
+        assert_eq!(
+            fs_err::metadata(dst_dir.path().join("subdir"))?
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700,
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -1,10 +1,12 @@
 //! Utilities for linking a file or directory with various options and automated fallback (e.g., to
 //! copying) when link methods are unsupported.
 
+use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
+use either::Either;
 use rustc_hash::FxHashMap;
 use tracing::debug;
 use uv_warnings::warn_user_once;
@@ -81,7 +83,14 @@ where
     F: Fn(&Path) -> bool,
 {
     if options.directory_symlinks {
-        return link_dir_entries(src, dst, options);
+        if same_file::is_same_file(src, dst).unwrap_or(false) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Cannot link a directory onto itself",
+            )
+            .into());
+        }
+        return link_dir_entries(src, dst, options.mode, true, options);
     }
     match options.mode {
         LinkMode::Clone => clone_dir(src, dst, options),
@@ -103,12 +112,18 @@ where
 #[derive(Debug, Default)]
 pub struct CopyLocks {
     dir_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
+    directory_parents: Mutex<FxHashMap<PathBuf, Arc<RwLock<()>>>>,
     directory_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
 }
 
 impl CopyLocks {
     /// Serialize changes to a directory's representation, including expanding a directory link
     /// before merging another package into it. Separate from the locks used while copying files.
+    ///
+    /// The parent directory must exist. Resolve aliases in the parent without following the final
+    /// directory link, which may itself be replaced while holding the lock.
+    /// ASCII names share the parent lock; non-ASCII names acquire it exclusively to account for
+    /// filesystem-specific Unicode aliases. Acquire ancestor locks before descendant locks.
     pub fn with_directory_lock<T, E>(
         &self,
         path: &Path,
@@ -117,11 +132,56 @@ impl CopyLocks {
     where
         E: From<io::Error>,
     {
+        let path = if let Some(parent) = path.parent()
+            && let Some(name) = path.file_name()
+        {
+            let parent = if parent.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                parent
+            };
+            fs_err::canonicalize(parent)?.join(name)
+        } else {
+            fs_err::canonicalize(path)?
+        };
+
+        let parent_lock = path
+            .parent()
+            .map(|parent| {
+                Ok::<_, io::Error>(
+                    self.directory_parents
+                        .lock()
+                        .map_err(|err| io::Error::other(err.to_string()))?
+                        .entry(parent.to_path_buf())
+                        .or_default()
+                        .clone(),
+                )
+            })
+            .transpose()?;
+        let _parent_guard = if let Some(lock) = &parent_lock {
+            Some(if path.file_name().is_some_and(OsStr::is_ascii) {
+                Either::Left(
+                    lock.read()
+                        .map_err(|err| io::Error::other(err.to_string()))?,
+                )
+            } else {
+                Either::Right(
+                    lock.write()
+                        .map_err(|err| io::Error::other(err.to_string()))?,
+                )
+            })
+        } else {
+            None
+        };
+        let path = path.file_name().map_or_else(
+            || path.clone(),
+            |name| path.with_file_name(name.to_ascii_lowercase()),
+        );
         let lock = self
             .directory_locks
             .lock()
             .map_err(|err| io::Error::other(err.to_string()))?
-            .entry(path.to_path_buf())
+            .entry(path)
             .or_default()
             .clone();
         let _guard = lock
@@ -168,7 +228,7 @@ pub struct LinkOptions<'a, F = fn(&Path) -> bool> {
     copy_locks: Option<&'a CopyLocks>,
     /// What to do when the destination directory already exists.
     on_existing_directory: OnExistingDirectory,
-    /// Allow top-level directories to be symlinked, expanding existing links before merging.
+    /// Allow directories to be symlinked, expanding existing links only where merging is needed.
     directory_symlinks: bool,
 }
 
@@ -236,8 +296,8 @@ impl<'a, F> LinkOptions<'a, F> {
         }
     }
 
-    /// Symlink top-level directories in [`LinkMode::Symlink`], unless the mutable-copy filter
-    /// selects the directory. Other modes expand existing directory links before merging.
+    /// Symlink directories in [`LinkMode::Symlink`], unless the mutable-copy filter selects the
+    /// directory or an ancestor. Existing directory links are expanded only where merging is needed.
     /// The filter must select every top-level directory containing mutable files: the contents
     /// of directories eligible for linking are not inspected.
     #[must_use]
@@ -260,17 +320,19 @@ impl<'a, F> LinkOptions<'a, F> {
     }
 }
 
-/// Link top-level entries independently so a package directory can be represented by one link.
+/// Link entries independently, descending into directory links only where merging is needed.
 fn link_dir_entries<F>(
     src: &Path,
     dst: &Path,
+    mode: LinkMode,
+    directory_symlinks: bool,
     options: &LinkOptions<'_, F>,
 ) -> Result<LinkMode, LinkError>
 where
     F: Fn(&Path) -> bool,
 {
     fs_err::create_dir_all(dst)?;
-    let mut state = LinkState::new(options.mode);
+    let mut state = LinkState::new(mode);
     for entry in fs_err::read_dir(src)? {
         let entry = entry?;
         let path = entry.path();
@@ -281,11 +343,19 @@ where
         }
 
         let operation = || {
-            materialize_symlink_dir(&target)?;
-            if state.mode == LinkMode::Symlink && !(options.needs_mutable_copy)(&path) {
+            let directory_symlinks = directory_symlinks && !(options.needs_mutable_copy)(&path);
+            if state.mode == LinkMode::Symlink && directory_symlinks {
                 match create_symlink(&path, &target) {
                     Ok(()) => return Ok(LinkMode::Symlink),
-                    Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+                    Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                        if options.on_existing_directory == OnExistingDirectory::Fail {
+                            return Err(LinkError::Symlink {
+                                from: path.clone(),
+                                to: target.clone(),
+                                err,
+                            });
+                        }
+                    }
                     Err(err) => debug!(
                         "Failed to symlink directory `{}` to `{}`: {err}; linking individual files",
                         path.display(),
@@ -293,7 +363,23 @@ where
                     ),
                 }
             }
-            // These helpers link individual files, without trying directory symlinks again.
+
+            match fs_err::symlink_metadata(&target) {
+                Ok(_) => {
+                    materialize_symlink_dir(&target)?;
+                    return link_dir_entries(
+                        &path,
+                        &target,
+                        state.mode,
+                        directory_symlinks,
+                        options,
+                    );
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+
+            // This subtree is new and cannot contain directory links that need expanding.
             match state.mode {
                 LinkMode::Clone => clone_dir(&path, &target, options),
                 mode => walk_and_link(&path, &target, mode, options),
@@ -309,8 +395,9 @@ where
     Ok(state.mode)
 }
 
-/// Replace a directory symlink with real directories and individual file symlinks before merging
-/// new files into it. The caller must serialize changes to `path` with other directory writers.
+/// Replace a directory symlink with a real directory containing links to its immediate children.
+/// Child directories stay linked until they need merging too. The caller must serialize changes
+/// to `path` with other directory writers.
 pub fn materialize_symlink_dir(path: &Path) -> Result<(), LinkError> {
     match fs_err::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => {}
@@ -323,11 +410,10 @@ pub fn materialize_symlink_dir(path: &Path) -> Result<(), LinkError> {
         .parent()
         .ok_or_else(|| io::Error::other("Directory link has no parent"))?;
     let temporary = tempfile::tempdir_in(parent)?;
-    walk_and_link(
+    link_dir(
         &source,
         temporary.path(),
-        LinkMode::Symlink,
-        &LinkOptions::new(LinkMode::Symlink),
+        &LinkOptions::new(LinkMode::Symlink).with_directory_symlinks(),
     )?;
     crate::remove_symlink(path)?;
     if let Err(err) = fs_err::rename(temporary.path(), path) {
@@ -766,7 +852,11 @@ where
     F: Fn(&Path) -> bool,
 {
     if (options.needs_mutable_copy)(path) {
-        copy_file(path, target, options)?;
+        if options.on_existing_directory == OnExistingDirectory::Merge {
+            atomic_copy_overwrite(path, target, options)?;
+        } else {
+            copy_file(path, target, options)?;
+        }
         return Ok(state);
     }
 
@@ -825,7 +915,11 @@ where
     F: Fn(&Path) -> bool,
 {
     if (options.needs_mutable_copy)(path) {
-        copy_file(path, target, options)?;
+        if options.on_existing_directory == OnExistingDirectory::Merge {
+            atomic_copy_overwrite(path, target, options)?;
+        } else {
+            copy_file(path, target, options)?;
+        }
         return Ok(state);
     }
 
@@ -1149,6 +1243,54 @@ mod tests {
         // If symlink succeeded, verify files are symlinks
         if result == LinkMode::Symlink {
             assert!(dst_dir.path().join("file1.txt").is_symlink());
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_directory_symlinks_fail_preserves_existing() {
+        let src_dir = test_tempdir();
+        let existing_dir = test_tempdir();
+        let dst_dir = test_tempdir();
+
+        fs_err::create_dir_all(src_dir.path().join("package")).unwrap();
+        fs_err::write(src_dir.path().join("package/new.txt"), "new").unwrap();
+        fs_err::write(existing_dir.path().join("existing.txt"), "existing").unwrap();
+        create_symlink(existing_dir.path(), &dst_dir.path().join("package")).unwrap();
+
+        let options = LinkOptions::new(LinkMode::Symlink)
+            .with_directory_symlinks()
+            .with_on_existing_directory(OnExistingDirectory::Fail);
+        let result = link_dir(src_dir.path(), dst_dir.path(), &options);
+
+        assert_matches!(result, Err(LinkError::Symlink { err, .. }) if err.kind() == io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            fs_err::read_link(dst_dir.path().join("package")).unwrap(),
+            existing_dir.path()
+        );
+        assert!(!existing_dir.path().join("new.txt").exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_directory_symlinks_onto_self() {
+        let src_dir = test_tempdir();
+        let aliases = test_tempdir();
+
+        create_test_tree(src_dir.path());
+        let alias = aliases.path().join("source");
+        create_symlink(src_dir.path(), &alias).unwrap();
+
+        let options = LinkOptions::new(LinkMode::Symlink)
+            .with_directory_symlinks()
+            .with_on_existing_directory(OnExistingDirectory::Merge);
+        for target in [src_dir.path(), alias.as_path()] {
+            let result = link_dir(src_dir.path(), target, &options);
+
+            assert_matches!(result, Err(LinkError::Io(err)) if err.kind() == io::ErrorKind::InvalidInput);
+            assert!(!src_dir.path().join("file1.txt").is_symlink());
+            assert!(!src_dir.path().join("subdir").is_symlink());
+            verify_test_tree(src_dir.path());
         }
     }
 

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -323,7 +323,7 @@ where
                     ),
                 }
             }
-            materialize_symlink_dir(&target)?;
+            materialize_symlink_dir(&target, &options.needs_mutable_copy)?;
             if state.mode == LinkMode::Clone && !target.try_exists()? {
                 // Reserve the new directory until cloning finishes, without creating it first.
                 return clone_dir(&path, &target, options).map(Some);
@@ -352,10 +352,13 @@ where
 /// Replace a directory symlink with real directories and symlinks to individual files.
 ///
 /// Missing paths and non-links are unchanged. The expanded directory never becomes a link again.
-/// If writes can overlap, hold [`CopyLocks::with_directory_lock`] for `path` throughout this call and
-/// use [`CopyLocks::with_file_write`] for competing file writes. Replacing the link briefly removes
-/// its name before publishing the expanded directory.
-pub fn materialize_symlink_dir(path: &Path) -> Result<(), LinkError> {
+/// Files matching `needs_mutable_copy` are copied instead of linked.
+/// If writes can overlap, hold [`CopyLocks::with_directory_lock`] for `path` throughout this call.
+/// Replacing the link briefly removes its name before publishing the expanded directory.
+pub fn materialize_symlink_dir(
+    path: &Path,
+    needs_mutable_copy: impl Fn(&Path) -> bool,
+) -> Result<(), LinkError> {
     match fs_err::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => {}
         Ok(_) => return Ok(()),
@@ -371,7 +374,7 @@ pub fn materialize_symlink_dir(path: &Path) -> Result<(), LinkError> {
         &source,
         temporary.path(),
         LinkMode::Symlink,
-        &LinkOptions::new(LinkMode::Symlink),
+        &LinkOptions::new(LinkMode::Symlink).with_mutable_copy_filter(needs_mutable_copy),
     )?;
     crate::remove_symlink(path)?;
     if let Err(err) = fs_err::rename(temporary.path(), path) {

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -124,8 +124,7 @@ struct DirectoryParent {
 }
 
 impl CopyLocks {
-    /// Resolve each parent once, interning aliases under the same canonical directory identity.
-    /// Parents must retain that identity for the lifetime of these locks.
+    /// Cache canonical parent identities so scheme aliases share the same publication gate.
     fn directory_parent(&self, path: &Path) -> io::Result<Arc<DirectoryParent>> {
         let path = std::path::absolute(if path.as_os_str().is_empty() {
             Path::new(".")
@@ -159,14 +158,12 @@ impl CopyLocks {
         Ok(parent)
     }
 
-    /// Serialize changes to a directory's representation, including expanding a directory link
-    /// before merging another package into it. Separate from the locks used while copying files.
+    /// Serialize directory creation and expansion against other directory and file writers.
     ///
-    /// The parent directory must exist. Resolve aliases in the parent without following the final
-    /// directory link, which may itself be replaced while holding the lock.
-    /// The parent's canonical identity must remain stable for the lifetime of these locks.
-    /// ASCII names share the parent lock; non-ASCII names acquire it exclusively to account for
-    /// filesystem-specific Unicode aliases. Acquire ancestor locks before descendant locks.
+    /// Resolve aliases in the parent without following the final directory link. The parent must
+    /// exist and retain its canonical identity for the lifetime of these locks. ASCII case variants
+    /// share an entry lock; non-ASCII names lock the whole parent to cover filesystem-specific aliases.
+    /// Acquire ancestors before descendants, and do not lock sibling entries from `operation`.
     pub fn with_directory_lock<T, E>(
         &self,
         path: &Path,
@@ -223,11 +220,12 @@ impl CopyLocks {
         operation()
     }
 
-    /// Publish a file without replacing a directory or racing its materialization.
+    /// Publish a file while excluding directory transitions in its parent.
     ///
-    /// The parent must already be prepared and retain its canonical identity for the lifetime of
-    /// these locks. File writers exclude directory transitions, including the brief absence while
-    /// replacing a directory link. Prepare temporary file contents before taking this lock.
+    /// Materialize package links in the parent path first, then keep its canonical identity stable
+    /// for the lifetime of these locks. Targets that resolve to directories are rejected.
+    /// The exclusive parent lock covers the gap while [`materialize_symlink_dir`] replaces a link.
+    /// Prepare temporary contents beforehand; `operation` must not lock another entry in this parent.
     pub fn with_file_write<T, E>(
         &self,
         path: &Path,
@@ -337,34 +335,29 @@ impl<'a, F> LinkOptions<'a, F> {
     /// When provided, file copy operations will acquire a directory-level lock before writing. This
     /// prevents corruption when multiple installations run concurrently.
     #[must_use]
-    pub fn with_copy_locks(self, locks: &'a CopyLocks) -> Self {
-        LinkOptions {
-            mode: self.mode,
-            needs_mutable_copy: self.needs_mutable_copy,
-            copy_locks: Some(locks),
-            on_existing_directory: self.on_existing_directory,
-            directory_symlinks: self.directory_symlinks,
-        }
+    pub fn with_copy_locks(mut self, locks: &'a CopyLocks) -> Self {
+        self.copy_locks = Some(locks);
+        self
     }
 
     /// Set the behavior when the destination directory already exists.
     #[must_use]
-    pub fn with_on_existing_directory(self, on_existing_directory: OnExistingDirectory) -> Self {
-        LinkOptions {
-            mode: self.mode,
-            needs_mutable_copy: self.needs_mutable_copy,
-            copy_locks: self.copy_locks,
-            on_existing_directory,
-            directory_symlinks: self.directory_symlinks,
-        }
+    pub fn with_on_existing_directory(
+        mut self,
+        on_existing_directory: OnExistingDirectory,
+    ) -> Self {
+        self.on_existing_directory = on_existing_directory;
+        self
     }
 
-    /// Symlink directories in [`LinkMode::Symlink`], unless the mutable-copy filter selects the
-    /// directory or an ancestor. Existing directory links are expanded only where merging is needed.
-    /// The filter must select every top-level directory containing mutable files: the contents
-    /// of directories eligible for linking are not inspected.
-    /// Source trees must not contain directory symlinks. Concurrent overlapping installs must share a
-    /// destination root and prepare ancestor directories before writing below them.
+    /// Symlink untouched directories in [`LinkMode::Symlink`], expanding shared links in any mode.
+    ///
+    /// The mutable-copy filter must select every top-level directory containing mutable files:
+    /// eligible directories are linked without inspecting their contents. Source trees must not
+    /// contain directory symlinks.
+    ///
+    /// Concurrent overlapping writers must share [`CopyLocks`] and a destination root, and prepare
+    /// ancestor directories before writing below them. Fresh subtrees rely on that ancestor lock.
     #[must_use]
     pub fn with_directory_symlinks(mut self) -> Self {
         self.directory_symlinks = true;
@@ -417,7 +410,10 @@ fn check_file_destination(path: &Path) -> io::Result<()> {
     }
 }
 
-/// Link entries independently, descending into directory links only where merging is needed.
+/// Merge shared directories one level at a time, leaving untouched subtrees linked.
+///
+/// `directory_symlinks` carries mutable-ancestor exclusions; the options still protect file writes
+/// in subtrees that must use real directories.
 fn link_dir_entries<F>(
     src: &Path,
     dst: &Path,
@@ -501,9 +497,12 @@ where
     Ok(state.mode)
 }
 
-/// Replace a directory symlink with a real directory containing links to its immediate children.
-/// Child directories stay linked until they need merging too. The caller must serialize changes
-/// to `path` with other directory writers.
+/// Replace a directory symlink with a real directory linking its immediate children.
+///
+/// Child directories stay linked until they need merging. Missing paths and non-links are unchanged.
+/// If writes can overlap, hold [`CopyLocks::with_directory_lock`] for `path` throughout this call and
+/// use [`CopyLocks::with_file_write`] for competing file writes. Replacing the link briefly removes
+/// its name before publishing the expanded directory.
 pub fn materialize_symlink_dir(path: &Path) -> Result<(), LinkError> {
     match fs_err::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => {}
@@ -967,54 +966,32 @@ where
         return Ok(state);
     }
 
-    match state.attempt {
-        LinkAttempt::Initial => {
-            if let Err(err) = try_hardlink_file(path, target, |from, to| {
-                options.with_file_write(to, || fs_err::hard_link(from, to))
-            }) {
-                if err.kind() == io::ErrorKind::IsADirectory {
-                    return Err(err.into());
-                }
-                if err.kind() == io::ErrorKind::AlreadyExists
-                    && options.on_existing_directory == OnExistingDirectory::Merge
-                {
-                    atomic_hardlink_overwrite(path, target, state, options)
-                } else {
-                    debug!(
-                        "Failed to hard link `{}` to `{}`: {}; falling back to copy",
-                        path.display(),
-                        target.display(),
-                        err
-                    );
-                    warn_user_once!(
-                        "Failed to hardlink files; falling back to full copy. This may lead to degraded performance.\n         \
-                        If the cache and target directories are on different filesystems, hardlinking may not be supported.\n         \
-                        If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
-                    );
-                    link_file(path, target, state.next_mode(), options)
-                }
-            } else {
-                Ok(state.mode_working())
-            }
+    match try_hardlink_file(path, target, |from, to| {
+        options.with_file_write(to, || fs_err::hard_link(from, to))
+    }) {
+        Ok(()) => Ok(state.mode_working()),
+        Err(err) if err.kind() == io::ErrorKind::IsADirectory => Err(err.into()),
+        Err(err)
+            if err.kind() == io::ErrorKind::AlreadyExists
+                && options.on_existing_directory == OnExistingDirectory::Merge =>
+        {
+            atomic_hardlink_overwrite(path, target, state, options)
         }
-        LinkAttempt::Subsequent => {
-            if let Err(err) = try_hardlink_file(path, target, |from, to| {
-                options.with_file_write(to, || fs_err::hard_link(from, to))
-            }) {
-                if err.kind() == io::ErrorKind::IsADirectory {
-                    return Err(err.into());
-                }
-                if err.kind() == io::ErrorKind::AlreadyExists
-                    && options.on_existing_directory == OnExistingDirectory::Merge
-                {
-                    atomic_hardlink_overwrite(path, target, state, options)
-                } else {
-                    Err(LinkError::Io(err))
-                }
-            } else {
-                Ok(state)
-            }
+        Err(err) if state.attempt == LinkAttempt::Initial => {
+            debug!(
+                "Failed to hard link `{}` to `{}`: {}; falling back to copy",
+                path.display(),
+                target.display(),
+                err
+            );
+            warn_user_once!(
+                "Failed to hardlink files; falling back to full copy. This may lead to degraded performance.\n         \
+                If the cache and target directories are on different filesystems, hardlinking may not be supported.\n         \
+                If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
+            );
+            link_file(path, target, state.next_mode(), options)
         }
+        Err(err) => Err(LinkError::Io(err)),
     }
 }
 
@@ -1040,54 +1017,34 @@ where
         return Ok(state);
     }
 
-    match state.attempt {
-        LinkAttempt::Initial => {
-            if let Err(err) = options.with_file_write(target, || create_symlink(path, target)) {
-                if err.kind() == io::ErrorKind::IsADirectory {
-                    return Err(err.into());
-                }
-                if err.kind() == io::ErrorKind::AlreadyExists
-                    && options.on_existing_directory == OnExistingDirectory::Merge
-                {
-                    atomic_symlink_overwrite(path, target, state, options)
-                } else {
-                    debug!(
-                        "Failed to symlink `{}` to `{}`: {}; falling back to copy",
-                        path.display(),
-                        target.display(),
-                        err
-                    );
-                    warn_user_once!(
-                        "Failed to symlink files; falling back to full copy. This may lead to degraded performance.\n         \
-                        If the cache and target directories are on different filesystems, symlinking may not be supported.\n         \
-                        If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
-                    );
-                    link_file(path, target, state.next_mode(), options)
-                }
-            } else {
-                Ok(state.mode_working())
-            }
+    match options.with_file_write(target, || create_symlink(path, target)) {
+        Ok(()) => Ok(state.mode_working()),
+        Err(err) if err.kind() == io::ErrorKind::IsADirectory => Err(err.into()),
+        Err(err)
+            if err.kind() == io::ErrorKind::AlreadyExists
+                && options.on_existing_directory == OnExistingDirectory::Merge =>
+        {
+            atomic_symlink_overwrite(path, target, state, options)
         }
-        LinkAttempt::Subsequent => {
-            if let Err(err) = options.with_file_write(target, || create_symlink(path, target)) {
-                if err.kind() == io::ErrorKind::IsADirectory {
-                    return Err(err.into());
-                }
-                if err.kind() == io::ErrorKind::AlreadyExists
-                    && options.on_existing_directory == OnExistingDirectory::Merge
-                {
-                    atomic_symlink_overwrite(path, target, state, options)
-                } else {
-                    Err(LinkError::Symlink {
-                        from: path.to_path_buf(),
-                        to: target.to_path_buf(),
-                        err,
-                    })
-                }
-            } else {
-                Ok(state)
-            }
+        Err(err) if state.attempt == LinkAttempt::Initial => {
+            debug!(
+                "Failed to symlink `{}` to `{}`: {}; falling back to copy",
+                path.display(),
+                target.display(),
+                err
+            );
+            warn_user_once!(
+                "Failed to symlink files; falling back to full copy. This may lead to degraded performance.\n         \
+                If the cache and target directories are on different filesystems, symlinking may not be supported.\n         \
+                If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
+            );
+            link_file(path, target, state.next_mode(), options)
         }
+        Err(err) => Err(LinkError::Symlink {
+            from: path.to_path_buf(),
+            to: target.to_path_buf(),
+            err,
+        }),
     }
 }
 
@@ -1108,7 +1065,7 @@ where
 
 /// Try to create a hard link, handling `TooManyLinks` (EMLINK/`ERROR_TOO_MANY_LINKS`)
 /// by copying the source to a fresh inode and retrying.
-/// The supplied operation locks publication without holding that lock while copying the source.
+/// The callback lets callers guard link creation without holding the guard while copying.
 fn try_hardlink_file(
     src: &Path,
     dst: &Path,

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -69,6 +69,11 @@ pub enum OnExistingDirectory {
 
 /// Link a directory tree from `src` to `dst` using the mode in `options`.
 ///
+/// [`LinkMode::Symlink`] links top-level directories without inspecting their contents. Shared
+/// directory links are fully expanded before merging, regardless of the requested mode. Source
+/// trees must not contain directory symlinks. Concurrent writers must share [`CopyLocks`] and a
+/// destination root, and prepare package directories before writing below them.
+///
 /// Returns the [`LinkMode`] that was actually used, which may differ from the requested mode if a
 /// fallback was needed, e.g., if hard linking was requested but the source and destination are on
 /// different filesystems.
@@ -80,20 +85,14 @@ pub fn link_dir<F>(
 where
     F: Fn(&Path) -> bool,
 {
-    if options.directory_symlinks {
-        if same_file::is_same_file(src, dst).unwrap_or(false) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Cannot link a directory onto itself",
-            )
-            .into());
-        }
-        return link_dir_entries(src, dst, options);
+    if same_file::is_same_file(src, dst).unwrap_or(false) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Cannot link a directory onto itself",
+        )
+        .into());
     }
-    match options.mode {
-        LinkMode::Clone => clone_dir(src, dst, options),
-        mode => walk_and_link(src, dst, mode, options),
-    }
+    link_dir_entries(src, dst, options)
 }
 
 /// Directory-level locks for concurrent copy operations.
@@ -201,8 +200,6 @@ pub struct LinkOptions<'a, F = fn(&Path) -> bool> {
     copy_locks: Option<&'a CopyLocks>,
     /// What to do when the destination directory already exists.
     on_existing_directory: OnExistingDirectory,
-    /// Allow top-level directories to be symlinked, fully expanding shared directory links.
-    directory_symlinks: bool,
 }
 
 impl LinkOptions<'static> {
@@ -213,7 +210,6 @@ impl LinkOptions<'static> {
             needs_mutable_copy: |_| false,
             copy_locks: None,
             on_existing_directory: OnExistingDirectory::default(),
-            directory_symlinks: false,
         }
     }
 }
@@ -227,6 +223,9 @@ impl<'a, F> LinkOptions<'a, F> {
     /// Files matching this predicate will use [`LinkMode::Copy`] instead when using
     /// [`LinkMode::Hardlink`] or [`LinkMode::Symlink`] are requested.
     ///
+    /// In [`LinkMode::Symlink`], also select top-level directories containing mutable files to
+    /// prevent linking the directory without inspecting its contents.
+    ///
     /// Has no effect when using [`LinkMode::Copy`] or [`LinkMode::Clone`], since the linked file is
     /// already mutable without affecting source.
     pub fn with_mutable_copy_filter<G>(self, f: G) -> LinkOptions<'a, G>
@@ -238,7 +237,6 @@ impl<'a, F> LinkOptions<'a, F> {
             needs_mutable_copy: f,
             copy_locks: self.copy_locks,
             on_existing_directory: self.on_existing_directory,
-            directory_symlinks: self.directory_symlinks,
         }
     }
 
@@ -259,20 +257,6 @@ impl<'a, F> LinkOptions<'a, F> {
         on_existing_directory: OnExistingDirectory,
     ) -> Self {
         self.on_existing_directory = on_existing_directory;
-        self
-    }
-
-    /// Symlink top-level directories in [`LinkMode::Symlink`], fully expanding shared links in any mode.
-    ///
-    /// The mutable-copy filter must select every top-level directory containing mutable files:
-    /// eligible directories are linked without inspecting their contents. Source trees must not
-    /// contain directory symlinks.
-    ///
-    /// Concurrent overlapping writers must share [`CopyLocks`] and a destination root, and prepare
-    /// package directories before writing below them. Shared directories use ordinary per-file linking.
-    #[must_use]
-    pub fn with_directory_symlinks(mut self) -> Self {
-        self.directory_symlinks = true;
         self
     }
 
@@ -382,9 +366,10 @@ pub fn materialize_symlink_dir(path: &Path) -> Result<(), LinkError> {
         .parent()
         .ok_or_else(|| io::Error::other("Directory link has no parent"))?;
     let temporary = tempfile::tempdir_in(parent)?;
-    link_dir(
+    walk_and_link(
         &source,
         temporary.path(),
+        LinkMode::Symlink,
         &LinkOptions::new(LinkMode::Symlink),
     )?;
     crate::remove_symlink(path)?;
@@ -1215,6 +1200,7 @@ mod tests {
         // If symlink succeeded, verify files are symlinks
         if result == LinkMode::Symlink {
             assert!(dst_dir.path().join("file1.txt").is_symlink());
+            assert!(dst_dir.path().join("subdir").is_symlink());
         }
     }
 

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -87,7 +87,60 @@ where
         )
         .into());
     }
-    link_dir_entries(src, dst, options)
+    fs_err::create_dir_all(dst)?;
+    let mut state = LinkState::new(options.mode);
+    for entry in fs_err::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        let operation = || {
+            if !entry.file_type()?.is_dir() {
+                check_file_destination(&target)?;
+                return link_file(&path, &target, state, options).map(|state| Some(state.mode));
+            }
+            if state.mode == LinkMode::Symlink && !(options.needs_mutable_copy)(&path) {
+                match create_symlink(&path, &target) {
+                    Ok(()) => return Ok(Some(LinkMode::Symlink)),
+                    Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                        if options.on_existing_directory == OnExistingDirectory::Fail {
+                            return Err(LinkError::Symlink {
+                                from: path.clone(),
+                                to: target.clone(),
+                                err,
+                            });
+                        }
+                    }
+                    Err(err) => debug!(
+                        "Failed to symlink directory `{}` to `{}`: {err}; linking individual files",
+                        path.display(),
+                        target.display(),
+                    ),
+                }
+            }
+            materialize_symlink_dir(&target, &options.needs_mutable_copy)?;
+            if state.mode == LinkMode::Clone && !target.try_exists()? {
+                // Reserve the new directory until cloning finishes, without creating it first.
+                return clone_dir(&path, &target, options).map(Some);
+            }
+            fs_err::create_dir_all(&target)?;
+            Ok(None)
+        };
+        let mode = if let Some(locks) = options.copy_locks {
+            locks.with_directory_lock(&target, operation)?
+        } else {
+            operation()?
+        };
+        // Once the destination is a real directory, concurrent installers can safely merge files
+        // using the existing linker. No directory links are created beneath this point.
+        state = LinkState::new(match mode {
+            Some(mode) => mode,
+            None => match state.mode {
+                LinkMode::Clone => clone_dir(&path, &target, options)?,
+                mode => walk_and_link(&path, &target, mode, options)?,
+            },
+        });
+    }
+    Ok(state.mode)
 }
 
 /// Directory-level locks for concurrent copy operations.
@@ -282,71 +335,6 @@ fn check_file_destination(path: &Path) -> io::Result<()> {
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err),
     }
-}
-
-/// Symlink top-level directories, using ordinary per-file linking for shared directories.
-fn link_dir_entries<F>(
-    src: &Path,
-    dst: &Path,
-    options: &LinkOptions<'_, F>,
-) -> Result<LinkMode, LinkError>
-where
-    F: Fn(&Path) -> bool,
-{
-    fs_err::create_dir_all(dst)?;
-    let mut state = LinkState::new(options.mode);
-    for entry in fs_err::read_dir(src)? {
-        let entry = entry?;
-        let path = entry.path();
-        let target = dst.join(entry.file_name());
-        let operation = || {
-            if !entry.file_type()?.is_dir() {
-                check_file_destination(&target)?;
-                return link_file(&path, &target, state, options).map(|state| Some(state.mode));
-            }
-            if state.mode == LinkMode::Symlink && !(options.needs_mutable_copy)(&path) {
-                match create_symlink(&path, &target) {
-                    Ok(()) => return Ok(Some(LinkMode::Symlink)),
-                    Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                        if options.on_existing_directory == OnExistingDirectory::Fail {
-                            return Err(LinkError::Symlink {
-                                from: path.clone(),
-                                to: target.clone(),
-                                err,
-                            });
-                        }
-                    }
-                    Err(err) => debug!(
-                        "Failed to symlink directory `{}` to `{}`: {err}; linking individual files",
-                        path.display(),
-                        target.display(),
-                    ),
-                }
-            }
-            materialize_symlink_dir(&target, &options.needs_mutable_copy)?;
-            if state.mode == LinkMode::Clone && !target.try_exists()? {
-                // Reserve the new directory until cloning finishes, without creating it first.
-                return clone_dir(&path, &target, options).map(Some);
-            }
-            fs_err::create_dir_all(&target)?;
-            Ok(None)
-        };
-        let mode = if let Some(locks) = options.copy_locks {
-            locks.with_directory_lock(&target, operation)?
-        } else {
-            operation()?
-        };
-        // Once the destination is a real directory, concurrent installers can safely merge files
-        // using the existing linker. No directory links are created beneath this point.
-        state = LinkState::new(match mode {
-            Some(mode) => mode,
-            None => match state.mode {
-                LinkMode::Clone => clone_dir(&path, &target, options)?,
-                mode => walk_and_link(&path, &target, mode, options)?,
-            },
-        });
-    }
-    Ok(state.mode)
 }
 
 /// Replace a directory symlink with real directories and symlinks to individual files.
@@ -557,6 +545,8 @@ where
 
 /// Dispatch a single file to the appropriate linking strategy based on the current state.
 ///
+/// Files matching [`LinkOptions::needs_mutable_copy`] are copied instead of hardlinked or symlinked.
+///
 /// Returns the (possibly updated) state for the next file. When a strategy fails, it
 /// transitions to [`LinkState::next_mode`] and re-dispatches through this function so the
 /// fallback chain is followed automatically.
@@ -571,9 +561,13 @@ where
 {
     match state.mode {
         LinkMode::Clone => reflink_file_with_fallback(path, target, state, options),
-        LinkMode::Hardlink => hardlink_file_with_fallback(path, target, state, options),
-        LinkMode::Symlink => symlink_file_with_fallback(path, target, state, options),
-        LinkMode::Copy => {
+        LinkMode::Hardlink if !(options.needs_mutable_copy)(path) => {
+            hardlink_file_with_fallback(path, target, state, options)
+        }
+        LinkMode::Symlink if !(options.needs_mutable_copy)(path) => {
+            symlink_file_with_fallback(path, target, state, options)
+        }
+        LinkMode::Copy | LinkMode::Hardlink | LinkMode::Symlink => {
             if options.on_existing_directory == OnExistingDirectory::Merge {
                 atomic_copy_overwrite(path, target, options)?;
             } else {
@@ -800,9 +794,6 @@ where
 }
 
 /// Attempt to hard link a single file, falling back via [`link_file`] on failure.
-///
-/// Files matching the [`LinkOptions::needs_mutable_copy`] predicate are always copied
-/// to avoid mutating the source through a hard link.
 fn hardlink_file_with_fallback<F>(
     path: &Path,
     target: &Path,
@@ -812,15 +803,6 @@ fn hardlink_file_with_fallback<F>(
 where
     F: Fn(&Path) -> bool,
 {
-    if (options.needs_mutable_copy)(path) {
-        if options.on_existing_directory == OnExistingDirectory::Merge {
-            atomic_copy_overwrite(path, target, options)?;
-        } else {
-            copy_file(path, target, options)?;
-        }
-        return Ok(state);
-    }
-
     match state.attempt {
         LinkAttempt::Initial => {
             if let Err(err) = try_hardlink_file(path, target) {
@@ -863,9 +845,6 @@ where
 }
 
 /// Attempt to symlink a single file, falling back via [`link_file`] on failure.
-///
-/// Files matching the [`LinkOptions::needs_mutable_copy`] predicate are always copied
-/// to avoid mutating the source through a symlink.
 fn symlink_file_with_fallback<F>(
     path: &Path,
     target: &Path,
@@ -875,15 +854,6 @@ fn symlink_file_with_fallback<F>(
 where
     F: Fn(&Path) -> bool,
 {
-    if (options.needs_mutable_copy)(path) {
-        if options.on_existing_directory == OnExistingDirectory::Merge {
-            atomic_copy_overwrite(path, target, options)?;
-        } else {
-            copy_file(path, target, options)?;
-        }
-        return Ok(state);
-    }
-
     match state.attempt {
         LinkAttempt::Initial => {
             if let Err(err) = create_symlink(path, target) {

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -165,7 +165,7 @@ pub struct CopyLocks {
 impl CopyLocks {
     /// Serialize changes to sibling directory entries.
     ///
-    /// Lock the canonical parent so scheme aliases and case-insensitive names share a lock.
+    /// The parent must exist. Its canonical path identifies the lock, including through aliases.
     pub fn with_directory_lock<T, E>(
         &self,
         path: &Path,
@@ -195,7 +195,8 @@ impl CopyLocks {
 
     /// Publish a file without replacing a package directory during expansion.
     ///
-    /// Prepare its parent first, so it remains a real directory throughout publication.
+    /// Prepare its parent first. The operation must replace file symlinks rather than write through
+    /// them; this check only rejects directory destinations.
     pub fn with_file_write<T, E>(
         &self,
         path: &Path,
@@ -322,7 +323,7 @@ impl<'a, F> LinkOptions<'a, F> {
     }
 }
 
-/// Reject directory destinations, following links so file publication cannot hide a package tree.
+/// Reject existing directory destinations, including directory symlinks.
 fn check_file_destination(path: &Path) -> io::Result<()> {
     match fs_err::metadata(path) {
         Ok(metadata) if metadata.is_dir() => Err(io::Error::new(
@@ -338,7 +339,7 @@ fn check_file_destination(path: &Path) -> io::Result<()> {
 /// Replace a directory symlink with real directories and symlinks to individual files.
 ///
 /// Missing paths and non-links are unchanged.
-/// Files matching `needs_mutable_copy` are copied instead of linked.
+/// Source files matching `needs_mutable_copy` are copied instead of linked.
 /// If writes can overlap, hold [`CopyLocks::with_directory_lock`] for `path` throughout this call.
 pub fn materialize_symlink_dir(
     path: &Path,

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -220,11 +220,12 @@ impl CopyLocks {
         operation()
     }
 
-    /// Publish a file while excluding directory transitions in its parent.
+    /// Publish a file while excluding directory transitions at the same destination.
     ///
     /// Materialize package links in the parent path first, then keep its canonical identity stable
     /// for the lifetime of these locks. Targets that resolve to directories are rejected.
-    /// The exclusive parent lock covers the gap while [`materialize_symlink_dir`] replaces a link.
+    /// Share the directory entry lock so sibling files can be written while a package tree is being
+    /// installed. Non-ASCII names still acquire the parent lock exclusively to cover aliases.
     /// Prepare temporary contents beforehand; `operation` must not lock another entry in this parent.
     pub fn with_file_write<T, E>(
         &self,
@@ -234,21 +235,10 @@ impl CopyLocks {
     where
         E: From<io::Error>,
     {
-        let parent = path
-            .parent()
-            .map(|parent| self.directory_parent(parent))
-            .transpose()?;
-        let _guard = parent
-            .as_ref()
-            .map(|parent| {
-                parent
-                    .gate
-                    .write()
-                    .map_err(|err| io::Error::other(err.to_string()))
-            })
-            .transpose()?;
-        check_file_destination(path)?;
-        operation()
+        self.with_directory_lock(path, || {
+            check_file_destination(path)?;
+            operation()
+        })
     }
 
     /// Copy a file with directory-level synchronization.
@@ -1397,72 +1387,82 @@ mod tests {
     }
 
     #[test]
-    fn test_shared_namespace_children_install_concurrently() -> Result<(), LinkError> {
-        let sources = [test_tempdir(), test_tempdir()];
+    fn test_shared_namespace_entries_install_concurrently() -> Result<(), LinkError> {
+        let sources = [test_tempdir(), test_tempdir(), test_tempdir()];
         let destination = test_tempdir();
         let locks = CopyLocks::default();
+        let files = [
+            "shared/child_0/file.txt",
+            "shared/child_1/file.txt",
+            "shared/file.txt",
+        ];
 
         fs_err::create_dir_all(destination.path().join("shared"))?;
-        for (index, source) in sources.iter().enumerate() {
-            let directory = source.path().join(format!("shared/child_{index}"));
-            fs_err::create_dir_all(&directory)?;
-            fs_err::write(directory.join("file.txt"), "content")?;
+        for (source, file) in sources.iter().zip(files) {
+            let path = source.path().join(file);
+            if let Some(parent) = path.parent() {
+                fs_err::create_dir_all(parent)?;
+            }
+            fs_err::write(path, "content")?;
         }
 
         let (entered_sender, entered_receiver) = mpsc::channel();
-        let both_entered = thread::scope(|scope| -> Result<bool, LinkError> {
+        let all_entered = thread::scope(|scope| -> Result<bool, LinkError> {
             let mut releases = Vec::new();
             let mut handles = Vec::new();
+            let mut directories_entered = false;
             for (index, source) in sources.iter().enumerate() {
-                let child = format!("child_{index}");
+                if index == 2 {
+                    directories_entered = (0..2).all(|_| {
+                        entered_receiver
+                            .recv_timeout(Duration::from_secs(10))
+                            .is_ok()
+                    });
+                }
                 let entered_sender = entered_sender.clone();
                 let (release_sender, release_receiver) = mpsc::channel::<()>();
                 releases.push(release_sender);
                 let destination = destination.path();
                 let locks = &locks;
                 handles.push(scope.spawn(move || {
-                    let options = LinkOptions::new(LinkMode::Copy)
+                    let options = LinkOptions::new(LinkMode::Hardlink)
                         .with_directory_symlinks()
                         .with_copy_locks(locks)
                         .with_on_existing_directory(OnExistingDirectory::Merge)
                         .with_mutable_copy_filter(|path| {
-                            if path.ends_with(&child) {
+                            if index < 2 && path.ends_with("file.txt") {
                                 let _ = entered_sender.send(());
                                 let _ = release_receiver.recv();
                             }
                             false
                         });
-                    link_dir(source.path(), destination, &options)
+                    let result = link_dir(source.path(), destination, &options);
+                    if index == 2 {
+                        let _ = entered_sender.send(());
+                    }
+                    result
                 }));
             }
 
-            // Both children must enter before either is released. Always release before joining,
-            // including when an ancestor lock prevented the second child from making progress.
-            let both_entered = (0..2).all(|_| {
-                entered_receiver
+            // Both directories must enter and the sibling file must finish before either directory
+            // is released. Always release before joining, even if a parent lock blocked progress.
+            let all_entered = directories_entered
+                && entered_receiver
                     .recv_timeout(Duration::from_secs(10))
-                    .is_ok()
-            });
+                    .is_ok();
             drop(releases);
             for handle in handles {
                 handle
                     .join()
                     .map_err(|_| io::Error::other("Namespace installation thread panicked"))??;
             }
-            Ok(both_entered)
+            Ok(all_entered)
         })?;
 
-        assert!(
-            both_entered,
-            "Shared namespace serialized disjoint children"
-        );
-        for index in 0..2 {
+        assert!(all_entered, "Shared namespace serialized disjoint entries");
+        for file in files {
             assert_eq!(
-                fs_err::read_to_string(
-                    destination
-                        .path()
-                        .join(format!("shared/child_{index}/file.txt"))
-                )?,
+                fs_err::read_to_string(destination.path().join(file))?,
                 "content"
             );
         }

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -97,14 +97,16 @@ where
 ///
 /// These locks are used whenever a file is physically copied, regardless of the requested
 /// [`LinkMode`], as all modes can fallback to copying.
-/// Directory links use separate locks while creating or expanding a shared directory.
+/// Directory entry operations can copy files while holding a lock, so they use separate locks.
 ///
 /// The intended pattern for usage is to create a [`CopyLocks`] instance then share it across all
 /// [`link_dir`] invocations that may conflict via [`LinkOptions::with_copy_locks`].
 #[derive(Debug, Default)]
 pub struct CopyLocks {
-    dir_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
-    directory_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
+    /// Serialize non-atomic file copies into the same directory.
+    file_copy_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
+    /// Serialize entry creation and replacement while directory links are created or expanded.
+    directory_entry_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
 }
 
 impl CopyLocks {
@@ -128,7 +130,7 @@ impl CopyLocks {
             parent
         })?;
         let lock = self
-            .directory_locks
+            .directory_entry_locks
             .lock()
             .map_err(|err| io::Error::other(err.to_string()))?
             .entry(parent)
@@ -166,7 +168,7 @@ impl CopyLocks {
         // TODO(zanieb): This unwrap was copied from `uv-install-wheel`; consider propagating the
         // error instead of panicking if `to` has no parent.
         let dir_lock = {
-            let mut locks_guard = self.dir_locks.lock().unwrap();
+            let mut locks_guard = self.file_copy_locks.lock().unwrap();
             locks_guard
                 .entry(to.parent().unwrap().to_path_buf())
                 .or_insert_with(|| Arc::new(Mutex::new(())))

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -112,16 +112,59 @@ where
 #[derive(Debug, Default)]
 pub struct CopyLocks {
     dir_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
-    directory_parents: Mutex<FxHashMap<PathBuf, Arc<RwLock<()>>>>,
+    directory_parents: Mutex<FxHashMap<PathBuf, Arc<DirectoryParent>>>,
     directory_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
 }
 
+/// A stable directory identity shared by its canonical path and any scheme aliases.
+#[derive(Debug)]
+struct DirectoryParent {
+    path: PathBuf,
+    gate: RwLock<()>,
+}
+
 impl CopyLocks {
+    /// Resolve each parent once, interning aliases under the same canonical directory identity.
+    /// Parents must retain that identity for the lifetime of these locks.
+    fn directory_parent(&self, path: &Path) -> io::Result<Arc<DirectoryParent>> {
+        let path = std::path::absolute(if path.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            path
+        })?;
+        if let Some(parent) = self
+            .directory_parents
+            .lock()
+            .map_err(|err| io::Error::other(err.to_string()))?
+            .get(&path)
+        {
+            return Ok(parent.clone());
+        }
+
+        let canonical = fs_err::canonicalize(&path)?;
+        let mut parents = self
+            .directory_parents
+            .lock()
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        let parent = parents
+            .entry(canonical.clone())
+            .or_insert_with(|| {
+                Arc::new(DirectoryParent {
+                    path: canonical,
+                    gate: RwLock::new(()),
+                })
+            })
+            .clone();
+        parents.insert(path, parent.clone());
+        Ok(parent)
+    }
+
     /// Serialize changes to a directory's representation, including expanding a directory link
     /// before merging another package into it. Separate from the locks used while copying files.
     ///
     /// The parent directory must exist. Resolve aliases in the parent without following the final
     /// directory link, which may itself be replaced while holding the lock.
+    /// The parent's canonical identity must remain stable for the lifetime of these locks.
     /// ASCII names share the parent lock; non-ASCII names acquire it exclusively to account for
     /// filesystem-specific Unicode aliases. Acquire ancestor locks before descendant locks.
     pub fn with_directory_lock<T, E>(
@@ -132,41 +175,31 @@ impl CopyLocks {
     where
         E: From<io::Error>,
     {
-        let path = if let Some(parent) = path.parent()
+        let (path, parent_lock) = if let Some(parent) = path.parent()
             && let Some(name) = path.file_name()
         {
-            let parent = if parent.as_os_str().is_empty() {
-                Path::new(".")
-            } else {
-                parent
-            };
-            fs_err::canonicalize(parent)?.join(name)
+            let parent = self.directory_parent(parent)?;
+            (parent.path.join(name), Some(parent))
         } else {
-            fs_err::canonicalize(path)?
+            let path = fs_err::canonicalize(path)?;
+            let parent = path
+                .parent()
+                .map(|parent| self.directory_parent(parent))
+                .transpose()?;
+            (path, parent)
         };
 
-        let parent_lock = path
-            .parent()
-            .map(|parent| {
-                Ok::<_, io::Error>(
-                    self.directory_parents
-                        .lock()
-                        .map_err(|err| io::Error::other(err.to_string()))?
-                        .entry(parent.to_path_buf())
-                        .or_default()
-                        .clone(),
-                )
-            })
-            .transpose()?;
         let _parent_guard = if let Some(lock) = &parent_lock {
             Some(if path.file_name().is_some_and(OsStr::is_ascii) {
                 Either::Left(
-                    lock.read()
+                    lock.gate
+                        .read()
                         .map_err(|err| io::Error::other(err.to_string()))?,
                 )
             } else {
                 Either::Right(
-                    lock.write()
+                    lock.gate
+                        .write()
                         .map_err(|err| io::Error::other(err.to_string()))?,
                 )
             })
@@ -187,6 +220,36 @@ impl CopyLocks {
         let _guard = lock
             .lock()
             .map_err(|err| io::Error::other(err.to_string()))?;
+        operation()
+    }
+
+    /// Publish a file without replacing a directory or racing its materialization.
+    ///
+    /// The parent must already be prepared and retain its canonical identity for the lifetime of
+    /// these locks. File writers exclude directory transitions, including the brief absence while
+    /// replacing a directory link. Prepare temporary file contents before taking this lock.
+    pub fn with_file_write<T, E>(
+        &self,
+        path: &Path,
+        operation: impl FnOnce() -> Result<T, E>,
+    ) -> Result<T, E>
+    where
+        E: From<io::Error>,
+    {
+        let parent = path
+            .parent()
+            .map(|parent| self.directory_parent(parent))
+            .transpose()?;
+        let _guard = parent
+            .as_ref()
+            .map(|parent| {
+                parent
+                    .gate
+                    .write()
+                    .map_err(|err| io::Error::other(err.to_string()))
+            })
+            .transpose()?;
+        check_file_destination(path)?;
         operation()
     }
 
@@ -317,6 +380,38 @@ impl<'a, F> LinkOptions<'a, F> {
             fs_err::copy(from, to)?;
             Ok(())
         }
+    }
+
+    /// Guard file publication when directory links may be present at the destination.
+    fn with_file_write<T, E>(
+        &self,
+        path: &Path,
+        operation: impl FnOnce() -> Result<T, E>,
+    ) -> Result<T, E>
+    where
+        E: From<io::Error>,
+    {
+        if !self.directory_symlinks {
+            return operation();
+        }
+        if let Some(locks) = self.copy_locks {
+            return locks.with_file_write(path, operation);
+        }
+        check_file_destination(path)?;
+        operation()
+    }
+}
+
+/// Reject directory destinations, following links so file publication cannot hide a package tree.
+fn check_file_destination(path: &Path) -> io::Result<()> {
+    match fs_err::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => Err(io::Error::new(
+            io::ErrorKind::IsADirectory,
+            format!("Cannot replace directory `{}` with a file", path.display()),
+        )),
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
     }
 }
 
@@ -674,9 +769,11 @@ fn reflink_file_with_fallback<F>(
 where
     F: Fn(&Path) -> bool,
 {
+    let result = options.with_file_write(target, || reflink_with_permissions(path, target));
     match state.attempt {
-        LinkAttempt::Initial => match reflink_with_permissions(path, target) {
+        LinkAttempt::Initial => match result {
             Ok(()) => Ok(state.mode_working()),
+            Err(err) if err.kind() == io::ErrorKind::IsADirectory => Err(err.into()),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 if options.on_existing_directory == OnExistingDirectory::Merge {
                     // File exists, overwrite atomically via temp file
@@ -684,7 +781,7 @@ where
                     let tempdir = tempfile::tempdir_in(parent)?;
                     let tempfile = tempdir.path().join(target.file_name().unwrap());
                     if reflink_with_permissions(path, &tempfile).is_ok() {
-                        fs_err::rename(&tempfile, target)?;
+                        options.with_file_write(target, || fs_err::rename(&tempfile, target))?;
                         Ok(state.mode_working())
                     } else {
                         debug!(
@@ -711,8 +808,9 @@ where
                 link_file(path, target, state.next_mode(), options)
             }
         },
-        LinkAttempt::Subsequent => match reflink_with_permissions(path, target) {
+        LinkAttempt::Subsequent => match result {
             Ok(()) => Ok(state),
+            Err(err) if err.kind() == io::ErrorKind::IsADirectory => Err(err.into()),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 if options.on_existing_directory == OnExistingDirectory::Merge {
                     let parent = target.parent().unwrap();
@@ -725,7 +823,7 @@ where
                             err,
                         }
                     })?;
-                    fs_err::rename(&tempfile, target)?;
+                    options.with_file_write(target, || fs_err::rename(&tempfile, target))?;
                     Ok(state)
                 } else {
                     Err(LinkError::Reflink {
@@ -780,11 +878,7 @@ where
 
 /// Clone a directory by merging into an existing destination.
 #[cfg(target_os = "macos")]
-fn clone_dir_merge<F>(
-    src: &Path,
-    dst: &Path,
-    _options: &LinkOptions<'_, F>,
-) -> Result<(), LinkError>
+fn clone_dir_merge<F>(src: &Path, dst: &Path, options: &LinkOptions<'_, F>) -> Result<(), LinkError>
 where
     F: Fn(&Path) -> bool,
 {
@@ -798,7 +892,7 @@ where
             match reflink_copy::reflink(&src_path, &dst_path) {
                 Ok(()) => {}
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                    clone_dir_merge(&src_path, &dst_path, _options)?;
+                    clone_dir_merge(&src_path, &dst_path, options)?;
                 }
                 Err(err) => {
                     return Err(LinkError::Reflink {
@@ -810,8 +904,10 @@ where
             }
         } else {
             // Try to clone the file
-            match reflink_copy::reflink(&src_path, &dst_path) {
+            match options.with_file_write(&dst_path, || reflink_copy::reflink(&src_path, &dst_path))
+            {
                 Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::IsADirectory => return Err(err.into()),
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                     // File exists, overwrite atomically via temp file
                     let tempdir = tempfile::tempdir_in(dst)?;
@@ -823,7 +919,7 @@ where
                             err,
                         }
                     })?;
-                    fs_err::rename(&tempfile, &dst_path)?;
+                    options.with_file_write(&dst_path, || fs_err::rename(&tempfile, &dst_path))?;
                 }
                 Err(err) => {
                     return Err(LinkError::Reflink {
@@ -862,7 +958,12 @@ where
 
     match state.attempt {
         LinkAttempt::Initial => {
-            if let Err(err) = try_hardlink_file(path, target) {
+            if let Err(err) = try_hardlink_file(path, target, |from, to| {
+                options.with_file_write(to, || fs_err::hard_link(from, to))
+            }) {
+                if err.kind() == io::ErrorKind::IsADirectory {
+                    return Err(err.into());
+                }
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
@@ -886,7 +987,12 @@ where
             }
         }
         LinkAttempt::Subsequent => {
-            if let Err(err) = try_hardlink_file(path, target) {
+            if let Err(err) = try_hardlink_file(path, target, |from, to| {
+                options.with_file_write(to, || fs_err::hard_link(from, to))
+            }) {
+                if err.kind() == io::ErrorKind::IsADirectory {
+                    return Err(err.into());
+                }
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
@@ -925,7 +1031,10 @@ where
 
     match state.attempt {
         LinkAttempt::Initial => {
-            if let Err(err) = create_symlink(path, target) {
+            if let Err(err) = options.with_file_write(target, || create_symlink(path, target)) {
+                if err.kind() == io::ErrorKind::IsADirectory {
+                    return Err(err.into());
+                }
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
@@ -949,7 +1058,10 @@ where
             }
         }
         LinkAttempt::Subsequent => {
-            if let Err(err) = create_symlink(path, target) {
+            if let Err(err) = options.with_file_write(target, || create_symlink(path, target)) {
+                if err.kind() == io::ErrorKind::IsADirectory {
+                    return Err(err.into());
+                }
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
@@ -973,18 +1085,25 @@ fn copy_file<F>(path: &Path, target: &Path, options: &LinkOptions<'_, F>) -> Res
 where
     F: Fn(&Path) -> bool,
 {
-    options
-        .copy_file(path, target)
-        .map_err(|err| LinkError::Copy {
-            to: target.to_path_buf(),
-            err,
-        })
+    options.with_file_write(target, || {
+        options
+            .copy_file(path, target)
+            .map_err(|err| LinkError::Copy {
+                to: target.to_path_buf(),
+                err,
+            })
+    })
 }
 
 /// Try to create a hard link, handling `TooManyLinks` (EMLINK/`ERROR_TOO_MANY_LINKS`)
 /// by copying the source to a fresh inode and retrying.
-fn try_hardlink_file(src: &Path, dst: &Path) -> io::Result<()> {
-    match fs_err::hard_link(src, dst) {
+/// The supplied operation locks publication without holding that lock while copying the source.
+fn try_hardlink_file(
+    src: &Path,
+    dst: &Path,
+    link: impl Fn(&Path, &Path) -> io::Result<()>,
+) -> io::Result<()> {
+    match link(src, dst) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::TooManyLinks => {
             debug!(
@@ -1001,7 +1120,7 @@ fn try_hardlink_file(src: &Path, dst: &Path) -> io::Result<()> {
             fs_err::copy(src, temp.path())?;
             // Linking a copy before renaming avoids the unlikely race where another process could
             // exhaust the fresh inode's links between the rename and our link.
-            fs_err::hard_link(temp.path(), dst)?;
+            link(temp.path(), dst)?;
             fs_err::rename(temp.path(), src)?;
             Ok(())
         }
@@ -1025,8 +1144,8 @@ where
     let tempdir = tempfile::tempdir_in(parent)?;
     let tempfile = tempdir.path().join(dst.file_name().unwrap());
 
-    if try_hardlink_file(src, &tempfile).is_ok() {
-        fs_err::rename(&tempfile, dst)?;
+    if try_hardlink_file(src, &tempfile, |from, to| fs_err::hard_link(from, to)).is_ok() {
+        options.with_file_write(dst, || fs_err::rename(&tempfile, dst))?;
         Ok(state.mode_working())
     } else {
         debug!(
@@ -1065,7 +1184,7 @@ where
             to: tempfile.clone(),
             err,
         })?;
-    fs_err::rename(&tempfile, dst)?;
+    options.with_file_write(dst, || fs_err::rename(&tempfile, dst))?;
     Ok(())
 }
 
@@ -1086,7 +1205,7 @@ where
     let tempfile = tempdir.path().join(dst.file_name().unwrap());
 
     if create_symlink(src, &tempfile).is_ok() {
-        fs_err::rename(&tempfile, dst)?;
+        options.with_file_write(dst, || fs_err::rename(&tempfile, dst))?;
         Ok(state.mode_working())
     } else {
         debug!(
@@ -1269,6 +1388,41 @@ mod tests {
             existing_dir.path()
         );
         assert!(!existing_dir.path().join("new.txt").exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_directory_symlinks_reject_files_without_locks() -> io::Result<()> {
+        let src_dir = test_tempdir();
+        let existing_dir = test_tempdir();
+        let dst_dir = test_tempdir();
+
+        fs_err::write(src_dir.path().join("package"), "new file")?;
+        fs_err::write(existing_dir.path().join("existing.txt"), "existing")?;
+        create_symlink(existing_dir.path(), &dst_dir.path().join("package"))?;
+
+        for mode in [
+            LinkMode::Clone,
+            LinkMode::Copy,
+            LinkMode::Hardlink,
+            LinkMode::Symlink,
+        ] {
+            let options = LinkOptions::new(mode)
+                .with_directory_symlinks()
+                .with_on_existing_directory(OnExistingDirectory::Merge);
+            let result = link_dir(src_dir.path(), dst_dir.path(), &options);
+
+            assert_matches!(result, Err(LinkError::Io(err)) if err.kind() == io::ErrorKind::IsADirectory);
+            assert_eq!(
+                fs_err::read_link(dst_dir.path().join("package"))?,
+                existing_dir.path()
+            );
+        }
+        assert_eq!(
+            fs_err::read_to_string(existing_dir.path().join("existing.txt"))?,
+            "existing"
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -80,6 +80,9 @@ pub fn link_dir<F>(
 where
     F: Fn(&Path) -> bool,
 {
+    if options.directory_symlinks {
+        return link_dir_entries(src, dst, options);
+    }
     match options.mode {
         LinkMode::Clone => clone_dir(src, dst, options),
         mode => walk_and_link(src, dst, mode, options),
@@ -93,15 +96,40 @@ where
 ///
 /// These locks are used whenever a file is physically copied, regardless of the requested
 /// [`LinkMode`], as all modes can fallback to copying.
+/// Directory links use separate locks while creating or expanding a shared directory.
 ///
 /// The intended pattern for usage is to create a [`CopyLocks`] instance then share it across all
 /// [`link_dir`] invocations that may conflict via [`LinkOptions::with_copy_locks`].
 #[derive(Debug, Default)]
 pub struct CopyLocks {
     dir_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
+    directory_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
 }
 
 impl CopyLocks {
+    /// Serialize changes to a directory's representation, including expanding a directory link
+    /// before merging another package into it. Separate from the locks used while copying files.
+    pub fn with_directory_lock<T, E>(
+        &self,
+        path: &Path,
+        operation: impl FnOnce() -> Result<T, E>,
+    ) -> Result<T, E>
+    where
+        E: From<io::Error>,
+    {
+        let lock = self
+            .directory_locks
+            .lock()
+            .map_err(|err| io::Error::other(err.to_string()))?
+            .entry(path.to_path_buf())
+            .or_default()
+            .clone();
+        let _guard = lock
+            .lock()
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        operation()
+    }
+
     /// Copy a file with directory-level synchronization.
     ///
     /// Acquires a lock on the parent directory before copying to prevent concurrent writes to the
@@ -140,6 +168,8 @@ pub struct LinkOptions<'a, F = fn(&Path) -> bool> {
     copy_locks: Option<&'a CopyLocks>,
     /// What to do when the destination directory already exists.
     on_existing_directory: OnExistingDirectory,
+    /// Allow top-level directories to be symlinked, expanding existing links before merging.
+    directory_symlinks: bool,
 }
 
 impl LinkOptions<'static> {
@@ -150,6 +180,7 @@ impl LinkOptions<'static> {
             needs_mutable_copy: |_| false,
             copy_locks: None,
             on_existing_directory: OnExistingDirectory::default(),
+            directory_symlinks: false,
         }
     }
 }
@@ -174,6 +205,7 @@ impl<'a, F> LinkOptions<'a, F> {
             needs_mutable_copy: f,
             copy_locks: self.copy_locks,
             on_existing_directory: self.on_existing_directory,
+            directory_symlinks: self.directory_symlinks,
         }
     }
 
@@ -188,6 +220,7 @@ impl<'a, F> LinkOptions<'a, F> {
             needs_mutable_copy: self.needs_mutable_copy,
             copy_locks: Some(locks),
             on_existing_directory: self.on_existing_directory,
+            directory_symlinks: self.directory_symlinks,
         }
     }
 
@@ -199,7 +232,18 @@ impl<'a, F> LinkOptions<'a, F> {
             needs_mutable_copy: self.needs_mutable_copy,
             copy_locks: self.copy_locks,
             on_existing_directory,
+            directory_symlinks: self.directory_symlinks,
         }
+    }
+
+    /// Symlink top-level directories in [`LinkMode::Symlink`], unless the mutable-copy filter
+    /// selects the directory. Other modes expand existing directory links before merging.
+    /// The filter must select every top-level directory containing mutable files: the contents
+    /// of directories eligible for linking are not inspected.
+    #[must_use]
+    pub fn with_directory_symlinks(mut self) -> Self {
+        self.directory_symlinks = true;
+        self
     }
 
     /// Copy a file, using synchronized copy if locks are configured.
@@ -214,6 +258,84 @@ impl<'a, F> LinkOptions<'a, F> {
             Ok(())
         }
     }
+}
+
+/// Link top-level entries independently so a package directory can be represented by one link.
+fn link_dir_entries<F>(
+    src: &Path,
+    dst: &Path,
+    options: &LinkOptions<'_, F>,
+) -> Result<LinkMode, LinkError>
+where
+    F: Fn(&Path) -> bool,
+{
+    fs_err::create_dir_all(dst)?;
+    let mut state = LinkState::new(options.mode);
+    for entry in fs_err::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        if !entry.file_type()?.is_dir() {
+            state = link_file(&path, &target, state, options)?;
+            continue;
+        }
+
+        let operation = || {
+            materialize_symlink_dir(&target)?;
+            if state.mode == LinkMode::Symlink && !(options.needs_mutable_copy)(&path) {
+                match create_symlink(&path, &target) {
+                    Ok(()) => return Ok(LinkMode::Symlink),
+                    Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+                    Err(err) => debug!(
+                        "Failed to symlink directory `{}` to `{}`: {err}; linking individual files",
+                        path.display(),
+                        target.display(),
+                    ),
+                }
+            }
+            // These helpers link individual files, without trying directory symlinks again.
+            match state.mode {
+                LinkMode::Clone => clone_dir(&path, &target, options),
+                mode => walk_and_link(&path, &target, mode, options),
+            }
+        };
+        let mode = if let Some(locks) = options.copy_locks {
+            locks.with_directory_lock(&target, operation)?
+        } else {
+            operation()?
+        };
+        state = LinkState::new(mode);
+    }
+    Ok(state.mode)
+}
+
+/// Replace a directory symlink with real directories and individual file symlinks before merging
+/// new files into it. The caller must serialize changes to `path` with other directory writers.
+pub fn materialize_symlink_dir(path: &Path) -> Result<(), LinkError> {
+    match fs_err::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {}
+        Ok(_) => return Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    }
+    let source = fs_err::canonicalize(path)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("Directory link has no parent"))?;
+    let temporary = tempfile::tempdir_in(parent)?;
+    walk_and_link(
+        &source,
+        temporary.path(),
+        LinkMode::Symlink,
+        &LinkOptions::new(LinkMode::Symlink),
+    )?;
+    crate::remove_symlink(path)?;
+    if let Err(err) = fs_err::rename(temporary.path(), path) {
+        // Restore the link if publishing the expanded directory failed.
+        let _ = create_symlink(&source, path);
+        return Err(err.into());
+    }
+    Ok(())
 }
 
 /// Whether the current linking strategy has been confirmed to work.

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -1,12 +1,10 @@
 //! Utilities for linking a file or directory with various options and automated fallback (e.g., to
 //! copying) when link methods are unsupported.
 
-use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
-use either::Either;
 use rustc_hash::FxHashMap;
 use tracing::debug;
 use uv_warnings::warn_user_once;
@@ -90,7 +88,7 @@ where
             )
             .into());
         }
-        return link_dir_entries(src, dst, options.mode, true, options);
+        return link_dir_entries(src, dst, options);
     }
     match options.mode {
         LinkMode::Clone => clone_dir(src, dst, options),
@@ -112,58 +110,15 @@ where
 #[derive(Debug, Default)]
 pub struct CopyLocks {
     dir_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
-    directory_parents: Mutex<FxHashMap<PathBuf, Arc<DirectoryParent>>>,
     directory_locks: Mutex<FxHashMap<PathBuf, Arc<Mutex<()>>>>,
 }
 
-/// A stable directory identity shared by its canonical path and any scheme aliases.
-#[derive(Debug)]
-struct DirectoryParent {
-    path: PathBuf,
-    gate: RwLock<()>,
-}
-
 impl CopyLocks {
-    /// Cache canonical parent identities so scheme aliases share the same publication gate.
-    fn directory_parent(&self, path: &Path) -> io::Result<Arc<DirectoryParent>> {
-        let path = std::path::absolute(if path.as_os_str().is_empty() {
-            Path::new(".")
-        } else {
-            path
-        })?;
-        if let Some(parent) = self
-            .directory_parents
-            .lock()
-            .map_err(|err| io::Error::other(err.to_string()))?
-            .get(&path)
-        {
-            return Ok(parent.clone());
-        }
-
-        let canonical = fs_err::canonicalize(&path)?;
-        let mut parents = self
-            .directory_parents
-            .lock()
-            .map_err(|err| io::Error::other(err.to_string()))?;
-        let parent = parents
-            .entry(canonical.clone())
-            .or_insert_with(|| {
-                Arc::new(DirectoryParent {
-                    path: canonical,
-                    gate: RwLock::new(()),
-                })
-            })
-            .clone();
-        parents.insert(path, parent.clone());
-        Ok(parent)
-    }
-
-    /// Serialize directory creation and expansion against other directory and file writers.
+    /// Serialize top-level directory creation and expansion with writes to sibling entries.
     ///
-    /// Resolve aliases in the parent without following the final directory link. The parent must
-    /// exist and retain its canonical identity for the lifetime of these locks. ASCII case variants
-    /// share an entry lock; non-ASCII names lock the whole parent to cover filesystem-specific aliases.
-    /// Acquire ancestors before descendants, and do not lock sibling entries from `operation`.
+    /// Lock the canonical parent so scheme aliases and case-insensitive names share a lock.
+    /// Release it before installing files beneath a real directory: real directories never become
+    /// links, and expanding a directory link leaves no directory links below it.
     pub fn with_directory_lock<T, E>(
         &self,
         path: &Path,
@@ -172,46 +127,17 @@ impl CopyLocks {
     where
         E: From<io::Error>,
     {
-        let (path, parent_lock) = if let Some(parent) = path.parent()
-            && let Some(name) = path.file_name()
-        {
-            let parent = self.directory_parent(parent)?;
-            (parent.path.join(name), Some(parent))
+        let parent = path.parent().unwrap_or(path);
+        let parent = fs_err::canonicalize(if parent.as_os_str().is_empty() {
+            Path::new(".")
         } else {
-            let path = fs_err::canonicalize(path)?;
-            let parent = path
-                .parent()
-                .map(|parent| self.directory_parent(parent))
-                .transpose()?;
-            (path, parent)
-        };
-
-        let _parent_guard = if let Some(lock) = &parent_lock {
-            Some(if path.file_name().is_some_and(OsStr::is_ascii) {
-                Either::Left(
-                    lock.gate
-                        .read()
-                        .map_err(|err| io::Error::other(err.to_string()))?,
-                )
-            } else {
-                Either::Right(
-                    lock.gate
-                        .write()
-                        .map_err(|err| io::Error::other(err.to_string()))?,
-                )
-            })
-        } else {
-            None
-        };
-        let path = path.file_name().map_or_else(
-            || path.clone(),
-            |name| path.with_file_name(name.to_ascii_lowercase()),
-        );
+            parent
+        })?;
         let lock = self
             .directory_locks
             .lock()
             .map_err(|err| io::Error::other(err.to_string()))?
-            .entry(path)
+            .entry(parent)
             .or_default()
             .clone();
         let _guard = lock
@@ -220,13 +146,9 @@ impl CopyLocks {
         operation()
     }
 
-    /// Publish a file while excluding directory transitions at the same destination.
+    /// Publish a file without replacing a package directory during expansion.
     ///
-    /// Materialize package links in the parent path first, then keep its canonical identity stable
-    /// for the lifetime of these locks. Targets that resolve to directories are rejected.
-    /// Share the directory entry lock so sibling files can be written while a package tree is being
-    /// installed. Non-ASCII names still acquire the parent lock exclusively to cover aliases.
-    /// Prepare temporary contents beforehand; `operation` must not lock another entry in this parent.
+    /// Prepare its parent first, so it remains a real directory throughout publication.
     pub fn with_file_write<T, E>(
         &self,
         path: &Path,
@@ -279,7 +201,7 @@ pub struct LinkOptions<'a, F = fn(&Path) -> bool> {
     copy_locks: Option<&'a CopyLocks>,
     /// What to do when the destination directory already exists.
     on_existing_directory: OnExistingDirectory,
-    /// Allow directories to be symlinked, expanding existing links only where merging is needed.
+    /// Allow top-level directories to be symlinked, fully expanding shared directory links.
     directory_symlinks: bool,
 }
 
@@ -340,14 +262,14 @@ impl<'a, F> LinkOptions<'a, F> {
         self
     }
 
-    /// Symlink untouched directories in [`LinkMode::Symlink`], expanding shared links in any mode.
+    /// Symlink top-level directories in [`LinkMode::Symlink`], fully expanding shared links in any mode.
     ///
     /// The mutable-copy filter must select every top-level directory containing mutable files:
     /// eligible directories are linked without inspecting their contents. Source trees must not
     /// contain directory symlinks.
     ///
     /// Concurrent overlapping writers must share [`CopyLocks`] and a destination root, and prepare
-    /// ancestor directories before writing below them. Fresh subtrees rely on that ancestor lock.
+    /// package directories before writing below them. Shared directories use ordinary per-file linking.
     #[must_use]
     pub fn with_directory_symlinks(mut self) -> Self {
         self.directory_symlinks = true;
@@ -366,25 +288,6 @@ impl<'a, F> LinkOptions<'a, F> {
             Ok(())
         }
     }
-
-    /// Guard file publication when directory links may be present at the destination.
-    fn with_file_write<T, E>(
-        &self,
-        path: &Path,
-        operation: impl FnOnce() -> Result<T, E>,
-    ) -> Result<T, E>
-    where
-        E: From<io::Error>,
-    {
-        if !self.directory_symlinks {
-            return operation();
-        }
-        if let Some(locks) = self.copy_locks {
-            return locks.with_file_write(path, operation);
-        }
-        check_file_destination(path)?;
-        operation()
-    }
 }
 
 /// Reject directory destinations, following links so file publication cannot hide a package tree.
@@ -400,34 +303,27 @@ fn check_file_destination(path: &Path) -> io::Result<()> {
     }
 }
 
-/// Merge shared directories one level at a time, leaving untouched subtrees linked.
-///
-/// `directory_symlinks` carries mutable-ancestor exclusions; the options still protect file writes
-/// in subtrees that must use real directories.
+/// Symlink top-level directories, using ordinary per-file linking for shared directories.
 fn link_dir_entries<F>(
     src: &Path,
     dst: &Path,
-    mode: LinkMode,
-    directory_symlinks: bool,
     options: &LinkOptions<'_, F>,
 ) -> Result<LinkMode, LinkError>
 where
     F: Fn(&Path) -> bool,
 {
     fs_err::create_dir_all(dst)?;
-    let mut state = LinkState::new(mode);
+    let mut state = LinkState::new(options.mode);
     for entry in fs_err::read_dir(src)? {
         let entry = entry?;
         let path = entry.path();
         let target = dst.join(entry.file_name());
-        if !entry.file_type()?.is_dir() {
-            state = link_file(&path, &target, state, options)?;
-            continue;
-        }
-
-        let directory_symlinks = directory_symlinks && !(options.needs_mutable_copy)(&path);
         let operation = || {
-            if state.mode == LinkMode::Symlink && directory_symlinks {
+            if !entry.file_type()?.is_dir() {
+                check_file_destination(&target)?;
+                return link_file(&path, &target, state, options).map(|state| Some(state.mode));
+            }
+            if state.mode == LinkMode::Symlink && !(options.needs_mutable_copy)(&path) {
                 match create_symlink(&path, &target) {
                     Ok(()) => return Ok(Some(LinkMode::Symlink)),
                     Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
@@ -446,50 +342,31 @@ where
                     ),
                 }
             }
-
-            match fs_err::symlink_metadata(&target) {
-                Ok(_) => {
-                    materialize_symlink_dir(&target)?;
-                    return Ok(None);
-                }
-                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-                Err(err) => return Err(err.into()),
-            }
-
-            // The ancestor lock reserves this new subtree until the bulk install finishes.
-            // Wheel contents are regular files and directories, and other installers must
-            // prepare this ancestor before writing below it, so per-file guards are redundant.
-            let subtree_options = LinkOptions {
-                mode: options.mode,
-                needs_mutable_copy: &options.needs_mutable_copy,
-                copy_locks: options.copy_locks,
-                on_existing_directory: options.on_existing_directory,
-                directory_symlinks: options.directory_symlinks && options.copy_locks.is_none(),
-            };
-            match state.mode {
-                LinkMode::Clone => clone_dir(&path, &target, &subtree_options),
-                mode => walk_and_link(&path, &target, mode, &subtree_options),
-            }
-            .map(Some)
+            materialize_symlink_dir(&target)?;
+            fs_err::create_dir_all(&target)?;
+            Ok(None)
         };
         let mode = if let Some(locks) = options.copy_locks {
             locks.with_directory_lock(&target, operation)?
         } else {
             operation()?
         };
-        // A real directory stays real throughout installation. Release its lock before descending
-        // so wheels sharing a namespace can install independent children concurrently.
+        // Once the destination is a real directory, concurrent installers can safely merge files
+        // using the existing linker. No directory links are created beneath this point.
         state = LinkState::new(match mode {
             Some(mode) => mode,
-            None => link_dir_entries(&path, &target, state.mode, directory_symlinks, options)?,
+            None => match state.mode {
+                LinkMode::Clone => clone_dir(&path, &target, options)?,
+                mode => walk_and_link(&path, &target, mode, options)?,
+            },
         });
     }
     Ok(state.mode)
 }
 
-/// Replace a directory symlink with a real directory linking its immediate children.
+/// Replace a directory symlink with real directories and symlinks to individual files.
 ///
-/// Child directories stay linked until they need merging. Missing paths and non-links are unchanged.
+/// Missing paths and non-links are unchanged. The expanded directory never becomes a link again.
 /// If writes can overlap, hold [`CopyLocks::with_directory_lock`] for `path` throughout this call and
 /// use [`CopyLocks::with_file_write`] for competing file writes. Replacing the link briefly removes
 /// its name before publishing the expanded directory.
@@ -508,7 +385,7 @@ pub fn materialize_symlink_dir(path: &Path) -> Result<(), LinkError> {
     link_dir(
         &source,
         temporary.path(),
-        &LinkOptions::new(LinkMode::Symlink).with_directory_symlinks(),
+        &LinkOptions::new(LinkMode::Symlink),
     )?;
     crate::remove_symlink(path)?;
     if let Err(err) = fs_err::rename(temporary.path(), path) {
@@ -769,11 +646,9 @@ fn reflink_file_with_fallback<F>(
 where
     F: Fn(&Path) -> bool,
 {
-    let result = options.with_file_write(target, || reflink_with_permissions(path, target));
     match state.attempt {
-        LinkAttempt::Initial => match result {
+        LinkAttempt::Initial => match reflink_with_permissions(path, target) {
             Ok(()) => Ok(state.mode_working()),
-            Err(err) if err.kind() == io::ErrorKind::IsADirectory => Err(err.into()),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 if options.on_existing_directory == OnExistingDirectory::Merge {
                     // File exists, overwrite atomically via temp file
@@ -781,7 +656,7 @@ where
                     let tempdir = tempfile::tempdir_in(parent)?;
                     let tempfile = tempdir.path().join(target.file_name().unwrap());
                     if reflink_with_permissions(path, &tempfile).is_ok() {
-                        options.with_file_write(target, || fs_err::rename(&tempfile, target))?;
+                        fs_err::rename(&tempfile, target)?;
                         Ok(state.mode_working())
                     } else {
                         debug!(
@@ -808,9 +683,8 @@ where
                 link_file(path, target, state.next_mode(), options)
             }
         },
-        LinkAttempt::Subsequent => match result {
+        LinkAttempt::Subsequent => match reflink_with_permissions(path, target) {
             Ok(()) => Ok(state),
-            Err(err) if err.kind() == io::ErrorKind::IsADirectory => Err(err.into()),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 if options.on_existing_directory == OnExistingDirectory::Merge {
                     let parent = target.parent().unwrap();
@@ -823,7 +697,7 @@ where
                             err,
                         }
                     })?;
-                    options.with_file_write(target, || fs_err::rename(&tempfile, target))?;
+                    fs_err::rename(&tempfile, target)?;
                     Ok(state)
                 } else {
                     Err(LinkError::Reflink {
@@ -878,7 +752,11 @@ where
 
 /// Clone a directory by merging into an existing destination.
 #[cfg(target_os = "macos")]
-fn clone_dir_merge<F>(src: &Path, dst: &Path, options: &LinkOptions<'_, F>) -> Result<(), LinkError>
+fn clone_dir_merge<F>(
+    src: &Path,
+    dst: &Path,
+    _options: &LinkOptions<'_, F>,
+) -> Result<(), LinkError>
 where
     F: Fn(&Path) -> bool,
 {
@@ -892,7 +770,7 @@ where
             match reflink_copy::reflink(&src_path, &dst_path) {
                 Ok(()) => {}
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                    clone_dir_merge(&src_path, &dst_path, options)?;
+                    clone_dir_merge(&src_path, &dst_path, _options)?;
                 }
                 Err(err) => {
                     return Err(LinkError::Reflink {
@@ -904,10 +782,8 @@ where
             }
         } else {
             // Try to clone the file
-            match options.with_file_write(&dst_path, || reflink_copy::reflink(&src_path, &dst_path))
-            {
+            match reflink_copy::reflink(&src_path, &dst_path) {
                 Ok(()) => {}
-                Err(err) if err.kind() == io::ErrorKind::IsADirectory => return Err(err.into()),
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                     // File exists, overwrite atomically via temp file
                     let tempdir = tempfile::tempdir_in(dst)?;
@@ -919,7 +795,7 @@ where
                             err,
                         }
                     })?;
-                    options.with_file_write(&dst_path, || fs_err::rename(&tempfile, &dst_path))?;
+                    fs_err::rename(&tempfile, &dst_path)?;
                 }
                 Err(err) => {
                     return Err(LinkError::Reflink {
@@ -956,32 +832,44 @@ where
         return Ok(state);
     }
 
-    match try_hardlink_file(path, target, |from, to| {
-        options.with_file_write(to, || fs_err::hard_link(from, to))
-    }) {
-        Ok(()) => Ok(state.mode_working()),
-        Err(err) if err.kind() == io::ErrorKind::IsADirectory => Err(err.into()),
-        Err(err)
-            if err.kind() == io::ErrorKind::AlreadyExists
-                && options.on_existing_directory == OnExistingDirectory::Merge =>
-        {
-            atomic_hardlink_overwrite(path, target, state, options)
+    match state.attempt {
+        LinkAttempt::Initial => {
+            if let Err(err) = try_hardlink_file(path, target) {
+                if err.kind() == io::ErrorKind::AlreadyExists
+                    && options.on_existing_directory == OnExistingDirectory::Merge
+                {
+                    atomic_hardlink_overwrite(path, target, state, options)
+                } else {
+                    debug!(
+                        "Failed to hard link `{}` to `{}`: {}; falling back to copy",
+                        path.display(),
+                        target.display(),
+                        err
+                    );
+                    warn_user_once!(
+                        "Failed to hardlink files; falling back to full copy. This may lead to degraded performance.\n         \
+                        If the cache and target directories are on different filesystems, hardlinking may not be supported.\n         \
+                        If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
+                    );
+                    link_file(path, target, state.next_mode(), options)
+                }
+            } else {
+                Ok(state.mode_working())
+            }
         }
-        Err(err) if state.attempt == LinkAttempt::Initial => {
-            debug!(
-                "Failed to hard link `{}` to `{}`: {}; falling back to copy",
-                path.display(),
-                target.display(),
-                err
-            );
-            warn_user_once!(
-                "Failed to hardlink files; falling back to full copy. This may lead to degraded performance.\n         \
-                If the cache and target directories are on different filesystems, hardlinking may not be supported.\n         \
-                If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
-            );
-            link_file(path, target, state.next_mode(), options)
+        LinkAttempt::Subsequent => {
+            if let Err(err) = try_hardlink_file(path, target) {
+                if err.kind() == io::ErrorKind::AlreadyExists
+                    && options.on_existing_directory == OnExistingDirectory::Merge
+                {
+                    atomic_hardlink_overwrite(path, target, state, options)
+                } else {
+                    Err(LinkError::Io(err))
+                }
+            } else {
+                Ok(state)
+            }
         }
-        Err(err) => Err(LinkError::Io(err)),
     }
 }
 
@@ -1007,34 +895,48 @@ where
         return Ok(state);
     }
 
-    match options.with_file_write(target, || create_symlink(path, target)) {
-        Ok(()) => Ok(state.mode_working()),
-        Err(err) if err.kind() == io::ErrorKind::IsADirectory => Err(err.into()),
-        Err(err)
-            if err.kind() == io::ErrorKind::AlreadyExists
-                && options.on_existing_directory == OnExistingDirectory::Merge =>
-        {
-            atomic_symlink_overwrite(path, target, state, options)
+    match state.attempt {
+        LinkAttempt::Initial => {
+            if let Err(err) = create_symlink(path, target) {
+                if err.kind() == io::ErrorKind::AlreadyExists
+                    && options.on_existing_directory == OnExistingDirectory::Merge
+                {
+                    atomic_symlink_overwrite(path, target, state, options)
+                } else {
+                    debug!(
+                        "Failed to symlink `{}` to `{}`: {}; falling back to copy",
+                        path.display(),
+                        target.display(),
+                        err
+                    );
+                    warn_user_once!(
+                        "Failed to symlink files; falling back to full copy. This may lead to degraded performance.\n         \
+                        If the cache and target directories are on different filesystems, symlinking may not be supported.\n         \
+                        If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
+                    );
+                    link_file(path, target, state.next_mode(), options)
+                }
+            } else {
+                Ok(state.mode_working())
+            }
         }
-        Err(err) if state.attempt == LinkAttempt::Initial => {
-            debug!(
-                "Failed to symlink `{}` to `{}`: {}; falling back to copy",
-                path.display(),
-                target.display(),
-                err
-            );
-            warn_user_once!(
-                "Failed to symlink files; falling back to full copy. This may lead to degraded performance.\n         \
-                If the cache and target directories are on different filesystems, symlinking may not be supported.\n         \
-                If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
-            );
-            link_file(path, target, state.next_mode(), options)
+        LinkAttempt::Subsequent => {
+            if let Err(err) = create_symlink(path, target) {
+                if err.kind() == io::ErrorKind::AlreadyExists
+                    && options.on_existing_directory == OnExistingDirectory::Merge
+                {
+                    atomic_symlink_overwrite(path, target, state, options)
+                } else {
+                    Err(LinkError::Symlink {
+                        from: path.to_path_buf(),
+                        to: target.to_path_buf(),
+                        err,
+                    })
+                }
+            } else {
+                Ok(state)
+            }
         }
-        Err(err) => Err(LinkError::Symlink {
-            from: path.to_path_buf(),
-            to: target.to_path_buf(),
-            err,
-        }),
     }
 }
 
@@ -1043,25 +945,18 @@ fn copy_file<F>(path: &Path, target: &Path, options: &LinkOptions<'_, F>) -> Res
 where
     F: Fn(&Path) -> bool,
 {
-    options.with_file_write(target, || {
-        options
-            .copy_file(path, target)
-            .map_err(|err| LinkError::Copy {
-                to: target.to_path_buf(),
-                err,
-            })
-    })
+    options
+        .copy_file(path, target)
+        .map_err(|err| LinkError::Copy {
+            to: target.to_path_buf(),
+            err,
+        })
 }
 
 /// Try to create a hard link, handling `TooManyLinks` (EMLINK/`ERROR_TOO_MANY_LINKS`)
 /// by copying the source to a fresh inode and retrying.
-/// The callback lets callers guard link creation without holding the guard while copying.
-fn try_hardlink_file(
-    src: &Path,
-    dst: &Path,
-    link: impl Fn(&Path, &Path) -> io::Result<()>,
-) -> io::Result<()> {
-    match link(src, dst) {
+fn try_hardlink_file(src: &Path, dst: &Path) -> io::Result<()> {
+    match fs_err::hard_link(src, dst) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::TooManyLinks => {
             debug!(
@@ -1078,7 +973,7 @@ fn try_hardlink_file(
             fs_err::copy(src, temp.path())?;
             // Linking a copy before renaming avoids the unlikely race where another process could
             // exhaust the fresh inode's links between the rename and our link.
-            link(temp.path(), dst)?;
+            fs_err::hard_link(temp.path(), dst)?;
             fs_err::rename(temp.path(), src)?;
             Ok(())
         }
@@ -1102,8 +997,8 @@ where
     let tempdir = tempfile::tempdir_in(parent)?;
     let tempfile = tempdir.path().join(dst.file_name().unwrap());
 
-    if try_hardlink_file(src, &tempfile, |from, to| fs_err::hard_link(from, to)).is_ok() {
-        options.with_file_write(dst, || fs_err::rename(&tempfile, dst))?;
+    if try_hardlink_file(src, &tempfile).is_ok() {
+        fs_err::rename(&tempfile, dst)?;
         Ok(state.mode_working())
     } else {
         debug!(
@@ -1142,7 +1037,7 @@ where
             to: tempfile.clone(),
             err,
         })?;
-    options.with_file_write(dst, || fs_err::rename(&tempfile, dst))?;
+    fs_err::rename(&tempfile, dst)?;
     Ok(())
 }
 
@@ -1163,7 +1058,7 @@ where
     let tempfile = tempdir.path().join(dst.file_name().unwrap());
 
     if create_symlink(src, &tempfile).is_ok() {
-        options.with_file_write(dst, || fs_err::rename(&tempfile, dst))?;
+        fs_err::rename(&tempfile, dst)?;
         Ok(state.mode_working())
     } else {
         debug!(
@@ -1201,9 +1096,6 @@ fn create_symlink(original: &Path, link: &Path) -> io::Result<()> {
 #[expect(clippy::print_stderr)]
 mod tests {
     use std::assert_matches;
-    use std::sync::mpsc;
-    use std::thread;
-    use std::time::Duration;
 
     use super::*;
     use tempfile::TempDir;
@@ -1323,172 +1215,6 @@ mod tests {
         // If symlink succeeded, verify files are symlinks
         if result == LinkMode::Symlink {
             assert!(dst_dir.path().join("file1.txt").is_symlink());
-        }
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_directory_symlinks_fail_preserves_existing() {
-        let src_dir = test_tempdir();
-        let existing_dir = test_tempdir();
-        let dst_dir = test_tempdir();
-
-        fs_err::create_dir_all(src_dir.path().join("package")).unwrap();
-        fs_err::write(src_dir.path().join("package/new.txt"), "new").unwrap();
-        fs_err::write(existing_dir.path().join("existing.txt"), "existing").unwrap();
-        create_symlink(existing_dir.path(), &dst_dir.path().join("package")).unwrap();
-
-        let options = LinkOptions::new(LinkMode::Symlink)
-            .with_directory_symlinks()
-            .with_on_existing_directory(OnExistingDirectory::Fail);
-        let result = link_dir(src_dir.path(), dst_dir.path(), &options);
-
-        assert_matches!(result, Err(LinkError::Symlink { err, .. }) if err.kind() == io::ErrorKind::AlreadyExists);
-        assert_eq!(
-            fs_err::read_link(dst_dir.path().join("package")).unwrap(),
-            existing_dir.path()
-        );
-        assert!(!existing_dir.path().join("new.txt").exists());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_directory_symlinks_reject_files_without_locks() -> io::Result<()> {
-        let src_dir = test_tempdir();
-        let existing_dir = test_tempdir();
-        let dst_dir = test_tempdir();
-
-        fs_err::write(src_dir.path().join("package"), "new file")?;
-        fs_err::write(existing_dir.path().join("existing.txt"), "existing")?;
-        create_symlink(existing_dir.path(), &dst_dir.path().join("package"))?;
-
-        for mode in [
-            LinkMode::Clone,
-            LinkMode::Copy,
-            LinkMode::Hardlink,
-            LinkMode::Symlink,
-        ] {
-            let options = LinkOptions::new(mode)
-                .with_directory_symlinks()
-                .with_on_existing_directory(OnExistingDirectory::Merge);
-            let result = link_dir(src_dir.path(), dst_dir.path(), &options);
-
-            assert_matches!(result, Err(LinkError::Io(err)) if err.kind() == io::ErrorKind::IsADirectory);
-            assert_eq!(
-                fs_err::read_link(dst_dir.path().join("package"))?,
-                existing_dir.path()
-            );
-        }
-        assert_eq!(
-            fs_err::read_to_string(existing_dir.path().join("existing.txt"))?,
-            "existing"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_shared_namespace_entries_install_concurrently() -> Result<(), LinkError> {
-        let sources = [test_tempdir(), test_tempdir(), test_tempdir()];
-        let destination = test_tempdir();
-        let locks = CopyLocks::default();
-        let files = [
-            "shared/child_0/file.txt",
-            "shared/child_1/file.txt",
-            "shared/file.txt",
-        ];
-
-        fs_err::create_dir_all(destination.path().join("shared"))?;
-        for (source, file) in sources.iter().zip(files) {
-            let path = source.path().join(file);
-            if let Some(parent) = path.parent() {
-                fs_err::create_dir_all(parent)?;
-            }
-            fs_err::write(path, "content")?;
-        }
-
-        let (entered_sender, entered_receiver) = mpsc::channel();
-        let all_entered = thread::scope(|scope| -> Result<bool, LinkError> {
-            let mut releases = Vec::new();
-            let mut handles = Vec::new();
-            let mut directories_entered = false;
-            for (index, source) in sources.iter().enumerate() {
-                if index == 2 {
-                    directories_entered = (0..2).all(|_| {
-                        entered_receiver
-                            .recv_timeout(Duration::from_secs(10))
-                            .is_ok()
-                    });
-                }
-                let entered_sender = entered_sender.clone();
-                let (release_sender, release_receiver) = mpsc::channel::<()>();
-                releases.push(release_sender);
-                let destination = destination.path();
-                let locks = &locks;
-                handles.push(scope.spawn(move || {
-                    let options = LinkOptions::new(LinkMode::Hardlink)
-                        .with_directory_symlinks()
-                        .with_copy_locks(locks)
-                        .with_on_existing_directory(OnExistingDirectory::Merge)
-                        .with_mutable_copy_filter(|path| {
-                            if index < 2 && path.ends_with("file.txt") {
-                                let _ = entered_sender.send(());
-                                let _ = release_receiver.recv();
-                            }
-                            false
-                        });
-                    let result = link_dir(source.path(), destination, &options);
-                    if index == 2 {
-                        let _ = entered_sender.send(());
-                    }
-                    result
-                }));
-            }
-
-            // Both directories must enter and the sibling file must finish before either directory
-            // is released. Always release before joining, even if a parent lock blocked progress.
-            let all_entered = directories_entered
-                && entered_receiver
-                    .recv_timeout(Duration::from_secs(10))
-                    .is_ok();
-            drop(releases);
-            for handle in handles {
-                handle
-                    .join()
-                    .map_err(|_| io::Error::other("Namespace installation thread panicked"))??;
-            }
-            Ok(all_entered)
-        })?;
-
-        assert!(all_entered, "Shared namespace serialized disjoint entries");
-        for file in files {
-            assert_eq!(
-                fs_err::read_to_string(destination.path().join(file))?,
-                "content"
-            );
-        }
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_directory_symlinks_onto_self() {
-        let src_dir = test_tempdir();
-        let aliases = test_tempdir();
-
-        create_test_tree(src_dir.path());
-        let alias = aliases.path().join("source");
-        create_symlink(src_dir.path(), &alias).unwrap();
-
-        let options = LinkOptions::new(LinkMode::Symlink)
-            .with_directory_symlinks()
-            .with_on_existing_directory(OnExistingDirectory::Merge);
-        for target in [src_dir.path(), alias.as_path()] {
-            let result = link_dir(src_dir.path(), target, &options);
-
-            assert_matches!(result, Err(LinkError::Io(err)) if err.kind() == io::ErrorKind::InvalidInput);
-            assert!(!src_dir.path().join("file1.txt").is_symlink());
-            assert!(!src_dir.path().join("subdir").is_symlink());
-            verify_test_tree(src_dir.path());
         }
     }
 

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -69,11 +69,6 @@ pub enum OnExistingDirectory {
 
 /// Link a directory tree from `src` to `dst` using the mode in `options`.
 ///
-/// [`LinkMode::Symlink`] links top-level directories without inspecting their contents. Shared
-/// directory links are fully expanded before merging, regardless of the requested mode. Source
-/// trees must not contain directory symlinks. Concurrent writers must share [`CopyLocks`] and a
-/// destination root, and prepare package directories before writing below them.
-///
 /// Returns the [`LinkMode`] that was actually used, which may differ from the requested mode if a
 /// fallback was needed, e.g., if hard linking was requested but the source and destination are on
 /// different filesystems.

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -163,11 +163,9 @@ pub struct CopyLocks {
 }
 
 impl CopyLocks {
-    /// Serialize top-level directory creation and expansion with writes to sibling entries.
+    /// Serialize changes to sibling directory entries.
     ///
     /// Lock the canonical parent so scheme aliases and case-insensitive names share a lock.
-    /// Release it before installing files beneath a real directory: real directories never become
-    /// links, and expanding a directory link leaves no directory links below it.
     pub fn with_directory_lock<T, E>(
         &self,
         path: &Path,
@@ -339,10 +337,9 @@ fn check_file_destination(path: &Path) -> io::Result<()> {
 
 /// Replace a directory symlink with real directories and symlinks to individual files.
 ///
-/// Missing paths and non-links are unchanged. The expanded directory never becomes a link again.
+/// Missing paths and non-links are unchanged.
 /// Files matching `needs_mutable_copy` are copied instead of linked.
 /// If writes can overlap, hold [`CopyLocks::with_directory_lock`] for `path` throughout this call.
-/// Replacing the link briefly removes its name before publishing the expanded directory.
 pub fn materialize_symlink_dir(
     path: &Path,
     needs_mutable_copy: impl Fn(&Path) -> bool,

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -363,6 +363,8 @@ impl<'a, F> LinkOptions<'a, F> {
     /// directory or an ancestor. Existing directory links are expanded only where merging is needed.
     /// The filter must select every top-level directory containing mutable files: the contents
     /// of directories eligible for linking are not inspected.
+    /// Source trees must not contain directory symlinks. Concurrent overlapping installs must share a
+    /// destination root and prepare ancestor directories before writing below them.
     #[must_use]
     pub fn with_directory_symlinks(mut self) -> Self {
         self.directory_symlinks = true;
@@ -437,11 +439,11 @@ where
             continue;
         }
 
+        let directory_symlinks = directory_symlinks && !(options.needs_mutable_copy)(&path);
         let operation = || {
-            let directory_symlinks = directory_symlinks && !(options.needs_mutable_copy)(&path);
             if state.mode == LinkMode::Symlink && directory_symlinks {
                 match create_symlink(&path, &target) {
-                    Ok(()) => return Ok(LinkMode::Symlink),
+                    Ok(()) => return Ok(Some(LinkMode::Symlink)),
                     Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                         if options.on_existing_directory == OnExistingDirectory::Fail {
                             return Err(LinkError::Symlink {
@@ -462,30 +464,39 @@ where
             match fs_err::symlink_metadata(&target) {
                 Ok(_) => {
                     materialize_symlink_dir(&target)?;
-                    return link_dir_entries(
-                        &path,
-                        &target,
-                        state.mode,
-                        directory_symlinks,
-                        options,
-                    );
+                    return Ok(None);
                 }
                 Err(err) if err.kind() == io::ErrorKind::NotFound => {}
                 Err(err) => return Err(err.into()),
             }
 
-            // This subtree is new and cannot contain directory links that need expanding.
+            // The ancestor lock reserves this new subtree until the bulk install finishes.
+            // Wheel contents are regular files and directories, and other installers must
+            // prepare this ancestor before writing below it, so per-file guards are redundant.
+            let subtree_options = LinkOptions {
+                mode: options.mode,
+                needs_mutable_copy: &options.needs_mutable_copy,
+                copy_locks: options.copy_locks,
+                on_existing_directory: options.on_existing_directory,
+                directory_symlinks: options.directory_symlinks && options.copy_locks.is_none(),
+            };
             match state.mode {
-                LinkMode::Clone => clone_dir(&path, &target, options),
-                mode => walk_and_link(&path, &target, mode, options),
+                LinkMode::Clone => clone_dir(&path, &target, &subtree_options),
+                mode => walk_and_link(&path, &target, mode, &subtree_options),
             }
+            .map(Some)
         };
         let mode = if let Some(locks) = options.copy_locks {
             locks.with_directory_lock(&target, operation)?
         } else {
             operation()?
         };
-        state = LinkState::new(mode);
+        // A real directory stays real throughout installation. Release its lock before descending
+        // so wheels sharing a namespace can install independent children concurrently.
+        state = LinkState::new(match mode {
+            Some(mode) => mode,
+            None => link_dir_entries(&path, &target, state.mode, directory_symlinks, options)?,
+        });
     }
     Ok(state.mode)
 }
@@ -1243,6 +1254,9 @@ fn create_symlink(original: &Path, link: &Path) -> io::Result<()> {
 #[expect(clippy::print_stderr)]
 mod tests {
     use std::assert_matches;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
 
     use super::*;
     use tempfile::TempDir;
@@ -1422,6 +1436,79 @@ mod tests {
             fs_err::read_to_string(existing_dir.path().join("existing.txt"))?,
             "existing"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_shared_namespace_children_install_concurrently() -> Result<(), LinkError> {
+        let sources = [test_tempdir(), test_tempdir()];
+        let destination = test_tempdir();
+        let locks = CopyLocks::default();
+
+        fs_err::create_dir_all(destination.path().join("shared"))?;
+        for (index, source) in sources.iter().enumerate() {
+            let directory = source.path().join(format!("shared/child_{index}"));
+            fs_err::create_dir_all(&directory)?;
+            fs_err::write(directory.join("file.txt"), "content")?;
+        }
+
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let both_entered = thread::scope(|scope| -> Result<bool, LinkError> {
+            let mut releases = Vec::new();
+            let mut handles = Vec::new();
+            for (index, source) in sources.iter().enumerate() {
+                let child = format!("child_{index}");
+                let entered_sender = entered_sender.clone();
+                let (release_sender, release_receiver) = mpsc::channel::<()>();
+                releases.push(release_sender);
+                let destination = destination.path();
+                let locks = &locks;
+                handles.push(scope.spawn(move || {
+                    let options = LinkOptions::new(LinkMode::Copy)
+                        .with_directory_symlinks()
+                        .with_copy_locks(locks)
+                        .with_on_existing_directory(OnExistingDirectory::Merge)
+                        .with_mutable_copy_filter(|path| {
+                            if path.ends_with(&child) {
+                                let _ = entered_sender.send(());
+                                let _ = release_receiver.recv();
+                            }
+                            false
+                        });
+                    link_dir(source.path(), destination, &options)
+                }));
+            }
+
+            // Both children must enter before either is released. Always release before joining,
+            // including when an ancestor lock prevented the second child from making progress.
+            let both_entered = (0..2).all(|_| {
+                entered_receiver
+                    .recv_timeout(Duration::from_secs(10))
+                    .is_ok()
+            });
+            drop(releases);
+            for handle in handles {
+                handle
+                    .join()
+                    .map_err(|_| io::Error::other("Namespace installation thread panicked"))??;
+            }
+            Ok(both_entered)
+        })?;
+
+        assert!(
+            both_entered,
+            "Shared namespace serialized disjoint children"
+        );
+        for index in 0..2 {
+            assert_eq!(
+                fs_err::read_to_string(
+                    destination
+                        .path()
+                        .join(format!("shared/child_{index}/file.txt"))
+                )?,
+                "content"
+            );
+        }
         Ok(())
     }
 

--- a/crates/uv-install-wheel/Cargo.toml
+++ b/crates/uv-install-wheel/Cargo.toml
@@ -30,9 +30,11 @@ uv-shell = { workspace = true }
 uv-trampoline-builder = { workspace = true }
 uv-warnings = { workspace = true }
 
+cap-primitives = { workspace = true }
 configparser = { workspace = true }
 csv = { workspace = true }
 data-encoding = { workspace = true }
+fastrand = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
 mailparse = { workspace = true }

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -4,7 +4,10 @@ use std::io;
 use std::ops::ControlFlow;
 use std::path::{Component, Path, PathBuf};
 
-use crate::Layout;
+use uv_fs::link::materialize_symlink_dir;
+
+use crate::linker::InstallState;
+use crate::{Error, Layout};
 
 /// Resolve installation-scheme aliases without following package directory links into the cache.
 pub(crate) struct LibraryDirectories {
@@ -34,6 +37,22 @@ impl LibraryDirectories {
         self.roots
             .iter()
             .any(|(_, root)| path != root && path.starts_with(root))
+    }
+
+    /// Create an installation directory, expanding package links before writing beneath them.
+    pub(crate) fn prepare(&self, path: &Path, state: &InstallState) -> Result<(), Error> {
+        let resolved = self.resolve(path, |directory| {
+            state.copy_locks().with_directory_lock(directory, || {
+                materialize_symlink_dir(directory)?;
+                fs_err::create_dir_all(directory)?;
+                Ok::<_, Error>(ControlFlow::<Infallible>::Continue(()))
+            })
+        })?;
+        match resolved {
+            ControlFlow::Continue(directory) => fs_err::create_dir_all(directory)?,
+            ControlFlow::Break(never) => match never {},
+        }
+        Ok(())
     }
 
     /// Visit directory components inside the libraries before following their symlinks.

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path, PathBuf};
 
 use uv_fs::link::{CopyLocks, materialize_symlink_dir};
 
+use crate::linker::needs_mutable_copy;
 use crate::{Error, Layout};
 
 /// Resolve installation-scheme aliases without following package directory links into the cache.
@@ -58,7 +59,7 @@ impl LibraryDirectories {
                 return Ok(ControlFlow::Continue(()));
             }
             locks.with_directory_lock(directory, || {
-                materialize_symlink_dir(directory)?;
+                materialize_symlink_dir(directory, needs_mutable_copy)?;
                 fs_err::create_dir_all(directory)?;
                 Ok::<_, Error>(ControlFlow::<Infallible>::Continue(()))
             })

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -9,11 +9,9 @@ use uv_fs::link::{CopyLocks, materialize_symlink_dir};
 use crate::linker::needs_mutable_copy;
 use crate::{Error, Layout};
 
-/// Resolve installation-scheme aliases without following package directory links into the cache.
+/// Resolve scheme aliases, such as `lib64 -> lib`, while letting callers handle package links.
 ///
-/// Scheme aliases such as `lib64 -> lib` are followed. Links below a library root, such as
-/// `site-packages/numpy -> <cache>/numpy`, are handled by the caller before traversal can enter
-/// the cache. Scheme aliases must remain stable while this resolver is in use.
+/// Scheme aliases must remain stable during resolution.
 pub(crate) struct LibraryDirectories {
     /// Library roots as (logical path, resolved path) pairs.
     roots: Vec<(PathBuf, PathBuf)>,
@@ -87,8 +85,7 @@ impl LibraryDirectories {
         E: From<io::Error>,
     {
         let path = std::path::absolute(path)?;
-        // Most RECORD paths start with a known library root. Avoid inspecting the same scheme
-        // directories for every file, while still visiting every package directory below them.
+        // Skip scheme traversal for paths starting with a known library root.
         let (mut resolved, relative) = self
             .roots
             .iter()

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -4,18 +4,22 @@ use std::io;
 use std::ops::ControlFlow;
 use std::path::{Component, Path, PathBuf};
 
-use uv_fs::link::materialize_symlink_dir;
+use uv_fs::link::{CopyLocks, materialize_symlink_dir};
 
-use crate::linker::InstallState;
 use crate::{Error, Layout};
 
 /// Resolve installation-scheme aliases without following package directory links into the cache.
+///
+/// Scheme aliases such as `lib64 -> lib` are followed. Links below a library root, such as
+/// `site-packages/numpy -> <cache>/numpy`, are handled by the caller before traversal can enter
+/// the cache. Scheme aliases must remain stable while this resolver is in use.
 pub(crate) struct LibraryDirectories {
     roots: Vec<(PathBuf, PathBuf)>,
 }
 
 impl LibraryDirectories {
-    /// Remember both spellings of the library roots, including roots that do not exist yet.
+    /// Cache both scheme and resolved root spellings so RECORD paths can skip repeated scheme
+    /// traversal. Existing ancestors are resolved even when the library directory does not exist yet.
     pub(crate) fn new(layout: &Layout) -> io::Result<Self> {
         let directories = Self { roots: Vec::new() };
         let mut roots = Vec::with_capacity(2);
@@ -40,9 +44,12 @@ impl LibraryDirectories {
     }
 
     /// Create an installation directory, expanding package links before writing beneath them.
-    pub(crate) fn prepare(&self, path: &Path, state: &InstallState) -> Result<(), Error> {
+    ///
+    /// Call this for a file's parent before publishing with the same [`CopyLocks`]. Each package
+    /// directory is expanded under its lock before traversal reaches its children.
+    pub(crate) fn prepare(&self, path: &Path, locks: &CopyLocks) -> Result<(), Error> {
         let resolved = self.resolve(path, |directory| {
-            state.copy_locks().with_directory_lock(directory, || {
+            locks.with_directory_lock(directory, || {
                 materialize_symlink_dir(directory)?;
                 fs_err::create_dir_all(directory)?;
                 Ok::<_, Error>(ControlFlow::<Infallible>::Continue(()))
@@ -55,12 +62,14 @@ impl LibraryDirectories {
         Ok(())
     }
 
-    /// Visit directory components inside the libraries before following their symlinks.
+    /// Resolve a directory path, visiting components below library roots before following their links.
     ///
-    /// The visitor must either leave a real directory or stop traversal. Installers expand links
-    /// under their directory lock; uninstallers stop at the first link and remove the link itself.
-    /// Aliases outside the libraries are followed component by component, since an alias can point
-    /// inside a package whose directory is still linked to the cache.
+    /// Visits run from parent to child. Returning [`ControlFlow::Continue`] requires the component
+    /// to be a real directory; [`ControlFlow::Break`] stops before its descendants are inspected.
+    /// Callers handling files must pass the parent path, leaving the final filename unresolved.
+    ///
+    /// Scheme aliases are followed component by component: an alias may point below a package link,
+    /// so canonicalizing the whole path could enter the cache before the visitor can handle it.
     pub(crate) fn resolve<B, E>(
         &self,
         path: &Path,

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -14,6 +14,7 @@ use crate::{Error, Layout};
 /// `site-packages/numpy -> <cache>/numpy`, are handled by the caller before traversal can enter
 /// the cache. Scheme aliases must remain stable while this resolver is in use.
 pub(crate) struct LibraryDirectories {
+    /// Library roots as (logical path, resolved path) pairs.
     roots: Vec<(PathBuf, PathBuf)>,
 }
 

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -1,0 +1,118 @@
+use std::collections::VecDeque;
+use std::convert::Infallible;
+use std::io;
+use std::ops::ControlFlow;
+use std::path::{Component, Path, PathBuf};
+
+use crate::Layout;
+
+/// Resolve installation-scheme aliases without following package directory links into the cache.
+pub(crate) struct LibraryDirectories {
+    roots: Vec<(PathBuf, PathBuf)>,
+}
+
+impl LibraryDirectories {
+    /// Remember both spellings of the library roots, including roots that do not exist yet.
+    pub(crate) fn new(layout: &Layout) -> io::Result<Self> {
+        let directories = Self { roots: Vec::new() };
+        let mut roots = Vec::with_capacity(2);
+        for path in [&layout.scheme.purelib, &layout.scheme.platlib] {
+            let path = std::path::absolute(path)?;
+            let resolved = match directories.resolve(&path, |_| {
+                Ok::<_, io::Error>(ControlFlow::<Infallible>::Continue(()))
+            })? {
+                ControlFlow::Continue(resolved) => resolved,
+                ControlFlow::Break(never) => match never {},
+            };
+            roots.push((path, resolved));
+        }
+        Ok(Self { roots })
+    }
+
+    /// Whether a resolved path is strictly inside a library directory.
+    pub(crate) fn contains(&self, path: &Path) -> bool {
+        self.roots
+            .iter()
+            .any(|(_, root)| path != root && path.starts_with(root))
+    }
+
+    /// Visit directory components inside the libraries before following their symlinks.
+    ///
+    /// The visitor must either leave a real directory or stop traversal. Installers expand links
+    /// under their directory lock; uninstallers stop at the first link and remove the link itself.
+    /// Aliases outside the libraries are followed component by component, since an alias can point
+    /// inside a package whose directory is still linked to the cache.
+    pub(crate) fn resolve<B, E>(
+        &self,
+        path: &Path,
+        mut visit: impl FnMut(&Path) -> Result<ControlFlow<B>, E>,
+    ) -> Result<ControlFlow<B, PathBuf>, E>
+    where
+        E: From<io::Error>,
+    {
+        let path = std::path::absolute(path)?;
+        // Most RECORD paths start with a known library root. Avoid inspecting the same scheme
+        // directories for every file, while still visiting every package directory below them.
+        let (mut resolved, relative) = self
+            .roots
+            .iter()
+            .filter_map(|(logical, resolved)| {
+                path.strip_prefix(logical)
+                    .or_else(|_| path.strip_prefix(resolved))
+                    .ok()
+                    .map(|relative| (resolved.clone(), relative))
+            })
+            .min_by_key(|(_, relative)| relative.as_os_str().len())
+            .unwrap_or_else(|| (PathBuf::new(), path.as_path()));
+        let mut pending: VecDeque<_> = relative
+            .components()
+            .map(|component| component.as_os_str().to_owned())
+            .collect();
+        let mut followed_symlinks = 0;
+        while let Some(component) = pending.pop_front() {
+            match Path::new(&component).components().next() {
+                Some(Component::ParentDir) => {
+                    resolved.pop();
+                }
+                Some(Component::CurDir) | None => {}
+                Some(Component::Prefix(_) | Component::RootDir) => resolved.push(component),
+                Some(Component::Normal(_)) => {
+                    resolved.push(component);
+                    if self.contains(&resolved) {
+                        if let ControlFlow::Break(value) = visit(&resolved)? {
+                            return Ok(ControlFlow::Break(value));
+                        }
+                        continue;
+                    }
+                    match fs_err::symlink_metadata(&resolved) {
+                        Ok(metadata) if metadata.file_type().is_symlink() => {
+                            followed_symlinks += 1;
+                            if followed_symlinks > 40 {
+                                return Err(io::Error::other(format!(
+                                    "Too many directory symlinks while resolving {}",
+                                    path.display()
+                                ))
+                                .into());
+                            }
+                            let target = fs_err::read_link(&resolved)?;
+                            resolved.pop();
+                            for component in target.components().rev() {
+                                pending.push_front(component.as_os_str().to_owned());
+                            }
+                        }
+                        // This component is not a package link. Canonicalizing a real directory
+                        // also recovers its spelling on case-insensitive filesystems before we
+                        // compare descendants with the library roots.
+                        Ok(metadata) if metadata.is_dir() => {
+                            resolved = fs_err::canonicalize(&resolved)?;
+                        }
+                        Ok(_) => {}
+                        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                        Err(err) => return Err(err.into()),
+                    }
+                }
+            }
+        }
+        Ok(ControlFlow::Continue(resolved))
+    }
+}

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -18,6 +18,10 @@ pub(crate) struct LibraryDirectories {
 }
 
 impl LibraryDirectories {
+    pub(crate) fn roots(&self) -> impl Iterator<Item = &Path> {
+        self.roots.iter().map(|(_, resolved)| resolved.as_path())
+    }
+
     /// Cache both scheme and resolved root spellings so RECORD paths can skip repeated scheme
     /// traversal. Existing ancestors are resolved even when the library directory does not exist yet.
     pub(crate) fn new(layout: &Layout) -> io::Result<Self> {

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -71,7 +71,8 @@ impl LibraryDirectories {
 
     /// Resolve a directory path, visiting each component below library roots before following links.
     ///
-    /// Visits run from parent to child. [`ControlFlow::Break`] stops before inspecting descendants.
+    /// Visits run from parent to child. The visitor must handle directory links before continuing
+    /// into their descendants; [`ControlFlow::Break`] skips those descendants.
     /// Callers handling files must pass the parent path, leaving the final filename unresolved.
     ///
     /// Scheme aliases are followed component by component: an alias may point below a package link,

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -50,6 +50,13 @@ impl LibraryDirectories {
     /// directories are fully expanded under their lock before traversal reaches their children.
     pub(crate) fn prepare(&self, path: &Path, locks: &CopyLocks) -> Result<(), Error> {
         let resolved = self.resolve(path, |directory| {
+            if !self
+                .roots
+                .iter()
+                .any(|(_, root)| directory.parent() == Some(root.as_path()))
+            {
+                return Ok(ControlFlow::Continue(()));
+            }
             locks.with_directory_lock(directory, || {
                 materialize_symlink_dir(directory)?;
                 fs_err::create_dir_all(directory)?;
@@ -63,10 +70,9 @@ impl LibraryDirectories {
         Ok(())
     }
 
-    /// Resolve a directory path, visiting top-level package directories before following their links.
+    /// Resolve a directory path, visiting each component below library roots before following links.
     ///
-    /// Returning [`ControlFlow::Continue`] requires the package tree to contain only real directories;
-    /// [`ControlFlow::Break`] stops before its descendants are inspected.
+    /// Visits run from parent to child. [`ControlFlow::Break`] stops before inspecting descendants.
     /// Callers handling files must pass the parent path, leaving the final filename unresolved.
     ///
     /// Scheme aliases are followed component by component: an alias may point below a package link,
@@ -108,12 +114,7 @@ impl LibraryDirectories {
                 Some(Component::Normal(_)) => {
                     resolved.push(component);
                     if self.contains(&resolved) {
-                        if self
-                            .roots
-                            .iter()
-                            .any(|(_, root)| resolved.parent() == Some(root.as_path()))
-                            && let ControlFlow::Break(value) = visit(&resolved)?
-                        {
+                        if let ControlFlow::Break(value) = visit(&resolved)? {
                             return Ok(ControlFlow::Break(value));
                         }
                         continue;

--- a/crates/uv-install-wheel/src/directory.rs
+++ b/crates/uv-install-wheel/src/directory.rs
@@ -45,8 +45,8 @@ impl LibraryDirectories {
 
     /// Create an installation directory, expanding package links before writing beneath them.
     ///
-    /// Call this for a file's parent before publishing with the same [`CopyLocks`]. Each package
-    /// directory is expanded under its lock before traversal reaches its children.
+    /// Call this for a file's parent before publishing with the same [`CopyLocks`]. Top-level package
+    /// directories are fully expanded under their lock before traversal reaches their children.
     pub(crate) fn prepare(&self, path: &Path, locks: &CopyLocks) -> Result<(), Error> {
         let resolved = self.resolve(path, |directory| {
             locks.with_directory_lock(directory, || {
@@ -62,10 +62,10 @@ impl LibraryDirectories {
         Ok(())
     }
 
-    /// Resolve a directory path, visiting components below library roots before following their links.
+    /// Resolve a directory path, visiting top-level package directories before following their links.
     ///
-    /// Visits run from parent to child. Returning [`ControlFlow::Continue`] requires the component
-    /// to be a real directory; [`ControlFlow::Break`] stops before its descendants are inspected.
+    /// Returning [`ControlFlow::Continue`] requires the package tree to contain only real directories;
+    /// [`ControlFlow::Break`] stops before its descendants are inspected.
     /// Callers handling files must pass the parent path, leaving the final filename unresolved.
     ///
     /// Scheme aliases are followed component by component: an alias may point below a package link,
@@ -107,7 +107,12 @@ impl LibraryDirectories {
                 Some(Component::Normal(_)) => {
                     resolved.push(component);
                     if self.contains(&resolved) {
-                        if let ControlFlow::Break(value) = visit(&resolved)? {
+                        if self
+                            .roots
+                            .iter()
+                            .any(|(_, root)| resolved.parent() == Some(root.as_path()))
+                            && let ControlFlow::Break(value) = visit(&resolved)?
+                        {
                             return Ok(ControlFlow::Break(value));
                         }
                         continue;

--- a/crates/uv-install-wheel/src/install.rs
+++ b/crates/uv-install-wheel/src/install.rs
@@ -100,13 +100,14 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
 
     let (console_scripts, gui_scripts) =
         parse_scripts(wheel, &dist_info_prefix, None, layout.python_version.1)?;
+    let locks = state.copy_locks();
 
     if console_scripts.is_empty() && gui_scripts.is_empty() {
         trace!(?name, "No entrypoints");
     } else {
         trace!(?name, "Writing entrypoints");
 
-        LibraryDirectories::new(layout)?.prepare(&layout.scheme.scripts, state)?;
+        LibraryDirectories::new(layout)?.prepare(&layout.scheme.scripts, locks)?;
         write_script_entrypoints(
             layout,
             relocatable,
@@ -114,7 +115,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
             &console_scripts,
             &mut record,
             false,
-            state,
+            locks,
         )?;
         write_script_entrypoints(
             layout,
@@ -123,7 +124,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
             &gui_scripts,
             &mut record,
             true,
-            state,
+            locks,
         )?;
     }
 
@@ -140,7 +141,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
             &console_scripts,
             &gui_scripts,
             &mut record,
-            state,
+            locks,
         )?;
         // 2.c If applicable, update scripts starting with #!python to point to the correct interpreter.
         // Script are unsupported through data

--- a/crates/uv-install-wheel/src/install.rs
+++ b/crates/uv-install-wheel/src/install.rs
@@ -114,6 +114,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
             &console_scripts,
             &mut record,
             false,
+            state,
         )?;
         write_script_entrypoints(
             layout,
@@ -122,6 +123,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
             &gui_scripts,
             &mut record,
             true,
+            state,
         )?;
     }
 

--- a/crates/uv-install-wheel/src/install.rs
+++ b/crates/uv-install-wheel/src/install.rs
@@ -137,6 +137,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
             &console_scripts,
             &gui_scripts,
             &mut record,
+            state,
         )?;
         // 2.c If applicable, update scripts starting with #!python to point to the correct interpreter.
         // Script are unsupported through data

--- a/crates/uv-install-wheel/src/install.rs
+++ b/crates/uv-install-wheel/src/install.rs
@@ -11,6 +11,7 @@ use uv_distribution_filename::WheelFilename;
 use uv_pep440::Version;
 use uv_pypi_types::{DirectUrl, Metadata10};
 
+use crate::directory::LibraryDirectories;
 use crate::linker::{InstallState, LinkMode, link_wheel_files};
 use crate::wheel::{
     LibKind, ValidatedWheel, WheelFile, dist_info_metadata, find_dist_info, install_data,
@@ -105,7 +106,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
     } else {
         trace!(?name, "Writing entrypoints");
 
-        fs_err::create_dir_all(&layout.scheme.scripts)?;
+        LibraryDirectories::new(layout)?.prepare(&layout.scheme.scripts, state)?;
         write_script_entrypoints(
             layout,
             relocatable,

--- a/crates/uv-install-wheel/src/lib.rs
+++ b/crates/uv-install-wheel/src/lib.rs
@@ -17,6 +17,7 @@ pub use record::RecordEntry;
 pub use uninstall::{Uninstall, uninstall_egg, uninstall_legacy_editable, uninstall_wheel};
 pub use wheel::{WheelFile, read_record, read_record_into_iter, validate_and_heal_record};
 
+mod directory;
 mod install;
 mod linker;
 mod record;

--- a/crates/uv-install-wheel/src/linker.rs
+++ b/crates/uv-install-wheel/src/linker.rs
@@ -43,7 +43,7 @@ impl InstallState {
     }
 
     /// Get the underlying copy locks for use with [`uv_fs::link::link_dir`] functions.
-    fn copy_locks(&self) -> &CopyLocks {
+    pub(crate) fn copy_locks(&self) -> &CopyLocks {
         &self.locks
     }
 
@@ -261,11 +261,17 @@ pub(crate) fn link_wheel_files(
     let site_packages = site_packages.as_ref();
     register_installed_paths(wheel, state, filename)?;
 
-    // The `RECORD` file is modified during installation, so it needs a real
-    // copy rather than a link back to the cache.
+    // Keep metadata and relocated data in real directories. The `RECORD` file is modified during
+    // installation, so it also needs a private copy.
     let options = LinkOptions::new(link_mode)
-        .with_mutable_copy_filter(|p: &Path| p.ends_with("RECORD"))
+        .with_mutable_copy_filter(|path: &Path| {
+            path.ends_with("RECORD")
+                || path
+                    .extension()
+                    .is_some_and(|extension| extension == "dist-info" || extension == "data")
+        })
         .with_copy_locks(state.copy_locks())
+        .with_directory_symlinks()
         .with_on_existing_directory(OnExistingDirectory::Merge);
     let used_link_mode = link_dir(wheel, site_packages, &options)?;
 

--- a/crates/uv-install-wheel/src/linker.rs
+++ b/crates/uv-install-wheel/src/linker.rs
@@ -250,11 +250,12 @@ impl InstallState {
 
 /// Whether a wheel entry must remain writable without changing the cache.
 pub(crate) fn needs_mutable_copy(path: &Path) -> bool {
-    path.ends_with("RECORD")
-        || path.ends_with("__pycache__")
-        || path.extension().is_some_and(|extension| {
-            extension == "dist-info" || extension == "data" || extension == "pyc"
-        })
+    match path.extension() {
+        Some(extension) => extension == "dist-info" || extension == "data" || extension == "pyc",
+        None => path
+            .file_name()
+            .is_some_and(|filename| filename == "RECORD" || filename == "__pycache__"),
+    }
 }
 
 /// Extract a wheel by linking all of its files into site packages.

--- a/crates/uv-install-wheel/src/linker.rs
+++ b/crates/uv-install-wheel/src/linker.rs
@@ -248,6 +248,15 @@ impl InstallState {
     }
 }
 
+/// Whether a wheel entry must remain writable without changing the cache.
+pub(crate) fn needs_mutable_copy(path: &Path) -> bool {
+    path.ends_with("RECORD")
+        || path.ends_with("__pycache__")
+        || path.extension().is_some_and(|extension| {
+            extension == "dist-info" || extension == "data" || extension == "pyc"
+        })
+}
+
 /// Extract a wheel by linking all of its files into site packages.
 #[instrument(skip_all)]
 pub(crate) fn link_wheel_files(
@@ -261,15 +270,10 @@ pub(crate) fn link_wheel_files(
     let site_packages = site_packages.as_ref();
     register_installed_paths(wheel, state, filename)?;
 
-    // Keep metadata and relocated data in real directories. The `RECORD` file is modified during
-    // installation, so it also needs a private copy.
+    // Keep metadata and relocated data in real directories. RECORD and bytecode files need
+    // private copies because installation or recompilation can overwrite them.
     let options = LinkOptions::new(link_mode)
-        .with_mutable_copy_filter(|path: &Path| {
-            path.ends_with("RECORD")
-                || path
-                    .extension()
-                    .is_some_and(|extension| extension == "dist-info" || extension == "data")
-        })
+        .with_mutable_copy_filter(needs_mutable_copy)
         .with_copy_locks(state.copy_locks())
         .with_on_existing_directory(OnExistingDirectory::Merge);
     let used_link_mode = link_dir(wheel, site_packages, &options)?;

--- a/crates/uv-install-wheel/src/linker.rs
+++ b/crates/uv-install-wheel/src/linker.rs
@@ -271,7 +271,6 @@ pub(crate) fn link_wheel_files(
                     .is_some_and(|extension| extension == "dist-info" || extension == "data")
         })
         .with_copy_locks(state.copy_locks())
-        .with_directory_symlinks()
         .with_on_existing_directory(OnExistingDirectory::Merge);
     let used_link_mode = link_dir(wheel, site_packages, &options)?;
 

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
 use std::ops::ControlFlow;
 use std::path::{Component, Path, PathBuf};
@@ -55,6 +56,7 @@ pub fn uninstall_wheel(
     let mut visited = BTreeSet::new();
     let mut checked_directories = HashSet::new();
     let mut removed_symlinks = HashSet::new();
+    let mut resolved_parents = HashMap::new();
     for entry in &record {
         if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
             continue;
@@ -66,35 +68,40 @@ pub fn uninstall_wheel(
         let (Some(parent), Some(filename)) = (normalized.parent(), normalized.file_name()) else {
             continue;
         };
-        let ControlFlow::Continue(parent) = libraries.resolve(parent, |directory| {
-            if removed_symlinks.contains(directory) {
-                return Ok(ControlFlow::Break(()));
-            }
-            if checked_directories.contains(directory) {
-                return Ok(ControlFlow::Continue(()));
-            }
-            match fs_err::symlink_metadata(directory) {
-                Ok(metadata) if metadata.file_type().is_symlink() => {
-                    remove_symlink(directory)?;
-                    trace!("Removed directory link: {}", directory.display());
-                    removed_symlinks.insert(directory.to_path_buf());
-                    if let Some(parent) = directory.parent() {
-                        visited.insert(parent.to_path_buf());
+        // Reuse each parent's resolution across its RECORD entries. Uninstall only removes
+        // entries, so resolved directories cannot change identity and missing paths stay absent.
+        let resolved = match resolved_parents.entry(parent.to_path_buf()) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(libraries.resolve(parent, |directory| {
+                if removed_symlinks.contains(directory) {
+                    return Ok(ControlFlow::Break(()));
+                }
+                if checked_directories.contains(directory) {
+                    return Ok(ControlFlow::Continue(()));
+                }
+                match fs_err::symlink_metadata(directory) {
+                    Ok(metadata) if metadata.file_type().is_symlink() => {
+                        remove_symlink(directory)?;
+                        trace!("Removed directory link: {}", directory.display());
+                        removed_symlinks.insert(directory.to_path_buf());
+                        if let Some(parent) = directory.parent() {
+                            visited.insert(parent.to_path_buf());
+                        }
+                        dir_count += 1;
+                        return Ok(ControlFlow::Break(()));
                     }
-                    dir_count += 1;
-                    return Ok(ControlFlow::Break(()));
+                    Ok(_) => {
+                        checked_directories.insert(directory.to_path_buf());
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        return Ok(ControlFlow::Break(()));
+                    }
+                    Err(err) => return Err(err.into()),
                 }
-                Ok(_) => {
-                    checked_directories.insert(directory.to_path_buf());
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    return Ok(ControlFlow::Break(()));
-                }
-                Err(err) => return Err(err.into()),
-            }
-            Ok::<_, Error>(ControlFlow::Continue(()))
-        })?
-        else {
+                Ok::<_, Error>(ControlFlow::Continue(()))
+            })?),
+        };
+        let ControlFlow::Continue(parent) = resolved else {
             continue;
         };
         let path = parent.join(filename);

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -16,6 +16,10 @@ use crate::wheel::read_record;
 use crate::{Error, Layout};
 
 /// Uninstall the wheel represented by the given `.dist-info` directory.
+///
+/// Directory links below the library roots are removed once without following RECORD paths into
+/// the cache. This relies on installers expanding directories shared by multiple wheels, so a
+/// remaining link owns only this wheel's files.
 pub fn uninstall_wheel(
     dist_info: &Path,
     distribution: impl Display,
@@ -56,9 +60,8 @@ pub fn uninstall_wheel(
             continue;
         }
 
-        // Resolve scheme aliases without following package directory links into the cache.
-        // A link owns all the files beneath it, so remove it once, including nested links left
-        // beneath shared namespace directories. Keep the final file component unresolved.
+        // Resolve parents, including links beneath shared namespaces. Keep the final filename
+        // unresolved so removing a file symlink does not remove its cache target.
         let normalized = normalize_path(&site_packages.join(&entry.path));
         let (Some(parent), Some(filename)) = (normalized.parent(), normalized.file_name()) else {
             continue;
@@ -67,26 +70,27 @@ pub fn uninstall_wheel(
             if removed_symlinks.contains(directory) {
                 return Ok(ControlFlow::Break(()));
             }
-            if !checked_directories.contains(directory) {
-                match fs_err::symlink_metadata(directory) {
-                    Ok(metadata) if metadata.file_type().is_symlink() => {
-                        remove_symlink(directory)?;
-                        trace!("Removed directory link: {}", directory.display());
-                        removed_symlinks.insert(directory.to_path_buf());
-                        if let Some(parent) = directory.parent() {
-                            visited.insert(parent.to_path_buf());
-                        }
-                        dir_count += 1;
-                        return Ok(ControlFlow::Break(()));
+            if checked_directories.contains(directory) {
+                return Ok(ControlFlow::Continue(()));
+            }
+            match fs_err::symlink_metadata(directory) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    remove_symlink(directory)?;
+                    trace!("Removed directory link: {}", directory.display());
+                    removed_symlinks.insert(directory.to_path_buf());
+                    if let Some(parent) = directory.parent() {
+                        visited.insert(parent.to_path_buf());
                     }
-                    Ok(_) => {
-                        checked_directories.insert(directory.to_path_buf());
-                    }
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                        return Ok(ControlFlow::Break(()));
-                    }
-                    Err(err) => return Err(err.into()),
+                    dir_count += 1;
+                    return Ok(ControlFlow::Break(()));
                 }
+                Ok(_) => {
+                    checked_directories.insert(directory.to_path_buf());
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(ControlFlow::Break(()));
+                }
+                Err(err) => return Err(err.into()),
             }
             Ok::<_, Error>(ControlFlow::Continue(()))
         })?

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -1,23 +1,27 @@
 use std::borrow::Cow;
-use std::collections::hash_map::Entry;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashSet};
+use std::convert::Infallible;
 use std::fmt::Display;
+use std::io;
 use std::ops::ControlFlow;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{LazyLock, Mutex, OnceLock};
 
+use cap_primitives::fs::{FollowSymlinks, read_base_dir, remove_dir_all, remove_file, stat};
 use tracing::trace;
 use walkdir::WalkDir;
 
-use uv_fs::link::materialize_symlink_dir;
-use uv_fs::{remove_symlink, write_atomic_sync};
+use uv_fs::write_atomic_sync;
 use uv_pypi_types::Identifier;
 use uv_warnings::warn_user;
 
 use crate::directory::LibraryDirectories;
-use crate::linker::needs_mutable_copy;
 use crate::wheel::read_record;
 use crate::{Error, Layout};
+
+use self::directory::Directory;
+
+mod directory;
 
 /// Uninstall the wheel represented by the given `.dist-info` directory.
 ///
@@ -47,6 +51,14 @@ pub fn uninstall_wheel(
         read_record(&mut record_file)?
     };
     let libraries = LibraryDirectories::new(layout)?;
+    let mut roots = Vec::new();
+    for path in libraries.roots() {
+        match Directory::open(path) {
+            Ok(directory) => roots.push(directory),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+    }
 
     let mut file_count = 0usize;
     let mut dir_count = 0usize;
@@ -56,64 +68,50 @@ pub fn uninstall_wheel(
 
     // Uninstall the files, keeping track of any directories that are left empty.
     let mut visited = BTreeSet::new();
-    let mut checked_directories = HashMap::new();
-    let mut resolved_parents = HashMap::new();
+    let mut cached_parent: Option<(PathBuf, Option<Directory>)> = None;
     let mut record_paths = None;
     for entry in &record {
         if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
             continue;
         }
 
-        // Resolve parents, removing directory links at any depth. Keep the final filename
-        // unresolved so removing a file symlink does not remove its cache target.
+        // Open parents without following package links. Keep the final filename unresolved so
+        // removing a file symlink does not remove its cache target.
         let normalized = normalize_path(&site_packages.join(&entry.path));
         let (Some(parent), Some(filename)) = (normalized.parent(), normalized.file_name()) else {
             continue;
         };
-        // Reuse each parent's resolution across its RECORD entries. Resolved directories remain
-        // real directories throughout uninstall, and missing paths stay absent.
-        let resolved = match resolved_parents.entry(parent.to_path_buf()) {
-            Entry::Occupied(entry) => entry.into_mut(),
-            Entry::Vacant(entry) => entry.insert(libraries.resolve(parent, |directory| {
-                if let Some(result) = checked_directories.get(directory) {
-                    return Ok(*result);
+        // RECORD usually groups sibling files. Retain that parent's handle without holding one
+        // descriptor per directory in a large wheel.
+        if cached_parent
+            .as_ref()
+            .is_none_or(|(path, _)| path != parent)
+        {
+            let directory = open_directory(parent, &libraries, &roots, |parent, name| {
+                let directory = parent.path().join(name);
+                let record_paths = record_paths.get_or_insert_with(|| {
+                    record
+                        .iter()
+                        .map(|entry| normalize_path(&site_packages.join(&entry.path)))
+                        .collect()
+                });
+                if !directory.try_exists()? || directory_is_owned(&directory, record_paths)? {
+                    parent.remove_symlink(name)?;
+                    trace!("Removed directory link: {}", directory.display());
+                    visited.insert(parent.path().to_path_buf());
+                    dir_count += 1;
+                    Ok(None)
+                } else {
+                    Ok(Some(parent.materialize(name)?))
                 }
-                let result = match fs_err::symlink_metadata(directory) {
-                    Ok(metadata) if metadata.file_type().is_symlink() => {
-                        let record_paths = record_paths.get_or_insert_with(|| {
-                            record
-                                .iter()
-                                .map(|entry| normalize_path(&site_packages.join(&entry.path)))
-                                .collect()
-                        });
-                        if !directory.try_exists()? || directory_is_owned(directory, record_paths)?
-                        {
-                            remove_symlink(directory)?;
-                            trace!("Removed directory link: {}", directory.display());
-                            if let Some(parent) = directory.parent() {
-                                visited.insert(parent.to_path_buf());
-                            }
-                            dir_count += 1;
-                            ControlFlow::Break(())
-                        } else {
-                            materialize_symlink_dir(directory, needs_mutable_copy)?;
-                            ControlFlow::Continue(())
-                        }
-                    }
-                    Ok(_) => ControlFlow::Continue(()),
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                        ControlFlow::Break(())
-                    }
-                    Err(err) => return Err(err.into()),
-                };
-                checked_directories.insert(directory.to_path_buf(), result);
-                Ok::<_, Error>(result)
-            })?),
-        };
-        let ControlFlow::Continue(parent) = resolved else {
+            })?;
+            cached_parent = Some((parent.to_path_buf(), directory));
+        }
+        let Some((_, Some(parent))) = &cached_parent else {
             continue;
         };
-        let path = parent.join(filename);
+        let filename = Path::new(filename);
+        let path = parent.path().join(filename);
 
         // On Windows, deleting the current executable is a special case.
         #[cfg(windows)]
@@ -140,7 +138,7 @@ pub fn uninstall_wheel(
             }
         }
 
-        match fs_err::remove_file(&path) {
+        match remove_file(parent.handle.file(), filename) {
             Ok(()) => {
                 trace!("Removed file: {}", path.display());
                 file_count += 1;
@@ -149,7 +147,7 @@ pub fn uninstall_wheel(
                 }
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => match fs_err::remove_dir_all(&path) {
+            Err(err) => match remove_dir_all(parent.handle.file(), filename) {
                 Ok(()) => {
                     trace!("Removed directory: {}", path.display());
                     dir_count += 1;
@@ -159,6 +157,7 @@ pub fn uninstall_wheel(
             },
         }
     }
+    drop(cached_parent);
 
     // If any directories were left empty, remove them. Iterate in reverse order such that we visit
     // the deepest directories first.
@@ -169,11 +168,14 @@ pub fn uninstall_wheel(
         // library root, and leave directories elsewhere in the scheme (like `bin`) alone.
         let mut path = path.as_path();
         while libraries.contains(path) {
+            let Some(directory) = open_directory(path, &libraries, &roots, |_, _| Ok(None))? else {
+                break;
+            };
             // If the directory contains a `__pycache__` directory, always remove it. `__pycache__`
             // may or may not be listed in the RECORD, but installers are expected to be smart
             // enough to remove it either way.
             let pycache = path.join("__pycache__");
-            match fs_err::remove_dir_all(&pycache) {
+            match remove_dir_all(directory.handle.file(), Path::new("__pycache__")) {
                 Ok(()) => {
                     trace!("Removed directory: {}", pycache.display());
                     dir_count += 1;
@@ -184,7 +186,7 @@ pub fn uninstall_wheel(
 
             // Try to read from the directory. If it doesn't exist, assume we deleted it in a
             // previous iteration.
-            let mut read_dir = match fs_err::read_dir(path) {
+            let mut read_dir = match read_base_dir(directory.handle.file()) {
                 Ok(read_dir) => read_dir,
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => break,
                 Err(err) => return Err(err.into()),
@@ -194,8 +196,9 @@ pub fn uninstall_wheel(
             if read_dir.next().is_some() {
                 break;
             }
+            drop(read_dir);
 
-            fs_err::remove_dir(path)?;
+            directory.remove()?;
 
             trace!("Removed directory: {}", path.display());
             dir_count += 1;
@@ -212,6 +215,60 @@ pub fn uninstall_wheel(
         file_count,
         dir_count,
     })
+}
+
+/// Resolve scheme aliases, then open each package component relative to its parent without following
+/// symlinks. The visitor may unlink a package link or replace it with a private directory.
+fn open_directory(
+    path: &Path,
+    libraries: &LibraryDirectories,
+    roots: &[Directory],
+    mut visit: impl FnMut(&Directory, &Path) -> Result<Option<Directory>, Error>,
+) -> Result<Option<Directory>, Error> {
+    let resolved = match libraries.resolve(path, |_| {
+        Ok::<_, Error>(ControlFlow::<Infallible>::Continue(()))
+    })? {
+        ControlFlow::Continue(path) => path,
+        ControlFlow::Break(never) => match never {},
+    };
+    let Some((root, relative)) = roots
+        .iter()
+        .filter_map(|root| {
+            resolved
+                .strip_prefix(root.path())
+                .ok()
+                .map(|path| (root, path))
+        })
+        .min_by_key(|(_, relative)| relative.as_os_str().len())
+    else {
+        if libraries.roots().any(|root| resolved.starts_with(root)) {
+            return Ok(None);
+        }
+        return match Directory::open(&resolved) {
+            Ok(directory) => Ok(Some(directory)),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err.into()),
+        };
+    };
+    let mut directory = root.open_dir(Path::new("."))?;
+    for component in relative.components() {
+        let name = Path::new(component.as_os_str());
+        directory = match directory.open_dir(name) {
+            Ok(child) => child,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => match stat(directory.handle.file(), name, FollowSymlinks::No) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    let Some(child) = visit(&directory, name)? else {
+                        return Ok(None);
+                    };
+                    child
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+                Ok(_) | Err(_) => return Err(err.into()),
+            },
+        };
+    }
+    Ok(Some(directory))
 }
 
 /// Whether every file beneath a directory link is in this wheel's RECORD, excluding bytecode caches.

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -7,20 +7,22 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::{LazyLock, Mutex, OnceLock};
 
 use tracing::trace;
+use walkdir::WalkDir;
 
+use uv_fs::link::materialize_symlink_dir;
 use uv_fs::{remove_symlink, write_atomic_sync};
 use uv_pypi_types::Identifier;
 use uv_warnings::warn_user;
 
 use crate::directory::LibraryDirectories;
+use crate::linker::needs_mutable_copy;
 use crate::wheel::read_record;
 use crate::{Error, Layout};
 
 /// Uninstall the wheel represented by the given `.dist-info` directory.
 ///
-/// Directory links below the library roots are removed once without following RECORD paths into
-/// the cache. This relies on installers expanding directories shared by multiple wheels, so a
-/// remaining link owns only this wheel's files.
+/// Directory links containing only this wheel's files are removed without following RECORD paths
+/// into their targets. Shared links are expanded before removing recorded files.
 pub fn uninstall_wheel(
     dist_info: &Path,
     distribution: impl Display,
@@ -56,6 +58,7 @@ pub fn uninstall_wheel(
     let mut visited = BTreeSet::new();
     let mut checked_directories = HashMap::new();
     let mut resolved_parents = HashMap::new();
+    let mut record_paths = None;
     for entry in &record {
         if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
             continue;
@@ -67,8 +70,8 @@ pub fn uninstall_wheel(
         let (Some(parent), Some(filename)) = (normalized.parent(), normalized.file_name()) else {
             continue;
         };
-        // Reuse each parent's resolution across its RECORD entries. Uninstall only removes
-        // entries, so resolved directories cannot change identity and missing paths stay absent.
+        // Reuse each parent's resolution across its RECORD entries. Resolved directories remain
+        // real directories throughout uninstall, and missing paths stay absent.
         let resolved = match resolved_parents.entry(parent.to_path_buf()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(libraries.resolve(parent, |directory| {
@@ -77,13 +80,25 @@ pub fn uninstall_wheel(
                 }
                 let result = match fs_err::symlink_metadata(directory) {
                     Ok(metadata) if metadata.file_type().is_symlink() => {
-                        remove_symlink(directory)?;
-                        trace!("Removed directory link: {}", directory.display());
-                        if let Some(parent) = directory.parent() {
-                            visited.insert(parent.to_path_buf());
+                        let record_paths = record_paths.get_or_insert_with(|| {
+                            record
+                                .iter()
+                                .map(|entry| normalize_path(&site_packages.join(&entry.path)))
+                                .collect()
+                        });
+                        if !directory.try_exists()? || directory_is_owned(directory, record_paths)?
+                        {
+                            remove_symlink(directory)?;
+                            trace!("Removed directory link: {}", directory.display());
+                            if let Some(parent) = directory.parent() {
+                                visited.insert(parent.to_path_buf());
+                            }
+                            dir_count += 1;
+                            ControlFlow::Break(())
+                        } else {
+                            materialize_symlink_dir(directory, needs_mutable_copy)?;
+                            ControlFlow::Continue(())
                         }
-                        dir_count += 1;
-                        ControlFlow::Break(())
                     }
                     Ok(_) => ControlFlow::Continue(()),
                     Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -197,6 +212,21 @@ pub fn uninstall_wheel(
         file_count,
         dir_count,
     })
+}
+
+/// Whether every file beneath a directory link is in this wheel's RECORD, excluding bytecode caches.
+fn directory_is_owned(directory: &Path, record_paths: &HashSet<PathBuf>) -> Result<bool, Error> {
+    for entry in WalkDir::new(directory)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(|entry| !entry.file_type().is_dir() || entry.file_name() != "__pycache__")
+    {
+        let entry = entry?;
+        if !entry.file_type().is_dir() && !record_paths.contains(entry.path()) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 static WARNED_FOR_RECORD_ENTRY_PACKAGE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -54,15 +54,14 @@ pub fn uninstall_wheel(
 
     // Uninstall the files, keeping track of any directories that are left empty.
     let mut visited = BTreeSet::new();
-    let mut checked_directories = HashSet::new();
-    let mut removed_symlinks = HashSet::new();
+    let mut checked_directories = HashMap::new();
     let mut resolved_parents = HashMap::new();
     for entry in &record {
         if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
             continue;
         }
 
-        // Resolve parents, including links beneath shared namespaces. Keep the final filename
+        // Resolve parents, removing top-level package links. Keep the final filename
         // unresolved so removing a file symlink does not remove its cache target.
         let normalized = normalize_path(&site_packages.join(&entry.path));
         let (Some(parent), Some(filename)) = (normalized.parent(), normalized.file_name()) else {
@@ -73,32 +72,27 @@ pub fn uninstall_wheel(
         let resolved = match resolved_parents.entry(parent.to_path_buf()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(libraries.resolve(parent, |directory| {
-                if removed_symlinks.contains(directory) {
-                    return Ok(ControlFlow::Break(()));
+                if let Some(result) = checked_directories.get(directory) {
+                    return Ok(*result);
                 }
-                if checked_directories.contains(directory) {
-                    return Ok(ControlFlow::Continue(()));
-                }
-                match fs_err::symlink_metadata(directory) {
+                let result = match fs_err::symlink_metadata(directory) {
                     Ok(metadata) if metadata.file_type().is_symlink() => {
                         remove_symlink(directory)?;
                         trace!("Removed directory link: {}", directory.display());
-                        removed_symlinks.insert(directory.to_path_buf());
                         if let Some(parent) = directory.parent() {
                             visited.insert(parent.to_path_buf());
                         }
                         dir_count += 1;
-                        return Ok(ControlFlow::Break(()));
+                        ControlFlow::Break(())
                     }
-                    Ok(_) => {
-                        checked_directories.insert(directory.to_path_buf());
-                    }
+                    Ok(_) => ControlFlow::Continue(()),
                     Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                        return Ok(ControlFlow::Break(()));
+                        ControlFlow::Break(())
                     }
                     Err(err) => return Err(err.into()),
-                }
-                Ok::<_, Error>(ControlFlow::Continue(()))
+                };
+                checked_directories.insert(directory.to_path_buf(), result);
+                Ok::<_, Error>(result)
             })?),
         };
         let ControlFlow::Continue(parent) = resolved else {

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -61,7 +61,7 @@ pub fn uninstall_wheel(
             continue;
         }
 
-        // Resolve parents, removing top-level package links. Keep the final filename
+        // Resolve parents, removing directory links at any depth. Keep the final filename
         // unresolved so removing a file symlink does not remove its cache target.
         let normalized = normalize_path(&site_packages.join(&entry.path));
         let (Some(parent), Some(filename)) = (normalized.parent(), normalized.file_name()) else {

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -6,7 +6,7 @@ use std::sync::{LazyLock, Mutex, OnceLock};
 
 use tracing::trace;
 
-use uv_fs::write_atomic_sync;
+use uv_fs::{remove_symlink, write_atomic_sync};
 use uv_pypi_types::Identifier;
 use uv_warnings::warn_user;
 
@@ -46,11 +46,35 @@ pub fn uninstall_wheel(
 
     // Uninstall the files, keeping track of any directories that are left empty.
     let mut visited = BTreeSet::new();
+    let mut checked_directories = HashSet::new();
+    let mut removed_symlinks = HashSet::new();
     for entry in &record {
         let path = site_packages.join(&entry.path);
 
         if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
             continue;
+        }
+
+        // A directory link owns all the files beneath it. Remove the link once instead of
+        // following RECORD paths into the shared wheel cache. Shared package directories are
+        // expanded into real directories during installation, so normal per-file removal applies.
+        let normalized = normalize_path(&path);
+        if let Ok(relative) = normalized.strip_prefix(site_packages) {
+            let mut components = relative.components();
+            if let Some(Component::Normal(name)) = components.next()
+                && components.next().is_some()
+            {
+                let directory = site_packages.join(name);
+                if removed_symlinks.contains(&directory) {
+                    continue;
+                }
+                if checked_directories.insert(directory.clone()) && directory.is_symlink() {
+                    remove_symlink(&directory)?;
+                    removed_symlinks.insert(directory);
+                    dir_count += 1;
+                    continue;
+                }
+            }
         }
 
         // On Windows, deleting the current executable is a special case.

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -215,6 +215,8 @@ pub fn uninstall_wheel(
 }
 
 /// Whether every file beneath a directory link is in this wheel's RECORD, excluding bytecode caches.
+///
+/// Paths are compared lexically. Nested symlinks are treated as entries rather than followed.
 fn directory_is_owned(directory: &Path, record_paths: &HashSet<PathBuf>) -> Result<bool, Error> {
     for entry in WalkDir::new(directory)
         .min_depth(1)

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::Display;
+use std::ops::ControlFlow;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{LazyLock, Mutex, OnceLock};
 
@@ -10,6 +11,7 @@ use uv_fs::{remove_symlink, write_atomic_sync};
 use uv_pypi_types::Identifier;
 use uv_warnings::warn_user;
 
+use crate::directory::LibraryDirectories;
 use crate::wheel::read_record;
 use crate::{Error, Layout};
 
@@ -37,6 +39,7 @@ pub fn uninstall_wheel(
         };
         read_record(&mut record_file)?
     };
+    let libraries = LibraryDirectories::new(layout)?;
 
     let mut file_count = 0usize;
     let mut dir_count = 0usize;
@@ -49,33 +52,48 @@ pub fn uninstall_wheel(
     let mut checked_directories = HashSet::new();
     let mut removed_symlinks = HashSet::new();
     for entry in &record {
-        let path = site_packages.join(&entry.path);
-
         if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
             continue;
         }
 
-        // A directory link owns all the files beneath it. Remove the link once instead of
-        // following RECORD paths into the shared wheel cache. Shared package directories are
-        // expanded into real directories during installation, so normal per-file removal applies.
-        let normalized = normalize_path(&path);
-        if let Ok(relative) = normalized.strip_prefix(site_packages) {
-            let mut components = relative.components();
-            if let Some(Component::Normal(name)) = components.next()
-                && components.next().is_some()
-            {
-                let directory = site_packages.join(name);
-                if removed_symlinks.contains(&directory) {
-                    continue;
-                }
-                if checked_directories.insert(directory.clone()) && directory.is_symlink() {
-                    remove_symlink(&directory)?;
-                    removed_symlinks.insert(directory);
-                    dir_count += 1;
-                    continue;
+        // Resolve scheme aliases without following package directory links into the cache.
+        // A link owns all the files beneath it, so remove it once, including nested links left
+        // beneath shared namespace directories. Keep the final file component unresolved.
+        let normalized = normalize_path(&site_packages.join(&entry.path));
+        let (Some(parent), Some(filename)) = (normalized.parent(), normalized.file_name()) else {
+            continue;
+        };
+        let ControlFlow::Continue(parent) = libraries.resolve(parent, |directory| {
+            if removed_symlinks.contains(directory) {
+                return Ok(ControlFlow::Break(()));
+            }
+            if !checked_directories.contains(directory) {
+                match fs_err::symlink_metadata(directory) {
+                    Ok(metadata) if metadata.file_type().is_symlink() => {
+                        remove_symlink(directory)?;
+                        trace!("Removed directory link: {}", directory.display());
+                        removed_symlinks.insert(directory.to_path_buf());
+                        if let Some(parent) = directory.parent() {
+                            visited.insert(parent.to_path_buf());
+                        }
+                        dir_count += 1;
+                        return Ok(ControlFlow::Break(()));
+                    }
+                    Ok(_) => {
+                        checked_directories.insert(directory.to_path_buf());
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        return Ok(ControlFlow::Break(()));
+                    }
+                    Err(err) => return Err(err.into()),
                 }
             }
-        }
+            Ok::<_, Error>(ControlFlow::Continue(()))
+        })?
+        else {
+            continue;
+        };
+        let path = parent.join(filename);
 
         // On Windows, deleting the current executable is a special case.
         #[cfg(windows)]
@@ -91,7 +109,7 @@ pub fn uninstall_wheel(
                             trace!("Removed file: {}", path.display());
                             file_count += 1;
                             if let Some(parent) = path.parent() {
-                                visited.insert(normalize_path(parent));
+                                visited.insert(parent.to_path_buf());
                             }
                         }
                         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -107,7 +125,7 @@ pub fn uninstall_wheel(
                 trace!("Removed file: {}", path.display());
                 file_count += 1;
                 if let Some(parent) = path.parent() {
-                    visited.insert(normalize_path(parent));
+                    visited.insert(parent.to_path_buf());
                 }
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -125,21 +143,12 @@ pub fn uninstall_wheel(
     // If any directories were left empty, remove them. Iterate in reverse order such that we visit
     // the deepest directories first.
     for path in visited.iter().rev() {
-        // No need to look at directories outside of `site-packages` (like `bin`).
-        if !path.starts_with(site_packages) {
-            continue;
-        }
-
         // Iterate up the directory tree, removing any empty directories. It's insufficient to
         // rely on `visited` alone here, because we may end up removing a directory whose parent
-        // directory doesn't contain any files, leaving the _parent_ directory empty.
+        // directory doesn't contain any files, leaving the _parent_ directory empty. Stop at the
+        // library root, and leave directories elsewhere in the scheme (like `bin`) alone.
         let mut path = path.as_path();
-        loop {
-            // If we reach the site-packages directory, we're done.
-            if path == site_packages {
-                break;
-            }
-
+        while libraries.contains(path) {
             // If the directory contains a `__pycache__` directory, always remove it. `__pycache__`
             // may or may not be listed in the RECORD, but installers are expected to be smart
             // enough to remove it either way.

--- a/crates/uv-install-wheel/src/uninstall/directory.rs
+++ b/crates/uv-install-wheel/src/uninstall/directory.rs
@@ -1,0 +1,201 @@
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cap_primitives::ambient_authority;
+use cap_primitives::fs::{
+    DirOptions, OpenOptions, create_dir, open, open_ambient_dir, open_dir_nofollow, remove_dir,
+    remove_dir_all, remove_file, rename,
+};
+use fs_err::File;
+#[cfg(windows)]
+use fs_err::os::windows::fs::{symlink_dir, symlink_file};
+
+use crate::linker::needs_mutable_copy;
+
+/// An opened uninstall directory. Full paths are used for diagnostics and source links, never deletion.
+pub(super) struct Directory {
+    pub(super) handle: Arc<File>,
+    parent: Option<Arc<File>>,
+}
+
+impl Directory {
+    pub(super) fn path(&self) -> &Path {
+        self.handle.path()
+    }
+
+    /// Open a resolved scheme path without following links introduced after scheme resolution.
+    pub(super) fn open(path: &Path) -> io::Result<Self> {
+        let path = std::path::absolute(path)?;
+        let root = path
+            .ancestors()
+            .last()
+            .ok_or_else(|| io::Error::other("Directory has no filesystem root"))?;
+        let mut file = Arc::new(File::from_parts(
+            open_ambient_dir(root, ambient_authority())?,
+            root,
+        ));
+        let mut parent = None;
+        for component in path
+            .strip_prefix(root)
+            .map_err(io::Error::other)?
+            .components()
+        {
+            let name = Path::new(component.as_os_str());
+            let child = Arc::new(File::from_parts(
+                open_dir_nofollow(file.file(), name)?,
+                file.path().join(name),
+            ));
+            parent = Some(file);
+            file = child;
+        }
+        Ok(Self {
+            handle: file,
+            parent,
+        })
+    }
+
+    /// Open one child without following symlinks, retaining its identity if an ancestor is renamed.
+    pub(super) fn open_dir(&self, name: &Path) -> io::Result<Self> {
+        Ok(Self {
+            handle: Arc::new(File::from_parts(
+                open_dir_nofollow(self.handle.file(), name)?,
+                self.path().join(name),
+            )),
+            parent: Some(Arc::clone(&self.handle)),
+        })
+    }
+
+    /// Remove an empty directory through its retained parent, without searching for its inode.
+    pub(super) fn remove(self) -> io::Result<()> {
+        let (Some(parent), Some(name)) = (self.parent, self.handle.path().file_name()) else {
+            return Err(io::Error::other("Cannot remove a filesystem root"));
+        };
+        // Windows requires closing the child handle before removing the entry.
+        let name = name.to_os_string();
+        drop(self.handle);
+        remove_dir(parent.file(), Path::new(&name))
+    }
+
+    /// Expand a shared directory link through its opened parent, then reopen without following links.
+    pub(super) fn materialize(&self, name: &Path) -> io::Result<Self> {
+        let source = fs_err::canonicalize(self.path().join(name))?;
+        let temporary = PathBuf::from(format!(".uv-{:032x}", fastrand::u128(..)));
+        create_dir(self.handle.file(), &temporary, &DirOptions::new())?;
+        let result = (|| {
+            copy_links(&source, &self.open_dir(&temporary)?)?;
+            self.remove_symlink(name)?;
+            if let Err(err) = rename(self.handle.file(), &temporary, self.handle.file(), name) {
+                let _ = symlink(&source, self, name);
+                return Err(err);
+            }
+            self.open_dir(name)
+        })();
+        let _ = remove_dir_all(self.handle.file(), &temporary);
+        result
+    }
+
+    pub(super) fn remove_symlink(&self, name: &Path) -> io::Result<()> {
+        #[cfg(not(windows))]
+        {
+            remove_file(self.handle.file(), name)
+        }
+        #[cfg(windows)]
+        {
+            remove_file(self.handle.file(), name)
+                .or_else(|err| remove_dir(self.handle.file(), name).or(Err(err)))
+        }
+    }
+}
+
+/// Populate a private directory with file links, copying files that may be mutated after installation.
+fn copy_links(source: &Path, destination: &Directory) -> io::Result<()> {
+    for entry in fs_err::read_dir(source)? {
+        let entry = entry?;
+        let source = entry.path();
+        let name = PathBuf::from(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            create_dir(destination.handle.file(), &name, &DirOptions::new())?;
+            copy_links(&source, &destination.open_dir(&name)?)?;
+        } else if needs_mutable_copy(&source) || symlink(&source, destination, &name).is_err() {
+            let mut source = fs_err::File::open(&source)?;
+            let mut target = open(
+                destination.handle.file(),
+                &name,
+                OpenOptions::new().write(true).create_new(true),
+            )?;
+            io::copy(&mut source, &mut target)?;
+            target.set_permissions(source.metadata()?.permissions())?;
+        }
+    }
+    Ok(())
+}
+
+/// Create a link relative to an opened parent, allowing absolute cache paths as its contents.
+fn symlink(source: &Path, parent: &Directory, name: &Path) -> io::Result<()> {
+    #[cfg(not(windows))]
+    {
+        cap_primitives::fs::symlink_contents(source, parent.handle.file(), name)
+    }
+    #[cfg(windows)]
+    {
+        // Directory handles are opened without FILE_SHARE_DELETE on Windows.
+        if source.is_dir() {
+            symlink_dir(source, parent.path().join(name))
+        } else {
+            symlink_file(source, parent.path().join(name))
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::path::Path;
+
+    use assert_fs::prelude::*;
+    use cap_primitives::fs::{remove_dir_all, remove_file};
+    use fs_err::os::unix::fs::symlink;
+
+    use super::Directory;
+
+    #[test]
+    fn remove_from_replaced_directory() -> anyhow::Result<()> {
+        let temporary = assert_fs::TempDir::new()?;
+        let package = temporary.child("package");
+        package.child("nested/module.py").touch()?;
+        package.child("nested/__pycache__/module.pyc").touch()?;
+        let store = temporary.child("store");
+        store.child("nested/module.py").write_str("keep source")?;
+        store
+            .child("nested/__pycache__/module.pyc")
+            .write_str("keep bytecode")?;
+
+        let root = Directory::open(&fs_err::canonicalize(temporary.path())?)?;
+        let directory = root
+            .open_dir(Path::new("package"))?
+            .open_dir(Path::new("nested"))?;
+        let renamed = temporary.child("renamed");
+        fs_err::rename(package.path(), renamed.path())?;
+        symlink(store.path(), package.path())?;
+
+        // A replacement before opening must be rejected; a replacement after opening must not
+        // redirect either individual file removal or recursive bytecode cleanup into the store.
+        assert!(root.open_dir(Path::new("package")).is_err());
+        remove_file(directory.handle.file(), Path::new("module.py"))?;
+        remove_dir_all(directory.handle.file(), Path::new("__pycache__"))?;
+        assert!(!renamed.child("nested/module.py").exists());
+        assert!(!renamed.child("nested/__pycache__").exists());
+        directory.remove()?;
+        assert!(!renamed.child("nested").exists());
+        assert!(package.is_symlink());
+        assert_eq!(
+            fs_err::read_to_string(store.child("nested/module.py"))?,
+            "keep source"
+        );
+        assert_eq!(
+            fs_err::read_to_string(store.child("nested/__pycache__/module.pyc"))?,
+            "keep bytecode"
+        );
+        Ok(())
+    }
+}

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -23,7 +23,6 @@ use uv_trampoline_builder::windows_script_launcher;
 use uv_warnings::warn_user_once;
 
 use crate::directory::LibraryDirectories;
-use crate::linker::InstallState;
 use crate::record::RecordEntry;
 use crate::script::{EntryPoints, Script};
 use crate::{Error, Layout};
@@ -337,7 +336,7 @@ pub(crate) fn write_script_entrypoints(
     entrypoints: &[Script],
     record: &mut Vec<RecordEntry>,
     is_gui: bool,
-    state: &InstallState,
+    locks: &CopyLocks,
 ) -> Result<(), Error> {
     for script in entrypoints {
         let script = ValidatedScript::try_from_script(script, layout)?;
@@ -345,7 +344,7 @@ pub(crate) fn write_script_entrypoints(
         if let Some(parent) = script.as_path().parent()
             && parent != layout.scheme.scripts
         {
-            LibraryDirectories::new(layout)?.prepare(parent, state)?;
+            LibraryDirectories::new(layout)?.prepare(parent, locks)?;
         }
 
         // Generate the launcher script.
@@ -363,28 +362,23 @@ pub(crate) fn write_script_entrypoints(
         } else {
             launcher_python_script.into_bytes()
         };
-        state
-            .copy_locks()
-            .with_file_write(&site_packages.join(&entrypoint_relative), || {
-                write_file_recorded(site_packages, &entrypoint_relative, &launcher, record)?;
+        locks.with_file_write(&site_packages.join(&entrypoint_relative), || {
+            write_file_recorded(site_packages, &entrypoint_relative, &launcher, record)?;
 
-                // Make the launcher executable before another installation can replace it.
-                #[cfg(unix)]
-                {
-                    use std::fs::Permissions;
-                    use std::os::unix::fs::PermissionsExt;
+            // Make the launcher executable before another installation can replace it.
+            #[cfg(unix)]
+            {
+                use std::fs::Permissions;
+                use std::os::unix::fs::PermissionsExt;
 
-                    let path = script.as_path();
-                    let permissions = fs::metadata(path)?.permissions();
-                    if permissions.mode() & 0o111 != 0o111 {
-                        fs::set_permissions(
-                            path,
-                            Permissions::from_mode(permissions.mode() | 0o111),
-                        )?;
-                    }
+                let path = script.as_path();
+                let permissions = fs::metadata(path)?.permissions();
+                if permissions.mode() & 0o111 != 0o111 {
+                    fs::set_permissions(path, Permissions::from_mode(permissions.mode() | 0o111))?;
                 }
-                Ok::<_, Error>(())
-            })?;
+            }
+            Ok::<_, Error>(())
+        })?;
     }
     Ok(())
 }
@@ -475,7 +469,7 @@ fn move_folder_recorded(
     layout: &Layout,
     site_packages: &Path,
     record: &mut [RecordEntry],
-    state: &InstallState,
+    locks: &CopyLocks,
 ) -> Result<(), Error> {
     let mut rename_or_copy = RenameOrCopy::default();
     let directories = LibraryDirectories::new(layout)?;
@@ -494,10 +488,10 @@ fn move_folder_recorded(
             .expect("prefix must not change");
         let target = dest_dir.join(relative_to_data);
         if entry.file_type().is_dir() {
-            directories.prepare(&target, state)?;
+            directories.prepare(&target, locks)?;
         } else {
             validate_data_script_destination(&target, &layout.scheme.scripts)?;
-            rename_or_copy.rename_or_copy(src, &target, state.copy_locks())?;
+            rename_or_copy.rename_or_copy(src, &target, locks)?;
             let entry = record
                 .iter_mut()
                 .find(|entry| Path::new(&entry.path) == relative_to_site_packages)
@@ -523,7 +517,7 @@ fn install_script(
     record: &mut [RecordEntry],
     file: &DirEntry,
     #[allow(unused)] rename_or_copy: &mut RenameOrCopy,
-    state: &InstallState,
+    locks: &CopyLocks,
 ) -> Result<(), Error> {
     let file_type = file.file_type()?;
 
@@ -632,7 +626,7 @@ fn install_script(
                     .set_permissions(Permissions::from_mode(permissions.mode() | 0o111))?;
             }
         }
-        state.copy_locks().with_file_write(&script_absolute, || {
+        locks.with_file_write(&script_absolute, || {
             persist_with_retry_sync(target, &script_absolute)
         })?;
         fs::remove_file(&path)?;
@@ -653,7 +647,7 @@ fn install_script(
             if permissions.mode() & 0o111 == 0o111 {
                 // If the permissions are already executable, we don't need to change them.
                 // We fall back to copy when the file is on another drive.
-                rename_or_copy.rename_or_copy(&path, &script_absolute, state.copy_locks())?;
+                rename_or_copy.rename_or_copy(&path, &script_absolute, locks)?;
             } else {
                 // If we have to modify the permissions, copy the file, since we might not own it,
                 // and we may not be allowed to change permissions on an unowned moved file.
@@ -667,7 +661,7 @@ fn install_script(
                 let target = uv_fs::tempfile_in(&layout.scheme.scripts)?;
                 fs::copy(&path, &target)?;
                 fs::set_permissions(&target, Permissions::from_mode(permissions.mode() | 0o111))?;
-                state.copy_locks().with_file_write(&script_absolute, || {
+                locks.with_file_write(&script_absolute, || {
                     persist_with_retry_sync(target, &script_absolute)
                 })?;
             }
@@ -678,7 +672,7 @@ fn install_script(
             // Here, two wrappers over rename are clashing: We want to retry for security software
             // blocking the file, but we also need the copy fallback is the problem was trying to
             // move a file cross-drive.
-            let renamed = state.copy_locks().with_file_write(&script_absolute, || {
+            let renamed = locks.with_file_write(&script_absolute, || {
                 Ok::<_, io::Error>(uv_fs::with_retry_sync(
                     &path,
                     &script_absolute,
@@ -693,7 +687,7 @@ fn install_script(
                     fs_err::copy(&path, &target)?;
                     Ok(())
                 })?;
-                state.copy_locks().with_file_write(&script_absolute, || {
+                locks.with_file_write(&script_absolute, || {
                     persist_with_retry_sync(target, &script_absolute)
                 })?;
             }
@@ -737,7 +731,7 @@ pub(crate) fn install_data(
     console_scripts: &[Script],
     gui_scripts: &[Script],
     record: &mut [RecordEntry],
-    state: &InstallState,
+    locks: &CopyLocks,
 ) -> Result<(), Error> {
     for entry in fs::read_dir(data_dir)? {
         let entry = entry?;
@@ -757,7 +751,7 @@ pub(crate) fn install_data(
                     layout,
                     site_packages,
                     record,
-                    state,
+                    locks,
                 )?;
             }
             Some("scripts") => {
@@ -789,7 +783,7 @@ pub(crate) fn install_data(
 
                     // Create the scripts directory, if it doesn't exist.
                     if !initialized {
-                        LibraryDirectories::new(layout)?.prepare(&layout.scheme.scripts, state)?;
+                        LibraryDirectories::new(layout)?.prepare(&layout.scheme.scripts, locks)?;
                         initialized = true;
                     }
 
@@ -800,7 +794,7 @@ pub(crate) fn install_data(
                         record,
                         &file,
                         &mut rename_or_copy,
-                        state,
+                        locks,
                     )?;
                 }
             }
@@ -811,7 +805,7 @@ pub(crate) fn install_data(
                     "Installing data/headers to {}",
                     target_path.user_display()
                 );
-                move_folder_recorded(&path, &target_path, layout, site_packages, record, state)?;
+                move_folder_recorded(&path, &target_path, layout, site_packages, record, locks)?;
             }
             Some("purelib") => {
                 trace!(
@@ -825,7 +819,7 @@ pub(crate) fn install_data(
                     layout,
                     site_packages,
                     record,
-                    state,
+                    locks,
                 )?;
             }
             Some("platlib") => {
@@ -840,7 +834,7 @@ pub(crate) fn install_data(
                     layout,
                     site_packages,
                     record,
-                    state,
+                    locks,
                 )?;
             }
             _ => {
@@ -1219,14 +1213,7 @@ impl RenameOrCopy {
     /// Usually, source and target are on the same device, so we can rename, but if that fails, we
     /// have to copy. If renaming failed once, we switch to copy permanently. Copies replace the
     /// destination atomically so an existing file symlink is never followed into the wheel cache.
-    fn rename_or_copy(
-        &mut self,
-        from: impl AsRef<Path>,
-        to: impl AsRef<Path>,
-        locks: &CopyLocks,
-    ) -> io::Result<()> {
-        let from = from.as_ref();
-        let to = to.as_ref();
+    fn rename_or_copy(&mut self, from: &Path, to: &Path, locks: &CopyLocks) -> io::Result<()> {
         if let Self::Rename = self {
             // Distinguish a directory conflict from a rename failure that permits copying.
             match locks.with_file_write(to, || Ok::<_, io::Error>(fs_err::rename(from, to)))? {

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -14,10 +14,8 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, instrument, trace, warn};
 use walkdir::WalkDir;
 
-use uv_fs::{
-    PortablePath, Simplified, copy_atomic_sync, normalize_path_under, persist_with_retry_sync,
-    relative_to,
-};
+use uv_fs::link::CopyLocks;
+use uv_fs::{PortablePath, Simplified, normalize_path_under, persist_with_retry_sync, relative_to};
 use uv_normalize::PackageName;
 use uv_pypi_types::DirectUrl;
 use uv_shell::escape_posix_for_single_quotes;
@@ -339,10 +337,16 @@ pub(crate) fn write_script_entrypoints(
     entrypoints: &[Script],
     record: &mut Vec<RecordEntry>,
     is_gui: bool,
+    state: &InstallState,
 ) -> Result<(), Error> {
     for script in entrypoints {
         let script = ValidatedScript::try_from_script(script, layout)?;
         let entrypoint_relative = script.relative_to_site_package(site_packages)?;
+        if let Some(parent) = script.as_path().parent()
+            && parent != layout.scheme.scripts
+        {
+            LibraryDirectories::new(layout)?.prepare(parent, state)?;
+        }
 
         // Generate the launcher script.
         let launcher_executable = get_script_executable(&layout.sys_executable, is_gui);
@@ -354,34 +358,33 @@ pub(crate) fn write_script_entrypoints(
         );
 
         // If necessary, wrap the launcher script in a Windows launcher binary.
-        if cfg!(windows) {
-            write_file_recorded(
-                site_packages,
-                &entrypoint_relative,
-                &windows_script_launcher(&launcher_python_script, is_gui, &launcher_executable)?,
-                record,
-            )?;
+        let launcher = if cfg!(windows) {
+            windows_script_launcher(&launcher_python_script, is_gui, &launcher_executable)?
         } else {
-            write_file_recorded(
-                site_packages,
-                &entrypoint_relative,
-                &launcher_python_script,
-                record,
-            )?;
+            launcher_python_script.into_bytes()
+        };
+        state
+            .copy_locks()
+            .with_file_write(&site_packages.join(&entrypoint_relative), || {
+                write_file_recorded(site_packages, &entrypoint_relative, &launcher, record)?;
 
-            // Make the launcher executable.
-            #[cfg(unix)]
-            {
-                use std::fs::Permissions;
-                use std::os::unix::fs::PermissionsExt;
+                // Make the launcher executable before another installation can replace it.
+                #[cfg(unix)]
+                {
+                    use std::fs::Permissions;
+                    use std::os::unix::fs::PermissionsExt;
 
-                let path = script.as_path();
-                let permissions = fs::metadata(path)?.permissions();
-                if permissions.mode() & 0o111 != 0o111 {
-                    fs::set_permissions(path, Permissions::from_mode(permissions.mode() | 0o111))?;
+                    let path = script.as_path();
+                    let permissions = fs::metadata(path)?.permissions();
+                    if permissions.mode() & 0o111 != 0o111 {
+                        fs::set_permissions(
+                            path,
+                            Permissions::from_mode(permissions.mode() | 0o111),
+                        )?;
+                    }
                 }
-            }
-        }
+                Ok::<_, Error>(())
+            })?;
     }
     Ok(())
 }
@@ -494,7 +497,7 @@ fn move_folder_recorded(
             directories.prepare(&target, state)?;
         } else {
             validate_data_script_destination(&target, &layout.scheme.scripts)?;
-            rename_or_copy.rename_or_copy(src, &target)?;
+            rename_or_copy.rename_or_copy(src, &target, state.copy_locks())?;
             let entry = record
                 .iter_mut()
                 .find(|entry| Path::new(&entry.path) == relative_to_site_packages)
@@ -520,6 +523,7 @@ fn install_script(
     record: &mut [RecordEntry],
     file: &DirEntry,
     #[allow(unused)] rename_or_copy: &mut RenameOrCopy,
+    state: &InstallState,
 ) -> Result<(), Error> {
     let file_type = file.file_type()?;
 
@@ -615,23 +619,23 @@ fn install_script(
         let mut target = uv_fs::tempfile_in(&layout.scheme.scripts)?;
         let size_and_encoded_hash = copy_and_hash(&mut start.chain(script), &mut target)?;
 
-        persist_with_retry_sync(target, &script_absolute)?;
-        fs::remove_file(&path)?;
-
-        // Make the script executable. We just created the file, so we can set permissions directly.
+        // Set permissions on the temporary file before publishing it.
         #[cfg(unix)]
         {
             use std::fs::Permissions;
             use std::os::unix::fs::PermissionsExt;
 
-            let permissions = fs::metadata(&script_absolute)?.permissions();
+            let permissions = target.as_file().metadata()?.permissions();
             if permissions.mode() & 0o111 != 0o111 {
-                fs::set_permissions(
-                    script_absolute,
-                    Permissions::from_mode(permissions.mode() | 0o111),
-                )?;
+                target
+                    .as_file()
+                    .set_permissions(Permissions::from_mode(permissions.mode() | 0o111))?;
             }
         }
+        state.copy_locks().with_file_write(&script_absolute, || {
+            persist_with_retry_sync(target, &script_absolute)
+        })?;
+        fs::remove_file(&path)?;
 
         Some(size_and_encoded_hash)
     } else {
@@ -649,7 +653,7 @@ fn install_script(
             if permissions.mode() & 0o111 == 0o111 {
                 // If the permissions are already executable, we don't need to change them.
                 // We fall back to copy when the file is on another drive.
-                rename_or_copy.rename_or_copy(&path, &script_absolute)?;
+                rename_or_copy.rename_or_copy(&path, &script_absolute, state.copy_locks())?;
             } else {
                 // If we have to modify the permissions, copy the file, since we might not own it,
                 // and we may not be allowed to change permissions on an unowned moved file.
@@ -660,12 +664,12 @@ fn install_script(
                     permissions.mode()
                 );
 
-                uv_fs::copy_atomic_sync(&path, &script_absolute)?;
-
-                fs::set_permissions(
-                    script_absolute,
-                    Permissions::from_mode(permissions.mode() | 0o111),
-                )?;
+                let target = uv_fs::tempfile_in(&layout.scheme.scripts)?;
+                fs::copy(&path, &target)?;
+                fs::set_permissions(&target, Permissions::from_mode(permissions.mode() | 0o111))?;
+                state.copy_locks().with_file_write(&script_absolute, || {
+                    persist_with_retry_sync(target, &script_absolute)
+                })?;
             }
         }
 
@@ -674,17 +678,24 @@ fn install_script(
             // Here, two wrappers over rename are clashing: We want to retry for security software
             // blocking the file, but we also need the copy fallback is the problem was trying to
             // move a file cross-drive.
-            match uv_fs::with_retry_sync(&path, &script_absolute, "renaming", || {
-                fs_err::rename(&path, &script_absolute)
-            }) {
-                Ok(()) => (),
-                Err(err) => {
-                    debug!("Failed to rename, falling back to copy: {err}");
-                    uv_fs::with_retry_sync(&path, &script_absolute, "copying", || {
-                        fs_err::copy(&path, &script_absolute)?;
-                        Ok(())
-                    })?;
-                }
+            let renamed = state.copy_locks().with_file_write(&script_absolute, || {
+                Ok::<_, io::Error>(uv_fs::with_retry_sync(
+                    &path,
+                    &script_absolute,
+                    "renaming",
+                    || fs_err::rename(&path, &script_absolute),
+                ))
+            })?;
+            if let Err(err) = renamed {
+                debug!("Failed to rename, falling back to copy: {err}");
+                let target = uv_fs::tempfile_in(&layout.scheme.scripts)?;
+                uv_fs::with_retry_sync(&path, &script_absolute, "copying", || {
+                    fs_err::copy(&path, &target)?;
+                    Ok(())
+                })?;
+                state.copy_locks().with_file_write(&script_absolute, || {
+                    persist_with_retry_sync(target, &script_absolute)
+                })?;
             }
         }
 
@@ -789,6 +800,7 @@ pub(crate) fn install_data(
                         record,
                         &file,
                         &mut rename_or_copy,
+                        state,
                     )?;
                 }
             }
@@ -1207,21 +1219,33 @@ impl RenameOrCopy {
     /// Usually, source and target are on the same device, so we can rename, but if that fails, we
     /// have to copy. If renaming failed once, we switch to copy permanently. Copies replace the
     /// destination atomically so an existing file symlink is never followed into the wheel cache.
-    fn rename_or_copy(&mut self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
-        match self {
-            Self::Rename => match fs_err::rename(from.as_ref(), to.as_ref()) {
-                Ok(()) => {}
+    fn rename_or_copy(
+        &mut self,
+        from: impl AsRef<Path>,
+        to: impl AsRef<Path>,
+        locks: &CopyLocks,
+    ) -> io::Result<()> {
+        let from = from.as_ref();
+        let to = to.as_ref();
+        if let Self::Rename = self {
+            // Distinguish a directory conflict from a rename failure that permits copying.
+            match locks.with_file_write(to, || Ok::<_, io::Error>(fs_err::rename(from, to)))? {
+                Ok(()) => return Ok(()),
                 Err(err) => {
                     *self = Self::Copy;
                     debug!("Failed to rename, falling back to copy: {err}");
-                    copy_atomic_sync(from.as_ref(), to.as_ref())?;
                 }
-            },
-            Self::Copy => {
-                copy_atomic_sync(from.as_ref(), to.as_ref())?;
             }
         }
-        Ok(())
+        let parent = to.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Copy destination has no parent",
+            )
+        })?;
+        let target = uv_fs::tempfile_in(parent)?;
+        fs::copy(from, &target)?;
+        locks.with_file_write(to, || persist_with_retry_sync(target, to))
     }
 }
 
@@ -1243,6 +1267,8 @@ mod test {
         Error, RecordEntry, Script, WheelFile, format_shebang, get_script_executable,
         parse_email_message_file, parse_scripts, read_record, write_installer_metadata,
     };
+    #[cfg(unix)]
+    use uv_fs::link::CopyLocks;
 
     #[cfg(unix)]
     #[test]
@@ -1256,7 +1282,7 @@ mod test {
         symlink(cached.path(), target.path())?;
 
         // Exercise the fallback without requiring two filesystems in the test environment.
-        RenameOrCopy::Copy.rename_or_copy(source.path(), target.path())?;
+        RenameOrCopy::Copy.rename_or_copy(source.path(), target.path(), &CopyLocks::default())?;
 
         assert!(!target.path().is_symlink());
         target.assert("new data");

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
+use std::convert::Infallible;
 use std::fmt::Display;
 use std::io;
 use std::io::{BufReader, Read, Write};
+use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 
 use data_encoding::BASE64URL_NOPAD;
@@ -15,13 +17,17 @@ use tracing::{debug, instrument, trace, warn};
 use walkdir::WalkDir;
 
 use uv_fs::link::materialize_symlink_dir;
-use uv_fs::{PortablePath, Simplified, normalize_path_under, persist_with_retry_sync, relative_to};
+use uv_fs::{
+    PortablePath, Simplified, copy_atomic_sync, normalize_path_under, persist_with_retry_sync,
+    relative_to,
+};
 use uv_normalize::PackageName;
 use uv_pypi_types::DirectUrl;
 use uv_shell::escape_posix_for_single_quotes;
 use uv_trampoline_builder::windows_script_launcher;
 use uv_warnings::warn_user_once;
 
+use crate::directory::LibraryDirectories;
 use crate::linker::InstallState;
 use crate::record::RecordEntry;
 use crate::script::{EntryPoints, Script};
@@ -472,7 +478,7 @@ fn move_folder_recorded(
     state: &InstallState,
 ) -> Result<(), Error> {
     let mut rename_or_copy = RenameOrCopy::default();
-    fs::create_dir_all(dest_dir)?;
+    let directories = LibraryDirectories::new(layout)?;
     for entry in WalkDir::new(src_dir) {
         let entry = entry?;
         let src = entry.path();
@@ -488,18 +494,16 @@ fn move_folder_recorded(
             .expect("prefix must not change");
         let target = dest_dir.join(relative_to_data);
         if entry.file_type().is_dir() {
-            // Only package directories can be links created by our installer. Preserve symlinks
-            // in the installation scheme itself (for example, a symlinked `lib` directory).
-            if target.parent().is_some_and(|parent| {
-                parent == layout.scheme.purelib || parent == layout.scheme.platlib
-            }) {
-                state.copy_locks().with_directory_lock(&target, || {
-                    materialize_symlink_dir(&target)?;
-                    fs::create_dir_all(&target)?;
-                    Ok::<_, Error>(())
-                })?;
-            } else {
-                fs::create_dir_all(&target)?;
+            let resolved = directories.resolve(&target, |directory| {
+                state.copy_locks().with_directory_lock(directory, || {
+                    materialize_symlink_dir(directory)?;
+                    fs::create_dir_all(directory)?;
+                    Ok::<_, Error>(ControlFlow::<Infallible>::Continue(()))
+                })
+            })?;
+            match resolved {
+                ControlFlow::Continue(directory) => fs::create_dir_all(directory)?,
+                ControlFlow::Break(never) => match never {},
             }
         } else {
             validate_data_script_destination(&target, &layout.scheme.scripts)?;
@@ -1214,7 +1218,8 @@ impl RenameOrCopy {
     /// Try to rename, and on failure, copy.
     ///
     /// Usually, source and target are on the same device, so we can rename, but if that fails, we
-    /// have to copy. If renaming failed once, we switch to copy permanently.
+    /// have to copy. If renaming failed once, we switch to copy permanently. Copies replace the
+    /// destination atomically so an existing file symlink is never followed into the wheel cache.
     fn rename_or_copy(&mut self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
         match self {
             Self::Rename => match fs_err::rename(from.as_ref(), to.as_ref()) {
@@ -1222,11 +1227,11 @@ impl RenameOrCopy {
                 Err(err) => {
                     *self = Self::Copy;
                     debug!("Failed to rename, falling back to copy: {err}");
-                    fs_err::copy(from.as_ref(), to.as_ref())?;
+                    copy_atomic_sync(from.as_ref(), to.as_ref())?;
                 }
             },
             Self::Copy => {
-                fs_err::copy(from.as_ref(), to.as_ref())?;
+                copy_atomic_sync(from.as_ref(), to.as_ref())?;
             }
         }
         Ok(())
@@ -1241,12 +1246,37 @@ mod test {
 
     use anyhow::Result;
     use assert_fs::prelude::*;
+    #[cfg(unix)]
+    use fs_err::os::unix::fs::symlink;
     use indoc::{formatdoc, indoc};
 
+    #[cfg(unix)]
+    use super::RenameOrCopy;
     use super::{
         Error, RecordEntry, Script, WheelFile, format_shebang, get_script_executable,
         parse_email_message_file, parse_scripts, read_record, write_installer_metadata,
     };
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_data_over_existing_symlink() -> Result<()> {
+        let temporary = assert_fs::TempDir::new()?;
+        let source = temporary.child("source");
+        let cached = temporary.child("cached");
+        let target = temporary.child("target");
+        source.write_str("new data")?;
+        cached.write_str("cached data")?;
+        symlink(cached.path(), target.path())?;
+
+        // Exercise the fallback without requiring two filesystems in the test environment.
+        RenameOrCopy::Copy.rename_or_copy(source.path(), target.path())?;
+
+        assert!(!target.path().is_symlink());
+        target.assert("new data");
+        cached.assert("cached data");
+        source.assert("new data");
+        Ok(())
+    }
 
     #[test]
     fn test_parse_email_message_file() {

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -1,9 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
-use std::convert::Infallible;
 use std::fmt::Display;
 use std::io;
 use std::io::{BufReader, Read, Write};
-use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 
 use data_encoding::BASE64URL_NOPAD;
@@ -16,7 +14,6 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, instrument, trace, warn};
 use walkdir::WalkDir;
 
-use uv_fs::link::materialize_symlink_dir;
 use uv_fs::{
     PortablePath, Simplified, copy_atomic_sync, normalize_path_under, persist_with_retry_sync,
     relative_to,
@@ -494,17 +491,7 @@ fn move_folder_recorded(
             .expect("prefix must not change");
         let target = dest_dir.join(relative_to_data);
         if entry.file_type().is_dir() {
-            let resolved = directories.resolve(&target, |directory| {
-                state.copy_locks().with_directory_lock(directory, || {
-                    materialize_symlink_dir(directory)?;
-                    fs::create_dir_all(directory)?;
-                    Ok::<_, Error>(ControlFlow::<Infallible>::Continue(()))
-                })
-            })?;
-            match resolved {
-                ControlFlow::Continue(directory) => fs::create_dir_all(directory)?,
-                ControlFlow::Break(never) => match never {},
-            }
+            directories.prepare(&target, state)?;
         } else {
             validate_data_script_destination(&target, &layout.scheme.scripts)?;
             rename_or_copy.rename_or_copy(src, &target)?;
@@ -791,7 +778,7 @@ pub(crate) fn install_data(
 
                     // Create the scripts directory, if it doesn't exist.
                     if !initialized {
-                        fs::create_dir_all(&layout.scheme.scripts)?;
+                        LibraryDirectories::new(layout)?.prepare(&layout.scheme.scripts, state)?;
                         initialized = true;
                     }
 

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -14,6 +14,7 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, instrument, trace, warn};
 use walkdir::WalkDir;
 
+use uv_fs::link::materialize_symlink_dir;
 use uv_fs::{PortablePath, Simplified, normalize_path_under, persist_with_retry_sync, relative_to};
 use uv_normalize::PackageName;
 use uv_pypi_types::DirectUrl;
@@ -21,6 +22,7 @@ use uv_shell::escape_posix_for_single_quotes;
 use uv_trampoline_builder::windows_script_launcher;
 use uv_warnings::warn_user_once;
 
+use crate::linker::InstallState;
 use crate::record::RecordEntry;
 use crate::script::{EntryPoints, Script};
 use crate::{Error, Layout};
@@ -464,9 +466,10 @@ pub(crate) enum LibKind {
 fn move_folder_recorded(
     src_dir: &Path,
     dest_dir: &Path,
-    scripts: &Path,
+    layout: &Layout,
     site_packages: &Path,
     record: &mut [RecordEntry],
+    state: &InstallState,
 ) -> Result<(), Error> {
     let mut rename_or_copy = RenameOrCopy::default();
     fs::create_dir_all(dest_dir)?;
@@ -485,9 +488,21 @@ fn move_folder_recorded(
             .expect("prefix must not change");
         let target = dest_dir.join(relative_to_data);
         if entry.file_type().is_dir() {
-            fs::create_dir_all(&target)?;
+            // Only package directories can be links created by our installer. Preserve symlinks
+            // in the installation scheme itself (for example, a symlinked `lib` directory).
+            if target.parent().is_some_and(|parent| {
+                parent == layout.scheme.purelib || parent == layout.scheme.platlib
+            }) {
+                state.copy_locks().with_directory_lock(&target, || {
+                    materialize_symlink_dir(&target)?;
+                    fs::create_dir_all(&target)?;
+                    Ok::<_, Error>(())
+                })?;
+            } else {
+                fs::create_dir_all(&target)?;
+            }
         } else {
-            validate_data_script_destination(&target, scripts)?;
+            validate_data_script_destination(&target, &layout.scheme.scripts)?;
             rename_or_copy.rename_or_copy(src, &target)?;
             let entry = record
                 .iter_mut()
@@ -720,6 +735,7 @@ pub(crate) fn install_data(
     console_scripts: &[Script],
     gui_scripts: &[Script],
     record: &mut [RecordEntry],
+    state: &InstallState,
 ) -> Result<(), Error> {
     for entry in fs::read_dir(data_dir)? {
         let entry = entry?;
@@ -736,9 +752,10 @@ pub(crate) fn install_data(
                 move_folder_recorded(
                     &path,
                     &layout.scheme.data,
-                    &layout.scheme.scripts,
+                    layout,
                     site_packages,
                     record,
+                    state,
                 )?;
             }
             Some("scripts") => {
@@ -791,13 +808,7 @@ pub(crate) fn install_data(
                     "Installing data/headers to {}",
                     target_path.user_display()
                 );
-                move_folder_recorded(
-                    &path,
-                    &target_path,
-                    &layout.scheme.scripts,
-                    site_packages,
-                    record,
-                )?;
+                move_folder_recorded(&path, &target_path, layout, site_packages, record, state)?;
             }
             Some("purelib") => {
                 trace!(
@@ -808,9 +819,10 @@ pub(crate) fn install_data(
                 move_folder_recorded(
                     &path,
                     &layout.scheme.purelib,
-                    &layout.scheme.scripts,
+                    layout,
                     site_packages,
                     record,
+                    state,
                 )?;
             }
             Some("platlib") => {
@@ -822,9 +834,10 @@ pub(crate) fn install_data(
                 move_folder_recorded(
                     &path,
                     &layout.scheme.platlib,
-                    &layout.scheme.scripts,
+                    layout,
                     site_packages,
                     record,
+                    state,
                 )?;
             }
             _ => {

--- a/crates/uv-installer/src/compile.rs
+++ b/crates/uv-installer/src/compile.rs
@@ -205,6 +205,7 @@ pub async fn compile_tree(
     let mut source_files = 0;
     let mut send_error = None;
     let walker = WalkDir::new(dir)
+        .follow_links(true)
         .into_iter()
         // Otherwise we stumble over temporary files from `compileall`.
         .filter_entry(|dir| dir.file_name() != "__pycache__");

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -332,6 +332,24 @@ fn install_symlink() -> Result<()> {
     "
     );
 
+    assert!(context.site_packages().join("markupsafe").is_symlink());
+    let metadata = context.site_packages().join("MarkupSafe-2.1.3.dist-info");
+    assert!(!metadata.is_symlink());
+    assert!(!metadata.join("RECORD").is_symlink());
+
+    // Uninstalling must preserve the cached package for an offline reinstall.
+    context.pip_uninstall().arg("MarkupSafe").assert().success();
+    uv_snapshot!(context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--link-mode=symlink")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + markupsafe==2.1.3
+    ");
+
     context
         .assert_command("from markupsafe import Markup")
         .success();

--- a/crates/uv/tests/pip/pip_uninstall.rs
+++ b/crates/uv/tests/pip/pip_uninstall.rs
@@ -5,7 +5,11 @@ use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
+#[cfg(unix)]
+use fs_err::os::unix::fs::symlink;
 
+#[cfg(unix)]
+use uv_extract::dirhash::dirhash_path;
 use uv_test::uv_snapshot;
 
 #[test]
@@ -102,6 +106,50 @@ fn uninstall() -> Result<()> {
 
     context.assert_command("import markupsafe").failure();
 
+    Ok(())
+}
+
+/// Uninstall directory links at any depth without modifying their targets.
+#[test]
+#[cfg(unix)]
+fn uninstall_nested_directory_symlink() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let site_packages = ChildPath::new(context.site_packages());
+    let dist_info = site_packages.child("example-1.0.0.dist-info");
+    dist_info
+        .child("METADATA")
+        .write_str("Metadata-Version: 2.1\nName: example\nVersion: 1.0.0\n")?;
+    dist_info.child("RECORD").write_str(
+        "example/nested/vendor/a.py,,\n\
+         example/nested/vendor/deeper/b.py,,\n\
+         example/local.py,,\n\
+         example-1.0.0.dist-info/METADATA,,\n\
+         example-1.0.0.dist-info/RECORD,,\n",
+    )?;
+    site_packages.child("example/local.py").touch()?;
+    site_packages.child("example/nested/other.py").touch()?;
+
+    let store = context.temp_dir.child("store");
+    store.child("a.py").write_str("VALUE = 1\n")?;
+    store.child("deeper/b.py").write_str("VALUE = 2\n")?;
+    store.child("__pycache__/a.cpython-312.pyc").touch()?;
+    let digest = dirhash_path(store.path())?;
+    let vendor = site_packages.child("example/nested/vendor");
+    symlink(store.path(), vendor.path())?;
+
+    uv_snapshot!(context.filters(), context.pip_uninstall().arg("example"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Uninstalled 1 package in [TIME]
+     - example==1.0.0
+    ");
+
+    assert!(!vendor.exists());
+    assert!(!vendor.is_symlink());
+    assert!(!site_packages.child("example/local.py").exists());
+    assert!(site_packages.child("example/nested/other.py").exists());
+    assert!(!dist_info.exists());
+    assert_eq!(dirhash_path(store.path())?, digest);
     Ok(())
 }
 

--- a/crates/uv/tests/pip/pip_uninstall.rs
+++ b/crates/uv/tests/pip/pip_uninstall.rs
@@ -122,6 +122,7 @@ fn uninstall_nested_directory_symlink() -> Result<()> {
     dist_info.child("RECORD").write_str(
         "example/nested/vendor/a.py,,\n\
          example/nested/vendor/deeper/b.py,,\n\
+         example/nested/missing/module.py,,\n\
          example/local.py,,\n\
          example-1.0.0.dist-info/METADATA,,\n\
          example-1.0.0.dist-info/RECORD,,\n",
@@ -136,6 +137,8 @@ fn uninstall_nested_directory_symlink() -> Result<()> {
     let digest = dirhash_path(store.path())?;
     let vendor = site_packages.child("example/nested/vendor");
     symlink(store.path(), vendor.path())?;
+    let missing = site_packages.child("example/nested/missing");
+    symlink(store.child("missing").path(), missing.path())?;
 
     uv_snapshot!(context.filters(), context.pip_uninstall().arg("example"), @"
     exit_code: 0 (success)
@@ -146,6 +149,7 @@ fn uninstall_nested_directory_symlink() -> Result<()> {
 
     assert!(!vendor.exists());
     assert!(!vendor.is_symlink());
+    assert!(!missing.is_symlink());
     assert!(!site_packages.child("example/local.py").exists());
     assert!(site_packages.child("example/nested/other.py").exists());
     assert!(!dist_info.exists());

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -328,512 +328,11 @@ fn compile_bytecode_with_symlink_link_mode() {
     );
 }
 
-/// Directory links retain private install metadata and can be uninstalled without changing the
-/// cached wheel. Bytecode compilation follows the directory link.
-#[test]
-#[cfg(unix)]
-fn directory_symlink_install() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let wheel = context
-        .temp_dir
-        .child("symlink_test-1.0.0-py3-none-any.whl");
-    write_test_wheel(
-        wheel.path(),
-        "symlink_test",
-        [
-            ("symlink_test/__init__.py", "VALUE = 1\n"),
-            ("symlink_test/nested/module.py", "VALUE = 2\n"),
-            ("symlink_module.py", "VALUE = 3\n"),
-            (
-                "symlink_test-1.0.0.data/purelib/symlink_data.py",
-                "VALUE = 4\n",
-            ),
-            (
-                "symlink_test-1.0.0.data/scripts/symlink-script",
-                "#!python\nprint('hello')\n",
-            ),
-        ],
-    )?;
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg(wheel.path())
-        .arg("--link-mode=symlink")
-        .arg("--compile-bytecode"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-    Bytecode compiled 4 files in [TIME]
-     + symlink-test==1.0.0 (from file://[TEMP_DIR]/symlink_test-1.0.0-py3-none-any.whl)
-    ");
-
-    let package = context.site_packages().join("symlink_test");
-    let cached_package = fs::read_link(&package)?;
-    let dist_info = context.site_packages().join("symlink_test-1.0.0.dist-info");
-    assert!(!dist_info.is_symlink());
-    assert!(!dist_info.join("RECORD").is_symlink());
-    assert!(dist_info.join("METADATA").is_symlink());
-    assert!(
-        context
-            .site_packages()
-            .join("symlink_module.py")
-            .is_symlink()
-    );
-    assert!(
-        cached_package
-            .join("__pycache__/__init__.cpython-312.pyc")
-            .is_file()
-    );
-    context
-        .assert_command(
-            "import symlink_test, symlink_test.nested.module, symlink_module, symlink_data",
-        )
-        .success();
-    Command::new(venv_bin_path(&context.venv).join("symlink-script"))
-        .assert()
-        .success()
-        .stdout("hello\n");
-
-    uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-test"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Uninstalled 1 package in [TIME]
-     - symlink-test==1.0.0 (from file://[TEMP_DIR]/symlink_test-1.0.0-py3-none-any.whl)
-    ");
-    assert!(!package.is_symlink());
-    assert_eq!(
-        fs::read_to_string(cached_package.join("__init__.py"))?,
-        "VALUE = 1\n"
-    );
-    assert_eq!(
-        fs::read_to_string(cached_package.join("nested/module.py"))?,
-        "VALUE = 2\n"
-    );
-
-    // Reuse the cached wheel after uninstalling it.
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg(wheel.path())
-        .arg("--link-mode=symlink")
-        .arg("--offline"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + symlink-test==1.0.0 (from file://[TEMP_DIR]/symlink_test-1.0.0-py3-none-any.whl)
-    ");
-    assert!(package.is_symlink());
-    context
-        .assert_command("import symlink_test.nested.module")
-        .success();
-    Ok(())
-}
-
-/// A later install expands only overlapping directories before merging, including when the new
-/// package uses another link mode or contributes its files through `.data`.
+/// Merging shared directories must not write through file links into the cache.
 #[test]
 #[cfg(unix)]
 fn directory_symlink_shared_namespace() -> Result<()> {
-    for link_mode in ["symlink", "copy", "hardlink", "clone"] {
-        for data in [false, true] {
-            let context = uv_test::test_context!("3.12");
-            let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
-            let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
-            write_test_wheel(
-                first.path(),
-                "symlink_a",
-                [
-                    ("shared/a/__init__.py", "VALUE = 1\n"),
-                    ("shared/collision/module.py", "VALUE = 1\n"),
-                    ("shared/collision/RECORD", "VALUE = 1\n"),
-                ],
-            )?;
-            let second_prefix = if data {
-                "symlink_b-1.0.0.data/purelib/"
-            } else {
-                ""
-            };
-            write_test_wheel(
-                second.path(),
-                "symlink_b",
-                [
-                    "shared/b/__init__.py",
-                    "shared/collision/module.py",
-                    "shared/collision/RECORD",
-                ]
-                .map(|path| (format!("{second_prefix}{path}"), "VALUE = 2\n")),
-            )?;
-
-            context
-                .pip_install()
-                .arg(first.path())
-                .arg("--link-mode=symlink")
-                .assert()
-                .success();
-            let shared = context.site_packages().join("shared");
-            let cached_shared = fs::read_link(&shared)?;
-            let cached_digest = dirhash_path(&cached_shared)?;
-            allow_duplicates! {
-                uv_snapshot!(context.filters(), context.pip_install()
-                    .arg(second.path()).arg("--link-mode").arg(link_mode), @"
-                exit_code: 0 (success)
-                ----- stderr -----
-                Resolved 1 package in [TIME]
-                Prepared 1 package in [TIME]
-                Installed 1 package in [TIME]
-                 + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
-                ");
-            }
-            assert!(!shared.is_symlink());
-            assert!(shared.join("a").is_symlink());
-            assert_eq!(
-                shared.join("b").is_symlink(),
-                link_mode == "symlink" && !data
-            );
-            assert!(!shared.join("collision").is_symlink());
-            assert_eq!(
-                fs::read_to_string(shared.join("collision/module.py"))?,
-                "VALUE = 2\n"
-            );
-            assert_eq!(
-                fs::read_to_string(shared.join("collision/RECORD"))?,
-                "VALUE = 2\n"
-            );
-            assert_eq!(dirhash_path(&cached_shared)?, cached_digest);
-            context
-                .assert_command("import shared.a, shared.b")
-                .success();
-
-            allow_duplicates! {
-                uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-a"), @"
-                exit_code: 0 (success)
-                ----- stderr -----
-                Uninstalled 1 package in [TIME]
-                 - symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-                ");
-            }
-            context.assert_command("import shared.b").success();
-            assert!(!shared.join("a").is_symlink());
-            assert_eq!(dirhash_path(&cached_shared)?, cached_digest);
-
-            // Concurrent installation must produce the same merged namespace.
-            if link_mode != "symlink" {
-                continue;
-            }
-            context.venv().arg("--clear").assert().success();
-            allow_duplicates! {
-                uv_snapshot!(context.filters(), context.pip_install()
-                    .arg(first.path()).arg(second.path()).arg("--link-mode=symlink")
-                    .env(EnvVars::UV_CONCURRENT_INSTALLS, "2"), @"
-                exit_code: 0 (success)
-                ----- stderr -----
-                Resolved 2 packages in [TIME]
-                Installed 2 packages in [TIME]
-                 + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-                 + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
-                ");
-            }
-            assert!(!shared.is_symlink());
-            assert!(shared.join("a").is_symlink());
-            assert!(!shared.join("collision").is_symlink());
-            assert_eq!(dirhash_path(&cached_shared)?, cached_digest);
-            context
-                .assert_command("import shared.a, shared.b")
-                .success();
-        }
-    }
-    Ok(())
-}
-
-/// `.data/data` can merge into packages through an installation-scheme alias without changing
-/// the cached wheel or expanding unrelated directories.
-#[test]
-#[cfg(unix)]
-fn directory_symlink_data_data() -> Result<()> {
-    for (destination, scheme_alias) in [
-        ("lib/python3.12/site-packages/shared/collision", None),
-        ("LIB/python3.12/site-packages/shared/collision", None),
-        (
-            "lib64/python3.12/site-packages/shared/collision",
-            Some(("lib64", "lib")),
-        ),
-        (
-            "alias",
-            Some(("alias", "lib/python3.12/site-packages/shared/collision")),
-        ),
-    ] {
-        for reverse in [false, true] {
-            let context = uv_test::test_context!("3.12");
-            if destination.starts_with("LIB/") && !context.venv.join("LIB").is_dir() {
-                continue;
-            }
-            let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
-            let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
-            write_test_wheel(
-                first.path(),
-                "symlink_a",
-                [
-                    ("shared/collision/original.py", "VALUE = 1\n"),
-                    ("shared/sibling/__init__.py", "VALUE = 2\n"),
-                ],
-            )?;
-            let expected = context.temp_dir.child("expected");
-            uv_extract::unzip(File::open(first.path())?, expected.path())?;
-            let cached_digest = dirhash_path(&expected.join("shared"))?;
-
-            let scheme_alias = if let Some((path, target)) = scheme_alias {
-                let path = context.venv.join(path);
-                if !path.is_symlink() {
-                    symlink(target, &path)?;
-                }
-                let target = fs::read_link(&path)?;
-                Some((path, target))
-            } else {
-                None
-            };
-            write_test_wheel(
-                second.path(),
-                "symlink_b",
-                [
-                    (
-                        format!("symlink_b-1.0.0.data/data/{destination}/added.py"),
-                        "VALUE = 3\n",
-                    ),
-                    (
-                        "symlink_b-1.0.0.data/data/share/symlink_b/config.txt".to_string(),
-                        "configuration\n",
-                    ),
-                ],
-            )?;
-
-            let wheels = if reverse {
-                [&second, &first]
-            } else {
-                [&first, &second]
-            };
-            for wheel in wheels {
-                context
-                    .pip_install()
-                    .arg(wheel.path())
-                    .arg("--link-mode=symlink")
-                    .assert()
-                    .success();
-            }
-
-            let shared = context.site_packages().join("shared");
-            assert!(!shared.is_symlink());
-            assert!(!shared.join("collision").is_symlink());
-            let cached_sibling = fs::read_link(shared.join("sibling"))?;
-            let cached_shared = cached_sibling
-                .parent()
-                .context("Missing cached package directory")?;
-            assert_eq!(dirhash_path(cached_shared)?, cached_digest);
-            let added = shared.join("collision/added.py");
-            let cached_added = fs::read_link(&added)?;
-            assert_eq!(fs::read_to_string(&cached_added)?, "VALUE = 3\n");
-            let config = context.venv.join("share/symlink_b/config.txt");
-            assert_eq!(fs::read_to_string(&config)?, "configuration\n");
-            if let Some((path, target)) = &scheme_alias {
-                assert_eq!(fs::read_link(path)?, *target);
-            }
-            context
-                .assert_command(
-                    "import shared.collision.original, shared.collision.added, shared.sibling",
-                )
-                .success();
-
-            allow_duplicates! {
-                uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-a"), @"
-                exit_code: 0 (success)
-                ----- stderr -----
-                Uninstalled 1 package in [TIME]
-                 - symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-                ");
-            }
-            assert!(!shared.join("sibling").is_symlink());
-            assert_eq!(dirhash_path(cached_shared)?, cached_digest);
-            context
-                .assert_command("import shared.collision.added")
-                .success();
-
-            allow_duplicates! {
-                uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-b"), @"
-                exit_code: 0 (success)
-                ----- stderr -----
-                Uninstalled 1 package in [TIME]
-                 - symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
-                ");
-            }
-            assert!(!added.exists());
-            assert!(!config.exists());
-            assert_eq!(dirhash_path(cached_shared)?, cached_digest);
-            assert_eq!(fs::read_to_string(&cached_added)?, "VALUE = 3\n");
-
-            // Reuse both cached wheels concurrently, including through the scheme alias.
-            allow_duplicates! {
-                uv_snapshot!(context.filters(), context.pip_install()
-                    .arg(first.path()).arg(second.path()).arg("--link-mode=symlink")
-                    .arg("--offline")
-                    .env(EnvVars::UV_CONCURRENT_INSTALLS, "2"), @"
-                exit_code: 0 (success)
-                ----- stderr -----
-                Resolved 2 packages in [TIME]
-                Installed 2 packages in [TIME]
-                 + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-                 + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
-                ");
-            }
-            assert!(shared.join("sibling").is_symlink());
-            assert_eq!(dirhash_path(cached_shared)?, cached_digest);
-            assert_eq!(fs::read_to_string(&cached_added)?, "VALUE = 3\n");
-            if let Some((path, target)) = &scheme_alias {
-                assert_eq!(fs::read_link(path)?, *target);
-            }
-            context
-                .assert_command(
-                    "import shared.collision.original, shared.collision.added, shared.sibling",
-                )
-                .success();
-        }
-    }
-    Ok(())
-}
-
-/// Scripts inside a `--target` library expand overlapping package links before being written.
-#[test]
-#[cfg(unix)]
-fn directory_symlink_target_scripts() -> Result<()> {
-    for (script_name, script_file, script_contents) in [
-        (
-            "symlink-script",
-            "symlink_b-1.0.0.dist-info/entry_points.txt",
-            "[console_scripts]\nsymlink-script = symlink_b:main\n",
-        ),
-        (
-            "nested/symlink-script",
-            "symlink_b-1.0.0.dist-info/entry_points.txt",
-            "[console_scripts]\nnested/symlink-script = symlink_b:main\n",
-        ),
-        (
-            "symlink-script",
-            "symlink_b-1.0.0.data/scripts/symlink-script",
-            "#!python\nprint('hello')\n",
-        ),
-    ] {
-        for order in ["package-first", "scripts-first", "concurrent"] {
-            let context = uv_test::test_context!("3.12")
-                .with_filtered_python_names()
-                .with_filtered_virtualenv_bin()
-                .with_filtered_exe_suffix();
-            let target = context.temp_dir.child("target");
-            let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
-            let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
-            write_test_wheel(
-                first.path(),
-                "symlink_a",
-                [
-                    ("bin/payload.py", "VALUE = 1\n"),
-                    ("bin/resources/config.txt", "configuration\n"),
-                    ("bin/nested/payload.py", "VALUE = 2\n"),
-                ],
-            )?;
-            write_test_wheel(
-                second.path(),
-                "symlink_b",
-                [
-                    ("symlink_b.py", "def main(): print('hello')\n"),
-                    (script_file, script_contents),
-                ],
-            )?;
-            let expected = context.temp_dir.child("expected");
-            uv_extract::unzip(File::open(first.path())?, expected.path())?;
-            let cached_digest = dirhash_path(&expected.join("bin"))?;
-
-            if order == "concurrent" {
-                allow_duplicates! {
-                    uv_snapshot!(context.filters(), context.pip_install()
-                        .arg(first.path()).arg(second.path()).arg("--link-mode=symlink")
-                        .arg("--target").arg(target.path())
-                        .env(EnvVars::UV_CONCURRENT_INSTALLS, "2"), @"
-                    exit_code: 0 (success)
-                    ----- stderr -----
-                    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
-                    Resolved 2 packages in [TIME]
-                    Prepared 2 packages in [TIME]
-                    Installed 2 packages in [TIME]
-                     + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-                     + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
-                    ");
-                }
-            } else {
-                let wheels = if order == "package-first" {
-                    [&first, &second]
-                } else {
-                    [&second, &first]
-                };
-                for wheel in wheels {
-                    context
-                        .pip_install()
-                        .arg(wheel.path())
-                        .arg("--link-mode=symlink")
-                        .arg("--target")
-                        .arg(target.path())
-                        .assert()
-                        .success();
-                    if order == "package-first" && wheel.path() == first.path() {
-                        assert!(target.join("bin").is_symlink());
-                    }
-                }
-            }
-
-            let scripts = target.join("bin");
-            assert!(!scripts.is_symlink());
-            let cached_resources = fs::read_link(scripts.join("resources"))?;
-            let cached_bin = cached_resources
-                .parent()
-                .context("Missing cached scripts directory")?;
-            assert_eq!(dirhash_path(cached_bin)?, cached_digest);
-            Command::new(scripts.join(script_name))
-                .env(EnvVars::PYTHONPATH, target.path())
-                .assert()
-                .success()
-                .stdout("hello\n");
-
-            allow_duplicates! {
-                uv_snapshot!(context.filters(), context.pip_uninstall()
-                    .arg("symlink-b").arg("--target").arg(target.path()), @"
-                exit_code: 0 (success)
-                ----- stderr -----
-                Uninstalled 1 package in [TIME]
-                 - symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
-                ");
-            }
-            assert!(!scripts.join(script_name).exists());
-            assert_eq!(
-                fs::read_to_string(scripts.join("payload.py"))?,
-                "VALUE = 1\n"
-            );
-            assert_eq!(
-                fs::read_to_string(scripts.join("nested/payload.py"))?,
-                "VALUE = 2\n"
-            );
-            assert!(scripts.join("resources").is_symlink());
-            assert_eq!(dirhash_path(cached_bin)?, cached_digest);
-        }
-    }
-    Ok(())
-}
-
-/// A file cannot replace another wheel's directory, including after a namespace is expanded.
-#[test]
-#[cfg(unix)]
-fn directory_symlink_file_directory_conflict() -> Result<()> {
-    for (link_mode, data) in [
-        ("copy", false),
-        ("hardlink", false),
-        ("clone", false),
-        ("symlink", false),
-        ("symlink", true),
-    ] {
+    for link_mode in ["symlink", "hardlink"] {
         let context = uv_test::test_context!("3.12");
         let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
         let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
@@ -841,17 +340,18 @@ fn directory_symlink_file_directory_conflict() -> Result<()> {
             first.path(),
             "symlink_a",
             [
-                ("shared/collision/payload.py", "VALUE = 1\n"),
-                ("shared/sibling/__init__.py", "VALUE = 2\n"),
+                ("shared/a.py", "VALUE = 1\n"),
+                ("shared/RECORD", "original\n"),
             ],
         )?;
-        let destination = if data {
-            "symlink_b-1.0.0.data/purelib/shared/collision"
-        } else {
-            "shared/collision"
-        };
-        write_test_wheel(second.path(), "symlink_b", [(destination, "replacement\n")])?;
-
+        write_test_wheel(
+            second.path(),
+            "symlink_b",
+            [
+                ("shared/b.py", "VALUE = 2\n"),
+                ("shared/RECORD", "replacement\n"),
+            ],
+        )?;
         context
             .pip_install()
             .arg(first.path())
@@ -859,106 +359,137 @@ fn directory_symlink_file_directory_conflict() -> Result<()> {
             .assert()
             .success();
         let shared = context.site_packages().join("shared");
-        let cached_shared = fs::read_link(&shared)?;
-        let cached_digest = dirhash_path(&cached_shared)?;
+        let cached = fs::read_link(&shared)?;
+        let digest = dirhash_path(&cached)?;
 
         allow_duplicates! {
             uv_snapshot!(context.filters(), context.pip_install()
                 .arg(second.path()).arg("--link-mode").arg(link_mode), @"
-            exit_code: 2 (failure)
+            exit_code: 0 (success)
             ----- stderr -----
             Resolved 1 package in [TIME]
             Prepared 1 package in [TIME]
-            error: Failed to install: symlink_b-1.0.0-py3-none-any.whl (symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl))
-              Caused by: Cannot replace directory `[SITE_PACKAGES]/shared/collision` with a file
+            Installed 1 package in [TIME]
+             + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
             ");
         }
-        assert!(shared.join("collision").is_dir());
-        assert_eq!(
-            fs::read_to_string(shared.join("collision/payload.py"))?,
-            "VALUE = 1\n"
-        );
-        assert!(shared.join("sibling").is_symlink());
-        assert_eq!(dirhash_path(&cached_shared)?, cached_digest);
+        assert!(!shared.is_symlink());
+        assert_eq!(fs::read_to_string(shared.join("RECORD"))?, "replacement\n");
+        context
+            .assert_command("import shared.a, shared.b")
+            .success();
+        context.pip_uninstall().arg("symlink-a").assert().success();
+        context.assert_command("import shared.b").success();
+        assert_eq!(dirhash_path(&cached)?, digest);
     }
     Ok(())
 }
 
-/// Generated and relocated scripts cannot replace directory links inside a `--target` library.
+/// Relocated data follows scheme aliases without writing into a linked package's cache.
 #[test]
 #[cfg(unix)]
-fn directory_symlink_target_script_directory_conflict() -> Result<()> {
-    for script in [
-        (
-            "symlink_b-1.0.0.dist-info/entry_points.txt",
-            "[console_scripts]\nsymlink-script = symlink_b:main\n",
-        ),
-        (
-            "symlink_b-1.0.0.data/scripts/symlink-script",
-            "#!python\nprint('replacement')\n",
-        ),
-        (
-            "symlink_b-1.0.0.data/scripts/symlink-script",
-            "#!/bin/sh\necho replacement\n",
-        ),
-    ] {
-        let context = uv_test::test_context!("3.12")
-            .with_filtered_python_names()
-            .with_filtered_virtualenv_bin()
-            .with_filtered_exe_suffix();
-        let target = context.temp_dir.child("target");
-        let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
-        let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
-        write_test_wheel(
-            first.path(),
-            "symlink_a",
-            [
-                ("bin/symlink-script/payload.py", "VALUE = 1\n"),
-                ("bin/resources/config.txt", "configuration\n"),
-            ],
-        )?;
-        write_test_wheel(
-            second.path(),
-            "symlink_b",
-            [
-                ("symlink_b.py", "def main(): print('replacement')\n"),
-                script,
-            ],
-        )?;
-
-        context
-            .pip_install()
-            .arg(first.path())
-            .arg("--link-mode=symlink")
-            .arg("--target")
-            .arg(target.path())
-            .assert()
-            .success();
-        let scripts = target.join("bin");
-        let cached_bin = fs::read_link(&scripts)?;
-        let cached_digest = dirhash_path(&cached_bin)?;
-
-        allow_duplicates! {
-            uv_snapshot!(context.filters(), context.pip_install()
-                .arg(second.path()).arg("--link-mode=symlink")
-                .arg("--target").arg(target.path()), @"
-            exit_code: 2 (failure)
-            ----- stderr -----
-            Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
-            Resolved 1 package in [TIME]
-            Prepared 1 package in [TIME]
-            error: Failed to install: symlink_b-1.0.0-py3-none-any.whl (symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl))
-              Caused by: Cannot replace directory `[TEMP_DIR]/target/[BIN]/symlink-script` with a file
-            ");
-        }
-        assert!(scripts.join("symlink-script").is_dir());
-        assert_eq!(
-            fs::read_to_string(scripts.join("symlink-script/payload.py"))?,
-            "VALUE = 1\n"
-        );
-        assert!(scripts.join("resources").is_symlink());
-        assert_eq!(dirhash_path(&cached_bin)?, cached_digest);
+fn directory_symlink_data_data() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_env(EnvVars::UV_LINK_MODE, "symlink");
+    let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
+    let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
+    write_test_wheel(
+        first.path(),
+        "symlink_a",
+        [("shared/original.py", "VALUE = 1\n")],
+    )?;
+    write_test_wheel(
+        second.path(),
+        "symlink_b",
+        [(
+            "symlink_b-1.0.0.data/data/lib64/python3.12/site-packages/shared/added.py",
+            "VALUE = 2\n",
+        )],
+    )?;
+    let alias = context.venv.join("lib64");
+    if !alias.is_symlink() {
+        symlink("lib", &alias)?;
     }
+    context.pip_install().arg(first.path()).assert().success();
+    let shared = context.site_packages().join("shared");
+    let cached = fs::read_link(&shared)?;
+    let digest = dirhash_path(&cached)?;
+
+    uv_snapshot!(context.filters(), context.pip_install().arg(second.path()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+    ");
+    assert!(!shared.is_symlink());
+    assert!(alias.is_symlink());
+    context
+        .assert_command("import shared.original, shared.added")
+        .success();
+    context.pip_uninstall().arg("symlink-b").assert().success();
+    assert!(!shared.join("added.py").exists());
+    assert_eq!(dirhash_path(&cached)?, digest);
+    Ok(())
+}
+
+/// Generated scripts expand an overlapping package directory in a `--target` installation.
+#[test]
+#[cfg(unix)]
+fn directory_symlink_target_scripts() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_env(EnvVars::UV_LINK_MODE, "symlink")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix();
+    let target = context.temp_dir.child("target");
+    let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
+    let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
+    write_test_wheel(
+        first.path(),
+        "symlink_a",
+        [("bin/nested/payload.py", "VALUE = 1\n")],
+    )?;
+    write_test_wheel(
+        second.path(),
+        "symlink_b",
+        [
+            ("symlink_b.py", "def main(): print('hello')\n"),
+            (
+                "symlink_b-1.0.0.dist-info/entry_points.txt",
+                "[console_scripts]\nnested/symlink-script = symlink_b:main\n",
+            ),
+        ],
+    )?;
+    context
+        .pip_install()
+        .arg(first.path())
+        .arg("--target")
+        .arg(target.path())
+        .assert()
+        .success();
+    let scripts = target.join("bin");
+    let cached = fs::read_link(&scripts)?;
+    let digest = dirhash_path(&cached)?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(second.path()).arg("--target").arg(target.path()), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+    ");
+    assert!(!scripts.is_symlink());
+    assert!(!scripts.join("nested").is_symlink());
+    Command::new(scripts.join("nested/symlink-script"))
+        .env(EnvVars::PYTHONPATH, target.path())
+        .assert()
+        .success()
+        .stdout("hello\n");
+    assert_eq!(dirhash_path(&cached)?, digest);
     Ok(())
 }
 
@@ -15627,6 +15158,8 @@ fn pip_install_build_dependencies_respect_locked_versions() -> Result<()> {
 #[test]
 fn overlapping_packages_warning() -> Result<()> {
     let context = uv_test::test_context!("3.12");
+    #[cfg(unix)]
+    let context = context.with_env(EnvVars::UV_LINK_MODE, "symlink");
 
     let built_by_uv = context.workspace_root.join("test/packages/built-by-uv");
 
@@ -15756,6 +15289,8 @@ fn overlapping_packages_warning() -> Result<()> {
 #[test]
 fn overlapping_empty_init_py() -> Result<()> {
     let context = uv_test::test_context!("3.12");
+    #[cfg(unix)]
+    let context = context.with_env(EnvVars::UV_LINK_MODE, "symlink");
 
     let gpu_a = context.temp_dir.child("gpu-a");
     gpu_a.child("pyproject.toml").write_str(
@@ -15838,6 +15373,8 @@ fn overlapping_empty_init_py() -> Result<()> {
 #[test]
 fn overlapping_nested_files() -> Result<()> {
     let context = uv_test::test_context!("3.12");
+    #[cfg(unix)]
+    let context = context.with_env(EnvVars::UV_LINK_MODE, "symlink");
 
     let gpu_a = context.temp_dir.child("gpu-a");
     gpu_a.child("pyproject.toml").write_str(

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -37,19 +37,35 @@ use uv_test::{
 };
 
 fn write_many_files_wheel(path: &Path, source_files: usize) -> Result<()> {
+    write_test_wheel(
+        path,
+        "large_wheel",
+        (0..source_files).map(|index| {
+            (
+                format!("large_wheel/module_{index:05}.py"),
+                "VALUE = 1\n".to_string(),
+            )
+        }),
+    )
+}
+
+fn write_test_wheel(
+    path: &Path,
+    name: &str,
+    files: impl IntoIterator<Item = (String, String)>,
+) -> Result<()> {
     let mut writer = ZipFileWriter::new(Vec::new());
     let mut record = String::new();
 
-    for index in 0..source_files {
-        let name = format!("large_wheel/module_{index:05}.py");
+    for (name, contents) in files {
         let entry = ZipEntryBuilder::new(name.clone().into(), Compression::Stored);
-        block_on(writer.write_entry_whole(entry, b"VALUE = 1\n"))?;
+        block_on(writer.write_entry_whole(entry, contents.as_bytes()))?;
         writeln!(record, "{name},,")?;
     }
 
-    let metadata = indoc! {"
+    let metadata = formatdoc! {"
         Metadata-Version: 2.1
-        Name: large-wheel
+        Name: {name}
         Version: 1.0.0
     "};
     let wheel = indoc! {"
@@ -59,16 +75,19 @@ fn write_many_files_wheel(path: &Path, source_files: usize) -> Result<()> {
         Tag: py3-none-any
     "};
     for (name, contents) in [
-        ("large_wheel-1.0.0.dist-info/METADATA", metadata),
-        ("large_wheel-1.0.0.dist-info/WHEEL", wheel),
+        (
+            format!("{name}-1.0.0.dist-info/METADATA"),
+            metadata.as_str(),
+        ),
+        (format!("{name}-1.0.0.dist-info/WHEEL"), wheel),
     ] {
-        let entry = ZipEntryBuilder::new(name.into(), Compression::Stored);
+        let entry = ZipEntryBuilder::new(name.clone().into(), Compression::Stored);
         block_on(writer.write_entry_whole(entry, contents.as_bytes()))?;
         writeln!(record, "{name},,")?;
     }
-    record.push_str("large_wheel-1.0.0.dist-info/RECORD,,\n");
+    writeln!(record, "{name}-1.0.0.dist-info/RECORD,,")?;
     let entry = ZipEntryBuilder::new(
-        "large_wheel-1.0.0.dist-info/RECORD".into(),
+        format!("{name}-1.0.0.dist-info/RECORD").into(),
         Compression::Stored,
     );
     block_on(writer.write_entry_whole(entry, record.as_bytes()))?;
@@ -311,6 +330,205 @@ fn compile_bytecode_with_symlink_link_mode() {
             .join("__init__.cpython-312.pyc")
             .exists()
     );
+}
+
+/// Directory links retain private install metadata and can be uninstalled without changing the
+/// cached wheel. Bytecode compilation follows the directory link.
+#[test]
+#[cfg(unix)]
+fn directory_symlink_install() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel = context
+        .temp_dir
+        .child("symlink_test-1.0.0-py3-none-any.whl");
+    write_test_wheel(
+        wheel.path(),
+        "symlink_test",
+        [
+            ("symlink_test/__init__.py", "VALUE = 1\n"),
+            ("symlink_test/nested/module.py", "VALUE = 2\n"),
+            ("symlink_module.py", "VALUE = 3\n"),
+            (
+                "symlink_test-1.0.0.data/purelib/symlink_data.py",
+                "VALUE = 4\n",
+            ),
+            (
+                "symlink_test-1.0.0.data/scripts/symlink-script",
+                "#!python\nprint('hello')\n",
+            ),
+        ]
+        .map(|(path, contents)| (path.to_string(), contents.to_string())),
+    )?;
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(wheel.path())
+        .arg("--link-mode=symlink")
+        .arg("--compile-bytecode"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+    Bytecode compiled 4 files in [TIME]
+     + symlink-test==1.0.0 (from file://[TEMP_DIR]/symlink_test-1.0.0-py3-none-any.whl)
+    ");
+
+    let package = context.site_packages().join("symlink_test");
+    let cached_package = fs::read_link(&package)?;
+    let dist_info = context.site_packages().join("symlink_test-1.0.0.dist-info");
+    assert!(!dist_info.is_symlink());
+    assert!(!dist_info.join("RECORD").is_symlink());
+    assert!(dist_info.join("METADATA").is_symlink());
+    assert!(
+        context
+            .site_packages()
+            .join("symlink_module.py")
+            .is_symlink()
+    );
+    assert!(
+        cached_package
+            .join("__pycache__/__init__.cpython-312.pyc")
+            .is_file()
+    );
+    context
+        .assert_command(
+            "import symlink_test, symlink_test.nested.module, symlink_module, symlink_data",
+        )
+        .success();
+    Command::new(venv_bin_path(&context.venv).join("symlink-script"))
+        .assert()
+        .success()
+        .stdout("hello\n");
+
+    uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-test"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Uninstalled 1 package in [TIME]
+     - symlink-test==1.0.0 (from file://[TEMP_DIR]/symlink_test-1.0.0-py3-none-any.whl)
+    ");
+    assert!(!package.is_symlink());
+    assert_eq!(
+        fs::read_to_string(cached_package.join("__init__.py"))?,
+        "VALUE = 1\n"
+    );
+    assert_eq!(
+        fs::read_to_string(cached_package.join("nested/module.py"))?,
+        "VALUE = 2\n"
+    );
+
+    // Reuse the cached wheel after uninstalling it.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(wheel.path())
+        .arg("--link-mode=symlink")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + symlink-test==1.0.0 (from file://[TEMP_DIR]/symlink_test-1.0.0-py3-none-any.whl)
+    ");
+    assert!(package.is_symlink());
+    context
+        .assert_command("import symlink_test.nested.module")
+        .success();
+    Ok(())
+}
+
+/// A later install expands a shared directory before merging, including when the new package
+/// uses another link mode or contributes its files through `.data`.
+#[test]
+#[cfg(unix)]
+fn directory_symlink_shared_namespace() -> Result<()> {
+    for link_mode in ["symlink", "copy", "hardlink", "clone"] {
+        for data in [false, true] {
+            let context = uv_test::test_context!("3.12");
+            let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
+            let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
+            write_test_wheel(
+                first.path(),
+                "symlink_a",
+                [(
+                    "shared/a/__init__.py".to_string(),
+                    "VALUE = 1\n".to_string(),
+                )],
+            )?;
+            let second_path = if data {
+                "symlink_b-1.0.0.data/purelib/shared/b/__init__.py"
+            } else {
+                "shared/b/__init__.py"
+            };
+            write_test_wheel(
+                second.path(),
+                "symlink_b",
+                [(second_path.to_string(), "VALUE = 2\n".to_string())],
+            )?;
+
+            allow_duplicates! {
+                uv_snapshot!(context.filters(), context.pip_install()
+                    .arg(first.path()).arg("--link-mode=symlink"), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Resolved 1 package in [TIME]
+                Prepared 1 package in [TIME]
+                Installed 1 package in [TIME]
+                 + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+                ");
+            }
+            let shared = context.site_packages().join("shared");
+            let cached_shared = fs::read_link(&shared)?;
+            allow_duplicates! {
+                uv_snapshot!(context.filters(), context.pip_install()
+                    .arg(second.path()).arg("--link-mode").arg(link_mode), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Resolved 1 package in [TIME]
+                Prepared 1 package in [TIME]
+                Installed 1 package in [TIME]
+                 + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+                ");
+            }
+            assert!(!shared.is_symlink());
+            assert!(shared.join("a/__init__.py").is_symlink());
+            assert!(!cached_shared.join("b").exists());
+            context
+                .assert_command("import shared.a, shared.b")
+                .success();
+
+            allow_duplicates! {
+                uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-a"), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Uninstalled 1 package in [TIME]
+                 - symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+                ");
+            }
+            context.assert_command("import shared.b").success();
+            assert!(cached_shared.join("a/__init__.py").is_file());
+
+            // Concurrent installation must produce the same merged namespace.
+            if link_mode != "symlink" {
+                continue;
+            }
+            context.venv().arg("--clear").assert().success();
+            allow_duplicates! {
+                uv_snapshot!(context.filters(), context.pip_install()
+                    .arg(first.path()).arg(second.path()).arg("--link-mode=symlink")
+                    .env(EnvVars::UV_CONCURRENT_INSTALLS, "2"), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Resolved 2 packages in [TIME]
+                Installed 2 packages in [TIME]
+                 + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+                 + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+                ");
+            }
+            assert!(!shared.is_symlink());
+            assert!(!cached_shared.join("b").exists());
+            context
+                .assert_command("import shared.a, shared.b")
+                .success();
+        }
+    }
+    Ok(())
 }
 
 /// Compile bytecode when installing into a relative `--target` or `--prefix` path.

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -433,8 +433,8 @@ fn directory_symlink_install() -> Result<()> {
     Ok(())
 }
 
-/// A later install expands a shared directory before merging, including when the new package
-/// uses another link mode or contributes its files through `.data`.
+/// A later install expands only overlapping directories before merging, including when the new
+/// package uses another link mode or contributes its files through `.data`.
 #[test]
 #[cfg(unix)]
 fn directory_symlink_shared_namespace() -> Result<()> {
@@ -446,20 +446,27 @@ fn directory_symlink_shared_namespace() -> Result<()> {
             write_test_wheel(
                 first.path(),
                 "symlink_a",
-                [(
-                    "shared/a/__init__.py".to_string(),
-                    "VALUE = 1\n".to_string(),
-                )],
+                [
+                    ("shared/a/__init__.py", "VALUE = 1\n"),
+                    ("shared/collision/module.py", "VALUE = 1\n"),
+                    ("shared/collision/RECORD", "VALUE = 1\n"),
+                ]
+                .map(|(path, contents)| (path.to_string(), contents.to_string())),
             )?;
-            let second_path = if data {
-                "symlink_b-1.0.0.data/purelib/shared/b/__init__.py"
+            let second_prefix = if data {
+                "symlink_b-1.0.0.data/purelib/"
             } else {
-                "shared/b/__init__.py"
+                ""
             };
             write_test_wheel(
                 second.path(),
                 "symlink_b",
-                [(second_path.to_string(), "VALUE = 2\n".to_string())],
+                [
+                    "shared/b/__init__.py",
+                    "shared/collision/module.py",
+                    "shared/collision/RECORD",
+                ]
+                .map(|path| (format!("{second_prefix}{path}"), "VALUE = 2\n".to_string())),
             )?;
 
             allow_duplicates! {
@@ -475,6 +482,7 @@ fn directory_symlink_shared_namespace() -> Result<()> {
             }
             let shared = context.site_packages().join("shared");
             let cached_shared = fs::read_link(&shared)?;
+            let cached_digest = dirhash_path(&cached_shared)?;
             allow_duplicates! {
                 uv_snapshot!(context.filters(), context.pip_install()
                     .arg(second.path()).arg("--link-mode").arg(link_mode), @"
@@ -487,8 +495,21 @@ fn directory_symlink_shared_namespace() -> Result<()> {
                 ");
             }
             assert!(!shared.is_symlink());
-            assert!(shared.join("a/__init__.py").is_symlink());
-            assert!(!cached_shared.join("b").exists());
+            assert!(shared.join("a").is_symlink());
+            assert_eq!(
+                shared.join("b").is_symlink(),
+                link_mode == "symlink" && !data
+            );
+            assert!(!shared.join("collision").is_symlink());
+            assert_eq!(
+                fs::read_to_string(shared.join("collision/module.py"))?,
+                "VALUE = 2\n"
+            );
+            assert_eq!(
+                fs::read_to_string(shared.join("collision/RECORD"))?,
+                "VALUE = 2\n"
+            );
+            assert_eq!(dirhash_path(&cached_shared)?, cached_digest);
             context
                 .assert_command("import shared.a, shared.b")
                 .success();
@@ -502,7 +523,8 @@ fn directory_symlink_shared_namespace() -> Result<()> {
                 ");
             }
             context.assert_command("import shared.b").success();
-            assert!(cached_shared.join("a/__init__.py").is_file());
+            assert!(!shared.join("a").is_symlink());
+            assert_eq!(dirhash_path(&cached_shared)?, cached_digest);
 
             // Concurrent installation must produce the same merged namespace.
             if link_mode != "symlink" {
@@ -522,9 +544,185 @@ fn directory_symlink_shared_namespace() -> Result<()> {
                 ");
             }
             assert!(!shared.is_symlink());
-            assert!(!cached_shared.join("b").exists());
+            assert!(shared.join("a").is_symlink());
+            assert!(!shared.join("collision").is_symlink());
+            assert_eq!(dirhash_path(&cached_shared)?, cached_digest);
             context
                 .assert_command("import shared.a, shared.b")
+                .success();
+        }
+    }
+    Ok(())
+}
+
+/// `.data/data` can merge into packages through an installation-scheme alias without changing
+/// the cached wheel or expanding unrelated directories.
+#[test]
+#[cfg(unix)]
+fn directory_symlink_data_data() -> Result<()> {
+    for (destination, scheme_alias) in [
+        ("lib/python3.12/site-packages/shared/collision", None),
+        ("LIB/python3.12/site-packages/shared/collision", None),
+        (
+            "lib64/python3.12/site-packages/shared/collision",
+            Some(("lib64", "lib")),
+        ),
+        (
+            "alias",
+            Some(("alias", "lib/python3.12/site-packages/shared/collision")),
+        ),
+    ] {
+        for reverse in [false, true] {
+            let context = uv_test::test_context!("3.12");
+            if destination.starts_with("LIB/") && !context.venv.join("LIB").is_dir() {
+                continue;
+            }
+            let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
+            let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
+            write_test_wheel(
+                first.path(),
+                "symlink_a",
+                [
+                    ("shared/collision/original.py", "VALUE = 1\n"),
+                    ("shared/sibling/__init__.py", "VALUE = 2\n"),
+                ]
+                .map(|(path, contents)| (path.to_string(), contents.to_string())),
+            )?;
+            let expected = context.temp_dir.child("expected");
+            uv_extract::unzip(File::open(first.path())?, expected.path())?;
+            let cached_digest = dirhash_path(&expected.join("shared"))?;
+
+            let scheme_alias = if let Some((path, target)) = scheme_alias {
+                let path = context.venv.join(path);
+                if !path.is_symlink() {
+                    symlink(target, &path)?;
+                }
+                let target = fs::read_link(&path)?;
+                Some((path, target))
+            } else {
+                None
+            };
+            write_test_wheel(
+                second.path(),
+                "symlink_b",
+                [
+                    (
+                        format!("symlink_b-1.0.0.data/data/{destination}/added.py"),
+                        "VALUE = 3\n".to_string(),
+                    ),
+                    (
+                        "symlink_b-1.0.0.data/data/share/symlink_b/config.txt".to_string(),
+                        "configuration\n".to_string(),
+                    ),
+                ],
+            )?;
+
+            let wheels = if reverse {
+                [&second, &first]
+            } else {
+                [&first, &second]
+            };
+            for wheel in wheels {
+                if wheel.path() == first.path() {
+                    allow_duplicates! {
+                        uv_snapshot!(context.filters(), context.pip_install()
+                            .arg(wheel.path()).arg("--link-mode=symlink"), @"
+                        exit_code: 0 (success)
+                        ----- stderr -----
+                        Resolved 1 package in [TIME]
+                        Prepared 1 package in [TIME]
+                        Installed 1 package in [TIME]
+                         + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+                        ");
+                    }
+                } else {
+                    allow_duplicates! {
+                        uv_snapshot!(context.filters(), context.pip_install()
+                            .arg(wheel.path()).arg("--link-mode=symlink"), @"
+                        exit_code: 0 (success)
+                        ----- stderr -----
+                        Resolved 1 package in [TIME]
+                        Prepared 1 package in [TIME]
+                        Installed 1 package in [TIME]
+                         + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+                        ");
+                    }
+                }
+            }
+
+            let shared = context.site_packages().join("shared");
+            assert!(!shared.is_symlink());
+            assert!(!shared.join("collision").is_symlink());
+            let cached_sibling = fs::read_link(shared.join("sibling"))?;
+            let cached_shared = cached_sibling
+                .parent()
+                .context("Missing cached package directory")?;
+            assert_eq!(dirhash_path(cached_shared)?, cached_digest);
+            let added = shared.join("collision/added.py");
+            let cached_added = fs::read_link(&added)?;
+            assert_eq!(fs::read_to_string(&cached_added)?, "VALUE = 3\n");
+            let config = context.venv.join("share/symlink_b/config.txt");
+            assert_eq!(fs::read_to_string(&config)?, "configuration\n");
+            if let Some((path, target)) = &scheme_alias {
+                assert_eq!(fs::read_link(path)?, *target);
+            }
+            context
+                .assert_command(
+                    "import shared.collision.original, shared.collision.added, shared.sibling",
+                )
+                .success();
+
+            allow_duplicates! {
+                uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-a"), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Uninstalled 1 package in [TIME]
+                 - symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+                ");
+            }
+            assert!(!shared.join("sibling").is_symlink());
+            assert_eq!(dirhash_path(cached_shared)?, cached_digest);
+            context
+                .assert_command("import shared.collision.added")
+                .success();
+
+            allow_duplicates! {
+                uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-b"), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Uninstalled 1 package in [TIME]
+                 - symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+                ");
+            }
+            assert!(!added.exists());
+            assert!(!config.exists());
+            assert_eq!(dirhash_path(cached_shared)?, cached_digest);
+            assert_eq!(fs::read_to_string(&cached_added)?, "VALUE = 3\n");
+
+            // Reuse both cached wheels concurrently, including through the scheme alias.
+            allow_duplicates! {
+                uv_snapshot!(context.filters(), context.pip_install()
+                    .arg(first.path()).arg(second.path()).arg("--link-mode=symlink")
+                    .arg("--offline")
+                    .env(EnvVars::UV_CONCURRENT_INSTALLS, "2"), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Resolved 2 packages in [TIME]
+                Installed 2 packages in [TIME]
+                 + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+                 + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+                ");
+            }
+            assert!(shared.join("sibling").is_symlink());
+            assert_eq!(dirhash_path(cached_shared)?, cached_digest);
+            assert_eq!(fs::read_to_string(&cached_added)?, "VALUE = 3\n");
+            if let Some((path, target)) = &scheme_alias {
+                assert_eq!(fs::read_link(path)?, *target);
+            }
+            context
+                .assert_command(
+                    "import shared.collision.original, shared.collision.added, shared.sibling",
+                )
                 .success();
         }
     }

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -729,6 +729,141 @@ fn directory_symlink_data_data() -> Result<()> {
     Ok(())
 }
 
+/// Scripts inside a `--target` library expand overlapping package links before being written.
+#[test]
+#[cfg(unix)]
+fn directory_symlink_target_scripts() -> Result<()> {
+    for data in [false, true] {
+        for order in ["package-first", "scripts-first", "concurrent"] {
+            let context = uv_test::test_context!("3.12")
+                .with_filtered_python_names()
+                .with_filtered_virtualenv_bin()
+                .with_filtered_exe_suffix();
+            let target = context.temp_dir.child("target");
+            let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
+            let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
+            write_test_wheel(
+                first.path(),
+                "symlink_a",
+                [
+                    ("bin/payload.py", "VALUE = 1\n"),
+                    ("bin/resources/config.txt", "configuration\n"),
+                ]
+                .map(|(path, contents)| (path.to_string(), contents.to_string())),
+            )?;
+            let script = if data {
+                (
+                    "symlink_b-1.0.0.data/scripts/symlink-script",
+                    "#!python\nprint('hello')\n",
+                )
+            } else {
+                (
+                    "symlink_b-1.0.0.dist-info/entry_points.txt",
+                    "[console_scripts]\nsymlink-script = symlink_b:main\n",
+                )
+            };
+            write_test_wheel(
+                second.path(),
+                "symlink_b",
+                [("symlink_b.py", "def main(): print('hello')\n"), script]
+                    .map(|(path, contents)| (path.to_string(), contents.to_string())),
+            )?;
+            let expected = context.temp_dir.child("expected");
+            uv_extract::unzip(File::open(first.path())?, expected.path())?;
+            let cached_digest = dirhash_path(&expected.join("bin"))?;
+
+            if order == "concurrent" {
+                allow_duplicates! {
+                    uv_snapshot!(context.filters(), context.pip_install()
+                        .arg(first.path()).arg(second.path()).arg("--link-mode=symlink")
+                        .arg("--target").arg(target.path())
+                        .env(EnvVars::UV_CONCURRENT_INSTALLS, "2"), @"
+                    exit_code: 0 (success)
+                    ----- stderr -----
+                    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+                    Resolved 2 packages in [TIME]
+                    Prepared 2 packages in [TIME]
+                    Installed 2 packages in [TIME]
+                     + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+                     + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+                    ");
+                }
+            } else {
+                let wheels = if order == "package-first" {
+                    [&first, &second]
+                } else {
+                    [&second, &first]
+                };
+                for wheel in wheels {
+                    if wheel.path() == first.path() {
+                        allow_duplicates! {
+                            uv_snapshot!(context.filters(), context.pip_install()
+                                .arg(wheel.path()).arg("--link-mode=symlink")
+                                .arg("--target").arg(target.path()), @"
+                            exit_code: 0 (success)
+                            ----- stderr -----
+                            Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+                            Resolved 1 package in [TIME]
+                            Prepared 1 package in [TIME]
+                            Installed 1 package in [TIME]
+                             + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+                            ");
+                        }
+                        if order == "package-first" {
+                            assert!(target.join("bin").is_symlink());
+                        }
+                    } else {
+                        allow_duplicates! {
+                            uv_snapshot!(context.filters(), context.pip_install()
+                                .arg(wheel.path()).arg("--link-mode=symlink")
+                                .arg("--target").arg(target.path()), @"
+                            exit_code: 0 (success)
+                            ----- stderr -----
+                            Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+                            Resolved 1 package in [TIME]
+                            Prepared 1 package in [TIME]
+                            Installed 1 package in [TIME]
+                             + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+                            ");
+                        }
+                    }
+                }
+            }
+
+            let scripts = target.join("bin");
+            assert!(!scripts.is_symlink());
+            let cached_resources = fs::read_link(scripts.join("resources"))?;
+            let cached_bin = cached_resources
+                .parent()
+                .context("Missing cached scripts directory")?;
+            assert_eq!(dirhash_path(cached_bin)?, cached_digest);
+            Command::new(scripts.join("symlink-script"))
+                .env(EnvVars::PYTHONPATH, target.path())
+                .assert()
+                .success()
+                .stdout("hello\n");
+
+            allow_duplicates! {
+                uv_snapshot!(context.filters(), context.pip_uninstall()
+                    .arg("symlink-b").arg("--target").arg(target.path()), @"
+                exit_code: 0 (success)
+                ----- stderr -----
+                Uninstalled 1 package in [TIME]
+                 - symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
+                ");
+            }
+            assert!(!scripts.join("symlink-script").exists());
+            assert_eq!(
+                fs::read_to_string(scripts.join("payload.py"))?,
+                "VALUE = 1\n"
+            );
+            assert!(scripts.join("resources").is_symlink());
+            assert_eq!(dirhash_path(cached_bin)?, cached_digest);
+        }
+    }
+    Ok(())
+}
+
 /// Compile bytecode when installing into a relative `--target` or `--prefix` path.
 #[test]
 fn compile_bytecode_for_relative_install_root() {

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -733,7 +733,11 @@ fn directory_symlink_data_data() -> Result<()> {
 #[test]
 #[cfg(unix)]
 fn directory_symlink_target_scripts() -> Result<()> {
-    for data in [false, true] {
+    for (data, script_name) in [
+        (false, "symlink-script"),
+        (false, "nested/symlink-script"),
+        (true, "symlink-script"),
+    ] {
         for order in ["package-first", "scripts-first", "concurrent"] {
             let context = uv_test::test_context!("3.12")
                 .with_filtered_python_names()
@@ -748,25 +752,31 @@ fn directory_symlink_target_scripts() -> Result<()> {
                 [
                     ("bin/payload.py", "VALUE = 1\n"),
                     ("bin/resources/config.txt", "configuration\n"),
+                    ("bin/nested/payload.py", "VALUE = 2\n"),
                 ]
                 .map(|(path, contents)| (path.to_string(), contents.to_string())),
             )?;
             let script = if data {
                 (
-                    "symlink_b-1.0.0.data/scripts/symlink-script",
-                    "#!python\nprint('hello')\n",
+                    "symlink_b-1.0.0.data/scripts/symlink-script".to_string(),
+                    "#!python\nprint('hello')\n".to_string(),
                 )
             } else {
                 (
-                    "symlink_b-1.0.0.dist-info/entry_points.txt",
-                    "[console_scripts]\nsymlink-script = symlink_b:main\n",
+                    "symlink_b-1.0.0.dist-info/entry_points.txt".to_string(),
+                    format!("[console_scripts]\n{script_name} = symlink_b:main\n"),
                 )
             };
             write_test_wheel(
                 second.path(),
                 "symlink_b",
-                [("symlink_b.py", "def main(): print('hello')\n"), script]
-                    .map(|(path, contents)| (path.to_string(), contents.to_string())),
+                [
+                    (
+                        "symlink_b.py".to_string(),
+                        "def main(): print('hello')\n".to_string(),
+                    ),
+                    script,
+                ],
             )?;
             let expected = context.temp_dir.child("expected");
             uv_extract::unzip(File::open(first.path())?, expected.path())?;
@@ -837,7 +847,7 @@ fn directory_symlink_target_scripts() -> Result<()> {
                 .parent()
                 .context("Missing cached scripts directory")?;
             assert_eq!(dirhash_path(cached_bin)?, cached_digest);
-            Command::new(scripts.join("symlink-script"))
+            Command::new(scripts.join(script_name))
                 .env(EnvVars::PYTHONPATH, target.path())
                 .assert()
                 .success()
@@ -852,14 +862,174 @@ fn directory_symlink_target_scripts() -> Result<()> {
                  - symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
                 ");
             }
-            assert!(!scripts.join("symlink-script").exists());
+            assert!(!scripts.join(script_name).exists());
             assert_eq!(
                 fs::read_to_string(scripts.join("payload.py"))?,
                 "VALUE = 1\n"
             );
+            assert_eq!(
+                fs::read_to_string(scripts.join("nested/payload.py"))?,
+                "VALUE = 2\n"
+            );
             assert!(scripts.join("resources").is_symlink());
             assert_eq!(dirhash_path(cached_bin)?, cached_digest);
         }
+    }
+    Ok(())
+}
+
+/// A file cannot replace another wheel's directory, including after a namespace is expanded.
+#[test]
+#[cfg(unix)]
+fn directory_symlink_file_directory_conflict() -> Result<()> {
+    for (link_mode, data) in [
+        ("copy", false),
+        ("hardlink", false),
+        ("clone", false),
+        ("symlink", false),
+        ("symlink", true),
+    ] {
+        let context = uv_test::test_context!("3.12");
+        let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
+        let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
+        write_test_wheel(
+            first.path(),
+            "symlink_a",
+            [
+                ("shared/collision/payload.py", "VALUE = 1\n"),
+                ("shared/sibling/__init__.py", "VALUE = 2\n"),
+            ]
+            .map(|(path, contents)| (path.to_string(), contents.to_string())),
+        )?;
+        let destination = if data {
+            "symlink_b-1.0.0.data/purelib/shared/collision"
+        } else {
+            "shared/collision"
+        };
+        write_test_wheel(
+            second.path(),
+            "symlink_b",
+            [(destination.to_string(), "replacement\n".to_string())],
+        )?;
+
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), context.pip_install()
+                .arg(first.path()).arg("--link-mode=symlink"), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Resolved 1 package in [TIME]
+            Prepared 1 package in [TIME]
+            Installed 1 package in [TIME]
+             + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+            ");
+        }
+        let shared = context.site_packages().join("shared");
+        let cached_shared = fs::read_link(&shared)?;
+        let cached_digest = dirhash_path(&cached_shared)?;
+
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), context.pip_install()
+                .arg(second.path()).arg("--link-mode").arg(link_mode), @"
+            exit_code: 2 (failure)
+            ----- stderr -----
+            Resolved 1 package in [TIME]
+            Prepared 1 package in [TIME]
+            error: Failed to install: symlink_b-1.0.0-py3-none-any.whl (symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl))
+              Caused by: Cannot replace directory `[SITE_PACKAGES]/shared/collision` with a file
+            ");
+        }
+        assert!(shared.join("collision").is_dir());
+        assert_eq!(
+            fs::read_to_string(shared.join("collision/payload.py"))?,
+            "VALUE = 1\n"
+        );
+        assert!(shared.join("sibling").is_symlink());
+        assert_eq!(dirhash_path(&cached_shared)?, cached_digest);
+    }
+    Ok(())
+}
+
+/// Generated and relocated scripts cannot replace directory links inside a `--target` library.
+#[test]
+#[cfg(unix)]
+fn directory_symlink_target_script_directory_conflict() -> Result<()> {
+    for script in [
+        (
+            "symlink_b-1.0.0.dist-info/entry_points.txt",
+            "[console_scripts]\nsymlink-script = symlink_b:main\n",
+        ),
+        (
+            "symlink_b-1.0.0.data/scripts/symlink-script",
+            "#!python\nprint('replacement')\n",
+        ),
+        (
+            "symlink_b-1.0.0.data/scripts/symlink-script",
+            "#!/bin/sh\necho replacement\n",
+        ),
+    ] {
+        let context = uv_test::test_context!("3.12")
+            .with_filtered_python_names()
+            .with_filtered_virtualenv_bin()
+            .with_filtered_exe_suffix();
+        let target = context.temp_dir.child("target");
+        let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
+        let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
+        write_test_wheel(
+            first.path(),
+            "symlink_a",
+            [
+                ("bin/symlink-script/payload.py", "VALUE = 1\n"),
+                ("bin/resources/config.txt", "configuration\n"),
+            ]
+            .map(|(path, contents)| (path.to_string(), contents.to_string())),
+        )?;
+        write_test_wheel(
+            second.path(),
+            "symlink_b",
+            [
+                ("symlink_b.py", "def main(): print('replacement')\n"),
+                script,
+            ]
+            .map(|(path, contents)| (path.to_string(), contents.to_string())),
+        )?;
+
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), context.pip_install()
+                .arg(first.path()).arg("--link-mode=symlink")
+                .arg("--target").arg(target.path()), @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+            Resolved 1 package in [TIME]
+            Prepared 1 package in [TIME]
+            Installed 1 package in [TIME]
+             + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
+            ");
+        }
+        let scripts = target.join("bin");
+        let cached_bin = fs::read_link(&scripts)?;
+        let cached_digest = dirhash_path(&cached_bin)?;
+
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), context.pip_install()
+                .arg(second.path()).arg("--link-mode=symlink")
+                .arg("--target").arg(target.path()), @"
+            exit_code: 2 (failure)
+            ----- stderr -----
+            Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+            Resolved 1 package in [TIME]
+            Prepared 1 package in [TIME]
+            error: Failed to install: symlink_b-1.0.0-py3-none-any.whl (symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl))
+              Caused by: Cannot replace directory `[TEMP_DIR]/target/[BIN]/symlink-script` with a file
+            ");
+        }
+        assert!(scripts.join("symlink-script").is_dir());
+        assert_eq!(
+            fs::read_to_string(scripts.join("symlink-script/payload.py"))?,
+            "VALUE = 1\n"
+        );
+        assert!(scripts.join("resources").is_symlink());
+        assert_eq!(dirhash_path(&cached_bin)?, cached_digest);
     }
     Ok(())
 }

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -394,6 +394,59 @@ fn directory_symlink_shared_namespace() -> Result<()> {
     Ok(())
 }
 
+/// Uninstalling a namespace sibling installed by pip must preserve the original package.
+#[test]
+#[cfg(unix)]
+fn directory_symlink_shared_with_pip() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((r"#sha256=[a-f0-9]{64}", "#sha256=[SHA256]"));
+    let first = context.temp_dir.child("symlink_a-1.0.0-py3-none-any.whl");
+    let second = context.temp_dir.child("symlink_b-1.0.0-py3-none-any.whl");
+    write_test_wheel(first.path(), "symlink_a", [("shared/a.py", "VALUE = 1\n")])?;
+    write_test_wheel(second.path(), "symlink_b", [("shared/b.py", "VALUE = 2\n")])?;
+    context
+        .pip_install()
+        .arg(first.path())
+        .arg("pip==24.0")
+        .arg("--link-mode=symlink")
+        .assert()
+        .success();
+    let shared = context.site_packages().join("shared");
+    let cached = fs::read_link(&shared)?;
+
+    context
+        .python_command()
+        .args([
+            "-m",
+            "pip",
+            "install",
+            "--no-index",
+            "--no-deps",
+            "--no-compile",
+        ])
+        .arg(second.path())
+        .assert()
+        .success();
+    assert!(shared.is_symlink());
+    context
+        .assert_command("import shared.a, shared.b")
+        .success();
+    let digest = dirhash_path(&cached)?;
+
+    uv_snapshot!(context.filters(), context.pip_uninstall().arg("symlink-b"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Uninstalled 1 package in [TIME]
+     - symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl#sha256=[SHA256])
+    ");
+
+    context.assert_command("import shared.a").success();
+    context.assert_command("import shared.b").failure();
+    assert!(!shared.is_symlink());
+    assert_eq!(dirhash_path(&cached)?, digest);
+    Ok(())
+}
+
 /// Relocated data follows scheme aliases without writing into a linked package's cache.
 #[test]
 #[cfg(unix)]

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -348,6 +348,7 @@ fn directory_symlink_shared_namespace() -> Result<()> {
             second.path(),
             "symlink_b",
             [
+                ("shared/a.py", "VALUE = 12345\n"),
                 ("shared/b.py", "VALUE = 2\n"),
                 ("shared/RECORD", "replacement\n"),
             ],
@@ -356,24 +357,32 @@ fn directory_symlink_shared_namespace() -> Result<()> {
             .pip_install()
             .arg(first.path())
             .arg("--link-mode=symlink")
+            .arg("--compile-bytecode")
             .assert()
             .success();
         let shared = context.site_packages().join("shared");
         let cached = fs::read_link(&shared)?;
         let digest = dirhash_path(&cached)?;
+        let bytecode = shared.join("__pycache__/a.cpython-312.pyc");
+        let original_bytecode = fs::read(&bytecode)?;
 
         allow_duplicates! {
             uv_snapshot!(context.filters(), context.pip_install()
-                .arg(second.path()).arg("--link-mode").arg(link_mode), @"
+                .arg(second.path()).arg("--link-mode").arg(link_mode)
+                .arg("--compile-bytecode")
+                .env(EnvVars::PYC_INVALIDATION_MODE, "CHECKED_HASH"), @"
             exit_code: 0 (success)
             ----- stderr -----
             Resolved 1 package in [TIME]
             Prepared 1 package in [TIME]
             Installed 1 package in [TIME]
+            Bytecode compiled 2 files in [TIME]
              + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
             ");
         }
         assert!(!shared.is_symlink());
+        assert!(!bytecode.is_symlink());
+        assert_ne!(fs::read(&bytecode)?, original_bytecode);
         assert_eq!(fs::read_to_string(shared.join("RECORD"))?, "replacement\n");
         context
             .assert_command("import shared.a, shared.b")

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -40,26 +40,22 @@ fn write_many_files_wheel(path: &Path, source_files: usize) -> Result<()> {
     write_test_wheel(
         path,
         "large_wheel",
-        (0..source_files).map(|index| {
-            (
-                format!("large_wheel/module_{index:05}.py"),
-                "VALUE = 1\n".to_string(),
-            )
-        }),
+        (0..source_files).map(|index| (format!("large_wheel/module_{index:05}.py"), "VALUE = 1\n")),
     )
 }
 
 fn write_test_wheel(
     path: &Path,
     name: &str,
-    files: impl IntoIterator<Item = (String, String)>,
+    files: impl IntoIterator<Item = (impl AsRef<str>, impl AsRef<str>)>,
 ) -> Result<()> {
     let mut writer = ZipFileWriter::new(Vec::new());
     let mut record = String::new();
 
     for (name, contents) in files {
-        let entry = ZipEntryBuilder::new(name.clone().into(), Compression::Stored);
-        block_on(writer.write_entry_whole(entry, contents.as_bytes()))?;
+        let name = name.as_ref();
+        let entry = ZipEntryBuilder::new(name.into(), Compression::Stored);
+        block_on(writer.write_entry_whole(entry, contents.as_ref().as_bytes()))?;
         writeln!(record, "{name},,")?;
     }
 
@@ -356,8 +352,7 @@ fn directory_symlink_install() -> Result<()> {
                 "symlink_test-1.0.0.data/scripts/symlink-script",
                 "#!python\nprint('hello')\n",
             ),
-        ]
-        .map(|(path, contents)| (path.to_string(), contents.to_string())),
+        ],
     )?;
     uv_snapshot!(context.filters(), context.pip_install()
         .arg(wheel.path())
@@ -450,8 +445,7 @@ fn directory_symlink_shared_namespace() -> Result<()> {
                     ("shared/a/__init__.py", "VALUE = 1\n"),
                     ("shared/collision/module.py", "VALUE = 1\n"),
                     ("shared/collision/RECORD", "VALUE = 1\n"),
-                ]
-                .map(|(path, contents)| (path.to_string(), contents.to_string())),
+                ],
             )?;
             let second_prefix = if data {
                 "symlink_b-1.0.0.data/purelib/"
@@ -466,20 +460,15 @@ fn directory_symlink_shared_namespace() -> Result<()> {
                     "shared/collision/module.py",
                     "shared/collision/RECORD",
                 ]
-                .map(|path| (format!("{second_prefix}{path}"), "VALUE = 2\n".to_string())),
+                .map(|path| (format!("{second_prefix}{path}"), "VALUE = 2\n")),
             )?;
 
-            allow_duplicates! {
-                uv_snapshot!(context.filters(), context.pip_install()
-                    .arg(first.path()).arg("--link-mode=symlink"), @"
-                exit_code: 0 (success)
-                ----- stderr -----
-                Resolved 1 package in [TIME]
-                Prepared 1 package in [TIME]
-                Installed 1 package in [TIME]
-                 + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-                ");
-            }
+            context
+                .pip_install()
+                .arg(first.path())
+                .arg("--link-mode=symlink")
+                .assert()
+                .success();
             let shared = context.site_packages().join("shared");
             let cached_shared = fs::read_link(&shared)?;
             let cached_digest = dirhash_path(&cached_shared)?;
@@ -585,8 +574,7 @@ fn directory_symlink_data_data() -> Result<()> {
                 [
                     ("shared/collision/original.py", "VALUE = 1\n"),
                     ("shared/sibling/__init__.py", "VALUE = 2\n"),
-                ]
-                .map(|(path, contents)| (path.to_string(), contents.to_string())),
+                ],
             )?;
             let expected = context.temp_dir.child("expected");
             uv_extract::unzip(File::open(first.path())?, expected.path())?;
@@ -608,11 +596,11 @@ fn directory_symlink_data_data() -> Result<()> {
                 [
                     (
                         format!("symlink_b-1.0.0.data/data/{destination}/added.py"),
-                        "VALUE = 3\n".to_string(),
+                        "VALUE = 3\n",
                     ),
                     (
                         "symlink_b-1.0.0.data/data/share/symlink_b/config.txt".to_string(),
-                        "configuration\n".to_string(),
+                        "configuration\n",
                     ),
                 ],
             )?;
@@ -623,31 +611,12 @@ fn directory_symlink_data_data() -> Result<()> {
                 [&first, &second]
             };
             for wheel in wheels {
-                if wheel.path() == first.path() {
-                    allow_duplicates! {
-                        uv_snapshot!(context.filters(), context.pip_install()
-                            .arg(wheel.path()).arg("--link-mode=symlink"), @"
-                        exit_code: 0 (success)
-                        ----- stderr -----
-                        Resolved 1 package in [TIME]
-                        Prepared 1 package in [TIME]
-                        Installed 1 package in [TIME]
-                         + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-                        ");
-                    }
-                } else {
-                    allow_duplicates! {
-                        uv_snapshot!(context.filters(), context.pip_install()
-                            .arg(wheel.path()).arg("--link-mode=symlink"), @"
-                        exit_code: 0 (success)
-                        ----- stderr -----
-                        Resolved 1 package in [TIME]
-                        Prepared 1 package in [TIME]
-                        Installed 1 package in [TIME]
-                         + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
-                        ");
-                    }
-                }
+                context
+                    .pip_install()
+                    .arg(wheel.path())
+                    .arg("--link-mode=symlink")
+                    .assert()
+                    .success();
             }
 
             let shared = context.site_packages().join("shared");
@@ -733,10 +702,22 @@ fn directory_symlink_data_data() -> Result<()> {
 #[test]
 #[cfg(unix)]
 fn directory_symlink_target_scripts() -> Result<()> {
-    for (data, script_name) in [
-        (false, "symlink-script"),
-        (false, "nested/symlink-script"),
-        (true, "symlink-script"),
+    for (script_name, script_file, script_contents) in [
+        (
+            "symlink-script",
+            "symlink_b-1.0.0.dist-info/entry_points.txt",
+            "[console_scripts]\nsymlink-script = symlink_b:main\n",
+        ),
+        (
+            "nested/symlink-script",
+            "symlink_b-1.0.0.dist-info/entry_points.txt",
+            "[console_scripts]\nnested/symlink-script = symlink_b:main\n",
+        ),
+        (
+            "symlink-script",
+            "symlink_b-1.0.0.data/scripts/symlink-script",
+            "#!python\nprint('hello')\n",
+        ),
     ] {
         for order in ["package-first", "scripts-first", "concurrent"] {
             let context = uv_test::test_context!("3.12")
@@ -753,29 +734,14 @@ fn directory_symlink_target_scripts() -> Result<()> {
                     ("bin/payload.py", "VALUE = 1\n"),
                     ("bin/resources/config.txt", "configuration\n"),
                     ("bin/nested/payload.py", "VALUE = 2\n"),
-                ]
-                .map(|(path, contents)| (path.to_string(), contents.to_string())),
+                ],
             )?;
-            let script = if data {
-                (
-                    "symlink_b-1.0.0.data/scripts/symlink-script".to_string(),
-                    "#!python\nprint('hello')\n".to_string(),
-                )
-            } else {
-                (
-                    "symlink_b-1.0.0.dist-info/entry_points.txt".to_string(),
-                    format!("[console_scripts]\n{script_name} = symlink_b:main\n"),
-                )
-            };
             write_test_wheel(
                 second.path(),
                 "symlink_b",
                 [
-                    (
-                        "symlink_b.py".to_string(),
-                        "def main(): print('hello')\n".to_string(),
-                    ),
-                    script,
+                    ("symlink_b.py", "def main(): print('hello')\n"),
+                    (script_file, script_contents),
                 ],
             )?;
             let expected = context.temp_dir.child("expected");
@@ -805,37 +771,16 @@ fn directory_symlink_target_scripts() -> Result<()> {
                     [&second, &first]
                 };
                 for wheel in wheels {
-                    if wheel.path() == first.path() {
-                        allow_duplicates! {
-                            uv_snapshot!(context.filters(), context.pip_install()
-                                .arg(wheel.path()).arg("--link-mode=symlink")
-                                .arg("--target").arg(target.path()), @"
-                            exit_code: 0 (success)
-                            ----- stderr -----
-                            Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
-                            Resolved 1 package in [TIME]
-                            Prepared 1 package in [TIME]
-                            Installed 1 package in [TIME]
-                             + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-                            ");
-                        }
-                        if order == "package-first" {
-                            assert!(target.join("bin").is_symlink());
-                        }
-                    } else {
-                        allow_duplicates! {
-                            uv_snapshot!(context.filters(), context.pip_install()
-                                .arg(wheel.path()).arg("--link-mode=symlink")
-                                .arg("--target").arg(target.path()), @"
-                            exit_code: 0 (success)
-                            ----- stderr -----
-                            Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
-                            Resolved 1 package in [TIME]
-                            Prepared 1 package in [TIME]
-                            Installed 1 package in [TIME]
-                             + symlink-b==1.0.0 (from file://[TEMP_DIR]/symlink_b-1.0.0-py3-none-any.whl)
-                            ");
-                        }
+                    context
+                        .pip_install()
+                        .arg(wheel.path())
+                        .arg("--link-mode=symlink")
+                        .arg("--target")
+                        .arg(target.path())
+                        .assert()
+                        .success();
+                    if order == "package-first" && wheel.path() == first.path() {
+                        assert!(target.join("bin").is_symlink());
                     }
                 }
             }
@@ -898,31 +843,21 @@ fn directory_symlink_file_directory_conflict() -> Result<()> {
             [
                 ("shared/collision/payload.py", "VALUE = 1\n"),
                 ("shared/sibling/__init__.py", "VALUE = 2\n"),
-            ]
-            .map(|(path, contents)| (path.to_string(), contents.to_string())),
+            ],
         )?;
         let destination = if data {
             "symlink_b-1.0.0.data/purelib/shared/collision"
         } else {
             "shared/collision"
         };
-        write_test_wheel(
-            second.path(),
-            "symlink_b",
-            [(destination.to_string(), "replacement\n".to_string())],
-        )?;
+        write_test_wheel(second.path(), "symlink_b", [(destination, "replacement\n")])?;
 
-        allow_duplicates! {
-            uv_snapshot!(context.filters(), context.pip_install()
-                .arg(first.path()).arg("--link-mode=symlink"), @"
-            exit_code: 0 (success)
-            ----- stderr -----
-            Resolved 1 package in [TIME]
-            Prepared 1 package in [TIME]
-            Installed 1 package in [TIME]
-             + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-            ");
-        }
+        context
+            .pip_install()
+            .arg(first.path())
+            .arg("--link-mode=symlink")
+            .assert()
+            .success();
         let shared = context.site_packages().join("shared");
         let cached_shared = fs::read_link(&shared)?;
         let cached_digest = dirhash_path(&cached_shared)?;
@@ -980,8 +915,7 @@ fn directory_symlink_target_script_directory_conflict() -> Result<()> {
             [
                 ("bin/symlink-script/payload.py", "VALUE = 1\n"),
                 ("bin/resources/config.txt", "configuration\n"),
-            ]
-            .map(|(path, contents)| (path.to_string(), contents.to_string())),
+            ],
         )?;
         write_test_wheel(
             second.path(),
@@ -989,23 +923,17 @@ fn directory_symlink_target_script_directory_conflict() -> Result<()> {
             [
                 ("symlink_b.py", "def main(): print('replacement')\n"),
                 script,
-            ]
-            .map(|(path, contents)| (path.to_string(), contents.to_string())),
+            ],
         )?;
 
-        allow_duplicates! {
-            uv_snapshot!(context.filters(), context.pip_install()
-                .arg(first.path()).arg("--link-mode=symlink")
-                .arg("--target").arg(target.path()), @"
-            exit_code: 0 (success)
-            ----- stderr -----
-            Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
-            Resolved 1 package in [TIME]
-            Prepared 1 package in [TIME]
-            Installed 1 package in [TIME]
-             + symlink-a==1.0.0 (from file://[TEMP_DIR]/symlink_a-1.0.0-py3-none-any.whl)
-            ");
-        }
+        context
+            .pip_install()
+            .arg(first.path())
+            .arg("--link-mode=symlink")
+            .arg("--target")
+            .arg(target.path())
+            .assert()
+            .success();
         let scripts = target.join("bin");
         let cached_bin = fs::read_link(&scripts)?;
         let cached_digest = dirhash_path(&cached_bin)?;

--- a/hawk.toml
+++ b/hawk.toml
@@ -177,14 +177,6 @@ reason = "read by the platform directory implementation"
 [[override]]
 lint = "hawk::dead_public"
 crate = "uv_static"
-item = "env_vars::EnvVars::PYC_INVALIDATION_MODE"
-kind = "inherent_associated_constant"
-level = "expect"
-reason = "read by the embedded bytecode compilation helper"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "uv_static"
 item = "env_vars::EnvVars::VIRTUAL_ENV_DISABLE_PROMPT"
 kind = "inherent_associated_constant"
 level = "expect"


### PR DESCRIPTION
## Summary

We now symlink top-level package directories directly to the cache with `--link-mode symlink`, avoiding a walk over their files. We keep `.dist-info` and `.data` as real directories, and `RECORD` gets a private copy because installation rewrites it.

When another installation, relocated data, or generated script needs to write beneath a directory link, we fully expand that package directory into real directories and symlinks to individual files.

Warm-cache installs with `--link-mode symlink` show:

| Package | Main | This PR | Change |
| --- | ---: | ---: | ---: |
| JupyterLab | 554 ms | 176 ms | -68% |
| requests | 26 ms | 26 ms | +2% |
| boto3 | 219 ms | 29 ms | -87% |
| NumPy + SciPy + pandas | 147 ms | 30 ms | -80% |
| Google Cloud storage + BigQuery | 46 ms | 44 ms | -5% |

The only case in which this is _worse_ is cold install for packages with lots of shared namespaces. On a synthetic, worst-case benchmark, it's 32% slower (135 to 177 ms), since overlapping packages expand the shared tree into individual file links.