### PR TITLE
Use package indices for additional lockfile traversals

### DIFF
--- a/crates/uv-resolver/src/lock/export/metadata.rs
+++ b/crates/uv-resolver/src/lock/export/metadata.rs
@@ -655,7 +655,7 @@ fn metadata_reachability(
             let mut dependency_reachability =
                 dependency.simplified_marker.as_simplified_marker_tree();
             dependency_reachability = dependency_reachability.and(parent_reachability);
-            let dependency_package = lock.find_by_id(&dependency.package_id);
+            let dependency_package = lock.package(dependency.index);
             if dependency.extra.is_empty() {
                 add_metadata_reachability(
                     workspace_root,

--- a/crates/uv-resolver/src/lock/export/mod.rs
+++ b/crates/uv-resolver/src/lock/export/mod.rs
@@ -16,7 +16,6 @@ use uv_pep508::MarkerTree;
 use uv_pypi_types::ConflictItem;
 
 use crate::graph_ops::Reachable;
-use crate::lock::LockErrorKind;
 pub use crate::lock::export::metadata::{Metadata, PythonReport};
 pub(crate) use crate::lock::export::metadata::{
     MetadataNode, MetadataNodeId, MetadataNodeKind, MetadataScript, MetadataWorkspace,
@@ -25,6 +24,7 @@ pub(crate) use crate::lock::export::metadata::{
 pub(crate) use crate::lock::export::pylock_toml::PylockTomlPackage;
 pub use crate::lock::export::pylock_toml::{PylockToml, PylockTomlError, PylockTomlErrorKind};
 pub use crate::lock::export::requirements_txt::RequirementsTxtExport;
+use crate::lock::{LockErrorKind, PackageIndex};
 use crate::universal_marker::resolve_activated_extras;
 use crate::{Installable, InstallableRootKind, LockError, Package};
 
@@ -60,9 +60,9 @@ impl<'lock> ExportableRequirements<'lock> {
     ) -> Result<Self, LockError> {
         let size_guess = target.lock().packages.len();
         let mut graph = Graph::<Node<'lock>, Edge<'lock>>::with_capacity(size_guess, size_guess);
-        let mut inverse = FxHashMap::with_capacity_and_hasher(size_guess, FxBuildHasher);
+        let mut inverse = vec![None; size_guess];
 
-        let mut queue: VecDeque<(&Package, Option<&ExtraName>)> = VecDeque::new();
+        let mut queue: VecDeque<(PackageIndex, Option<&ExtraName>)> = VecDeque::new();
         let mut seen = FxHashSet::default();
         let mut activated_items = FxHashMap::default();
 
@@ -98,10 +98,11 @@ impl<'lock> ExportableRequirements<'lock> {
             }
 
             if root_kind == InstallableRootKind::Production && groups.prod() {
+                let package_index = target.lock().by_id[&dist.id];
+
                 // Add the workspace package to the graph.
-                let index = *inverse
-                    .entry(&dist.id)
-                    .or_insert_with(|| graph.add_node(Node::Package(dist)));
+                let index = *inverse[package_index.0]
+                    .get_or_insert_with(|| graph.add_node(Node::Package(dist)));
                 graph.add_edge(
                     root,
                     index,
@@ -112,9 +113,9 @@ impl<'lock> ExportableRequirements<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                queue.push_back((dist, None));
+                queue.push_back((package_index, None));
                 for extra in extras.extra_names(dist.optional_dependencies.keys()) {
-                    queue.push_back((dist, Some(extra)));
+                    queue.push_back((package_index, Some(extra)));
                     activated_items.insert(
                         ConflictItem::from((dist.id.name.clone(), extra.clone())),
                         MarkerTree::TRUE,
@@ -145,12 +146,11 @@ impl<'lock> ExportableRequirements<'lock> {
                     continue;
                 }
 
-                let dep_dist = target.lock().find_by_id(&dep.package_id);
+                let dep_dist = target.lock().package(dep.index);
 
                 // Add the dependency to the graph.
-                let dep_index = *inverse
-                    .entry(&dep.package_id)
-                    .or_insert_with(|| graph.add_node(Node::Package(dep_dist)));
+                let dep_index = *inverse[dep.index.0]
+                    .get_or_insert_with(|| graph.add_node(Node::Package(dep_dist)));
 
                 // Add an edge from the root. Development dependencies may be installed without
                 // installing the workspace package itself (which can never have markers on it
@@ -166,12 +166,12 @@ impl<'lock> ExportableRequirements<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((&dep.package_id, None)) {
-                    queue.push_back((dep_dist, None));
+                if seen.insert((dep.index, None)) {
+                    queue.push_back((dep.index, None));
                 }
                 for extra in &dep.extra {
-                    if seen.insert((&dep.package_id, Some(extra))) {
-                        queue.push_back((dep_dist, Some(extra)));
+                    if seen.insert((dep.index, Some(extra))) {
+                        queue.push_back((dep.index, Some(extra)));
                     }
                 }
             }
@@ -226,11 +226,11 @@ impl<'lock> ExportableRequirements<'lock> {
                     else {
                         continue;
                     };
+                    let package_index = target.lock().by_id[&dist.id];
 
                     // Add the dependency to the graph and get its index.
-                    let dep_index = *inverse
-                        .entry(&dist.id)
-                        .or_insert_with(|| graph.add_node(Node::Package(dist)));
+                    let dep_index = *inverse[package_index.0]
+                        .get_or_insert_with(|| graph.add_node(Node::Package(dist)));
 
                     // Add an edge from the root.
                     graph.add_edge(
@@ -243,12 +243,12 @@ impl<'lock> ExportableRequirements<'lock> {
                     );
 
                     // Push its dependencies on the queue.
-                    if seen.insert((&dist.id, None)) {
-                        queue.push_back((dist, None));
+                    if seen.insert((package_index, None)) {
+                        queue.push_back((package_index, None));
                     }
                     for extra in &requirement.extras {
-                        if seen.insert((&dist.id, Some(extra))) {
-                            queue.push_back((dist, Some(extra)));
+                        if seen.insert((package_index, Some(extra))) {
+                            queue.push_back((package_index, Some(extra)));
                         }
                     }
                 }
@@ -256,8 +256,9 @@ impl<'lock> ExportableRequirements<'lock> {
         }
 
         // Create all the relevant nodes.
-        while let Some((package, extra)) = queue.pop_front() {
-            let index = inverse[&package.id];
+        while let Some((package_index, extra)) = queue.pop_front() {
+            let index = inverse[package_index.0].expect("queued package has a graph node");
+            let package = target.lock().package(package_index);
 
             let deps = if let Some(extra) = extra {
                 Either::Left(
@@ -277,12 +278,11 @@ impl<'lock> ExportableRequirements<'lock> {
                 }
 
                 // Evaluate the conflict marker.
-                let dep_dist = target.lock().find_by_id(&dep.package_id);
+                let dep_dist = target.lock().package(dep.index);
 
                 // Add the dependency to the graph.
-                let dep_index = *inverse
-                    .entry(&dep.package_id)
-                    .or_insert_with(|| graph.add_node(Node::Package(dep_dist)));
+                let dep_index = *inverse[dep.index.0]
+                    .get_or_insert_with(|| graph.add_node(Node::Package(dep_dist)));
 
                 let dep_extras = dep.extra.iter().collect::<Vec<_>>();
                 graph.add_edge(
@@ -303,12 +303,12 @@ impl<'lock> ExportableRequirements<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((&dep.package_id, None)) {
-                    queue.push_back((dep_dist, None));
+                if seen.insert((dep.index, None)) {
+                    queue.push_back((dep.index, None));
                 }
                 for extra in &dep.extra {
-                    if seen.insert((&dep.package_id, Some(extra))) {
-                        queue.push_back((dep_dist, Some(extra)));
+                    if seen.insert((dep.index, Some(extra))) {
+                        queue.push_back((dep.index, Some(extra)));
                     }
                 }
             }

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -408,7 +408,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     continue;
                 }
 
-                let dep_dist = &self.lock().packages[dep.index.0];
+                let dep_dist = self.lock().package(dep.index);
 
                 // Add the package to the graph.
                 let dep_index = match inverse[dep.index.0] {
@@ -665,7 +665,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
             let mut queue = queue.clone();
             let mut reachability = conflict_reachability;
             while let Some((package_index, extra)) = queue.pop_front() {
-                let package = &self.lock().packages[package_index.0];
+                let package = self.lock().package(package_index);
                 let Some(parent_reachability) = reachability.get(&(package_index, extra)).copied()
                 else {
                     continue;
@@ -750,7 +750,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
         );
 
         while let Some((package_index, extra)) = queue.pop_front() {
-            let package = &self.lock().packages[package_index.0];
+            let package = self.lock().package(package_index);
             for dep in package_dependencies(package, extra) {
                 if validate_conflicts && dep.complexified_marker.has_conflict_marker() {
                     dependencies_for_conflict_validation.push((package, dep));
@@ -762,7 +762,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
                     continue;
                 }
 
-                let dep_dist = &self.lock().packages[dep.index.0];
+                let dep_dist = self.lock().package(dep.index);
 
                 // Add the dependency to the graph.
                 let dep_index = match inverse[dep.index.0] {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1605,7 +1605,7 @@ impl Lock {
                 continue;
             }
 
-            let package = self.find_by_id(&dependency.package_id);
+            let package = self.package(dependency.index);
             if selected
                 .as_ref()
                 .is_some_and(|selected| selected.package.id != package.id)
@@ -1654,7 +1654,7 @@ impl Lock {
                 continue;
             }
 
-            let package = self.find_by_id(&dependency.package_id);
+            let package = self.package(dependency.index);
             if selected
                 .as_ref()
                 .is_some_and(|selected| selected.package.id != package.id)
@@ -1736,48 +1736,52 @@ impl Lock {
     {
         // Enqueue a dependency for auditability checks: base package (no extra) first, then each activated extra.
         fn enqueue_dep<'lock>(
-            lock: &'lock Lock,
-            seen: &mut FxHashSet<(&'lock PackageId, Option<&'lock ExtraName>)>,
-            queue: &mut VecDeque<(&'lock Package, Option<&'lock ExtraName>)>,
+            seen: &mut FxHashSet<(PackageIndex, Option<&'lock ExtraName>)>,
+            queue: &mut VecDeque<(PackageIndex, Option<&'lock ExtraName>)>,
             dep: &'lock Dependency,
         ) {
-            let dep_pkg = lock.find_by_id(&dep.package_id);
             for maybe_extra in std::iter::once(None).chain(dep.extra.iter().map(Some)) {
-                if seen.insert((&dep.package_id, maybe_extra)) {
-                    queue.push_back((dep_pkg, maybe_extra));
+                if seen.insert((dep.index, maybe_extra)) {
+                    queue.push_back((dep.index, maybe_extra));
                 }
             }
         }
 
         // Identify workspace members (the implicit root counts for single-member workspaces).
-        let workspace_member_ids: FxHashSet<&PackageId> = if self.members().is_empty() {
-            self.root().into_iter().map(|package| &package.id).collect()
+        let workspace_members: FxHashSet<PackageIndex> = if self.members().is_empty() {
+            self.root()
+                .into_iter()
+                .map(|package| self.by_id[&package.id])
+                .collect()
         } else {
             self.packages
                 .iter()
-                .filter(|package| self.members().contains(&package.id.name))
-                .map(|package| &package.id)
+                .enumerate()
+                .filter(|(_, package)| self.members().contains(&package.id.name))
+                .map(|(index, _)| PackageIndex(index))
                 .collect()
         };
 
         // Lockfile traversal state: (package, optional extra to activate on that package).
-        let mut queue: VecDeque<(&Package, Option<&ExtraName>)> = VecDeque::new();
-        let mut seen: FxHashSet<(&PackageId, Option<&ExtraName>)> = FxHashSet::default();
+        let mut queue: VecDeque<(PackageIndex, Option<&ExtraName>)> = VecDeque::new();
+        let mut seen: FxHashSet<(PackageIndex, Option<&ExtraName>)> = FxHashSet::default();
 
         // Seed from workspace members. Always queue with `None` so that we can traverse
         // their dependency groups; only queue extras when prod mode is active.
-        for package in self
+        for (index, package) in self
             .packages
             .iter()
-            .filter(|p| workspace_member_ids.contains(&p.id))
+            .enumerate()
+            .filter(|(index, _)| workspace_members.contains(&PackageIndex(*index)))
         {
-            if seen.insert((&package.id, None)) {
-                queue.push_back((package, None));
+            let index = PackageIndex(index);
+            if seen.insert((index, None)) {
+                queue.push_back((index, None));
             }
             if groups.prod() {
                 for extra in extras.extra_names(package.optional_dependencies.keys()) {
-                    if seen.insert((&package.id, Some(extra))) {
-                        queue.push_back((package, Some(extra)));
+                    if seen.insert((index, Some(extra))) {
+                        queue.push_back((index, Some(extra)));
                     }
                 }
             }
@@ -1785,17 +1789,19 @@ impl Lock {
 
         // Seed from requirements attached directly to the lock (e.g., PEP 723 scripts).
         for requirement in self.requirements() {
-            for package in self
+            for (index, _) in self
                 .packages
                 .iter()
-                .filter(|p| p.id.name == requirement.name)
+                .enumerate()
+                .filter(|(_, package)| package.id.name == requirement.name)
             {
-                if seen.insert((&package.id, None)) {
-                    queue.push_back((package, None));
+                let index = PackageIndex(index);
+                if seen.insert((index, None)) {
+                    queue.push_back((index, None));
                 }
                 for extra in &*requirement.extras {
-                    if seen.insert((&package.id, Some(extra))) {
-                        queue.push_back((package, Some(extra)));
+                    if seen.insert((index, Some(extra))) {
+                        queue.push_back((index, Some(extra)));
                     }
                 }
             }
@@ -1808,25 +1814,28 @@ impl Lock {
                 continue;
             }
             for requirement in requirements {
-                for package in self
+                for (index, _) in self
                     .packages
                     .iter()
-                    .filter(|p| p.id.name == requirement.name)
+                    .enumerate()
+                    .filter(|(_, package)| package.id.name == requirement.name)
                 {
-                    if seen.insert((&package.id, None)) {
-                        queue.push_back((package, None));
+                    let index = PackageIndex(index);
+                    if seen.insert((index, None)) {
+                        queue.push_back((index, None));
                     }
                     for extra in &*requirement.extras {
-                        if seen.insert((&package.id, Some(extra))) {
-                            queue.push_back((package, Some(extra)));
+                        if seen.insert((index, Some(extra))) {
+                            queue.push_back((index, Some(extra)));
                         }
                     }
                 }
             }
         }
 
-        while let Some((package, extra)) = queue.pop_front() {
-            let is_member = workspace_member_ids.contains(&package.id);
+        while let Some((index, extra)) = queue.pop_front() {
+            let package = self.package(index);
+            let is_member = workspace_members.contains(&index);
 
             // Collect non-workspace packages that have version information
             // and pass the caller's filter.
@@ -1849,7 +1858,7 @@ impl Lock {
                     .filter(|(group, _)| groups.contains(group))
                     .flat_map(|(_, deps)| deps)
                 {
-                    enqueue_dep(self, &mut seen, &mut queue, dep);
+                    enqueue_dep(&mut seen, &mut queue, dep);
                 }
             }
 
@@ -1866,7 +1875,7 @@ impl Lock {
             };
 
             for dep in dependencies {
-                enqueue_dep(self, &mut seen, &mut queue, dep);
+                enqueue_dep(&mut seen, &mut queue, dep);
             }
         }
     }
@@ -2069,10 +2078,9 @@ impl Lock {
         Ok(found_dist)
     }
 
-    fn find_by_id(&self, id: &PackageId) -> &Package {
-        let index = *self.by_id.get(id).expect("locked package for ID");
-
-        (self.packages.get(index.0).expect("valid index for package")) as _
+    /// Return the [`Package`] at an index in this lock's package ordering.
+    fn package(&self, index: PackageIndex) -> &Package {
+        &self.packages[index.0]
     }
 
     /// Return a [`SatisfiesResult`] if the given extras do not match the [`Package`] metadata.
@@ -2365,10 +2373,11 @@ impl Lock {
     ) -> Result<SatisfiesResult<'_>, LockError> {
         let allow_missing_package_metadata =
             allow_missing_package_metadata && self.supports_missing_package_metadata();
-        let mut queue: VecDeque<&Package> = VecDeque::new();
+        let mut queue: VecDeque<PackageIndex> = VecDeque::new();
         let mut seen = FxHashSet::default();
         let mut activated_extras: FxHashMap<PackageId, BTreeSet<ExtraName>> = FxHashMap::default();
-        let mut validated_extras: FxHashMap<PackageId, BTreeSet<ExtraName>> = FxHashMap::default();
+        let mut validated_extras: FxHashMap<PackageIndex, BTreeSet<ExtraName>> =
+            FxHashMap::default();
 
         // Validate that the lockfile was generated with the same root members.
         {
@@ -2655,8 +2664,9 @@ impl Lock {
                 return Ok(SatisfiesResult::MissingRoot(root_name.clone()));
             };
 
-            if seen.insert(&root.id) {
-                queue.push_back(root);
+            let package_index = self.by_id[&root.id];
+            if seen.insert(package_index) {
+                queue.push_back(package_index);
             }
         }
 
@@ -2705,14 +2715,16 @@ impl Lock {
                         .or_default()
                         .extend(requirement.extras.iter().cloned());
 
-                    if seen.insert(&package.id) {
-                        queue.push_back(package);
+                    let package_index = self.by_id[&package.id];
+                    if seen.insert(package_index) {
+                        queue.push_back(package_index);
                     }
                 }
             }
         }
 
-        while let Some(package) = queue.pop_front() {
+        while let Some(package_index) = queue.pop_front() {
+            let package = self.package(package_index);
             // If the lockfile references an index that was not provided, we can't validate it.
             if let Source::Registry(index) = &package.id.source {
                 match index {
@@ -3024,7 +3036,7 @@ impl Lock {
             // Revisit an already-validated dependency if another parent activated more extras.
             // Empty extras have no locked edges, so their activation is otherwise order-dependent.
             validated_extras.insert(
-                package.id.clone(),
+                package_index,
                 activated_extras
                     .get(&package.id)
                     .cloned()
@@ -3032,12 +3044,11 @@ impl Lock {
             );
             for dependency in package.all_dependencies() {
                 let needs_extra_validation = validated_extras
-                    .get(&dependency.package_id)
+                    .get(&dependency.index)
                     .zip(activated_extras.get(&dependency.package_id))
                     .is_some_and(|(validated, activated)| !activated.is_subset(validated));
-                if seen.insert(&dependency.package_id) || needs_extra_validation {
-                    let dependency_package = self.find_by_id(&dependency.package_id);
-                    queue.push_back(dependency_package);
+                if seen.insert(dependency.index) || needs_extra_validation {
+                    queue.push_back(dependency.index);
                 }
             }
         }
@@ -6289,7 +6300,7 @@ impl TryFrom<WheelWire> for Wheel {
     }
 }
 
-/// The position of a package in [`Lock::packages`].
+/// The position of a package in [`Lock::packages`], valid only for that lock's ordering.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct PackageIndex(usize);
 

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -24,7 +24,7 @@ use crate::lock::export::{
     MetadataNode, MetadataNodeId, MetadataNodeKind, MetadataScript, MetadataWorkspace,
     MetadataWorkspaceMember,
 };
-use crate::lock::{Package, PackageId};
+use crate::lock::{Package, PackageId, PackageIndex};
 use crate::{ConflictMarker, Lock, PackageMap, UniversalMarker};
 
 #[derive(Debug, Clone, Copy)]
@@ -45,7 +45,7 @@ impl<'a> TreeJsonTarget<'a> {
 #[derive(Debug)]
 pub struct TreeDisplay<'env> {
     /// The constructed dependency graph.
-    graph: petgraph::graph::Graph<Node<'env>, Edge<'env>, petgraph::Directed>,
+    graph: petgraph::graph::Graph<Node, Edge<'env>, petgraph::Directed>,
     /// The packages considered as roots of the dependency tree.
     roots: Vec<NodeIndex>,
     /// The latest known version of each package.
@@ -115,8 +115,8 @@ impl<'env> TreeDisplay<'env> {
         let size_guess = lock.packages.len();
         let mut graph =
             Graph::<Node, Edge, petgraph::Directed>::with_capacity(size_guess, size_guess);
-        let mut inverse = FxHashMap::with_capacity_and_hasher(size_guess, FxBuildHasher);
-        let mut queue: VecDeque<(&PackageId, Option<&ExtraName>)> = VecDeque::new();
+        let mut inverse = vec![None; size_guess];
+        let mut queue: VecDeque<(PackageIndex, Option<&ExtraName>)> = VecDeque::new();
         let mut seen = FxHashSet::default();
 
         let root = graph.add_node(Node::Root);
@@ -127,28 +127,28 @@ impl<'env> TreeDisplay<'env> {
                 continue;
             }
 
-            let dist = lock.find_by_id(id);
+            let package_index = lock.by_id[id];
+            let dist = lock.package(package_index);
 
             // Add the workspace package to the graph. Under `--only-group`, the workspace member
             // may not be installed, but it's still relevant for the dependency tree, since we want
             // to show the connection from the workspace package to the enabled dependency groups.
-            let index = *inverse
-                .entry(id)
-                .or_insert_with(|| graph.add_node(Node::Package(id)));
+            let index = *inverse[package_index.0]
+                .get_or_insert_with(|| graph.add_node(Node::Package(package_index)));
 
             // Add an edge from the root.
             graph.add_edge(root, index, Edge::Prod(None, UniversalMarker::TRUE));
 
             if groups.prod() {
                 // Push its dependencies on the queue.
-                if seen.insert((id, None)) {
-                    queue.push_back((id, None));
+                if seen.insert((package_index, None)) {
+                    queue.push_back((package_index, None));
                 }
 
                 // Push any extras on the queue.
                 for extra in dist.optional_dependencies.keys() {
-                    if seen.insert((id, Some(extra))) {
-                        queue.push_back((id, Some(extra)));
+                    if seen.insert((package_index, Some(extra))) {
+                        queue.push_back((package_index, Some(extra)));
                     }
                 }
             }
@@ -177,9 +177,8 @@ impl<'env> TreeDisplay<'env> {
                 }
 
                 // Add the dependency to the graph and get its index.
-                let dep_index = *inverse
-                    .entry(&dep.package_id)
-                    .or_insert_with(|| graph.add_node(Node::Package(&dep.package_id)));
+                let dep_index = *inverse[dep.index.0]
+                    .get_or_insert_with(|| graph.add_node(Node::Package(dep.index)));
 
                 // Add an edge from the workspace package.
                 graph.add_edge(
@@ -193,12 +192,12 @@ impl<'env> TreeDisplay<'env> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((&dep.package_id, None)) {
-                    queue.push_back((&dep.package_id, None));
+                if seen.insert((dep.index, None)) {
+                    queue.push_back((dep.index, None));
                 }
                 for extra in &dep.extra {
-                    if seen.insert((&dep.package_id, Some(extra))) {
-                        queue.push_back((&dep.package_id, Some(extra)));
+                    if seen.insert((dep.index, Some(extra))) {
+                        queue.push_back((dep.index, Some(extra)));
                     }
                 }
             }
@@ -215,10 +214,12 @@ impl<'env> TreeDisplay<'env> {
         {
             // Index the lockfile by name.
             let by_name: FxHashMap<_, Vec<_>> = {
-                lock.packages().iter().fold(
+                lock.packages().iter().enumerate().fold(
                     FxHashMap::with_capacity_and_hasher(lock.len(), FxBuildHasher),
-                    |mut map, package| {
-                        map.entry(&package.id.name).or_default().push(package);
+                    |mut map, (index, package)| {
+                        map.entry(&package.id.name)
+                            .or_default()
+                            .push(PackageIndex(index));
                         map
                     },
                 )
@@ -226,7 +227,8 @@ impl<'env> TreeDisplay<'env> {
 
             // Identify any requirements attached to the workspace itself.
             for requirement in lock.requirements() {
-                for package in by_name.get(&requirement.name).into_iter().flatten() {
+                for &package_index in by_name.get(&requirement.name).into_iter().flatten() {
+                    let package = lock.package(package_index);
                     // Determine whether this entry is "relevant" for the requirement, by intersecting
                     // the markers.
                     let marker = if package.fork_markers.is_empty() {
@@ -246,14 +248,13 @@ impl<'env> TreeDisplay<'env> {
                         continue;
                     }
                     // Add the package to the graph.
-                    let index = inverse
-                        .entry(&package.id)
-                        .or_insert_with(|| graph.add_node(Node::Package(&package.id)));
+                    let index = *inverse[package_index.0]
+                        .get_or_insert_with(|| graph.add_node(Node::Package(package_index)));
 
                     // Add an edge from the root.
                     graph.add_edge(
                         root,
-                        *index,
+                        index,
                         Edge::Prod(
                             Some(RequestedExtras::Requirement(requirement.extras.as_ref())),
                             UniversalMarker::from_combined(marker),
@@ -261,12 +262,12 @@ impl<'env> TreeDisplay<'env> {
                     );
 
                     // Push its dependencies on the queue.
-                    if seen.insert((&package.id, None)) {
-                        queue.push_back((&package.id, None));
+                    if seen.insert((package_index, None)) {
+                        queue.push_back((package_index, None));
                     }
                     for extra in &*requirement.extras {
-                        if seen.insert((&package.id, Some(extra))) {
-                            queue.push_back((&package.id, Some(extra)));
+                        if seen.insert((package_index, Some(extra))) {
+                            queue.push_back((package_index, Some(extra)));
                         }
                     }
                 }
@@ -278,7 +279,8 @@ impl<'env> TreeDisplay<'env> {
                     continue;
                 }
                 for requirement in requirements {
-                    for package in by_name.get(&requirement.name).into_iter().flatten() {
+                    for &package_index in by_name.get(&requirement.name).into_iter().flatten() {
+                        let package = lock.package(package_index);
                         // Determine whether this entry is "relevant" for the requirement, by intersecting
                         // the markers.
                         let marker = if package.fork_markers.is_empty() {
@@ -298,14 +300,13 @@ impl<'env> TreeDisplay<'env> {
                             continue;
                         }
                         // Add the package to the graph.
-                        let index = inverse
-                            .entry(&package.id)
-                            .or_insert_with(|| graph.add_node(Node::Package(&package.id)));
+                        let index = *inverse[package_index.0]
+                            .get_or_insert_with(|| graph.add_node(Node::Package(package_index)));
 
                         // Add an edge from the root.
                         graph.add_edge(
                             root,
-                            *index,
+                            index,
                             Edge::Dev(
                                 group,
                                 Some(RequestedExtras::Requirement(requirement.extras.as_ref())),
@@ -314,12 +315,12 @@ impl<'env> TreeDisplay<'env> {
                         );
 
                         // Push its dependencies on the queue.
-                        if seen.insert((&package.id, None)) {
-                            queue.push_back((&package.id, None));
+                        if seen.insert((package_index, None)) {
+                            queue.push_back((package_index, None));
                         }
                         for extra in &*requirement.extras {
-                            if seen.insert((&package.id, Some(extra))) {
-                                queue.push_back((&package.id, Some(extra)));
+                            if seen.insert((package_index, Some(extra))) {
+                                queue.push_back((package_index, Some(extra)));
                             }
                         }
                     }
@@ -328,9 +329,9 @@ impl<'env> TreeDisplay<'env> {
         }
 
         // Create all the relevant nodes.
-        while let Some((id, extra)) = queue.pop_front() {
-            let index = inverse[&id];
-            let package = lock.find_by_id(id);
+        while let Some((package_index, extra)) = queue.pop_front() {
+            let index = inverse[package_index.0].expect("queued package has a graph node");
+            let package = lock.package(package_index);
 
             let deps = if let Some(extra) = extra {
                 Either::Left(
@@ -356,9 +357,8 @@ impl<'env> TreeDisplay<'env> {
                 }
 
                 // Add the dependency to the graph.
-                let dep_index = *inverse
-                    .entry(&dep.package_id)
-                    .or_insert_with(|| graph.add_node(Node::Package(&dep.package_id)));
+                let dep_index = *inverse[dep.index.0]
+                    .get_or_insert_with(|| graph.add_node(Node::Package(dep.index)));
 
                 // Add an edge from the workspace package.
                 graph.add_edge(
@@ -379,12 +379,12 @@ impl<'env> TreeDisplay<'env> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((&dep.package_id, None)) {
-                    queue.push_back((&dep.package_id, None));
+                if seen.insert((dep.index, None)) {
+                    queue.push_back((dep.index, None));
                 }
                 for extra in &dep.extra {
-                    if seen.insert((&dep.package_id, Some(extra))) {
-                        queue.push_back((&dep.package_id, Some(extra)));
+                    if seen.insert((dep.index, Some(extra))) {
+                        queue.push_back((dep.index, Some(extra)));
                     }
                 }
             }
@@ -395,7 +395,9 @@ impl<'env> TreeDisplay<'env> {
             let mut reachable = graph
                 .node_indices()
                 .filter(|index| match graph[*index] {
-                    Node::Package(package_id) => members.contains(package_id),
+                    Node::Package(package_index) => {
+                        members.contains(&lock.package(package_index).id)
+                    }
                     Node::Root => true,
                 })
                 .collect::<FxHashSet<_>>();
@@ -422,10 +424,10 @@ impl<'env> TreeDisplay<'env> {
             let mut reachable = graph
                 .node_indices()
                 .filter(|index| {
-                    let Node::Package(package_id) = graph[*index] else {
+                    let Node::Package(package_index) = graph[*index] else {
                         return false;
                     };
-                    packages.contains(&package_id.name)
+                    packages.contains(&lock.package(package_index).id.name)
                 })
                 .collect::<FxHashSet<_>>();
             let mut stack = reachable.iter().copied().collect::<VecDeque<_>>();
@@ -448,15 +450,15 @@ impl<'env> TreeDisplay<'env> {
                 let mut roots = graph
                     .node_indices()
                     .filter(|index| {
-                        let Node::Package(package_id) = graph[*index] else {
+                        let Node::Package(package_index) = graph[*index] else {
                             return false;
                         };
-                        packages.contains(&package_id.name)
+                        packages.contains(&lock.package(package_index).id.name)
                     })
                     .collect::<Vec<_>>();
 
                 // Sort the roots.
-                roots.sort_by_key(|index| &graph[*index]);
+                roots.sort_by_key(|index| graph[*index].sort_key(lock));
 
                 roots
             } else {
@@ -480,7 +482,7 @@ impl<'env> TreeDisplay<'env> {
                         .collect::<Vec<_>>()
                 };
 
-                roots.sort_by_key(|index| &graph[*index]);
+                roots.sort_by_key(|index| graph[*index].sort_key(lock));
                 roots
             }
         };
@@ -504,7 +506,7 @@ impl<'env> TreeDisplay<'env> {
     fn visit(
         &'env self,
         cursor: Cursor,
-        visited: &mut FxHashMap<VisitedNode<'env>, Vec<&'env PackageId>>,
+        visited: &mut FxHashMap<VisitedNode<'env>, Vec<PackageIndex>>,
         path: &mut Vec<VisitedNode<'env>>,
     ) -> Vec<String> {
         // Short-circuit if the current path is longer than the provided depth.
@@ -512,15 +514,16 @@ impl<'env> TreeDisplay<'env> {
             return Vec::new();
         }
 
-        let Node::Package(package_id) = self.graph[cursor.node()] else {
+        let Node::Package(package_index) = self.graph[cursor.node()] else {
             return Vec::new();
         };
         let edge = cursor.edge().map(|edge_id| &self.graph[edge_id]);
-        let package = self.lock.find_by_id(package_id);
+        let package = self.lock.package(package_index);
+        let package_id = &package.id;
 
         let expanded_extras = self.expanded_extras(package, edge);
         let visited_node = VisitedNode {
-            package_id,
+            package_index,
             expanded_extras: expanded_extras.clone(),
             marker: self.invert.then_some(cursor.marker()),
         };
@@ -636,7 +639,7 @@ impl<'env> TreeDisplay<'env> {
                 .collect::<Vec<_>>()
         };
         dependencies.sort_by_key(|cursor| {
-            let node = &self.graph[cursor.node()];
+            let node = self.graph[cursor.node()].sort_key(self.lock);
             let edge = cursor
                 .edge()
                 .map(|edge_id| &self.graph[edge_id])
@@ -654,7 +657,7 @@ impl<'env> TreeDisplay<'env> {
                 dependencies
                     .iter()
                     .filter_map(|node| match self.graph[node.node()] {
-                        Node::Package(package_id) => Some(package_id),
+                        Node::Package(package_index) => Some(package_index),
                         Node::Root => None,
                     })
                     .collect(),
@@ -784,13 +787,13 @@ impl<'env> TreeDisplay<'env> {
             match self.graph[*root] {
                 Node::Root => {
                     for edge in self.graph.edges_directed(*root, Direction::Outgoing) {
-                        let Node::Package(package_id) = self.graph[edge.target()] else {
+                        let Node::Package(package_index) = self.graph[edge.target()] else {
                             continue;
                         };
                         let state = JsonTraversalNode {
                             index: edge.target(),
                             expanded_extras: self.expanded_extras(
-                                self.lock.find_by_id(package_id),
+                                self.lock.package(package_index),
                                 Some(edge.weight()),
                             ),
                             marker: UniversalMarker::TRUE,
@@ -802,11 +805,11 @@ impl<'env> TreeDisplay<'env> {
                         }
                     }
                 }
-                Node::Package(package_id) => {
+                Node::Package(package_index) => {
                     let state = JsonTraversalNode {
                         index: *root,
                         expanded_extras: self
-                            .expanded_extras(self.lock.find_by_id(package_id), None),
+                            .expanded_extras(self.lock.package(package_index), None),
                         marker: if self.invert {
                             self.conflict_marker
                         } else {
@@ -868,13 +871,13 @@ impl<'env> TreeDisplay<'env> {
                     edges.insert(edge.id());
                     continue;
                 }
-                let Node::Package(package_id) = self.graph[target] else {
+                let Node::Package(package_index) = self.graph[target] else {
                     continue;
                 };
                 let state = JsonTraversalNode {
                     index: target,
                     expanded_extras: self
-                        .expanded_extras(self.lock.find_by_id(package_id), Some(edge.weight())),
+                        .expanded_extras(self.lock.package(package_index), Some(edge.weight())),
                     marker,
                     reached_via_dependency_group: self.invert && edge_kind.is_dev(),
                 };
@@ -1027,10 +1030,10 @@ impl JsonGraph {
         let mut builder = JsonGraphBuilder::new(tree, workspace_root.clone());
 
         for index in traversal.nodes.iter().copied() {
-            let Node::Package(package_id) = tree.graph[index] else {
+            let Node::Package(package_index) = tree.graph[index] else {
                 continue;
             };
-            builder.ensure_package(package_id, MetadataNodeKind::Package);
+            builder.ensure_package(package_index, MetadataNodeKind::Package);
         }
 
         for edge in tree
@@ -1096,12 +1099,13 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
         id
     }
 
-    fn ensure_package(&mut self, package_id: &'env PackageId, kind: MetadataNodeKind) -> String {
+    fn ensure_package(&mut self, package_index: PackageIndex, kind: MetadataNodeKind) -> String {
+        let package = self.tree.lock.package(package_index);
+        let package_id = &package.id;
         let is_package = matches!(kind, MetadataNodeKind::Package);
         let id = MetadataNodeId::from_package_id(&self.workspace_root, package_id, kind.clone())
             .to_flat();
         self.resolution.entry(id.clone()).or_insert_with(|| {
-            let package = self.tree.lock.find_by_id(package_id);
             let mut node = MetadataNode::from_package_id(&self.workspace_root, package_id, kind);
             if is_package {
                 node.set_latest_version(self.tree.latest.get(package_id).cloned());
@@ -1112,9 +1116,9 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
         id
     }
 
-    fn ensure_extra(&mut self, package_id: &'env PackageId, extra: &ExtraName) -> String {
-        let package = self.ensure_package(package_id, MetadataNodeKind::Package);
-        let extra_id = self.ensure_package(package_id, MetadataNodeKind::Extra(extra.clone()));
+    fn ensure_extra(&mut self, package_index: PackageIndex, extra: &ExtraName) -> String {
+        let package = self.ensure_package(package_index, MetadataNodeKind::Package);
+        let extra_id = self.ensure_package(package_index, MetadataNodeKind::Extra(extra.clone()));
         self.add_link(
             package.clone(),
             extra_id.clone(),
@@ -1124,9 +1128,9 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
         extra_id
     }
 
-    fn ensure_group(&mut self, package_id: &'env PackageId, group: &GroupName) -> String {
-        let package = self.ensure_package(package_id, MetadataNodeKind::Package);
-        let group_id = self.ensure_package(package_id, MetadataNodeKind::Group(group.clone()));
+    fn ensure_group(&mut self, package_index: PackageIndex, group: &GroupName) -> String {
+        let package = self.ensure_package(package_index, MetadataNodeKind::Package);
+        let group_id = self.ensure_package(package_index, MetadataNodeKind::Group(group.clone()));
         self.add_link(package, group_id.clone(), JsonLink::Group(group.clone()));
         group_id
     }
@@ -1151,15 +1155,15 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
 
     fn dependency_targets(
         &mut self,
-        package_id: &'env PackageId,
+        package_index: PackageIndex,
         extras: Option<RequestedExtras<'env>>,
     ) -> Vec<String> {
         let Some(extras) = extras.filter(|extras| !extras.is_empty()) else {
-            return vec![self.ensure_package(package_id, MetadataNodeKind::Package)];
+            return vec![self.ensure_package(package_index, MetadataNodeKind::Package)];
         };
         extras
             .iter()
-            .map(|extra| self.ensure_extra(package_id, extra))
+            .map(|extra| self.ensure_extra(package_index, extra))
             .collect()
     }
 
@@ -1272,8 +1276,9 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
         }
     }
 
-    fn add_package_roots(&mut self, roots: &mut Vec<JsonRoot>, package_id: &'env PackageId) {
-        let package = self.tree.lock.find_by_id(package_id);
+    fn add_package_roots(&mut self, roots: &mut Vec<JsonRoot>, package_index: PackageIndex) {
+        let package = self.tree.lock.package(package_index);
+        let package_id = &package.id;
         let extras = package
             .optional_dependencies
             .keys()
@@ -1288,7 +1293,7 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
 
         if self.tree.prod {
             roots.push(JsonRoot {
-                id: self.ensure_package(package_id, MetadataNodeKind::Package),
+                id: self.ensure_package(package_index, MetadataNodeKind::Package),
             });
             for extra in &extras {
                 let id = MetadataNodeId::from_package_id(
@@ -1320,13 +1325,13 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
         let mut roots = Vec::new();
         for root in &self.tree.roots {
             match self.tree.graph[*root] {
-                Node::Package(package_id) => {
+                Node::Package(package_index) => {
                     if self.tree.invert {
                         roots.push(JsonRoot {
-                            id: self.ensure_package(package_id, MetadataNodeKind::Package),
+                            id: self.ensure_package(package_index, MetadataNodeKind::Package),
                         });
                     } else {
-                        self.add_package_roots(&mut roots, package_id);
+                        self.add_package_roots(&mut roots, package_index);
                     }
                 }
                 Node::Root => match target {
@@ -1341,15 +1346,15 @@ impl<'tree, 'env> JsonGraphBuilder<'tree, 'env> {
                             .edges_directed(*root, Direction::Outgoing)
                             .filter(|edge| matches!(edge.weight(), Edge::Prod(..)))
                             .filter_map(|edge| {
-                                let Node::Package(package_id) = self.tree.graph[edge.target()]
+                                let Node::Package(package_index) = self.tree.graph[edge.target()]
                                 else {
                                     return None;
                                 };
-                                Some(package_id)
+                                Some(package_index)
                             })
                             .collect::<Vec<_>>();
-                        for package_id in packages {
-                            self.add_package_roots(&mut roots, package_id);
+                        for package_index in packages {
+                            self.add_package_roots(&mut roots, package_index);
                         }
                         let groups = self
                             .tree
@@ -1443,17 +1448,27 @@ struct JsonRoot {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct VisitedNode<'env> {
-    package_id: &'env PackageId,
+    package_index: PackageIndex,
     expanded_extras: BTreeSet<&'env ExtraName>,
     marker: Option<UniversalMarker>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
-enum Node<'env> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Node {
     /// The synthetic root node.
     Root,
     /// A package in the dependency graph.
-    Package(&'env PackageId),
+    Package(PackageIndex),
+}
+
+impl Node {
+    /// Preserve package identity ordering independently of positions in the lock.
+    fn sort_key(self, lock: &Lock) -> Option<&PackageId> {
+        match self {
+            Self::Root => None,
+            Self::Package(index) => Some(&lock.package(index).id),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]


### PR DESCRIPTION
## Summary

Extend the `PackageIndex` introduced in #21373 to exports, dependency trees, audits, and lock freshness checks. Use cached indices for dependency lookups and traversal state, and dense vectors for the export and tree graph lookups.

Add a shared `Lock::package` accessor. Package IDs continue to define serialized identities, tree ordering, and comparisons between lockfiles.

The following full-command medians compare #21373 at `8f0f824` with this change at `e84ad64`, before rebasing onto `main`. Measured on a quiet Linux/x86-64 devbox with optimized `profiling` builds, warm caches, one pinned CPU, and 16 samples per variant in counterbalanced blocks. Both commands used frozen, offline operation.

| Project                             | Command                 |   #21373 | Follow-up | Change |
| ----------------------------------- | ----------------------- | -------: | --------: | -----: |
| Airflow (585 lock entries)          | Export requirements.txt | 48.87 ms |  48.15 ms |  -1.5% |
| Airflow (585 lock entries)          | Universal tree          | 30.24 ms |  29.46 ms |  -2.6% |
| Home Assistant (1,456 lock entries) | Export requirements.txt | 96.11 ms |  94.88 ms |  -1.3% |
| Home Assistant (1,456 lock entries) | Universal tree          | 53.98 ms |  52.74 ms |  -2.3% |

All eight paired Airflow blocks favored this change. Home Assistant was noisier: seven of eight blocks favored this change for export, and five of eight for tree. All samples were retained. Outputs were byte-identical across every run, and lockfiles and environments were unchanged.
