### PR TITLE
Fix pip overrides path with spaces (#21477)

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1585,12 +1585,20 @@ pub struct PipCompileArgs {
     #[arg(
         long,
         alias = "override",
+        value_parser = parse_maybe_file_path,
+        value_hint = ValueHint::FilePath,
+    )]
+    pub overrides: Vec<Maybe<PathBuf>>,
+
+    #[arg(
+        long = "override-env",
+        hide = true,
         env = EnvVars::UV_OVERRIDE,
         value_delimiter = ' ',
         value_parser = parse_maybe_file_path,
         value_hint = ValueHint::FilePath,
     )]
-    pub overrides: Vec<Maybe<PathBuf>>,
+    pub overrides_from_env: Vec<Maybe<PathBuf>>,
 
     /// Exclude packages from resolution using the given requirements files.
     ///
@@ -2282,12 +2290,20 @@ pub struct PipInstallArgs {
     #[arg(
         long,
         alias = "override",
+        value_parser = parse_maybe_file_path,
+        value_hint = ValueHint::FilePath,
+    )]
+    pub overrides: Vec<Maybe<PathBuf>>,
+
+    #[arg(
+        long = "override-env",
+        hide = true,
         env = EnvVars::UV_OVERRIDE,
         value_delimiter = ' ',
         value_parser = parse_maybe_file_path,
         value_hint = ValueHint::FilePath,
     )]
-    pub overrides: Vec<Maybe<PathBuf>>,
+    pub overrides_from_env: Vec<Maybe<PathBuf>>,
 
     /// Exclude packages from resolution using the given requirements files.
     ///

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -3492,6 +3492,7 @@ impl PipCompileSettings {
             src_file,
             constraints,
             overrides,
+            overrides_from_env,
             excludes,
             extra,
             all_extras,
@@ -3609,6 +3610,7 @@ impl PipCompileSettings {
                 .collect(),
             overrides: overrides
                 .into_iter()
+                .chain(overrides_from_env)
                 .filter_map(Maybe::into_option)
                 .collect(),
             excludes: excludes
@@ -3814,6 +3816,7 @@ impl PipInstallSettings {
             no_editable_package,
             constraints,
             overrides,
+            overrides_from_env,
             excludes,
             build_constraints,
             extra,
@@ -3902,6 +3905,7 @@ impl PipInstallSettings {
                 .collect(),
             overrides: overrides
                 .into_iter()
+                .chain(overrides_from_env)
                 .filter_map(Maybe::into_option)
                 .collect(),
             excludes: excludes

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -16596,3 +16596,54 @@ fn compile_bytecode_excludes_stdlib() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn pip_install_overrides_path_with_spaces_via_cli() -> Result<()> {
+    // Regression for https://github.com/astral-sh/uv/issues/21477
+    // A CLI --override path containing spaces must be treated as a single path,
+    // not split on whitespace. Only UV_OVERRIDE env var should split on spaces.
+    let context = uv_test::test_context!("3.12");
+
+    // Create an overrides file under a directory whose name contains a space.
+    let spaced_dir = context.temp_dir.child("my overrides");
+    spaced_dir.create_dir_all()?;
+    let overrides_txt = spaced_dir.child("overrides.txt");
+    overrides_txt.write_str("anyio==4.0.0")?;
+
+    // Install with --override pointing at the spaced path. Before the fix this
+    // was split into two bogus paths and failed with "No such file or directory".
+    context
+        .pip_install()
+        .arg("anyio==3.7.0")
+        .arg("--override")
+        .arg(overrides_txt.path())
+        .arg("--no-deps")
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+#[test]
+fn pip_install_overrides_env_var_still_splits_on_spaces() -> Result<()> {
+    // UV_OVERRIDE should still accept multiple space-separated files.
+    let context = uv_test::test_context!("3.12");
+
+    let a_txt = context.temp_dir.child("a.txt");
+    a_txt.write_str("anyio==4.0.0")?;
+    let b_txt = context.temp_dir.child("b.txt");
+    b_txt.write_str("idna==3.6")?;
+
+    // Pass two overrides via the env var as a single space-separated string.
+    let combined = format!("{} {}", a_txt.path().display(), b_txt.path().display());
+    context
+        .pip_install()
+        .arg("anyio==3.7.0")
+        .arg("idna==3.6")
+        .env(EnvVars::UV_OVERRIDE, combined)
+        .arg("--no-deps")
+        .assert()
+        .success();
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #21477

## Summary
CLI `--override` paths containing spaces were incorrectly split on whitespace because `UV_OVERRIDE` (env var) and `--override` shared the same `value_delimiter = ' '`. The env var intentionally accepts multiple space-separated files, but a quoted CLI path like `"my overrides/overrides.txt"` must remain a single path.

## Root cause
`crates/uv-cli/src/lib.rs` defined `--override` with `env = UV_OVERRIDE` and `value_delimiter = ' '`. Clap applied the delimiter to both sources, so `uv pip install --override "my overrides/overrides.txt"` was parsed as two paths and failed with `No such file or directory`.

## Fix
- Split `--override` into two Clap inputs: `overrides` (CLI, no delimiter) and `overrides_from_env` (hidden, `UV_OVERRIDE` with `value_delimiter`).
- Merge both in `crates/uv/src/settings.rs` for `PipCompile` and `PipInstall` (`overrides.into_iter().chain(overrides_from_env)`).
- Preserve existing behavior: `UV_OVERRIDE="a.txt b.txt"` still resolves to two files.
- Add regression tests in `crates/uv/tests/pip_install/pip_install.rs`:
  - `pip_install_overrides_path_with_spaces_via_cli` — verifies a spaced CLI path works.
  - `pip_install_overrides_env_var_still_splits_on_spaces` — verifies env var splitting still works.

## Testing
- `cargo fmt --check` and `cargo check -p uv-cli -p uv` pass.
- `cargo test -p uv --test pip_install -- pip_install_overrides_path_with_spaces_via_cli pip_install_overrides_env_var_still_splits_on_spaces` — both pass.