### PR TITLE
Bump async_http_range_reader to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "astral_async_http_range_reader"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f"
+checksum = "1d5ba70a583d0819c44078238014752e85ebca0cb398ab712bbd2e40fb754b80"
 dependencies = [
  "astral-reqwest-middleware",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ async-compression = { version = "0.4.12", features = [
   "zstd",
 ] }
 async-trait = { version = "0.1.82" }
-async_http_range_reader = { version = "0.11.0", package = "astral_async_http_range_reader" }
+async_http_range_reader = { version = "0.11.1", package = "astral_async_http_range_reader" }
 async_zip = { version = "0.0.20", package = "astral_async_zip", features = [
   "deflate",
   "tokio",


### PR DESCRIPTION
## Summary

This version of async_http_range_reader fixes a memory un-safety bug which can be triggered when trying to range-request metadata out of a malicious wheel or from a malicious wheel host. I have not been able to rule out that we're affected, but I have also not been able to get us to trigger it. The difficulty is mainly down to us using a single threaded executor.

## Test Plan

Test suite.