### PR TITLE
Revert "Limit CI planner checkout depth"

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.head-sha }}
-          fetch-depth: 2
+          fetch-depth: 0
           persist-credentials: false
 
       - name: "Plan"


### PR DESCRIPTION
The shallow checkout introduced in #21291 can leave the PR event's base commit unavailable when the checked-out merge ref has advanced. For example, [this plan job](https://github.com/astral-sh/uv/actions/runs/32879928850/job/97908302255) logged `Invalid symmetric difference expression` but reported success, causing tests and builds to be skipped.

Revert #21291 and restore `fetch-depth: 0` so the planner has the history needed to resolve the comparison base.
