### PR TITLE
refactor(settings): move UV_LOCK_TIMEOUT parsing to EnvironmentOptions

### DIFF
--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -22,23 +22,21 @@ static LOCK_TIMEOUT_SECS: AtomicU32 = AtomicU32::new(0);
 
 /// Set the lock timeout globally.
 pub fn set_lock_timeout(timeout: Duration) {
-    LOCK_TIMEOUT_SECS.store(
-        timeout.as_secs().min(u32::MAX as u64) as u32,
-        Ordering::Relaxed,
-    );
+    let secs = u32::try_from(timeout.as_secs()).unwrap_or(u32::MAX);
+    LOCK_TIMEOUT_SECS.store(secs, Ordering::Relaxed);
 }
 
-/// Retrieve the current lock timeout, falling back to reading `UV_LOCK_TIMEOUT` directly
+/// Retrieve the current lock timeout, falling back to reading UV_LOCK_TIMEOUT directly
 /// or defaulting to 5 minutes if unset.
-pub fn lock_timeout() -> Duration {
+pub(crate) fn lock_timeout() -> Duration {
     let secs = LOCK_TIMEOUT_SECS.load(Ordering::Relaxed);
     if secs > 0 {
-        Duration::from_secs(secs as u64)
+        Duration::from_secs(u64::from(secs))
     } else {
         env::var_os(EnvVars::UV_LOCK_TIMEOUT)
             .and_then(|v| v.to_str().and_then(|s| s.parse::<u64>().ok()))
             .map(Duration::from_secs)
-            .unwrap_or(Duration::from_secs(DEFAULT_LOCK_TIMEOUT_SECS as u64))
+            .unwrap_or(Duration::from_secs(u64::from(DEFAULT_LOCK_TIMEOUT_SECS)))
     }
 }
 

--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -30,7 +30,7 @@ pub fn set_lock_timeout(timeout: Duration) {
 
 /// Retrieve the current lock timeout, falling back to reading `UV_LOCK_TIMEOUT` directly
 /// or defaulting to 5 minutes if unset.
-pub(crate) fn lock_timeout() -> Duration {
+fn lock_timeout() -> Duration {
     let secs = LOCK_TIMEOUT_SECS.load(Ordering::Relaxed);
     if secs > 0 {
         Duration::from_secs(u64::from(secs))

--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -1,7 +1,7 @@
 use std::convert::Into;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 use std::{env, io};
 
@@ -14,27 +14,33 @@ use windows::Win32::Foundation::ERROR_LOCK_VIOLATION;
 
 use crate::{Simplified, is_known_already_locked_error};
 
-/// Parsed value of `UV_LOCK_TIMEOUT`, with a default of 5 min.
-static LOCK_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
-    let default_timeout = Duration::from_mins(5);
-    let Some(lock_timeout) = env::var_os(EnvVars::UV_LOCK_TIMEOUT) else {
-        return default_timeout;
-    };
+/// Default lock timeout if not specified (5 minutes).
+const DEFAULT_LOCK_TIMEOUT_SECS: u32 = 5 * 60;
 
-    if let Some(lock_timeout) = lock_timeout
-        .to_str()
-        .and_then(|lock_timeout| lock_timeout.parse::<u64>().ok())
-    {
-        Duration::from_secs(lock_timeout)
+/// Global lock timeout in seconds, configured via [`EnvironmentOptions`].
+static LOCK_TIMEOUT_SECS: AtomicU32 = AtomicU32::new(0);
+
+/// Set the lock timeout globally.
+pub fn set_lock_timeout(timeout: Duration) {
+    LOCK_TIMEOUT_SECS.store(
+        timeout.as_secs().min(u32::MAX as u64) as u32,
+        Ordering::Relaxed,
+    );
+}
+
+/// Retrieve the current lock timeout, falling back to reading `UV_LOCK_TIMEOUT` directly
+/// or defaulting to 5 minutes if unset.
+pub fn lock_timeout() -> Duration {
+    let secs = LOCK_TIMEOUT_SECS.load(Ordering::Relaxed);
+    if secs > 0 {
+        Duration::from_secs(secs as u64)
     } else {
-        warn!(
-            "Could not parse value of {} as integer: {:?}",
-            EnvVars::UV_LOCK_TIMEOUT,
-            lock_timeout
-        );
-        default_timeout
+        env::var_os(EnvVars::UV_LOCK_TIMEOUT)
+            .and_then(|v| v.to_str().and_then(|s| s.parse::<u64>().ok()))
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(DEFAULT_LOCK_TIMEOUT_SECS as u64))
     }
-});
+}
 
 #[derive(Debug, Error)]
 pub enum LockedFileError {
@@ -224,10 +230,11 @@ impl LockedFile {
         );
         let path = file.path().to_path_buf();
         let lock_exclusive = tokio::task::spawn_blocking(move || (mode.lock(&file), file));
-        let (result, file) = tokio::time::timeout(*LOCK_TIMEOUT, lock_exclusive)
+        let timeout = lock_timeout();
+        let (result, file) = tokio::time::timeout(timeout, lock_exclusive)
             .await
             .map_err(|_| LockedFileError::Timeout {
-                timeout: *LOCK_TIMEOUT,
+                timeout,
                 resource: resource.to_string(),
                 path: path.clone(),
             })??;

--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 use std::{env, io};
 
 use thiserror::Error;
-use tracing::{debug, error, info, trace, warn};
+#[cfg(unix)]
+use tracing::warn;
+use tracing::{debug, error, info, trace};
 
 use uv_static::EnvVars;
 #[cfg(windows)]

--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -28,7 +28,7 @@ pub fn set_lock_timeout(timeout: Duration) {
     LOCK_TIMEOUT_SECS.store(secs, Ordering::Relaxed);
 }
 
-/// Retrieve the current lock timeout, falling back to reading UV_LOCK_TIMEOUT directly
+/// Retrieve the current lock timeout, falling back to reading `UV_LOCK_TIMEOUT` directly
 /// or defaulting to 5 minutes if unset.
 pub(crate) fn lock_timeout() -> Duration {
     let secs = LOCK_TIMEOUT_SECS.load(Ordering::Relaxed);

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -745,6 +745,7 @@ pub struct EnvironmentOptions {
     /// timeout.
     pub http_read_timeout_upload: Duration,
     pub http_retries: u32,
+    pub lock_timeout: Option<Duration>,
     pub concurrency: Concurrency,
     #[cfg(feature = "tracing-durations-export")]
     pub tracing_durations_file: Option<PathBuf>,
@@ -871,6 +872,11 @@ impl EnvironmentOptions {
             .unwrap_or(DEFAULT_CONNECT_TIMEOUT),
             http_retries: parse_integer_environment_variable(EnvVars::UV_HTTP_RETRIES, None)?
                 .unwrap_or(uv_client::DEFAULT_RETRIES),
+            lock_timeout: parse_integer_environment_variable(
+                EnvVars::UV_LOCK_TIMEOUT,
+                Some("value should be an integer number of seconds"),
+            )?
+            .map(Duration::from_secs),
             #[cfg(feature = "tracing-durations-export")]
             tracing_durations_file: parse_path_environment_variable(
                 EnvVars::TRACING_DURATIONS_FILE,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -188,6 +188,10 @@ async fn run_with_workspace_cache(
     // Load environment variables not handled by Clap.
     let environment = EnvironmentOptions::new()?;
 
+    if let Some(lock_timeout) = environment.lock_timeout {
+        uv_fs::set_lock_timeout(lock_timeout);
+    }
+
     // Resolve preview flags before config discovery for decisions that affect the discovery root.
     let early_preview = settings::resolve_preview(&cli.top_level.global_args, None, &environment)?;
 


### PR DESCRIPTION
## Summary

Moves the parsing of `UV_LOCK_TIMEOUT` from an ad-hoc `LazyLock` call in `crates/uv-fs/src/locked_file.rs` to `EnvironmentOptions` in `crates/uv-settings/src/lib.rs`.

This follows the standard pattern for environment variable options, providing early structured validation with user-friendly error reporting if an invalid integer is passed, while preserving full backward compatibility and the default 5-minute timeout.

Resolves https://github.com/astral-sh/uv/pull/16342#discussion_r2448547512
Relates https://github.com/astral-sh/uv/issues/14720

## Test Plan

- Existing integration test in `crates/uv/tests/python/venv.rs` verifies that `.env(EnvVars::UV_LOCK_TIMEOUT, "1")` is respected.
- Verified that passing non-integer values generates a clear validation error from `EnvironmentOptions`.
