### PR TITLE
Update Rust toolchain to 1.98.1

### DIFF
--- a/crates/uv-build/rust-toolchain.toml
+++ b/crates/uv-build/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"


### PR DESCRIPTION
## Summary

Update the Rust toolchain to 1.98.1, which fixes the vtable-generation miscompilation issue in Rust 1.98.0.

## Test Plan

CI
