### PR TITLE
uv publish: support token burning

### DIFF
--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -42,10 +42,9 @@ use uv_pypi_types::{HashAlgorithm, HashDigest, Metadata23, MetadataError};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_warnings::warn_user;
 
+pub use crate::trusted_publishing::TrustedPublishingToken;
 use crate::trusted_publishing::pypi::PyPIPublishingService;
-use crate::trusted_publishing::{
-    TrustedPublishingError, TrustedPublishingService, TrustedPublishingToken,
-};
+use crate::trusted_publishing::{TrustedPublishingError, TrustedPublishingService};
 
 #[derive(Error, Debug)]
 pub enum PublishError {
@@ -475,6 +474,19 @@ pub async fn check_trusted_publishing(
         }
         TrustedPublishing::Never => Ok(TrustedPublishResult::Skipped),
     }
+}
+
+/// Request revocation of a token obtained through trusted publishing.
+///
+/// A successful request does not guarantee that the token was revoked.
+pub async fn burn_trusted_publishing_token(
+    token: &TrustedPublishingToken,
+    registry: &DisplaySafeUrl,
+    client: &BaseClient,
+) -> Result<(), TrustedPublishingError> {
+    PyPIPublishingService::new(registry, client)
+        .burn_token(token)
+        .await
 }
 
 /// Upload a file to a registry.

--- a/crates/uv-publish/src/trusted_publishing.rs
+++ b/crates/uv-publish/src/trusted_publishing.rs
@@ -45,7 +45,7 @@ pub enum TrustedPublishingError {
     InvalidOidcToken(StatusCode, String),
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct TrustedPublishingToken(String);
 
@@ -71,6 +71,12 @@ struct MintTokenRequest {
 #[derive(Deserialize)]
 struct PublishToken {
     token: TrustedPublishingToken,
+}
+
+/// The body for querying `https://pypi.org/_/oidc/burn-token`.
+#[derive(Serialize)]
+struct BurnTokenRequest<'a> {
+    token: &'a TrustedPublishingToken,
 }
 
 /// The payload of the OIDC token.
@@ -117,7 +123,7 @@ pub struct BuildkiteTokenClaims {
 
 /// A service (i.e. uploadable index) that supports trusted publishing.
 ///
-/// Interactions should go through the default [`get_token`]; implementors
+/// Token acquisition should go through the default [`Self::get_token`]; implementors
 /// should implement the constituent trait methods.
 pub(crate) trait TrustedPublishingService {
     /// Borrow an HTTP client with middleware.
@@ -131,6 +137,12 @@ pub(crate) trait TrustedPublishingService {
         &self,
         oidc_token: ambient_id::IdToken,
     ) -> Result<TrustedPublishingToken, TrustedPublishingError>;
+
+    /// Request revocation of a short-lived upload token once publishing has finished.
+    async fn burn_token(
+        &self,
+        token: &TrustedPublishingToken,
+    ) -> Result<(), TrustedPublishingError>;
 
     /// Perform the full trusted publishing token exchange.
     async fn get_token(&self) -> Result<Option<TrustedPublishingToken>, TrustedPublishingError> {

--- a/crates/uv-publish/src/trusted_publishing/pypi.rs
+++ b/crates/uv-publish/src/trusted_publishing/pypi.rs
@@ -7,8 +7,8 @@ use uv_client::BaseClient;
 use uv_redacted::DisplaySafeUrl;
 
 use crate::trusted_publishing::{
-    Audience, MintTokenRequest, PublishToken, TrustedPublishingError, TrustedPublishingService,
-    decode_oidc_token,
+    Audience, BurnTokenRequest, MintTokenRequest, PublishToken, TrustedPublishingError,
+    TrustedPublishingService, TrustedPublishingToken, decode_oidc_token,
 };
 
 pub(crate) struct PyPIPublishingService<'a> {
@@ -28,6 +28,35 @@ impl<'a> PyPIPublishingService<'a> {
 impl TrustedPublishingService for PyPIPublishingService<'_> {
     fn client(&self) -> &ClientWithMiddleware {
         self.client
+    }
+
+    async fn burn_token(
+        &self,
+        token: &TrustedPublishingToken,
+    ) -> Result<(), TrustedPublishingError> {
+        // Prefer HTTPS for token revocation; allow HTTP only in test builds.
+        let scheme = if cfg!(feature = "test") {
+            self.registry.scheme()
+        } else {
+            "https"
+        };
+        let burn_token_url = DisplaySafeUrl::parse(&format!(
+            "{}://{}/_/oidc/burn-token",
+            scheme,
+            self.registry.authority()
+        ))?;
+        debug!("Requesting revocation of the trusted publishing upload token at {burn_token_url}");
+        self.client
+            .post(Url::from(burn_token_url.clone()))
+            .json(&BurnTokenRequest { token })
+            .send()
+            .await
+            .map_err(|err| TrustedPublishingError::ReqwestMiddleware(burn_token_url.clone(), err))?
+            .error_for_status()
+            .map_err(|err| TrustedPublishingError::Reqwest(burn_token_url, err))?;
+
+        // PyPI returns HTTP 202 regardless of whether the token was revoked.
+        Ok(())
     }
 
     async fn audience(&self) -> Result<String, super::TrustedPublishingError> {

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -18,7 +18,8 @@ use uv_distribution_types::{IndexCapabilities, IndexLocations, IndexUrl};
 use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 use uv_publish::{
     CheckUrlClient, FormMetadata, PublishError, TrustedPublishResult, TrustedPublishingToken,
-    burn_trusted_publishing_token, check_trusted_publishing, group_files_for_publishing, upload,
+    UploadDistribution, burn_trusted_publishing_token, check_trusted_publishing,
+    group_files_for_publishing, upload,
 };
 use uv_redacted::DisplaySafeUrl;
 use uv_settings::EnvironmentOptions;
@@ -139,10 +140,6 @@ pub(crate) async fn publish(
         .client_name("oidc")
         .build()?;
 
-    let retry_policy = client_builder.retry_policy();
-    // We're only checking a single URL and one at a time, so 1 permit is sufficient
-    let download_concurrency = Arc::new(Semaphore::new(1));
-
     // Load credentials.
     let (publish_url, credentials) = gather_credentials(
         publish_url,
@@ -176,139 +173,16 @@ pub(crate) async fn publish(
     };
 
     // Keep the publishing result so token revocation also runs after an upload or metadata error.
-    let result = async {
-        let mut error_count: usize = 0;
-
-        for group in groups {
-            // Check if the filename is normalized (e.g., version `2025.09.4` should be `2025.9.4`).
-            let normalized_filename = group.filename.to_string();
-            if group.raw_filename != normalized_filename {
-                warn_user_once!(
-                    "`{}` has a non-normalized filename (expected `{normalized_filename}`), skipping",
-                    group.raw_filename
-                );
-                continue;
-            }
-
-            let reporter = Arc::new(PublishReporter::single(printer));
-
-            if let Some(check_url_client) = &check_url_client {
-                match uv_publish::check_url(
-                    check_url_client,
-                    &group.file,
-                    &group.filename,
-                    &download_concurrency,
-                    reporter.clone(),
-                )
-                .await
-                {
-                    Ok(true) => {
-                        writeln!(
-                            printer.stderr(),
-                            "File {} already exists, skipping",
-                            group.filename
-                        )?;
-                        continue;
-                    }
-                    Ok(false) => {}
-                    Err(err) => {
-                        if dry_run {
-                            write_error_chain_with_options(
-                                &err,
-                                Hints::none(),
-                                ErrorOptions::default().with_stream(printer.stderr()),
-                            )?;
-                            error_count += 1;
-                            continue;
-                        }
-                        return Err(err.into());
-                    }
-                }
-            }
-
-            let bytes = human_readable_bytes(fs_err::metadata(&group.file)?.len());
-            if dry_run {
-                writeln!(
-                    printer.stderr(),
-                    "{} {} {}",
-                    "Checking".bold().cyan(),
-                    group.filename,
-                    format!("({bytes:.1})").dimmed()
-                )?;
-            } else {
-                writeln!(
-                    printer.stderr(),
-                    "{} {} {}",
-                    "Hashing".bold().green(),
-                    group.filename,
-                    format!("({bytes:.1})").dimmed()
-                )?;
-            }
-
-            // Collect the metadata for the file.
-            let form_metadata =
-                match FormMetadata::read_from_file(&group.file, &group.filename, reporter.clone())
-                    .await
-                    .map_err(|err| PublishError::PublishPrepare(group.file.clone(), Box::new(err)))
-                {
-                    Ok(metadata) => metadata,
-                    Err(err) => {
-                        if dry_run {
-                            write_error_chain_with_options(
-                                &err,
-                                Hints::none(),
-                                ErrorOptions::default().with_stream(printer.stderr()),
-                            )?;
-                            error_count += 1;
-                            continue;
-                        }
-                        return Err(err.into());
-                    }
-                };
-
-            if dry_run {
-                continue;
-            }
-
-            writeln!(
-                printer.stderr(),
-                "{} {} {}",
-                "Uploading".bold().green(),
-                group.filename,
-                format!("({bytes:.1})").dimmed()
-            )?;
-
-            let uploaded = upload(
-                &group,
-                &form_metadata,
-                &publish_url,
-                &upload_client,
-                retry_policy,
-                &upload_credentials,
-                check_url_client.as_ref(),
-                &download_concurrency,
-                reporter.clone(),
-            )
-            .await?;
-            info!("Upload succeeded");
-
-            if !uploaded {
-                writeln!(
-                    printer.stderr(),
-                    "{}",
-                    "File already exists, skipping".dimmed()
-                )?;
-            }
-        }
-
-        if error_count > 0 {
-            let failed = if error_count == 1 { "file" } else { "files" };
-            writeln!(printer.stderr(), "Found issues with {error_count} {failed}")?;
-            return Ok(ExitStatus::Failure);
-        }
-
-        Ok(ExitStatus::Success)
-    }
+    let result = publish_files(
+        &groups,
+        &publish_url,
+        client_builder,
+        &upload_client,
+        &upload_credentials,
+        check_url_client.as_ref(),
+        dry_run,
+        printer,
+    )
     .await;
 
     if let PublishingCredentials::TrustedPublishing(token) = &credentials
@@ -321,6 +195,190 @@ pub(crate) async fn publish(
     }
 
     result
+}
+
+/// Publish each distribution, reporting all validation failures during a dry run.
+async fn publish_files(
+    groups: &[UploadDistribution],
+    publish_url: &DisplaySafeUrl,
+    client_builder: &BaseClientBuilder<'_>,
+    upload_client: &BaseClient,
+    credentials: &Credentials,
+    check_url_client: Option<&CheckUrlClient<'_>>,
+    dry_run: bool,
+    printer: Printer,
+) -> Result<ExitStatus> {
+    // We're only checking a single URL and one at a time, so 1 permit is sufficient.
+    let download_concurrency = Semaphore::new(1);
+    let mut error_count: usize = 0;
+
+    for group in groups {
+        match publish_file(
+            group,
+            publish_url,
+            client_builder,
+            upload_client,
+            credentials,
+            check_url_client,
+            &download_concurrency,
+            dry_run,
+            printer,
+        )
+        .await?
+        {
+            PublishResult::Success => {}
+            PublishResult::Failure => error_count += 1,
+        }
+    }
+
+    if error_count > 0 {
+        let failed = if error_count == 1 { "file" } else { "files" };
+        writeln!(printer.stderr(), "Found issues with {error_count} {failed}")?;
+        return Ok(ExitStatus::Failure);
+    }
+
+    Ok(ExitStatus::Success)
+}
+
+/// The outcome of checking or publishing a single distribution.
+enum PublishResult {
+    /// The distribution was checked, uploaded, or skipped successfully.
+    Success,
+    /// A validation error was reported during a dry run.
+    Failure,
+}
+
+/// Check and prepare a distribution, then upload it unless this is a dry run.
+async fn publish_file(
+    group: &UploadDistribution,
+    publish_url: &DisplaySafeUrl,
+    client_builder: &BaseClientBuilder<'_>,
+    upload_client: &BaseClient,
+    credentials: &Credentials,
+    check_url_client: Option<&CheckUrlClient<'_>>,
+    download_concurrency: &Semaphore,
+    dry_run: bool,
+    printer: Printer,
+) -> Result<PublishResult> {
+    // Check if the filename is normalized (e.g., version `2025.09.4` should be `2025.9.4`).
+    let normalized_filename = group.filename.to_string();
+    if group.raw_filename != normalized_filename {
+        warn_user_once!(
+            "`{}` has a non-normalized filename (expected `{normalized_filename}`), skipping",
+            group.raw_filename
+        );
+        return Ok(PublishResult::Success);
+    }
+
+    let reporter = Arc::new(PublishReporter::single(printer));
+
+    if let Some(check_url_client) = check_url_client {
+        match uv_publish::check_url(
+            check_url_client,
+            &group.file,
+            &group.filename,
+            download_concurrency,
+            reporter.clone(),
+        )
+        .await
+        {
+            Ok(true) => {
+                writeln!(
+                    printer.stderr(),
+                    "File {} already exists, skipping",
+                    group.filename
+                )?;
+                return Ok(PublishResult::Success);
+            }
+            Ok(false) => {}
+            Err(err) => {
+                if dry_run {
+                    write_error_chain_with_options(
+                        &err,
+                        Hints::none(),
+                        ErrorOptions::default().with_stream(printer.stderr()),
+                    )?;
+                    return Ok(PublishResult::Failure);
+                }
+                return Err(err.into());
+            }
+        }
+    }
+
+    let bytes = human_readable_bytes(fs_err::metadata(&group.file)?.len());
+    if dry_run {
+        writeln!(
+            printer.stderr(),
+            "{} {} {}",
+            "Checking".bold().cyan(),
+            group.filename,
+            format!("({bytes:.1})").dimmed()
+        )?;
+    } else {
+        writeln!(
+            printer.stderr(),
+            "{} {} {}",
+            "Hashing".bold().green(),
+            group.filename,
+            format!("({bytes:.1})").dimmed()
+        )?;
+    }
+
+    // Collect the metadata for the file.
+    let form_metadata =
+        match FormMetadata::read_from_file(&group.file, &group.filename, reporter.clone())
+            .await
+            .map_err(|err| PublishError::PublishPrepare(group.file.clone(), Box::new(err)))
+        {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                if dry_run {
+                    write_error_chain_with_options(
+                        &err,
+                        Hints::none(),
+                        ErrorOptions::default().with_stream(printer.stderr()),
+                    )?;
+                    return Ok(PublishResult::Failure);
+                }
+                return Err(err.into());
+            }
+        };
+
+    if dry_run {
+        return Ok(PublishResult::Success);
+    }
+
+    writeln!(
+        printer.stderr(),
+        "{} {} {}",
+        "Uploading".bold().green(),
+        group.filename,
+        format!("({bytes:.1})").dimmed()
+    )?;
+
+    let uploaded = upload(
+        group,
+        &form_metadata,
+        publish_url,
+        upload_client,
+        client_builder.retry_policy(),
+        credentials,
+        check_url_client,
+        download_concurrency,
+        reporter.clone(),
+    )
+    .await?;
+    info!("Upload succeeded");
+
+    if !uploaded {
+        writeln!(
+            printer.stderr(),
+            "{}",
+            "File already exists, skipping".dimmed()
+        )?;
+    }
+
+    Ok(PublishResult::Success)
 }
 
 /// Credentials for publishing, including whether they require revocation after use.

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -224,10 +224,20 @@ async fn publish_files(
             dry_run,
             printer,
         )
-        .await?
+        .await
         {
-            PublishResult::Success => {}
-            PublishResult::Failure => error_count += 1,
+            Ok(()) => {}
+            Err(err) => {
+                if !dry_run {
+                    return Err(err);
+                }
+                write_error_chain_with_options(
+                    err.as_ref(),
+                    Hints::none(),
+                    ErrorOptions::default().with_stream(printer.stderr()),
+                )?;
+                error_count += 1;
+            }
         }
     }
 
@@ -238,14 +248,6 @@ async fn publish_files(
     }
 
     Ok(ExitStatus::Success)
-}
-
-/// The outcome of checking or publishing a single distribution.
-enum PublishResult {
-    /// The distribution was checked, uploaded, or skipped successfully.
-    Success,
-    /// A validation error was reported during a dry run.
-    Failure,
 }
 
 /// Check and prepare a distribution, then upload it unless this is a dry run.
@@ -259,7 +261,7 @@ async fn publish_file(
     download_concurrency: &Semaphore,
     dry_run: bool,
     printer: Printer,
-) -> Result<PublishResult> {
+) -> Result<()> {
     // Check if the filename is normalized (e.g., version `2025.09.4` should be `2025.9.4`).
     let normalized_filename = group.filename.to_string();
     if group.raw_filename != normalized_filename {
@@ -267,42 +269,27 @@ async fn publish_file(
             "`{}` has a non-normalized filename (expected `{normalized_filename}`), skipping",
             group.raw_filename
         );
-        return Ok(PublishResult::Success);
+        return Ok(());
     }
 
     let reporter = Arc::new(PublishReporter::single(printer));
 
-    if let Some(check_url_client) = check_url_client {
-        match uv_publish::check_url(
+    if let Some(check_url_client) = check_url_client
+        && uv_publish::check_url(
             check_url_client,
             &group.file,
             &group.filename,
             download_concurrency,
             reporter.clone(),
         )
-        .await
-        {
-            Ok(true) => {
-                writeln!(
-                    printer.stderr(),
-                    "File {} already exists, skipping",
-                    group.filename
-                )?;
-                return Ok(PublishResult::Success);
-            }
-            Ok(false) => {}
-            Err(err) => {
-                if dry_run {
-                    write_error_chain_with_options(
-                        &err,
-                        Hints::none(),
-                        ErrorOptions::default().with_stream(printer.stderr()),
-                    )?;
-                    return Ok(PublishResult::Failure);
-                }
-                return Err(err.into());
-            }
-        }
+        .await?
+    {
+        writeln!(
+            printer.stderr(),
+            "File {} already exists, skipping",
+            group.filename
+        )?;
+        return Ok(());
     }
 
     let bytes = human_readable_bytes(fs_err::metadata(&group.file)?.len());
@@ -326,26 +313,12 @@ async fn publish_file(
 
     // Collect the metadata for the file.
     let form_metadata =
-        match FormMetadata::read_from_file(&group.file, &group.filename, reporter.clone())
+        FormMetadata::read_from_file(&group.file, &group.filename, reporter.clone())
             .await
-            .map_err(|err| PublishError::PublishPrepare(group.file.clone(), Box::new(err)))
-        {
-            Ok(metadata) => metadata,
-            Err(err) => {
-                if dry_run {
-                    write_error_chain_with_options(
-                        &err,
-                        Hints::none(),
-                        ErrorOptions::default().with_stream(printer.stderr()),
-                    )?;
-                    return Ok(PublishResult::Failure);
-                }
-                return Err(err.into());
-            }
-        };
+            .map_err(|err| PublishError::PublishPrepare(group.file.clone(), Box::new(err)))?;
 
     if dry_run {
-        return Ok(PublishResult::Success);
+        return Ok(());
     }
 
     writeln!(
@@ -378,7 +351,7 @@ async fn publish_file(
         )?;
     }
 
-    Ok(PublishResult::Success)
+    Ok(())
 }
 
 /// Credentials for publishing, including whether they require revocation after use.

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -143,7 +144,7 @@ pub(crate) async fn publish(
     let download_concurrency = Arc::new(Semaphore::new(1));
 
     // Load credentials.
-    let (publish_url, credentials, trusted_publishing_token) = gather_credentials(
+    let (publish_url, credentials) = gather_credentials(
         publish_url,
         username,
         password,
@@ -155,6 +156,7 @@ pub(crate) async fn publish(
         printer,
     )
     .await?;
+    let upload_credentials = credentials.as_credentials();
 
     // Initialize the registry client.
     let check_url_client = if let Some(index_url) = &check_url {
@@ -282,7 +284,7 @@ pub(crate) async fn publish(
                 &publish_url,
                 &upload_client,
                 retry_policy,
-                &credentials,
+                &upload_credentials,
                 check_url_client.as_ref(),
                 &download_concurrency,
                 reporter.clone(),
@@ -309,8 +311,8 @@ pub(crate) async fn publish(
     }
     .await;
 
-    if let Some(token) = trusted_publishing_token
-        && let Err(err) = burn_trusted_publishing_token(&token, &publish_url, &oidc_client).await
+    if let PublishingCredentials::TrustedPublishing(token) = &credentials
+        && let Err(err) = burn_trusted_publishing_token(token, &publish_url, &oidc_client).await
     {
         warn_user!(
             "Failed to revoke trusted publishing token: {err}. The token will expire naturally."
@@ -319,6 +321,27 @@ pub(crate) async fn publish(
     }
 
     result
+}
+
+/// Credentials for publishing, including whether they require revocation after use.
+enum PublishingCredentials {
+    /// Credentials supplied by the user or resolved by the authentication middleware.
+    Standard(Credentials),
+    /// A short-lived token obtained through trusted publishing.
+    TrustedPublishing(TrustedPublishingToken),
+}
+
+impl PublishingCredentials {
+    /// Return the HTTP credentials to use for uploads.
+    fn as_credentials(&self) -> Cow<'_, Credentials> {
+        match self {
+            Self::Standard(credentials) => Cow::Borrowed(credentials),
+            Self::TrustedPublishing(token) => Cow::Owned(Credentials::basic(
+                Some("__token__".to_string()),
+                Some(token.to_string()),
+            )),
+        }
+    }
 }
 
 /// Whether to allow prompting for username and password.
@@ -359,7 +382,7 @@ enum Prompt {
 /// If no credentials are found, the auth middleware does a final check for cached credentials and
 /// otherwise errors without sending the request.
 ///
-/// Returns the publish URL, credentials, and any trusted publishing token to revoke after use.
+/// Returns the publish URL and [`PublishingCredentials`].
 async fn gather_credentials(
     mut publish_url: DisplaySafeUrl,
     mut username: Option<String>,
@@ -370,7 +393,7 @@ async fn gather_credentials(
     check_url: Option<&IndexUrl>,
     prompt: Prompt,
     printer: Printer,
-) -> Result<(DisplaySafeUrl, Credentials, Option<TrustedPublishingToken>)> {
+) -> Result<(DisplaySafeUrl, PublishingCredentials)> {
     // Support reading username and password from the URL, for symmetry with the index API.
     if let Some(url_password) = publish_url.password() {
         if password.is_some_and(|password| password != url_password) {
@@ -393,7 +416,7 @@ async fn gather_credentials(
     }
 
     // If applicable, attempt obtaining a token for trusted publishing.
-    let trusted_publishing_token = check_trusted_publishing(
+    let trusted_publishing_error = match check_trusted_publishing(
         username.as_deref(),
         password.as_deref(),
         keyring_provider,
@@ -401,19 +424,23 @@ async fn gather_credentials(
         &publish_url,
         oidc_client,
     )
-    .await?;
+    .await?
+    {
+        TrustedPublishResult::Configured(token) => {
+            return Ok((publish_url, PublishingCredentials::TrustedPublishing(token)));
+        }
+        TrustedPublishResult::Skipped => None,
+        TrustedPublishResult::Ignored(err) => Some(err),
+    };
 
-    let (username, mut password) =
-        if let TrustedPublishResult::Configured(password) = &trusted_publishing_token {
-            (Some("__token__".to_string()), Some(password.to_string()))
-        } else if username.is_none() && password.is_none() {
-            match prompt {
-                Prompt::Enabled => prompt_username_and_password()?,
-                Prompt::Disabled => (None, None),
-            }
-        } else {
-            (username, password)
-        };
+    let (username, mut password) = if username.is_none() && password.is_none() {
+        match prompt {
+            Prompt::Enabled => prompt_username_and_password()?,
+            Prompt::Disabled => (None, None),
+        }
+    } else {
+        (username, password)
+    };
 
     if password.is_some() && username.is_none() {
         bail!(
@@ -423,37 +450,31 @@ async fn gather_credentials(
         );
     }
 
-    let trusted_publishing_token = match trusted_publishing_token {
-        TrustedPublishResult::Configured(token) => Some(token),
-        TrustedPublishResult::Skipped => None,
-        TrustedPublishResult::Ignored(err) => {
-            if username.is_none()
-                && password.is_none()
-                && keyring_provider == KeyringProviderType::Disabled
-            {
-                // The user has configured something incorrectly:
-                // * The user forgot to configure credentials.
-                // * The user forgot to forward the secrets as env vars (or used the wrong ones).
-                // * The trusted publishing configuration is wrong.
-                writeln!(
-                    printer.stderr(),
-                    "Note: Neither credentials nor keyring are configured, and there was an error \
-                    fetching the trusted publishing token. If you don't want to use trusted \
-                    publishing, you can ignore this error, but you need to provide credentials."
-                )?;
+    if username.is_none()
+        && password.is_none()
+        && keyring_provider == KeyringProviderType::Disabled
+        && let Some(err) = trusted_publishing_error
+    {
+        // The user has configured something incorrectly:
+        // * The user forgot to configure credentials.
+        // * The user forgot to forward the secrets as env vars (or used the wrong ones).
+        // * The trusted publishing configuration is wrong.
+        writeln!(
+            printer.stderr(),
+            "Note: Neither credentials nor keyring are configured, and there was an error \
+            fetching the trusted publishing token. If you don't want to use trusted \
+            publishing, you can ignore this error, but you need to provide credentials."
+        )?;
 
-                trace!("Error trace: {err:?}");
-                write_error_chain_with_options(
-                    anyhow::Error::from(err)
-                        .context("Trusted publishing failed")
-                        .as_ref(),
-                    Hints::none(),
-                    ErrorOptions::default().with_stream(printer.stderr()),
-                )?;
-            }
-            None
-        }
-    };
+        trace!("Error trace: {err:?}");
+        write_error_chain_with_options(
+            anyhow::Error::from(err)
+                .context("Trusted publishing failed")
+                .as_ref(),
+            Hints::none(),
+            ErrorOptions::default().with_stream(printer.stderr()),
+        )?;
+    }
 
     // If applicable, fetch the password from the keyring eagerly to avoid user confusion about
     // missing keyring entries later.
@@ -485,7 +506,7 @@ async fn gather_credentials(
 
     let credentials = Credentials::basic(username, password);
 
-    Ok((publish_url, credentials, trusted_publishing_token))
+    Ok((publish_url, PublishingCredentials::Standard(credentials)))
 }
 
 fn prompt_username_and_password() -> Result<(Option<String>, Option<String>)> {
@@ -529,7 +550,7 @@ mod tests {
             Printer::Quiet,
         )
         .await
-        .map(|(publish_url, credentials, _)| (publish_url, credentials))
+        .map(|(publish_url, credentials)| (publish_url, credentials.as_credentials().into_owned()))
     }
 
     #[tokio::test]

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -326,7 +326,7 @@ pub(crate) async fn publish(
 /// Credentials for publishing, including whether they require revocation after use.
 enum PublishingCredentials {
     /// Credentials supplied by the user or resolved by the authentication middleware.
-    Standard(Credentials),
+    Supplied(Credentials),
     /// A short-lived token obtained through trusted publishing.
     TrustedPublishing(TrustedPublishingToken),
 }
@@ -335,7 +335,7 @@ impl PublishingCredentials {
     /// Return the HTTP credentials to use for uploads.
     fn as_credentials(&self) -> Cow<'_, Credentials> {
         match self {
-            Self::Standard(credentials) => Cow::Borrowed(credentials),
+            Self::Supplied(credentials) => Cow::Borrowed(credentials),
             Self::TrustedPublishing(token) => Cow::Owned(Credentials::basic(
                 Some("__token__".to_string()),
                 Some(token.to_string()),
@@ -416,7 +416,7 @@ async fn gather_credentials(
     }
 
     // If applicable, attempt obtaining a token for trusted publishing.
-    let trusted_publishing_error = match check_trusted_publishing(
+    let trusted_publishing_status = match check_trusted_publishing(
         username.as_deref(),
         password.as_deref(),
         keyring_provider,
@@ -453,7 +453,7 @@ async fn gather_credentials(
     if username.is_none()
         && password.is_none()
         && keyring_provider == KeyringProviderType::Disabled
-        && let Some(err) = trusted_publishing_error
+        && let Some(err) = trusted_publishing_status
     {
         // The user has configured something incorrectly:
         // * The user forgot to configure credentials.
@@ -506,7 +506,7 @@ async fn gather_credentials(
 
     let credentials = Credentials::basic(username, password);
 
-    Ok((publish_url, PublishingCredentials::Standard(credentials)))
+    Ok((publish_url, PublishingCredentials::Supplied(credentials)))
 }
 
 fn prompt_username_and_password() -> Result<(Option<String>, Option<String>)> {

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -189,7 +189,7 @@ pub(crate) async fn publish(
         && let Err(err) = burn_trusted_publishing_token(token, &publish_url, &oidc_client).await
     {
         warn_user!(
-            "Failed to revoke trusted publishing token: {err}. The token will expire naturally."
+            "Failed to invalidate trusted publishing token. It will expire naturally. Cause: {err}"
         );
         debug!("Trusted publishing token revocation failed: {err:?}");
     }

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -16,12 +16,12 @@ use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{IndexCapabilities, IndexLocations, IndexUrl};
 use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 use uv_publish::{
-    CheckUrlClient, FormMetadata, PublishError, TrustedPublishResult, check_trusted_publishing,
-    group_files_for_publishing, upload,
+    CheckUrlClient, FormMetadata, PublishError, TrustedPublishResult, TrustedPublishingToken,
+    burn_trusted_publishing_token, check_trusted_publishing, group_files_for_publishing, upload,
 };
 use uv_redacted::DisplaySafeUrl;
 use uv_settings::EnvironmentOptions;
-use uv_warnings::warn_user_once;
+use uv_warnings::{warn_user, warn_user_once};
 
 use crate::commands::reporters::PublishReporter;
 use crate::commands::{ExitStatus, human_readable_bytes};
@@ -143,7 +143,7 @@ pub(crate) async fn publish(
     let download_concurrency = Arc::new(Semaphore::new(1));
 
     // Load credentials.
-    let (publish_url, credentials) = gather_credentials(
+    let (publish_url, credentials, trusted_publishing_token) = gather_credentials(
         publish_url,
         username,
         password,
@@ -173,137 +173,152 @@ pub(crate) async fn publish(
         None
     };
 
-    let mut error_count: usize = 0;
+    // Keep the publishing result so token revocation also runs after an upload or metadata error.
+    let result = async {
+        let mut error_count: usize = 0;
 
-    for group in groups {
-        // Check if the filename is normalized (e.g., version `2025.09.4` should be `2025.9.4`).
-        let normalized_filename = group.filename.to_string();
-        if group.raw_filename != normalized_filename {
-            warn_user_once!(
-                "`{}` has a non-normalized filename (expected `{normalized_filename}`), skipping",
-                group.raw_filename
-            );
-            continue;
-        }
+        for group in groups {
+            // Check if the filename is normalized (e.g., version `2025.09.4` should be `2025.9.4`).
+            let normalized_filename = group.filename.to_string();
+            if group.raw_filename != normalized_filename {
+                warn_user_once!(
+                    "`{}` has a non-normalized filename (expected `{normalized_filename}`), skipping",
+                    group.raw_filename
+                );
+                continue;
+            }
 
-        let reporter = Arc::new(PublishReporter::single(printer));
+            let reporter = Arc::new(PublishReporter::single(printer));
 
-        if let Some(check_url_client) = &check_url_client {
-            match uv_publish::check_url(
-                check_url_client,
-                &group.file,
-                &group.filename,
+            if let Some(check_url_client) = &check_url_client {
+                match uv_publish::check_url(
+                    check_url_client,
+                    &group.file,
+                    &group.filename,
+                    &download_concurrency,
+                    reporter.clone(),
+                )
+                .await
+                {
+                    Ok(true) => {
+                        writeln!(
+                            printer.stderr(),
+                            "File {} already exists, skipping",
+                            group.filename
+                        )?;
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(err) => {
+                        if dry_run {
+                            write_error_chain_with_options(
+                                &err,
+                                Hints::none(),
+                                ErrorOptions::default().with_stream(printer.stderr()),
+                            )?;
+                            error_count += 1;
+                            continue;
+                        }
+                        return Err(err.into());
+                    }
+                }
+            }
+
+            let bytes = human_readable_bytes(fs_err::metadata(&group.file)?.len());
+            if dry_run {
+                writeln!(
+                    printer.stderr(),
+                    "{} {} {}",
+                    "Checking".bold().cyan(),
+                    group.filename,
+                    format!("({bytes:.1})").dimmed()
+                )?;
+            } else {
+                writeln!(
+                    printer.stderr(),
+                    "{} {} {}",
+                    "Hashing".bold().green(),
+                    group.filename,
+                    format!("({bytes:.1})").dimmed()
+                )?;
+            }
+
+            // Collect the metadata for the file.
+            let form_metadata =
+                match FormMetadata::read_from_file(&group.file, &group.filename, reporter.clone())
+                    .await
+                    .map_err(|err| PublishError::PublishPrepare(group.file.clone(), Box::new(err)))
+                {
+                    Ok(metadata) => metadata,
+                    Err(err) => {
+                        if dry_run {
+                            write_error_chain_with_options(
+                                &err,
+                                Hints::none(),
+                                ErrorOptions::default().with_stream(printer.stderr()),
+                            )?;
+                            error_count += 1;
+                            continue;
+                        }
+                        return Err(err.into());
+                    }
+                };
+
+            if dry_run {
+                continue;
+            }
+
+            writeln!(
+                printer.stderr(),
+                "{} {} {}",
+                "Uploading".bold().green(),
+                group.filename,
+                format!("({bytes:.1})").dimmed()
+            )?;
+
+            let uploaded = upload(
+                &group,
+                &form_metadata,
+                &publish_url,
+                &upload_client,
+                retry_policy,
+                &credentials,
+                check_url_client.as_ref(),
                 &download_concurrency,
                 reporter.clone(),
             )
-            .await
-            {
-                Ok(true) => {
-                    writeln!(
-                        printer.stderr(),
-                        "File {} already exists, skipping",
-                        group.filename
-                    )?;
-                    continue;
-                }
-                Ok(false) => {}
-                Err(err) => {
-                    if dry_run {
-                        write_error_chain_with_options(
-                            &err,
-                            Hints::none(),
-                            ErrorOptions::default().with_stream(printer.stderr()),
-                        )?;
-                        error_count += 1;
-                        continue;
-                    }
-                    return Err(err.into());
-                }
+            .await?;
+            info!("Upload succeeded");
+
+            if !uploaded {
+                writeln!(
+                    printer.stderr(),
+                    "{}",
+                    "File already exists, skipping".dimmed()
+                )?;
             }
         }
 
-        let bytes = human_readable_bytes(fs_err::metadata(&group.file)?.len());
-        if dry_run {
-            writeln!(
-                printer.stderr(),
-                "{} {} {}",
-                "Checking".bold().cyan(),
-                group.filename,
-                format!("({bytes:.1})").dimmed()
-            )?;
-        } else {
-            writeln!(
-                printer.stderr(),
-                "{} {} {}",
-                "Hashing".bold().green(),
-                group.filename,
-                format!("({bytes:.1})").dimmed()
-            )?;
+        if error_count > 0 {
+            let failed = if error_count == 1 { "file" } else { "files" };
+            writeln!(printer.stderr(), "Found issues with {error_count} {failed}")?;
+            return Ok(ExitStatus::Failure);
         }
 
-        // Collect the metadata for the file.
-        let form_metadata =
-            match FormMetadata::read_from_file(&group.file, &group.filename, reporter.clone())
-                .await
-                .map_err(|err| PublishError::PublishPrepare(group.file.clone(), Box::new(err)))
-            {
-                Ok(metadata) => metadata,
-                Err(err) => {
-                    if dry_run {
-                        write_error_chain_with_options(
-                            &err,
-                            Hints::none(),
-                            ErrorOptions::default().with_stream(printer.stderr()),
-                        )?;
-                        error_count += 1;
-                        continue;
-                    }
-                    return Err(err.into());
-                }
-            };
+        Ok(ExitStatus::Success)
+    }
+    .await;
 
-        if dry_run {
-            continue;
-        }
-
-        writeln!(
-            printer.stderr(),
-            "{} {} {}",
-            "Uploading".bold().green(),
-            group.filename,
-            format!("({bytes:.1})").dimmed()
-        )?;
-
-        let uploaded = upload(
-            &group,
-            &form_metadata,
-            &publish_url,
-            &upload_client,
-            retry_policy,
-            &credentials,
-            check_url_client.as_ref(),
-            &download_concurrency,
-            reporter.clone(),
-        )
-        .await?;
-        info!("Upload succeeded");
-
-        if !uploaded {
-            writeln!(
-                printer.stderr(),
-                "{}",
-                "File already exists, skipping".dimmed()
-            )?;
-        }
+    if let Some(token) = trusted_publishing_token
+        && let Err(err) = burn_trusted_publishing_token(&token, &publish_url, &oidc_client).await
+    {
+        warn_user!(
+            "Failed to revoke trusted publishing token: {err}. The token will expire naturally."
+        );
+        debug!("Trusted publishing token revocation failed: {err:?}");
     }
 
-    if error_count > 0 {
-        let failed = if error_count == 1 { "file" } else { "files" };
-        writeln!(printer.stderr(), "Found issues with {error_count} {failed}")?;
-        return Ok(ExitStatus::Failure);
-    }
-
-    Ok(ExitStatus::Success)
+    result
 }
 
 /// Whether to allow prompting for username and password.
@@ -344,7 +359,7 @@ enum Prompt {
 /// If no credentials are found, the auth middleware does a final check for cached credentials and
 /// otherwise errors without sending the request.
 ///
-/// Returns the publish URL, the username and the password.
+/// Returns the publish URL, credentials, and any trusted publishing token to revoke after use.
 async fn gather_credentials(
     mut publish_url: DisplaySafeUrl,
     mut username: Option<String>,
@@ -355,7 +370,7 @@ async fn gather_credentials(
     check_url: Option<&IndexUrl>,
     prompt: Prompt,
     printer: Printer,
-) -> Result<(DisplaySafeUrl, Credentials)> {
+) -> Result<(DisplaySafeUrl, Credentials, Option<TrustedPublishingToken>)> {
     // Support reading username and password from the URL, for symmetry with the index API.
     if let Some(url_password) = publish_url.password() {
         if password.is_some_and(|password| password != url_password) {
@@ -408,31 +423,37 @@ async fn gather_credentials(
         );
     }
 
-    if username.is_none()
-        && password.is_none()
-        && keyring_provider == KeyringProviderType::Disabled
-        && let TrustedPublishResult::Ignored(err) = trusted_publishing_token
-    {
-        // The user has configured something incorrectly:
-        // * The user forgot to configure credentials.
-        // * The user forgot to forward the secrets as env vars (or used the wrong ones).
-        // * The trusted publishing configuration is wrong.
-        writeln!(
-            printer.stderr(),
-            "Note: Neither credentials nor keyring are configured, and there was an error \
-            fetching the trusted publishing token. If you don't want to use trusted \
-            publishing, you can ignore this error, but you need to provide credentials."
-        )?;
+    let trusted_publishing_token = match trusted_publishing_token {
+        TrustedPublishResult::Configured(token) => Some(token),
+        TrustedPublishResult::Skipped => None,
+        TrustedPublishResult::Ignored(err) => {
+            if username.is_none()
+                && password.is_none()
+                && keyring_provider == KeyringProviderType::Disabled
+            {
+                // The user has configured something incorrectly:
+                // * The user forgot to configure credentials.
+                // * The user forgot to forward the secrets as env vars (or used the wrong ones).
+                // * The trusted publishing configuration is wrong.
+                writeln!(
+                    printer.stderr(),
+                    "Note: Neither credentials nor keyring are configured, and there was an error \
+                    fetching the trusted publishing token. If you don't want to use trusted \
+                    publishing, you can ignore this error, but you need to provide credentials."
+                )?;
 
-        trace!("Error trace: {err:?}");
-        write_error_chain_with_options(
-            anyhow::Error::from(err)
-                .context("Trusted publishing failed")
-                .as_ref(),
-            Hints::none(),
-            ErrorOptions::default().with_stream(printer.stderr()),
-        )?;
-    }
+                trace!("Error trace: {err:?}");
+                write_error_chain_with_options(
+                    anyhow::Error::from(err)
+                        .context("Trusted publishing failed")
+                        .as_ref(),
+                    Hints::none(),
+                    ErrorOptions::default().with_stream(printer.stderr()),
+                )?;
+            }
+            None
+        }
+    };
 
     // If applicable, fetch the password from the keyring eagerly to avoid user confusion about
     // missing keyring entries later.
@@ -464,7 +485,7 @@ async fn gather_credentials(
 
     let credentials = Credentials::basic(username, password);
 
-    Ok((publish_url, credentials))
+    Ok((publish_url, credentials, trusted_publishing_token))
 }
 
 fn prompt_username_and_password() -> Result<(Option<String>, Option<String>)> {
@@ -508,6 +529,7 @@ mod tests {
             Printer::Quiet,
         )
         .await
+        .map(|(publish_url, credentials, _)| (publish_url, credentials))
     }
 
     #[tokio::test]

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use uv_static::EnvVars;
 use uv_test::{uv_snapshot, venv_bin_path};
-use wiremock::matchers::{basic_auth, method, path};
+use wiremock::matchers::{basic_auth, body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn test_link(filename: &str) -> PathBuf {
@@ -615,7 +615,7 @@ async fn check_url_missing_package_follows_redirect() {
     );
 }
 
-/// Native GitLab CI trusted publishing using `PYPI_ID_TOKEN`
+/// Native GitLab CI trusted publishing using `PYPI_ID_TOKEN` revokes the token after all uploads.
 #[tokio::test]
 async fn gitlab_trusted_publishing_pypi_id_token() {
     let context = uv_test::test_context!("3.12").with_filtered_sizes();
@@ -645,23 +645,51 @@ async fn gitlab_trusted_publishing_pypi_id_token() {
         .and(path("/upload"))
         .and(basic_auth("__token__", "apitoken"))
         .respond_with(ResponseTemplate::new(200))
+        .expect(2)
         .mount(&server)
         .await;
 
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/burn-token"))
+        .and(body_json(json!({ "token": "apitoken" })))
+        .respond_with(ResponseTemplate::new(202))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Trusted publishing is detected automatically without an explicit flag.
     uv_snapshot!(context.filters(), context.publish()
-        .arg("--trusted-publishing")
-        .arg("always")
         .arg("--publish-url")
         .arg(format!("{}/upload", server.uri()))
         .arg(dummy_wheel())
+        .arg(basic_app_wheel())
         .env(EnvVars::GITLAB_CI, "true")
         .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
     exit_code: 0 (success)
     ----- stderr -----
-    Publishing 1 file to http://[LOCALHOST]/upload
+    Publishing 2 files to http://[LOCALHOST]/upload
+    Hashing basic_app-0.1.0-py3-none-any.whl ([SIZE]KiB)
+    Uploading basic_app-0.1.0-py3-none-any.whl ([SIZE]KiB)
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     "
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("Request recording is enabled");
+    insta::assert_debug_snapshot!(
+        requests.iter().map(|request| request.url.path()).collect::<Vec<_>>(),
+        @r#"
+    [
+        "/_/oidc/audience",
+        "/_/oidc/mint-token",
+        "/upload",
+        "/upload",
+        "/_/oidc/burn-token",
+    ]
+    "#
     );
 }
 
@@ -696,6 +724,15 @@ async fn gitlab_trusted_publishing_testpypi_id_token() {
         .and(path("/upload"))
         .and(basic_auth("__token__", "apitoken"))
         .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/burn-token"))
+        .and(body_json(json!({ "token": "apitoken" })))
+        .respond_with(ResponseTemplate::new(202))
+        .expect(1)
         .mount(&server)
         .await;
 
@@ -708,6 +745,178 @@ async fn gitlab_trusted_publishing_testpypi_id_token() {
         // Emulate GitLab CI with TESTPYPI_ID_TOKEN present
         .env(EnvVars::GITLAB_CI, "true")
         .env(EnvVars::TESTPYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    "
+    );
+}
+
+/// Failure to revoke a token must not change the outcome of publishing.
+#[tokio::test]
+async fn trusted_publishing_burn_failure() {
+    let context = uv_test::test_context!("3.12").with_filtered_sizes();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/_/oidc/audience"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "audience": "pypi" })))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/mint-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": "apitoken" })))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/burn-token"))
+        .and(body_json(json!({ "token": "apitoken" })))
+        // An index implementing the minting API may not support token revocation yet.
+        // Response bodies must not be logged, as they could echo the token.
+        .respond_with(ResponseTemplate::new(404).set_body_raw("apitoken", "text/plain"))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .and(basic_auth("__token__", "apitoken"))
+        .respond_with(ResponseTemplate::new(200))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(dummy_wheel())
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    warning: Failed to revoke trusted publishing token: Failed to fetch: `http://[LOCALHOST]/_/oidc/burn-token`. The token will expire naturally.
+    "
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .and(basic_auth("__token__", "apitoken"))
+        .respond_with(ResponseTemplate::new(400).set_body_raw("Upload failed", "text/plain"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(dummy_wheel())
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    warning: Failed to revoke trusted publishing token: Failed to fetch: `http://[LOCALHOST]/_/oidc/burn-token`. The token will expire naturally.
+    error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
+      Caused by: Server returned status code 400 Bad Request. Server says: Upload failed
+    "
+    );
+}
+
+/// A token is revoked even if reading distribution metadata fails before the upload.
+#[tokio::test]
+async fn trusted_publishing_burn_after_prepare_failure() {
+    let context = uv_test::test_context!("3.12").with_filtered_sizes();
+    let server = MockServer::start().await;
+    let wheel = context.temp_dir.child("a-1.0.0-py3-none-any.whl");
+    wheel.touch().expect("Failed to create wheel");
+
+    Mock::given(method("GET"))
+        .and(path("/_/oidc/audience"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "audience": "pypi" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/mint-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": "apitoken" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/burn-token"))
+        .and(body_json(json!({ "token": "apitoken" })))
+        .respond_with(ResponseTemplate::new(202))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(wheel.path())
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Hashing a-1.0.0-py3-none-any.whl ([SIZE]B)
+    error: Failed to publish: `a-1.0.0-py3-none-any.whl`
+      Caused by: Failed to read metadata
+      Caused by: Failed to read from zip file
+      Caused by: unable to locate the end of central directory record
+    "
+    );
+}
+
+/// Explicit credentials are not revoked, even in a trusted publishing environment.
+#[tokio::test]
+async fn trusted_publishing_does_not_burn_explicit_token() {
+    let context = uv_test::test_context!("3.12").with_filtered_sizes();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/burn-token"))
+        .respond_with(ResponseTemplate::new(202))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .and(basic_auth("__token__", "explicit-token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--token")
+        .arg("explicit-token")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(dummy_wheel())
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Publishing 1 file to http://[LOCALHOST]/upload

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -803,7 +803,7 @@ async fn trusted_publishing_burn_failure() {
     Publishing 1 file to http://[LOCALHOST]/upload
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
-    warning: Failed to revoke trusted publishing token: Failed to fetch: `http://[LOCALHOST]/_/oidc/burn-token`. The token will expire naturally.
+    warning: Failed to invalidate trusted publishing token. It will expire naturally. Cause: Failed to fetch: `http://[LOCALHOST]/_/oidc/burn-token`
     "
     );
 
@@ -828,7 +828,7 @@ async fn trusted_publishing_burn_failure() {
     Publishing 1 file to http://[LOCALHOST]/upload
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
-    warning: Failed to revoke trusted publishing token: Failed to fetch: `http://[LOCALHOST]/_/oidc/burn-token`. The token will expire naturally.
+    warning: Failed to invalidate trusted publishing token. It will expire naturally. Cause: Failed to fetch: `http://[LOCALHOST]/_/oidc/burn-token`
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
       Caused by: Server returned status code 400 Bad Request. Server says: Upload failed
     "

--- a/docs/guides/package.md
+++ b/docs/guides/package.md
@@ -136,6 +136,10 @@ PyPI from GitHub Actions or another Trusted Publisher, you don't need to set any
 Instead,
 [add a trusted publisher to the PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).
 
+When using trusted publishing, uv requests revocation of the short-lived PyPI token after
+publishing, even if publishing fails. If revocation fails, uv emits a warning without changing the
+publishing result. Tokens provided explicitly with `--token` or `UV_PUBLISH_TOKEN` are not revoked.
+
 !!! note
 
     PyPI does not support publishing with username and password anymore, instead you need to

--- a/docs/guides/package.md
+++ b/docs/guides/package.md
@@ -136,9 +136,12 @@ PyPI from GitHub Actions or another Trusted Publisher, you don't need to set any
 Instead,
 [add a trusted publisher to the PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).
 
-When using trusted publishing, uv requests revocation of the short-lived PyPI token after
-publishing, even if publishing fails. If revocation fails, uv emits a warning without changing the
-publishing result. Tokens provided explicitly with `--token` or `UV_PUBLISH_TOKEN` are not revoked.
+When using trusted publishing, uv will attempt to invalidate the short-lived PyPI token after
+publishing, even if publishing fails. This further reduces the exposure period for the short-lived
+token, beyond its already short lifetime.
+
+If invalidation fails, uv emits a warning without changing the publishing result. Tokens provided
+explicitly with `--token` or `UV_PUBLISH_TOKEN` are not revoked.
 
 !!! note
 


### PR DESCRIPTION
## Summary

~~WIP, not ready yet.~~

See https://github.com/pypi/warehouse/pull/20197 for context.

TL;DR PyPI now lets TP clients "burn" their token after they're done using it, allowing it to be proactively revoked rather than expiring on its own terms. This results in a small net posture improvement, since the short lived TP token's lifetime becomes even shorter.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added integration tests. The real publishing tests should also continue to function. 

<!-- How was it tested? -->
