### PR TITLE
Fix signing dry-run secret access and manifest generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,11 @@ jobs:
           TAG: ${{ needs.plan.outputs.tag-flag }}
         run: |
           temp_manifest=target/local-dist-manifest.json.tmp
-          uv run --only-dev dist manifest "$TAG" --output-format=json --no-local-paths --artifacts=local > "$temp_manifest"
+          tag_args=()
+          if [[ -n "$TAG" ]]; then
+            tag_args=("$TAG")
+          fi
+          uv run --only-dev dist manifest "${tag_args[@]}" --output-format=json --no-local-paths --artifacts=local > "$temp_manifest"
           python3 scripts/patch-dist-manifest-checksums.py --manifest "$temp_manifest" --artifacts-dir target/distrib
           mv "$temp_manifest" target/distrib/local-dist-manifest.json
       - name: Upload synthesized local dist manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
       - release-gate
     if: ${{ inputs.tag == 'dry-run' && github.repository == 'astral-sh/uv' && github.ref == 'refs/heads/main' }}
     uses: $/.github/workflows/sign-release-binaries.yml
+    secrets: inherit
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
The [release dry-run](https://github.com/astral-sh/uv/actions/runs/33918220819) reached both signing jobs with empty Azure login inputs. Pass secrets to the reusable signing workflow so its `release` environment settings are available to the jobs.

The same run passed an empty tag as a positional argument to `dist manifest`. Omit that argument when the dry-run has no tag.
