### PR TITLE
Create atomic replacement links without temporary directories

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -1564,22 +1564,15 @@ mod tests {
     fn test_replace_archive_link() {
         let cache = Cache::temp().unwrap();
         let link = cache.root().join("link");
-        let first = ArchiveId::new();
-        let second = ArchiveId::new();
-        fs_err::create_dir_all(cache.archive(&first)).unwrap();
-        fs_err::create_dir_all(cache.archive(&second)).unwrap();
-
-        cache.create_link(&first, &link).unwrap();
-        assert_eq!(
-            cache.resolve_link(&link).unwrap(),
-            cache.archive(&first).canonicalize().unwrap()
-        );
-
-        cache.create_link(&second, &link).unwrap();
-        assert_eq!(
-            cache.resolve_link(&link).unwrap(),
-            cache.archive(&second).canonicalize().unwrap()
-        );
+        for id in [ArchiveId::new(), ArchiveId::new()] {
+            let archive = cache.archive(&id);
+            fs_err::create_dir_all(&archive).unwrap();
+            cache.create_link(&id, &link).unwrap();
+            assert_eq!(
+                cache.resolve_link(&link).unwrap(),
+                archive.canonicalize().unwrap()
+            );
+        }
     }
 
     #[test]

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -917,15 +917,7 @@ impl Cache {
                 Ok(())
             }
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                // Write to a temporary file, then move it into place.
-                let temp_dir = tempfile::tempdir_in(dst.as_ref().parent().unwrap())?;
-                let temp_file = temp_dir.path().join("link");
-                fs_err::write(&temp_file, contents.as_bytes())?;
-
-                // Move the symlink into the target location.
-                fs_err::rename(&temp_file, dst.as_ref())?;
-
-                Ok(())
+                uv_fs::write_atomic_sync(dst, contents.as_bytes())
             }
             Err(err) => Err(err),
         }
@@ -964,22 +956,7 @@ impl Cache {
         // Construct the relative link target.
         let src = uv_fs::relative_to(self.archive(id), dst_parent)?;
 
-        // Attempt to create the symlink directly.
-        match fs_err::os::unix::fs::symlink(&src, dst) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                // Create a symlink, using a temporary file to ensure atomicity.
-                let temp_dir = tempfile::tempdir_in(dst_parent)?;
-                let temp_file = temp_dir.path().join("link");
-                fs_err::os::unix::fs::symlink(&src, &temp_file)?;
-
-                // Move the symlink into the target location.
-                fs_err::rename(&temp_file, dst)?;
-
-                Ok(())
-            }
-            Err(err) => Err(err),
-        }
+        uv_fs::replace_symlink(&src, dst)
     }
 
     /// Resolve an archive link, returning the fully-resolved path.
@@ -1571,7 +1548,7 @@ mod tests {
 
     use crate::ArchiveId;
 
-    use super::Link;
+    use super::{Cache, Link};
 
     #[test]
     fn test_link_round_trip() {
@@ -1581,6 +1558,28 @@ mod tests {
         let parsed = Link::from_str(&s).unwrap();
         assert_eq!(link.id, parsed.id);
         assert_eq!(link.version, parsed.version);
+    }
+
+    #[test]
+    fn test_replace_archive_link() {
+        let cache = Cache::temp().unwrap();
+        let link = cache.root().join("link");
+        let first = ArchiveId::new();
+        let second = ArchiveId::new();
+        fs_err::create_dir_all(cache.archive(&first)).unwrap();
+        fs_err::create_dir_all(cache.archive(&second)).unwrap();
+
+        cache.create_link(&first, &link).unwrap();
+        assert_eq!(
+            cache.resolve_link(&link).unwrap(),
+            cache.archive(&first).canonicalize().unwrap()
+        );
+
+        cache.create_link(&second, &link).unwrap();
+        assert_eq!(
+            cache.resolve_link(&link).unwrap(),
+            cache.archive(&second).canonicalize().unwrap()
+        );
     }
 
     #[test]

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -314,20 +314,20 @@ fn replace_with_symlink_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
 
 /// Create a symlink at `dst` pointing to `src`, replacing any existing symlink if necessary.
 ///
-/// On Unix, this method creates a temporary file, then moves it into place.
+/// On Unix, an existing link is replaced by creating an adjacent temporary symlink and renaming it.
 #[cfg(unix)]
 pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
     // Attempt to create the symlink directly.
     match fs_err::os::unix::fs::symlink(src.as_ref(), dst.as_ref()) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-            // Create a symlink, using a temporary file to ensure atomicity.
-            let temp_dir = tempfile::tempdir_in(dst.as_ref().parent().unwrap())?;
-            let temp_file = temp_dir.path().join("link");
-            fs_err::os::unix::fs::symlink(src, &temp_file)?;
-
-            // Move the symlink into the target location.
-            fs_err::rename(&temp_file, dst.as_ref())?;
+            let temp_file = tempfile::Builder::new().make_in(
+                dst.as_ref()
+                    .parent()
+                    .expect("Symlink path must have a parent"),
+                |path| fs_err::os::unix::fs::symlink(src.as_ref(), path),
+            )?;
+            temp_file.persist(dst.as_ref()).map_err(|err| err.error)?;
 
             Ok(())
         }
@@ -505,12 +505,12 @@ pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std
 
 /// Write `data` to `path` atomically using a temporary file and atomic rename.
 pub fn write_atomic_sync(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std::io::Result<()> {
-    let temp_file = tempfile_in(
+    let mut temp_file = tempfile_in(
         path.as_ref()
             .parent()
             .expect("Write path must have a parent"),
     )?;
-    fs_err::write(&temp_file, &data)?;
+    temp_file.write_all(data.as_ref())?;
     persist_with_retry_sync(temp_file, path.as_ref())
 }
 

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -314,7 +314,7 @@ fn replace_with_symlink_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
 
 /// Create a symlink at `dst` pointing to `src`, replacing any existing symlink if necessary.
 ///
-/// On Unix, an existing link is replaced by creating an adjacent temporary symlink and renaming it.
+/// On Unix, existing links are replaced atomically.
 #[cfg(unix)]
 pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
     // Attempt to create the symlink directly.
@@ -327,7 +327,7 @@ pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io:
                     .expect("Symlink path must have a parent"),
                 |path| fs_err::os::unix::fs::symlink(src.as_ref(), path),
             )?;
-            temp_file.persist(dst.as_ref()).map_err(|err| err.error)?;
+            fs_err::rename(temp_file.path(), dst.as_ref())?;
 
             Ok(())
         }

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -314,10 +314,9 @@ fn replace_with_symlink_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
 
 /// Create a symlink at `dst` pointing to `src`, replacing any existing symlink if necessary.
 ///
-/// On Unix, existing links are replaced atomically.
+/// On Unix, this method creates a temporary file, then moves it into place.
 #[cfg(unix)]
 pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    // Attempt to create the symlink directly.
     match fs_err::os::unix::fs::symlink(src.as_ref(), dst.as_ref()) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -796,6 +796,7 @@ fn atomic_hardlink_overwrite(
     dst: &Path,
     state: LinkState,
 ) -> Result<LinkState, LinkError> {
+    // TODO(zanieb): Consider propagating an error instead of panicking if `dst` has no parent.
     if let Ok(temp_file) = tempfile::Builder::new().make_in(
         dst.parent().expect("Link path must have a parent"),
         |temp_path| try_hardlink_file(src, temp_path),
@@ -833,6 +834,7 @@ fn atomic_symlink_overwrite(
     dst: &Path,
     state: LinkState,
 ) -> Result<LinkState, LinkError> {
+    // TODO(zanieb): Consider propagating an error instead of panicking if `dst` has no parent.
     if let Ok(temp_file) = tempfile::Builder::new().make_in(
         dst.parent().expect("Link path must have a parent"),
         |temp_path| create_symlink(src, temp_path),

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -63,8 +63,7 @@ pub enum OnExistingDirectory {
     /// Fail if the destination directory already exists.
     #[default]
     Fail,
-    /// Merge into the existing directory, overwriting files atomically via temporary paths
-    /// and rename.
+    /// Merge into the existing directory, overwriting files via atomic renames.
     Merge,
 }
 
@@ -473,12 +472,11 @@ where
             Ok(()) => Ok(state.mode_working()),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 if options.on_existing_directory == OnExistingDirectory::Merge {
-                    let temp_file = tempfile::Builder::new().make_in(
+                    if let Ok(temp_file) = tempfile::Builder::new().make_in(
                         target.parent().expect("Link path must have a parent"),
                         |temp_path| reflink_with_permissions(path, temp_path),
-                    );
-                    if let Ok(temp_file) = temp_file {
-                        temp_file.persist(target).map_err(|err| err.error)?;
+                    ) {
+                        fs_err::rename(temp_file.path(), target)?;
                         Ok(state.mode_working())
                     } else {
                         debug!(
@@ -519,7 +517,7 @@ where
                             to: target.to_path_buf(),
                             err,
                         })?;
-                    temp_file.persist(target).map_err(|err| err.error)?;
+                    fs_err::rename(temp_file.path(), target)?;
                     Ok(state)
                 } else {
                     Err(LinkError::Reflink {
@@ -614,7 +612,7 @@ where
                             to: dst_path.clone(),
                             err,
                         })?;
-                    temp_file.persist(&dst_path).map_err(|err| err.error)?;
+                    fs_err::rename(temp_file.path(), &dst_path)?;
                 }
                 Err(err) => {
                     return Err(LinkError::Reflink {
@@ -798,13 +796,12 @@ fn atomic_hardlink_overwrite(
     dst: &Path,
     state: LinkState,
 ) -> Result<LinkState, LinkError> {
-    let temp_file = tempfile::Builder::new().make_in(
+    if let Ok(temp_file) = tempfile::Builder::new().make_in(
         dst.parent().expect("Link path must have a parent"),
         |temp_path| try_hardlink_file(src, temp_path),
-    );
-
-    if let Ok(temp_file) = temp_file {
-        temp_file.persist(dst).map_err(|err| err.error)?;
+    ) {
+        // `persist` resets Windows file attributes, which are shared with the source.
+        fs_err::rename(temp_file.path(), dst)?;
         Ok(state.mode_working())
     } else {
         debug!(
@@ -836,18 +833,17 @@ fn atomic_symlink_overwrite(
     dst: &Path,
     state: LinkState,
 ) -> Result<LinkState, LinkError> {
-    let temp_file = tempfile::Builder::new().make_in(
+    if let Ok(temp_file) = tempfile::Builder::new().make_in(
         dst.parent().expect("Link path must have a parent"),
         |temp_path| create_symlink(src, temp_path),
-    );
-
-    if let Ok(temp_file) = temp_file {
-        temp_file.persist(dst).map_err(|err| {
-            // TempPath uses `remove_file`, which cannot remove a directory symlink on Windows.
-            #[cfg(windows)]
-            let _ = crate::remove_symlink(err.file.path());
-            err.error
-        })?;
+    ) {
+        let result = fs_err::rename(temp_file.path(), dst);
+        // TempPath uses `remove_file`, which cannot remove a directory symlink on Windows.
+        #[cfg(windows)]
+        if result.is_err() {
+            let _ = crate::remove_symlink(temp_file.path());
+        }
+        result?;
         Ok(state.mode_working())
     } else {
         debug!(
@@ -1519,11 +1515,21 @@ mod tests {
         fs_err::create_dir_all(dst_dir.path()).unwrap();
         fs_err::write(dst_dir.path().join("file1.txt"), "old").unwrap();
 
+        let source = src_dir.path().join("file1.txt");
+        let original_permissions = fs_err::metadata(&source).unwrap().permissions();
+        let mut permissions = original_permissions.clone();
+        permissions.set_readonly(true);
+        fs_err::set_permissions(&source, permissions).unwrap();
+
         let options = LinkOptions::new(LinkMode::Hardlink)
             .with_on_existing_directory(OnExistingDirectory::Merge);
         let result = link_dir(src_dir.path(), dst_dir.path(), &options).unwrap();
 
         assert!(result == LinkMode::Hardlink || result == LinkMode::Copy);
+
+        let source_is_readonly = fs_err::metadata(&source).unwrap().permissions().readonly();
+        fs_err::set_permissions(&source, original_permissions).unwrap();
+        assert!(source_is_readonly);
 
         // Content should be overwritten
         assert_eq!(

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -63,7 +63,8 @@ pub enum OnExistingDirectory {
     /// Fail if the destination directory already exists.
     #[default]
     Fail,
-    /// Merge into the existing directory, overwriting files atomically via temp-file renames.
+    /// Merge into the existing directory, overwriting files atomically via temporary paths
+    /// and rename.
     Merge,
 }
 
@@ -472,12 +473,12 @@ where
             Ok(()) => Ok(state.mode_working()),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 if options.on_existing_directory == OnExistingDirectory::Merge {
-                    // File exists, overwrite atomically via temp file
-                    let parent = target.parent().unwrap();
-                    let tempdir = tempfile::tempdir_in(parent)?;
-                    let tempfile = tempdir.path().join(target.file_name().unwrap());
-                    if reflink_with_permissions(path, &tempfile).is_ok() {
-                        fs_err::rename(&tempfile, target)?;
+                    let temp_file = tempfile::Builder::new().make_in(
+                        target.parent().expect("Link path must have a parent"),
+                        |temp_path| reflink_with_permissions(path, temp_path),
+                    );
+                    if let Ok(temp_file) = temp_file {
+                        temp_file.persist(target).map_err(|err| err.error)?;
                         Ok(state.mode_working())
                     } else {
                         debug!(
@@ -508,17 +509,17 @@ where
             Ok(()) => Ok(state),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 if options.on_existing_directory == OnExistingDirectory::Merge {
-                    let parent = target.parent().unwrap();
-                    let tempdir = tempfile::tempdir_in(parent)?;
-                    let tempfile = tempdir.path().join(target.file_name().unwrap());
-                    reflink_with_permissions(path, &tempfile).map_err(|err| {
-                        LinkError::Reflink {
+                    let temp_file = tempfile::Builder::new()
+                        .make_in(
+                            target.parent().expect("Link path must have a parent"),
+                            |temp_path| reflink_with_permissions(path, temp_path),
+                        )
+                        .map_err(|err| LinkError::Reflink {
                             from: path.to_path_buf(),
-                            to: tempfile.clone(),
+                            to: target.to_path_buf(),
                             err,
-                        }
-                    })?;
-                    fs_err::rename(&tempfile, target)?;
+                        })?;
+                    temp_file.persist(target).map_err(|err| err.error)?;
                     Ok(state)
                 } else {
                     Err(LinkError::Reflink {
@@ -606,17 +607,14 @@ where
             match reflink_copy::reflink(&src_path, &dst_path) {
                 Ok(()) => {}
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                    // File exists, overwrite atomically via temp file
-                    let tempdir = tempfile::tempdir_in(dst)?;
-                    let tempfile = tempdir.path().join(entry.file_name());
-                    reflink_copy::reflink(&src_path, &tempfile).map_err(|err| {
-                        LinkError::Reflink {
+                    let temp_file = tempfile::Builder::new()
+                        .make_in(dst, |temp_path| reflink_copy::reflink(&src_path, temp_path))
+                        .map_err(|err| LinkError::Reflink {
                             from: src_path.clone(),
-                            to: tempfile.clone(),
+                            to: dst_path.clone(),
                             err,
-                        }
-                    })?;
-                    fs_err::rename(&tempfile, &dst_path)?;
+                        })?;
+                    temp_file.persist(&dst_path).map_err(|err| err.error)?;
                 }
                 Err(err) => {
                     return Err(LinkError::Reflink {
@@ -800,14 +798,13 @@ fn atomic_hardlink_overwrite(
     dst: &Path,
     state: LinkState,
 ) -> Result<LinkState, LinkError> {
-    // TODO(zanieb): These unwraps were copied from `uv-install-wheel`; consider propagating errors
-    // instead of panicking if `dst` has no parent or file name.
-    let parent = dst.parent().unwrap();
-    let tempdir = tempfile::tempdir_in(parent)?;
-    let tempfile = tempdir.path().join(dst.file_name().unwrap());
+    let temp_file = tempfile::Builder::new().make_in(
+        dst.parent().expect("Link path must have a parent"),
+        |temp_path| try_hardlink_file(src, temp_path),
+    );
 
-    if try_hardlink_file(src, &tempfile).is_ok() {
-        fs_err::rename(&tempfile, dst)?;
+    if let Ok(temp_file) = temp_file {
+        temp_file.persist(dst).map_err(|err| err.error)?;
         Ok(state.mode_working())
     } else {
         debug!(
@@ -839,14 +836,18 @@ fn atomic_symlink_overwrite(
     dst: &Path,
     state: LinkState,
 ) -> Result<LinkState, LinkError> {
-    // TODO(zanieb): These unwraps were copied from `uv-install-wheel`; consider propagating errors
-    // instead of panicking if `dst` has no parent or file name.
-    let parent = dst.parent().unwrap();
-    let tempdir = tempfile::tempdir_in(parent)?;
-    let tempfile = tempdir.path().join(dst.file_name().unwrap());
+    let temp_file = tempfile::Builder::new().make_in(
+        dst.parent().expect("Link path must have a parent"),
+        |temp_path| create_symlink(src, temp_path),
+    );
 
-    if create_symlink(src, &tempfile).is_ok() {
-        fs_err::rename(&tempfile, dst)?;
+    if let Ok(temp_file) = temp_file {
+        temp_file.persist(dst).map_err(|err| {
+            // TempPath uses `remove_file`, which cannot remove a directory symlink on Windows.
+            #[cfg(windows)]
+            let _ = crate::remove_symlink(err.file.path());
+            err.error
+        })?;
         Ok(state.mode_working())
     } else {
         debug!(


### PR DESCRIPTION
## Summary

When merging into an existing directory, we create a temporary directory for each hard link, symlink, or reflink we replace, then remove it after the rename. We now create each replacement at a unique adjacent name with `tempfile::Builder::make_in` and rename it over the destination. Cache archive links share the symlink replacement helper, and synchronous atomic writes use the temporary file's open handle instead of reopening its path.

On a Linux/ext4 host, controlled benchmarks of the production `uv-fs` APIs reduced full-overlap hardlink merges by 65.9% (95% interval: 65.2–66.5%) and symlink merges by 62.3% (60.3–63.8%).

<details>
<summary>Benchmark method and complete Linux results</summary>

Compared `a061206b0` against `3c979abda4`, using the same optimized `profiling` build settings and Ohm 1.98.0-2 compiler on an AMD EPYC-Milan KVM host with ext4 (Linux 6.8.0-106; one CPU pinned). Each scenario has 16 measurements per variant in eight ABBA/BAAB blocks after four warmups; scenario order is shuffled within each block. All samples are retained, including a slow Linux write outlier. The existing volume was about 98% full, so these results remain host-specific.

Tree merges contain 2,048 files in 64 directories (8.5 MiB total; 64 B–16 KiB per file). Overlap levels mean 0, 21, or 2,048 existing filenames. Every trial starts with a freshly prepared destination containing distinct old inodes and contents. Setup, process startup, cleanup, and full output validation are outside the timed section. Writes use 64 destination paths in rotation; symlink replacements alternate between two directory targets.

Cells show geometric-mean **base → PR milliseconds per batch; elapsed-time reduction [95% interval]**. Negative reductions mean slower. Intervals bootstrap the eight complete four-run blocks with 20,000 resamples.

| Workload | Linux / ext4 |
| --- | --- |
| Hardlink merge, 0% overlap | 44.8 → 45.4; -1.3% [-3.2, +0.2] |
| Hardlink merge, 1% overlap | 49.5 → 48.0; +3.1% [-1.7, +5.7] |
| Hardlink merge, 100% overlap | 433.5 → 147.8; +65.9% [+65.2, +66.5] |
| Symlink merge, 0% overlap | 68.4 → 68.1; +0.5% [-0.6, +2.1] |
| Symlink merge, 1% overlap | 74.0 → 70.2; +5.1% [+2.7, +8.4] |
| Symlink merge, 100% overlap | 474.9 → 179.1; +62.3% [+60.3, +63.8] |
| 1,024 atomic writes, 4 KiB each | 338.1 → 274.2; +18.9% [+7.1, +35.0] |
| 1,024 atomic writes, 64 KiB each | 427.5 → 388.8; +9.0% [+2.0, +17.7] |
| 1,024 symlink replacements | 208.5 → 67.6; +67.6% [+66.3, +68.8] |

Separate `strace` runs confirm that a full 2,048-file merge removes 2,048 temporary-directory creations and removals, along with their opens and metadata reads; the PR instead makes 2,048 unsuccessful cleanup unlinks after successful renames. Atomic writes remove one file open per call. Traced runs are excluded from the timings.

Reflinks fell back to hardlinks on this filesystem and are omitted. A macOS run was excluded after a disk audit detected substantial concurrent cleanup. No Windows or cold-cache performance claim is made.

</details>
