### PR TITLE
Allow negating locked and frozen modes

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -677,14 +677,22 @@ pub struct VersionArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
     /// uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Update the version without re-locking the project [env: UV_FROZEN=]
     ///
     /// The project environment will not be synced.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     #[command(flatten)]
     pub installer: ResolverInstallerArgs,
@@ -3653,8 +3661,12 @@ pub struct RunArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or
     /// needs to be updated, uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Run without updating the `uv.lock` file [env: UV_FROZEN=]
     ///
@@ -3662,8 +3674,12 @@ pub struct RunArgs {
     /// source of truth. If the lockfile is missing, uv will exit with an error. If the
     /// `pyproject.toml` includes changes to dependencies that have not been included in the
     /// lockfile yet, they will not be present in the environment.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     /// Run the given path as a Python script.
     ///
@@ -3930,8 +3946,12 @@ pub struct SyncArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
     /// uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Sync without updating the `uv.lock` file [env: UV_FROZEN=]
     ///
@@ -3939,8 +3959,12 @@ pub struct SyncArgs {
     /// source of truth. If the lockfile is missing, uv will exit with an error. If the
     /// `pyproject.toml` includes changes to dependencies that have not been included in the
     /// lockfile yet, they will not be present in the environment.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     /// Perform a dry run, without writing the lockfile or modifying the project environment.
     ///
@@ -4065,7 +4089,7 @@ pub struct LockArgs {
     /// missing or needs to be updated, uv will exit with an error.
     ///
     /// Equivalent to `--locked`.
-    #[arg(long, value_parser = clap::builder::BoolishValueParser::new(), conflicts_with_all = ["check_exists", "upgrade"], overrides_with = "check")]
+    #[arg(long, value_parser = clap::builder::BoolishValueParser::new(), conflicts_with_all = ["check_exists", "upgrade"], overrides_with_all = ["check", "no_locked"])]
     pub check: bool,
 
     /// Check if the lockfile is up-to-date [env: UV_LOCKED=]
@@ -4074,18 +4098,26 @@ pub struct LockArgs {
     /// missing or needs to be updated, uv will exit with an error.
     ///
     /// Equivalent to `--check`.
-    #[arg(long, conflicts_with_all = ["check_exists", "upgrade"], hide = true)]
+    #[arg(long, conflicts_with_all = ["check_exists", "upgrade"], hide = true, overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with_all = ["locked", "check"], hide = true)]
+    pub no_locked: bool,
 
     /// Assert that a `uv.lock` exists without checking if it is up-to-date [env: UV_FROZEN=]
     ///
     /// Equivalent to `--frozen`.
-    #[arg(long, conflicts_with_all = ["check", "locked"])]
+    #[arg(long, conflicts_with_all = ["check", "locked"], overrides_with = "no_frozen")]
     pub check_exists: bool,
 
     /// Equivalent to `--check-exists`.
-    #[arg(long, hide = true, conflicts_with_all = ["check_exists", "check", "locked", "dry_run"])]
+    #[arg(long, hide = true, conflicts_with_all = ["check_exists", "check", "locked", "dry_run"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with_all = ["frozen", "check_exists"], hide = true)]
+    pub no_frozen: bool,
 
     /// Perform a dry run, without writing the lockfile.
     ///
@@ -4298,14 +4330,22 @@ pub struct AddArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
     /// uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Add dependencies without re-locking the project [env: UV_FROZEN=]
     ///
     /// The project environment will not be synced.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     /// Prefer the active virtual environment over the project's virtual environment.
     ///
@@ -4549,14 +4589,22 @@ pub struct RemoveArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
     /// uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Remove dependencies without re-locking the project [env: UV_FROZEN=]
     ///
     /// The project environment will not be synced.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     #[command(flatten)]
     pub installer: ResolverInstallerArgs,
@@ -4618,14 +4666,22 @@ pub struct TreeArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
     /// uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Display the requirements without locking the project [env: UV_FROZEN=]
     ///
     /// If the lockfile is missing, uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     #[command(flatten)]
     pub build: BuildOptionsArgs,
@@ -4889,14 +4945,22 @@ pub struct ExportArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
     /// uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Do not update the `uv.lock` before exporting [env: UV_FROZEN=]
     ///
     /// If a `uv.lock` does not exist, uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     #[command(flatten)]
     pub resolver: ResolverArgs,
@@ -5092,8 +5156,12 @@ pub struct CheckArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
     /// uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Sync without updating the `uv.lock` file [env: UV_FROZEN=]
     ///
@@ -5101,8 +5169,12 @@ pub struct CheckArgs {
     /// source of truth. If the lockfile is missing, uv will exit with an error. If the
     /// `pyproject.toml` includes changes to dependencies that have not been included in the
     /// lockfile yet, they will not be present in the environment.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     /// Avoid syncing the virtual environment [env: UV_NO_SYNC=]
     #[arg(long)]
@@ -5272,14 +5344,22 @@ pub struct AuditArgs {
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
     /// uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
+
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
 
     /// Audit the requirements without locking the project [env: UV_FROZEN=]
     ///
     /// If the lockfile is missing, uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     #[command(flatten)]
     pub audit: AuditCommonArgs,
@@ -7773,12 +7853,20 @@ pub struct MetadataArgs {
     ///
     /// Asserts that the `uv.lock` would remain unchanged after a resolution. If the lockfile is
     /// missing or needs to be updated, uv will exit with an error.
-    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"], overrides_with = "no_locked")]
     pub locked: bool,
 
+    /// Disable locked mode, overriding `UV_LOCKED`.
+    #[arg(long, overrides_with = "locked", hide = true)]
+    pub no_locked: bool,
+
     /// Assert that a `uv.lock` exists without checking if it is up-to-date [env: UV_FROZEN=]
-    #[arg(long, conflicts_with_all = ["locked"])]
+    #[arg(long, conflicts_with_all = ["locked"], overrides_with = "no_frozen")]
     pub frozen: bool,
+
+    /// Disable frozen mode, overriding `UV_FROZEN`.
+    #[arg(long, overrides_with = "frozen", hide = true)]
+    pub no_frozen: bool,
 
     /// Perform a dry run, without writing the lockfile.
     ///

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -735,10 +735,19 @@ fn resolve_lock_flags(
 /// Resolve frozen mode and its source from CLI arguments and the environment.
 fn resolve_frozen(
     enabled: bool,
+    disabled: bool,
     cli_flag: FrozenFlag,
     environment: EnvFlag,
 ) -> Option<FrozenSource> {
-    match resolve_flag(enabled, cli_flag.name(), environment) {
+    let (flag, _) = resolve_flag_pair(
+        enabled,
+        disabled,
+        cli_flag.name(),
+        "no-frozen",
+        Some(environment),
+        None,
+    );
+    match flag {
         Flag::Enabled { source, .. } => Some(match source {
             FlagSource::Cli => FrozenSource::Cli(cli_flag),
             FlagSource::Env(_) => FrozenSource::Env,
@@ -749,8 +758,21 @@ fn resolve_frozen(
 }
 
 /// Resolve a lock check and its source from CLI arguments and the environment.
-fn resolve_lock_check(enabled: bool, cli_flag: LockedFlag, environment: EnvFlag) -> LockCheck {
-    match resolve_flag(enabled, cli_flag.name(), environment) {
+fn resolve_lock_check(
+    enabled: bool,
+    disabled: bool,
+    cli_flag: LockedFlag,
+    environment: EnvFlag,
+) -> LockCheck {
+    let (flag, _) = resolve_flag_pair(
+        enabled,
+        disabled,
+        cli_flag.name(),
+        "no-locked",
+        Some(environment),
+        None,
+    );
+    match flag {
         Flag::Enabled { source, .. } => LockCheck::Enabled(match source {
             FlagSource::Cli => LockedSource::Cli(cli_flag),
             FlagSource::Env(_) => LockedSource::Env,
@@ -837,7 +859,9 @@ impl RunSettings {
             no_active,
             no_sync,
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             installer,
             build,
             refresh,
@@ -858,8 +882,8 @@ impl RunSettings {
             .unwrap_or_default();
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
         let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
@@ -1993,7 +2017,9 @@ impl SyncSettings {
             no_install_package,
             only_install_package,
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             active,
             no_active,
             dry_run,
@@ -2026,8 +2052,8 @@ impl SyncSettings {
         };
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
 
@@ -2172,8 +2198,10 @@ impl LockSettings {
         let LockArgs {
             check,
             locked,
+            no_locked,
             check_exists,
             frozen,
+            no_frozen,
             dry_run,
             script,
             resolver,
@@ -2190,6 +2218,7 @@ impl LockSettings {
         // Resolve flags from CLI and environment variables.
         let locked = resolve_lock_check(
             locked || check,
+            no_locked,
             if check {
                 LockedFlag::Check
             } else {
@@ -2199,6 +2228,7 @@ impl LockSettings {
         );
         let frozen = resolve_frozen(
             frozen || check_exists,
+            no_frozen,
             if check_exists {
                 FrozenFlag::CheckExists
             } else {
@@ -2292,7 +2322,9 @@ impl MetadataSettings {
         let MetadataArgs {
             script,
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             dry_run,
             resolver,
             build,
@@ -2309,8 +2341,8 @@ impl MetadataSettings {
             .unwrap_or_default();
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
 
@@ -2405,7 +2437,9 @@ impl AddSettings {
             lfs,
             no_sync,
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             active,
             no_active,
             installer,
@@ -2519,8 +2553,8 @@ impl AddSettings {
         let lfs = GitLfsSetting::new(lfs.then_some(true), environment.lfs);
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
         let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
@@ -2649,7 +2683,9 @@ impl RemoveSettings {
             group,
             no_sync,
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             active,
             no_active,
             installer,
@@ -2684,8 +2720,8 @@ impl RemoveSettings {
             .collect();
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
         let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
@@ -2755,7 +2791,9 @@ impl VersionSettings {
             dry_run,
             no_sync,
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             active,
             no_active,
             installer,
@@ -2771,8 +2809,8 @@ impl VersionSettings {
             .unwrap_or_default();
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
         let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
@@ -2856,7 +2894,9 @@ impl TreeSettings {
                     all_groups,
                 },
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             build,
             resolver,
             script,
@@ -2871,8 +2911,8 @@ impl TreeSettings {
             .unwrap_or_default();
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
 
@@ -2998,7 +3038,9 @@ impl ExportSettings {
             no_emit_package,
             only_emit_package,
             locked,
+            no_locked,
             frozen: frozen_cli,
+            no_frozen,
             resolver,
             build,
             refresh,
@@ -3011,8 +3053,13 @@ impl ExportSettings {
             .unwrap_or_default();
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen_cli, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(
+            frozen_cli,
+            no_frozen,
+            FrozenFlag::Frozen,
+            environment.frozen,
+        );
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
 
@@ -3194,7 +3241,9 @@ impl CheckSettings {
                     all_groups,
                 },
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             no_sync,
             no_install_project,
             isolated,
@@ -3213,8 +3262,8 @@ impl CheckSettings {
             .map(|fs| fs.install_mirrors.clone())
             .unwrap_or_default();
 
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
         let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
         let no_install_project = resolve_flag(
             no_install_project,
@@ -3323,7 +3372,9 @@ impl AuditSettings {
             python_version,
             python_platform,
             locked,
+            no_locked,
             frozen,
+            no_frozen,
             audit:
                 AuditCommonArgs {
                     output_format,
@@ -3349,8 +3400,8 @@ impl AuditSettings {
         let no_dev = no_dev || environment.no_dev.value == Some(true);
 
         // Resolve flags from CLI and environment variables.
-        let locked = resolve_lock_check(locked, LockedFlag::Locked, environment.locked);
-        let frozen = resolve_frozen(frozen, FrozenFlag::Frozen, environment.frozen);
+        let locked = resolve_lock_check(locked, no_locked, LockedFlag::Locked, environment.locked);
+        let frozen = resolve_frozen(frozen, no_frozen, FrozenFlag::Frozen, environment.frozen);
 
         let (locked, frozen) = resolve_lock_flags(locked, frozen)?;
 

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -38226,6 +38226,133 @@ fn lock_tilde_equal_version_u64_max_rejected() -> Result<()> {
     Ok(())
 }
 
+/// Negating locked mode permits lockfile changes despite `UV_LOCKED` or an earlier CLI flag.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_no_locked() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+    "#})?;
+
+    // Negating the CLI flag must also suppress the environment value when creating a lockfile.
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--locked")
+        .arg("--no-locked")
+        .env(EnvVars::UV_LOCKED, "1"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+    assert!(context.temp_dir.child("uv.lock").exists());
+
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.2.0"
+        requires-python = ">=3.12"
+    "#})?;
+
+    // The negation also overrides the `--check` spelling and allows a stale lockfile to update.
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--check")
+        .arg("--no-locked"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Updated project v0.1.0 -> v0.2.0
+    ");
+    let lock = context.read("uv.lock");
+
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.3.0"
+        requires-python = ">=3.12"
+    "#})?;
+
+    // A later positive flag restores the check and must leave the stale lockfile unchanged.
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--no-locked")
+        .arg("--check"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+    assert_eq!(context.read("uv.lock"), lock);
+
+    Ok(())
+}
+
+/// Negating frozen mode permits lockfile changes despite `UV_FROZEN` or an earlier CLI flag.
+#[cfg(feature = "test-universal")]
+#[test]
+fn lock_no_frozen() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+    "#})?;
+
+    // Negating the CLI flag must also suppress the environment value when creating a lockfile.
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--frozen")
+        .arg("--no-frozen")
+        .env(EnvVars::UV_FROZEN, "1"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+    assert!(context.temp_dir.child("uv.lock").exists());
+
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.2.0"
+        requires-python = ">=3.12"
+    "#})?;
+
+    // The negation also overrides the `--check-exists` spelling and permits re-locking.
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--check-exists")
+        .arg("--no-frozen"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Updated project v0.1.0 -> v0.2.0
+    ");
+    let lock = context.read("uv.lock");
+
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.3.0"
+        requires-python = ">=3.12"
+    "#})?;
+
+    // A later positive flag restores frozen mode and keeps using the existing lockfile.
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--no-frozen")
+        .arg("--check-exists"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: The lockfile at `uv.lock` was only checked for validity, not whether it is up-to-date, because `--check-exists` was provided; use `--check` instead
+    ");
+    assert_eq!(context.read("uv.lock"), lock);
+
+    Ok(())
+}
+
 /// `--check` overrides `UV_FROZEN` when checking a stale lockfile.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -118,6 +118,68 @@ fn sync_lock_flags_override_environment() -> Result<()> {
     Ok(())
 }
 
+/// A negation disables only its own lock mode, leaving the other environment setting intact.
+#[test]
+fn sync_no_lock_flags_override_environment() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+    "#})?;
+    context.lock().assert().success();
+    let lock = context.read("uv.lock");
+
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.2.0"
+        requires-python = ">=3.12"
+    "#})?;
+
+    // Negating locked mode preserves `UV_FROZEN` and reuses the stale lockfile.
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--no-locked")
+        .env(EnvVars::UV_LOCKED, "1")
+        .env(EnvVars::UV_FROZEN, "1"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Checked in [TIME]
+    ");
+    assert_eq!(context.read("uv.lock"), lock);
+
+    // Negating frozen mode preserves `UV_LOCKED`, which rejects the stale lockfile.
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--no-frozen")
+        .env(EnvVars::UV_LOCKED, "1")
+        .env(EnvVars::UV_FROZEN, "1"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `UV_LOCKED=1` was provided.
+
+    hint: To update the lockfile, run `uv lock`.
+    ");
+    assert_eq!(context.read("uv.lock"), lock);
+
+    // Negating both modes permits the lockfile update without changing the environment variables.
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--no-locked")
+        .arg("--no-frozen")
+        .env(EnvVars::UV_LOCKED, "1")
+        .env(EnvVars::UV_FROZEN, "1"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    ");
+    assert_ne!(context.read("uv.lock"), lock);
+
+    Ok(())
+}
+
 /// Conflicting lock modes from the same source still fail.
 #[test]
 fn sync_lock_flags_conflict() {


### PR DESCRIPTION
With `UV_LOCKED=1` or `UV_FROZEN=1` set globally, creating or updating a lockfile can require changing the environment. Add `--no-locked` and `--no-frozen` so a single invocation can disable either mode. Each negation affects only its own mode and follows the existing last-argument-wins convention, including the `--check` and `--check-exists` spellings accepted by `uv lock`.
