### PR TITLE
Avoid per-file temporary directories for merged copies

### DIFF
--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -88,11 +88,12 @@ where
 
 /// Directory-level locks for concurrent copy operations.
 ///
-/// Copying is the only non-atomic [`LinkMode`]: it creates a file then writes bytes, so concurrent
-/// copies to the same directory can produce corrupted files.
+/// Copying directly to the destination creates a file then writes bytes, so concurrent copies to
+/// the same directory can produce corrupted files.
 ///
-/// These locks are used whenever a file is physically copied, regardless of the requested
-/// [`LinkMode`], as all modes can fallback to copying.
+/// These locks are used for copies that write directly to their destination. When merging,
+/// copies are written to unique temporary files and then published atomically, so they don't
+/// require synchronization.
 ///
 /// The intended pattern for usage is to create a [`CopyLocks`] instance then share it across all
 /// [`link_dir`] invocations that may conflict via [`LinkOptions::with_copy_locks`].
@@ -179,8 +180,8 @@ impl<'a, F> LinkOptions<'a, F> {
 
     /// Set the locks for synchronized copying.
     ///
-    /// When provided, file copy operations will acquire a directory-level lock before writing. This
-    /// prevents corruption when multiple installations run concurrently.
+    /// When provided, copies that write directly to their destination acquire a directory-level
+    /// lock before writing. This prevents corruption when multiple installations run concurrently.
     #[must_use]
     pub fn with_copy_locks(self, locks: &'a CopyLocks) -> Self {
         LinkOptions {
@@ -406,7 +407,7 @@ where
         LinkMode::Symlink => symlink_file_with_fallback(path, target, state, options),
         LinkMode::Copy => {
             if options.on_existing_directory == OnExistingDirectory::Merge {
-                atomic_copy_overwrite(path, target, options)?;
+                atomic_copy_overwrite(path, target)?;
             } else {
                 copy_file(path, target, options)?;
             }
@@ -654,7 +655,7 @@ where
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
-                    atomic_hardlink_overwrite(path, target, state, options)
+                    atomic_hardlink_overwrite(path, target, state)
                 } else {
                     debug!(
                         "Failed to hard link `{}` to `{}`: {}; falling back to copy",
@@ -678,7 +679,7 @@ where
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
-                    atomic_hardlink_overwrite(path, target, state, options)
+                    atomic_hardlink_overwrite(path, target, state)
                 } else {
                     Err(LinkError::Io(err))
                 }
@@ -713,7 +714,7 @@ where
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
-                    atomic_symlink_overwrite(path, target, state, options)
+                    atomic_symlink_overwrite(path, target, state)
                 } else {
                     debug!(
                         "Failed to symlink `{}` to `{}`: {}; falling back to copy",
@@ -737,7 +738,7 @@ where
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
-                    atomic_symlink_overwrite(path, target, state, options)
+                    atomic_symlink_overwrite(path, target, state)
                 } else {
                     Err(LinkError::Symlink {
                         from: path.to_path_buf(),
@@ -794,15 +795,11 @@ fn try_hardlink_file(src: &Path, dst: &Path) -> io::Result<()> {
 }
 
 /// Atomically overwrite an existing file with a hard link.
-fn atomic_hardlink_overwrite<F>(
+fn atomic_hardlink_overwrite(
     src: &Path,
     dst: &Path,
     state: LinkState,
-    options: &LinkOptions<'_, F>,
-) -> Result<LinkState, LinkError>
-where
-    F: Fn(&Path) -> bool,
-{
+) -> Result<LinkState, LinkError> {
     // TODO(zanieb): These unwraps were copied from `uv-install-wheel`; consider propagating errors
     // instead of panicking if `dst` has no parent or file name.
     let parent = dst.parent().unwrap();
@@ -823,46 +820,25 @@ where
             If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
         );
         let state = state.next_mode();
-        atomic_copy_overwrite(src, dst, options)?;
+        atomic_copy_overwrite(src, dst)?;
         Ok(state)
     }
 }
 
 /// Atomically overwrite an existing file with a copy.
-fn atomic_copy_overwrite<F>(
-    src: &Path,
-    dst: &Path,
-    options: &LinkOptions<'_, F>,
-) -> Result<(), LinkError>
-where
-    F: Fn(&Path) -> bool,
-{
-    // TODO(zanieb): These unwraps were copied from `uv-install-wheel`; consider propagating errors
-    // instead of panicking if `dst` has no parent or file name.
-    let parent = dst.parent().unwrap();
-    let tempdir = tempfile::tempdir_in(parent)?;
-    let tempfile = tempdir.path().join(dst.file_name().unwrap());
-
-    options
-        .copy_file(src, &tempfile)
-        .map_err(|err| LinkError::Copy {
-            to: tempfile.clone(),
-            err,
-        })?;
-    fs_err::rename(&tempfile, dst)?;
-    Ok(())
+fn atomic_copy_overwrite(src: &Path, dst: &Path) -> Result<(), LinkError> {
+    crate::copy_atomic_sync(src, dst).map_err(|err| LinkError::Copy {
+        to: dst.to_path_buf(),
+        err,
+    })
 }
 
 /// Atomically overwrite an existing file with a symlink.
-fn atomic_symlink_overwrite<F>(
+fn atomic_symlink_overwrite(
     src: &Path,
     dst: &Path,
     state: LinkState,
-    options: &LinkOptions<'_, F>,
-) -> Result<LinkState, LinkError>
-where
-    F: Fn(&Path) -> bool,
-{
+) -> Result<LinkState, LinkError> {
     // TODO(zanieb): These unwraps were copied from `uv-install-wheel`; consider propagating errors
     // instead of panicking if `dst` has no parent or file name.
     let parent = dst.parent().unwrap();
@@ -883,7 +859,7 @@ where
             If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning."
         );
         let state = state.next_mode();
-        atomic_copy_overwrite(src, dst, options)?;
+        atomic_copy_overwrite(src, dst)?;
         Ok(state)
     }
 }
@@ -908,6 +884,8 @@ fn create_symlink(original: &Path, link: &Path) -> io::Result<()> {
 #[expect(clippy::print_stderr)]
 mod tests {
     use std::assert_matches;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     use super::*;
     use tempfile::TempDir;
@@ -1352,6 +1330,44 @@ mod tests {
             fs_err::read_to_string(dst_dir.path().join("existing.txt")).unwrap(),
             "should remain"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_copy_merge_replaces_symlink_and_preserves_permissions() -> Result<(), LinkError> {
+        let src_dir = test_tempdir();
+        let dst_dir = test_tempdir();
+
+        let source = src_dir.path().join("script");
+        fs_err::write(&source, "new content")?;
+        fs_err::set_permissions(&source, std::fs::Permissions::from_mode(0o751))?;
+
+        let destination = dst_dir.path().join("script");
+        fs_err::write(dst_dir.path().join("original"), "original content")?;
+        fs_err::os::unix::fs::symlink("original", &destination)?;
+
+        let locks = CopyLocks::default();
+        let options = LinkOptions::new(LinkMode::Copy)
+            .with_copy_locks(&locks)
+            .with_on_existing_directory(OnExistingDirectory::Merge);
+        assert_eq!(
+            link_dir(src_dir.path(), dst_dir.path(), &options)?,
+            LinkMode::Copy
+        );
+
+        assert!(fs_err::symlink_metadata(&destination)?.is_file());
+        assert_eq!(fs_err::read_to_string(&destination)?, "new content");
+        assert_eq!(
+            fs_err::metadata(&destination)?.permissions().mode() & 0o777,
+            0o751
+        );
+        assert_eq!(
+            fs_err::read_to_string(dst_dir.path().join("original"))?,
+            "original content"
+        );
+        assert_eq!(fs_err::read_dir(dst_dir.path())?.count(), 2);
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

We currently create and remove a temporary directory for every file when merging copied wheels into an existing installation, then register a copy lock under that one-off directory. We now copy into a unique temporary file in the destination directory and publish it by atomic rename. The old lock could not coordinate distinct copies because each directory was unique; copies that write directly to a shared destination keep their locks.

Ordinary failures drop and remove the temporary file. An abrupt termination may leave an orphan file where the previous implementation could leave an orphan directory; neither changes the destination before the rename. This provides per-file atomicity, not an all-or-nothing wheel install.

In eight randomized paired runs on Linux with a warm offline cache and a fresh virtual environment per sample, we measured these install-phase medians:

| Workload | Before | After |
| --- | ---: | ---: |
| One 10,000-file wheel | 3.44 s | 2.87 s |
| JupyterLab, 90 wheels | 1.99 s | 1.68 s |
