### PR TITLE
Require a project name when for `uv init` in a directory called `python`

### DIFF
--- a/crates/uv-install-wheel/src/lib.rs
+++ b/crates/uv-install-wheel/src/lib.rs
@@ -15,7 +15,9 @@ pub use install::{install_wheel, installed_dist_info_path};
 pub use linker::{InstallState, LinkMode};
 pub use record::RecordEntry;
 pub use uninstall::{Uninstall, uninstall_egg, uninstall_legacy_editable, uninstall_wheel};
-pub use wheel::{WheelFile, read_record, read_record_into_iter, validate_and_heal_record};
+pub use wheel::{
+    WheelFile, read_record, read_record_into_iter, reserved_script_name, validate_and_heal_record,
+};
 
 mod install;
 mod linker;

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -169,7 +169,7 @@ const RESERVED_SCRIPT_NAMES_WARN: &[&str; 2] = &["activate", "activate_this.py"]
 
 /// Return the reserved interpreter name if a script would overwrite a Python executable.
 ///
-/// The caller must lowercase the name before checking.
+/// Expects a lowercase string.
 pub fn reserved_script_name(name: &str) -> Option<&str> {
     let normalized_name = name.strip_suffix(".py").unwrap_or(name);
     (RESERVED_SCRIPT_NAMES_ERROR.contains(&normalized_name)

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -167,7 +167,10 @@ const RESERVED_VERSIONED_SCRIPT_NAME_PREFIX_ERROR: &str = "python3.";
 const RESERVED_FREE_THREADED_SCRIPT_NAME_PREFIXES_ERROR: &[&str; 2] = &["python3.", "pythonw3."];
 const RESERVED_SCRIPT_NAMES_WARN: &[&str; 2] = &["activate", "activate_this.py"];
 
-fn reserved_script_name(name: &str) -> Option<&str> {
+/// Return the reserved interpreter name if a script would overwrite a Python executable.
+///
+/// The caller must lowercase the name before checking.
+pub fn reserved_script_name(name: &str) -> Option<&str> {
     let normalized_name = name.strip_suffix(".py").unwrap_or(name);
     (RESERVED_SCRIPT_NAMES_ERROR.contains(&normalized_name)
         || normalized_name

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -127,7 +127,8 @@ pub(crate) async fn init(
                     match PackageName::from_owned(candidate) {
                         Ok(name) if reserved_script_name(name.as_str()).is_some() => {
                             anyhow::bail!(
-                                "The directory name (`{directory_name}`) cannot be used as project name, please provide a package name with `--name`."
+                                "The directory name (`{directory_name}`) cannot be used as project \
+                                name, please provide a package name with `--name`."
                             );
                         }
                         Ok(name) => name,

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -126,7 +126,7 @@ pub(crate) async fn init(
                     match PackageName::from_owned(candidate) {
                         Ok(name) if name.as_str() == "python" => {
                             anyhow::bail!(
-                                "The directory name (`{directory_name}`) would result in the reserved executable name `python`. Please provide a package name with `--name`."
+                                "The directory name (`{directory_name}`) cannot be used as project name, please provide a package name with `--name`."
                             );
                         }
                         Ok(name) => name,

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -18,6 +18,7 @@ use uv_configuration::{
 use uv_distribution_types::RequiresPython;
 use uv_fs::{CWD, Simplified};
 use uv_git::GIT;
+use uv_install_wheel::reserved_script_name;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_python::{
@@ -124,7 +125,7 @@ pub(crate) async fn init(
                     // whitespace, and replacing any internal whitespace with hyphens.
                     let candidate = directory_name.trim().replace(' ', "-");
                     match PackageName::from_owned(candidate) {
-                        Ok(name) if name.as_str() == "python" => {
+                        Ok(name) if reserved_script_name(name.as_str()).is_some() => {
                             anyhow::bail!(
                                 "The directory name (`{directory_name}`) cannot be used as project name, please provide a package name with `--name`."
                             );

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -124,6 +124,11 @@ pub(crate) async fn init(
                     // whitespace, and replacing any internal whitespace with hyphens.
                     let candidate = directory_name.trim().replace(' ', "-");
                     match PackageName::from_owned(candidate) {
+                        Ok(name) if name.as_str() == "python" => {
+                            anyhow::bail!(
+                                "The directory name (`{directory_name}`) would result in the reserved executable name `python`. Please provide a package name with `--name`."
+                            );
+                        }
                         Ok(name) => name,
                         Err(_) => {
                             let directory_description = if explicit_path.is_some() {

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -2697,37 +2697,11 @@ fn init_python_directory() -> Result<()> {
     error: The directory name (`python`) cannot be used as project name, please provide a package name with `--name`.
     ");
 
-    assert!(fs_err::read_dir(directory.path())?.next().is_none());
-
     uv_snapshot!(context.filters(), context.init().current_dir(&directory).arg("--name").arg("foo"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Initialized project `foo`
     ");
-
-    let pyproject = context.read("python/pyproject.toml");
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            pyproject, @r#"
-        [project]
-        name = "foo"
-        version = "0.1.0"
-        description = "Add your description here"
-        readme = "README.md"
-        requires-python = ">=3.12"
-        dependencies = []
-
-        [project.scripts]
-        foo = "foo:main"
-
-        [build-system]
-        requires = ["uv_build>=[CURRENT_VERSION],<[NEXT_BREAKING]"]
-        build-backend = "uv_build"
-        "#
-        );
-    });
 
     Ok(())
 }
@@ -2745,29 +2719,12 @@ fn init_python_current_directory() -> Result<()> {
     error: The directory name (`Python`) cannot be used as project name, please provide a package name with `--name`.
     ");
 
-    assert!(fs_err::read_dir(directory.path())?.next().is_none());
-
     // An explicit name is allowed, even if it is `python`.
     uv_snapshot!(context.filters(), context.init().current_dir(&directory).arg("--name").arg("python").arg("--bare"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Initialized project `python`
     ");
-
-    let pyproject = context.read("Python/pyproject.toml");
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            pyproject, @r#"
-        [project]
-        name = "python"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = []
-        "#
-        );
-    });
 
     Ok(())
 }

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -2685,24 +2685,24 @@ fn init_unmanaged() -> Result<()> {
 }
 
 #[test]
-fn init_python_directory() {
+fn init_python_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
-    uv_snapshot!(context.filters(), context.init().arg("python"), @"
+    let directory = context.temp_dir.child("python");
+    directory.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&directory), @"
     exit_code: 2 (failure)
     ----- stderr -----
     error: The directory name (`python`) cannot be used as project name, please provide a package name with `--name`.
     ");
 
-    context
-        .temp_dir
-        .child("python")
-        .assert(predicate::path::missing());
+    assert!(fs_err::read_dir(directory.path())?.next().is_none());
 
-    uv_snapshot!(context.filters(), context.init().arg("python").arg("--name").arg("foo"), @"
+    uv_snapshot!(context.filters(), context.init().current_dir(&directory).arg("--name").arg("foo"), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Initialized project `foo` at `[TEMP_DIR]/python`
+    Initialized project `foo`
     ");
 
     let pyproject = context.read("python/pyproject.toml");
@@ -2728,6 +2728,8 @@ fn init_python_directory() {
         "#
         );
     });
+
+    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -2685,6 +2685,92 @@ fn init_unmanaged() -> Result<()> {
 }
 
 #[test]
+fn init_python_directory() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.init().arg("python"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: The directory name (`python`) would result in the reserved executable name `python`. Please provide a package name with `--name`.
+    ");
+
+    context
+        .temp_dir
+        .child("python")
+        .assert(predicate::path::missing());
+
+    uv_snapshot!(context.filters(), context.init().arg("python").arg("--name").arg("foo"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Initialized project `foo` at `[TEMP_DIR]/python`
+    ");
+
+    let pyproject = context.read("python/pyproject.toml");
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        description = "Add your description here"
+        readme = "README.md"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [project.scripts]
+        foo = "foo:main"
+
+        [build-system]
+        requires = ["uv_build>=[CURRENT_VERSION],<[NEXT_BREAKING]"]
+        build-backend = "uv_build"
+        "#
+        );
+    });
+}
+
+#[test]
+fn init_python_current_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let directory = context.temp_dir.child("Python");
+    directory.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&directory), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: The directory name (`Python`) would result in the reserved executable name `python`. Please provide a package name with `--name`.
+    ");
+
+    assert!(fs_err::read_dir(directory.path())?.next().is_none());
+
+    // An explicit name is allowed, even if it is `python`.
+    uv_snapshot!(context.filters(), context.init().current_dir(&directory).arg("--name").arg("python").arg("--bare"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Initialized project `python`
+    ");
+
+    let pyproject = context.read("Python/pyproject.toml");
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "python"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+#[test]
 fn init_hidden() {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -2685,28 +2685,6 @@ fn init_unmanaged() -> Result<()> {
 }
 
 #[test]
-fn init_python_directory() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let directory = context.temp_dir.child("python");
-    directory.create_dir_all()?;
-
-    uv_snapshot!(context.filters(), context.init().current_dir(&directory), @"
-    exit_code: 2 (failure)
-    ----- stderr -----
-    error: The directory name (`python`) cannot be used as project name, please provide a package name with `--name`.
-    ");
-
-    uv_snapshot!(context.filters(), context.init().current_dir(&directory).arg("--name").arg("foo"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Initialized project `foo`
-    ");
-
-    Ok(())
-}
-
-#[test]
 fn init_python_current_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -2691,7 +2691,7 @@ fn init_python_directory() {
     uv_snapshot!(context.filters(), context.init().arg("python"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    error: The directory name (`python`) would result in the reserved executable name `python`. Please provide a package name with `--name`.
+    error: The directory name (`python`) cannot be used as project name, please provide a package name with `--name`.
     ");
 
     context
@@ -2740,7 +2740,7 @@ fn init_python_current_directory() -> Result<()> {
     uv_snapshot!(context.filters(), context.init().current_dir(&directory), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    error: The directory name (`Python`) would result in the reserved executable name `python`. Please provide a package name with `--name`.
+    error: The directory name (`Python`) cannot be used as project name, please provide a package name with `--name`.
     ");
 
     assert!(fs_err::read_dir(directory.path())?.next().is_none());


### PR DESCRIPTION
`uv init` uses the directory name as the project name, so a folder named `Python` produces a `python` console script that the installer rejects.

Require `--name` when the inferred name is `python`, with an error before any project files are created. The check is case insensitive and still allows explicit names, including `--name python`.

Fixes #21393.

<!-- codex-thread: 01a05c9c-6224-7352-aa52-e8ecd2c02b2b -->
