### PR TITLE
Use papaya without fast-barrier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,9 +3217,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "papaya"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+checksum = "da2442474a9404698c42509b8967f437249dbc7b50493e83020333d3943ec0ae"
 dependencies = [
  "equivalent",
  "seize",
@@ -4590,10 +4590,6 @@ name = "seize"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "self-replace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ memchr = { version = "2.7.4" }
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 nix = { version = "0.31.2", features = ["resource", "signal"] }
 owo-colors = { version = "4.1.0" }
-papaya = { version = "0.2.4" }
+papaya = { version = "0.2.4" , default-features = false }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 percent-encoding = { version = "2.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ memchr = { version = "2.7.4" }
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 nix = { version = "0.31.2", features = ["resource", "signal"] }
 owo-colors = { version = "4.1.0" }
-papaya = { version = "0.2.4" , default-features = false }
+papaya = { version = "0.2.5" , default-features = false }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 percent-encoding = { version = "2.3.1" }


### PR DESCRIPTION
Remove the fast-barrier feature from seize through papaya, to remove the performance bottleneck identified in https://github.com/astral-sh/uv/pull/20989.

Initializing the hashmap is fast, but I didn't see walltime changes, due to the workaround https://github.com/astral-sh/uv/pull/20989. The effect is rather that we can remove that workaround.