### PR TITLE
Warn when pylock artifact hash tables are empty

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -12,6 +12,7 @@ use jiff::tz::{Offset, TimeZone};
 use petgraph::graph::NodeIndex;
 use serde::Deserialize;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
+use toml::Table as TomlTable;
 use toml_edit::{Array, ArrayOfTables, Item, Table, Value, value};
 use url::Url;
 
@@ -43,6 +44,7 @@ use uv_pypi_types::{
 };
 use uv_redacted::DisplaySafeUrl;
 use uv_small_str::SmallString;
+use uv_warnings::warn_user_once;
 
 use crate::lock::export::ExportableRequirements;
 use crate::lock::{Source, WheelTagHint, is_wheel_unreachable};
@@ -281,6 +283,21 @@ where
     Ok(version)
 }
 
+/// Deserialize artifact [`Hashes`], warning about invalid empty tables.
+fn deserialize_hashes<'de, D>(deserializer: D) -> Result<Hashes, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    // Check the original table, since `Hashes` discards unsupported algorithms.
+    let hashes = TomlTable::deserialize(deserializer)?;
+    if hashes.is_empty() {
+        warn_user_once!(
+            "Empty hash tables in `pylock.toml` will be rejected in a future uv version. Rerun the original `uv export` or `uv pip compile` command to regenerate the file."
+        );
+    }
+    hashes.try_into().map_err(serde::de::Error::custom)
+}
+
 /// The location of a distribution file with missing hashes.
 enum HashSource {
     Url(DisplaySafeUrl),
@@ -440,6 +457,7 @@ struct PylockTomlArchive {
     upload_time: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     subdirectory: Option<PortablePathBuf>,
+    #[serde(deserialize_with = "deserialize_hashes")]
     hashes: Hashes,
 }
 
@@ -461,6 +479,7 @@ struct PylockTomlSdist {
     upload_time: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     size: Option<u64>,
+    #[serde(deserialize_with = "deserialize_hashes")]
     hashes: Hashes,
 }
 
@@ -482,6 +501,7 @@ struct PylockTomlWheel {
     upload_time: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     size: Option<u64>,
+    #[serde(deserialize_with = "deserialize_hashes")]
     hashes: Hashes,
 }
 

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -5621,6 +5621,55 @@ fn pep_751_requires_packages() -> Result<()> {
 }
 
 #[test]
+fn pep_751_empty_hashes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = PackseServer::new("simple/single-package.toml");
+    context
+        .temp_dir
+        .child("pylock.toml")
+        .write_str(&formatdoc! {r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "a"
+        version = "1.0.0"
+        wheels = [{{ url = "{wheel_url}", hashes = {{}} }}]
+    "#,
+            wheel_url = server.file_url("a-1.0.0-py3-none-any.whl"),
+        })?;
+
+    // Empty hash tables should warn without preventing installation by default.
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("--dry-run")
+        .arg("pylock.toml"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Empty hash tables in `pylock.toml` will be rejected in a future uv version. Rerun the original `uv export` or `uv pip compile` command to regenerate the file.
+    Would download 1 package
+    Would install 1 package
+     + a==1.0.0
+    ");
+
+    // Empty hash tables should warn even when verification is disabled.
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("--no-verify-hashes")
+        .arg("pylock.toml"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Empty hash tables in `pylock.toml` will be rejected in a future uv version. Rerun the original `uv export` or `uv pip compile` command to regenerate the file.
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + a==1.0.0
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_validates_archive_size() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     context

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -16,6 +16,8 @@ use http::StatusCode;
 #[cfg(feature = "test-universal")]
 use indoc::formatdoc;
 use indoc::indoc;
+#[cfg(feature = "test-universal")]
+use regex::Regex;
 use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -17864,6 +17866,12 @@ fn pep_751_compile_preferences() -> Result<()> {
     // Modify the requirements to loosen the `anyio` version.
     requirements_txt.write_str("anyio")?;
 
+    // Empty hash tables should warn without discarding version preferences.
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+    let content = fs_err::read_to_string(&pylock_toml)?;
+    pylock_toml
+        .write_str(&Regex::new(r"hashes = \{[^}]*\}")?.replace_all(&content, "hashes = {}"))?;
+
     // The `anyio` version should be retained, since we respect the existing preferences.
     uv_snapshot!(context.filters(), context
         .pip_compile()
@@ -17898,6 +17906,7 @@ fn pep_751_compile_preferences() -> Result<()> {
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 
     ----- stderr -----
+    warning: Empty hash tables in `pylock.toml` will be rejected in a future uv version. Rerun the original `uv export` or `uv pip compile` command to regenerate the file.
     Resolved 3 packages in [TIME]
     "#);
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13323,6 +13323,50 @@ fn pep_751_install_path_sdist() -> Result<()> {
 }
 
 #[test]
+fn pep_751_unsupported_hashes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("pylock.toml").write_str(indoc! {r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "iniconfig"
+        version = "2.0.0"
+        wheels = [{ url = "https://example.com/iniconfig-2.0.0-py3-none-any.whl", hashes = { sha3_256 = "0000000000000000000000000000000000000000000000000000000000000000" } }]
+    "#})?;
+
+    // Unsupported algorithms should remain valid when parsing a pylock file.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("--dry-run")
+        .arg("--no-verify-hashes")
+        .arg("-r")
+        .arg("pylock.toml"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Would download 1 package
+    Would install 1 package
+     + iniconfig==2.0.0
+    ");
+
+    // Requiring hashes should reject artifacts with only unsupported algorithms.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("--dry-run")
+        .arg("--require-hashes")
+        .arg("-r")
+        .arg("pylock.toml"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have a hash, but none were provided for: iniconfig
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_hash_mismatch() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -13344,9 +13388,10 @@ fn pep_751_hash_mismatch() -> Result<()> {
         [[packages]]
         name = "iniconfig"
         version = "2.0.0"
-        archive = { path = "iniconfig-2.0.0-py3-none-any.whl", hashes = { sha256 = "c5185871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }
+        archive = { path = "iniconfig-2.0.0-py3-none-any.whl", hashes = { sha256 = "c5185871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", sha3_256 = "0000000000000000000000000000000000000000000000000000000000000000" } }
     "#)?;
 
+    // An unsupported algorithm should not prevent verification of a supported hash.
     uv_snapshot!(context.filters(), context.pip_install()
         .arg("--preview")
         .arg("-r")
@@ -13363,6 +13408,22 @@ fn pep_751_hash_mismatch() -> Result<()> {
             sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     "
     );
+
+    pylock_toml.write_str(&fs::read_to_string(&pylock_toml)?.replace(
+        "c5185871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374",
+        "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374",
+    ))?;
+
+    // A matching supported hash should permit installation alongside an unsupported algorithm.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("-r")
+        .arg("pylock.toml"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0 (from file://[TEMP_DIR]/iniconfig-2.0.0-py3-none-any.whl)
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -13323,6 +13323,129 @@ fn pep_751_install_path_sdist() -> Result<()> {
 }
 
 #[test]
+fn pep_751_empty_hashes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+
+    allow_duplicates! {
+        for (table, filename) in [
+            ("[packages.archive]", "iniconfig-2.0.0.tar.gz"),
+            ("[packages.sdist]", "iniconfig-2.0.0.tar.gz"),
+            ("[[packages.wheels]]", "iniconfig-2.0.0-py3-none-any.whl"),
+        ] {
+            pylock_toml.write_str(&formatdoc! {r#"
+                lock-version = "1.0"
+                created-by = "uv"
+
+                [[packages]]
+                name = "iniconfig"
+                version = "2.0.0"
+                {table}
+                url = "https://example.com/{filename}"
+                hashes = {{}}
+            "#})?;
+
+            // Requiring hashes should still reject artifacts with empty hash tables.
+            uv_snapshot!(context.filters(), context.pip_install()
+                .arg("--preview")
+                .arg("--offline")
+                .arg("--dry-run")
+                .arg("--require-hashes")
+                .arg("-r")
+                .arg("pylock.toml"), @"
+            exit_code: 2 (failure)
+            ----- stderr -----
+            warning: Empty hash tables in `pylock.toml` will be rejected in a future uv version. Rerun the original `uv export` or `uv pip compile` command to regenerate the file.
+            error: In `--require-hashes` mode, all requirements must have a hash, but none were provided for: iniconfig
+            ");
+        }
+        Ok::<(), anyhow::Error>(())
+    }?;
+
+    Ok(())
+}
+
+#[test]
+fn pep_751_missing_hashes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("pylock.toml").write_str(indoc! {r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "iniconfig"
+        version = "2.0.0"
+        wheels = [{ url = "https://example.com/iniconfig-2.0.0-py3-none-any.whl" }]
+    "#})?;
+
+    // Omitting the required hashes field should fail even with verification disabled.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("--dry-run")
+        .arg("--no-verify-hashes")
+        .arg("-r")
+        .arg("pylock.toml"), @r#"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Not a valid `pylock.toml` file: pylock.toml
+      Caused by: TOML parse error at line 7, column 11
+          |
+        7 | wheels = [{ url = "https://example.com/iniconfig-2.0.0-py3-none-any.whl" }]
+          |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        missing field `hashes`
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn pep_751_empty_hashes_unselected_artifacts() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    fs::copy(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+        context.temp_dir.child("ok-1.0.0-py3-none-any.whl"),
+    )?;
+    context.temp_dir.child("pylock.toml").write_str(indoc! {r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "ok"
+        version = "1.0.0"
+        sdist = { url = "https://example.com/ok-1.0.0.tar.gz", hashes = {} }
+        wheels = [
+            { url = "https://example.com/ok-1.0.0-cp311-cp311-win32.whl", hashes = { sha3_256 = "0000000000000000000000000000000000000000000000000000000000000000" } },
+            { path = "ok-1.0.0-py3-none-any.whl", hashes = { sha256 = "79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f" } },
+        ]
+
+        [[packages]]
+        name = "unused"
+        version = "1.0.0"
+        marker = "python_version < '3'"
+        archive = { url = "https://example.com/unused-1.0.0.tar.gz", hashes = {} }
+    "#})?;
+
+    // Empty tables on unselected artifacts should warn once without preventing installation.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("--offline")
+        .arg("-r")
+        .arg("pylock.toml"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Empty hash tables in `pylock.toml` will be rejected in a future uv version. Rerun the original `uv export` or `uv pip compile` command to regenerate the file.
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_unsupported_hashes() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     context.temp_dir.child("pylock.toml").write_str(indoc! {r#"


### PR DESCRIPTION
## Summary

`pylock.toml` specified in [PEP 751](https://peps.python.org/pep-0751/) requires that archives, wheels and sdists have non-empty hash tables. We currently produce empty tables (see #20146) when hashes are unavailable, and we currently accept this. So this PR just makes this a warning in preparation for a future breaking change making it an error.

This builds on #20146, which makes the warning actionable.

## Test Plan

New tests added + existing coverage.
