### PR TITLE
Protect non-virtualenv directories with --active --script

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -243,6 +243,9 @@ pub(crate) enum ProjectError {
     #[error("Project virtual environment directory `{0}` cannot be used because {1}")]
     InvalidProjectEnvironmentDir(PathBuf, String),
 
+    #[error("Script virtual environment directory `{0}` cannot be used because {1}")]
+    InvalidScriptEnvironmentDir(PathBuf, String),
+
     #[error("Failed to parse `uv.lock`")]
     UvLockParse(#[source] toml::de::Error),
 
@@ -2167,6 +2170,36 @@ impl ScriptEnvironment {
             ScriptInterpreter::Interpreter(interpreter) => {
                 let root = ScriptInterpreter::root(script, active, cache);
 
+                // The derived cache entry belongs to uv, but an active environment can point
+                // outside the cache. Only replace it if it is a virtual environment.
+                let replace_environment =
+                    if root == ScriptInterpreter::root(script, Some(false), cache) {
+                        true
+                    } else {
+                        match (root.try_exists(), root.join("pyvenv.cfg").try_exists()) {
+                            (_, Ok(true)) => true,
+                            (Ok(false), Ok(false)) => false,
+                            (Ok(true), Ok(false)) => {
+                                if root.read_dir().is_ok_and(|mut dir| dir.next().is_none()) {
+                                    false
+                                } else {
+                                    return Err(ProjectError::InvalidScriptEnvironmentDir(
+                                        root,
+                                        "it is not a virtual environment".to_string(),
+                                    ));
+                                }
+                            }
+                            (_, Err(err)) | (Err(err), _) => {
+                                return Err(ProjectError::InvalidScriptEnvironmentDir(
+                                    root,
+                                    format!(
+                                        "uv cannot determine if it is a virtual environment: {err}"
+                                    ),
+                                ));
+                            }
+                        }
+                    };
+
                 // Determine a prompt for the environment, in order of preference:
                 //
                 // 1) The name of the script
@@ -2193,7 +2226,7 @@ impl ScriptEnvironment {
                         uv_virtualenv::Seed::Disabled,
                         upgradeable,
                     )?;
-                    return Ok(if root.exists() {
+                    return Ok(if replace_environment && root.exists() {
                         Self::WouldReplace(root, environment, temp_dir)
                     } else {
                         Self::WouldCreate(root, environment, temp_dir)
@@ -2201,16 +2234,20 @@ impl ScriptEnvironment {
                 }
 
                 // Remove the existing virtual environment.
-                let replaced = match uv_fs::remove_virtualenv(&root) {
-                    Ok(()) => {
-                        debug!(
-                            "Removed virtual environment at: {}",
-                            root.user_display().cyan()
-                        );
-                        true
+                let replaced = if replace_environment {
+                    match uv_fs::remove_virtualenv(&root) {
+                        Ok(()) => {
+                            debug!(
+                                "Removed virtual environment at: {}",
+                                root.user_display().cyan()
+                            );
+                            true
+                        }
+                        Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+                        Err(err) => return Err(uv_virtualenv::Error::from(err).into()),
                     }
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
-                    Err(err) => return Err(uv_virtualenv::Error::from(err).into()),
+                } else {
+                    false
                 };
 
                 debug!(
@@ -2223,9 +2260,7 @@ impl ScriptEnvironment {
                     interpreter,
                     prompt,
                     false,
-                    uv_virtualenv::OnExisting::Remove(
-                        uv_virtualenv::RemovalReason::ManagedEnvironment,
-                    ),
+                    uv_virtualenv::OnExisting::Fail,
                     false,
                     uv_virtualenv::Seed::Disabled,
                     upgradeable,

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -4690,19 +4690,102 @@ fn run_active_script_environment_non_virtualenv() -> Result<()> {
         .child("important.txt")
         .write_str("important data")?;
 
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--active")
+        .arg("--script")
+        .arg("main.py")
+        .env_remove(EnvVars::RUST_LOG)
+        .env(EnvVars::VIRTUAL_ENV, "foo"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Script virtual environment directory `[TEMP_DIR]/foo` cannot be used because it is not a virtual environment
+    ");
+
+    active_environment
+        .child("important.txt")
+        .assert("important data");
+
+    // Sync uses the same environment initialization and must also preserve the directory.
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--active")
+        .arg("--script")
+        .arg("main.py")
+        .env_remove(EnvVars::RUST_LOG)
+        .env(EnvVars::VIRTUAL_ENV, "foo"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Script virtual environment directory `[TEMP_DIR]/foo` cannot be used because it is not a virtual environment
+    ");
+
+    active_environment
+        .child("important.txt")
+        .assert("important data");
+
+    // An empty active destination can be initialized without removing user data.
+    let empty_environment = context.temp_dir.child("empty");
+    empty_environment.create_dir_all()?;
     context
         .run()
         .arg("--active")
         .arg("--script")
         .arg("main.py")
-        .env(EnvVars::VIRTUAL_ENV, "foo")
+        .env(EnvVars::VIRTUAL_ENV, "empty")
         .assert()
         .success();
+    empty_environment
+        .child("pyvenv.cfg")
+        .assert(predicate::path::is_file());
 
-    active_environment.assert(predicate::path::is_dir());
-    // Silently deleting user data outside a virtual environment is undesirable.
-    active_environment
-        .child("important.txt")
+    Ok(())
+}
+
+#[test]
+fn run_script_environment_cache_repair() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("main.py").write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = []
+        # ///
+
+        import sys
+
+        print(sys.prefix)
+        "#
+    })?;
+
+    let output = uv_snapshot!(context.filters(), context.run()
+        .arg("--script")
+        .arg("main.py")
+        .env_remove(EnvVars::RUST_LOG), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [CACHE_DIR]/environments-v2/main-[HASH]
+    ");
+
+    let environment = ChildPath::new(String::from_utf8(output.stdout)?.trim());
+    assert!(environment.path().starts_with(context.cache_dir.path()));
+    fs_err::remove_dir_all(&environment)?;
+    environment.create_dir_all()?;
+    environment
+        .child("stale.txt")
+        .write_str("stale cache data")?;
+
+    // A damaged derived cache entry belongs to uv and can still be replaced.
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--script")
+        .arg("main.py")
+        .env_remove(EnvVars::RUST_LOG), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [CACHE_DIR]/environments-v2/main-[HASH]
+    ");
+
+    environment
+        .child("pyvenv.cfg")
+        .assert(predicate::path::is_file());
+    environment
+        .child("stale.txt")
         .assert(predicate::path::missing());
 
     Ok(())


### PR DESCRIPTION
`uv run --active --script` and `uv sync --active --script` can delete a nonempty `VIRTUAL_ENV` directory when it cannot be reused, even if it is not a virtual environment.

Reject nonempty active destinations without `pyvenv.cfg` before removal. Preserve creation in missing or empty directories, virtualenv replacement, and repair of uv's derived cache entries. Use `OnExisting::Fail` after conditional removal to prevent another unchecked removal during creation.

Fixes #21364.
