### PR TITLE
Use positioned reads for seekable ZIP extraction

### DIFF
--- a/crates/uv-extract/src/dirhash/seek.rs
+++ b/crates/uv-extract/src/dirhash/seek.rs
@@ -65,8 +65,6 @@ fn unzip_inner(
     target: &Path,
     hash_contents: bool,
 ) -> Result<UnzipOutput, Error> {
-    let (reader, _) = reader.into_parts();
-
     // Parse the central directory once, then clone the archive reader per Rayon worker so
     // extraction stays parallel for already-downloaded wheels. AllowStdIo adapts synchronous
     // file I/O to async_zip; extraction itself runs on blocking and Rayon threads.

--- a/crates/uv-extract/src/vendor/cloneable_seekable_reader.rs
+++ b/crates/uv-extract/src/vendor/cloneable_seekable_reader.rs
@@ -9,28 +9,25 @@
 #![expect(clippy::cast_sign_loss)]
 
 use std::{
-    io::{BufRead, BufReader, Cursor, Read, Seek, SeekFrom},
-    sync::{Arc, Mutex},
+    io::{BufRead, Read, Seek, SeekFrom},
+    sync::Arc,
 };
+
+#[cfg(unix)]
+use fs_err::os::unix::fs::FileExt;
+#[cfg(windows)]
+use fs_err::os::windows::fs::FileExt;
 
 // Chosen from extraction benchmarks to reduce read calls without adding too
 // much per-clone buffering.
 const BUFFER_SIZE: usize = 64 * 1024;
 
-/// A trait to represent some reader which has a total length known in
-/// advance. This is roughly equivalent to the nightly
-/// [`Seek::stream_len`] API.
-pub(crate) trait HasLength {
-    /// Return the current total length of this stream.
-    fn len(&self) -> u64;
-}
-
 /// A [`Read`] which refers to its underlying stream by reference count,
 /// and thus can be cloned cheaply. It supports seeking; each cloned instance
-/// maintains its own pointer into the file, and the underlying instance
-/// is seeked prior to each read.
-pub(crate) struct CloneableSeekableReader<R: Read + Seek + HasLength> {
-    file: Arc<Mutex<R>>,
+/// maintains its own position and uses positioned reads so clones can read
+/// concurrently without sharing a file cursor.
+pub(crate) struct CloneableSeekableReader {
+    file: Arc<fs_err::File>,
     pos: u64,
     // TODO determine and store this once instead of per cloneable file
     file_length: Option<u64>,
@@ -39,7 +36,7 @@ pub(crate) struct CloneableSeekableReader<R: Read + Seek + HasLength> {
     buffer_length: usize,
 }
 
-impl<R: Read + Seek + HasLength> Clone for CloneableSeekableReader<R> {
+impl Clone for CloneableSeekableReader {
     fn clone(&self) -> Self {
         Self {
             file: self.file.clone(),
@@ -52,15 +49,15 @@ impl<R: Read + Seek + HasLength> Clone for CloneableSeekableReader<R> {
     }
 }
 
-impl<R: Read + Seek + HasLength> CloneableSeekableReader<R> {
-    /// Constructor. Takes ownership of the underlying `Read`.
-    /// You should pass in only streams whose total length you expect
+impl CloneableSeekableReader {
+    /// Constructor. Takes ownership of the underlying file.
+    /// You should pass in only files whose total length you expect
     /// to be fixed and unchanging. Odd behavior may occur if the length
     /// of the stream changes; any subsequent seeks will not take account
     /// of the changed stream length.
-    pub(crate) fn new(file: R) -> Self {
+    pub(crate) fn new(file: fs_err::File) -> Self {
         Self {
-            file: Arc::new(Mutex::new(file)),
+            file: Arc::new(file),
             pos: 0u64,
             file_length: None,
             buffer: Box::new([0; BUFFER_SIZE]),
@@ -70,12 +67,13 @@ impl<R: Read + Seek + HasLength> CloneableSeekableReader<R> {
     }
 
     /// Determine the length of the underlying stream.
-    fn ascertain_file_length(&mut self) -> u64 {
-        self.file_length.unwrap_or_else(|| {
-            let len = self.file.lock().unwrap().len();
-            self.file_length = Some(len);
-            len
-        })
+    fn ascertain_file_length(&mut self) -> std::io::Result<u64> {
+        if let Some(len) = self.file_length {
+            return Ok(len);
+        }
+        let len = self.file.metadata()?.len();
+        self.file_length = Some(len);
+        Ok(len)
     }
 
     fn buffered_len(&self) -> usize {
@@ -99,7 +97,7 @@ impl<R: Read + Seek + HasLength> CloneableSeekableReader<R> {
     }
 }
 
-impl<R: Read + Seek + HasLength> Read for CloneableSeekableReader<R> {
+impl Read for CloneableSeekableReader {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         if self.buffered_len() > 0 {
             let amount = buf.len().min(self.buffered_len());
@@ -109,11 +107,7 @@ impl<R: Read + Seek + HasLength> Read for CloneableSeekableReader<R> {
             return Ok(amount);
         }
 
-        let mut underlying_file = self.file.lock().unwrap();
-        // TODO share an object which knows current position to avoid unnecessary
-        // seeks
-        underlying_file.seek(SeekFrom::Start(self.pos))?;
-        let read_result = underlying_file.read(buf);
+        let read_result = read_at(&self.file, buf, self.pos);
         if let Ok(bytes_read) = read_result {
             // TODO, once stabilised, use checked_add_signed
             self.pos += bytes_read as u64;
@@ -122,12 +116,12 @@ impl<R: Read + Seek + HasLength> Read for CloneableSeekableReader<R> {
     }
 }
 
-impl<R: Read + Seek + HasLength> Seek for CloneableSeekableReader<R> {
+impl Seek for CloneableSeekableReader {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
         let new_pos = match pos {
             SeekFrom::Start(pos) => pos,
             SeekFrom::End(offset_from_end) => {
-                let file_len = self.ascertain_file_length();
+                let file_len = self.ascertain_file_length()?;
                 if -offset_from_end as u64 > file_len {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
@@ -152,12 +146,10 @@ impl<R: Read + Seek + HasLength> Seek for CloneableSeekableReader<R> {
     }
 }
 
-impl<R: Read + Seek + HasLength> BufRead for CloneableSeekableReader<R> {
+impl BufRead for CloneableSeekableReader {
     fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
         if self.buffered_len() == 0 {
-            let mut underlying_file = self.file.lock().unwrap();
-            underlying_file.seek(SeekFrom::Start(self.pos))?;
-            self.buffer_length = underlying_file.read(&mut *self.buffer)?;
+            self.buffer_length = read_at(&self.file, &mut *self.buffer, self.pos)?;
             self.buffer_position = 0;
         }
 
@@ -169,48 +161,42 @@ impl<R: Read + Seek + HasLength> BufRead for CloneableSeekableReader<R> {
     }
 }
 
-impl<R: HasLength> HasLength for BufReader<R> {
-    fn len(&self) -> u64 {
-        self.get_ref().len()
+/// Read at an explicit offset without relying on the shared file cursor.
+fn read_at(file: &fs_err::File, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+    // File offsets are signed. On Windows, negative offsets can also select the shared
+    // cursor instead of an explicit position, so reject them before calling `seek_read`.
+    if offset > i64::MAX as u64 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Seek position exceeds the maximum file offset",
+        ));
     }
-}
-
-#[expect(clippy::disallowed_types)]
-impl HasLength for std::fs::File {
-    fn len(&self) -> u64 {
-        self.metadata().unwrap().len()
+    #[cfg(unix)]
+    {
+        file.read_at(buf, offset)
     }
-}
-
-impl HasLength for fs_err::File {
-    fn len(&self) -> u64 {
-        self.metadata().unwrap().len()
-    }
-}
-
-impl HasLength for Cursor<Vec<u8>> {
-    fn len(&self) -> u64 {
-        self.get_ref().len() as u64
-    }
-}
-
-impl HasLength for Cursor<&Vec<u8>> {
-    fn len(&self) -> u64 {
-        self.get_ref().len() as u64
+    #[cfg(windows)]
+    {
+        file.seek_read(buf, offset)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::io::{Cursor, Read, Seek, SeekFrom};
+    use std::{
+        io::{BufRead, Read, Seek, SeekFrom},
+        sync::Barrier,
+        thread,
+    };
 
-    use super::CloneableSeekableReader;
+    use super::{BUFFER_SIZE, CloneableSeekableReader};
 
     #[test]
-    fn test_cloneable_seekable_reader() {
-        let buf: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let buf = Cursor::new(buf);
-        let mut reader = CloneableSeekableReader::new(buf);
+    fn test_cloneable_seekable_reader() -> std::io::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("archive.zip");
+        fs_err::write(&path, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])?;
+        let mut reader = CloneableSeekableReader::new(fs_err::File::open(path)?);
         let mut out = vec![0; 2];
         assert!(reader.read_exact(&mut out).is_ok());
         assert_eq!(out[0], 0);
@@ -228,5 +214,100 @@ mod test {
         assert_eq!(out[0], 8);
         assert_eq!(out[1], 9);
         assert!(reader.read_exact(&mut out).is_err());
+
+        // These positions must not become negative Windows file-offset sentinels.
+        for position in [i64::MAX as u64 + 1, u64::MAX - 1, u64::MAX] {
+            reader.seek(SeekFrom::Start(position))?;
+            assert_eq!(
+                reader.read(&mut out).unwrap_err().kind(),
+                std::io::ErrorKind::InvalidInput
+            );
+            assert_eq!(
+                reader.fill_buf().unwrap_err().kind(),
+                std::io::ErrorKind::InvalidInput
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_clones_have_independent_buffers_and_positions() -> std::io::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("archive.zip");
+        let contents: Vec<u8> = (0..=255).cycle().take(2 * BUFFER_SIZE + 17).collect();
+        fs_err::write(&path, &contents)?;
+        let mut reader = CloneableSeekableReader::new(fs_err::File::open(path)?);
+
+        assert_eq!(reader.fill_buf()?, &contents[..BUFFER_SIZE]);
+        reader.consume(13);
+        let mut cloned = reader.clone();
+
+        // A clone starts at the consumed position, not the end of the read-ahead buffer.
+        let mut output = [0; 7];
+        cloned.read_exact(&mut output)?;
+        assert_eq!(output, contents[13..20]);
+        reader.read_exact(&mut output)?;
+        assert_eq!(output, contents[13..20]);
+
+        // Filling a clone's buffer must not disturb the original reader's next refill.
+        cloned.seek(SeekFrom::Start((BUFFER_SIZE + 3) as u64))?;
+        assert_eq!(
+            cloned.fill_buf()?,
+            &contents[BUFFER_SIZE + 3..2 * BUFFER_SIZE + 3]
+        );
+        let mut remainder = Vec::new();
+        reader.read_to_end(&mut remainder)?;
+        assert_eq!(remainder, contents[20..]);
+
+        // Seeking discards the old buffer, including when the next read reaches EOF.
+        cloned.seek(SeekFrom::End(-7))?;
+        assert_eq!(cloned.fill_buf()?, &contents[contents.len() - 7..]);
+        cloned.consume(7);
+        assert!(cloned.fill_buf()?.is_empty());
+        assert_eq!(cloned.read(&mut output)?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_concurrent_clones_read_distinct_offsets() -> std::io::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("archive.zip");
+        let contents: Vec<u8> = (0..8)
+            .flat_map(|value| std::iter::repeat_n(value, 4096))
+            .collect();
+        fs_err::write(&path, &contents)?;
+        let reader = CloneableSeekableReader::new(fs_err::File::open(path)?);
+        let barrier = Barrier::new(8);
+
+        thread::scope(|scope| {
+            let threads: Vec<_> = (0..8)
+                .map(|index| {
+                    let mut reader = reader.clone();
+                    let contents = &contents;
+                    let barrier = &barrier;
+                    scope.spawn(move || -> std::io::Result<()> {
+                        let mut output = [0; 4096];
+                        barrier.wait();
+                        for iteration in 0..32 {
+                            reader.seek(SeekFrom::Start((index * 4096) as u64))?;
+                            if iteration % 2 == 0 {
+                                reader.read_exact(&mut output)?;
+                                assert_eq!(output, contents[index * 4096..(index + 1) * 4096]);
+                            } else {
+                                assert_eq!(reader.fill_buf()?, &contents[index * 4096..]);
+                                reader.consume(4096);
+                            }
+                        }
+                        Ok(())
+                    })
+                })
+                .collect();
+            for thread in threads {
+                thread
+                    .join()
+                    .map_err(|_| std::io::Error::other("reader thread panicked"))??;
+            }
+            Ok(())
+        })
     }
 }


### PR DESCRIPTION
## Summary

Replace the shared, mutex-protected ZIP file cursor with positioned reads. Each reader can read at its own offset without locking or seeking the shared file.

Local-wheel installs were 4.5% faster for botocore, 5.2% faster for NumPy, and 9.7% faster for SymPy. Requests was 0.9% slower, though its confidence interval includes zero.

Measured on Linux/ext4 with four cores, a warm filesystem cache, and uv's cache disabled, using 12 samples per version. [Benchmark results and reproducer](https://gist.github.com/charliermarsh/a38d8b4b77f6438578b880fdf6baa7fa).
