### PR TITLE
Finalize publishing sessions with an explicit outcome

### DIFF
--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1,5 +1,6 @@
 mod trusted_publishing;
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -172,6 +173,27 @@ pub trait Reporter: Send + Sync + 'static {
     fn on_hash_complete(&self, id: usize);
 }
 
+/// Credentials for publishing, including whether they require revocation after use.
+pub enum PublishingCredentials {
+    /// Credentials supplied by the user or resolved by the authentication middleware.
+    Supplied(Credentials),
+    /// A short-lived token obtained through trusted publishing.
+    TrustedPublishing(TrustedPublishingToken),
+}
+
+impl PublishingCredentials {
+    /// Return the HTTP credentials to use for uploads.
+    pub fn as_credentials(&self) -> Cow<'_, Credentials> {
+        match self {
+            Self::Supplied(credentials) => Cow::Borrowed(credentials),
+            Self::TrustedPublishing(token) => Cow::Owned(Credentials::basic(
+                Some("__token__".to_string()),
+                Some(token.to_string()),
+            )),
+        }
+    }
+}
+
 /// The result of uploading a prepared distribution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UploadOutcome {
@@ -179,6 +201,25 @@ pub enum UploadOutcome {
     Uploaded,
     /// An identical file already exists on the registry.
     AlreadyExists,
+}
+
+/// The outcome of preparation and uploads, before finalizing the session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishOutcome {
+    /// All files were uploaded or skipped because they did not require uploading.
+    Success,
+    /// Preparation or uploading failed.
+    Failed,
+    /// Validation succeeded without uploading any files.
+    DryRun,
+}
+
+/// A failure while finalizing a publishing session.
+#[derive(Debug, Error)]
+pub enum PublishFinalizeError {
+    /// Token invalidation is best effort and must not change the publishing result.
+    #[error("Failed to invalidate trusted publishing token")]
+    TokenInvalidation(#[source] TrustedPublishingError),
 }
 
 /// A distribution and its associated attestation paths, collected by [`PublishSession::prepare`].
@@ -254,15 +295,19 @@ struct CheckUrlClient<'a> {
     cache: &'a Cache,
 }
 
-/// Shared state for preparing and uploading a set of distributions.
+/// Shared state for preparing, uploading, and finalizing a set of distributions.
 ///
 /// Collect distributions with [`Self::prepare`], then pass each one to [`Self::upload`].
-/// Hashes, metadata, and attestations are read immediately before each upload.
-#[must_use]
+/// Hashes, metadata, and attestations are read immediately before each upload. Call
+/// [`Self::finalize`] after processing the files, including after validation or upload errors
+/// and after a dry run. Finalization is explicit and asynchronous; dropping a session does not
+/// perform cleanup.
+#[must_use = "publishing sessions must be finalized after use"]
 pub struct PublishSession<'a> {
     publish_url: DisplaySafeUrl,
-    credentials: Credentials,
+    credentials: PublishingCredentials,
     upload_client: &'a BaseClient,
+    oidc_client: &'a BaseClient,
     retry_policy: ExponentialBackoff,
     check_url_client: Option<CheckUrlClient<'a>>,
     download_concurrency: Semaphore,
@@ -543,34 +588,23 @@ pub async fn check_trusted_publishing(
     }
 }
 
-/// Request revocation of a token obtained through trusted publishing.
-///
-/// A successful request does not guarantee that the token was revoked.
-pub async fn burn_trusted_publishing_token(
-    token: &TrustedPublishingToken,
-    registry: &DisplaySafeUrl,
-    client: &BaseClient,
-) -> Result<(), TrustedPublishingError> {
-    PyPIPublishingService::new(registry, client)
-        .burn_token(token)
-        .await
-}
-
 impl<'a> PublishSession<'a> {
     /// Start a session with resolved credentials and configured HTTP clients.
     ///
     /// The retry policy applies to streaming uploads, whose client must have automatic retries
-    /// and redirects disabled.
+    /// and redirects disabled. The OIDC client uses its own retry and timeout settings.
     pub fn new(
         publish_url: DisplaySafeUrl,
-        credentials: Credentials,
+        credentials: PublishingCredentials,
         upload_client: &'a BaseClient,
+        oidc_client: &'a BaseClient,
         retry_policy: ExponentialBackoff,
     ) -> Self {
         Self {
             publish_url,
             credentials,
             upload_client,
+            oidc_client,
             retry_policy,
             check_url_client: None,
             // Check URL requests are made one at a time against a single index.
@@ -878,6 +912,26 @@ impl<'a> PublishSession<'a> {
             }
         } else {
             Err(PublishError::MissingHash(Box::new(filename.clone())))
+        }
+    }
+
+    /// Finish the session and request invalidation of any trusted publishing token.
+    ///
+    /// Currently, finalization only invalidates credentials, regardless of the outcome. A future
+    /// upload protocol may publish staged files atomically on [`PublishOutcome::Success`]; failed
+    /// runs and dry runs must only clean up, without publishing staged files.
+    ///
+    /// A successful invalidation request does not guarantee that the token was revoked.
+    pub async fn finalize(self, outcome: PublishOutcome) -> Result<(), PublishFinalizeError> {
+        debug!("Finalizing publishing session: {outcome:?}");
+        match self.credentials {
+            PublishingCredentials::Supplied(_) => Ok(()),
+            PublishingCredentials::TrustedPublishing(token) => {
+                PyPIPublishingService::new(&self.publish_url, self.oidc_client)
+                    .burn_token(&token)
+                    .await
+                    .map_err(PublishFinalizeError::TokenInvalidation)
+            }
         }
     }
 }
@@ -1216,7 +1270,7 @@ impl PublishSession<'_> {
         registry: &DisplaySafeUrl,
         reporter: Arc<impl Reporter>,
     ) -> Result<(RequestBuilder<'_>, usize), PublishPrepareError> {
-        let credentials = &self.credentials;
+        let credentials = self.credentials.as_credentials();
         let mut form = Form::new();
         for (key, value) in form_metadata.iter() {
             form = form.text(*key, value.clone());
@@ -1267,7 +1321,7 @@ impl PublishSession<'_> {
                 "application/json;q=0.9, text/plain;q=0.8, text/html;q=0.7",
             );
 
-        match credentials {
+        match credentials.as_ref() {
             Credentials::Basic { password, .. } => {
                 if password.is_some() {
                     debug!("Using HTTP Basic authentication");
@@ -1376,8 +1430,8 @@ mod tests {
     use uv_redacted::DisplaySafeUrl;
 
     use crate::{
-        FormMetadata, PublishError, PublishPrepareError, PublishSession, Reporter, UploadOutcome,
-        group_files, source_dist_pkg_info,
+        FormMetadata, PublishError, PublishOutcome, PublishPrepareError, PublishSession,
+        PublishingCredentials, Reporter, UploadOutcome, group_files, source_dist_pkg_info,
     };
     use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
     use wiremock::matchers::{method, path};
@@ -1478,7 +1532,11 @@ mod tests {
     fn test_session(registry: DisplaySafeUrl, client: &BaseClient) -> PublishSession<'_> {
         PublishSession::new(
             registry,
-            Credentials::basic(Some("ferris".to_string()), Some("F3RR!S".to_string())),
+            PublishingCredentials::Supplied(Credentials::basic(
+                Some("ferris".to_string()),
+                Some("F3RR!S".to_string()),
+            )),
+            client,
             client,
             client.retry_policy(),
         )
@@ -1501,7 +1559,16 @@ mod tests {
             .expect("Valid registry URL");
         let mut session = test_session(registry, &client);
         let prepared = preparation.pop().expect("Distribution should be found");
-        session.upload(prepared, Arc::new(DummyReporter)).await
+        let result = session.upload(prepared, Arc::new(DummyReporter)).await;
+        let outcome = match &result {
+            Ok(UploadOutcome::Uploaded | UploadOutcome::AlreadyExists) => PublishOutcome::Success,
+            Err(_) => PublishOutcome::Failed,
+        };
+        session
+            .finalize(outcome)
+            .await
+            .expect("Finalization failed");
+        result
     }
 
     #[test]
@@ -1944,6 +2011,11 @@ mod tests {
             }
             "#);
         });
+        drop(request);
+        session
+            .finalize(PublishOutcome::DryRun)
+            .await
+            .expect("Finalization failed");
     }
 
     /// Snapshot the data we send for an upload request for a wheel.
@@ -2106,6 +2178,11 @@ mod tests {
             }
             "#);
         });
+        drop(request);
+        session
+            .finalize(PublishOutcome::DryRun)
+            .await
+            .expect("Finalization failed");
     }
 
     #[tokio::test]

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -2,6 +2,7 @@ mod trusted_publishing;
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::fmt::Display;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -212,6 +213,16 @@ pub enum PublishOutcome {
     Failed,
     /// Validation succeeded without uploading any files.
     DryRun,
+}
+
+impl Display for PublishOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Success => write!(f, "success"),
+            Self::Failed => write!(f, "failed"),
+            Self::DryRun => write!(f, "dry-run"),
+        }
+    }
 }
 
 /// A failure while finalizing a publishing session.
@@ -923,7 +934,7 @@ impl<'a> PublishSession<'a> {
     ///
     /// A successful invalidation request does not guarantee that the token was revoked.
     pub async fn finalize(self, outcome: PublishOutcome) -> Result<(), PublishFinalizeError> {
-        debug!("Finalizing publishing session: {outcome:?}");
+        debug!("Finalizing publishing session: {outcome}");
         match self.credentials {
             PublishingCredentials::Supplied(_) => Ok(()),
             PublishingCredentials::TrustedPublishing(token) => {

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -15,8 +14,8 @@ use uv_configuration::{KeyringProviderType, TrustedPublishing};
 use uv_distribution_types::{IndexLocations, IndexUrl};
 use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 use uv_publish::{
-    PreparedDistribution, PublishSession, TrustedPublishResult, TrustedPublishingToken,
-    UploadOutcome, burn_trusted_publishing_token, check_trusted_publishing,
+    PreparedDistribution, PublishFinalizeError, PublishOutcome, PublishSession,
+    PublishingCredentials, TrustedPublishResult, UploadOutcome, check_trusted_publishing,
 };
 use uv_redacted::DisplaySafeUrl;
 use uv_settings::EnvironmentOptions;
@@ -133,7 +132,7 @@ pub(crate) async fn publish(
         .client_name("oidc")
         .build()?;
 
-    // Load credentials.
+    // Load credentials and immediately transfer them to the session.
     let (publish_url, credentials) = gather_credentials(
         publish_url,
         username,
@@ -147,9 +146,10 @@ pub(crate) async fn publish(
     )
     .await?;
     let mut session = PublishSession::new(
-        publish_url.clone(),
-        credentials.as_credentials().into_owned(),
+        publish_url,
+        credentials,
         &upload_client,
+        &oidc_client,
         client_builder.retry_policy(),
     );
     if let Some(index_url) = check_url {
@@ -160,19 +160,23 @@ pub(crate) async fn publish(
         session = session.with_check_url(index_url, registry_client_builder, cache);
     }
 
-    // Keep the publishing result so token revocation also runs after an upload or metadata error.
+    // Keep the result so finalization also runs after a preparation or upload error.
     let result = publish_files(distributions, &mut session, dry_run, printer).await;
-
-    if let PublishingCredentials::TrustedPublishing(token) = &credentials
-        && let Err(err) = burn_trusted_publishing_token(token, &publish_url, &oidc_client).await
-    {
-        warn_user!(
-            "Failed to invalidate trusted publishing token. It will expire naturally. Cause: {err}"
-        );
-        debug!("Trusted publishing token revocation failed: {err:?}");
+    let outcome = result.as_ref().copied().unwrap_or(PublishOutcome::Failed);
+    match session.finalize(outcome).await {
+        Ok(()) => {}
+        Err(PublishFinalizeError::TokenInvalidation(err)) => {
+            warn_user!(
+                "Failed to invalidate trusted publishing token. It will expire naturally. Cause: {err}"
+            );
+            debug!("Trusted publishing token revocation failed: {err:?}");
+        }
     }
 
-    result
+    result.map(|outcome| match outcome {
+        PublishOutcome::Success | PublishOutcome::DryRun => ExitStatus::Success,
+        PublishOutcome::Failed => ExitStatus::Failure,
+    })
 }
 
 /// Publish each distribution, reporting all validation failures during a dry run.
@@ -181,7 +185,7 @@ async fn publish_files(
     session: &mut PublishSession<'_>,
     dry_run: bool,
     printer: Printer,
-) -> Result<ExitStatus> {
+) -> Result<PublishOutcome> {
     let mut error_count: usize = 0;
 
     for prepared in distributions {
@@ -205,10 +209,14 @@ async fn publish_files(
     if error_count > 0 {
         let failed = if error_count == 1 { "file" } else { "files" };
         writeln!(printer.stderr(), "Found issues with {error_count} {failed}")?;
-        return Ok(ExitStatus::Failure);
+        return Ok(PublishOutcome::Failed);
     }
 
-    Ok(ExitStatus::Success)
+    Ok(if dry_run {
+        PublishOutcome::DryRun
+    } else {
+        PublishOutcome::Success
+    })
 }
 
 /// Upload a prepared distribution unless this is a dry run.
@@ -257,27 +265,6 @@ async fn publish_file(
     }
 
     Ok(())
-}
-
-/// Credentials for publishing, including whether they require revocation after use.
-enum PublishingCredentials {
-    /// Credentials supplied by the user or resolved by the authentication middleware.
-    Supplied(Credentials),
-    /// A short-lived token obtained through trusted publishing.
-    TrustedPublishing(TrustedPublishingToken),
-}
-
-impl PublishingCredentials {
-    /// Return the HTTP credentials to use for uploads.
-    fn as_credentials(&self) -> Cow<'_, Credentials> {
-        match self {
-            Self::Supplied(credentials) => Cow::Borrowed(credentials),
-            Self::TrustedPublishing(token) => Cow::Owned(Credentials::basic(
-                Some("__token__".to_string()),
-                Some(token.to_string()),
-            )),
-        }
-    }
 }
 
 /// Whether to allow prompting for username and password.

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -48,6 +48,29 @@ fn upload_attestations(request: &Request) -> Option<Value> {
     Some(serde_json::from_str(attestations).expect("Attestations are JSON"))
 }
 
+/// Mock token acquisition and invalidation for the expected number of publishing runs.
+async fn mock_trusted_publishing(server: &MockServer, runs: u64) {
+    Mock::given(method("GET"))
+        .and(path("/_/oidc/audience"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "audience": "pypi" })))
+        .expect(runs)
+        .mount(server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/mint-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": "apitoken" })))
+        .expect(runs)
+        .mount(server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/burn-token"))
+        .and(body_json(json!({ "token": "apitoken" })))
+        .respond_with(ResponseTemplate::new(202))
+        .expect(runs)
+        .mount(server)
+        .await;
+}
+
 #[test]
 fn username_password_no_longer_supported() {
     let context = uv_test::test_context!("3.12").with_filtered_sizes();
@@ -856,26 +879,27 @@ async fn trusted_publishing_burn_after_prepare_failure() {
     Mock::given(method("GET"))
         .and(path("/_/oidc/audience"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "audience": "pypi" })))
-        .expect(1)
+        .expect(2)
         .mount(&server)
         .await;
     Mock::given(method("POST"))
         .and(path("/_/oidc/mint-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": "apitoken" })))
-        .expect(1)
+        .expect(2)
         .mount(&server)
         .await;
     Mock::given(method("POST"))
         .and(path("/_/oidc/burn-token"))
         .and(body_json(json!({ "token": "apitoken" })))
         .respond_with(ResponseTemplate::new(202))
-        .expect(1)
+        .expect(2)
         .mount(&server)
         .await;
     Mock::given(method("POST"))
         .and(path("/upload"))
+        .and(basic_auth("__token__", "apitoken"))
         .respond_with(ResponseTemplate::new(200))
-        .expect(0)
+        .expect(1)
         .mount(&server)
         .await;
 
@@ -896,6 +920,203 @@ async fn trusted_publishing_burn_after_prepare_failure() {
       Caused by: Failed to read from zip file
       Caused by: unable to locate the end of central directory record
     "
+    );
+
+    // Preparation remains per-file: the valid wheel uploads before a later preparation fails.
+    let later_wheel = context.temp_dir.child("z-1.0.0-py3-none-any.whl");
+    later_wheel.touch().expect("Failed to create wheel");
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(dummy_wheel())
+        .arg(later_wheel.path())
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Publishing 2 files to http://[LOCALHOST]/upload
+    Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    Hashing z-1.0.0-py3-none-any.whl ([SIZE]B)
+    error: Failed to publish: `z-1.0.0-py3-none-any.whl`
+      Caused by: Failed to read metadata
+      Caused by: Failed to read from zip file
+      Caused by: unable to locate the end of central directory record
+    "
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("Request recording is enabled");
+    insta::assert_debug_snapshot!(
+        requests.iter().map(|request| request.url.path()).collect::<Vec<_>>(),
+        @r#"
+    [
+        "/_/oidc/audience",
+        "/_/oidc/mint-token",
+        "/_/oidc/burn-token",
+        "/_/oidc/audience",
+        "/_/oidc/mint-token",
+        "/upload",
+        "/_/oidc/burn-token",
+    ]
+    "#
+    );
+}
+
+/// Both successful and failed dry runs finalize the session without uploading.
+#[tokio::test]
+async fn trusted_publishing_dry_run() {
+    let context = uv_test::test_context!("3.12").with_filtered_sizes();
+    let server = MockServer::start().await;
+
+    mock_trusted_publishing(&server, 2).await;
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--dry-run")
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(dummy_wheel())
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Checking 1 file against http://[LOCALHOST]/upload
+    Checking ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    "
+    );
+
+    let wheel = context.temp_dir.child("a-1.0.0-py3-none-any.whl");
+    wheel.touch().expect("Failed to create wheel");
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--dry-run")
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(wheel.path())
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Checking 1 file against http://[LOCALHOST]/upload
+    Checking a-1.0.0-py3-none-any.whl ([SIZE]B)
+    error: Failed to publish: `a-1.0.0-py3-none-any.whl`
+      Caused by: Failed to read metadata
+      Caused by: Failed to read from zip file
+      Caused by: unable to locate the end of central directory record
+    Found issues with 1 file
+    "
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("Request recording is enabled");
+    insta::assert_debug_snapshot!(
+        requests.iter().map(|request| request.url.path()).collect::<Vec<_>>(),
+        @r#"
+    [
+        "/_/oidc/audience",
+        "/_/oidc/mint-token",
+        "/_/oidc/burn-token",
+        "/_/oidc/audience",
+        "/_/oidc/mint-token",
+        "/_/oidc/burn-token",
+    ]
+    "#
+    );
+}
+
+/// Skipped files are not prepared, and the session still invalidates its token.
+#[tokio::test]
+async fn trusted_publishing_all_skipped() {
+    let context = uv_test::test_context!("3.12").with_filtered_sizes();
+    let server = MockServer::start().await;
+    let non_normalized = context.temp_dir.child("ok-1.01.0-py3-none-any.whl");
+    non_normalized.touch().expect("Failed to create wheel");
+    let attestation = context
+        .temp_dir
+        .child("ok-1.0.0-py3-none-any.whl.publish.attestation");
+    attestation
+        .write_str("not JSON")
+        .expect("Failed to write attestation");
+
+    mock_trusted_publishing(&server, 1).await;
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let sha256 = hex::encode(Sha256::digest(
+        fs_err::read(dummy_wheel()).expect("Failed to read wheel"),
+    ));
+    Mock::given(method("GET"))
+        .and(path("/simple/ok/"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(
+                json!({
+                    "files": [{
+                        "filename": "ok-1.0.0-py3-none-any.whl",
+                        "hashes": { "sha256": sha256 },
+                        "url": format!("{}/ok-1.0.0-py3-none-any.whl", server.uri()),
+                    }]
+                })
+                .to_string(),
+                "application/vnd.pypi.simple.v1+json",
+            ),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg("--check-url")
+        .arg(format!("{}/simple/", server.uri()))
+        .arg(dummy_wheel())
+        .arg(attestation.path())
+        .arg(non_normalized.path())
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::PYPI_ID_TOKEN, "gitlab-oidc-jwt"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Publishing 2 files to http://[LOCALHOST]/upload
+    File ok-1.0.0-py3-none-any.whl already exists, skipping
+    warning: `ok-1.01.0-py3-none-any.whl` has a non-normalized filename (expected `ok-1.1.0-py3-none-any.whl`), skipping
+    "
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("Request recording is enabled");
+    insta::assert_debug_snapshot!(
+        requests.iter().map(|request| request.url.path()).collect::<Vec<_>>(),
+        @r#"
+    [
+        "/_/oidc/audience",
+        "/_/oidc/mint-token",
+        "/simple/ok/",
+        "/_/oidc/burn-token",
+    ]
+    "#
     );
 }
 


### PR DESCRIPTION
## Summary

3/3 in the upload session stack.

This moves the token invalidation work into a "finalize" step, which is suitable for future extension (i.e. with Upload 2.0).

## Test Plan

- Publishing tests passed, including successful and failed dry runs, all-skipped runs, and preparation failure after an earlier upload.
- Clippy passed for `uv` and `uv-publish` with all targets and features; formatting and whitespace checks passed.
