### PR TITLE
Require an explicit project name when initializing in a python directory

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -124,6 +124,11 @@ pub(crate) async fn init(
                     // whitespace, and replacing any internal whitespace with hyphens.
                     let candidate = directory_name.trim().replace(' ', "-");
                     match PackageName::from_owned(candidate) {
+                        Ok(name) if name.as_str() == "python" => {
+                            anyhow::bail!(
+                                "The directory name (`{directory_name}`) would result in the reserved executable name `python`. Please provide a package name with `--name`."
+                            );
+                        }
                         Ok(name) => name,
                         Err(_) => {
                             let directory_description = if explicit_path.is_some() {

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -2685,6 +2685,92 @@ fn init_unmanaged() -> Result<()> {
 }
 
 #[test]
+fn init_python_directory() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.init().arg("python"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: The directory name (`python`) would result in the reserved executable name `python`. Please provide a package name with `--name`.
+    ");
+
+    context
+        .temp_dir
+        .child("python")
+        .assert(predicate::path::missing());
+
+    uv_snapshot!(context.filters(), context.init().arg("python").arg("--name").arg("foo"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Initialized project `foo` at `[TEMP_DIR]/python`
+    ");
+
+    let pyproject = context.read("python/pyproject.toml");
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        description = "Add your description here"
+        readme = "README.md"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [project.scripts]
+        foo = "foo:main"
+
+        [build-system]
+        requires = ["uv_build>=[CURRENT_VERSION],<[NEXT_BREAKING]"]
+        build-backend = "uv_build"
+        "#
+        );
+    });
+}
+
+#[test]
+fn init_python_current_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let directory = context.temp_dir.child("Python");
+    directory.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&directory), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: The directory name (`Python`) would result in the reserved executable name `python`. Please provide a package name with `--name`.
+    ");
+
+    assert!(fs_err::read_dir(directory.path())?.next().is_none());
+
+    // An explicit name is allowed, even if it is `python`.
+    uv_snapshot!(context.filters(), context.init().current_dir(&directory).arg("--name").arg("python").arg("--bare"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Initialized project `python`
+    ");
+
+    let pyproject = context.read("Python/pyproject.toml");
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "python"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+#[test]
 fn init_hidden() {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
`uv init` uses the directory name as the project name, so a folder named `Python` produces a `python` console script that the installer rejects.

Require `--name` when the inferred name is `python`, with an error before any project files are created. The check is case insensitive and still allows explicit names, including `--name python`.

Fixes #21393.
