### PR TITLE
Skip invalid scripts in `uv workspace list --scripts`

### DIFF
--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -44,6 +44,19 @@ pub(crate) async fn list(
 
     if scripts {
         let mut scripts = find_scripts(workspace.install_path(), cache)
+            .filter_map(|script| match script {
+                Ok(script) => Some(Ok(script)),
+                Err(ScriptDiscoveryError::Parse { path, source }) => {
+                    warn_user!(
+                        "Skipping invalid PEP 723 script `{}`: {source}",
+                        path.simplified_display()
+                    );
+                    None
+                }
+                Err(
+                    error @ (ScriptDiscoveryError::Walk(_) | ScriptDiscoveryError::Read { .. }),
+                ) => Some(Err(error)),
+            })
             .collect::<Result<Vec<_>, _>>()
             .with_context(|| {
                 format!(

--- a/crates/uv/tests/workspace/workspace_list.rs
+++ b/crates/uv/tests/workspace/workspace_list.rs
@@ -365,7 +365,7 @@ fn workspace_list_scripts() -> Result<()> {
     Ok(())
 }
 
-/// Explicit script discovery should identify both the invalid script and the workspace root.
+/// Script discovery should warn about invalid metadata and continue listing valid scripts.
 #[test]
 fn workspace_list_scripts_invalid_metadata() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -381,6 +381,14 @@ fn workspace_list_scripts_invalid_metadata() -> Result<()> {
         "#})?;
     context
         .temp_dir
+        .child("scripts/valid-script.py")
+        .write_str(indoc::indoc! {r"
+            # /// script
+            # dependencies = []
+            # ///
+        "})?;
+    context
+        .temp_dir
         .child("fixtures/invalid-script.py")
         .write_str(indoc::indoc! {r"
             # /// script
@@ -393,12 +401,39 @@ fn workspace_list_scripts_invalid_metadata() -> Result<()> {
         "})?;
 
     uv_snapshot!(context.filters(), context.workspace_list().arg("--scripts"), @"
-    exit_code: 2 (failure)
+    exit_code: 0 (success)
+    ----- stdout -----
+    scripts/valid-script.py
+
     ----- stderr -----
     warning: The `--scripts` option is experimental and may change without warning. Pass `--preview-features workspace-list-scripts` to disable this warning.
-    error: Failed to discover PEP 723 scripts under workspace root `[TEMP_DIR]/`
-      Caused by: Failed to parse PEP 723 script: [TEMP_DIR]/fixtures/invalid-script.py
-      Caused by: The script contains multiple PEP 723 metadata blocks
+    warning: Skipping invalid PEP 723 script `[TEMP_DIR]/fixtures/invalid-script.py`: The script contains multiple PEP 723 metadata blocks
+    ");
+
+    // Invalid TOML should also be skipped, including when the preview feature is enabled.
+    context
+        .temp_dir
+        .child("fixtures/invalid-script.py")
+        .write_str(indoc::indoc! {r"
+            # /// script
+            # dependencies = [
+            # ///
+        "})?;
+
+    uv_snapshot!(context.filters(), context.workspace_list()
+        .arg("--scripts")
+        .arg("--preview-features")
+        .arg("workspace-list-scripts"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    scripts/valid-script.py
+
+    ----- stderr -----
+    warning: Skipping invalid PEP 723 script `[TEMP_DIR]/fixtures/invalid-script.py`: TOML parse error at line 1, column 17
+      |
+    1 | dependencies = [
+      |                 ^
+    unclosed array, expected `]`
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

`uv workspace list --scripts` now warns instead of failing if a script's PEP 723 metadata couldn't be parsed. Other errors (like I/O errors from the workspace walk or reading) continue to be hard failures.

Fixes #21398.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Updated the `workspace_list_scripts_invalid_metadata` test to demonstrate skippage instead of failure.

<!-- How was it tested? -->
