### PR TITLE
Deduplicate concurrent cacheable Simple API requests

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -102,6 +102,16 @@ impl CacheEntry {
         )
         .await?)
     }
+
+    /// Try to acquire the [`CacheEntry`] as an exclusive lock without waiting.
+    pub fn try_lock(&self) -> Result<Option<LockedFile>, Error> {
+        fs_err::create_dir_all(self.dir())?;
+        Ok(LockedFile::acquire_no_wait(
+            self.path(),
+            LockedFileMode::Exclusive,
+            self.path().display(),
+        ))
+    }
 }
 
 impl AsRef<Path> for CacheEntry {

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -222,6 +222,66 @@ impl CachedClient {
         self.0.certificate_source()
     }
 
+    /// Return a cached response without making an HTTP request, if permitted by the cache policy.
+    ///
+    /// A cache miss or stale response can be retried after acquiring the cache entry's lock.
+    #[instrument(skip_all)]
+    pub(crate) async fn get_fresh_cached<Payload: Cacheable + 'static>(
+        &self,
+        mut request: Request,
+        cache_entry: &CacheEntry,
+        cache_control: &CacheControl,
+    ) -> Option<Payload::Target> {
+        match cache_control {
+            CacheControl::AllowStale => {
+                let (_, cached) = self
+                    .read_and_decode_stale_cache::<Payload>(request, cache_entry)
+                    .await;
+                return cached.ok().flatten();
+            }
+            CacheControl::MustRevalidate => {
+                request.headers_mut().insert(
+                    http::header::CACHE_CONTROL,
+                    http::HeaderValue::from_static("no-cache"),
+                );
+            }
+            CacheControl::None | CacheControl::Override(_) => {}
+        }
+
+        // Leave corrupt entries untouched: the caller can heal them after acquiring the lock.
+        let cached =
+            DataWithCachePolicy::from_path_async(cache_entry.path(), self.0.cache_read_runtime())
+                .await
+                .ok()?;
+        match cached.cache_policy.before_request(&mut request) {
+            BeforeRequest::Fresh => {}
+            BeforeRequest::Stale(_) | BeforeRequest::NoMatch => return None,
+        }
+
+        match self
+            .0
+            .cache_read_runtime()
+            .spawn_blocking(move || Payload::from_aligned_bytes(cached.data))
+            .await
+        {
+            Ok(Ok(payload)) => Some(payload),
+            Ok(Err(err)) => {
+                warn!(
+                    "Broken fresh cache payload at {}: {err}",
+                    cache_entry.path().display()
+                );
+                None
+            }
+            Err(err) => {
+                warn!(
+                    "Failed to decode fresh cache payload at {}: {err}",
+                    cache_entry.path().display()
+                );
+                None
+            }
+        }
+    }
+
     /// Make a cached request with a custom response transformation while using
     /// the `Cacheable` trait to (de)serialize cached responses.
     ///

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -560,14 +560,13 @@ impl RegistryClient {
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
-        // Acquire an advisory lock, to guard against concurrent writes.
-        #[cfg(windows)]
-        let _lock = {
-            let lock_entry = cache_entry.with_file(format!("{package_name}.lock"));
-            lock_entry.lock().await.map_err(ErrorKind::CacheLock)?
-        };
-
         let result = if matches!(index, IndexUrl::Path(_)) {
+            // Reading a local index needs no cache entry, but retain the existing lock on Windows.
+            #[cfg(windows)]
+            let _lock = {
+                let lock_entry = cache_entry.with_file(format!("{package_name}.lock"));
+                lock_entry.lock().await.map_err(ErrorKind::CacheLock)?
+            };
             self.fetch_local_simple_detail(package_name, &url).await
         } else {
             self.fetch_remote_simple_detail(package_name, &url, &cache_entry, cache_control)
@@ -623,6 +622,80 @@ impl RegistryClient {
             .map_err(|err| {
                 ErrorKind::from_reqwest(url.clone(), err, self.client.certificate_source())
             })?;
+
+        // Fresh cache entries don't need to wait on another process. On Windows, retain the
+        // existing lock around cache reads so they cannot race with a file replacement.
+        if !cfg!(windows)
+            && !self.cache.is_temporary()
+            && !self.connectivity.is_offline()
+            && let Some(request) = simple_request.try_clone()
+            && let Some(cached) = self
+                .cached_client()
+                .get_fresh_cached::<OwnedArchive<SimpleDetailMetadata>>(
+                    request,
+                    cache_entry,
+                    &cache_control,
+                )
+                .await
+        {
+            return Ok(cached);
+        }
+
+        // Only persistent online caches can share a fetch between processes. Temporary caches
+        // are private to an invocation; Windows still needs its existing write lock for them.
+        let (lock, waited) =
+            if cfg!(windows) || (!self.cache.is_temporary() && !self.connectivity.is_offline()) {
+                let lock_entry = cache_entry.with_file(format!("{package_name}.lock"));
+                if !cfg!(windows)
+                    && let Some(lock) = lock_entry.try_lock().map_err(ErrorKind::CacheLock)?
+                {
+                    (Some(lock), false)
+                } else {
+                    (
+                        Some(lock_entry.lock().await.map_err(ErrorKind::CacheLock)?),
+                        !cfg!(windows),
+                    )
+                }
+            } else {
+                (None, false)
+            };
+
+        // A preceding process may have refreshed this package while we waited. Honor this
+        // invocation's refresh cutoff, but don't revalidate a newer entry unnecessarily.
+        let cache_control = if matches!(cache_control, CacheControl::MustRevalidate)
+            && self
+                .cache
+                .freshness(cache_entry, Some(package_name), None)
+                .map_err(ErrorKind::Io)?
+                .is_fresh()
+        {
+            CacheControl::None
+        } else {
+            cache_control
+        };
+
+        let _lock = if waited {
+            if let Some(request) = simple_request.try_clone()
+                && let Some(cached) = self
+                    .cached_client()
+                    .get_fresh_cached::<OwnedArchive<SimpleDetailMetadata>>(
+                        request,
+                        cache_entry,
+                        &cache_control,
+                    )
+                    .await
+            {
+                return Ok(cached);
+            }
+
+            // If the preceding request left no reusable entry (for example, `no-store` or an
+            // immediately stale response), fetching under the lock would serialize every waiter.
+            drop(lock);
+            None
+        } else {
+            lock
+        };
+
         let parse_simple_response = |response: Response| {
             async {
                 // Use the response URL, rather than the request URL, as the base for relative URLs.

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -5,6 +5,11 @@ use std::env::current_dir;
 use std::fs;
 use std::process::Command;
 use std::str::FromStr;
+#[cfg(not(windows))]
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
+use std::time::Duration;
 
 use anyhow::Result;
 #[cfg(feature = "test-universal")]
@@ -16,9 +21,12 @@ use http::StatusCode;
 #[cfg(feature = "test-universal")]
 use indoc::formatdoc;
 use indoc::indoc;
+use serde_json::json;
+#[cfg(not(windows))]
+use tokio::sync::Notify;
 use url::Url;
 use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
@@ -58,6 +66,207 @@ fn compile_requirements_in() -> Result<()> {
     ");
 
     Ok(())
+}
+
+/// Concurrent commands sharing a cache fetch a package's Simple API page only once, including
+/// when revalidating an existing entry.
+#[tokio::test]
+async fn compile_concurrent_simple_index_requests() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("requirements.in")
+        .write_str("ok==1.0.0")?;
+
+    let server = MockServer::start().await;
+    let index = simple_index_body(&server);
+    let revalidate = Arc::new(AtomicBool::new(false));
+    let revalidate_on_request = Arc::clone(&revalidate);
+    Mock::given(method("GET"))
+        .and(path("/simple/ok/"))
+        .respond_with(move |_: &Request| {
+            let response = if revalidate_on_request.load(Ordering::Relaxed) {
+                ResponseTemplate::new(304)
+            } else {
+                ResponseTemplate::new(200)
+                    .set_body_raw(index.clone(), "application/vnd.pypi.simple.v1+json")
+            };
+            response
+                .insert_header("Cache-Control", "max-age=600")
+                .insert_header("ETag", "\"v1\"")
+                .set_delay(Duration::from_millis(500))
+        })
+        .mount(&server)
+        .await;
+    mount_simple_metadata(&server).await;
+
+    let index_url = format!("{}/simple", server.uri());
+    let cold = compile_parallel_with_shared_cache(&context, &index_url, false).await?;
+    insta::assert_snapshot!(String::from_utf8_lossy(&cold), @"ok==1.0.0");
+    assert_eq!(count_simple_requests(&server).await, 1);
+
+    let warm = compile_parallel_with_shared_cache(&context, &index_url, false).await?;
+    assert_eq!(cold, warm);
+    assert_eq!(count_simple_requests(&server).await, 1);
+
+    revalidate.store(true, Ordering::Relaxed);
+    let refreshed = compile_parallel_with_shared_cache(&context, &index_url, true).await?;
+    assert_eq!(cold, refreshed);
+    assert_eq!(count_simple_requests(&server).await, 2);
+
+    Ok(())
+}
+
+/// Once a no-store response has been received, waiting compiles can fetch independently.
+#[cfg(not(windows))]
+#[tokio::test]
+async fn compile_concurrent_uncacheable_simple_index_requests() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("requirements.in")
+        .write_str("ok==1.0.0")?;
+
+    let server = MockServer::start().await;
+    let index = simple_index_body(&server);
+    let requests = Arc::new(AtomicUsize::new(0));
+    let requests_on_response = Arc::clone(&requests);
+    let second_request = Arc::new(Notify::new());
+    let second_request_on_response = Arc::clone(&second_request);
+    let index_mock = Mock::given(method("GET"))
+        .and(path("/simple/ok/"))
+        .respond_with(move |_: &Request| {
+            let response = ResponseTemplate::new(200)
+                .set_body_raw(index.clone(), "application/vnd.pypi.simple.v1+json")
+                .insert_header("Cache-Control", "no-store");
+
+            match requests_on_response.fetch_add(1, Ordering::Relaxed) {
+                0 => response.set_delay(Duration::from_millis(500)),
+                1 => {
+                    second_request_on_response.notify_one();
+                    response.set_delay(Duration::from_secs(5))
+                }
+                _ => response,
+            }
+        })
+        .expect(8)
+        .mount_as_scoped(&server)
+        .await;
+    mount_simple_metadata(&server).await;
+
+    let index_url = format!("{}/simple", server.uri());
+    let compiles = tokio::spawn(async move {
+        compile_parallel_with_shared_cache(&context, &index_url, false).await
+    });
+
+    // The first request completes before followers can proceed. Start the deadline when the
+    // second request arrives, avoiding a dependency on subprocess startup speed. The other six
+    // requests should arrive while its response is delayed; a serialized fetch would not.
+    let second_request_arrived =
+        tokio::time::timeout(Duration::from_secs(20), second_request.notified())
+            .await
+            .is_ok();
+    let concurrent = if second_request_arrived {
+        tokio::time::timeout(Duration::from_secs(4), index_mock.wait_until_satisfied())
+            .await
+            .is_ok()
+    } else {
+        false
+    };
+
+    let output = compiles.await??;
+    insta::assert_snapshot!(String::from_utf8_lossy(&output), @"ok==1.0.0");
+    assert_eq!(count_simple_requests(&server).await, 8);
+    assert!(second_request_arrived, "Expected multiple index requests");
+    assert!(
+        concurrent,
+        "No-store responses must not serialize every fetch"
+    );
+
+    Ok(())
+}
+
+fn simple_index_body(server: &MockServer) -> String {
+    let filename = "ok-1.0.0-py3-none-any.whl";
+    json!({
+        "name": "ok",
+        "files": [{
+            "filename": filename,
+            "hashes": {},
+            "url": format!("{}/files/{filename}", server.uri()),
+            "core-metadata": true,
+            "upload-time": "2024-03-24T00:00:00Z",
+        }],
+    })
+    .to_string()
+}
+
+async fn mount_simple_metadata(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/files/ok-1.0.0-py3-none-any.whl.metadata"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(indoc! {"
+            Metadata-Version: 2.1
+            Name: ok
+            Version: 1.0.0
+            Requires-Python: >=3.8
+        "}))
+        .mount(server)
+        .await;
+}
+
+async fn compile_parallel_with_shared_cache(
+    context: &TestContext,
+    index_url: &str,
+    refresh: bool,
+) -> Result<Vec<u8>> {
+    const COMPILES: usize = 8;
+    let barrier = Arc::new(Barrier::new(COMPILES));
+    let mut tasks = Vec::with_capacity(COMPILES);
+    for _ in 0..COMPILES {
+        let mut command = context.pip_compile();
+        command
+            .arg("requirements.in")
+            .arg("--index-url")
+            .arg(index_url)
+            .arg("--no-header")
+            .arg("--no-annotate");
+        if refresh {
+            command.arg("--refresh");
+        }
+        let barrier = Arc::clone(&barrier);
+        tasks.push(tokio::task::spawn_blocking(move || {
+            barrier.wait();
+            command.output()
+        }));
+    }
+
+    let mut outputs = Vec::with_capacity(COMPILES);
+    for task in tasks {
+        let output = task.await??;
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        outputs.push(output.stdout);
+    }
+    let first = outputs
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("No compiles were started"))?;
+    for output in &outputs {
+        assert_eq!(output, first);
+    }
+    Ok(first.clone())
+}
+
+async fn count_simple_requests(server: &MockServer) -> usize {
+    server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|request| request.url.path() == "/simple/ok/")
+        .count()
 }
 
 /// Resolve a specific version of `anyio` from a `requirements.in` file with a `--annotation-style=line` flag.


### PR DESCRIPTION
## Summary

When multiple commands share a cold or stale cache, we can fetch the same package's Simple API page once per process. We now coordinate persistent online caches with a per-index, per-package advisory lock and recheck both HTTP freshness and the command's refresh cutoff after acquiring it. Fresh Unix cache reads stay lock-free; Windows retains its existing cache-file lock, and temporary and offline caches retain their previous behavior.

If the preceding request left no reusable response (`no-store`, an immediately stale policy, or an error), Unix waiters release the lock and fetch concurrently. We still honor HTTP cache policy: these responses cannot be deduplicated via the disk cache, and the wait for the first request adds some latency.

In five paired localhost trials with eight simultaneous compiles and an 80 ms Simple response delay, we measured:

| Simple response | GETs before | GETs after | Cold before | Cold after |
| --- | ---: | ---: | ---: | ---: |
| `max-age=3600` | 8 | 1 | 248 ms | 235 ms |
| `no-store` | 8 | 8 | 257 ms | 273 ms |
| `max-age=0` | 8 | 8 | 243 ms | 270 ms |

All outputs matched byte-for-byte. Warm follow-ups made no Simple GETs for cacheable responses and one each for immediately stale or uncacheable responses. In the cacheable trials, all eight processes still fetched wheel metadata. These controlled measurements demonstrate reduced index traffic, not a projected end-to-end speedup for other workloads.
