### PR TITLE
Warn on unqueryable interpreters in `uv python list`

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::env::consts::EXE_SUFFIX;
 use std::fmt::{self, Debug, Formatter};
+use std::sync::atomic::Ordering;
 use std::{env, io, iter};
 use std::{path::Path, path::PathBuf, str::FromStr};
 use thiserror::Error;
@@ -1058,25 +1059,9 @@ impl Error {
             // When querying the Python interpreter fails, we will only raise errors that demonstrate that something is broken
             // If the Python interpreter returned a bad response, we'll continue searching for one that works
             Self::Query(err, _, source) => match &**err {
-                InterpreterError::Encode(_) | InterpreterError::Io(_) => true,
-                InterpreterError::SpawnFailed { path, err } => match source {
-                    PythonSource::SearchPath | PythonSource::SearchPathFirst => {
-                        debug!(
-                            "Skipping unexecutable interpreter at {} from {source}: {err}",
-                            path.display()
-                        );
-                        false
-                    }
-                    PythonSource::ProvidedPath
-                    | PythonSource::ActiveEnvironment
-                    | PythonSource::CondaPrefix
-                    | PythonSource::BaseCondaPrefix
-                    | PythonSource::DiscoveredEnvironment
-                    | PythonSource::Registry
-                    | PythonSource::MicrosoftStore
-                    | PythonSource::Managed
-                    | PythonSource::ParentInterpreter => true,
-                },
+                InterpreterError::Encode(_)
+                | InterpreterError::Io(_)
+                | InterpreterError::SpawnFailed { .. } => true,
                 InterpreterError::UnexpectedResponse(UnexpectedResponseError { path, .. })
                 | InterpreterError::StatusCode(StatusCodeError { path, .. }) => {
                     debug!(
@@ -1380,8 +1365,8 @@ fn find_python_installations_with_strategy<'a>(
 /// concurrently.
 ///
 /// Unlike [`find_python_installations`], this eagerly collects matching installations instead of
-/// returning a lazy iterator. Non-critical discovery errors are dropped, while critical errors are
-/// propagated in discovery order.
+/// returning a lazy iterator. Interpreter query failures produce warnings and are skipped. Other
+/// non-critical discovery errors are dropped, while critical errors are propagated in discovery order.
 pub fn find_all_python_installations(
     request: &PythonRequest,
     environments: EnvironmentPreference,
@@ -1400,6 +1385,12 @@ pub fn find_all_python_installations(
         match result {
             Ok(Ok(installation)) => installations.push(installation),
             Ok(Err(_)) => {}
+            Err(err @ Error::Query(..)) => {
+                if uv_warnings::ENABLED.load(Ordering::Relaxed) {
+                    write_warning_chain(&err, Hints::none())
+                        .expect("writing to stderr should not fail");
+                }
+            }
             Err(err) if err.is_critical() => return Err(err),
             Err(_) => {}
         }
@@ -3875,39 +3866,6 @@ mod tests {
         PythonExecutableGroup, PythonPreference, PythonSource, PythonVariant, QueryStrategy,
         python_installations_from_executables, sort_installations_by_key,
     };
-
-    #[test]
-    fn interpreter_spawn_failures_are_noncritical_only_on_search_path() {
-        for (source, is_critical) in [
-            (PythonSource::SearchPath, false),
-            (PythonSource::SearchPathFirst, false),
-            (PythonSource::ProvidedPath, true),
-            (PythonSource::ActiveEnvironment, true),
-            (PythonSource::CondaPrefix, true),
-            (PythonSource::BaseCondaPrefix, true),
-            (PythonSource::DiscoveredEnvironment, true),
-            (PythonSource::Registry, true),
-            (PythonSource::MicrosoftStore, true),
-            (PythonSource::Managed, true),
-            (PythonSource::ParentInterpreter, true),
-        ] {
-            let path = PathBuf::from("python");
-            let error = Error::Query(
-                Box::new(InterpreterError::SpawnFailed {
-                    path: path.clone(),
-                    err: io::Error::other("unsupported executable format"),
-                }),
-                path,
-                source,
-            );
-
-            assert_eq!(
-                error.is_critical(),
-                is_critical,
-                "unexpected criticality for {source}",
-            );
-        }
-    }
 
     // Testing this at a higher level would necessitate relying on filesystem ordering.
     #[test]

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1058,9 +1058,25 @@ impl Error {
             // When querying the Python interpreter fails, we will only raise errors that demonstrate that something is broken
             // If the Python interpreter returned a bad response, we'll continue searching for one that works
             Self::Query(err, _, source) => match &**err {
-                InterpreterError::Encode(_)
-                | InterpreterError::Io(_)
-                | InterpreterError::SpawnFailed { .. } => true,
+                InterpreterError::Encode(_) | InterpreterError::Io(_) => true,
+                InterpreterError::SpawnFailed { path, err } => match source {
+                    PythonSource::SearchPath | PythonSource::SearchPathFirst => {
+                        debug!(
+                            "Skipping unexecutable interpreter at {} from {source}: {err}",
+                            path.display()
+                        );
+                        false
+                    }
+                    PythonSource::ProvidedPath
+                    | PythonSource::ActiveEnvironment
+                    | PythonSource::CondaPrefix
+                    | PythonSource::BaseCondaPrefix
+                    | PythonSource::DiscoveredEnvironment
+                    | PythonSource::Registry
+                    | PythonSource::MicrosoftStore
+                    | PythonSource::Managed
+                    | PythonSource::ParentInterpreter => true,
+                },
                 InterpreterError::UnexpectedResponse(UnexpectedResponseError { path, .. })
                 | InterpreterError::StatusCode(StatusCodeError { path, .. }) => {
                     debug!(
@@ -3859,6 +3875,39 @@ mod tests {
         PythonExecutableGroup, PythonPreference, PythonSource, PythonVariant, QueryStrategy,
         python_installations_from_executables, sort_installations_by_key,
     };
+
+    #[test]
+    fn interpreter_spawn_failures_are_noncritical_only_on_search_path() {
+        for (source, is_critical) in [
+            (PythonSource::SearchPath, false),
+            (PythonSource::SearchPathFirst, false),
+            (PythonSource::ProvidedPath, true),
+            (PythonSource::ActiveEnvironment, true),
+            (PythonSource::CondaPrefix, true),
+            (PythonSource::BaseCondaPrefix, true),
+            (PythonSource::DiscoveredEnvironment, true),
+            (PythonSource::Registry, true),
+            (PythonSource::MicrosoftStore, true),
+            (PythonSource::Managed, true),
+            (PythonSource::ParentInterpreter, true),
+        ] {
+            let path = PathBuf::from("python");
+            let error = Error::Query(
+                Box::new(InterpreterError::SpawnFailed {
+                    path: path.clone(),
+                    err: io::Error::other("unsupported executable format"),
+                }),
+                path,
+                source,
+            );
+
+            assert_eq!(
+                error.is_critical(),
+                is_critical,
+                "unexpected criticality for {source}",
+            );
+        }
+    }
 
     // Testing this at a higher level would necessitate relying on filesystem ordering.
     #[test]

--- a/crates/uv/tests/python/python_list.rs
+++ b/crates/uv/tests/python/python_list.rs
@@ -101,7 +101,7 @@ fn python_list() {
 
 #[cfg(unix)]
 #[test]
-fn python_list_ignores_noncritical_explicit_path_errors() -> Result<()> {
+fn python_list_warns_on_noncritical_explicit_path_errors() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let contents = r"#!/bin/sh
     echo 'error: intentionally broken python executable' >&2
@@ -117,6 +117,12 @@ fn python_list_ignores_noncritical_explicit_path_errors() -> Result<()> {
         .arg(&python)
         .arg("--only-installed"), @"
     exit_code: 0 (success)
+    ----- stderr -----
+    warning: Failed to inspect Python interpreter from provided path at `python`
+      Caused by: Querying Python at `[TEMP_DIR]/python` failed with exit status exit status: 1
+
+        [stderr]
+        error: intentionally broken python executable
     ");
 
     let environment = context.temp_dir.join("environment");
@@ -129,6 +135,12 @@ fn python_list_ignores_noncritical_explicit_path_errors() -> Result<()> {
         .arg(&environment)
         .arg("--only-installed"), @"
     exit_code: 0 (success)
+    ----- stderr -----
+    warning: Failed to inspect Python interpreter from provided path at `environment`
+      Caused by: Querying Python at `[TEMP_DIR]/environment/bin/python` failed with exit status exit status: 1
+
+        [stderr]
+        error: intentionally broken python executable
     ");
 
     Ok(())
@@ -136,7 +148,7 @@ fn python_list_ignores_noncritical_explicit_path_errors() -> Result<()> {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn python_list_ignores_non_native_search_path_interpreters() -> Result<()> {
+fn python_list_warns_on_non_native_search_path_interpreters() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.12"])
         .with_filtered_python_symlinks()
         .with_filtered_python_keys()
@@ -169,6 +181,37 @@ fn python_list_ignores_non_native_search_path_interpreters() -> Result<()> {
     exit_code: 0 (success)
     ----- stdout -----
     cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+
+    ----- stderr -----
+    warning: Failed to inspect Python interpreter from first executable in the search path at `foreign-bin/python`
+     Caused by: Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
+     Caused by: Bad CPU type in executable (os error 86)
+    ");
+
+    uv_snapshot!(context.filters(), context.python_list()
+        .arg("--only-installed")
+        .arg("--quiet")
+        .env(EnvVars::UV_PYTHON_SEARCH_PATH, &python_search_path), @"
+    exit_code: 0 (success)
+    ");
+
+    uv_snapshot!(context.filters(), context.python_list()
+        .arg(&foreign_python)
+        .arg("--only-installed"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Failed to inspect Python interpreter from provided path at `foreign-bin/python`
+     Caused by: Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
+     Caused by: Bad CPU type in executable (os error 86)
+    ");
+
+    uv_snapshot!(context.filters(), context.python_find()
+        .env(EnvVars::UV_PYTHON_SEARCH_PATH, &python_search_path), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Failed to inspect Python interpreter from first executable in the search path at `foreign-bin/python`
+     Caused by: Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
+     Caused by: Bad CPU type in executable (os error 86)
     ");
 
     uv_snapshot!(context.filters(), context.python_find()

--- a/crates/uv/tests/python/python_list.rs
+++ b/crates/uv/tests/python/python_list.rs
@@ -1,3 +1,6 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use uv_platform::{Arch, Os};
 use uv_static::EnvVars;
 
@@ -99,8 +102,6 @@ fn python_list() {
 #[cfg(unix)]
 #[test]
 fn python_list_ignores_noncritical_explicit_path_errors() -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
     let context = uv_test::test_context_with_versions!(&[]);
     let contents = r"#!/bin/sh
     echo 'error: intentionally broken python executable' >&2
@@ -128,6 +129,55 @@ fn python_list_ignores_noncritical_explicit_path_errors() -> Result<()> {
         .arg(&environment)
         .arg("--only-installed"), @"
     exit_code: 0 (success)
+    ");
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn python_list_ignores_non_native_search_path_interpreters() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.12"])
+        .with_filtered_python_symlinks()
+        .with_filtered_python_keys()
+        .with_collapsed_whitespace();
+
+    let foreign_bin = context.temp_dir.join("foreign-bin");
+    fs_err::create_dir_all(&foreign_bin)?;
+
+    // A 64-bit PowerPC Mach-O cannot execute on supported macOS architectures.
+    let foreign_python = foreign_bin.join("python");
+    fs_err::write(
+        &foreign_python,
+        [
+            0xcf, 0xfa, 0xed, 0xfe, 0x12, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ],
+    )?;
+    let mut permissions = fs_err::metadata(&foreign_python)?.permissions();
+    permissions.set_mode(0o755);
+    fs_err::set_permissions(&foreign_python, permissions)?;
+
+    let python_search_path = std::env::join_paths(
+        std::iter::once(foreign_bin).chain(std::env::split_paths(&context.python_path())),
+    )?;
+
+    uv_snapshot!(context.filters(), context.python_list()
+        .arg("--only-installed")
+        .env(EnvVars::UV_PYTHON_SEARCH_PATH, &python_search_path), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    ");
+
+    uv_snapshot!(context.filters(), context.python_find()
+        .arg(&foreign_python), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Failed to inspect Python interpreter from provided path at `foreign-bin/python`
+     Caused by: Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
+     Caused by: Bad CPU type in executable (os error 86)
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

We now warn and continue when `uv python list` cannot query an interpreter, including non-native executables on `PATH`. Python discovery in other commands retains its existing critical-error behavior, so `uv python find` still fails when the first interpreter on `PATH` cannot be launched.

Includes regression coverage for non-native executables, explicit-path query failures, and `--quiet`.

Closes https://github.com/astral-sh/uv/issues/15667.
