### PR TITLE
Reuse directory handles for Linux hardlink installation

### DIFF
--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -2,6 +2,8 @@
 //! copying) when link methods are unsupported.
 
 use std::io;
+#[cfg(target_os = "linux")]
+use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -361,6 +363,8 @@ where
     F: Fn(&Path) -> bool,
 {
     let mut state = LinkState::new(mode);
+    #[cfg(target_os = "linux")]
+    let mut hardlinker = Hardlinker::default();
 
     for entry in WalkDir::new(src) {
         let entry = entry.map_err(|err| LinkError::WalkDir {
@@ -376,6 +380,14 @@ where
             fs_err::create_dir_all(&target).map_err(|err| LinkError::CreateDir {
                 path: target.clone(),
                 err,
+            })?;
+            continue;
+        }
+
+        #[cfg(target_os = "linux")]
+        if state.mode == LinkMode::Hardlink {
+            state = hardlink_file_with_fallback(path, &target, state, options, |path, target| {
+                hardlinker.link(path, target)
             })?;
             continue;
         }
@@ -402,7 +414,9 @@ where
 {
     match state.mode {
         LinkMode::Clone => reflink_file_with_fallback(path, target, state, options),
-        LinkMode::Hardlink => hardlink_file_with_fallback(path, target, state, options),
+        LinkMode::Hardlink => {
+            hardlink_file_with_fallback(path, target, state, options, try_hardlink_file)
+        }
         LinkMode::Symlink => symlink_file_with_fallback(path, target, state, options),
         LinkMode::Copy => {
             if options.on_existing_directory == OnExistingDirectory::Merge {
@@ -639,6 +653,7 @@ fn hardlink_file_with_fallback<F>(
     target: &Path,
     state: LinkState,
     options: &LinkOptions<'_, F>,
+    hardlink: impl FnOnce(&Path, &Path) -> io::Result<()>,
 ) -> Result<LinkState, LinkError>
 where
     F: Fn(&Path) -> bool,
@@ -650,7 +665,7 @@ where
 
     match state.attempt {
         LinkAttempt::Initial => {
-            if let Err(err) = try_hardlink_file(path, target) {
+            if let Err(err) = hardlink(path, target) {
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
@@ -674,7 +689,7 @@ where
             }
         }
         LinkAttempt::Subsequent => {
-            if let Err(err) = try_hardlink_file(path, target) {
+            if let Err(err) = hardlink(path, target) {
                 if err.kind() == io::ErrorKind::AlreadyExists
                     && options.on_existing_directory == OnExistingDirectory::Merge
                 {
@@ -763,6 +778,76 @@ where
             to: target.to_path_buf(),
             err,
         })
+}
+
+/// Reuse parent directory handles when hard linking adjacent files on Linux.
+///
+/// Keep only the most recent pair so deeply nested trees cannot exhaust file descriptors.
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct Hardlinker {
+    directories: Option<HardlinkDirectories>,
+}
+
+#[cfg(target_os = "linux")]
+struct HardlinkDirectories {
+    source_path: PathBuf,
+    target_path: PathBuf,
+    source: OwnedFd,
+    target: OwnedFd,
+}
+
+#[cfg(target_os = "linux")]
+impl HardlinkDirectories {
+    /// Open directories for path lookup without requiring read access to the destination.
+    fn open(source_path: &Path, target_path: &Path) -> io::Result<Self> {
+        let flags =
+            rustix::fs::OFlags::PATH | rustix::fs::OFlags::DIRECTORY | rustix::fs::OFlags::CLOEXEC;
+        Ok(Self {
+            source_path: source_path.to_path_buf(),
+            target_path: target_path.to_path_buf(),
+            source: rustix::fs::open(source_path, flags, rustix::fs::Mode::empty())?,
+            target: rustix::fs::open(target_path, flags, rustix::fs::Mode::empty())?,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Hardlinker {
+    /// Link by basename, retaining the path-based fallback and its error context.
+    fn link(&mut self, source: &Path, target: &Path) -> io::Result<()> {
+        if let (Some(source_parent), Some(target_parent), Some(source_name), Some(target_name)) = (
+            source.parent(),
+            target.parent(),
+            source.file_name(),
+            target.file_name(),
+        ) {
+            if self.directories.as_ref().is_none_or(|directories| {
+                directories.source_path.as_os_str() != source_parent.as_os_str()
+                    || directories.target_path.as_os_str() != target_parent.as_os_str()
+            }) {
+                self.directories = HardlinkDirectories::open(source_parent, target_parent).ok();
+            }
+
+            if let Some(directories) = &self.directories
+                && rustix::fs::linkat(
+                    &directories.source,
+                    source_name,
+                    &directories.target,
+                    target_name,
+                    // Like link(2), link the symlink itself instead of its target.
+                    rustix::fs::AtFlags::empty(),
+                )
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+
+        // Retry failures through the existing path, including the link-count limit recovery.
+        // Failure to open directory handles must not prevent a path-based link from working.
+        try_hardlink_file(source, target)
+    }
 }
 
 /// Try to create a hard link, handling `TooManyLinks` (EMLINK/`ERROR_TOO_MANY_LINKS`)
@@ -908,6 +993,8 @@ fn create_symlink(original: &Path, link: &Path) -> io::Result<()> {
 #[expect(clippy::print_stderr)]
 mod tests {
     use std::assert_matches;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::MetadataExt;
 
     use super::*;
     use tempfile::TempDir;
@@ -1007,6 +1094,50 @@ mod tests {
             let dst_meta = fs_err::metadata(dst_dir.path().join("file1.txt")).unwrap();
             assert_eq!(src_meta.ino(), dst_meta.ino());
         }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_hardlink_preserves_source_symlinks() {
+        let root = test_tempdir();
+        let source = root.path().join("source");
+        let target = root.path().join("target");
+        fs_err::create_dir_all(source.join("package")).unwrap();
+        fs_err::create_dir_all(&target).unwrap();
+        fs_err::write(source.join("package/file.txt"), "content").unwrap();
+        fs_err::os::unix::fs::symlink("package/file.txt", source.join("file-link")).unwrap();
+        fs_err::os::unix::fs::symlink("package", source.join("directory-link")).unwrap();
+        fs_err::os::unix::fs::symlink("missing", source.join("dangling-link")).unwrap();
+
+        // The source's ancestors and the destination root may be directory symlinks.
+        let source_parent_alias = root.path().join("source-parent-alias");
+        let target_alias = root.path().join("target-alias");
+        fs_err::os::unix::fs::symlink(root.path(), &source_parent_alias).unwrap();
+        fs_err::os::unix::fs::symlink(&target, &target_alias).unwrap();
+
+        let options = LinkOptions::new(LinkMode::Hardlink);
+        let result =
+            link_dir(&source_parent_alias.join("source"), &target_alias, &options).unwrap();
+        assert_eq!(result, LinkMode::Hardlink);
+
+        for name in ["file-link", "directory-link", "dangling-link"] {
+            assert_eq!(
+                fs_err::read_link(source.join(name)).unwrap(),
+                fs_err::read_link(target.join(name)).unwrap(),
+            );
+            assert_eq!(
+                fs_err::symlink_metadata(source.join(name)).unwrap().ino(),
+                fs_err::symlink_metadata(target.join(name)).unwrap().ino(),
+            );
+        }
+        assert_eq!(
+            fs_err::metadata(source.join("package/file.txt"))
+                .unwrap()
+                .ino(),
+            fs_err::metadata(target.join("package/file.txt"))
+                .unwrap()
+                .ino(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**This prototype is not recommended for merge as implemented.** Warm-cache botocore, SymPy, and NumPy installs took 4.0–4.5% longer; Requests was inconclusive. The dense synthetic tree linked 6.0% faster, while the sparse tree regressed 14.5%.

The larger real-wheel trees execute 13.6–16.2% more simulated userspace instructions. Fresh botocore linking adds 938 `open` and 938 `close` calls, while its `linkat` count stays unchanged. Existing-file replacements add another failed `linkat` per immutable file.

When hardlinking a wheel on Linux, we repeatedly resolve the full source and destination paths. We keep the most recent pair of parent-directory handles open and call `linkat` with file basenames. We retain the existing path-based fallback, mutable `RECORD` copies, symlink-leaf behavior, merge handling, and link-count-limit recovery. Only one directory pair is cached, so nesting does not cause unbounded descriptor use.

## Benchmarks

[Benchmark scripts, raw samples, and environment metadata](https://gist.github.com/charliermarsh/a38d8b4b77f6438578b880fdf6baa7fa).

These results measure the complete `uv pip install --offline --no-deps` subprocess for one local wheel into a fresh Python environment, using a preseeded uv cache and `--link-mode hardlink`. Environment creation, cache preseeding, validation, and cleanup are outside the timer. The OS page cache is warm; this is not a cold-disk or network benchmark.

| Wheel | Base (ms) | This PR (ms) | Time reduction | 95% interval for reduction | Observed direction |
| --- | --- | --- | --- | --- | --- |
| requests 2.32.5 | 24.209 | 24.149 | +0.25% | -2.23% to +3.53% | Interval includes zero |
| botocore 1.40.20 | 220.336 | 229.647 | -4.23% | -5.02% to -3.07% | Higher time |
| sympy 1.14.0 | 88.372 | 92.392 | -4.55% | -6.23% to -3.30% | Higher time |
| numpy 2.3.2 | 61.895 | 64.384 | -4.02% | -5.61% to -2.59% | Higher time |

Times are geometric means. Time reduction is `1 - head/base`; negative values indicate regressions. A positive point estimate with an interval including zero does not establish a benefit. These are six-block bootstrap intervals for this host and workload, not a claim about all installations.

Base `59ef21b99ae4c819de89fd591f1b7c92cb895de3` and this PR `db1553416553c4fed6bdac2f32787fa36ff7194c` used the same compiler (`rustc 1.98.0-dev (e03456bd2 2026-08-21) (ohm-1.98.0-2)`) and `profiling: opt-level=3, debug=2, lto=false, panic=abort; no additional RUSTFLAGS` on Linux/ext4 (AMD EPYC 9V74 80-Core Processor). Runs were serial. API cases used one or four Rayon threads as labeled; CLI cases used four threads pinned to four physical cores. Instruction and syscall runs used one Rayon thread. Each walltime case used two warmups per variant followed by six alternating ABBA/BAAB blocks: 12 measured samples per variant.

Directory-link sources sit below `/tmp/uv-bun-io-prs/fixtures/trees/cache/archive-v0/7f/0123456789abcdef0123456789abcdef` (8 directory components before the workload name). This path depth is part of the workload and affects pathname-resolution costs. Dense, sparse, deep, 100% overlap, and copy-control cases are retained below. Overlap destinations begin with independent inodes and different contents.

Cached directory handles pin directory inodes during a walk. Normal installation holds the environment lock; concurrent parent-directory replacement has different behavior from resolving the full path for every link.

<details>
<summary>Complete production-API walltime results</summary>

These timers cover the production extraction/link operation only, excluding setup, cleanup, and full-output validation. All output paths, contents, sizes, and executable status were checked after every trial. Link trials also checked permissions and inode sharing, including independent mutable RECORD copies.

| Workload / operation | Base (ms) | This PR (ms) | Time reduction | 95% interval for reduction | Observed direction |
| --- | --- | --- | --- | --- | --- |
| requests; link-copy; 1 thread(s); fresh | 9.275 | 9.197 | +0.84% | -4.48% to +5.72% | Interval includes zero |
| botocore; link-hardlink; 1 thread(s); fresh | 182.622 | 191.850 | -5.05% | -6.27% to -3.94% | Higher time |
| botocore; link-hardlink; 1 thread(s); overlap | 628.431 | 653.383 | -3.97% | -4.95% to -2.61% | Higher time |
| deep-tree; link-hardlink; 1 thread(s); fresh | 179.762 | 184.235 | -2.49% | -4.73% to +1.21% | Interval includes zero |
| many-small; link-hardlink; 1 thread(s); fresh | 108.638 | 102.127 | +5.99% | +5.65% to +6.36% | Lower time |
| numpy; link-hardlink; 1 thread(s); fresh | 34.974 | 36.989 | -5.76% | -10.07% to -3.08% | Higher time |
| requests; link-hardlink; 1 thread(s); fresh | 1.258 | 1.293 | -2.77% | -4.81% to -1.10% | Higher time |
| sparse-tree; link-hardlink; 1 thread(s); fresh | 94.846 | 108.588 | -14.49% | -14.98% to -13.72% | Higher time |
| sparse-tree; link-hardlink; 1 thread(s); overlap | 171.388 | 188.433 | -9.94% | -10.41% to -9.44% | Higher time |
| sympy; link-hardlink; 1 thread(s); fresh | 61.581 | 64.719 | -5.10% | -5.54% to -4.60% | Higher time |

</details>

<details>
<summary>Whole-process instruction counts</summary>

Cachegrind (`--cache-sim=no --branch-sim=no`) counts simulated userspace instructions for the complete harness process, including startup and Rayon initialization. It excludes kernel instructions and waiting. These are geometric means of two runs per variant with one Rayon thread; they do not share the narrower API walltime scope. No instruction-count confidence interval is claimed.

| Workload / operation | Base instructions | This PR instructions | Instruction reduction |
| --- | --- | --- | --- |
| requests; link-copy; 1 thread(s); fresh | 1,214,065 | 1,216,845 | -0.23% |
| botocore; link-hardlink; 1 thread(s); fresh | 22,708,157 | 25,795,282 | -13.59% |
| botocore; link-hardlink; 1 thread(s); overlap | 36,067,733 | 40,218,903 | -11.51% |
| deep-tree; link-hardlink; 1 thread(s); fresh | 35,693,162 | 40,713,727 | -14.07% |
| many-small; link-hardlink; 1 thread(s); fresh | 30,702,106 | 35,830,396 | -16.70% |
| numpy; link-hardlink; 1 thread(s); fresh | 7,921,215 | 9,172,434 | -15.80% |
| requests; link-hardlink; 1 thread(s); fresh | 1,082,533 | 1,114,076 | -2.91% |
| sparse-tree; link-hardlink; 1 thread(s); fresh | 9,658,720 | 10,612,884 | -9.88% |
| sparse-tree; link-hardlink; 1 thread(s); overlap | 13,295,774 | 14,519,717 | -9.21% |
| sympy; link-hardlink; 1 thread(s); fresh | 13,233,965 | 15,380,874 | -16.22% |

</details>

<details>
<summary>Selected syscall counts</summary>

Each cell shows base → this PR, from one `strace -f -c` run per variant. Totals include all syscalls; named columns select calls relevant to the mechanism. The traced runtimes are not used as timing evidence.

| Workload / operation | Total calls | link | linkat | open | openat | close |
| --- | --- | --- | --- | --- | --- | --- |
| botocore; link-hardlink; 1 thread(s); fresh | 7,311 → 9,187 | 0 → 0 | 1,908 → 1,908 | 2 → 940 | 880 → 880 | 882 → 1,820 |
| botocore; link-hardlink; 1 thread(s); overlap | 31,084 → 34,868 | 0 → 0 | 3,816 → 5,724 | 2 → 940 | 2,788 → 2,788 | 2,790 → 3,728 |
| many-small; link-hardlink; 1 thread(s); fresh | 4,653 → 4,913 | 0 → 0 | 4,098 → 4,098 | 2 → 132 | 73 → 73 | 75 → 205 |
| sparse-tree; link-hardlink; 1 thread(s); fresh | 3,757 → 5,809 | 0 → 0 | 514 → 514 | 2 → 1,028 | 521 → 521 | 523 → 1,549 |
| sparse-tree; link-hardlink; 1 thread(s); overlap | 10,439 → 13,005 | 0 → 0 | 1,028 → 1,542 | 2 → 1,028 | 1,035 → 1,035 | 1,037 → 2,063 |

</details>

<details>
<summary>Fixtures and reproduction data</summary>

| Fixture | Version | Files | Directories | Wheel MiB | Uncompressed MiB |
| --- | --- | --- | --- | --- | --- |
| requests | 2.32.5 | 23 | 3 | 0.062 | 0.195 |
| botocore | 1.40.20 | 1,909 | 873 | 13.345 | 17.488 |
| sympy | 1.14.0 | 1,570 | 171 | 6.008 | 25.598 |
| numpy | 2.3.2 | 901 | 90 | 15.870 | 55.225 |
| many-small (synthetic) | 1.0.0 | 4,099 | 66 | 16.980 | 16.551 |
| sparse-tree (synthetic) | 1.0.0 | 515 | 514 | 0.162 | 0.111 |
| deep-tree (synthetic) | 1.0.0 | 4,099 | 514 | 1.495 | 0.981 |

Exact source commits, binary and wheel SHA256 digests, compiler details, commands, raw JSONL, output checks, and per-trial machine counters are retained in the campaign artifacts. `raw-walltime.csv`, `raw-cli.csv`, `raw-instructions.csv`, and `raw-syscalls.csv` provide compact samples, including warmups where applicable. The benchmark drivers and fixture manifest are retained beside the data.

</details>

On Linux, the uv-fs link tests completed successfully (42 tests reported passing). Linux Clippy also passed for uv-fs with all targets, all features, and warnings denied. The logs reported these skipped checks: `Skipping: UV_INTERNAL__TEST_COW_FS not set`.

macOS also passed all 44 link tests, including APFS clone cases, plus all-target/all-feature Clippy and formatting.

Each prototype is compared independently against the same baseline. These measurements do not establish that the improvements add together.
