### PR TITLE
Avoid virtual environment warnings when editing without sync

### DIFF
--- a/crates/uv-configuration/src/active_environment.rs
+++ b/crates/uv-configuration/src/active_environment.rs
@@ -3,7 +3,7 @@
 pub enum ActiveEnvironment {
     /// Ignore a mismatched active environment and warn.
     #[default]
-    Default,
+    Warn,
     /// Ignore the active environment without warning.
     Ignore,
     /// Prefer the active environment, if one is set.
@@ -15,7 +15,7 @@ impl ActiveEnvironment {
     #[must_use]
     pub fn without_warning(self) -> Self {
         match self {
-            Self::Default | Self::Ignore => Self::Ignore,
+            Self::Warn | Self::Ignore => Self::Ignore,
             Self::Prefer => Self::Prefer,
         }
     }
@@ -24,7 +24,7 @@ impl ActiveEnvironment {
 impl From<Option<bool>> for ActiveEnvironment {
     fn from(active: Option<bool>) -> Self {
         match active {
-            None => Self::Default,
+            None => Self::Warn,
             Some(false) => Self::Ignore,
             Some(true) => Self::Prefer,
         }

--- a/crates/uv-configuration/src/active_environment.rs
+++ b/crates/uv-configuration/src/active_environment.rs
@@ -1,0 +1,32 @@
+/// Whether to use the active virtual environment instead of the project or script environment.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ActiveEnvironment {
+    /// Ignore a mismatched active environment and warn.
+    #[default]
+    Default,
+    /// Ignore the active environment without warning.
+    Ignore,
+    /// Prefer the active environment, if one is set.
+    Prefer,
+}
+
+impl ActiveEnvironment {
+    /// Suppress mismatch warnings while preserving an explicit preference for the active environment.
+    #[must_use]
+    pub fn without_warning(self) -> Self {
+        match self {
+            Self::Default | Self::Ignore => Self::Ignore,
+            Self::Prefer => Self::Prefer,
+        }
+    }
+}
+
+impl From<Option<bool>> for ActiveEnvironment {
+    fn from(active: Option<bool>) -> Self {
+        match active {
+            None => Self::Default,
+            Some(false) => Self::Ignore,
+            Some(true) => Self::Prefer,
+        }
+    }
+}

--- a/crates/uv-configuration/src/lib.rs
+++ b/crates/uv-configuration/src/lib.rs
@@ -1,3 +1,4 @@
+pub use active_environment::*;
 pub use authentication::*;
 pub use build_options::*;
 pub use concurrency::*;
@@ -25,6 +26,7 @@ pub use trusted_host::*;
 pub use trusted_publishing::*;
 pub use vcs::*;
 
+mod active_environment;
 mod authentication;
 mod build_options;
 mod concurrency;

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -16,7 +16,7 @@ use rustc_hash::{FxHashSet, FxHasher};
 use tracing::{debug, trace, warn};
 
 use uv_cache::Cache;
-use uv_configuration::{DependencyGroupsWithDefaults, ExcludeDependency};
+use uv_configuration::{ActiveEnvironment, DependencyGroupsWithDefaults, ExcludeDependency};
 use uv_distribution_types::{Index, Requirement, RequirementSource};
 use uv_fs::{CWD, Simplified, normalize_path};
 use uv_normalize::{DEV_DEPENDENCIES, GroupName, PackageName};
@@ -897,10 +897,10 @@ impl Workspace {
     /// If `UV_PROJECT_ENVIRONMENT` is set, it will take precedence. If a relative path is provided,
     /// it is resolved relative to the install path.
     ///
-    /// If `active` is `true`, the `VIRTUAL_ENV` variable will be preferred. If it is `false`, any
-    /// warnings about mismatch between the active environment and the project environment will be
-    /// silenced.
-    pub fn environment_selection(&self, active: Option<bool>) -> ProjectEnvironmentSelection {
+    /// If `active` is [`ActiveEnvironment::Prefer`], the `VIRTUAL_ENV` variable will be preferred.
+    /// If it is [`ActiveEnvironment::Ignore`], warnings about mismatches between the active
+    /// environment and the project environment will be silenced.
+    pub fn environment_selection(&self, active: ActiveEnvironment) -> ProjectEnvironmentSelection {
         /// Resolve the `UV_PROJECT_ENVIRONMENT` value, if any.
         fn from_project_environment_variable(workspace: &Workspace) -> Option<PathBuf> {
             let value = std::env::var_os(EnvVars::UV_PROJECT_ENVIRONMENT)?;
@@ -949,7 +949,7 @@ impl Workspace {
                 uv_fs::is_same_file_allow_missing(&from_virtual_env, &project_environment_path)
                     .unwrap_or(false);
             match active {
-                Some(true) => {
+                ActiveEnvironment::Prefer => {
                     if !matches_project {
                         debug!(
                             "Using active virtual environment `{}` instead of project environment `{}`",
@@ -959,18 +959,18 @@ impl Workspace {
                     }
                     return ProjectEnvironmentSelection::Active(from_virtual_env);
                 }
-                Some(false) => {}
-                None if !matches_project => {
+                ActiveEnvironment::Ignore => {}
+                ActiveEnvironment::Default if !matches_project => {
                     warn_user_once!(
                         "`VIRTUAL_ENV={}` does not match the project environment path `{}` and will be ignored; use `--active` to target the active environment instead",
                         from_virtual_env.user_display(),
                         project_environment_path.user_display()
                     );
                 }
-                None => {}
+                ActiveEnvironment::Default => {}
             }
         } else {
-            if active.unwrap_or_default() {
+            if active == ActiveEnvironment::Prefer {
                 debug!(
                     "Use of the active virtual environment was requested, but `VIRTUAL_ENV` is not set"
                 );

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -960,14 +960,14 @@ impl Workspace {
                     return ProjectEnvironmentSelection::Active(from_virtual_env);
                 }
                 ActiveEnvironment::Ignore => {}
-                ActiveEnvironment::Default if !matches_project => {
+                ActiveEnvironment::Warn if !matches_project => {
                     warn_user_once!(
                         "`VIRTUAL_ENV={}` does not match the project environment path `{}` and will be ignored; use `--active` to target the active environment instead",
                         from_virtual_env.user_display(),
                         project_environment_path.user_display()
                     );
                 }
-                ActiveEnvironment::Default => {}
+                ActiveEnvironment::Warn => {}
             }
         } else {
             if active == ActiveEnvironment::Prefer {

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -299,7 +299,8 @@ pub(crate) async fn add(
                 python_downloads,
                 &install_mirrors,
                 ProjectEnvironmentPolicy::Optional,
-                active,
+                // Suppress warnings about the active environment when we won't modify it.
+                active.or(Some(false)),
                 cache,
                 printer,
             )

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -16,9 +16,9 @@ use uv_cache::Cache;
 use uv_cache_key::RepositoryUrl;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, Constraints, DependencyGroups, DependencyGroupsWithDefaults, DevMode, DryRun,
-    EditableMode, ExtrasSpecification, ExtrasSpecificationWithDefaults, GitLfsSetting,
-    InstallOptions, NoSources,
+    ActiveEnvironment, Concurrency, Constraints, DependencyGroups, DependencyGroupsWithDefaults,
+    DevMode, DryRun, EditableMode, ExtrasSpecification, ExtrasSpecificationWithDefaults,
+    GitLfsSetting, InstallOptions, NoSources,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies};
@@ -72,7 +72,7 @@ pub(crate) async fn add(
     project_dir: &Path,
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
-    active: Option<bool>,
+    active: ActiveEnvironment,
     no_sync: bool,
     no_install_project: bool,
     only_install_project: bool,
@@ -300,7 +300,7 @@ pub(crate) async fn add(
                 &install_mirrors,
                 ProjectEnvironmentPolicy::Optional,
                 // Suppress warnings about the active environment when we won't modify it.
-                active.or(Some(false)),
+                active.without_warning(),
                 cache,
                 printer,
             )

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -29,8 +29,8 @@ use uv_cache::Cache;
 use uv_cli::AuditOutputFormat;
 use uv_client::{BaseClientBuilder, CachedClient, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, DependencyGroups, DependencyGroupsWithDefaults, ExtrasSpecification,
-    ExtrasSpecificationWithDefaults, TargetTriple,
+    ActiveEnvironment, Concurrency, DependencyGroups, DependencyGroupsWithDefaults,
+    ExtrasSpecification, ExtrasSpecificationWithDefaults, TargetTriple,
 };
 use uv_distribution_types::{IndexCapabilities, IndexUrl};
 use uv_fs::{CWD, find_git_repository_root, relative_to};
@@ -134,7 +134,7 @@ pub(crate) async fn audit(
                 &install_mirrors,
                 false,
                 config_discovery,
-                Some(false),
+                ActiveEnvironment::Ignore,
                 &cache,
                 printer,
             )
@@ -158,7 +158,7 @@ pub(crate) async fn audit(
                     python_downloads,
                     &install_mirrors,
                     ProjectEnvironmentPolicy::Optional,
-                    Some(false),
+                    ActiveEnvironment::Ignore,
                     &cache,
                     printer,
                 )

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -8,8 +8,8 @@ use uv_cache::Cache;
 use uv_cli::ColorChoice;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{
-    Concurrency, DependencyGroups, DependencyGroupsWithDefaults, DryRun, ExtrasSpecification,
-    InstallOptions,
+    ActiveEnvironment, Concurrency, DependencyGroups, DependencyGroupsWithDefaults, DryRun,
+    ExtrasSpecification, InstallOptions,
 };
 use uv_fs::normalize_path;
 use uv_normalize::{DEV_DEPENDENCIES, DefaultExtras, PackageName};
@@ -295,7 +295,7 @@ pub(crate) async fn check(
                 &install_mirrors,
                 false,
                 config_discovery,
-                Some(false),
+                ActiveEnvironment::Ignore,
                 cache,
                 printer,
             )
@@ -375,7 +375,7 @@ pub(crate) async fn check(
                 &install_mirrors,
                 no_sync,
                 config_discovery,
-                Some(false),
+                ActiveEnvironment::Ignore,
                 cache,
                 DryRun::Disabled,
                 printer,
@@ -511,7 +511,7 @@ pub(crate) async fn check(
                 python_downloads,
                 no_sync,
                 config_discovery,
-                None,
+                ActiveEnvironment::Default,
                 cache,
                 DryRun::Disabled,
                 LinkErrorReporting::User,
@@ -542,7 +542,7 @@ pub(crate) async fn check(
                     python_downloads,
                     &install_mirrors,
                     ProjectEnvironmentPolicy::Optional,
-                    None,
+                    ActiveEnvironment::Default,
                     cache,
                     printer,
                 )

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -511,7 +511,7 @@ pub(crate) async fn check(
                 python_downloads,
                 no_sync,
                 config_discovery,
-                ActiveEnvironment::Default,
+                ActiveEnvironment::Warn,
                 cache,
                 DryRun::Disabled,
                 LinkErrorReporting::User,
@@ -542,7 +542,7 @@ pub(crate) async fn check(
                     python_downloads,
                     &install_mirrors,
                     ProjectEnvironmentPolicy::Optional,
-                    ActiveEnvironment::Default,
+                    ActiveEnvironment::Warn,
                     cache,
                     printer,
                 )

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -12,7 +12,8 @@ use rustc_hash::FxHashSet;
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{
-    Concurrency, DependencyGroups, EditableMode, ExportFormat, ExtrasSpecification, InstallOptions,
+    ActiveEnvironment, Concurrency, DependencyGroups, EditableMode, ExportFormat,
+    ExtrasSpecification, InstallOptions,
 };
 use uv_distribution_types::Verbatim;
 use uv_normalize::{DefaultExtras, DefaultGroups, PackageName};
@@ -175,7 +176,7 @@ pub(crate) async fn export(
                 &install_mirrors,
                 false,
                 config_discovery,
-                Some(false),
+                ActiveEnvironment::Ignore,
                 cache,
                 printer,
             )
@@ -199,7 +200,7 @@ pub(crate) async fn export(
                     python_downloads,
                     &install_mirrors,
                     ProjectEnvironmentPolicy::Optional,
-                    Some(false),
+                    ActiveEnvironment::Ignore,
                     cache,
                     printer,
                 )

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -12,8 +12,8 @@ use tracing::debug;
 use uv_cache::{Cache, Refresh};
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, Constraints, DependencyGroupsWithDefaults, DryRun, ExcludeDependency,
-    ExtrasSpecification, Override, PackageOverride, Reinstall, Upgrade,
+    ActiveEnvironment, Concurrency, Constraints, DependencyGroupsWithDefaults, DryRun,
+    ExcludeDependency, ExtrasSpecification, Override, PackageOverride, Reinstall, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies};
@@ -169,7 +169,7 @@ pub(crate) async fn lock(
                     python_downloads,
                     &install_mirrors,
                     ProjectEnvironmentPolicy::Optional,
-                    Some(false),
+                    ActiveEnvironment::Ignore,
                     cache,
                     printer,
                 )
@@ -185,7 +185,7 @@ pub(crate) async fn lock(
                 &install_mirrors,
                 false,
                 config_discovery,
-                Some(false),
+                ActiveEnvironment::Ignore,
                 cache,
                 printer,
             )

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -767,7 +767,7 @@ impl ScriptInterpreter {
                         return from_virtual_env;
                     }
                     ActiveEnvironment::Ignore => {}
-                    ActiveEnvironment::Default => {
+                    ActiveEnvironment::Warn => {
                         warn_user_once!(
                             "`VIRTUAL_ENV={}` does not match the script environment path `{}` and will be ignored; use `--active` to target the active environment instead",
                             from_virtual_env.user_display(),

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -14,8 +14,9 @@ use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::{cache_digest, cache_name};
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, Constraints, DependencyGroupsWithDefaults, DryRun, ExtrasSpecification,
-    GitLfsSetting, Override, PackageOverride, Reinstall, TargetTriple, Upgrade,
+    ActiveEnvironment, Concurrency, Constraints, DependencyGroupsWithDefaults, DryRun,
+    ExtrasSpecification, GitLfsSetting, Override, PackageOverride, Reinstall, TargetTriple,
+    Upgrade,
 };
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies, LoweredRequirement};
@@ -707,7 +708,7 @@ impl ScriptInterpreter {
     /// If `--active` is set, the active virtual environment will be preferred.
     ///
     /// See: [`Workspace::environment_selection`].
-    fn root(script: Pep723ItemRef<'_>, active: Option<bool>, cache: &Cache) -> PathBuf {
+    fn root(script: Pep723ItemRef<'_>, active: ActiveEnvironment, cache: &Cache) -> PathBuf {
         /// Resolve the `VIRTUAL_ENV` variable, if any.
         fn from_virtual_env_variable() -> Option<PathBuf> {
             let value = std::env::var_os(EnvVars::VIRTUAL_ENV)?;
@@ -757,7 +758,7 @@ impl ScriptInterpreter {
         if let Some(from_virtual_env) = from_virtual_env_variable() {
             if !uv_fs::is_same_file_allow_missing(&from_virtual_env, &cache_env).unwrap_or(false) {
                 match active {
-                    Some(true) => {
+                    ActiveEnvironment::Prefer => {
                         debug!(
                             "Using active virtual environment `{}` instead of script environment `{}`",
                             from_virtual_env.user_display(),
@@ -765,8 +766,8 @@ impl ScriptInterpreter {
                         );
                         return from_virtual_env;
                     }
-                    Some(false) => {}
-                    None => {
+                    ActiveEnvironment::Ignore => {}
+                    ActiveEnvironment::Default => {
                         warn_user_once!(
                             "`VIRTUAL_ENV={}` does not match the script environment path `{}` and will be ignored; use `--active` to target the active environment instead",
                             from_virtual_env.user_display(),
@@ -776,7 +777,7 @@ impl ScriptInterpreter {
                 }
             }
         } else {
-            if active.unwrap_or_default() {
+            if active == ActiveEnvironment::Prefer {
                 debug!(
                     "Use of the active virtual environment was requested, but `VIRTUAL_ENV` is not set"
                 );
@@ -790,7 +791,7 @@ impl ScriptInterpreter {
     /// Discover an existing script environment without selecting or downloading an interpreter.
     pub(crate) fn discover_existing(
         script: Pep723ItemRef<'_>,
-        active: Option<bool>,
+        active: ActiveEnvironment,
         cache: &Cache,
     ) -> Option<PythonEnvironment> {
         let root = Self::root(script, active, cache);
@@ -814,7 +815,7 @@ impl ScriptInterpreter {
         install_mirrors: &PythonInstallMirrors,
         keep_incompatible: bool,
         config_discovery: ConfigDiscovery,
-        active: Option<bool>,
+        active: ActiveEnvironment,
         cache: &Cache,
         printer: Printer,
     ) -> Result<Self, ProjectError> {
@@ -1382,7 +1383,7 @@ impl ProjectInterpreter {
     /// Discover an existing project environment without selecting or downloading an interpreter.
     pub(crate) fn discover_existing(
         workspace: &Workspace,
-        active: Option<bool>,
+        active: ActiveEnvironment,
         cache: &Cache,
     ) -> Result<Option<PythonEnvironment>, ProjectError> {
         let selection = workspace.environment_selection(active);
@@ -1416,7 +1417,7 @@ impl ProjectInterpreter {
         python_downloads: PythonDownloads,
         install_mirrors: &PythonInstallMirrors,
         policy: ProjectEnvironmentPolicy,
-        active: Option<bool>,
+        active: ActiveEnvironment,
         cache: &Cache,
         printer: Printer,
     ) -> Result<Self, ProjectError> {
@@ -1838,7 +1839,7 @@ impl ProjectEnvironment {
         python_downloads: PythonDownloads,
         no_sync: bool,
         config_discovery: ConfigDiscovery,
-        active: Option<bool>,
+        active: ActiveEnvironment,
         cache: &Cache,
         dry_run: DryRun,
         link_error_reporting: LinkErrorReporting,
@@ -2128,7 +2129,7 @@ impl ScriptEnvironment {
         install_mirrors: &PythonInstallMirrors,
         no_sync: bool,
         config_discovery: ConfigDiscovery,
-        active: Option<bool>,
+        active: ActiveEnvironment,
         cache: &Cache,
         dry_run: DryRun,
         printer: Printer,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -243,7 +243,8 @@ pub(crate) async fn remove(
                     python_downloads,
                     &install_mirrors,
                     ProjectEnvironmentPolicy::Optional,
-                    active,
+                    // Suppress warnings about the active environment when we won't modify it.
+                    active.or(Some(false)),
                     cache,
                     printer,
                 )

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn};
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{
-    Concurrency, DependencyGroups, DryRun, ExtrasSpecification, InstallOptions,
+    ActiveEnvironment, Concurrency, DependencyGroups, DryRun, ExtrasSpecification, InstallOptions,
 };
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
@@ -44,7 +44,7 @@ pub(crate) async fn remove(
     project_dir: &Path,
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
-    active: Option<bool>,
+    active: ActiveEnvironment,
     no_sync: bool,
     packages: Vec<PackageName>,
     dependency_type: DependencyType,
@@ -244,7 +244,7 @@ pub(crate) async fn remove(
                     &install_mirrors,
                     ProjectEnvironmentPolicy::Optional,
                     // Suppress warnings about the active environment when we won't modify it.
-                    active.or(Some(false)),
+                    active.without_warning(),
                     cache,
                     printer,
                 )

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -21,8 +21,8 @@ use uv_cache::Cache;
 use uv_cli::{ExternalCommand, GlobalArgs};
 use uv_client::BaseClientBuilder;
 use uv_configuration::{
-    Concurrency, Constraints, DependencyGroups, DryRun, EditableMode, EnvFile, ExtrasSpecification,
-    InstallOptions, TargetTriple,
+    ActiveEnvironment, Concurrency, Constraints, DependencyGroups, DryRun, EditableMode, EnvFile,
+    ExtrasSpecification, InstallOptions, TargetTriple,
 };
 use uv_distribution::LoweredExtraBuildDependencies;
 use uv_distribution_types::Requirement;
@@ -94,7 +94,7 @@ pub(crate) async fn run(
     show_resolution: bool,
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
-    active: Option<bool>,
+    active: ActiveEnvironment,
     no_sync: bool,
     isolated: bool,
     all_packages: bool,
@@ -216,7 +216,7 @@ pub(crate) async fn run(
                 &install_mirrors,
                 no_sync,
                 config_discovery,
-                active.map_or(Some(false), Some),
+                active.without_warning(),
                 &cache,
                 DryRun::Disabled,
                 printer,
@@ -389,7 +389,7 @@ pub(crate) async fn run(
                     &install_mirrors,
                     no_sync,
                     config_discovery,
-                    active.map_or(Some(false), Some),
+                    active.without_warning(),
                     &cache,
                     DryRun::Disabled,
                     printer,
@@ -473,7 +473,7 @@ pub(crate) async fn run(
                     &install_mirrors,
                     no_sync,
                     config_discovery,
-                    active.map_or(Some(false), Some),
+                    active.without_warning(),
                     &cache,
                     printer,
                 )

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -14,9 +14,9 @@ use uv_cache::Cache;
 use uv_cli::SyncFormat;
 use uv_client::{BaseClientBuilder, CachedClient, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, Constraints, DependencyGroups, DependencyGroupsWithDefaults, DryRun, EditableMode,
-    ExtrasSpecification, ExtrasSpecificationWithDefaults, HashCheckingMode, InstallOptions,
-    TargetTriple, Upgrade,
+    ActiveEnvironment, Concurrency, Constraints, DependencyGroups, DependencyGroupsWithDefaults,
+    DryRun, EditableMode, ExtrasSpecification, ExtrasSpecificationWithDefaults, HashCheckingMode,
+    InstallOptions, TargetTriple, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::LoweredExtraBuildDependencies;
@@ -69,7 +69,7 @@ pub(crate) async fn sync(
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
     dry_run: DryRun,
-    active: Option<bool>,
+    active: ActiveEnvironment,
     all_packages: bool,
     package: Vec<PackageName>,
     extras: ExtrasSpecification,

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -8,7 +8,7 @@ use uv_cache::{Cache, Refresh};
 use uv_cache_info::Timestamp;
 use uv_cli::TreeFormat;
 use uv_client::{BaseClientBuilder, RegistryClientBuilder};
-use uv_configuration::{Concurrency, DependencyGroups, TargetTriple};
+use uv_configuration::{ActiveEnvironment, Concurrency, DependencyGroups, TargetTriple};
 use uv_distribution_types::IndexCapabilities;
 use uv_normalize::DefaultGroups;
 use uv_normalize::PackageName;
@@ -111,7 +111,7 @@ pub(crate) async fn tree(
                 &install_mirrors,
                 false,
                 config_discovery,
-                Some(false),
+                ActiveEnvironment::Ignore,
                 cache,
                 printer,
             )
@@ -135,7 +135,7 @@ pub(crate) async fn tree(
                     python_downloads,
                     &install_mirrors,
                     ProjectEnvironmentPolicy::Optional,
-                    Some(false),
+                    ActiveEnvironment::Ignore,
                     cache,
                     printer,
                 )

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -8,7 +8,9 @@ use anyhow::{Context, Result, anyhow, bail};
 use itertools::Itertools;
 use uv_cache::{Cache, Refresh};
 use uv_client::BaseClientBuilder;
-use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun, Upgrade};
+use uv_configuration::{
+    ActiveEnvironment, Concurrency, DependencyGroupsWithDefaults, DryRun, Upgrade,
+};
 use uv_distribution::{ArchiveMetadata, Metadata};
 use uv_distribution_types::{Identifier, RequiresPython};
 use uv_normalize::PackageName;
@@ -220,7 +222,7 @@ pub(crate) async fn upgrade(
             python_downloads,
             &install_mirrors,
             ProjectEnvironmentPolicy::Optional,
-            Some(false),
+            ActiveEnvironment::Ignore,
             cache,
             printer,
         )
@@ -379,7 +381,7 @@ pub(crate) async fn upgrade(
             python_downloads,
             &install_mirrors,
             ProjectEnvironmentPolicy::Optional,
-            Some(false),
+            ActiveEnvironment::Ignore,
             &cache,
             printer,
         )

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -12,7 +12,7 @@ use uv_cli::version::ProjectVersionInfo;
 use uv_cli::{VersionBump, VersionBumpSpec, VersionFormat};
 use uv_client::BaseClientBuilder;
 use uv_configuration::{
-    Concurrency, DependencyGroups, DryRun, ExtrasSpecification, InstallOptions,
+    ActiveEnvironment, Concurrency, DependencyGroups, DryRun, ExtrasSpecification, InstallOptions,
 };
 use uv_fs::Simplified;
 use uv_normalize::DefaultExtras;
@@ -80,7 +80,7 @@ pub(crate) async fn project_version(
     dry_run: bool,
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
-    active: Option<bool>,
+    active: ActiveEnvironment,
     no_sync: bool,
     python: Option<String>,
     install_mirrors: PythonInstallMirrors,
@@ -539,7 +539,7 @@ async fn lock_and_sync(
     project_dir: &Path,
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
-    active: Option<bool>,
+    active: ActiveEnvironment,
     no_sync: bool,
     python: Option<String>,
     install_mirrors: PythonInstallMirrors,

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
-use uv_configuration::DependencyGroupsWithDefaults;
+use uv_configuration::{ActiveEnvironment, DependencyGroupsWithDefaults};
 use uv_errors::ErrorWithHints;
 use uv_fs::Simplified;
 use uv_python::{
@@ -157,7 +157,7 @@ pub(crate) async fn find_script(
         &PythonInstallMirrors::default(),
         false,
         config_discovery,
-        Some(false),
+        ActiveEnvironment::Ignore,
         cache,
         printer,
     )

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -11,8 +11,8 @@ use tracing::warn;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    BuildOptions, Concurrency, Constraints, DependencyGroups, DryRun, IndexStrategy,
-    KeyringProviderType, NoBinary, NoBuild, NoSources,
+    ActiveEnvironment, BuildOptions, Concurrency, Constraints, DependencyGroups, DryRun,
+    IndexStrategy, KeyringProviderType, NoBinary, NoBuild, NoSources,
 };
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{
@@ -131,7 +131,12 @@ pub(crate) async fn venv(
         .as_ref()
         .map(VirtualProject::workspace)
         .filter(|workspace| path.is_none() && workspace.install_path() == project_dir)
-        .map(|workspace| (workspace, workspace.environment_selection(Some(false))));
+        .map(|workspace| {
+            (
+                workspace,
+                workspace.environment_selection(ActiveEnvironment::Ignore),
+            )
+        });
 
     let centralized_workspace = project_environment
         .as_ref()

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use uv_cache::{Cache, Refresh};
 use uv_client::BaseClientBuilder;
-use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun};
+use uv_configuration::{ActiveEnvironment, Concurrency, DependencyGroupsWithDefaults, DryRun};
 use uv_preview::{Preview, PreviewFeature};
 use uv_python::{ConfigDiscovery, PythonDownloads, PythonPreference, PythonRequest};
 use uv_resolver::Metadata;
@@ -36,7 +36,7 @@ pub(crate) async fn metadata(
     dry_run: DryRun,
     refresh: Refresh,
     sync: Option<Modifications>,
-    active: bool,
+    active: ActiveEnvironment,
     python: Option<String>,
     install_mirrors: PythonInstallMirrors,
     malware_settings: MalwareCheckSettings,
@@ -91,7 +91,7 @@ pub(crate) async fn metadata(
                 &install_mirrors,
                 false,
                 config_discovery,
-                Some(active),
+                active,
                 cache,
                 printer,
             )
@@ -119,7 +119,7 @@ pub(crate) async fn metadata(
                     } else {
                         ProjectEnvironmentPolicy::Optional
                     },
-                    Some(active),
+                    active,
                     cache,
                     printer,
                 )
@@ -186,7 +186,7 @@ pub(crate) async fn metadata(
                         python_downloads,
                         false,
                         config_discovery,
-                        Some(active),
+                        active,
                         cache,
                         DryRun::Disabled,
                         LinkErrorReporting::User,
@@ -203,7 +203,7 @@ pub(crate) async fn metadata(
                         &install_mirrors,
                         false,
                         config_discovery,
-                        Some(active),
+                        active,
                         cache,
                         DryRun::Disabled,
                         printer,
@@ -214,10 +214,10 @@ pub(crate) async fn metadata(
             } else {
                 match target {
                     LockTarget::Workspace(workspace) => {
-                        ProjectInterpreter::discover_existing(workspace, Some(active), cache)?
+                        ProjectInterpreter::discover_existing(workspace, active, cache)?
                     }
                     LockTarget::Script(script) => {
-                        ScriptInterpreter::discover_existing(script.into(), Some(active), cache)
+                        ScriptInterpreter::discover_existing(script.into(), active, cache)
                     }
                 }
             };

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -34,11 +34,12 @@ use uv_cli::{
 };
 use uv_client::{Certificates, Connectivity, MetadataRangeRequest};
 use uv_configuration::{
-    BuildIsolation, BuildOptions, Concurrency, DependencyGroups, DevMode, DryRun, EditableMode,
-    EnvFile, ExcludeDependency, ExportFormat, ExtrasSpecification, GitLfsSetting, HashCheckingMode,
-    IndexStrategy, InstallOptions, KeyringProviderType, NoBinary, NoBuild, NoSources, Override,
-    PackageOverride, PipCompileFormat, ProjectBuildBackend, ProxyUrl, Reinstall, RequiredVersion,
-    TargetTriple, TrustedHost, TrustedPublishing, Upgrade, VersionControlSystem,
+    ActiveEnvironment, BuildIsolation, BuildOptions, Concurrency, DependencyGroups, DevMode,
+    DryRun, EditableMode, EnvFile, ExcludeDependency, ExportFormat, ExtrasSpecification,
+    GitLfsSetting, HashCheckingMode, IndexStrategy, InstallOptions, KeyringProviderType, NoBinary,
+    NoBuild, NoSources, Override, PackageOverride, PipCompileFormat, ProjectBuildBackend, ProxyUrl,
+    Reinstall, RequiredVersion, TargetTriple, TrustedHost, TrustedPublishing, Upgrade,
+    VersionControlSystem,
 };
 use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations, IndexUrl,
@@ -773,7 +774,7 @@ pub(crate) struct RunSettings {
     pub(crate) all_packages: bool,
     pub(crate) package: Option<PackageName>,
     pub(crate) no_project: bool,
-    pub(crate) active: Option<bool>,
+    pub(crate) active: ActiveEnvironment,
     pub(crate) no_sync: bool,
     pub(crate) python: Option<String>,
     pub(crate) python_platform: Option<TargetTriple>,
@@ -936,7 +937,7 @@ impl RunSettings {
             package,
             no_project,
             no_sync: no_sync.is_enabled(),
-            active: flag(active, no_active, "active")?,
+            active: flag(active, no_active, "active")?.into(),
             python: python.and_then(Maybe::into_option),
             python_platform,
             refresh: Refresh::try_from(refresh)?,
@@ -1937,7 +1938,7 @@ pub(crate) struct SyncSettings {
     pub(super) frozen: Option<FrozenSource>,
     pub(super) dry_run: DryRun,
     pub(super) script: Option<PathBuf>,
-    pub(super) active: Option<bool>,
+    pub(super) active: ActiveEnvironment,
     pub(super) extras: ExtrasSpecification,
     pub(super) groups: DependencyGroups,
     pub(super) editable: Option<EditableMode>,
@@ -2094,7 +2095,7 @@ impl SyncSettings {
             frozen,
             dry_run,
             script,
-            active: flag(active, no_active, "active")?,
+            active: flag(active, no_active, "active")?.into(),
             extras: ExtrasSpecification::from_args(
                 extra.unwrap_or_default(),
                 no_extra,
@@ -2278,7 +2279,7 @@ pub(crate) struct MetadataSettings {
     pub(crate) frozen: Option<FrozenSource>,
     pub(crate) dry_run: DryRun,
     pub(crate) sync: Option<Modifications>,
-    pub(crate) active: bool,
+    pub(crate) active: ActiveEnvironment,
     pub(crate) python: Option<String>,
     pub(crate) install_mirrors: PythonInstallMirrors,
     pub(crate) refresh: Refresh,
@@ -2332,7 +2333,7 @@ impl MetadataSettings {
             } else {
                 Modifications::Sufficient
             }),
-            active,
+            active: Some(active).into(),
             python: python.and_then(Maybe::into_option),
             refresh: Refresh::try_from(refresh)?,
             settings: ResolverSettings::resolve(resolver, build, filesystem, &environment)?,
@@ -2350,7 +2351,7 @@ impl MetadataSettings {
 pub(crate) struct AddSettings {
     pub(crate) lock_check: LockCheck,
     pub(crate) frozen: Option<FrozenSource>,
-    pub(crate) active: Option<bool>,
+    pub(crate) active: ActiveEnvironment,
     pub(crate) no_sync: bool,
     pub(crate) packages: Vec<String>,
     pub(crate) requirements: Vec<PathBuf>,
@@ -2569,7 +2570,7 @@ impl AddSettings {
         let only_install_local = only_install_local.is_enabled();
 
         let malware_settings = MalwareCheckSettings::resolve(filesystem.as_ref(), &environment);
-        let active = flag(active, no_active, "active")?;
+        let active = flag(active, no_active, "active")?.into();
         let workspace = flag(workspace, no_workspace, "workspace")?;
         let editable = EditableMode::from_args(
             flag(editable.into(), no_editable.into(), "editable")?,
@@ -2630,7 +2631,7 @@ impl AddSettings {
 pub(crate) struct RemoveSettings {
     pub(super) lock_check: LockCheck,
     pub(super) frozen: Option<FrozenSource>,
-    pub(super) active: Option<bool>,
+    pub(super) active: ActiveEnvironment,
     pub(super) no_sync: bool,
     pub(super) packages: Vec<PackageName>,
     pub(super) dependency_type: DependencyType,
@@ -2708,7 +2709,7 @@ impl RemoveSettings {
         Ok(Self {
             lock_check: locked,
             frozen,
-            active: flag(active, no_active, "active")?,
+            active: flag(active, no_active, "active")?.into(),
             no_sync: no_sync.is_enabled(),
             packages,
             dependency_type,
@@ -2740,7 +2741,7 @@ pub(crate) struct VersionSettings {
     pub(crate) dry_run: bool,
     pub(crate) lock_check: LockCheck,
     pub(crate) frozen: Option<FrozenSource>,
-    pub(crate) active: Option<bool>,
+    pub(crate) active: ActiveEnvironment,
     pub(crate) no_sync: bool,
     pub(crate) package: Option<PackageName>,
     pub(crate) python: Option<String>,
@@ -2802,7 +2803,7 @@ impl VersionSettings {
             dry_run,
             lock_check: locked,
             frozen,
-            active: flag(active, no_active, "active")?,
+            active: flag(active, no_active, "active")?.into(),
             no_sync: no_sync.is_enabled(),
             package,
             python: python.and_then(Maybe::into_option),

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -4306,7 +4306,7 @@ fn add_frozen() -> Result<()> {
         dependencies = []
     "#})?;
 
-    uv_snapshot!(context.filters(), context.add().arg("anyio==3.7.0").arg("--frozen"), @"
+    uv_snapshot!(context.filters(), context.add().arg("anyio==3.7.0").arg("--frozen").env(EnvVars::VIRTUAL_ENV, "active"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
@@ -4380,6 +4380,117 @@ fn add_no_sync() -> Result<()> {
 
     assert!(context.temp_dir.join("uv.lock").exists());
     assert!(!context.venv.exists());
+
+    Ok(())
+}
+
+/// Editing without synchronization does not target either virtual environment.
+#[test]
+fn edit_no_sync_active_environment_mismatch() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    fs_err::remove_dir_all(&context.venv)?;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+        context.temp_dir.join("ok-1.0.0-py3-none-any.whl"),
+    )?;
+
+    uv_snapshot!(context.filters(), context
+        .add()
+        .arg("./ok-1.0.0-py3-none-any.whl")
+        .arg("--no-sync")
+        .arg("--offline")
+        .env(EnvVars::VIRTUAL_ENV, "active"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
+    ");
+
+    assert!(!context.venv.exists());
+
+    uv_snapshot!(context.filters(), context
+        .remove()
+        .arg("ok")
+        .arg("--no-sync")
+        .arg("--offline")
+        .env(EnvVars::VIRTUAL_ENV, "active"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 1 package in [TIME]
+    ");
+
+    assert!(!context.venv.exists());
+
+    context
+        .venv()
+        .arg("active")
+        .arg("--python")
+        .arg("3.12")
+        .assert()
+        .success();
+
+    // An explicitly requested active environment still determines the interpreter.
+    uv_snapshot!(context.filters(), context
+        .add()
+        .arg("./ok-1.0.0-py3-none-any.whl")
+        .arg("--no-sync")
+        .arg("--offline")
+        .arg("--active")
+        .env(EnvVars::VIRTUAL_ENV, "active")
+        .env(EnvVars::UV_PYTHON_SEARCH_PATH, ""), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    assert!(!context.venv.exists());
+
+    uv_snapshot!(context.filters(), context
+        .remove()
+        .arg("ok")
+        .arg("--no-sync")
+        .arg("--offline")
+        .arg("--active")
+        .env(EnvVars::VIRTUAL_ENV, "active")
+        .env(EnvVars::UV_PYTHON_SEARCH_PATH, ""), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    assert!(!context.venv.exists());
+
+    // Commands that synchronize the project environment must retain the mismatch warning.
+    uv_snapshot!(context.filters(), context
+        .sync()
+        .arg("--offline")
+        .env(EnvVars::VIRTUAL_ENV, "active"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: `VIRTUAL_ENV=active` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    ");
+
+    assert!(context.venv.exists());
 
     Ok(())
 }

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -775,7 +775,7 @@ fn version_baseline() {
         dry_run: false,
         lock_check: Disabled,
         frozen: None,
-        active: Default,
+        active: Warn,
         no_sync: false,
         package: None,
         python: None,

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -775,7 +775,7 @@ fn version_baseline() {
         dry_run: false,
         lock_check: Disabled,
         frozen: None,
-        active: None,
+        active: Default,
         no_sync: false,
         package: None,
         python: None,


### PR DESCRIPTION
## Summary

We now suppress `VIRTUAL_ENV` mismatch warnings when `uv add --no-sync`, `uv remove --no-sync`, or `uv add --frozen` only need an interpreter. Explicit `--active` selection and warnings for commands that synchronize the project environment are preserved.

Represent active-environment behavior with `ActiveEnvironment::{Warn, Ignore, Prefer}` throughout the internal APIs, converting the CLI flags when resolving settings. Callers use `active.without_warning()` to suppress the warning while preserving an explicit preference for the active environment.

Closes https://github.com/astral-sh/uv/issues/7073.
