### PR TITLE
Add UV_LOCKED to all of our CI workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,6 +13,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   benchmarks-walltime-build:

--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -14,6 +14,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   build-binary-linux-libc:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -33,6 +33,7 @@ env:
   ACTIONS_CACHE_MODE: none
   UV_GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ inputs.push-dev && 'uv-dev' || 'uv' }}
   UV_DOCKERHUB_IMAGE: ${{ !inputs.push-dev && 'docker.io/astral/uv' || '' }}
+  UV_LOCKED: 1
 
 permissions:
   contents: read

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -29,6 +29,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 permissions:
   contents: read

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -4,6 +4,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   docs:
     timeout-minutes: 10

--- a/.github/workflows/check-fmt.yml
+++ b/.github/workflows/check-fmt.yml
@@ -4,6 +4,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   rust:
     timeout-minutes: 10

--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -17,6 +17,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   cargo-dev-generate-all:

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -19,6 +19,7 @@ env:
   # renovate: datasource=github-releases depName=astral-sh/hawk
   HAWK_VERSION: 0.1.13
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   ruff:

--- a/.github/workflows/check-lock.yml
+++ b/.github/workflows/check-lock.yml
@@ -4,6 +4,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   lock:
     timeout-minutes: 10

--- a/.github/workflows/check-publish.yml
+++ b/.github/workflows/check-publish.yml
@@ -9,6 +9,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   cargo-publish-dry-run:

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   dist-plan:
     name: "dist plan"

--- a/.github/workflows/check-zizmor.yml
+++ b/.github/workflows/check-zizmor.yml
@@ -4,6 +4,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   zizmor:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   plan:
     uses: $/.github/workflows/plan.yml

--- a/.github/workflows/diagnose-workflow-failure.yml
+++ b/.github/workflows/diagnose-workflow-failure.yml
@@ -17,6 +17,7 @@ permissions: {}
 
 env:
   MAX_FLAKE_RERUN_ATTEMPTS: "3"
+  UV_LOCKED: 1
 
 jobs:
   diagnose:

--- a/.github/workflows/fix-bug.yml
+++ b/.github/workflows/fix-bug.yml
@@ -47,6 +47,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   fix:
     if: github.repository == 'astral-sh/uv'

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -13,6 +13,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   initialize-context:
     if: github.repository == 'astral-sh/uv'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -67,6 +67,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   plan:
     runs-on: depot-ubuntu-24.04

--- a/.github/workflows/promote-pull-request.yml
+++ b/.github/workflows/promote-pull-request.yml
@@ -18,6 +18,7 @@ env:
   UV_REPOSITORY_ID: "699532645"
   AUTOMATIONS_BOT_ID: "305554984"
   UV_SECURITY_PUBLISH_LABEL: "bot:promote"
+  UV_LOCKED: 1
 
 concurrency:
   group: promote-pull-request-${{ inputs.pull_request }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   ACTIONS_CACHE_MODE: none
+  UV_LOCKED: 1
 
 jobs:
   crates-publish-uv:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,6 +21,7 @@ permissions: {}
 
 env:
   ACTIONS_CACHE_MODE: none
+  UV_LOCKED: 1
 
 jobs:
   mkdocs:

--- a/.github/workflows/publish-mirror.yml
+++ b/.github/workflows/publish-mirror.yml
@@ -14,6 +14,7 @@ permissions: {}
 
 env:
   ACTIONS_CACHE_MODE: none
+  UV_LOCKED: 1
 
 jobs:
   publish-mirror:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   ACTIONS_CACHE_MODE: none
+  UV_LOCKED: 1
 
 jobs:
   pypi-publish-uv:

--- a/.github/workflows/publish-versions.yml
+++ b/.github/workflows/publish-versions.yml
@@ -15,6 +15,7 @@ permissions: {}
 
 env:
   ACTIONS_CACHE_MODE: none
+  UV_LOCKED: 1
 
 jobs:
   publish-versions:

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -29,6 +29,9 @@ concurrency:
   # Let an in-progress rebase finish; newer pushes replace the single pending run.
   cancel-in-progress: false
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   identify:
     name: Identify conflicted pull requests

--- a/.github/workflows/pull-request-labels.yml
+++ b/.github/workflows/pull-request-labels.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ inputs.pull_request }}
   cancel-in-progress: true
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   labels:
     if: github.repository == 'astral-sh/uv' || github.repository == 'astral-sh/uv-dev'

--- a/.github/workflows/pull-request-security-review.yml
+++ b/.github/workflows/pull-request-security-review.yml
@@ -3,6 +3,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   review:
     name: "security review"

--- a/.github/workflows/rebase-conflicted-pull-request.yml
+++ b/.github/workflows/rebase-conflicted-pull-request.yml
@@ -25,6 +25,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   rebase:
     name: "Rebase pull request #${{ inputs.number }}"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -11,6 +11,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   prepare-release:
     if: github.repository == 'astral-sh/uv'

--- a/.github/workflows/reproduce-bug.yml
+++ b/.github/workflows/reproduce-bug.yml
@@ -57,6 +57,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   reproduce:
     if: github.repository == 'astral-sh/uv'

--- a/.github/workflows/sync-python-releases.yml
+++ b/.github/workflows/sync-python-releases.yml
@@ -9,6 +9,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   sync:
     if: github.repository == 'astral-sh/uv'

--- a/.github/workflows/sync-uv-dev.yml
+++ b/.github/workflows/sync-uv-dev.yml
@@ -11,6 +11,9 @@ concurrency:
   group: sync-uv-dev-main
   cancel-in-progress: false
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   sync:
     name: Sync uv-dev

--- a/.github/workflows/sync-uv-security.yml
+++ b/.github/workflows/sync-uv-security.yml
@@ -11,6 +11,9 @@ concurrency:
   group: sync-uv-security-main
   cancel-in-progress: false
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   sync:
     name: Sync uv-security

--- a/.github/workflows/test-ecosystem.yml
+++ b/.github/workflows/test-ecosystem.yml
@@ -58,6 +58,9 @@ jobs:
         run: chmod +x ./uv
 
       - name: "Test"
+        env:
+          # These commands intentionally create and upgrade ecosystem lockfiles.
+          UV_LOCKED: 0
         run: |
           echo '${{ toJSON(matrix.commands) }}' | jq -r '.[]' | while read cmd; do
             echo "+ $cmd" >&2

--- a/.github/workflows/test-ecosystem.yml
+++ b/.github/workflows/test-ecosystem.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   ecosystem-test:
     name: "${{ matrix.repo }}"

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -15,6 +15,7 @@ env:
   CARGO_TERM_COLOR: always
   PYTHON_VERSION: "3.12"
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   integration-test-nushell:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -801,6 +801,9 @@ jobs:
     name: "github actions"
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    env:
+      # This job creates and updates test projects without existing lockfiles.
+      UV_LOCKED: 0
     steps:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -14,6 +14,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   smoke-test-linux:

--- a/.github/workflows/test-system.yml
+++ b/.github/workflows/test-system.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   system-test-debian:
     timeout-minutes: 10

--- a/.github/workflows/test-windows-trampolines.yml
+++ b/.github/workflows/test-windows-trampolines.yml
@@ -15,6 +15,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   # Verify windows crate version matches between workspaces

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ env:
   PYTHON_VERSION: "3.12"
   RUSTC_BOOTSTRAP: 1
   RUSTUP_MAX_RETRIES: 10
+  UV_LOCKED: 1
 
 jobs:
   # We use the large GitHub actions runners

--- a/.github/workflows/update-issue-context.yml
+++ b/.github/workflows/update-issue-context.yml
@@ -7,6 +7,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   update:
     if: github.repository == 'astral-sh/uv' && !github.event.issue.pull_request

--- a/.github/workflows/update-pull-request-parent.yml
+++ b/.github/workflows/update-pull-request-parent.yml
@@ -37,6 +37,9 @@ on:
 
 permissions: {}
 
+env:
+  UV_LOCKED: 1
+
 jobs:
   update:
     name: "Update parent of pull request #${{ inputs.number }}"

--- a/crates/uv-bench/benches/workspace_discovery.rs
+++ b/crates/uv-bench/benches/workspace_discovery.rs
@@ -352,6 +352,8 @@ fn run_python_version_cli(workspace_dir: &str, cache_dir: &str, offline: bool) -
     let mut args = vec![
         "uv",
         "run",
+        // The synthetic workspace needs to create and update its own lockfile.
+        "--no-locked",
         "--directory",
         workspace_dir,
         "--cache-dir",

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -1205,6 +1205,13 @@ impl TestContext {
         command
     }
 
+    /// Create a command for an external program with the test environment.
+    pub fn child_command(&self, program: impl AsRef<Path>) -> Command {
+        let mut command = Self::new_command_with(program.as_ref());
+        self.add_shared_env(&mut command, false);
+        command
+    }
+
     pub fn disallow_git_cli(bin_dir: &Path) -> std::io::Result<()> {
         let contents = r"#!/bin/sh
     echo 'error: `git` operations are not allowed — are you missing a cfg for the `git` feature?' >&2

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -1206,7 +1206,7 @@ impl TestContext {
     }
 
     /// Create a command for an external program with the test environment.
-    pub fn child_command(&self, program: impl AsRef<Path>) -> Command {
+    pub fn external_command(&self, program: impl AsRef<Path>) -> Command {
         let mut command = Self::new_command_with(program.as_ref());
         self.add_shared_env(&mut command, false);
         command

--- a/crates/uv/tests/it/resource_limits.rs
+++ b/crates/uv/tests/it/resource_limits.rs
@@ -1,5 +1,3 @@
-use std::process::Command;
-
 use uv_static::EnvVars;
 use uv_test::{get_bin, uv_snapshot};
 
@@ -8,8 +6,7 @@ fn adjust_open_file_limit() {
     let context = uv_test::test_context!("3.12");
     let python = &context.python_versions[0].1;
 
-    let mut command = Command::new("sh");
-    context.add_shared_env(&mut command, false);
+    let mut command = context.child_command("sh");
     command
         .arg("-c")
         .arg("ulimit -S -n 128; exec \"$@\"")
@@ -80,8 +77,7 @@ fn run_open_file_limit_override_exceeds_hard_limit() {
     let context = uv_test::test_context!("3.12");
     let python = &context.python_versions[0].1;
 
-    let mut command = Command::new("sh");
-    context.add_shared_env(&mut command, false);
+    let mut command = context.child_command("sh");
     command
         .arg("-c")
         .arg("ulimit -S -n 128; ulimit -H -n 128; exec \"$@\"")

--- a/crates/uv/tests/it/resource_limits.rs
+++ b/crates/uv/tests/it/resource_limits.rs
@@ -6,7 +6,7 @@ fn adjust_open_file_limit() {
     let context = uv_test::test_context!("3.12");
     let python = &context.python_versions[0].1;
 
-    let mut command = context.child_command("sh");
+    let mut command = context.external_command("sh");
     command
         .arg("-c")
         .arg("ulimit -S -n 128; exec \"$@\"")
@@ -77,7 +77,7 @@ fn run_open_file_limit_override_exceeds_hard_limit() {
     let context = uv_test::test_context!("3.12");
     let python = &context.python_versions[0].1;
 
-    let mut command = context.child_command("sh");
+    let mut command = context.external_command("sh");
     command
         .arg("-c")
         .arg("ulimit -S -n 128; ulimit -H -n 128; exec \"$@\"")

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -5836,13 +5836,12 @@ fn detect_infinite_recursion() -> Result<()> {
 
     fs_err::set_permissions(test_script.path(), PermissionsExt::from_mode(0o0744))?;
 
-    let mut cmd = std::process::Command::new(test_script.as_os_str());
-    context.add_shared_env(&mut cmd, false);
+    let mut command = context.child_command(&test_script);
 
     // Set the max recursion depth to a lower amount to speed up testing.
-    cmd.env(EnvVars::UV_RUN_MAX_RECURSION_DEPTH, "5");
+    command.env(EnvVars::UV_RUN_MAX_RECURSION_DEPTH, "5");
 
-    uv_snapshot!(context.filters(), cmd, @"
+    uv_snapshot!(context.filters(), command, @"
     exit_code: 2 (failure)
     ----- stderr -----
     error: `uv run` was recursively invoked 6 times which exceeds the limit of 5

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -5836,7 +5836,7 @@ fn detect_infinite_recursion() -> Result<()> {
 
     fs_err::set_permissions(test_script.path(), PermissionsExt::from_mode(0o0744))?;
 
-    let mut command = context.child_command(&test_script);
+    let mut command = context.external_command(&test_script);
 
     // Set the max recursion depth to a lower amount to speed up testing.
     command.env(EnvVars::UV_RUN_MAX_RECURSION_DEPTH, "5");

--- a/scripts/build_uv_pgo.py
+++ b/scripts/build_uv_pgo.py
@@ -372,6 +372,8 @@ def run_workloads(
         raise RuntimeError(f"uv binary not found: {binary}")
 
     training_environment = environment.copy()
+    # Training creates lockfiles for the corpus independently of CI's locked mode.
+    training_environment.pop("UV_LOCKED", None)
     training_environment.pop("UV_OFFLINE", None)
     training_environment.update(
         {

--- a/scripts/registries-test.py
+++ b/scripts/registries-test.py
@@ -234,6 +234,8 @@ def run_test(
             cmd.extend(["-" + "v" * verbosity])
 
         command_env = env.copy()
+        # Each test creates a project without a lockfile; ignore the runner's locked mode.
+        command_env.pop("UV_LOCKED", None)
         if require_metadata_range_requests:
             command_env["UV_REQUIRE_METADATA_RANGE_REQUESTS"] = "true"
 


### PR DESCRIPTION
## Summary

~~This will almost certainly break something, keeping drafted for now.~~

This sets `UV_LOCKED=1` at the top of all of our workflows. I haven't bothered to prune out superfluous `--locked` flags yet, I figure that's good for a follow-up? But can also do it here.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

NFC, CI.

<!-- How was it tested? -->
