### PR TITLE
Encapsulate wheel extraction directory ownership

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -40,7 +40,7 @@ use uv_types::{BuildContext, BuildStack};
 
 use crate::archive::Archive;
 use crate::error::PythonVersion;
-use crate::extracted_wheel::{ExtractedWheel, HashedWheel};
+use crate::extracted_wheel::{ExtractedWheel, HashedWheel, WheelExtractor};
 use crate::hash::http_hash_algorithms;
 use crate::metadata::{ArchiveMetadata, Metadata};
 use crate::source::SourceDistributionBuilder;
@@ -725,27 +725,24 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
                 // Download and unzip the wheel to a temporary directory.
-                let temp_dir = tempfile::tempdir_in(self.build_context.cache().root())
-                    .map_err(Error::CacheWrite)?;
+                let extractor = WheelExtractor::new(
+                    self.build_context.cache().root(),
+                    self.content_addressed_cache,
+                )
+                .map_err(Error::CacheWrite)?;
 
-                let (temp_dir, mut extracted) = match progress {
+                let mut extracted = match progress {
                     Some((reporter, progress)) => {
                         let mut reader = ProgressReader::new(&mut hasher, progress, &**reporter);
-                        ExtractedWheel::extract_streaming(
-                            &mut reader,
-                            temp_dir,
-                            self.content_addressed_cache,
-                        )
-                        .await
-                        .map_err(|err| Error::Extract(filename.to_string(), err))?
+                        extractor
+                            .extract_streaming(&mut reader)
+                            .await
+                            .map_err(|err| Error::Extract(filename.to_string(), err))?
                     }
-                    None => ExtractedWheel::extract_streaming(
-                        &mut hasher,
-                        temp_dir,
-                        self.content_addressed_cache,
-                    )
-                    .await
-                    .map_err(|err| Error::Extract(filename.to_string(), err))?,
+                    None => extractor
+                        .extract_streaming(&mut hasher)
+                        .await
+                        .map_err(|err| Error::Extract(filename.to_string(), err))?,
                 };
                 // Exhaust the reader to compute the hashes.
                 hasher.finish().await.map_err(Error::HashExhaustion)?;
@@ -762,11 +759,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 // Before we make the wheel accessible by persisting it, ensure that the RECORD is
                 // valid.
-                extracted.validate_and_heal_record(temp_dir.path(), dist)?;
+                extracted.validate_and_heal_record(dist)?;
 
                 // Persist the temporary directory to the directory store.
                 let id = self
-                    .persist_extracted_wheel(temp_dir, wheel_entry.path(), extracted.into_hashed())
+                    .persist_extracted_wheel(extracted, wheel_entry.path())
                     .await?;
 
                 if let Some((reporter, progress)) = progress {
@@ -945,29 +942,28 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let actual_size = hasher.bytes_read();
 
                 // Unzip the wheel to a temporary directory.
-                let temp_dir = tempfile::tempdir_in(self.build_context.cache().root())
-                    .map_err(Error::CacheWrite)?;
+                let extractor =
+                    WheelExtractor::new(self.build_context.cache().root(), content_addressed_cache)
+                        .map_err(Error::CacheWrite)?;
                 let mut file = writer.into_inner();
                 file.seek(io::SeekFrom::Start(0))
                     .await
                     .map_err(Error::CacheWrite)?;
 
-                let target = temp_dir.path().to_owned();
                 let file = file.into_std().await;
-                let mut extracted = tokio::task::spawn_blocking(move || {
-                    ExtractedWheel::extract_seekable(file, &target, content_addressed_cache)
-                })
-                .await?
-                .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                let mut extracted =
+                    tokio::task::spawn_blocking(move || extractor.extract_seekable(file))
+                        .await?
+                        .map_err(|err| Error::Extract(filename.to_string(), err))?;
                 let hashes = hashers.into_iter().map(HashDigest::from).collect();
 
                 // Before we make the wheel accessible by persisting it, ensure that the RECORD is
                 // valid.
-                extracted.validate_and_heal_record(temp_dir.path(), dist)?;
+                extracted.validate_and_heal_record(dist)?;
 
                 // Persist the temporary directory to the directory store.
                 let id = self
-                    .persist_extracted_wheel(temp_dir, wheel_entry.path(), extracted.into_hashed())
+                    .persist_extracted_wheel(extracted, wheel_entry.path())
                     .await?;
 
                 if let Some((reporter, progress)) = progress {
@@ -1140,8 +1136,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             let file = fs_err::tokio::File::open(path)
                 .await
                 .map_err(Error::CacheRead)?;
-            let temp_dir = tempfile::tempdir_in(self.build_context.cache().root())
-                .map_err(Error::CacheWrite)?;
+            let extractor = WheelExtractor::new(
+                self.build_context.cache().root(),
+                self.content_addressed_cache,
+            )
+            .map_err(Error::CacheWrite)?;
 
             // Create a hasher for each hash algorithm.
             let algorithms = hashes.algorithms();
@@ -1149,13 +1148,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             let mut hasher = uv_extract::hash::HashReader::new(file, &mut hashers);
 
             // Unzip the wheel to a temporary directory.
-            let (temp_dir, mut extracted) = ExtractedWheel::extract_streaming(
-                &mut hasher,
-                temp_dir,
-                self.content_addressed_cache,
-            )
-            .await
-            .map_err(|err| Error::Extract(filename.to_string(), err))?;
+            let mut extracted = extractor
+                .extract_streaming(&mut hasher)
+                .await
+                .map_err(|err| Error::Extract(filename.to_string(), err))?;
 
             // Exhaust the reader to compute the hash.
             hasher.finish().await.map_err(Error::HashExhaustion)?;
@@ -1164,11 +1160,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
             // Before we make the wheel accessible by persisting it, ensure that the RECORD is
             // valid.
-            extracted.validate_and_heal_record(temp_dir.path(), dist)?;
+            extracted.validate_and_heal_record(dist)?;
 
             // Persist the temporary directory to the directory store.
             let id = self
-                .persist_extracted_wheel(temp_dir, wheel_entry.path(), extracted.into_hashed())
+                .persist_extracted_wheel(extracted, wheel_entry.path())
                 .await?;
 
             // Create an archive.
@@ -1205,31 +1201,26 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     ) -> Result<ArchiveId, Error> {
         let content_addressed_cache = self.content_addressed_cache;
 
-        let (temp_dir, mut extracted) = tokio::task::spawn_blocking({
+        let mut extracted = tokio::task::spawn_blocking({
             let path = path.to_owned();
             let root = self.build_context.cache().root().to_path_buf();
             move || -> Result<_, Error> {
                 // Unzip the wheel into a temporary directory.
-                let temp_dir = tempfile::tempdir_in(root).map_err(Error::CacheWrite)?;
+                let extractor = WheelExtractor::new(&root, content_addressed_cache)
+                    .map_err(Error::CacheWrite)?;
                 let reader = fs_err::File::open(&path).map_err(Error::CacheWrite)?;
-                let extracted = ExtractedWheel::extract_seekable(
-                    reader,
-                    temp_dir.path(),
-                    content_addressed_cache,
-                )
-                .map_err(|err| Error::Extract(path.to_string_lossy().into_owned(), err))?;
-                Ok((temp_dir, extracted))
+                extractor
+                    .extract_seekable(reader)
+                    .map_err(|err| Error::Extract(path.to_string_lossy().into_owned(), err))
             }
         })
         .await??;
 
         // Before we make the wheel accessible by persisting it, ensure that the RECORD is valid.
-        extracted.validate_and_heal_record(temp_dir.path(), dist)?;
+        extracted.validate_and_heal_record(dist)?;
 
         // Persist the temporary directory to the directory store.
-        let id = self
-            .persist_extracted_wheel(temp_dir, target, extracted.into_hashed())
-            .await?;
+        let id = self.persist_extracted_wheel(extracted, target).await?;
 
         Ok(id)
     }
@@ -1240,10 +1231,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     /// persistence retains the existing behavior of assigning a unique archive ID.
     async fn persist_extracted_wheel(
         &self,
-        temp_dir: tempfile::TempDir,
+        extracted: ExtractedWheel,
         target: &Path,
-        hashed_wheel: Option<HashedWheel>,
     ) -> Result<ArchiveId, Error> {
+        let (temp_dir, hashed_wheel) = extracted.into_parts();
         let cache = self.build_context.cache();
         let (temp_dir, id) = if let Some(HashedWheel { files, tree }) = hashed_wheel {
             let digest = DirectoryDigest::from(tree.hash());

--- a/crates/uv-distribution/src/extracted_wheel.rs
+++ b/crates/uv-distribution/src/extracted_wheel.rs
@@ -1,7 +1,9 @@
 use std::fmt::Display;
+use std::io;
 use std::path::Path;
 
 use either::Either;
+use tempfile::TempDir;
 use tokio::io::AsyncRead;
 
 use uv_extract::dirhash::{DirhashTree, HashedFile, UnhashedFile, dirhash_path};
@@ -16,68 +18,96 @@ pub(crate) struct HashedWheel {
     pub(crate) tree: DirhashTree,
 }
 
+/// A temporary directory and configuration for extracting a wheel.
+pub(crate) struct WheelExtractor {
+    temp_dir: TempDir,
+    content_addressed: bool,
+}
+
+/// An extracted wheel that owns its temporary directory until persistence.
+pub(crate) struct ExtractedWheel {
+    temp_dir: TempDir,
+    files: ExtractedFiles,
+}
+
 /// Files extracted from a wheel, with or without content-addressing metadata.
-pub(crate) enum ExtractedWheel {
+enum ExtractedFiles {
     Unhashed(Vec<UnhashedFile>),
     Hashed(HashedWheel),
 }
 
-impl ExtractedWheel {
+impl WheelExtractor {
+    /// Create a temporary directory under the cache root for extracting a wheel.
+    pub(crate) fn new(root: &Path, content_addressed: bool) -> io::Result<Self> {
+        Ok(Self {
+            temp_dir: tempfile::tempdir_in(root)?,
+            content_addressed,
+        })
+    }
+
     /// Extract a wheel from a streaming reader, optionally retaining its per-file digests.
     ///
     /// See [`uv_extract::stream::unzip`] for buffering, cleanup, and download hash requirements.
     pub(crate) async fn extract_streaming<R>(
+        self,
         reader: R,
-        temp_dir: tempfile::TempDir,
-        content_addressed: bool,
-    ) -> Result<(tempfile::TempDir, Self), uv_extract::Error>
+    ) -> Result<ExtractedWheel, uv_extract::Error>
     where
         R: AsyncRead + Unpin,
     {
-        if content_addressed {
+        if self.content_addressed {
             let (temp_dir, files, tree) =
-                uv_extract::stream::unzip_and_hash(reader, temp_dir).await?;
-            Ok((temp_dir, Self::Hashed(HashedWheel { files, tree })))
+                uv_extract::stream::unzip_and_hash(reader, self.temp_dir).await?;
+            Ok(ExtractedWheel {
+                temp_dir,
+                files: ExtractedFiles::Hashed(HashedWheel { files, tree }),
+            })
         } else {
-            let (temp_dir, files) = uv_extract::stream::unzip(reader, temp_dir).await?;
-            Ok((temp_dir, Self::Unhashed(files)))
+            let (temp_dir, files) = uv_extract::stream::unzip(reader, self.temp_dir).await?;
+            Ok(ExtractedWheel {
+                temp_dir,
+                files: ExtractedFiles::Unhashed(files),
+            })
         }
     }
 
     /// Extract a wheel from a seekable file, optionally retaining its per-file digests.
     pub(crate) fn extract_seekable(
+        self,
         reader: fs_err::File,
-        target: &Path,
-        content_addressed: bool,
-    ) -> Result<Self, uv_extract::Error> {
-        if content_addressed {
-            let (files, tree) = uv_extract::unzip_and_hash(reader, target)?;
-            Ok(Self::Hashed(HashedWheel { files, tree }))
+    ) -> Result<ExtractedWheel, uv_extract::Error> {
+        let files = if self.content_addressed {
+            let (files, tree) = uv_extract::unzip_and_hash(reader, self.temp_dir.path())?;
+            ExtractedFiles::Hashed(HashedWheel { files, tree })
         } else {
-            let files = uv_extract::unzip(reader, target)?;
-            Ok(Self::Unhashed(files))
-        }
+            let files = uv_extract::unzip(reader, self.temp_dir.path())?;
+            ExtractedFiles::Unhashed(files)
+        };
+        Ok(ExtractedWheel {
+            temp_dir: self.temp_dir,
+            files,
+        })
     }
+}
 
-    /// Return the hashed wheel if content hashing was enabled.
-    pub(crate) fn into_hashed(self) -> Option<HashedWheel> {
-        match self {
-            Self::Unhashed(_) => None,
-            Self::Hashed(wheel) => Some(wheel),
-        }
+impl ExtractedWheel {
+    /// Return the temporary directory and optional content hashes for persistence.
+    pub(crate) fn into_parts(self) -> (TempDir, Option<HashedWheel>) {
+        let hashed_wheel = match self.files {
+            ExtractedFiles::Unhashed(_) => None,
+            ExtractedFiles::Hashed(wheel) => Some(wheel),
+        };
+        (self.temp_dir, hashed_wheel)
     }
 
     /// Heal the wheel's `RECORD` and keep its hash tree consistent with the repaired contents.
-    pub(crate) fn validate_and_heal_record(
-        &mut self,
-        root: &Path,
-        dist: impl Display,
-    ) -> Result<(), Error> {
-        let files = match self {
-            Self::Unhashed(files) => {
+    pub(crate) fn validate_and_heal_record(&mut self, dist: impl Display) -> Result<(), Error> {
+        let root = self.temp_dir.path();
+        let files = match &self.files {
+            ExtractedFiles::Unhashed(files) => {
                 Either::Left(files.iter().map(|file| (file.path(), file.size())))
             }
-            Self::Hashed(wheel) => {
+            ExtractedFiles::Hashed(wheel) => {
                 Either::Right(wheel.files.iter().map(|file| (file.path(), file.size())))
             }
         };
@@ -86,7 +116,7 @@ impl ExtractedWheel {
         else {
             return Ok(());
         };
-        let Self::Hashed(hashed_wheel) = self else {
+        let ExtractedFiles::Hashed(hashed_wheel) = &mut self.files else {
             return Ok(());
         };
 


### PR DESCRIPTION
## Summary

Stacked on #21372.

We now create wheel extraction directories through `WheelExtractor`. Both streaming and seekable extraction consume it and return an `ExtractedWheel` that owns the directory and file metadata through `RECORD` validation and cache persistence.

This removes the separate `TempDir` transfers from callers and keeps the seekable worker's directory alive until extraction finishes. Implements the ownership refactor suggested in https://github.com/astral-sh/uv/pull/21372#discussion_r3906888921.
