### PR TITLE
Make file move retry timeout configurable

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -365,7 +365,7 @@ pub struct GlobalArgs {
     pub show_settings: bool,
 
     /// On Windows, the maximum time, in seconds, spent waiting to retry file moves blocked by
-    /// another process. [env: UV_FILE_MOVE_RETRY_TIMEOUT=]
+    /// another process.
     ///
     /// Antivirus and EDR software can temporarily lock files while scanning them.
     #[arg(

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -364,6 +364,19 @@ pub struct GlobalArgs {
     #[arg(global = true, long, hide = true)]
     pub show_settings: bool,
 
+    /// On Windows, the maximum time, in seconds, spent waiting to retry file moves blocked by
+    /// another process. [env: UV_FILE_MOVE_RETRY_TIMEOUT=]
+    ///
+    /// Antivirus and EDR software can temporarily lock files while scanning them.
+    #[arg(
+        global = true,
+        long,
+        env = EnvVars::UV_FILE_MOVE_RETRY_TIMEOUT,
+        value_name = "SECONDS",
+        hide = true
+    )]
+    pub file_move_retry_timeout: Option<u64>,
+
     /// Hide all progress outputs [env: UV_NO_PROGRESS=]
     ///
     /// For example, spinners or progress bars.

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -1072,7 +1072,11 @@ mod tests {
         let total_delay: std::time::Duration = std::iter::from_fn(|| backoff.next()).sum();
 
         assert!(total_delay <= DEFAULT_FILE_MOVE_RETRY_TIMEOUT);
-        assert!(total_delay >= DEFAULT_FILE_MOVE_RETRY_TIMEOUT.saturating_sub(std::time::Duration::from_secs(1)));
+        assert!(
+            total_delay
+                >= DEFAULT_FILE_MOVE_RETRY_TIMEOUT
+                    .saturating_sub(std::time::Duration::from_secs(1))
+        );
     }
 
     #[test]

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -1072,7 +1072,7 @@ mod tests {
         let total_delay: std::time::Duration = std::iter::from_fn(|| backoff.next()).sum();
 
         assert!(total_delay <= DEFAULT_FILE_MOVE_RETRY_TIMEOUT);
-        assert!(total_delay >= DEFAULT_FILE_MOVE_RETRY_TIMEOUT - std::time::Duration::from_secs(1));
+        assert!(total_delay >= DEFAULT_FILE_MOVE_RETRY_TIMEOUT.saturating_sub(std::time::Duration::from_secs(1)));
     }
 
     #[test]

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -6,6 +6,8 @@ use std::time::SystemTime;
 use std::os::unix::fs::MetadataExt;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
+#[cfg(windows)]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(target_os = "linux")]
 use std::time::{Duration, UNIX_EPOCH};
@@ -522,16 +524,32 @@ pub fn copy_atomic_sync(from: impl AsRef<Path>, to: impl AsRef<Path>) -> std::io
 }
 
 #[cfg(windows)]
+const DEFAULT_FILE_MOVE_RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[cfg(windows)]
+static FILE_MOVE_RETRY_TIMEOUT_SECONDS: AtomicU64 =
+    AtomicU64::new(DEFAULT_FILE_MOVE_RETRY_TIMEOUT.as_secs());
+
+/// Set the maximum total delay between retries of file moves blocked by other processes.
+pub fn set_file_move_retry_timeout(timeout: std::time::Duration) {
+    #[cfg(windows)]
+    FILE_MOVE_RETRY_TIMEOUT_SECONDS.store(timeout.as_secs(), Ordering::Relaxed);
+
+    #[cfg(not(windows))]
+    let _ = timeout;
+}
+
+#[cfg(windows)]
 fn backoff_file_move() -> backon::ExponentialBackoff {
     use backon::BackoffBuilder;
-    // This amounts to 10 total seconds of trying the operation.
-    // We retry 10 times, starting at 10*(2^0) milliseconds for the first retry, doubling with each
-    // retry, so the last (10th) one will take about 10*(2^9) milliseconds ~= 5 seconds. All other
-    // attempts combined should equal the length of the last attempt (because it's a sum of powers
-    // of 2), so 10 seconds overall.
+
+    let timeout =
+        std::time::Duration::from_secs(FILE_MOVE_RETRY_TIMEOUT_SECONDS.load(Ordering::Relaxed));
     backon::ExponentialBuilder::default()
         .with_min_delay(std::time::Duration::from_millis(10))
-        .with_max_times(10)
+        .with_max_delay(std::time::Duration::from_secs(1))
+        .without_max_times()
+        .with_total_delay(Some(timeout))
         .build()
 }
 
@@ -1046,6 +1064,16 @@ mod tests {
     use std::assert_matches;
 
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn file_move_backoff_respects_default_timeout() {
+        let mut backoff = backoff_file_move();
+        let total_delay: std::time::Duration = std::iter::from_fn(|| backoff.next()).sum();
+
+        assert!(total_delay <= DEFAULT_FILE_MOVE_RETRY_TIMEOUT);
+        assert!(total_delay >= DEFAULT_FILE_MOVE_RETRY_TIMEOUT - std::time::Duration::from_secs(1));
+    }
 
     #[test]
     fn remove_symlink_removes_directory_link_without_removing_target() -> io::Result<()> {

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -834,6 +834,13 @@ impl EnvVars {
     #[attr_added_in("0.7.21")]
     pub const UV_HTTP_RETRIES: &'static str = "UV_HTTP_RETRIES";
 
+    /// On Windows, the maximum time, in seconds, spent waiting to retry file moves blocked by
+    /// another process. (default: 10 s)
+    ///
+    /// Antivirus and EDR software can temporarily lock files while scanning them.
+    #[attr_added_in("next release")]
+    pub const UV_FILE_MOVE_RETRY_TIMEOUT: &'static str = "UV_FILE_MOVE_RETRY_TIMEOUT";
+
     /// Timeout (in seconds) for HTTP requests. Equivalent to `UV_HTTP_TIMEOUT`.
     #[attr_added_in("0.1.6")]
     pub const UV_REQUEST_TIMEOUT: &'static str = "UV_REQUEST_TIMEOUT";

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::process::ExitCode;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use anyhow::{Result, anyhow, bail};
 use clap::error::{ContextKind, ContextValue};
@@ -147,6 +148,10 @@ async fn run_with_workspace_cache(
     global_initialization: GlobalInitialization,
     workspace_cache: WorkspaceCache,
 ) -> Result<ExitStatus> {
+    if let Some(timeout) = cli.top_level.global_args.file_move_retry_timeout {
+        uv_fs::set_file_move_retry_timeout(Duration::from_secs(timeout));
+    }
+
     let config_discovery = ConfigDiscovery::from_args(cli.top_level.no_config);
 
     // Configure color before resolving settings so argument errors retain their styling.

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -1,6 +1,27 @@
+use assert_cmd::assert::OutputAssertExt;
 use uv_static::EnvVars;
 
 use uv_test::uv_snapshot;
+
+#[test]
+fn file_move_retry_timeout_is_configurable() {
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    context
+        .command()
+        .arg("--file-move-retry-timeout")
+        .arg("20")
+        .arg("--version")
+        .assert()
+        .success();
+
+    context
+        .command()
+        .env(EnvVars::UV_FILE_MOVE_RETRY_TIMEOUT, "20")
+        .arg("--version")
+        .assert()
+        .success();
+}
 
 #[test]
 fn cert_is_limited_to_pip() {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
## Summary

Make the Windows file-move retry timeout configurable through:

- `--file-move-retry-timeout <SECONDS>`
- `UV_FILE_MOVE_RETRY_TIMEOUT`

The timeout defaults to 10 seconds, preserving the existing behavior. Increasing it helps when antivirus or EDR software locks extracted files for longer than the default retry period.

The configured timeout applies to rename, persist, and atomic copy operations using the existing exponential backoff.

Fixes #17679. The idea is from [this comment](https://github.com/astral-sh/uv/issues/17679#issuecomment-5049686662).

## Test Plan

In my concrete case I always had the problem when installing `zensical`. I got the following error message using the default behavior on my coperate pc:

```
  × Failed to download `zensical==0.0.58`
  ├─▶ Failed to write to the distribution cache
  ╰─▶ failed to rename file from C:\Users\<USERNAME>\AppData\Local\uv\cache\.tmpIxjewy to
      C:\Users\<USERNAME>\AppData\Local\uv\cache\archive-v0\uXy9NOT2I8s7uiM6: Zugriff verweigert (os error 5)
```

With this changes I had to increase the timeout to 30s to get it working. I have verified it with:

```
C:\<PATH_TO_UV_REPO>\target\debug\uv.exe sync --file-move-retry-timeout 30
```
and

```
 $env:UV_FILE_MOVE_RETRY_TIMEOUT = 30   
 C:\<PATH_TO_UV_REPO>\target\debug\uv.exe sync
```