### PR TITLE
Fix macOS signature verification requirement syntax

### DIFF
--- a/scripts/verify-release-binaries-macos.py
+++ b/scripts/verify-release-binaries-macos.py
@@ -43,7 +43,7 @@ def verify_binaries(signed: Path, directory: Path, binaries: list[str]) -> None:
                     "--verify",
                     "--strict",
                     "-R",
-                    "anchor apple generic",
+                    "=anchor apple generic",
                     path,
                 ],
                 check=True,


### PR DESCRIPTION
The [release dry-run](https://github.com/astral-sh/uv/actions/runs/34037325859/job/101502296287) signs and assembles the macOS artifacts, but verification fails with `anchor apple generic: No such file or directory`. `codesign -R` treats the unprefixed requirement as a file path. Prefix the existing Apple-rooted requirement with `=` so it is evaluated as source text.
