### PR TITLE
Consolidate lock dependency traversal queues

### DIFF
--- a/crates/uv-resolver/src/lock/export/mod.rs
+++ b/crates/uv-resolver/src/lock/export/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::collections::hash_map::Entry;
 
 use either::Either;
@@ -14,8 +13,10 @@ use uv_configuration::{
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep508::MarkerTree;
 use uv_pypi_types::ConflictItem;
+use uv_types::OnceQueue;
 
 use crate::graph_ops::Reachable;
+use crate::lock::LockErrorKind;
 pub use crate::lock::export::metadata::{Metadata, PythonReport};
 pub(crate) use crate::lock::export::metadata::{
     MetadataNode, MetadataNodeId, MetadataNodeKind, MetadataScript, MetadataWorkspace,
@@ -24,7 +25,6 @@ pub(crate) use crate::lock::export::metadata::{
 pub(crate) use crate::lock::export::pylock_toml::PylockTomlPackage;
 pub use crate::lock::export::pylock_toml::{PylockToml, PylockTomlError, PylockTomlErrorKind};
 pub use crate::lock::export::requirements_txt::RequirementsTxtExport;
-use crate::lock::{LockErrorKind, PackageIndex};
 use crate::universal_marker::resolve_activated_extras;
 use crate::{Installable, InstallableRootKind, LockError, Package};
 
@@ -62,22 +62,13 @@ impl<'lock> ExportableRequirements<'lock> {
         let mut graph = Graph::<Node<'lock>, Edge<'lock>>::with_capacity(size_guess, size_guess);
         let mut inverse = vec![None; size_guess];
 
-        let mut queue: VecDeque<(PackageIndex, Option<&ExtraName>)> = VecDeque::new();
-        let mut seen = FxHashSet::default();
+        let mut queue = OnceQueue::default();
         let mut activated_items = FxHashMap::default();
 
         let root = graph.add_node(Node::Root);
 
         // Add the workspace packages and any additional dependency-group roots to the queue.
-        for (root_name, root_kind) in target
-            .roots()
-            .map(|root| (root, InstallableRootKind::Production))
-            .chain(
-                target
-                    .group_root(groups)
-                    .map(|root| (root, InstallableRootKind::DependencyGroups)),
-            )
-        {
+        for (root_name, root_kind) in target.roots_with_kind(groups) {
             if prune.contains(root_name) {
                 continue;
             }
@@ -113,9 +104,9 @@ impl<'lock> ExportableRequirements<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                queue.push_back((package_index, None));
+                queue.push((package_index, None));
                 for extra in extras.extra_names(dist.optional_dependencies.keys()) {
-                    queue.push_back((package_index, Some(extra)));
+                    queue.push((package_index, Some(extra)));
                     activated_items.insert(
                         ConflictItem::from((dist.id.name.clone(), extra.clone())),
                         MarkerTree::TRUE,
@@ -166,13 +157,9 @@ impl<'lock> ExportableRequirements<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((dep.index, None)) {
-                    queue.push_back((dep.index, None));
-                }
+                queue.push((dep.index, None));
                 for extra in &dep.extra {
-                    if seen.insert((dep.index, Some(extra))) {
-                        queue.push_back((dep.index, Some(extra)));
-                    }
+                    queue.push((dep.index, Some(extra)));
                 }
             }
         }
@@ -180,23 +167,7 @@ impl<'lock> ExportableRequirements<'lock> {
         // Add requirements that are exclusive to the workspace root (e.g., dependency groups in
         // non-project workspace roots).
         let root_requirements = target
-            .lock()
-            .requirements()
-            .iter()
-            .chain(
-                target
-                    .lock()
-                    .dependency_groups()
-                    .iter()
-                    .filter_map(|(group, deps)| {
-                        if target.includes_group(None, group, groups) {
-                            Some(deps)
-                        } else {
-                            None
-                        }
-                    })
-                    .flatten(),
-            )
+            .root_requirements(groups)
             .filter(|dep| !prune.contains(&dep.name))
             .collect::<Vec<_>>();
 
@@ -243,20 +214,16 @@ impl<'lock> ExportableRequirements<'lock> {
                     );
 
                     // Push its dependencies on the queue.
-                    if seen.insert((package_index, None)) {
-                        queue.push_back((package_index, None));
-                    }
+                    queue.push((package_index, None));
                     for extra in &requirement.extras {
-                        if seen.insert((package_index, Some(extra))) {
-                            queue.push_back((package_index, Some(extra)));
-                        }
+                        queue.push((package_index, Some(extra)));
                     }
                 }
             }
         }
 
         // Create all the relevant nodes.
-        while let Some((package_index, extra)) = queue.pop_front() {
+        while let Some((package_index, extra)) = queue.pop() {
             let index = inverse[package_index.0].expect("queued package has a graph node");
             let package = target.lock().package(package_index);
 
@@ -303,13 +270,9 @@ impl<'lock> ExportableRequirements<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((dep.index, None)) {
-                    queue.push_back((dep.index, None));
-                }
+                queue.push((dep.index, None));
                 for extra in &dep.extra {
-                    if seen.insert((dep.index, Some(extra))) {
-                        queue.push_back((dep.index, Some(extra)));
-                    }
+                    queue.push((dep.index, Some(extra)));
                 }
             }
         }

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -13,10 +13,11 @@ use uv_configuration::{
     BuildOptions, DependencyGroupsWithDefaults, ExtrasSpecification,
     ExtrasSpecificationWithDefaults, InstallOptions,
 };
-use uv_distribution_types::{Edge, FirstParty, Node, Resolution, ResolvedDist};
+use uv_distribution_types::{Edge, FirstParty, Node, Requirement, Resolution, ResolvedDist};
 use uv_normalize::{DefaultExtras, ExtraName, GroupName, PackageName};
 use uv_platform_tags::Tags;
 use uv_pypi_types::{ConflictKind, ConflictSet, ResolverMarkerEnvironment};
+use uv_types::OnceQueue;
 
 use crate::lock::{
     Dependency, DependencySelectionContext, HashedDist, LockErrorKind, Package, PackageIndex,
@@ -38,29 +39,47 @@ fn newly_activated_extras<'lock>(
         .collect()
 }
 
-/// Record another condition under which a locked package and optional extra are reachable.
+type TraversalState<'lock> = (PackageIndex, Option<&'lock ExtraName>);
+
+/// A queue for fixed-point reachability propagation.
 ///
-/// Returns `true` when the combined reachability changed.
-fn add_reachability<'lock>(
-    reachability: &mut FxHashMap<(PackageIndex, Option<&'lock ExtraName>), UniversalMarker>,
-    key: (PackageIndex, Option<&'lock ExtraName>),
-    marker: UniversalMarker,
-) -> bool {
-    match reachability.entry(key) {
-        Entry::Occupied(mut entry) => {
-            let mut combined = *entry.get();
-            combined.or(marker);
-            if combined == *entry.get() {
-                false
-            } else {
-                entry.insert(combined);
+/// Unlike [`OnceQueue`], a state can be revisited when its accumulated reachability changes. A
+/// state that is already pending is not queued again; the next visit observes the combined value.
+#[derive(Default)]
+struct ReachabilityQueue<'lock> {
+    queue: VecDeque<TraversalState<'lock>>,
+    queued: FxHashSet<TraversalState<'lock>>,
+    reachability: FxHashMap<TraversalState<'lock>, UniversalMarker>,
+}
+
+impl<'lock> ReachabilityQueue<'lock> {
+    fn push(&mut self, state: TraversalState<'lock>, marker: UniversalMarker) {
+        let changed = match self.reachability.entry(state) {
+            Entry::Occupied(mut entry) => {
+                let mut combined = *entry.get();
+                combined.or(marker);
+                if combined == *entry.get() {
+                    false
+                } else {
+                    entry.insert(combined);
+                    true
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(marker);
                 true
             }
+        };
+        if changed && self.queued.insert(state) {
+            self.queue.push_back(state);
         }
-        Entry::Vacant(entry) => {
-            entry.insert(marker);
-            true
-        }
+    }
+
+    fn pop(&mut self) -> Option<(TraversalState<'lock>, UniversalMarker)> {
+        let state = self.queue.pop_front()?;
+        self.queued.remove(&state);
+        let marker = *self.reachability.get(&state)?;
+        Some((state, marker))
     }
 }
 
@@ -118,6 +137,45 @@ pub trait Installable<'lock> {
         groups.contains(group)
     }
 
+    /// Return the package roots and the dependencies to include from each root.
+    fn roots_with_kind<'target>(
+        &'target self,
+        groups: &'target DependencyGroupsWithDefaults,
+    ) -> impl Iterator<Item = (&'target PackageName, InstallableRootKind)> + 'target
+    where
+        'lock: 'target,
+    {
+        self.roots()
+            .map(|root| (root, InstallableRootKind::Production))
+            .chain(
+                self.group_root(groups)
+                    .map(|root| (root, InstallableRootKind::DependencyGroups)),
+            )
+    }
+
+    /// Return requirements declared directly on the lock target.
+    ///
+    /// This includes requirements from dependency groups selected for a non-project workspace
+    /// root.
+    fn root_requirements<'target>(
+        &'target self,
+        groups: &'target DependencyGroupsWithDefaults,
+    ) -> impl Iterator<Item = &'lock Requirement> + 'target
+    where
+        'lock: 'target,
+    {
+        self.lock().requirements().iter().chain(
+            self.lock()
+                .dependency_groups()
+                .iter()
+                .filter_map(|(group, dependencies)| {
+                    self.includes_group(None, group, groups)
+                        .then_some(dependencies)
+                })
+                .flatten(),
+        )
+    }
+
     /// Return the [`PackageName`] of the target, if available.
     fn project_name(&self) -> Option<&PackageName>;
 
@@ -143,11 +201,15 @@ pub trait Installable<'lock> {
                     })
                 })
         };
-        let roots = self
-            .roots()
-            .map(&resolve_root)
-            .collect::<Result<Vec<_>, LockError>>()?;
-        let group_root = self.group_root(groups).map(resolve_root).transpose()?;
+        let mut roots = Vec::new();
+        let mut group_root = None;
+        for (root, kind) in self.roots_with_kind(groups) {
+            let root = resolve_root(root)?;
+            match kind {
+                InstallableRootKind::Production => roots.push(root),
+                InstallableRootKind::DependencyGroups => group_root = Some(root),
+            }
+        }
 
         InstallableExt::to_resolution_from_packages(
             self,
@@ -267,9 +329,8 @@ trait InstallableExt<'lock>: Installable<'lock> {
         let mut petgraph = Graph::with_capacity(size_guess, size_guess);
         let mut inverse = vec![None; size_guess];
 
-        let mut queue: VecDeque<(PackageIndex, Option<&ExtraName>)> = VecDeque::new();
-        let mut seen = FxHashSet::default();
-        let mut conflict_reachability = FxHashMap::default();
+        let mut queue = OnceQueue::default();
+        let mut reachability_queue = ReachabilityQueue::default();
         let mut activated_projects: Vec<&PackageName> = vec![];
         let mut activated_extras: Vec<(&PackageName, &ExtraName)> = vec![];
         let mut activated_groups: Vec<(&PackageName, &GroupName)> = vec![];
@@ -363,19 +424,11 @@ trait InstallableExt<'lock>: Installable<'lock> {
         for (dist, package_index, index, root_kind) in initialized_roots {
             if root_kind == InstallableRootKind::Production && groups.prod() {
                 // Push its dependencies onto the queue.
-                queue.push_back((package_index, None));
-                add_reachability(
-                    &mut conflict_reachability,
-                    (package_index, None),
-                    UniversalMarker::TRUE,
-                );
+                queue.push((package_index, None));
+                reachability_queue.push((package_index, None), UniversalMarker::TRUE);
                 for extra in extras.extra_names(dist.optional_dependencies.keys()) {
-                    queue.push_back((package_index, Some(extra)));
-                    add_reachability(
-                        &mut conflict_reachability,
-                        (package_index, Some(extra)),
-                        UniversalMarker::TRUE,
-                    );
+                    queue.push((package_index, Some(extra)));
+                    reachability_queue.push((package_index, Some(extra)), UniversalMarker::TRUE);
                 }
             }
 
@@ -460,23 +513,11 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 }
 
                 // Push its dependencies on the queue.
-                add_reachability(
-                    &mut conflict_reachability,
-                    (dep.index, None),
-                    dep.complexified_marker,
-                );
-                if seen.insert((dep.index, None)) {
-                    queue.push_back((dep.index, None));
-                }
+                reachability_queue.push((dep.index, None), dep.complexified_marker);
+                queue.push((dep.index, None));
                 for extra in &dep.extra {
-                    add_reachability(
-                        &mut conflict_reachability,
-                        (dep.index, Some(extra)),
-                        dep.complexified_marker,
-                    );
-                    if seen.insert((dep.index, Some(extra))) {
-                        queue.push_back((dep.index, Some(extra)));
-                    }
+                    reachability_queue.push((dep.index, Some(extra)), dep.complexified_marker);
+                    queue.push((dep.index, Some(extra)));
                 }
             }
         }
@@ -513,23 +554,11 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 petgraph.add_edge(root, index, Edge::Prod);
 
                 // Push its dependencies on the queue.
-                add_reachability(
-                    &mut conflict_reachability,
-                    (package_index, None),
-                    UniversalMarker::TRUE,
-                );
-                if seen.insert((package_index, None)) {
-                    queue.push_back((package_index, None));
-                }
+                reachability_queue.push((package_index, None), UniversalMarker::TRUE);
+                queue.push((package_index, None));
                 for extra in &dependency.extras {
-                    add_reachability(
-                        &mut conflict_reachability,
-                        (package_index, Some(extra)),
-                        UniversalMarker::TRUE,
-                    );
-                    if seen.insert((package_index, Some(extra))) {
-                        queue.push_back((package_index, Some(extra)));
-                    }
+                    reachability_queue.push((package_index, Some(extra)), UniversalMarker::TRUE);
+                    queue.push((package_index, Some(extra)));
                 }
             }
 
@@ -610,23 +639,11 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 }
 
                 // Push its dependencies on the queue.
-                add_reachability(
-                    &mut conflict_reachability,
-                    (package_index, None),
-                    UniversalMarker::TRUE,
-                );
-                if seen.insert((package_index, None)) {
-                    queue.push_back((package_index, None));
-                }
+                reachability_queue.push((package_index, None), UniversalMarker::TRUE);
+                queue.push((package_index, None));
                 for extra in &dependency.extras {
-                    add_reachability(
-                        &mut conflict_reachability,
-                        (package_index, Some(extra)),
-                        UniversalMarker::TRUE,
-                    );
-                    if seen.insert((package_index, Some(extra))) {
-                        queue.push_back((package_index, Some(extra)));
-                    }
+                    reachability_queue.push((package_index, Some(extra)), UniversalMarker::TRUE);
+                    queue.push((package_index, Some(extra)));
                 }
             }
         }
@@ -662,14 +679,9 @@ trait InstallableExt<'lock>: Installable<'lock> {
         if has_conflicts {
             let mut activated_extras_set: BTreeSet<(&PackageName, &ExtraName)> =
                 activated_extras.iter().copied().collect();
-            let mut queue = queue.clone();
-            let mut reachability = conflict_reachability;
-            while let Some((package_index, extra)) = queue.pop_front() {
+            while let Some(((package_index, extra), parent_reachability)) = reachability_queue.pop()
+            {
                 let package = self.lock().package(package_index);
-                let Some(parent_reachability) = reachability.get(&(package_index, extra)).copied()
-                else {
-                    continue;
-                };
                 for dep in package_dependencies(package, extra) {
                     let mut dep_reachability = dep.complexified_marker;
                     dep_reachability.and(parent_reachability);
@@ -699,17 +711,9 @@ trait InstallableExt<'lock>: Installable<'lock> {
                         activated_extras.push(key);
                     }
                     // Push its dependencies on the queue.
-                    if add_reachability(&mut reachability, (dep.index, None), dep_reachability) {
-                        queue.push_back((dep.index, None));
-                    }
+                    reachability_queue.push((dep.index, None), dep_reachability);
                     for extra in &dep.extra {
-                        if add_reachability(
-                            &mut reachability,
-                            (dep.index, Some(extra)),
-                            dep_reachability,
-                        ) {
-                            queue.push_back((dep.index, Some(extra)));
-                        }
+                        reachability_queue.push((dep.index, Some(extra)), dep_reachability);
                     }
                 }
             }
@@ -749,7 +753,7 @@ trait InstallableExt<'lock>: Installable<'lock> {
             activated_groups.iter().copied(),
         );
 
-        while let Some((package_index, extra)) = queue.pop_front() {
+        while let Some((package_index, extra)) = queue.pop() {
             let package = self.lock().package(package_index);
             for dep in package_dependencies(package, extra) {
                 if validate_conflicts && dep.complexified_marker.has_conflict_marker() {
@@ -804,13 +808,9 @@ trait InstallableExt<'lock>: Installable<'lock> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((dep.index, None)) {
-                    queue.push_back((dep.index, None));
-                }
+                queue.push((dep.index, None));
                 for extra in &dep.extra {
-                    if seen.insert((dep.index, Some(extra))) {
-                        queue.push_back((dep.index, Some(extra)));
-                    }
+                    queue.push((dep.index, Some(extra)));
                 }
             }
         }

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -19,6 +19,7 @@ use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
 use uv_pypi_types::ResolverMarkerEnvironment;
+use uv_types::OnceQueue;
 
 use crate::lock::export::{
     MetadataNode, MetadataNodeId, MetadataNodeKind, MetadataScript, MetadataWorkspace,
@@ -116,8 +117,7 @@ impl<'env> TreeDisplay<'env> {
         let mut graph =
             Graph::<Node, Edge, petgraph::Directed>::with_capacity(size_guess, size_guess);
         let mut inverse = vec![None; size_guess];
-        let mut queue: VecDeque<(PackageIndex, Option<&ExtraName>)> = VecDeque::new();
-        let mut seen = FxHashSet::default();
+        let mut queue = OnceQueue::default();
 
         let root = graph.add_node(Node::Root);
 
@@ -141,15 +141,11 @@ impl<'env> TreeDisplay<'env> {
 
             if groups.prod() {
                 // Push its dependencies on the queue.
-                if seen.insert((package_index, None)) {
-                    queue.push_back((package_index, None));
-                }
+                queue.push((package_index, None));
 
                 // Push any extras on the queue.
                 for extra in dist.optional_dependencies.keys() {
-                    if seen.insert((package_index, Some(extra))) {
-                        queue.push_back((package_index, Some(extra)));
-                    }
+                    queue.push((package_index, Some(extra)));
                 }
             }
 
@@ -192,13 +188,9 @@ impl<'env> TreeDisplay<'env> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((dep.index, None)) {
-                    queue.push_back((dep.index, None));
-                }
+                queue.push((dep.index, None));
                 for extra in &dep.extra {
-                    if seen.insert((dep.index, Some(extra))) {
-                        queue.push_back((dep.index, Some(extra)));
-                    }
+                    queue.push((dep.index, Some(extra)));
                 }
             }
         }
@@ -262,13 +254,9 @@ impl<'env> TreeDisplay<'env> {
                     );
 
                     // Push its dependencies on the queue.
-                    if seen.insert((package_index, None)) {
-                        queue.push_back((package_index, None));
-                    }
+                    queue.push((package_index, None));
                     for extra in &*requirement.extras {
-                        if seen.insert((package_index, Some(extra))) {
-                            queue.push_back((package_index, Some(extra)));
-                        }
+                        queue.push((package_index, Some(extra)));
                     }
                 }
             }
@@ -315,13 +303,9 @@ impl<'env> TreeDisplay<'env> {
                         );
 
                         // Push its dependencies on the queue.
-                        if seen.insert((package_index, None)) {
-                            queue.push_back((package_index, None));
-                        }
+                        queue.push((package_index, None));
                         for extra in &*requirement.extras {
-                            if seen.insert((package_index, Some(extra))) {
-                                queue.push_back((package_index, Some(extra)));
-                            }
+                            queue.push((package_index, Some(extra)));
                         }
                     }
                 }
@@ -329,7 +313,7 @@ impl<'env> TreeDisplay<'env> {
         }
 
         // Create all the relevant nodes.
-        while let Some((package_index, extra)) = queue.pop_front() {
+        while let Some((package_index, extra)) = queue.pop() {
             let index = inverse[package_index.0].expect("queued package has a graph node");
             let package = lock.package(package_index);
 
@@ -379,13 +363,9 @@ impl<'env> TreeDisplay<'env> {
                 );
 
                 // Push its dependencies on the queue.
-                if seen.insert((dep.index, None)) {
-                    queue.push_back((dep.index, None));
-                }
+                queue.push((dep.index, None));
                 for extra in &dep.extra {
-                    if seen.insert((dep.index, Some(extra))) {
-                        queue.push_back((dep.index, Some(extra)));
-                    }
+                    queue.push((dep.index, Some(extra)));
                 }
             }
         }


### PR DESCRIPTION
Apply the shared `OnceQueue` to lock installation, export, and tree traversals. Fixed-point conflict reachability uses a resolver-local `ReachabilityQueue`, allowing a state to be revisited only when its accumulated marker changes while suppressing duplicate pending states. Install-target roots and lock-manifest requirements are selected through `Installable`, keeping workspace group shadowing consistent across consumers.