### PR TITLE
Publish signed macOS and Windows release artifacts

### DIFF
--- a/.github/workflows/publish-mirror.yml
+++ b/.github/workflows/publish-mirror.yml
@@ -9,6 +9,10 @@ on:
       plan:
         required: true
         type: string
+      github-archives:
+        description: "Artifact ID for the verified signed GitHub release archives"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -27,7 +31,13 @@ jobs:
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: artifacts-*
+          pattern: "artifacts-!(*-apple-darwin|*-pc-windows-msvc)"
+          path: artifacts
+          merge-multiple: true
+      - name: "Download signed GitHub release archives"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ inputs.github-archives }}
           path: artifacts
           merge-multiple: true
       - name: "Upload to R2"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,6 +10,14 @@ on:
       plan:
         required: true
         type: string
+      uv-wheels:
+        description: "Artifact ID for the verified signed uv wheels"
+        required: true
+        type: string
+      uv-build-wheels:
+        description: "Artifact ID for the verified signed uv_build wheels"
+        required: true
+        type: string
 
 env:
   ACTIONS_CACHE_MODE: none
@@ -32,7 +40,13 @@ jobs:
           enable-cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: wheels_uv-*
+          pattern: "wheels_uv-!(*-apple-darwin|*-pc-windows-msvc)"
+          path: wheels_uv
+          merge-multiple: true
+      - name: "Download signed uv wheels"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ inputs.uv-wheels }}
           path: wheels_uv
           merge-multiple: true
       - name: Publish to PyPI
@@ -54,7 +68,13 @@ jobs:
           enable-cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: wheels_uv_build-*
+          pattern: "wheels_uv_build-!(*-apple-darwin|*-pc-windows-msvc)"
+          path: wheels_uv_build
+          merge-multiple: true
+      - name: "Download signed uv_build wheels"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ inputs.uv-build-wheels }}
           path: wheels_uv_build
           merge-multiple: true
       - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,8 +254,8 @@ jobs:
       - build-docker
       - build-global-artifacts
       - sign-release-binaries
-    # Publishing requires all build and signing jobs to succeed.
-    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    # Only run if we're publishing and the required builds and signing succeeded (skipped builds are fine).
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && needs.sign-release-binaries.result == 'success' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-release-binaries.result == 'skipped' || needs.build-release-binaries.result == 'success') && (needs.build-docker.result == 'skipped' || needs.build-docker.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "depot-ubuntu-latest-4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
     needs:
       - build-release-binaries
       - release-gate
-    if: ${{ inputs.tag == 'dry-run' && github.repository == 'astral-sh/uv' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.repository == 'astral-sh/uv' && github.ref == 'refs/heads/main' }}
     uses: $/.github/workflows/sign-release-binaries.yml
     secrets: inherit
     permissions:
@@ -148,6 +148,7 @@ jobs:
     needs:
       - plan
       - build-release-binaries
+      - sign-release-binaries
     if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run' }}
     runs-on: "depot-ubuntu-latest-4"
     steps:
@@ -162,7 +163,14 @@ jobs:
       - name: Fetch local artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: artifacts-*
+          # The macOS and Windows archives come from the signing job below.
+          pattern: "artifacts-!(*-apple-darwin|*-pc-windows-msvc)"
+          path: target/distrib/
+          merge-multiple: true
+      - name: Fetch signed GitHub release archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.sign-release-binaries.outputs.github-archives }}
           path: target/distrib/
           merge-multiple: true
       - name: Generate local dist manifest
@@ -191,6 +199,7 @@ jobs:
       - build-release-binaries
       - build-docker
       - generate-checksum-manifest
+      - sign-release-binaries
     runs-on: "depot-ubuntu-latest-4"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -207,7 +216,13 @@ jobs:
       - name: Fetch local artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: artifacts-*
+          pattern: "artifacts-!(*-apple-darwin|*-pc-windows-msvc)"
+          path: target/distrib/
+          merge-multiple: true
+      - name: Fetch signed GitHub release archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.sign-release-binaries.outputs.github-archives }}
           path: target/distrib/
           merge-multiple: true
       - id: cargo-dist
@@ -238,8 +253,9 @@ jobs:
       - build-release-binaries
       - build-docker
       - build-global-artifacts
-    # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-release-binaries.result == 'skipped' || needs.build-release-binaries.result == 'success') && (needs.build-docker.result == 'skipped' || needs.build-docker.result == 'success') }}
+      - sign-release-binaries
+    # Publishing requires all build and signing jobs to succeed.
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "depot-ubuntu-latest-4"
@@ -257,7 +273,13 @@ jobs:
       - name: Fetch artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: artifacts-*
+          pattern: "artifacts-!(*-apple-darwin|*-pc-windows-msvc)"
+          path: target/distrib/
+          merge-multiple: true
+      - name: Fetch signed GitHub release archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.sign-release-binaries.outputs.github-archives }}
           path: target/distrib/
           merge-multiple: true
       # This is a harmless no-op for GitHub Releases, hosting for that happens in "publish-github"
@@ -282,10 +304,13 @@ jobs:
       - plan
       - host
       - release-gate
+      - sign-release-binaries
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     uses: $/.github/workflows/publish-pypi.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
+      uv-wheels: ${{ needs.sign-release-binaries.outputs.uv-wheels }}
+      uv-build-wheels: ${{ needs.sign-release-binaries.outputs.uv-build-wheels }}
     secrets: inherit
     # publish jobs get escalated permissions
     permissions:
@@ -315,11 +340,12 @@ jobs:
       - host
       - release-gate
       - publish-pypi
+      - sign-release-binaries
     # use "always() && ..." to allow publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     # `publish-crates` is intentionally not a dependency: it's not
     # critical to the release and isn't idempotent on retry.
-    if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.publish-pypi.result == 'skipped' || needs.publish-pypi.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && needs.sign-release-binaries.result == 'success' && (needs.publish-pypi.result == 'skipped' || needs.publish-pypi.result == 'success') }}
     runs-on: "ubuntu-latest"
     environment:
       name: release
@@ -336,7 +362,13 @@ jobs:
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: artifacts-*
+          pattern: "artifacts-!(*-apple-darwin|*-pc-windows-msvc)"
+          path: artifacts
+          merge-multiple: true
+      - name: "Download signed GitHub release archives"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.sign-release-binaries.outputs.github-archives }}
           path: artifacts
           merge-multiple: true
       - name: Cleanup
@@ -403,10 +435,12 @@ jobs:
     needs:
       - plan
       - publish-github
-    if: ${{ always() && needs.publish-github.result == 'success' }}
+      - sign-release-binaries
+    if: ${{ always() && needs.publish-github.result == 'success' && needs.sign-release-binaries.result == 'success' }}
     uses: $/.github/workflows/publish-mirror.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
+      github-archives: ${{ needs.sign-release-binaries.outputs.github-archives }}
     secrets: inherit
     permissions:
       "contents": "read"


### PR DESCRIPTION
We added signing of artifacts in dry-run in #21525, here, we hook them up to the production publication pipeline.