### PR TITLE
Fix editable installs not rebuilding when generated files are deleted

### DIFF
--- a/crates/uv-cache-info/src/cache_info.rs
+++ b/crates/uv-cache-info/src/cache_info.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Deserialize;
 use tracing::{debug, info_span, warn};
 
-use uv_fs::{Simplified, created_time};
+use uv_fs::{PortablePath, created_time};
 
 use crate::git_info::{Commit, Tags};
 use crate::glob::cluster_globs;
@@ -24,11 +24,25 @@ pub enum CacheInfoError {
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct CacheInfo {
-    /// The timestamp of the most recent `ctime` of any relevant files, at the time of the build.
-    /// The timestamp will typically be the maximum of the `ctime` values of the `pyproject.toml`,
-    /// `setup.py`, and `setup.cfg` files, if they exist; however, users can provide additional
-    /// files to timestamp via the `cache-keys` field.
+    /// The timestamp of a single relevant file, at the time of the build.
+    ///
+    /// This is only populated when the [`CacheInfo`] is derived from a single file (e.g., a
+    /// source distribution archive) via [`CacheInfo::from_file`]; freshness checks for a source
+    /// tree are instead tracked per-file in [`CacheInfo::files`], so that the disappearance of a
+    /// single cache-key file doesn't go unnoticed.
     timestamp: Option<Timestamp>,
+    /// The timestamp of each individual `cache-keys` file that was considered when building the
+    /// distribution, at the time of the build, keyed by the path of the file relative to the
+    /// source tree.
+    ///
+    /// A `None` value records that the file did _not_ exist at the time of the build. This is
+    /// itself meaningful: if a cache-key file is later deleted (e.g., a build backend that
+    /// generates a file into the source tree, like a compiled extension module, is deleted along
+    /// with the virtual environment), the absence must be distinguishable from the file having
+    /// never been tracked at all, so that the deletion is treated as a cache-invalidating change
+    /// rather than being silently ignored.
+    #[serde(default)]
+    files: BTreeMap<Cow<'static, str>, Option<Timestamp>>,
     /// The commit at which the distribution was built.
     commit: Option<Commit>,
     /// The Git tags present at the time of the build.
@@ -64,7 +78,7 @@ impl CacheInfo {
     pub fn from_directory(directory: &Path) -> Result<Self, CacheInfoError> {
         let mut commit = None;
         let mut tags = None;
-        let mut last_changed: Option<(PathBuf, Timestamp)> = None;
+        let mut files: BTreeMap<Cow<'static, str>, Option<Timestamp>> = BTreeMap::new();
         let mut directories = BTreeMap::new();
         let mut env = BTreeMap::new();
 
@@ -117,6 +131,12 @@ impl CacheInfo {
                     let metadata = match path.metadata() {
                         Ok(metadata) => metadata,
                         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                            // Record the absence explicitly: if the file previously existed (e.g.,
+                            // it's a file that a build backend generates into the source tree),
+                            // its disappearance must be distinguishable from it never having been
+                            // tracked, or a deleted file would silently fail to invalidate the
+                            // cache.
+                            files.insert(file, None);
                             continue;
                         }
                         Err(err) => {
@@ -131,12 +151,7 @@ impl CacheInfo {
                         );
                         continue;
                     }
-                    let timestamp = Timestamp::from_metadata(&metadata);
-                    if last_changed.as_ref().is_none_or(|(_, prev_timestamp)| {
-                        *prev_timestamp < Timestamp::from_metadata(&metadata)
-                    }) {
-                        last_changed = Some((path, timestamp));
-                    }
+                    files.insert(file, Some(Timestamp::from_metadata(&metadata)));
                 }
                 CacheKey::Directory { dir } => {
                     // Treat the path as a directory.
@@ -268,28 +283,34 @@ impl CacheInfo {
                         }
                         continue;
                     }
-                    let timestamp = Timestamp::from_metadata(&metadata);
-                    if last_changed.as_ref().is_none_or(|(_, prev_timestamp)| {
-                        *prev_timestamp < Timestamp::from_metadata(&metadata)
-                    }) {
-                        last_changed = Some((entry.into_path(), timestamp));
-                    }
+
+                    // Key each match by its path relative to the source directory, using a
+                    // portable (forward-slash) representation, so that keys are stable across
+                    // platforms and comparable between separate calls to `from_directory`.
+                    //
+                    // Unlike explicitly-named `CacheKey::Path`/`CacheKey::File` entries, we don't
+                    // record an explicit `None` for glob matches that disappear: since a glob
+                    // pattern doesn't enumerate the files that *could* match, there's no fixed set
+                    // of keys to mark as absent. Instead, a file that no longer matches is simply
+                    // missing from `files` on the next computation, which is already sufficient
+                    // for the map comparison in `PartialEq` to detect the change.
+                    let path = entry.into_path();
+                    let relative = path.strip_prefix(directory).unwrap_or(&path);
+                    let key = Cow::Owned(PortablePath::from(relative).to_string());
+                    files.insert(key, Some(Timestamp::from_metadata(&metadata)));
                 }
             }
         }
 
-        let timestamp = if let Some((path, timestamp)) = last_changed {
+        if !(files.is_empty() && directories.is_empty() && env.is_empty()) {
             debug!(
-                "Computed cache info: {timestamp:?}, {commit:?}, {tags:?}, {env:?}, {directories:?}. Most recently modified: {}",
-                path.user_display()
+                "Computed cache info: {files:?}, {commit:?}, {tags:?}, {env:?}, {directories:?}"
             );
-            Some(timestamp)
-        } else {
-            None
-        };
+        }
 
         Ok(Self {
-            timestamp,
+            timestamp: None,
+            files,
             commit,
             tags,
             env,
@@ -311,6 +332,7 @@ impl CacheInfo {
     /// Returns `true` if the cache info is empty.
     pub fn is_empty(&self) -> bool {
         self.timestamp.is_none()
+            && self.files.is_empty()
             && self.commit.is_none()
             && self.tags.is_none()
             && self.env.is_empty()
@@ -379,6 +401,8 @@ enum DirectoryTimestamp {
 
 #[cfg(all(test, unix))]
 mod tests_unix {
+    use std::collections::BTreeMap;
+
     use anyhow::Result;
 
     use super::{CacheInfo, Timestamp};
@@ -410,36 +434,86 @@ mod tests_unix {
             Ok(Timestamp::from_metadata(&path.metadata()?))
         };
 
-        let cache_timestamp = || -> Result<_> { Ok(CacheInfo::from_directory(&dir)?.timestamp) };
+        // Each tracked cache-key file is now recorded individually (as opposed to collapsing to a
+        // single "most recently modified" timestamp), so that a file disappearing from the set is
+        // itself a detectable change rather than being silently absorbed into an unrelated file's
+        // timestamp.
+        let cache_files = || -> Result<BTreeMap<String, Option<Timestamp>>> {
+            Ok(CacheInfo::from_directory(&dir)?
+                .files
+                .into_iter()
+                .map(|(path, timestamp)| (path.into_owned(), timestamp))
+                .collect())
+        };
 
         write_manifest("x/**")?;
-        assert_eq!(cache_timestamp()?, None);
+        assert_eq!(cache_files()?, BTreeMap::new());
         let y = touch("x/y")?;
-        assert_eq!(cache_timestamp()?, Some(y));
+        assert_eq!(
+            cache_files()?,
+            BTreeMap::from([("x/y".to_string(), Some(y))])
+        );
         let z = touch("x/z")?;
-        assert_eq!(cache_timestamp()?, Some(z));
+        assert_eq!(
+            cache_files()?,
+            BTreeMap::from([("x/y".to_string(), Some(y)), ("x/z".to_string(), Some(z))])
+        );
 
         // leaf entry symlink should be resolved
         let a = touch("../a")?;
         fs_err::os::unix::fs::symlink(dir.join("../a"), dir.join("x/a"))?;
-        assert_eq!(cache_timestamp()?, Some(a));
+        assert_eq!(
+            cache_files()?,
+            BTreeMap::from([
+                ("x/a".to_string(), Some(a)),
+                ("x/y".to_string(), Some(y)),
+                ("x/z".to_string(), Some(z)),
+            ])
+        );
 
         // symlink directories should not be followed while globbing
-        let c = touch("../b/c")?;
+        let _c = touch("../b/c")?;
         fs_err::os::unix::fs::symlink(dir.join("../b"), dir.join("x/b"))?;
-        assert_eq!(cache_timestamp()?, Some(a));
+        assert_eq!(
+            cache_files()?,
+            BTreeMap::from([
+                ("x/a".to_string(), Some(a)),
+                ("x/y".to_string(), Some(y)),
+                ("x/z".to_string(), Some(z)),
+            ])
+        );
 
         // no globs, should work as expected
         write_manifest("x/y")?;
-        assert_eq!(cache_timestamp()?, Some(y));
+        assert_eq!(
+            cache_files()?,
+            BTreeMap::from([("x/y".to_string(), Some(y))])
+        );
         write_manifest("x/a")?;
-        assert_eq!(cache_timestamp()?, Some(a));
+        assert_eq!(
+            cache_files()?,
+            BTreeMap::from([("x/a".to_string(), Some(a))])
+        );
         write_manifest("x/b/c")?;
-        assert_eq!(cache_timestamp()?, Some(c));
+        let c = Timestamp::from_metadata(&dir.join("x/b/c").metadata()?);
+        assert_eq!(
+            cache_files()?,
+            BTreeMap::from([("x/b/c".to_string(), Some(c))])
+        );
 
         // symlink pointing to a directory
         write_manifest("x/*b*")?;
-        assert_eq!(cache_timestamp()?, None);
+        assert_eq!(cache_files()?, BTreeMap::new());
+
+        // A cache-key file that is deleted after having existed must be distinguishable from one
+        // that never existed: the deletion itself is a cache-invalidating change.
+        write_manifest("x/y")?;
+        assert_eq!(
+            cache_files()?,
+            BTreeMap::from([("x/y".to_string(), Some(y))])
+        );
+        fs_err::remove_file(dir.join("x/y"))?;
+        assert_eq!(cache_files()?, BTreeMap::from([("x/y".to_string(), None)]));
 
         Ok(())
     }

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1387,7 +1387,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             return Err(Error::HashesNotSupportedSourceTree(source.to_string()));
         }
 
-        let cache_shard = self.build_context.cache().shard(
+        let revision_shard = self.build_context.cache().shard(
             CacheBucket::SourceDistributions,
             if resource.editable.unwrap_or(false) {
                 WheelCache::Editable(resource.url).root()
@@ -1397,19 +1397,19 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         );
 
         // Acquire the advisory lock.
-        let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
+        let _lock = revision_shard.lock().await.map_err(Error::CacheLock)?;
 
         // Fetch the revision for the source distribution.
         let LocalRevisionPointer {
             cache_info,
             revision,
         } = self
-            .source_tree_revision(source, resource, &cache_shard)
+            .source_tree_revision(source, resource, &revision_shard)
             .await?;
 
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
-        let cache_shard = cache_shard.shard(revision.id());
+        let cache_shard = revision_shard.shard(revision.id());
 
         // If there are build settings or extra build dependencies, we need to scope to a cache shard.
         let config_settings = self.config_settings_for(source.name());
@@ -1460,6 +1460,23 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 reporter.on_build_complete(source, task);
             }
         }
+
+        // Recompute the cache info now that the build has completed. Some build backends (e.g.,
+        // `maturin`, `setuptools-rust`) write generated files (like a compiled extension module)
+        // directly into the source tree as a side effect of an (editable) build. The pre-build
+        // `cache_info` fetched above only reflects the source tree as it looked *before* the
+        // build ran, so persisting it as-is would leave future freshness checks unable to notice
+        // if such generated files are later modified or deleted: from the cache's perspective,
+        // they would look identical to files that never existed. Re-snapshotting here ensures the
+        // recorded `cache_info` reflects reality post-build, so that a later `uv sync` can tell
+        // the difference.
+        let cache_info = CacheInfo::from_directory(resource.install_path)?;
+        LocalRevisionPointer {
+            cache_info: cache_info.clone(),
+            revision: revision.clone(),
+        }
+        .write_to(&revision_shard.entry(LOCAL_REVISION))
+        .await?;
 
         // Store the metadata.
         let metadata_entry = cache_shard.entry(METADATA);

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -956,7 +956,7 @@ fn pyproject_build_system(package: &PackageName, build_backend: ProjectBuildBack
                 python-source = "src"
 
                 [tool.uv]
-                cache-keys = [{{ file = "pyproject.toml" }}, {{ file = "src/**/*.rs" }}, {{ file = "Cargo.toml" }}, {{ file = "Cargo.lock" }}]
+                cache-keys = [{{ file = "pyproject.toml" }}, {{ file = "src/**/*.rs" }}, {{ file = "Cargo.toml" }}, {{ file = "Cargo.lock" }}, {{ file = "src/**/*.so" }}, {{ file = "src/**/*.pyd" }}]
 
                 [build-system]
                 requires = ["maturin>=1.0,<2.0"]
@@ -968,7 +968,7 @@ fn pyproject_build_system(package: &PackageName, build_backend: ProjectBuildBack
                 build-dir = "build/{wheel_tag}"
 
                 [tool.uv]
-                cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.{h,c,hpp,cpp}" }, { file = "CMakeLists.txt" }]
+                cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.{h,c,hpp,cpp}" }, { file = "CMakeLists.txt" }, { file = "src/**/*.so" }, { file = "src/**/*.pyd" }]
 
                 [build-system]
                 requires = ["scikit-build-core>=0.12", "pybind11>=3"]

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -3373,7 +3373,7 @@ fn init_app_build_backend_maturin() -> Result<()> {
         python-source = "src"
 
         [tool.uv]
-        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.rs" }, { file = "Cargo.toml" }, { file = "Cargo.lock" }]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.rs" }, { file = "Cargo.toml" }, { file = "Cargo.lock" }, { file = "src/**/*.so" }, { file = "src/**/*.pyd" }]
 
         [build-system]
         requires = ["maturin>=1.0,<2.0"]
@@ -3499,7 +3499,7 @@ fn init_app_build_backend_scikit() -> Result<()> {
         build-dir = "build/{wheel_tag}"
 
         [tool.uv]
-        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.{h,c,hpp,cpp}" }, { file = "CMakeLists.txt" }]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.{h,c,hpp,cpp}" }, { file = "CMakeLists.txt" }, { file = "src/**/*.so" }, { file = "src/**/*.pyd" }]
 
         [build-system]
         requires = ["scikit-build-core>=0.12", "pybind11>=3"]
@@ -3618,7 +3618,7 @@ fn init_lib_build_backend_maturin() -> Result<()> {
         python-source = "src"
 
         [tool.uv]
-        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.rs" }, { file = "Cargo.toml" }, { file = "Cargo.lock" }]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.rs" }, { file = "Cargo.toml" }, { file = "Cargo.lock" }, { file = "src/**/*.so" }, { file = "src/**/*.pyd" }]
 
         [build-system]
         requires = ["maturin>=1.0,<2.0"]
@@ -3741,7 +3741,7 @@ fn init_lib_build_backend_scikit() -> Result<()> {
         build-dir = "build/{wheel_tag}"
 
         [tool.uv]
-        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.{h,c,hpp,cpp}" }, { file = "CMakeLists.txt" }]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.{h,c,hpp,cpp}" }, { file = "CMakeLists.txt" }, { file = "src/**/*.so" }, { file = "src/**/*.pyd" }]
 
         [build-system]
         requires = ["scikit-build-core>=0.12", "pybind11>=3"]

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -16718,3 +16718,115 @@ fn sync_frozen_workspace_member_git_credentials() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test for #11390: some build backends (e.g. `maturin`, `setuptools-rust`) write
+/// generated files -- such as a compiled extension module -- directly into the source tree as a
+/// side effect of an editable build. If such a file is later lost (e.g. via `git clean -fdx`, or
+/// by deleting `.venv` and re-syncing into a fresh one), `uv sync` must notice that the cached
+/// build is no longer valid and re-invoke the build backend, rather than treating the missing
+/// output as if nothing had changed.
+///
+/// This also guards against the opposite failure mode: since the generated file is itself listed
+/// in `cache-keys`, and it did not yet exist before the very first build, a naive fix could cause
+/// uv to think the source is out-of-date (and thus needlessly rebuild) on *every* subsequent sync.
+#[test]
+fn sync_editable_rebuild_after_generated_file_deleted() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["hatchling"]
+        backend-path = ["."]
+        build-backend = "build_backend"
+
+        [tool.uv]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "src/project/_generated.py" }]
+    "#})?;
+
+    // A build backend that, like `maturin`'s editable builds, writes a generated file into the
+    // source tree as a side effect of building, in addition to producing the wheel itself. It
+    // also records how many times it has been invoked, in a file that is *not* a cache key, so
+    // the test can tell whether a given `uv sync` actually triggered a rebuild.
+    let build_backend = context.temp_dir.child("build_backend.py");
+    build_backend.write_str(indoc! {r#"
+        import pathlib
+        from hatchling.build import *
+        from hatchling.build import build_editable as _build_editable
+
+        def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+            pathlib.Path("src/project/_generated.py").write_text("VALUE = 1\n")
+            counter = pathlib.Path("build_count.txt")
+            count = int(counter.read_text()) if counter.exists() else 0
+            counter.write_text(str(count + 1))
+            return _build_editable(wheel_directory, config_settings, metadata_directory)
+    "#})?;
+
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    let generated = context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("_generated.py");
+    let build_count_path = context.temp_dir.child("build_count.txt");
+    let build_count = || -> Result<u32> { Ok(fs_err::read_to_string(&build_count_path)?.parse()?) };
+
+    // First sync: the build backend runs and generates `_generated.py`.
+    context.sync().assert().success();
+    assert!(
+        generated.exists(),
+        "generated file should exist after the first sync"
+    );
+    assert_eq!(build_count()?, 1);
+
+    // Second sync: nothing changed, so the cached build should be reused, and the build backend
+    // should *not* be invoked again -- even though the generated file (an output, not an input)
+    // now exists where it didn't before the first build.
+    context.sync().assert().success();
+    assert!(generated.exists());
+    assert_eq!(
+        build_count()?,
+        1,
+        "the cached build should have been reused"
+    );
+
+    // Simulate the generated file being lost, e.g. via `git clean -fdx` or a `.venv` rebuild.
+    fs_err::remove_file(generated.path())?;
+    assert!(!generated.exists());
+
+    // Third sync: none of the cache-key *inputs* changed, but uv must still detect that the
+    // build's *output* is missing and re-invoke the build backend to restore it.
+    context.sync().assert().success();
+    assert!(
+        generated.exists(),
+        "uv should have rebuilt after the generated file was deleted"
+    );
+    assert_eq!(
+        build_count()?,
+        2,
+        "uv should have rebuilt after the generated file was deleted"
+    );
+
+    // Fourth sync: the generated file is back in place, so the cache should be considered fresh
+    // again.
+    context.sync().assert().success();
+    assert!(generated.exists());
+    assert_eq!(
+        build_count()?,
+        2,
+        "the cached build should have been reused"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

## Summary

Some build backends, such as maturin and setuptools-rust, write generated files like a compiled extension module directly into the source tree as a side effect of an editable build. If that file is later lost, for example by deleting `.venv` and re-syncing, or via `git clean`, `uv sync` did not notice and left the editable install broken.

This turned out to be two related bugs in the source tree cache freshness check.

`CacheInfo::from_directory` collapsed every tracked `cache-keys` file into a single most recently modified timestamp. A file that existed and was later deleted was simply skipped instead of being recorded as absent, so never existed and existed then deleted looked identical to the cache.

Worse, that snapshot was computed and persisted before the build backend ran. Since the generated file did not exist yet at snapshot time, every following sync recomputed a different snapshot (now including the generated file) and triggered an unnecessary rebuild every time. If the generated file was later deleted, the source tree matched the original pre build snapshot again, so uv treated it as unchanged and skipped the rebuild. This second effect is what actually produces the reported bug.

## Changes

- `CacheInfo` now tracks each cache key file individually, including whether it exists or not, the same way directory keys already work, instead of collapsing everything to one timestamp.
- The build cache now re-snapshots `CacheInfo` after the build completes rather than before, so the recorded state reflects what is actually on disk once the build backend has run.
- Extended the default `cache-keys` generated by `uv init` for the maturin and scikit-build-core backends to include the compiled extension glob (`src/**/*.so`, `src/**/*.pyd`), so a missing extension module is caught with the default configuration and not just when a user manually adds a cache key for it.

## Testing

- Added `sync_editable_rebuild_after_generated_file_deleted`, a four step sync test using a build invocation counter, that fails on the old code with a needless rebuild on the second sync and passes with the fix.
- Updated the `uv-cache-info` unit test for the new per-file representation and added a deletion specific case.
- Updated the four `uv init` snapshot tests affected by the template change.
- Ran the full `sync` and `project` integration suites, all passing aside from unrelated environment gaps (missing Python 3.8 and git-lfs locally).
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --check` clean.

Fixes #11390

