### PR TITLE
Use Namespace runners for Windows release builds

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -301,9 +301,12 @@ jobs:
         # See: https://aws.github.io/aws-lc-rs/requirements/windows.html#build-requirements
         if: contains(matrix.platform.target, 'x86') || contains(matrix.platform.target, 'i686')
         run: |
-          $installer = Join-Path $env:RUNNER_TEMP 'nasm-3.02-installer-x64.exe'
-          Invoke-WebRequest 'https://www.nasm.us/pub/nasm/releasebuilds/3.02/win64/nasm-3.02-installer-x64.exe' -OutFile $installer
-          if ((Get-FileHash $installer -Algorithm SHA256).Hash -ne '0DDB40310861EB29F4D649FEB9466779982A2D251C0DB2B9CF0D21CF591171F3') {
+          # Namespace runners do not include winget.
+          $version = '3.02'
+          $sha256 = '0DDB40310861EB29F4D649FEB9466779982A2D251C0DB2B9CF0D21CF591171F3'
+          $installer = Join-Path $env:RUNNER_TEMP "nasm-${version}-installer-x64.exe"
+          Invoke-WebRequest "https://www.nasm.us/pub/nasm/releasebuilds/$version/win64/nasm-${version}-installer-x64.exe" -OutFile $installer
+          if ((Get-FileHash $installer -Algorithm SHA256).Hash -ne $sha256) {
             throw 'NASM installer checksum mismatch'
           }
           $installation = Start-Process $installer -ArgumentList '/S' -Wait -PassThru
@@ -357,6 +360,7 @@ jobs:
             fi
           done
       - name: "Test wheel"
+        # We test aarch64 on a native runner in a separate job.
         if: matrix.platform.target != 'aarch64-pc-windows-msvc'
         shell: bash
         run: |
@@ -399,6 +403,7 @@ jobs:
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.cmd
       - name: "Test wheel uv-build"
+        # We test aarch64 on a native runner in a separate job.
         if: matrix.platform.target != 'aarch64-pc-windows-msvc'
         shell: bash
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -270,19 +270,16 @@ jobs:
 
   windows:
     name: ${{ matrix.platform.target }}
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: namespace-profile-windows-2022-x86-64-16x32
     strategy:
       matrix:
         platform:
           - target: x86_64-pc-windows-msvc
             arch: x64
-            runner: github-windows-2025-x86_64-8
           - target: i686-pc-windows-msvc
             arch: x86
-            runner: github-windows-2025-x86_64-8
           - target: aarch64-pc-windows-msvc
-            arch: arm64
-            runner: github-windows-11-aarch64-8
+            arch: x64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -304,7 +301,15 @@ jobs:
         # See: https://aws.github.io/aws-lc-rs/requirements/windows.html#build-requirements
         if: contains(matrix.platform.target, 'x86') || contains(matrix.platform.target, 'i686')
         run: |
-          winget install NASM.NASM --accept-source-agreements --accept-package-agreements
+          $installer = Join-Path $env:RUNNER_TEMP 'nasm-3.02-installer-x64.exe'
+          Invoke-WebRequest 'https://www.nasm.us/pub/nasm/releasebuilds/3.02/win64/nasm-3.02-installer-x64.exe' -OutFile $installer
+          if ((Get-FileHash $installer -Algorithm SHA256).Hash -ne '0DDB40310861EB29F4D649FEB9466779982A2D251C0DB2B9CF0D21CF591171F3') {
+            throw 'NASM installer checksum mismatch'
+          }
+          $installation = Start-Process $installer -ArgumentList '/S' -Wait -PassThru
+          if ($installation.ExitCode -ne 0) {
+            throw "NASM installation failed: $($installation.ExitCode)"
+          }
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: "Install LLVM profiling tools"
         if: ${{ matrix.platform.target == 'x86_64-pc-windows-msvc' }}
@@ -352,6 +357,7 @@ jobs:
             fi
           done
       - name: "Test wheel"
+        if: matrix.platform.target != 'aarch64-pc-windows-msvc'
         shell: bash
         run: |
           pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
@@ -393,6 +399,7 @@ jobs:
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.cmd
       - name: "Test wheel uv-build"
+        if: matrix.platform.target != 'aarch64-pc-windows-msvc'
         shell: bash
         run: |
           pip install ${PACKAGE_NAME}_build --no-index --find-links crates/uv-build/dist --force-reinstall
@@ -403,6 +410,36 @@ jobs:
         with:
           name: wheels_uv_build-${{ matrix.platform.target }}
           path: crates/uv-build/dist
+
+  test-windows-aarch64:
+    name: "test aarch64-pc-windows-msvc wheels"
+    needs: windows
+    runs-on: github-windows-11-aarch64-8
+    steps:
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          cache: ""
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: arm64
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels_*-aarch64-pc-windows-msvc
+          path: dist
+          merge-multiple: true
+      - name: "Test wheel"
+        shell: bash
+        run: |
+          pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
+          ${MODULE_NAME} --help
+          python -m ${MODULE_NAME} --help
+          uvx --help
+          uvw --help
+      - name: "Test wheel uv-build"
+        shell: bash
+        run: |
+          pip install ${PACKAGE_NAME}_build --no-index --find-links dist/ --force-reinstall
+          ${MODULE_NAME}-build --help
+          python -m ${MODULE_NAME}_build --help
 
   linux:
     name: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

This PR moves Windows release builds to the 16-core Namespace profile that we already use in Windows tests. For ARM, we cross-compile (and run its wheel smoke tests in a separate native job).

Windows x64 was the slowest job in the [uv 0.12.8 release](https://github.com/astral-sh/uv/actions/runs/33440288847/job/99646850772): 58m40s, including 40m12s for the PGO build/training step and 14m02s for the final uv wheel build.

For ARM64, the first comparison at the same Rust source revision (`68209e5c6`) reduced the combined wheel-build time by 55%:

| Wheel build | [GitHub native ARM64, 8 vCPUs](https://github.com/astral-sh/uv/actions/runs/33440288847/job/99646850768) | [Namespace x64 cross-build, 16 vCPUs](https://github.com/astral-sh/uv/actions/runs/33450410999/job/99678939550) |
| ----------- | -------------------------------------------------------------------------------------------------------: | --------------------------------------------------------------------------------------------------------------: |
| uv          |                                                                                                   26m24s |                                                                                                          11m47s |
| uv-build    |                                                                                                    2m07s |                                                                                                             58s |
| Total       |                                                                                                   28m31s |                                                                                                          12m45s |

These are wheel-build step timings, excluding runner queueing and native smoke tests. The comparison includes the hardware change and uses one run per configuration.
