### PR TITLE
Reuse environments when PEP 723 dependencies are omitted

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -3286,10 +3286,12 @@ pub(crate) async fn script_specification(
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     credentials_cache: &CredentialsCache,
-) -> Result<Option<RequirementsSpecification>, ProjectError> {
-    let Some(dependencies) = script.metadata().dependencies.as_ref() else {
-        return Ok(None);
-    };
+) -> Result<RequirementsSpecification, ProjectError> {
+    let dependencies = script
+        .metadata()
+        .dependencies
+        .as_deref()
+        .unwrap_or_default();
 
     let script_dir = script.directory()?;
     let script_indexes = script
@@ -3419,7 +3421,7 @@ pub(crate) async fn script_specification(
         RequirementsSpecification::from_excludes(requirements, constraints, Vec::new(), Vec::new());
     specification.override_dependencies = overrides;
     specification.excludes = excludes;
-    Ok(Some(specification))
+    Ok(specification)
 }
 
 /// Determine the extra build requires for a script.

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -72,9 +72,9 @@ use crate::commands::project::lock::LockMode;
 use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
     EnvironmentSpecification, LinkErrorReporting, PreferenceLocation, ProjectEnvironment,
-    ProjectError, ScriptEnvironment, ScriptInterpreter, UniversalState, WorkspacePython,
-    default_dependency_groups, script_extra_build_requires, script_specification,
-    update_environment, validate_project_requires_python,
+    ProjectError, ScriptEnvironment, UniversalState, WorkspacePython, default_dependency_groups,
+    script_extra_build_requires, script_specification, update_environment,
+    validate_project_requires_python,
 };
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::{ExitStatus, diagnostics, project, read_env_files};
@@ -178,7 +178,6 @@ pub(crate) async fn run(
     let mut base_lock: Option<(Lock, PathBuf)> = None;
 
     // Determine whether the command to execute is a PEP 723 script.
-    let temp_dir;
     let script_interpreter = if let Some(script) = script {
         match &script {
             Pep723Item::Script(script) => {
@@ -361,8 +360,16 @@ pub(crate) async fn run(
                 }
             }
 
-            // Install the script requirements, if necessary. Otherwise, use an isolated environment.
-            if let Some(spec) = script_specification(
+            // Install the script requirements, if necessary.
+            let spec = script_specification(
+                (&script).into(),
+                &settings.resolver,
+                &cache,
+                workspace_cache,
+                client_builder.credentials_cache(),
+            )
+            .await?;
+            let script_extra_build_requires = script_extra_build_requires(
                 (&script).into(),
                 &settings.resolver,
                 &cache,
@@ -370,131 +377,88 @@ pub(crate) async fn run(
                 client_builder.credentials_cache(),
             )
             .await?
-            {
-                let script_extra_build_requires = script_extra_build_requires(
-                    (&script).into(),
-                    &settings.resolver,
-                    &cache,
-                    workspace_cache,
-                    client_builder.credentials_cache(),
-                )
-                .await?
-                .into_inner();
-                let environment = ScriptEnvironment::get_or_init(
-                    (&script).into(),
-                    python.as_deref().map(PythonRequest::parse),
-                    &client_builder,
-                    python_preference,
-                    python_downloads,
-                    &install_mirrors,
-                    no_sync,
-                    config_discovery,
-                    active.map_or(Some(false), Some),
-                    &cache,
-                    DryRun::Disabled,
-                    printer,
-                )
-                .await?
-                .into_environment()?;
+            .into_inner();
+            let environment = ScriptEnvironment::get_or_init(
+                (&script).into(),
+                python.as_deref().map(PythonRequest::parse),
+                &client_builder,
+                python_preference,
+                python_downloads,
+                &install_mirrors,
+                no_sync,
+                config_discovery,
+                active.map_or(Some(false), Some),
+                &cache,
+                DryRun::Disabled,
+                printer,
+            )
+            .await?
+            .into_environment()?;
 
-                let build_constraints = script
-                    .metadata()
-                    .tool
-                    .as_ref()
-                    .and_then(|tool| {
-                        tool.uv
-                            .as_ref()
-                            .and_then(|uv| uv.build_constraint_dependencies.as_ref())
-                    })
-                    .map(|constraints| {
-                        Constraints::from_requirements(
-                            constraints
-                                .iter()
-                                .map(|constraint| Requirement::from(constraint.clone())),
-                        )
-                    });
+            let build_constraints = script
+                .metadata()
+                .tool
+                .as_ref()
+                .and_then(|tool| {
+                    tool.uv
+                        .as_ref()
+                        .and_then(|uv| uv.build_constraint_dependencies.as_ref())
+                })
+                .map(|constraints| {
+                    Constraints::from_requirements(
+                        constraints
+                            .iter()
+                            .map(|constraint| Requirement::from(constraint.clone())),
+                    )
+                });
 
-                let _lock = environment
-                    .lock()
-                    .await
-                    .inspect_err(|err| {
-                        warn!("Failed to acquire environment lock: {err}");
-                    })
-                    .ok();
-
-                match update_environment(
-                    environment,
-                    spec,
-                    modifications,
-                    python_platform.as_ref(),
-                    SourceTreeEditablePolicy::Project,
-                    build_constraints.unwrap_or_default(),
-                    script_extra_build_requires,
-                    &settings,
-                    &client_builder,
-                    &sync_state,
-                    if show_resolution {
-                        Box::new(DefaultResolveLogger)
-                    } else {
-                        Box::new(SummaryResolveLogger)
-                    },
-                    if show_resolution {
-                        Box::new(DefaultInstallLogger)
-                    } else {
-                        Box::new(SummaryInstallLogger)
-                    },
-                    installer_metadata,
-                    &concurrency,
-                    &cache,
-                    workspace_cache,
-                    DryRun::Disabled,
-                    printer,
-                    preview,
-                )
+            let _lock = environment
+                .lock()
                 .await
-                {
-                    Ok(update) => Some(update.into_environment().into_interpreter()),
-                    Err(ProjectError::Operation(err)) => {
-                        return diagnostics::OperationDiagnostic::default()
-                            .with_context("script")
-                            .report(err)
-                            .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
-                    }
-                    Err(err) => return Err(err.into()),
+                .inspect_err(|err| {
+                    warn!("Failed to acquire environment lock: {err}");
+                })
+                .ok();
+
+            match update_environment(
+                environment,
+                spec,
+                modifications,
+                python_platform.as_ref(),
+                SourceTreeEditablePolicy::Project,
+                build_constraints.unwrap_or_default(),
+                script_extra_build_requires,
+                &settings,
+                &client_builder,
+                &sync_state,
+                if show_resolution {
+                    Box::new(DefaultResolveLogger)
+                } else {
+                    Box::new(SummaryResolveLogger)
+                },
+                if show_resolution {
+                    Box::new(DefaultInstallLogger)
+                } else {
+                    Box::new(SummaryInstallLogger)
+                },
+                installer_metadata,
+                &concurrency,
+                &cache,
+                workspace_cache,
+                DryRun::Disabled,
+                printer,
+                preview,
+            )
+            .await
+            {
+                Ok(update) => Some(update.into_environment().into_interpreter()),
+                Err(ProjectError::Operation(err)) => {
+                    return diagnostics::OperationDiagnostic::default()
+                        .with_context("script")
+                        .report(err)
+                        .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
-            } else {
-                // Create a virtual environment.
-                let interpreter = ScriptInterpreter::discover(
-                    (&script).into(),
-                    python.as_deref().map(PythonRequest::parse),
-                    &client_builder,
-                    python_preference,
-                    python_downloads,
-                    &install_mirrors,
-                    no_sync,
-                    config_discovery,
-                    active.map_or(Some(false), Some),
-                    &cache,
-                    printer,
-                )
-                .await?
-                .into_interpreter();
-
-                temp_dir = cache.venv_dir()?;
-                let environment = uv_virtualenv::create_venv(
-                    temp_dir.path(),
-                    interpreter,
-                    uv_virtualenv::Prompt::None,
-                    false,
-                    uv_virtualenv::OnExisting::Remove(
-                        uv_virtualenv::RemovalReason::TemporaryEnvironment,
-                    ),
-                    false,
-                    uv_virtualenv::Seed::Disabled,
-                    false,
-                )?;
-
-                Some(environment.into_interpreter())
+                Err(err) => return Err(err.into()),
             }
         }
     } else {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -248,8 +248,7 @@ pub(crate) async fn sync(
                 workspace_cache,
                 client_builder.credentials_cache(),
             )
-            .await?
-            .unwrap_or_default();
+            .await?;
             let script_extra_build_requires = script_extra_build_requires(
                 script.into(),
                 &settings.resolver,

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -382,12 +382,15 @@ fn run_pep723_script() -> Result<()> {
     Checked 4 packages in [TIME]
     ");
 
-    // If the script contains a PEP 723 tag, it can omit the dependencies field.
+    // Omitting the dependencies field should retain previously installed script requirements,
+    // just like an empty dependency list.
     let test_script = context.temp_dir.child("main.py");
     test_script.write_str(indoc! { r#"
         # /// script
         # requires-python = ">=3.11"
         # ///
+
+        import iniconfig
 
         print("Hello, world!")
        "#
@@ -497,6 +500,42 @@ fn run_pep723_script() -> Result<()> {
     ----- stderr -----
     error: The script contains multiple PEP 723 metadata blocks
     ");
+
+    Ok(())
+}
+
+/// Omitting dependencies should use the cached or explicitly requested active environment.
+#[test]
+fn run_pep723_script_without_dependencies() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("main.py").write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # ///
+
+        import sys
+
+        print(sys.prefix)
+        "#
+    })?;
+
+    uv_snapshot!(context.filters(), context.run().arg("main.py"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [CACHE_DIR]/environments-v2/main-[HASH]
+    ");
+
+    uv_snapshot!(context.filters(), context.run().arg("--active").arg("--no-sync").arg("main.py")
+        .env(EnvVars::VIRTUAL_ENV, "active"), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [TEMP_DIR]/active
+
+    ----- stderr -----
+    warning: `--no-sync` is a no-op for Python scripts with inline metadata, which always run in isolation
+    ");
+
+    assert!(!context.temp_dir.child("main.py.lock").exists());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`uv run` currently creates a temporary environment when a PEP 723 script omits `dependencies`, while `dependencies = []` uses a persistent environment.

Treat omitted dependencies as an empty list, reusing the cached script environment or the environment selected by `--active`.

## Test plan (on top of CI)

Benchmarked on a Linux devbox with Rust 1.98 profiling builds, using 200 randomized pairs per case. Warm runs with omitted dependencies improved from 35.99 ms to 30.82 ms (14.4%). Fresh-cache runs and explicit empty-list controls showed no clear change. OS page caches were warm.
