### PR TITLE
Omit yanked files from lockfiles

### DIFF
--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -422,7 +422,18 @@ impl PrioritizedDist {
         }
         // Track the highest-priority source.
         if let Some((.., existing_compatibility)) = &self.0.source {
-            if compatibility.is_more_compatible(existing_compatibility) {
+            // Prefer a source that can be retained in the lockfile, even if builds are disabled.
+            let is_preferred = match (
+                compatibility.is_excluded(),
+                existing_compatibility.is_excluded(),
+            ) {
+                (false, true) => true,
+                (true, false) => false,
+                (false, false) | (true, true) => {
+                    compatibility.is_more_compatible(existing_compatibility)
+                }
+            };
+            if is_preferred {
                 self.0.source = Some((dist, compatibility));
             }
         } else {
@@ -540,7 +551,12 @@ impl PrioritizedDist {
             adjusted_wheels.push(wheel.clone());
         }
 
-        let sdist = self.0.source.as_ref().map(|(sdist, _)| sdist.clone());
+        let sdist = self
+            .0
+            .source
+            .as_ref()
+            .filter(|(_, compatibility)| !compatibility.is_excluded())
+            .map(|(sdist, _)| sdist.clone());
         Some(RegistryBuiltDist {
             wheels: adjusted_wheels,
             best_wheel_index: adjusted_best_index,
@@ -565,6 +581,7 @@ impl PrioritizedDist {
             .0
             .wheels
             .iter()
+            .filter(|(_, compatibility)| !compatibility.is_excluded())
             .map(|(wheel, _)| wheel.clone())
             .collect();
         Some(sdist)
@@ -681,7 +698,18 @@ impl WheelCompatibility {
 
     /// Return `true` if the distribution is excluded.
     fn is_excluded(&self) -> bool {
-        matches!(self, Self::Incompatible(IncompatibleWheel::ExcludeNewer(_)))
+        match self {
+            Self::Incompatible(
+                IncompatibleWheel::ExcludeNewer(_) | IncompatibleWheel::Yanked(_),
+            ) => true,
+            Self::Incompatible(
+                IncompatibleWheel::Tag(_)
+                | IncompatibleWheel::RequiresPython(..)
+                | IncompatibleWheel::NoBinary
+                | IncompatibleWheel::MissingPlatform(_),
+            )
+            | Self::Compatible(..) => false,
+        }
     }
 
     /// Return `true` if the current compatibility is more compatible than another.
@@ -713,10 +741,17 @@ impl SourceDistCompatibility {
 
     /// Return `true` if the distribution is excluded.
     fn is_excluded(&self) -> bool {
-        matches!(
-            self,
-            Self::Incompatible(IncompatibleSource::ExcludeNewer(_))
-        )
+        match self {
+            Self::Incompatible(
+                IncompatibleSource::ExcludeNewer(_) | IncompatibleSource::Yanked(_),
+            ) => true,
+            Self::Incompatible(
+                IncompatibleSource::RequiresPython(..)
+                | IncompatibleSource::NoBuild
+                | IncompatibleSource::NotPep625Filename,
+            )
+            | Self::Compatible(_) => false,
+        }
     }
 
     /// Return the higher priority compatibility.

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -729,11 +729,6 @@ impl VersionMapLazy {
         excluded: bool,
         upload_time: Option<i64>,
     ) -> SourceDistCompatibility {
-        // Check if builds are disabled
-        if self.no_build {
-            return SourceDistCompatibility::Incompatible(IncompatibleSource::NoBuild);
-        }
-
         // Check if after upload time cutoff
         if excluded {
             return SourceDistCompatibility::Incompatible(IncompatibleSource::ExcludeNewer(
@@ -752,6 +747,11 @@ impl VersionMapLazy {
                     yanked.clone(),
                 ));
             }
+        }
+
+        // Check file exclusions before build settings so excluded files are omitted from the lock.
+        if self.no_build {
+            return SourceDistCompatibility::Incompatible(IncompatibleSource::NoBuild);
         }
 
         // Check if the filename is PEP 625-compliant.
@@ -790,11 +790,6 @@ impl VersionMapLazy {
         excluded: bool,
         upload_time: Option<i64>,
     ) -> WheelCompatibility {
-        // Check if binaries are disabled
-        if self.no_binary {
-            return WheelCompatibility::Incompatible(IncompatibleWheel::NoBinary);
-        }
-
         // Check if after upload time cutoff
         if excluded {
             return WheelCompatibility::Incompatible(IncompatibleWheel::ExcludeNewer(upload_time));
@@ -805,6 +800,11 @@ impl VersionMapLazy {
             if yanked.is_yanked() && !self.allowed_yanks.contains(name, version) {
                 return WheelCompatibility::Incompatible(IncompatibleWheel::Yanked(yanked.clone()));
             }
+        }
+
+        // Check file exclusions before build settings so excluded files are omitted from the lock.
+        if self.no_binary {
+            return WheelCompatibility::Incompatible(IncompatibleWheel::NoBinary);
         }
 
         // Determine a compatibility for the wheel based on tags.

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -35102,6 +35102,455 @@ fn lock_invalid_fork_markers() -> Result<()> {
     Ok(())
 }
 
+/// Omit yanked files even when another wheel makes the release usable.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_omit_yanked_files() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+    let server = MockServer::start().await;
+
+    let simple_index = json!({
+        "meta": { "api-version": "1.1" },
+        "name": "basic-package",
+        "files": [{
+            "filename": "basic_package-0.1.0-1-py3-none-any.whl",
+            "url": format!("{}/files/basic_package-0.1.0-1-py3-none-any.whl", server.uri()),
+            "hashes": { "sha256": "7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+            "core-metadata": true,
+            "yanked": "broken wheel"
+        }, {
+            "filename": "basic_package-0.1.0-py3-none-any.whl",
+            "url": format!("{}/files/basic_package-0.1.0-py3-none-any.whl", server.uri()),
+            "hashes": { "sha256": "7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+            "core-metadata": true,
+            "yanked": false
+        }, {
+            "filename": "basic_package-0.1.0.tar.gz",
+            "url": format!("{}/files/basic_package-0.1.0.tar.gz", server.uri()),
+            "hashes": { "sha256": "af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4" },
+            "yanked": true
+        }]
+    });
+    Mock::given(method("GET"))
+        .and(path("/simple/basic-package/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            simple_index.to_string(),
+            "application/vnd.pypi.simple.v1+json",
+        ))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/files/basic_package-0.1.0-py3-none-any.whl.metadata"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(indoc! {"
+            Metadata-Version: 2.3
+            Name: basic-package
+            Version: 0.1.0
+            Requires-Python: >=3.13
+        "}))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/files/basic_package-0.1.0-py3-none-any.whl"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_bytes(fs_err::read(
+                context
+                    .workspace_root
+                    .join("test/links/basic_package-0.1.0-py3-none-any.whl"),
+            )?),
+        )
+        .mount(&server)
+        .await;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["basic-package>=0.1.0"]
+
+        [[tool.uv.index]]
+        url = "{}/simple"
+        default = true
+    "#, server.uri()})?;
+
+    uv_snapshot!(context.filters(), context.lock().env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.13"
+
+        [[package]]
+        name = "basic-package"
+        version = "0.1.0"
+        source = { registry = "http://[LOCALHOST]/simple" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/basic_package-0.1.0-py3-none-any.whl", hash = "sha256:7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "basic-package" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "basic-package", specifier = ">=0.1.0" }]
+        "#);
+    });
+
+    // The yanked wheel has a higher build tag, so retaining it would break frozen sync.
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + basic-package==0.1.0
+    ");
+
+    let lock = context.read("uv.lock");
+    uv_snapshot!(context.filters(), context.lock().arg("--upgrade").arg("--no-build").env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+    assert_eq!(context.read("uv.lock"), lock);
+
+    Ok(())
+}
+
+/// Omit yanked wheels when resolving from a source distribution.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_omit_yanked_wheel_with_sdist() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+    let server = MockServer::start().await;
+
+    let simple_index = json!({
+        "meta": { "api-version": "1.1" },
+        "name": "basic-package",
+        "files": [{
+            "filename": "basic_package-0.1.0-py3-none-any.whl",
+            "url": format!("{}/files/basic_package-0.1.0-py3-none-any.whl", server.uri()),
+            "hashes": { "sha256": "7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+            "core-metadata": true,
+            "yanked": true
+        }, {
+            "filename": "basic_package-0.1.0.tar.gz",
+            "url": format!("{}/files/basic_package-0.1.0.tar.gz", server.uri()),
+            "hashes": { "sha256": "af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4" }
+        }]
+    });
+    Mock::given(method("GET"))
+        .and(path("/simple/basic-package/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            simple_index.to_string(),
+            "application/vnd.pypi.simple.v1+json",
+        ))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/files/basic_package-0.1.0.tar.gz"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_bytes(fs_err::read(
+                context
+                    .workspace_root
+                    .join("test/links/basic_package-0.1.0.tar.gz"),
+            )?),
+        )
+        .mount(&server)
+        .await;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["basic-package>=0.1.0"]
+
+        [[tool.uv.index]]
+        url = "{}/simple"
+        default = true
+    "#, server.uri()})?;
+
+    uv_snapshot!(context.filters(), context.lock().env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.13"
+
+        [[package]]
+        name = "basic-package"
+        version = "0.1.0"
+        source = { registry = "http://[LOCALHOST]/simple" }
+        sdist = { url = "http://[LOCALHOST]/files/basic_package-0.1.0.tar.gz", hash = "sha256:af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4" }
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "basic-package" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "basic-package", specifier = ">=0.1.0" }]
+        "#);
+    });
+
+    let lock = context.read("uv.lock");
+    uv_snapshot!(context.filters(), context.lock().arg("--upgrade").arg("--no-binary").env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+    assert_eq!(context.read("uv.lock"), lock);
+
+    Ok(())
+}
+
+/// Use an unyanked incompatible wheel for metadata while locking only the source distribution.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_omit_yanked_wheel_with_incompatible_wheel() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+    let server = MockServer::start().await;
+
+    let simple_index = json!({
+        "meta": { "api-version": "1.1" },
+        "name": "basic-package",
+        "files": [{
+            "filename": "basic_package-0.1.0-py3-none-any.whl",
+            "url": format!("{}/files/basic_package-0.1.0-py3-none-any.whl", server.uri()),
+            "hashes": { "sha256": "7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+            "core-metadata": true,
+            "yanked": true
+        }, {
+            "filename": "basic_package-0.1.0-cp312-cp312-any.whl",
+            "url": format!("{}/files/basic_package-0.1.0-cp312-cp312-any.whl", server.uri()),
+            "hashes": { "sha256": "7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+            "core-metadata": true
+        }, {
+            "filename": "basic_package-0.1.0.tar.gz",
+            "url": format!("{}/files/basic_package-0.1.0.tar.gz", server.uri()),
+            "hashes": { "sha256": "af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4" }
+        }]
+    });
+    Mock::given(method("GET"))
+        .and(path("/simple/basic-package/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            simple_index.to_string(),
+            "application/vnd.pypi.simple.v1+json",
+        ))
+        .mount(&server)
+        .await;
+    // Only the incompatible wheel's metadata is available; the sdist cannot be downloaded.
+    Mock::given(method("GET"))
+        .and(path(
+            "/files/basic_package-0.1.0-cp312-cp312-any.whl.metadata",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(indoc! {"
+            Metadata-Version: 2.3
+            Name: basic-package
+            Version: 0.1.0
+        "}))
+        .mount(&server)
+        .await;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["basic-package>=0.1.0"]
+
+        [[tool.uv.index]]
+        url = "{}/simple"
+        default = true
+    "#, server.uri()})?;
+
+    uv_snapshot!(context.filters(), context.lock().env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.13"
+
+        [[package]]
+        name = "basic-package"
+        version = "0.1.0"
+        source = { registry = "http://[LOCALHOST]/simple" }
+        sdist = { url = "http://[LOCALHOST]/files/basic_package-0.1.0.tar.gz", hash = "sha256:af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4" }
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "basic-package" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "basic-package", specifier = ">=0.1.0" }]
+        "#);
+    });
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--locked")
+        .arg("--offline")
+        .arg("--no-cache")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+    assert_eq!(context.read("uv.lock"), lock);
+
+    Ok(())
+}
+
+/// Retain an unyanked source archive when builds are disabled and another source archive is yanked.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_omit_yanked_sdist_no_build() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+    let server = MockServer::start().await;
+
+    let simple_index = json!({
+        "meta": { "api-version": "1.1" },
+        "name": "basic-package",
+        "files": [{
+            "filename": "basic_package-0.1.0-py3-none-any.whl",
+            "url": format!("{}/files/basic_package-0.1.0-py3-none-any.whl", server.uri()),
+            "hashes": { "sha256": "7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+            "core-metadata": true
+        }, {
+            "filename": "basic_package-0.1.0.tar.gz",
+            "url": format!("{}/files/basic_package-0.1.0.tar.gz", server.uri()),
+            "hashes": { "sha256": "af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4" }
+        }, {
+            "filename": "basic_package-0.1.0.zip",
+            "url": format!("{}/files/basic_package-0.1.0.zip", server.uri()),
+            "hashes": {},
+            "yanked": true
+        }]
+    });
+    Mock::given(method("GET"))
+        .and(path("/simple/basic-package/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            simple_index.to_string(),
+            "application/vnd.pypi.simple.v1+json",
+        ))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/files/basic_package-0.1.0-py3-none-any.whl.metadata"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(indoc! {"
+            Metadata-Version: 2.3
+            Name: basic-package
+            Version: 0.1.0
+            Requires-Python: >=3.13
+        "}))
+        .mount(&server)
+        .await;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["basic-package>=0.1.0"]
+
+        [[tool.uv.index]]
+        url = "{}/simple"
+        default = true
+    "#, server.uri()})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--no-build").env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("uv.lock"), @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.13"
+
+        [[package]]
+        name = "basic-package"
+        version = "0.1.0"
+        source = { registry = "http://[LOCALHOST]/simple" }
+        sdist = { url = "http://[LOCALHOST]/files/basic_package-0.1.0.tar.gz", hash = "sha256:af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4" }
+        wheels = [
+            { url = "http://[LOCALHOST]/files/basic_package-0.1.0-py3-none-any.whl", hash = "sha256:7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "basic-package" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "basic-package", specifier = ">=0.1.0" }]
+        "#);
+    });
+
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--no-binary").arg("--dry-run"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would use project environment at: .venv
+    Would download 1 package
+    Would install 1 package
+     + basic-package==0.1.0
+    ");
+
+    Ok(())
+}
+
 #[cfg(feature = "test-universal")]
 #[test]
 fn lock_omit_wheels_exclude_newer() -> Result<()> {


### PR DESCRIPTION
When only some files in a release are yanked, uv can exclude them during resolution but still write their URLs into `uv.lock`. A later `uv sync --frozen` can select one of those files.

Apply the resolver's yank exclusions to both wheel and sdist entries, including with `--no-build` or `--no-binary`. Prefer an unyanked source archive when another is excluded, so the lock keeps its source fallback. The existing exceptions for explicit pins and locked versions still apply.

Add regression coverage for frozen installs, source and incompatible-wheel metadata, build restrictions, and offline lock validation.

Fixes #21430.
