### PR TITLE
Treat any received TLS alert as fatal in retry classification

### DIFF
--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -9,7 +9,7 @@ use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{
     RetryPolicy, Retryable, RetryableStrategy, default_on_request_error, default_on_request_success,
 };
-use rustls::{AlertDescription, Error as RustlsError};
+use rustls::Error as RustlsError;
 use tracing::{debug, trace};
 use url::Url;
 
@@ -273,32 +273,21 @@ fn is_retryable_status_error(reqwest_err: &reqwest::Error) -> bool {
         || status == StatusCode::TOO_MANY_REQUESTS
 }
 
+/// Whether a request failed because the TLS handshake produced a fatal verdict: uv rejected the
+/// peer's certificate, or the peer sent an alert to abort the handshake. These are deterministic,
+/// so we treat them as fatal rather than retrying. Transient handshake failures instead surface as
+/// [`io::Error`]s, handled by [`retryable_on_request_failure`].
 fn is_tls_certificate_error(reqwest_err: &reqwest::Error) -> bool {
     let Some(rustls_error) = find_source::<RustlsError>(reqwest_err) else {
         return false;
     };
 
-    // TODO(konsti): https://github.com/seanmonstar/reqwest/issues/2819#issuecomment-5032072023
-    match rustls_error {
-        RustlsError::InvalidCertificate(_) | RustlsError::NoCertificatesPresented => true,
-        RustlsError::AlertReceived(alert) => matches!(
-            alert,
-            AlertDescription::AccessDenied
-                | AlertDescription::BadCertificate
-                | AlertDescription::BadCertificateHashValue
-                | AlertDescription::BadCertificateStatusResponse
-                | AlertDescription::CertificateExpired
-                | AlertDescription::CertificateRequired
-                | AlertDescription::CertificateRevoked
-                | AlertDescription::CertificateUnknown
-                | AlertDescription::CertificateUnobtainable
-                | AlertDescription::DecryptError
-                | AlertDescription::NoCertificate
-                | AlertDescription::UnknownCA
-                | AlertDescription::UnsupportedCertificate
-        ),
-        _ => false,
-    }
+    matches!(
+        rustls_error,
+        RustlsError::InvalidCertificate(_)
+            | RustlsError::NoCertificatesPresented
+            | RustlsError::AlertReceived(_)
+    )
 }
 
 /// Finds the request URL for diagnostics, including transparent middleware and retry wrappers.

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -551,30 +551,22 @@ async fn test_expired_cert_rejected() -> Result<()> {
     Ok(())
 }
 
-/// TLS protocol failures that are not certificate errors remain retryable.
+/// Any fatal TLS alert is treated as fatal, including non-certificate alerts such as
+/// `internal_error`. An aborted handshake is a deterministic failure, not a transient one that a
+/// retry could recover.
 #[tokio::test]
-async fn test_non_certificate_tls_errors_are_retried() -> Result<()> {
+async fn test_non_certificate_tls_alerts_are_not_retried() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
     let server_task = tokio::spawn(async move {
-        for _ in 0..4 {
-            let (mut stream, _) = listener.accept().await?;
-            // A fatal TLS `internal_error` alert.
-            send_tls_alert(&mut stream, 0x50).await?;
-        }
+        let (mut stream, _) = listener.accept().await?;
+        // A fatal TLS `internal_error` alert.
+        send_tls_alert(&mut stream, 0x50).await?;
         Ok::<_, anyhow::Error>(())
     });
 
     let response = send_request(addr, false, None).await;
-    let Err(reqwest_middleware::Error::Middleware(middleware_error)) = response else {
-        panic!("expected middleware error, got: {response:?}");
-    };
-    let Some(reqwest_retry::RetryError::WithRetries { retries, .. }) =
-        middleware_error.downcast_ref::<reqwest_retry::RetryError>()
-    else {
-        panic!("expected retries after a non-certificate TLS error, got: {middleware_error:?}");
-    };
-    assert_eq!(*retries, 3);
+    assert_fatal_reqwest_error(&response);
     server_task.await??;
     Ok(())
 }


### PR DESCRIPTION
## Summary

`is_tls_certificate_error` decides whether a failed request died from a TLS
problem we should give up on rather than retry. It used to match `AlertReceived`
against a hand-picked list of certificate-specific alerts, which is the wrong
distinction. What matters for a retry is whether the failure is deterministic or
transient, not whether it happens to be about a certificate.

Every alert a client can receive during a TLS 1.2 or 1.3 handshake is a
deterministic verdict: a rejected certificate, no shared protocol version or
cipher, an unrecognized name, a failed ALPN, or the peer rejecting our client
certificate under mTLS. None of them get better on a second attempt, so the old
list was too narrow. It retried `HandshakeFailure`, `ProtocolVersion`, and a few
others three times before failing, and it also carried three variants a modern
client can no longer receive.

This commit collapses the alert arm to `AlertReceived(_)`. The genuinely transient
handshake failures, like resets, timeouts, and truncated reads, never reach this
function as a `RustlsError`. They arrive as `io::Error` and are still retried by
`retryable_on_request_failure`. rustls only reports `AlertReceived` for an alert
that aborts the connection, and we still gate on `AlertReceived` rather than "the
source chain contains a `RustlsError`", so transient non-alert TLS errors stay
retryable.

## Test Plan

I ran tests locally.
