### PR TITLE
Add a once queue for graph traversal

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -57,7 +57,7 @@ use uv_pypi_types::{
 };
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_small_str::SmallString;
-use uv_types::{BuildContext, HashStrategy};
+use uv_types::{BuildContext, HashStrategy, OnceQueue};
 use uv_warnings::warn_user_once;
 use uv_workspace::{Editability, WorkspaceMember};
 
@@ -1736,14 +1736,11 @@ impl Lock {
     {
         // Enqueue a dependency for auditability checks: base package (no extra) first, then each activated extra.
         fn enqueue_dep<'lock>(
-            seen: &mut FxHashSet<(PackageIndex, Option<&'lock ExtraName>)>,
-            queue: &mut VecDeque<(PackageIndex, Option<&'lock ExtraName>)>,
+            queue: &mut OnceQueue<(PackageIndex, Option<&'lock ExtraName>)>,
             dep: &'lock Dependency,
         ) {
             for maybe_extra in std::iter::once(None).chain(dep.extra.iter().map(Some)) {
-                if seen.insert((dep.index, maybe_extra)) {
-                    queue.push_back((dep.index, maybe_extra));
-                }
+                queue.push((dep.index, maybe_extra));
             }
         }
 
@@ -1763,8 +1760,7 @@ impl Lock {
         };
 
         // Lockfile traversal state: (package, optional extra to activate on that package).
-        let mut queue: VecDeque<(PackageIndex, Option<&ExtraName>)> = VecDeque::new();
-        let mut seen: FxHashSet<(PackageIndex, Option<&ExtraName>)> = FxHashSet::default();
+        let mut queue = OnceQueue::default();
 
         // Seed from workspace members. Always queue with `None` so that we can traverse
         // their dependency groups; only queue extras when prod mode is active.
@@ -1775,14 +1771,10 @@ impl Lock {
             .filter(|(index, _)| workspace_members.contains(&PackageIndex(*index)))
         {
             let index = PackageIndex(index);
-            if seen.insert((index, None)) {
-                queue.push_back((index, None));
-            }
+            queue.push((index, None));
             if groups.prod() {
                 for extra in extras.extra_names(package.optional_dependencies.keys()) {
-                    if seen.insert((index, Some(extra))) {
-                        queue.push_back((index, Some(extra)));
-                    }
+                    queue.push((index, Some(extra)));
                 }
             }
         }
@@ -1796,13 +1788,9 @@ impl Lock {
                 .filter(|(_, package)| package.id.name == requirement.name)
             {
                 let index = PackageIndex(index);
-                if seen.insert((index, None)) {
-                    queue.push_back((index, None));
-                }
+                queue.push((index, None));
                 for extra in &*requirement.extras {
-                    if seen.insert((index, Some(extra))) {
-                        queue.push_back((index, Some(extra)));
-                    }
+                    queue.push((index, Some(extra)));
                 }
             }
         }
@@ -1821,19 +1809,15 @@ impl Lock {
                     .filter(|(_, package)| package.id.name == requirement.name)
                 {
                     let index = PackageIndex(index);
-                    if seen.insert((index, None)) {
-                        queue.push_back((index, None));
-                    }
+                    queue.push((index, None));
                     for extra in &*requirement.extras {
-                        if seen.insert((index, Some(extra))) {
-                            queue.push_back((index, Some(extra)));
-                        }
+                        queue.push((index, Some(extra)));
                     }
                 }
             }
         }
 
-        while let Some((index, extra)) = queue.pop_front() {
+        while let Some((index, extra)) = queue.pop() {
             let package = self.package(index);
             let is_member = workspace_members.contains(&index);
 
@@ -1858,7 +1842,7 @@ impl Lock {
                     .filter(|(group, _)| groups.contains(group))
                     .flat_map(|(_, deps)| deps)
                 {
-                    enqueue_dep(&mut seen, &mut queue, dep);
+                    enqueue_dep(&mut queue, dep);
                 }
             }
 
@@ -1875,7 +1859,7 @@ impl Lock {
             };
 
             for dep in dependencies {
-                enqueue_dep(&mut seen, &mut queue, dep);
+                enqueue_dep(&mut queue, dep);
             }
         }
     }

--- a/crates/uv-types/src/lib.rs
+++ b/crates/uv-types/src/lib.rs
@@ -2,11 +2,13 @@
 pub use builds::*;
 pub use downloads::*;
 pub use hash::*;
+pub use once_queue::*;
 pub use requirements::*;
 pub use traits::*;
 
 mod builds;
 mod downloads;
 mod hash;
+mod once_queue;
 mod requirements;
 mod traits;

--- a/crates/uv-types/src/once_queue.rs
+++ b/crates/uv-types/src/once_queue.rs
@@ -1,0 +1,63 @@
+use std::collections::VecDeque;
+use std::hash::Hash;
+
+use rustc_hash::FxHashSet;
+
+/// A first-in, first-out queue that accepts each distinct value at most once.
+///
+/// Popped values remain recorded and cannot be pushed again.
+#[derive(Debug)]
+pub struct OnceQueue<T> {
+    queue: VecDeque<T>,
+    seen: FxHashSet<T>,
+}
+
+impl<T> Default for OnceQueue<T> {
+    fn default() -> Self {
+        Self {
+            queue: VecDeque::new(),
+            seen: FxHashSet::default(),
+        }
+    }
+}
+
+impl<T> OnceQueue<T>
+where
+    T: Clone + Eq + Hash,
+{
+    /// Push a value onto the queue if it has not been seen before.
+    ///
+    /// Returns `true` if the value was added.
+    pub fn push(&mut self, value: T) -> bool {
+        if self.seen.insert(value.clone()) {
+            self.queue.push_back(value);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Pop the next value from the queue.
+    pub fn pop(&mut self) -> Option<T> {
+        self.queue.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OnceQueue;
+
+    #[test]
+    fn accepts_each_value_once() {
+        let mut queue = OnceQueue::default();
+
+        assert!(queue.push("a"));
+        assert!(queue.push("b"));
+        assert!(!queue.push("a"));
+
+        assert_eq!(queue.pop(), Some("a"));
+        assert!(!queue.push("a"));
+        assert_eq!(queue.pop(), Some("b"));
+        assert_eq!(queue.pop(), None);
+    }
+}


### PR DESCRIPTION
Dependency graph traversals currently pair a queue with a visited set at each call site, making it easy to deduplicate after dequeue and accumulate redundant states. Add a small FIFO `OnceQueue` that records each value on enqueue and never accepts it again, and use the audit traversal as its first consumer.

This replaces #20289 after moving the shared traversal work beneath the removal changes.