### PR TITLE
Use rcodesign's default Apple timestamp server

### DIFF
--- a/scripts/sign-release-macos.py
+++ b/scripts/sign-release-macos.py
@@ -163,8 +163,6 @@ def sign_binaries(unsigned: Path, signed: Path) -> None:
                         os.environ["KEY_NAME"],
                         "--code-signature-flags",
                         "runtime",
-                        "--timestamp-url",
-                        "http://timestamp.apple.com/ts",
                         unsigned / binary,
                         signed / binary,
                     ],


### PR DESCRIPTION
The [macOS signing dry-run](https://github.com/astral-sh/uv/actions/runs/33969528747/job/101333691269) reaches timestamping, then fails on the first executable with `Time-Stamp Protocol error: bad HTTP response`. We explicitly pass `http://timestamp.apple.com/ts`, while `rcodesign` defaults to Apple's `/ts01` endpoint. Drop the override and keep timestamping enabled through its default.
