### PR TITLE
Try CodSpeed's Ryzen runner for walltime benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,7 +53,10 @@ jobs:
         run: cargo codspeed build -m walltime --profile profiling -p uv-bench --bench uv --bench workspace_discovery
 
       - name: "Create artifact archive"
-        run: tar -cvf benchmarks-walltime.tar target/codspeed target/debug/uv .cache
+        run: |
+          mkdir -p target/codspeed-bin
+          cp "$(command -v cargo-codspeed)" target/codspeed-bin/
+          tar -cvf benchmarks-walltime.tar target/codspeed target/codspeed-bin target/debug/uv .cache
 
       - name: "Upload benchmark artifacts"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -75,11 +78,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: "Install codspeed"
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
-        with:
-          tool: cargo-codspeed
-
       - name: "Download benchmark artifacts"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -87,6 +85,9 @@ jobs:
 
       - name: "Extract artifact archive"
         run: tar -xvf benchmarks-walltime.tar
+
+      - name: "Add codspeed to PATH"
+        run: echo "$GITHUB_WORKSPACE/target/codspeed-bin" >> "$GITHUB_PATH"
 
       - name: "Create venv"
         run: ./target/debug/uv venv --cache-dir .cache

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,8 +18,7 @@ env:
 jobs:
   benchmarks-walltime-build:
     name: "walltime build"
-    # codspeed-macro doesn't support Ubuntu 24.04 yet
-    runs-on: depot-ubuntu-22.04-arm-4
+    runs-on: depot-ubuntu-24.04-4
     if: ${{ github.repository == 'astral-sh/uv' }}
     timeout-minutes: 30
     steps:
@@ -30,6 +29,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          prefix-key: v0-rust-walltime-${{ runner.arch }}
           save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Install Rust toolchain"
@@ -63,8 +63,8 @@ jobs:
           retention-days: 1
 
   benchmarks-walltime-run:
-    name: "walltime on aarch64 linux"
-    runs-on: codspeed-macro
+    name: "walltime on x86_64 linux"
+    runs-on: codspeed-macro-x86-ryzen-9950x-ubuntu-24-04
     needs: benchmarks-walltime-build
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
Move the walltime benchmarks to CodSpeed's x86 Ryzen 9950X runner to evaluate the new hardware. Build the benchmark artifacts on x86 Ubuntu 24.04 and give the Rust cache a separate architecture-specific prefix so the trial cannot restore ARM build artifacts. The simulated benchmarks are unchanged.

The CodSpeed installer fails on the Ryzen image when opening a Bash process-substitution path under `/dev/fd`. Include the build job's `cargo-codspeed` binary in the benchmark artifact and add it to `PATH` after extraction, so the run job uses the same CLI without reinstalling it.
