### PR TITLE
Retry `PermissionDenied` errors on Windows in the request retry layer

### DIFF
--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -229,6 +229,19 @@ pub fn retryable_on_request_failure(err: &(dyn Error + 'static)) -> Option<Retry
                 return Some(Retryable::Transient);
             }
 
+            // On Windows, antivirus and EDR software can transiently hold a lock on a file
+            // we're trying to rename or persist into the cache, which surfaces as a
+            // `PermissionDenied` error. `uv_fs::rename_with_retry` and friends already retry
+            // such errors for about ten seconds, but some software holds the lock longer than
+            // that. Retrying the entire operation gives the lock more time to clear and starts
+            // over with a fresh temporary file, sidestepping the one that was locked.
+            //
+            // See: <https://github.com/astral-sh/uv/issues/17679>
+            if cfg!(windows) && io_err.kind() == io::ErrorKind::PermissionDenied {
+                trace!("Transient IO error: `{}`", io_err.kind());
+                return Some(Retryable::Transient);
+            }
+
             trace!(
                 "Fatal IO error `{}`, not a transient IO error kind",
                 io_err.kind()
@@ -363,6 +376,29 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::{UvRetryableStrategy, retryable_on_request_failure};
+
+    /// On Windows, antivirus and EDR software can transiently hold a lock on a file we're
+    /// trying to rename or persist into the cache, so we retry `PermissionDenied` errors.
+    ///
+    /// See: <https://github.com/astral-sh/uv/issues/17679>
+    #[cfg(windows)]
+    #[test]
+    fn permission_denied_is_retryable_on_windows() {
+        let err = io::Error::new(io::ErrorKind::PermissionDenied, "access is denied");
+        assert!(matches!(
+            retryable_on_request_failure(&err),
+            Some(Retryable::Transient)
+        ));
+    }
+
+    /// Off Windows, a `PermissionDenied` error is not the transient antivirus-lock issue seen
+    /// on Windows, so we don't retry it.
+    #[cfg(not(windows))]
+    #[test]
+    fn permission_denied_is_fatal_off_windows() {
+        let err = io::Error::new(io::ErrorKind::PermissionDenied, "permission denied");
+        assert!(retryable_on_request_failure(&err).is_none());
+    }
 
     #[tokio::test]
     #[traced_test]


### PR DESCRIPTION
## Summary

On Windows, antivirus/EDR software can transiently hold a lock on a file uv is trying to rename or persist into the cache, which surfaces as `PermissionDenied` (`os error 5`). `uv_fs::rename_with_retry` (and friends) already retry such errors for about ten seconds, but some security software holds the lock longer than that, so the low-level retry budget runs out before the file becomes available.

The outer request-retry layer (`retryable_on_request_failure` in `crates/uv-client/src/retry.rs`) never treated `PermissionDenied` as retryable, so once the low-level retry gave up, the *entire* download (which is already wrapped in a bounded exponential-backoff retry loop for exactly this kind of transient failure) was never retried. This PR makes `PermissionDenied` retryable at that layer, gated to Windows only (mirroring the existing Windows-only gating on the low-level rename retry), so the whole operation gets retried with a fresh temporary file — giving antivirus software substantially more time to release its lock, for free, with the existing default retry count/backoff.

Fixes #17679. Based on the shared symptom (`failed to rename file [...] Access is denied / PermissionDenied`) and root cause, this likely also addresses #11018, #15108, #11409, #2810, #20792, #1491, and #9531.

## Test plan

- `cargo test -p uv-client --lib retry::` — added unit tests covering both the Windows-retryable and non-Windows-fatal branches, following this file's existing test style; all pass
- `cargo clippy -p uv-client --lib --tests -- -D warnings` — clean
- `cargo xwin clippy -p uv-client --target x86_64-pc-windows-msvc --tests -- -D warnings` — clean (verified the Windows-specific code path compiles and lints cleanly, since I developed this from Linux)
- `cargo fmt -p uv-client -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)