### PR TITLE
Refuse to remove non-virtualenv directories in `remove_virtualenv`

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -894,6 +894,15 @@ pub fn is_virtualenv_executable(executable: impl AsRef<Path>) -> bool {
         .is_some_and(is_virtualenv_base)
 }
 
+/// Should [`remove_virtualenv`] remove an entry that is not a virtual environment.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ClearNonVirtualenv {
+    /// Allow clearing a non-virtual environment directory.
+    Allow,
+    /// Refuse to clear a non-virtual environment directory.
+    Error,
+}
+
 /// Returns `true` if a path is the base path of a virtual environment,
 /// indicated by the presence of a `pyvenv.cfg` file.
 ///
@@ -902,6 +911,52 @@ pub fn is_virtualenv_executable(executable: impl AsRef<Path>) -> bool {
 /// unnecessary.
 pub fn is_virtualenv_base(path: impl AsRef<Path>) -> bool {
     path.as_ref().join("pyvenv.cfg").is_file()
+}
+
+/// Ensure that the directory can be removed by checking if it is a
+/// virtual environment (following symlinks) or it is empty
+fn ensure_removable(location: &Path, metadata: &std::fs::Metadata) -> io::Result<()> {
+    let is_dir = if metadata.is_symlink() {
+        location.is_dir()
+    } else {
+        metadata.is_dir()
+    };
+    if is_dir {
+        if is_virtualenv_base(location) {
+            return Ok(());
+        }
+        if !metadata.is_symlink() && fs_err::read_dir(location)?.next().is_none() {
+            return Ok(());
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("`{}` is not a virtual environment", location.display()),
+    ))
+}
+
+/// Checks if [`remove_virtualenv`] would remove an existing entry at `location`
+///
+/// Returns `Ok(false)` if nothing exists at `location` or if it is an empty directory.
+/// Returns an [`io::ErrorKind::InvalidInput`] error if `clear_non_virtualenv` forbids removing
+/// the directory.
+pub fn would_replace_virtualenv(
+    location: &Path,
+    clear_non_virtualenv: ClearNonVirtualenv,
+) -> io::Result<bool> {
+    let metadata = match ::fs_err::symlink_metadata(location) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err),
+    };
+    match clear_non_virtualenv {
+        ClearNonVirtualenv::Allow => {}
+        ClearNonVirtualenv::Error => ensure_removable(location, &metadata)?,
+    }
+    if metadata.is_dir() && fs_err::read_dir(location)?.next().is_none() {
+        return Ok(false);
+    }
+    Ok(true)
 }
 
 /// Whether the error is due to a lock being held.
@@ -970,8 +1025,17 @@ pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Re
 /// Perform a safe removal of a virtual environment.
 ///
 /// The link or file at `location` is removed without following it.
-pub fn remove_virtualenv(location: &Path) -> io::Result<()> {
-    if !fs_err::symlink_metadata(location)?.is_dir() {
+/// Checks first if removing the directory is allowed.
+pub fn remove_virtualenv(
+    location: &Path,
+    clear_non_virtualenv: ClearNonVirtualenv,
+) -> io::Result<()> {
+    let metadata = fs_err::symlink_metadata(location)?;
+    match clear_non_virtualenv {
+        ClearNonVirtualenv::Allow => {}
+        ClearNonVirtualenv::Error => ensure_removable(location, &metadata)?,
+    }
+    if !metadata.is_dir() {
         return remove_symlink(location);
     }
 
@@ -1028,11 +1092,14 @@ pub fn remove_virtualenv(location: &Path) -> io::Result<()> {
 /// Prepare an empty virtual environment directory, resolving links when possible.
 ///
 /// Returns whether an existing entry was found.
-pub fn clear_virtualenv(location: &Path) -> io::Result<bool> {
+pub fn clear_virtualenv(
+    location: &Path,
+    clear_non_virtualenv: ClearNonVirtualenv,
+) -> io::Result<bool> {
     let location = location
         .canonicalize()
         .unwrap_or_else(|_| location.to_path_buf());
-    let cleared = match remove_virtualenv(&location) {
+    let cleared = match remove_virtualenv(&location, clear_non_virtualenv) {
         Ok(()) => true,
         Err(err) if err.kind() == io::ErrorKind::NotFound => false,
         Err(err) => return Err(err),
@@ -1075,8 +1142,8 @@ mod tests {
         fs_err::write(&marker, "")?;
         let environment = tempdir.path().join("environment");
         create_symlink(&target, &environment)?;
-
-        remove_virtualenv(&environment)?;
+        let clear_non_virtualenv = ClearNonVirtualenv::Allow;
+        remove_virtualenv(&environment, clear_non_virtualenv)?;
 
         assert_matches!(
             fs_err::symlink_metadata(environment),
@@ -1090,9 +1157,48 @@ mod tests {
     fn clear_virtualenv_recreates_missing_directory() -> io::Result<()> {
         let tempdir = tempfile::tempdir()?;
         let environment = tempdir.path().join("environment");
-
-        assert!(!clear_virtualenv(&environment)?);
+        let clear_non_virtualenv = ClearNonVirtualenv::Error;
+        assert!(!clear_virtualenv(&environment, clear_non_virtualenv)?);
         assert!(environment.is_dir());
+        Ok(())
+    }
+
+    #[test]
+    fn remove_virtualenv_refuses_non_virtualenv_directory() -> io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let directory = tempdir.path().join("directory");
+        fs_err::create_dir(&directory)?;
+        let important = directory.join("important.txt");
+        fs_err::write(&important, "content")?;
+
+        assert_matches!(
+            remove_virtualenv(&directory, ClearNonVirtualenv::Error),
+            Err(err) if err.kind() == io::ErrorKind::InvalidInput
+        );
+        assert_eq!(fs_err::read_to_string(&important)?, "content");
+
+        // A pyvenv.cfg marks the directory as a virtual environment that uv
+        // may remove.
+        fs_err::write(directory.join("pyvenv.cfg"), "")?;
+        remove_virtualenv(&directory, ClearNonVirtualenv::Error)?;
+        assert!(!directory.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn remove_virtualenv_refuses_file() -> io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let file = tempdir.path().join("file");
+        fs_err::write(&file, "content")?;
+
+        assert_matches!(
+            remove_virtualenv(&file, ClearNonVirtualenv::Error),
+            Err(err) if err.kind() == io::ErrorKind::InvalidInput
+        );
+        assert_eq!(fs_err::read_to_string(&file)?, "content");
+
+        remove_virtualenv(&file, ClearNonVirtualenv::Allow)?;
+        assert!(!file.exists());
         Ok(())
     }
 }

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn};
 
 use uv_cache::Cache;
 use uv_dirs::user_executable_directory;
-use uv_fs::{LockedFile, LockedFileError, LockedFileMode, Simplified};
+use uv_fs::{ClearNonVirtualenv, LockedFile, LockedFileError, LockedFileMode, Simplified};
 use uv_install_wheel::read_record;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
@@ -256,7 +256,8 @@ impl InstalledTools {
             environment_path.user_display()
         );
 
-        uv_fs::remove_virtualenv(environment_path.as_path()).map_err(uv_virtualenv::Error::from)?;
+        uv_fs::remove_virtualenv(environment_path.as_path(), ClearNonVirtualenv::Allow)
+            .map_err(uv_virtualenv::Error::from)?;
 
         Ok(())
     }
@@ -329,7 +330,7 @@ impl InstalledTools {
         let environment_path = self.tool_dir(name);
 
         // Remove any existing environment.
-        match uv_fs::remove_virtualenv(&environment_path) {
+        match uv_fs::remove_virtualenv(&environment_path, ClearNonVirtualenv::Allow) {
             Ok(()) => {
                 debug!(
                     "Removed existing environment for tool `{name}`: {}",

--- a/crates/uv-virtualenv/src/lib.rs
+++ b/crates/uv-virtualenv/src/lib.rs
@@ -6,7 +6,8 @@ use thiserror::Error;
 use uv_fs::Simplified;
 use uv_python::{Interpreter, PythonEnvironment};
 
-pub use virtualenv::{ClearNonVirtualenv, OnExisting, RemovalReason, Seed};
+pub use uv_fs::ClearNonVirtualenv;
+pub use virtualenv::{OnExisting, RemovalReason, Seed};
 
 mod virtualenv;
 

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -15,7 +15,7 @@ use owo_colors::OwoColorize;
 use tracing::{debug, trace};
 
 use crate::{Error, Prompt};
-use uv_fs::{CWD, PythonExt, Simplified, cachedir};
+use uv_fs::{CWD, ClearNonVirtualenv, PythonExt, Simplified, cachedir};
 use uv_platform_tags::Os;
 use uv_preview::PreviewFeature;
 use uv_pypi_types::Scheme;
@@ -144,20 +144,22 @@ pub(crate) fn create(
                     debug!("Allowing existing {name} due to `--allow-existing`");
                 }
                 OnExisting::Remove(reason) => {
-                    if !is_virtualenv
-                        && let RemovalReason::UserRequest(clear_non_virtualenv) = reason
-                    {
-                        match clear_non_virtualenv {
-                            ClearNonVirtualenv::Allow => {}
-                            ClearNonVirtualenv::Error => {
-                                return Err(Error::ClearNonVirtualenv {
-                                    path: location.to_path_buf(),
-                                });
-                            }
+                    let clear_non_virtualenv = match reason {
+                        RemovalReason::UserRequest(clear_non_virtualenv) => clear_non_virtualenv,
+                        RemovalReason::TemporaryEnvironment | RemovalReason::ManagedEnvironment => {
+                            ClearNonVirtualenv::Allow
                         }
-                    }
+                    };
                     debug!("Removing existing {name} ({reason})");
-                    uv_fs::clear_virtualenv(location)?;
+                    uv_fs::clear_virtualenv(location, clear_non_virtualenv).map_err(|err| {
+                        if err.kind() == io::ErrorKind::InvalidInput {
+                            Error::ClearNonVirtualenv {
+                                path: location.to_path_buf(),
+                            }
+                        } else {
+                            Error::Io(err)
+                        }
+                    })?;
                 }
                 OnExisting::Fail => return err,
                 // If not a virtual environment, fail without prompting.
@@ -166,7 +168,7 @@ pub(crate) fn create(
                     match confirm_clear(location, name)? {
                         Some(true) => {
                             debug!("Removing existing {name} due to confirmation");
-                            uv_fs::clear_virtualenv(location)?;
+                            uv_fs::clear_virtualenv(location, ClearNonVirtualenv::Error)?;
                         }
                         Some(false) => return err,
                         // When we don't have a TTY, require `--clear` explicitly.
@@ -660,22 +662,16 @@ fn confirm_clear(location: &Path, name: &'static str) -> Result<Option<bool>, io
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum ClearNonVirtualenv {
-    /// Allow clearing a non-virtual environment directory.
-    Allow,
-    /// Refuse to clear a non-virtual environment directory.
-    Error,
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum RemovalReason {
     /// The removal was explicitly requested, i.e., with `--clear`.
     UserRequest(ClearNonVirtualenv),
     /// The environment can be removed because it is considered temporary, e.g., a build
-    /// environment.
+    /// environment. This authorizes the removal of content that are not virtual environments
+    /// so a caller must only use it for paths that uv owns.
     TemporaryEnvironment,
     /// The environment can be removed because it is managed by uv, e.g., a project or tool
-    /// environment.
+    /// environment. This authorizes the removal of content that are not virtual environments
+    /// so a caller must only use it for paths that uv owns.
     ManagedEnvironment,
 }
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -245,6 +245,9 @@ pub(crate) enum ProjectError {
     #[error("Project virtual environment directory `{0}` cannot be used because {1}")]
     InvalidProjectEnvironmentDir(PathBuf, String),
 
+    #[error("Script virtual environment directory `{0}` cannot be used because {1}")]
+    InvalidScriptEnvironmentDir(PathBuf, String),
+
     #[error("Failed to parse `uv.lock`")]
     UvLockParse(#[source] toml::de::Error),
 
@@ -2152,6 +2155,18 @@ impl ScriptEnvironment {
             ScriptInterpreter::Interpreter(interpreter) => {
                 let root = ScriptInterpreter::root(script, active, cache);
 
+                // The derived cache entry belongs to uv, but an active environment can point
+                // outside the cache and is only replaced if it is a virtual environment.
+                let clear_non_virtualenv =
+                    if root == ScriptInterpreter::root(script, Some(false), cache) {
+                        ClearNonVirtualenv::Allow
+                    } else {
+                        ClearNonVirtualenv::Error
+                    };
+                let replace_environment =
+                    uv_fs::would_replace_virtualenv(&root, clear_non_virtualenv)
+                        .map_err(|err| invalid_script_environment(&root, &err))?;
+
                 // Determine a prompt for the environment, in order of preference:
                 //
                 // 1) The name of the script
@@ -2178,7 +2193,7 @@ impl ScriptEnvironment {
                         uv_virtualenv::Seed::Disabled,
                         upgradeable,
                     )?;
-                    return Ok(if root.exists() {
+                    return Ok(if replace_environment {
                         Self::WouldReplace(root, environment, temp_dir)
                     } else {
                         Self::WouldCreate(root, environment, temp_dir)
@@ -2186,16 +2201,20 @@ impl ScriptEnvironment {
                 }
 
                 // Remove the existing virtual environment.
-                let replaced = match uv_fs::remove_virtualenv(&root, ClearNonVirtualenv::Allow) {
-                    Ok(()) => {
-                        debug!(
-                            "Removed virtual environment at: {}",
-                            root.user_display().cyan()
-                        );
-                        true
+                let replaced = if replace_environment {
+                    match uv_fs::remove_virtualenv(&root, clear_non_virtualenv) {
+                        Ok(()) => {
+                            debug!(
+                                "Removed virtual environment at: {}",
+                                root.user_display().cyan()
+                            );
+                            true
+                        }
+                        Err(err) if err.kind() == io::ErrorKind::NotFound => false,
+                        Err(err) => return Err(invalid_script_environment(&root, &err)),
                     }
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
-                    Err(err) => return Err(uv_virtualenv::Error::from(err).into()),
+                } else {
+                    false
                 };
 
                 debug!(
@@ -2208,9 +2227,7 @@ impl ScriptEnvironment {
                     interpreter,
                     prompt,
                     false,
-                    uv_virtualenv::OnExisting::Remove(
-                        uv_virtualenv::RemovalReason::ManagedEnvironment,
-                    ),
+                    uv_virtualenv::OnExisting::Fail,
                     false,
                     uv_virtualenv::Seed::Disabled,
                     upgradeable,
@@ -3575,4 +3592,15 @@ fn format_optional_requires_python_sources(
     }
     // Otherwise don't elaborate
     String::new()
+}
+
+fn invalid_script_environment(root: &Path, err: &io::Error) -> ProjectError {
+    ProjectError::InvalidScriptEnvironmentDir(
+        root.to_path_buf(),
+        if err.kind() == io::ErrorKind::InvalidInput {
+            "it is not a virtual environment".to_string()
+        } else {
+            format!("uv cannot determine if it is a virtual environment: {err}")
+        },
+    )
 }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -24,7 +24,9 @@ use uv_distribution_types::{
     IndexUrlError, Requirement, RequiresPython, Resolution, UnresolvedRequirement,
     UnresolvedRequirementSpecification,
 };
-use uv_fs::{CWD, LockedFile, LockedFileError, LockedFileMode, Simplified, verbatim_path};
+use uv_fs::{
+    CWD, ClearNonVirtualenv, LockedFile, LockedFileError, LockedFileMode, Simplified, verbatim_path,
+};
 use uv_git::ResolvedRepositoryReference;
 use uv_installer::{InstallationStrategy, SatisfiesResult, SitePackages};
 use uv_normalize::{DEV_DEPENDENCIES, DefaultGroups, ExtraName, GroupName, PackageName};
@@ -1319,7 +1321,7 @@ pub(crate) fn update_project_environment_link(
 
     if fs_err::symlink_metadata(&link).is_ok_and(|metadata| metadata.is_dir()) {
         if uv_fs::is_virtualenv_base(&link) {
-            if let Err(err) = uv_fs::remove_virtualenv(&link) {
+            if let Err(err) = uv_fs::remove_virtualenv(&link, ClearNonVirtualenv::Error) {
                 report_error(format_args!(
                     "Failed to remove existing local virtual environment: {err}"
                 ));
@@ -1988,13 +1990,14 @@ impl ProjectEnvironment {
                 if replace_environment {
                     // Remove centralized references directly to preserve their cached targets.
                     let removed = if centralized_environment_reference {
-                        match uv_fs::remove_virtualenv(&root) {
+                        match uv_fs::remove_virtualenv(&root, ClearNonVirtualenv::Allow) {
                             Ok(()) => true,
                             Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
                             Err(err) => return Err(uv_virtualenv::Error::from(err).into()),
                         }
                     } else {
-                        uv_fs::clear_virtualenv(&root).map_err(uv_virtualenv::Error::from)?
+                        uv_fs::clear_virtualenv(&root, ClearNonVirtualenv::Allow)
+                            .map_err(uv_virtualenv::Error::from)?
                     };
                     if removed {
                         let removed_entry = if centralized_environment_reference {
@@ -2201,7 +2204,7 @@ impl ScriptEnvironment {
                 }
 
                 // Remove the existing virtual environment.
-                let replaced = match uv_fs::remove_virtualenv(&root) {
+                let replaced = match uv_fs::remove_virtualenv(&root, ClearNonVirtualenv::Allow) {
                     Ok(()) => {
                         debug!(
                             "Removed virtual environment at: {}",

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1909,42 +1909,24 @@ impl ProjectEnvironment {
                 let centralized_environment_reference =
                     !centralized && is_centralized_environment_reference(&root, cache);
 
-                // Avoid removing things that are not virtual environments and are outside the
-                // environment cache.
-                let replace_environment = if centralized_environment_reference {
-                    true
+                // The centralized store and links are owned by uv, so their contents can be
+                // replaced, even if they are not valid environments. Anything else has to be
+                // either a virtual environment or empty before uv removes it.
+                let clear_non_virtualenv = if centralized || centralized_environment_reference {
+                    ClearNonVirtualenv::Allow
                 } else {
-                    match (root.try_exists(), root.join("pyvenv.cfg").try_exists()) {
-                        // It's a virtual environment we can remove it
-                        (_, Ok(true)) => true,
-                        // It doesn't exist at all, we should use it without deleting it to avoid TOCTOU bugs
-                        (Ok(false), Ok(false)) => false,
-                        // If it's not a virtual environment, bail
-                        (Ok(true), Ok(false)) => {
-                            // Unless it's empty, in which case we just ignore it
-                            if root.read_dir().is_ok_and(|mut dir| dir.next().is_none()) {
-                                false
-                            } else if centralized {
-                                // Unless it's the derived cache entry, which is uv-owned and safe to replace
-                                true
-                            } else {
-                                return Err(ProjectError::InvalidProjectEnvironmentDir(
-                                    root,
-                                    "it is not a compatible environment but cannot be recreated because it is not a virtual environment".to_string(),
-                                ));
-                            }
-                        }
-                        // Similarly, if we can't _tell_ if it exists we should bail
-                        (_, Err(err)) | (Err(err), _) => {
-                            return Err(ProjectError::InvalidProjectEnvironmentDir(
-                                root,
-                                format!(
-                                    "it is not a compatible environment but cannot be recreated because uv cannot determine if it is a virtual environment: {err}"
-                                ),
-                            ));
-                        }
-                    }
+                    ClearNonVirtualenv::Error
                 };
+                let replace_environment = uv_fs::would_replace_virtualenv(&root, clear_non_virtualenv)
+                .map_err(|err| {
+                    ProjectError::InvalidProjectEnvironmentDir(root.clone(),
+                    if err.kind() == io::ErrorKind::InvalidInput {
+                        "it is not a compatible environment but cannot be recreated because it is not a virtual environment".to_string()
+                    } else {
+                        format!("it is not a compatible environment but cannot be recreated because uv cannot determine if it is a virtual environment: {err}")
+                    }
+                )
+                })?;
 
                 // Determine a prompt for the environment, in order of preference:
                 //
@@ -1996,7 +1978,7 @@ impl ProjectEnvironment {
                             Err(err) => return Err(uv_virtualenv::Error::from(err).into()),
                         }
                     } else {
-                        uv_fs::clear_virtualenv(&root, ClearNonVirtualenv::Allow)
+                        uv_fs::clear_virtualenv(&root, clear_non_virtualenv)
                             .map_err(uv_virtualenv::Error::from)?
                     };
                     if removed {

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -19,7 +19,7 @@ use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildRequires, Index, IndexLocations,
     PackageConfigSettings, Requirement,
 };
-use uv_fs::Simplified;
+use uv_fs::{ClearNonVirtualenv, Simplified};
 use uv_install_wheel::LinkMode;
 use uv_normalize::DefaultGroups;
 use uv_preview::Preview;
@@ -255,7 +255,8 @@ pub(crate) async fn venv(
             if is_centralized_environment_reference(&path, cache) =>
         {
             // Remove `.venv` without following it into the cache.
-            uv_fs::remove_virtualenv(&path).map_err(|err| VenvError::Creation(err.into()))?;
+            uv_fs::remove_virtualenv(&path, ClearNonVirtualenv::Allow)
+                .map_err(|err| VenvError::Creation(err.into()))?;
             on_existing
         }
         OnExisting::Allow
@@ -264,7 +265,8 @@ pub(crate) async fn venv(
         {
             // TODO(tk): Revisit after PEP 832.
             // Ignore uv-owned path files when creating a local environment.
-            uv_fs::remove_virtualenv(&path).map_err(|err| VenvError::Creation(err.into()))?;
+            uv_fs::remove_virtualenv(&path, ClearNonVirtualenv::Allow)
+                .map_err(|err| VenvError::Creation(err.into()))?;
             on_existing
         }
         _ => on_existing,

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -4690,19 +4690,102 @@ fn run_active_script_environment_non_virtualenv() -> Result<()> {
         .child("important.txt")
         .write_str("important data")?;
 
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--active")
+        .arg("--script")
+        .arg("main.py")
+        .env_remove(EnvVars::RUST_LOG)
+        .env(EnvVars::VIRTUAL_ENV, "foo"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Script virtual environment directory `[TEMP_DIR]/foo` cannot be used because it is not a virtual environment
+    ");
+
+    active_environment
+        .child("important.txt")
+        .assert("important data");
+
+    // Sync uses the same environment initialization and must also preserve the directory.
+    uv_snapshot!(context.filters(), context.sync()
+        .arg("--active")
+        .arg("--script")
+        .arg("main.py")
+        .env_remove(EnvVars::RUST_LOG)
+        .env(EnvVars::VIRTUAL_ENV, "foo"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Script virtual environment directory `[TEMP_DIR]/foo` cannot be used because it is not a virtual environment
+    ");
+
+    active_environment
+        .child("important.txt")
+        .assert("important data");
+
+    // An empty active destination can be initialized without removing user data.
+    let empty_environment = context.temp_dir.child("empty");
+    empty_environment.create_dir_all()?;
     context
         .run()
         .arg("--active")
         .arg("--script")
         .arg("main.py")
-        .env(EnvVars::VIRTUAL_ENV, "foo")
+        .env(EnvVars::VIRTUAL_ENV, "empty")
         .assert()
         .success();
+    empty_environment
+        .child("pyvenv.cfg")
+        .assert(predicate::path::is_file());
 
-    active_environment.assert(predicate::path::is_dir());
-    // Silently deleting user data outside a virtual environment is undesirable.
-    active_environment
-        .child("important.txt")
+    Ok(())
+}
+
+#[test]
+fn run_script_environment_cache_repair() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    context.temp_dir.child("main.py").write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = []
+        # ///
+
+        import sys
+
+        print(sys.prefix)
+        "#
+    })?;
+
+    let output = uv_snapshot!(context.filters(), context.run()
+        .arg("--script")
+        .arg("main.py")
+        .env_remove(EnvVars::RUST_LOG), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [CACHE_DIR]/environments-v2/main-[HASH]
+    ");
+
+    let environment = ChildPath::new(String::from_utf8(output.stdout)?.trim());
+    assert!(environment.path().starts_with(context.cache_dir.path()));
+    fs_err::remove_dir_all(&environment)?;
+    environment.create_dir_all()?;
+    environment
+        .child("stale.txt")
+        .write_str("stale cache data")?;
+
+    // A damaged derived cache entry belongs to uv and can still be replaced.
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--script")
+        .arg("main.py")
+        .env_remove(EnvVars::RUST_LOG), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [CACHE_DIR]/environments-v2/main-[HASH]
+    ");
+
+    environment
+        .child("pyvenv.cfg")
+        .assert(predicate::path::is_file());
+    environment
+        .child("stale.txt")
         .assert(predicate::path::missing());
 
     Ok(())

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -7830,7 +7830,7 @@ fn run_centralized_environment_path_file() -> Result<()> {
 
     // Point the path file at an environment outside the centralized store.
     let environment = context.temp_dir.child(".venv");
-    uv_fs::remove_virtualenv(environment.path())?;
+    uv_fs::remove_virtualenv(environment.path(), uv_fs::ClearNonVirtualenv::Allow)?;
     let external = context.temp_dir.child("external");
     context
         .venv()

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -505,7 +505,7 @@ fn create_centralized_project_environment_path_file() -> Result<()> {
     let marker = target.join("marker");
     fs_err::write(&marker, "")?;
 
-    uv_fs::remove_virtualenv(environment.path())?;
+    uv_fs::remove_virtualenv(environment.path(), uv_fs::ClearNonVirtualenv::Allow)?;
     environment.write_str(&target.to_string_lossy())?;
 
     // With the preview, `--allow-existing` selects the root for the requested interpreter.
@@ -524,7 +524,7 @@ fn create_centralized_project_environment_path_file() -> Result<()> {
     assert_ne!(target, fs_err::read_link(environment.path())?);
     assert!(marker.is_file());
 
-    uv_fs::remove_virtualenv(environment.path())?;
+    uv_fs::remove_virtualenv(environment.path(), uv_fs::ClearNonVirtualenv::Allow)?;
     environment.write_str(&target.to_string_lossy())?;
 
     // Without the preview, `--allow-existing` replaces the path file without clearing its target.

--- a/crates/uv/tests/sync/centralized_project_envs.rs
+++ b/crates/uv/tests/sync/centralized_project_envs.rs
@@ -487,8 +487,8 @@ fn sync_recovers_incomplete_centralized_environment() -> Result<()> {
     let target = fs_err::read_link(link.path())?;
 
     // Simulate a mangled environment (e.g., due to interruption).
-    uv_fs::remove_virtualenv(link.path())?;
-    uv_fs::remove_virtualenv(&target)?;
+    uv_fs::remove_virtualenv(link.path(), uv_fs::ClearNonVirtualenv::Allow)?;
+    uv_fs::remove_virtualenv(&target, uv_fs::ClearNonVirtualenv::Allow)?;
     fs_err::create_dir(&target)?;
     uv_fs::cachedir::ensure_tag(&target)?;
     fs_err::write(target.join(".gitignore"), "*")?;


### PR DESCRIPTION

## Summary

This is a follow up to #21464 (cc @zsol) and it is intended to land after it. 
It preserves the user facing behaviour and the test coverage found in that PR, but moves the safety check into `uv_fs::remove_virtualenv` as sketched in #21364 (cc @zanieb).

The problem described in #21364 is that `uv_fs::remove_virtualenv` deletes any target and relies on the caller to validate it first. At the time of the issue, the project path did the check, while the script path didn't. This allowed a `VIRTUAL_ENV` pointing at an ordinary directory to be emptied by `uv run --active --script` or `uv sync --active --script`.

Thi PR moves the check to the deletion boundary so the callers cannot omit it:

- Move `ClearNonVirtualenv` from `uv-virtualenv` into `uv-fs` and re-export it from `uv-virtualenv` for existing callers. Both `remove_virtualenv` and `clear_virtualenv` enforce it. If `ClearNonVirtualenv::Error` is passed, then they remove an entry only if it is a virtual environment (following symlinks) or an empty directory. Files, dangling symlinks and non-empty directories without a `pyvenv.cfg` are refused with `InvalidInput`.
- Add `would_replace_virtualenv` so callers can make the same decision without modifying the filesystem. The project and script paths use it during `--dry-run` to distinguish between replaced environments from newly created ones.
- Replace the project path's local copy of the replacement check with the shared one. 
- Treat the derived cache entry as owned by uv and all other active environment paths as owned by the user. Refuse a non-empty non-virtualenv active directory, and use `OnExsisting::Fail` during creation to prevent removal after validation.

Paths owned by uv use `Allow`, including tool environments, centralized environment entries and references, and the `ManagedEnvironment` and `TemporaryEnvironment` removal reasons in `create_venv`.


## Test Plan

- Unit tests in `uv-fs` cover the refusing of a non-empty non-virtualenv directory and a regular file, and permit removal after a `pyvenv.cfg` file is added.
- `run_active_script_environment_non_virtualenv` verifies that both `uv run` and `uv sync` refuse the directory without modifying its contents, and that an empty active directory can still initialized.
- `run_script_environment_cache_repair` verifies that a derived cache entry that is damaged without a `pyvenv.cfg` can still be replaced.
- Updated tests that now require a `ClearNonVirtualenv` policy to be passed.