### PR TITLE
Verify all macOS and Windows release targets in dry-runs

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -142,7 +142,7 @@ jobs:
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels_uv-macos-x86_64
+          name: wheels_uv-x86_64-apple-darwin
           path: dist
       - name: "Archive binary"
         run: |
@@ -158,7 +158,7 @@ jobs:
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: artifacts-macos-x86_64
+          name: artifacts-x86_64-apple-darwin
           path: |
             *.tar.gz
             *.sha256
@@ -179,7 +179,7 @@ jobs:
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels_uv_build-macos-x86_64
+          name: wheels_uv_build-x86_64-apple-darwin
           path: crates/uv-build/dist
 
   macos-aarch64:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -143,6 +143,7 @@ jobs:
             [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" ]] && release_build_changed=1
             [[ "$file" == scripts/extract-wheel-binaries.py* || "$file" == scripts/sign-release-macos.py* || "$file" == scripts/verify-release-*.py* || "$file" == scripts/verify-release-*.ps1 || "$file" == scripts/test-release-wheels-* ]] && release_build_changed=1
             [[ "$file" == scripts/extract-github-release-binaries.py* || "$file" == scripts/inject-signed-github-release-binaries.py* || "$file" == scripts/verify-github-release-* ]] && release_build_changed=1
+            [[ "$file" == "dist-workspace.toml" || "$file" == scripts/plan-release-signing.py* ]] && release_build_changed=1
             [[ "$file" == ".github/workflows/ci.yml" ]] && ci_workflow_changed=1
             [[ "$file" == "uv.schema.json" ]] && schema_changed=1
             [[ "$file" =~ ^crates/uv-publish/ || "$file" =~ ^scripts/publish/ || "$file" == "crates/uv/src/commands/publish.rs" ]] && publish_code_changed=1

--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -29,7 +29,8 @@ jobs:
     permissions:
       contents: read
     outputs:
-      targets: ${{ steps.targets.outputs.plan }}
+      macos: ${{ steps.targets.outputs.macos }}
+      windows: ${{ steps.targets.outputs.windows }}
       unsigned-macos: ${{ steps.macos.outputs.artifact-id }}
       unsigned-windows: ${{ steps.windows.outputs.artifact-id }}
       assembly: ${{ steps.assembly.outputs.artifact-id }}
@@ -47,7 +48,7 @@ jobs:
 
       - name: "Plan signed release targets"
         id: targets
-        run: echo "plan=$(uv run scripts/plan-release-signing.py)" >> "$GITHUB_OUTPUT"
+        run: uv run scripts/plan-release-signing.py >> "$GITHUB_OUTPUT"
 
       - name: "Download unsigned macOS wheels"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -78,18 +79,20 @@ jobs:
       - name: "Extract executable wheel members"
         shell: bash
         env:
-          TARGETS: ${{ steps.targets.outputs.plan }}
+          MACOS_TARGETS: ${{ steps.targets.outputs.macos }}
+          WINDOWS_TARGETS: ${{ steps.targets.outputs.windows }}
         run: |
           set -euo pipefail
           # uv and uv_build keep their executables in .data/scripts.
           for system in macos windows; do
+            if [[ "$system" == macos ]]; then targets=$MACOS_TARGETS; else targets=$WINDOWS_TARGETS; fi
             while read -r target; do
               mkdir -p "wheels/$target"
               cp wheel-artifacts/"wheels_uv-$target"/*.whl "wheels/$target/"
               cp wheel-artifacts/"wheels_uv_build-$target"/*.whl "wheels/$target/"
               uv run scripts/extract-wheel-binaries.py \
                 --output "./unsigned/$system/$target" wheels/"$target"/*.whl
-            done < <(jq -r --arg system "$system" '.[$system][].target' <<< "$TARGETS")
+            done < <(jq -r '.[].target' <<< "$targets")
           done
 
       - name: "Upload unsigned macOS executables"
@@ -158,7 +161,7 @@ jobs:
       - name: "Sign executable wheel members through Azure Key Vault"
         shell: bash
         env:
-          TARGETS: ${{ toJSON(fromJSON(needs.prepare.outputs.targets).macos) }}
+          TARGETS: ${{ needs.prepare.outputs.macos }}
           STORAGE_ACCOUNT: ${{ secrets.CODESIGN_STORAGE_ACCOUNT }}
           STORAGE_CONTAINER: ${{ secrets.CODESIGN_STORAGE_CONTAINER }}
           # N.B. rcodesign reads RCODESIGN_* as configuration, avoid using that prefix
@@ -214,7 +217,7 @@ jobs:
       - name: "Copy executable wheel members for signing"
         shell: pwsh
         env:
-          TARGETS: ${{ toJSON(fromJSON(needs.prepare.outputs.targets).windows) }}
+          TARGETS: ${{ needs.prepare.outputs.windows }}
         run: |
           foreach ($platform in ($env:TARGETS | ConvertFrom-Json)) {
             $target = $platform.target
@@ -244,7 +247,7 @@ jobs:
       - name: "Verify signed executable identities"
         shell: pwsh
         env:
-          TARGETS: ${{ toJSON(fromJSON(needs.prepare.outputs.targets).windows) }}
+          TARGETS: ${{ needs.prepare.outputs.windows }}
           CERTIFICATE_SUBJECT: ${{ secrets.CODESIGN_CERTIFICATE_SUBJECT }}
         run: |
           $ErrorActionPreference = 'Stop'
@@ -315,12 +318,14 @@ jobs:
       - name: "Replace executable wheel members"
         shell: bash
         env:
-          TARGETS: ${{ needs.prepare.outputs.targets }}
+          MACOS_TARGETS: ${{ needs.prepare.outputs.macos }}
+          WINDOWS_TARGETS: ${{ needs.prepare.outputs.windows }}
         run: |
           set -euo pipefail
           shopt -s failglob
           mkdir -p signed-pypi/uv signed-pypi/uv_build
           for system in macos windows; do
+            if [[ "$system" == macos ]]; then targets=$MACOS_TARGETS; else targets=$WINDOWS_TARGETS; fi
             while read -r target; do
               mkdir -p "signed-wheels/$system/$target"
               for package in uv uv_build; do
@@ -332,7 +337,7 @@ jobs:
                   --output "$output" --signed-binaries "./signed/$target"
                 cp "$output" "signed-pypi/$package/"
               done
-            done < <(jq -r --arg system "$system" '.[$system][].target' <<< "$TARGETS")
+            done < <(jq -r '.[].target' <<< "$targets")
           done
           uv run --no-project scripts/check_uv_wheel_contents.py \
             signed-pypi/uv/*.whl signed-pypi/uv_build/*.whl
@@ -340,18 +345,20 @@ jobs:
       - name: "Replace GitHub release archive executables"
         shell: bash
         env:
-          TARGETS: ${{ needs.prepare.outputs.targets }}
+          MACOS_TARGETS: ${{ needs.prepare.outputs.macos }}
+          WINDOWS_TARGETS: ${{ needs.prepare.outputs.windows }}
         run: |
           set -euo pipefail
           for system in macos windows; do
             if [[ "$system" == macos ]]; then extension=tar.gz; else extension=zip; fi
+            if [[ "$system" == macos ]]; then targets=$MACOS_TARGETS; else targets=$WINDOWS_TARGETS; fi
             while read -r target; do
               uv run scripts/extract-wheel-binaries.py \
                 --output "./unsigned/$target" wheels/"$target"/*.whl
               uv run scripts/inject-signed-github-release-binaries.py \
                 "./github-archives/uv-$target.$extension" \
                 "./unsigned/$target" "./signed/$target" ./signed-github-archives
-            done < <(jq -r --arg system "$system" '.[$system][].target' <<< "$TARGETS")
+            done < <(jq -r '.[].target' <<< "$targets")
           done
 
       - name: "Upload signed macOS wheels"
@@ -400,7 +407,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(needs.prepare.outputs.targets).macos }}
+        platform: ${{ fromJSON(needs.prepare.outputs.macos) }}
     runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
@@ -460,7 +467,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(needs.prepare.outputs.targets).windows }}
+        platform: ${{ fromJSON(needs.prepare.outputs.windows) }}
     runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read

--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -6,13 +6,13 @@ on:
     outputs:
       uv-wheels:
         description: "Artifact ID for the signed uv wheels"
-        value: ${{ jobs.complete.outputs.uv-wheels }}
+        value: ${{ jobs.assemble.outputs.uv-wheels }}
       uv-build-wheels:
         description: "Artifact ID for the signed uv_build wheels"
-        value: ${{ jobs.complete.outputs.uv-build-wheels }}
+        value: ${{ jobs.assemble.outputs.uv-build-wheels }}
       github-archives:
         description: "Artifact ID for the signed GitHub release archives and checksums"
-        value: ${{ jobs.complete.outputs.github-archives }}
+        value: ${{ jobs.assemble.outputs.github-archives }}
 
 permissions: {}
 
@@ -526,29 +526,3 @@ jobs:
       - name: "Install and run the signed wheels"
         shell: pwsh
         run: ./scripts/test-release-wheels-windows.ps1 "./wheels/$env:TARGET"
-
-  complete:
-    name: "require verified signing outputs"
-    needs: [assemble, verify-macos, verify-windows]
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-slim
-    outputs:
-      uv-wheels: ${{ needs.assemble.outputs.uv-wheels }}
-      uv-build-wheels: ${{ needs.assemble.outputs.uv-build-wheels }}
-      github-archives: ${{ needs.assemble.outputs.github-archives }}
-    steps:
-      - name: "Require every package to have passed verification"
-        env:
-          ASSEMBLY: ${{ needs.assemble.result }}
-          MACOS: ${{ needs.verify-macos.result }}
-          WINDOWS: ${{ needs.verify-windows.result }}
-          UV_WHEELS: ${{ needs.assemble.outputs.uv-wheels }}
-          UV_BUILD_WHEELS: ${{ needs.assemble.outputs.uv-build-wheels }}
-          GITHUB_ARCHIVES: ${{ needs.assemble.outputs.github-archives }}
-        run: |
-          test "$ASSEMBLY" = success
-          test "$MACOS" = success
-          test "$WINDOWS" = success
-          test -n "$UV_WHEELS"
-          test -n "$UV_BUILD_WHEELS"
-          test -n "$GITHUB_ARCHIVES"

--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -1,8 +1,18 @@
-# Sign uv's macOS arm64 and Windows x86-64 wheels and GitHub archives during dry-runs.
+# Sign and verify uv's macOS and Windows wheels and GitHub release archives.
 name: "Sign release binaries"
 
 on:
   workflow_call:
+    outputs:
+      uv-wheels:
+        description: "Artifact ID for the signed uv wheels"
+        value: ${{ jobs.complete.outputs.uv-wheels }}
+      uv-build-wheels:
+        description: "Artifact ID for the signed uv_build wheels"
+        value: ${{ jobs.complete.outputs.uv-build-wheels }}
+      github-archives:
+        description: "Artifact ID for the signed GitHub release archives and checksums"
+        value: ${{ jobs.complete.outputs.github-archives }}
 
 permissions: {}
 
@@ -19,6 +29,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      targets: ${{ steps.targets.outputs.plan }}
       unsigned-macos: ${{ steps.macos.outputs.artifact-id }}
       unsigned-windows: ${{ steps.windows.outputs.artifact-id }}
       assembly: ${{ steps.assembly.outputs.artifact-id }}
@@ -34,40 +45,51 @@ jobs:
           checksum: "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b"
           enable-cache: false
 
+      - name: "Plan signed release targets"
+        id: targets
+        run: echo "plan=$(uv run scripts/plan-release-signing.py)" >> "$GITHUB_OUTPUT"
+
       - name: "Download unsigned macOS wheels"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: wheels_*-aarch64-apple-darwin
-          path: wheels/aarch64-apple-darwin
-          merge-multiple: true
+          pattern: wheels_*-*-apple-darwin
+          path: wheel-artifacts
 
       - name: "Download unsigned Windows wheels"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: wheels_*-x86_64-pc-windows-msvc
-          path: wheels/x86_64-pc-windows-msvc
+          pattern: wheels_*-*-pc-windows-msvc
+          path: wheel-artifacts
+
+      - name: "Download unsigned macOS GitHub release archives"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: artifacts-*-apple-darwin
+          path: github-archives
           merge-multiple: true
 
-      - name: "Download unsigned macOS GitHub release archive"
+      - name: "Download unsigned Windows GitHub release archives"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: artifacts-aarch64-apple-darwin
+          pattern: artifacts-*-pc-windows-msvc
           path: github-archives
-
-      - name: "Download unsigned Windows GitHub release archive"
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: artifacts-x86_64-pc-windows-msvc
-          path: github-archives
+          merge-multiple: true
 
       - name: "Extract executable wheel members"
         shell: bash
+        env:
+          TARGETS: ${{ steps.targets.outputs.plan }}
         run: |
           set -euo pipefail
           # uv and uv_build keep their executables in .data/scripts.
-          for target in aarch64-apple-darwin x86_64-pc-windows-msvc; do
-            uv run scripts/extract-wheel-binaries.py \
-              --output "./unsigned/$target" wheels/"$target"/*.whl
+          for system in macos windows; do
+            while read -r target; do
+              mkdir -p "wheels/$target"
+              cp wheel-artifacts/"wheels_uv-$target"/*.whl "wheels/$target/"
+              cp wheel-artifacts/"wheels_uv_build-$target"/*.whl "wheels/$target/"
+              uv run scripts/extract-wheel-binaries.py \
+                --output "./unsigned/$system/$target" wheels/"$target"/*.whl
+            done < <(jq -r --arg system "$system" '.[$system][].target' <<< "$TARGETS")
           done
 
       - name: "Upload unsigned macOS executables"
@@ -75,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-macos-${{ github.run_id }}-${{ github.run_attempt }}
-          path: unsigned/aarch64-apple-darwin/*
+          path: unsigned/macos
           if-no-files-found: error
 
       - name: "Upload unsigned Windows executables"
@@ -83,7 +105,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows-${{ github.run_id }}-${{ github.run_attempt }}
-          path: unsigned/x86_64-pc-windows-msvc/*
+          path: unsigned/windows
           if-no-files-found: error
 
       - name: "Upload assembly inputs"
@@ -136,6 +158,7 @@ jobs:
       - name: "Sign executable wheel members through Azure Key Vault"
         shell: bash
         env:
+          TARGETS: ${{ toJSON(fromJSON(needs.prepare.outputs.targets).macos) }}
           STORAGE_ACCOUNT: ${{ secrets.CODESIGN_STORAGE_ACCOUNT }}
           STORAGE_CONTAINER: ${{ secrets.CODESIGN_STORAGE_CONTAINER }}
           # N.B. rcodesign reads RCODESIGN_* as configuration, avoid using that prefix
@@ -148,14 +171,19 @@ jobs:
           AZURE_KEYVAULT_KEY_VERSION: ${{ secrets.CODESIGN_AZURE_KEYVAULT_KEY_VERSION }}
           KEY_NAME: ${{ secrets.CODESIGN_KEY_NAME }}
           CERTIFICATE_SHA256: ${{ secrets.CODESIGN_CERTIFICATE_SHA256 }}
-        run: uv run scripts/sign-release-macos.py ./unsigned ./signed
+        run: |
+          set -euo pipefail
+          mkdir signed
+          while read -r target; do
+            uv run scripts/sign-release-macos.py "./unsigned/$target" "./signed/$target"
+          done < <(jq -r '.[].target' <<< "$TARGETS")
 
       - name: "Upload signed executable wheel members"
         id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signed-macos-${{ github.run_id }}-${{ github.run_attempt }}
-          path: signed/*
+          path: signed
           if-no-files-found: error
 
   sign-windows:
@@ -185,10 +213,15 @@ jobs:
 
       - name: "Copy executable wheel members for signing"
         shell: pwsh
+        env:
+          TARGETS: ${{ toJSON(fromJSON(needs.prepare.outputs.targets).windows) }}
         run: |
-          New-Item signed -ItemType Directory | Out-Null
-          foreach ($binary in @('uv.exe', 'uvx.exe', 'uvw.exe', 'uv-build.exe')) {
-            Copy-Item (Join-Path unsigned $binary) (Join-Path signed $binary)
+          foreach ($platform in ($env:TARGETS | ConvertFrom-Json)) {
+            $target = $platform.target
+            New-Item "signed/$target" -ItemType Directory -Force | Out-Null
+            foreach ($binary in @('uv.exe', 'uvx.exe', 'uvw.exe', 'uv-build.exe')) {
+              Copy-Item "unsigned/$target/$binary" "signed/$target/$binary"
+            }
           }
 
       - name: "Sign executable wheel members with Azure Artifact Signing"
@@ -197,11 +230,9 @@ jobs:
           endpoint: ${{ secrets.CODESIGN_ENDPOINT }}
           signing-account-name: ${{ secrets.CODESIGN_SIGNING_ACCOUNT_NAME }}
           certificate-profile-name: ${{ secrets.CODESIGN_CERTIFICATE_PROFILE_NAME }}
-          files: |
-            ${{ github.workspace }}/signed/uv.exe
-            ${{ github.workspace }}/signed/uvx.exe
-            ${{ github.workspace }}/signed/uvw.exe
-            ${{ github.workspace }}/signed/uv-build.exe
+          files-folder: ${{ github.workspace }}/signed
+          files-folder-filter: exe
+          files-folder-recurse: true
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
@@ -213,16 +244,19 @@ jobs:
       - name: "Verify signed executable identities"
         shell: pwsh
         env:
+          TARGETS: ${{ toJSON(fromJSON(needs.prepare.outputs.targets).windows) }}
           CERTIFICATE_SUBJECT: ${{ secrets.CODESIGN_CERTIFICATE_SUBJECT }}
         run: |
           $ErrorActionPreference = 'Stop'
           if (-not $env:CERTIFICATE_SUBJECT) { throw 'Missing signing certificate subject' }
-          foreach ($binary in @('uv.exe', 'uvx.exe', 'uvw.exe', 'uv-build.exe')) {
-            $path = Join-Path signed $binary
-            $signature = Get-AuthenticodeSignature $path
-            if ($signature.Status -ne 'Valid' -or $null -eq $signature.TimeStamperCertificate -or
-                $signature.SignerCertificate.Subject -ne $env:CERTIFICATE_SUBJECT) {
-              throw "Expected a timestamped signature from the configured publisher: $binary"
+          foreach ($platform in ($env:TARGETS | ConvertFrom-Json)) {
+            foreach ($binary in @('uv.exe', 'uvx.exe', 'uvw.exe', 'uv-build.exe')) {
+              $path = "signed/$($platform.target)/$binary"
+              $signature = Get-AuthenticodeSignature $path
+              if ($signature.Status -ne 'Valid' -or $null -eq $signature.TimeStamperCertificate -or
+                  $signature.SignerCertificate.Subject -ne $env:CERTIFICATE_SUBJECT) {
+                throw "Expected a timestamped signature from the configured publisher: $path"
+              }
             }
           }
 
@@ -231,7 +265,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signed-windows-${{ github.run_id }}-${{ github.run_attempt }}
-          path: signed/*
+          path: signed
           if-no-files-found: error
 
   assemble:
@@ -243,6 +277,8 @@ jobs:
     outputs:
       macos-wheels: ${{ steps.macos-wheels.outputs.artifact-id }}
       windows-wheels: ${{ steps.windows-wheels.outputs.artifact-id }}
+      uv-wheels: ${{ steps.uv-wheels.outputs.artifact-id }}
+      uv-build-wheels: ${{ steps.uv-build-wheels.outputs.artifact-id }}
       github-archives: ${{ steps.github-archives.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -266,50 +302,64 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact }}
-          path: signed/aarch64-apple-darwin
+          path: signed
           merge-multiple: true
 
       - name: "Download signed Windows executables"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           artifact-ids: ${{ needs.sign-windows.outputs.artifact }}
-          path: signed/x86_64-pc-windows-msvc
+          path: signed
           merge-multiple: true
 
       - name: "Replace executable wheel members"
         shell: bash
+        env:
+          TARGETS: ${{ needs.prepare.outputs.targets }}
         run: |
           set -euo pipefail
-          for target in aarch64-apple-darwin x86_64-pc-windows-msvc; do
-            mkdir -p "signed-wheels/$target"
-            for wheel in wheels/"$target"/*.whl; do
-              uv run scripts/inject-signed-wheel-binaries.py --input "$wheel" \
-                --output "signed-wheels/$target/${wheel##*/}" \
-                --signed-binaries "./signed/$target"
-            done
+          shopt -s failglob
+          mkdir -p signed-pypi/uv signed-pypi/uv_build
+          for system in macos windows; do
+            while read -r target; do
+              mkdir -p "signed-wheels/$system/$target"
+              for package in uv uv_build; do
+                wheels=(wheels/"$target"/"$package"-*.whl)
+                [[ ${#wheels[@]} -eq 1 ]] || { echo "Expected one $package wheel for $target" >&2; exit 1; }
+                wheel=${wheels[0]}
+                output="signed-wheels/$system/$target/${wheel##*/}"
+                uv run scripts/inject-signed-wheel-binaries.py --input "$wheel" \
+                  --output "$output" --signed-binaries "./signed/$target"
+                cp "$output" "signed-pypi/$package/"
+              done
+            done < <(jq -r --arg system "$system" '.[$system][].target' <<< "$TARGETS")
           done
+          uv run --no-project scripts/check_uv_wheel_contents.py \
+            signed-pypi/uv/*.whl signed-pypi/uv_build/*.whl
 
       - name: "Replace GitHub release archive executables"
         shell: bash
+        env:
+          TARGETS: ${{ needs.prepare.outputs.targets }}
         run: |
           set -euo pipefail
-          for target in aarch64-apple-darwin x86_64-pc-windows-msvc; do
-            uv run scripts/extract-wheel-binaries.py \
-              --output "./unsigned/$target" wheels/"$target"/*.whl
+          for system in macos windows; do
+            if [[ "$system" == macos ]]; then extension=tar.gz; else extension=zip; fi
+            while read -r target; do
+              uv run scripts/extract-wheel-binaries.py \
+                --output "./unsigned/$target" wheels/"$target"/*.whl
+              uv run scripts/inject-signed-github-release-binaries.py \
+                "./github-archives/uv-$target.$extension" \
+                "./unsigned/$target" "./signed/$target" ./signed-github-archives
+            done < <(jq -r --arg system "$system" '.[$system][].target' <<< "$TARGETS")
           done
-          uv run scripts/inject-signed-github-release-binaries.py \
-            ./github-archives/uv-aarch64-apple-darwin.tar.gz \
-            ./unsigned/aarch64-apple-darwin ./signed/aarch64-apple-darwin ./signed-github-archives
-          uv run scripts/inject-signed-github-release-binaries.py \
-            ./github-archives/uv-x86_64-pc-windows-msvc.zip \
-            ./unsigned/x86_64-pc-windows-msvc ./signed/x86_64-pc-windows-msvc ./signed-github-archives
 
       - name: "Upload signed macOS wheels"
         id: macos-wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signed-macos-wheels-${{ github.run_id }}-${{ github.run_attempt }}
-          path: signed-wheels/aarch64-apple-darwin/*.whl
+          path: signed-wheels/macos
           if-no-files-found: error
 
       - name: "Upload signed Windows wheels"
@@ -317,7 +367,23 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signed-windows-wheels-${{ github.run_id }}-${{ github.run_attempt }}
-          path: signed-wheels/x86_64-pc-windows-msvc/*.whl
+          path: signed-wheels/windows
+          if-no-files-found: error
+
+      - name: "Upload signed uv wheels"
+        id: uv-wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: signed-uv-wheels-${{ github.run_id }}-${{ github.run_attempt }}
+          path: signed-pypi/uv
+          if-no-files-found: error
+
+      - name: "Upload signed uv_build wheels"
+        id: uv-build-wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: signed-uv-build-wheels-${{ github.run_id }}-${{ github.run_attempt }}
+          path: signed-pypi/uv_build
           if-no-files-found: error
 
       - name: "Upload signed GitHub release archives"
@@ -329,21 +395,33 @@ jobs:
           if-no-files-found: error
 
   verify-macos:
-    name: "verify signed macos artifacts"
-    needs: [sign-macos, assemble]
-    runs-on: namespace-profile-macos-15
+    name: "verify signed ${{ matrix.platform.target }} artifacts"
+    needs: [prepare, sign-macos, assemble]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(needs.prepare.outputs.targets).macos }}
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
+    env:
+      TARGET: ${{ matrix.platform.target }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          cache: ""
+          python-version: "3.13"
+          architecture: ${{ matrix.platform.python-architecture }}
+
       - name: "Install uv"
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.10"
-          checksum: "51c6170e8e3a01cef9f33b94f582b7b81ac65046f55d40afb35f9cff5a68c179"
+          checksum: ${{ matrix.platform.uv-checksum }}
           enable-cache: false
 
       - name: "Download signed executables"
@@ -361,7 +439,7 @@ jobs:
           merge-multiple: true
 
       - name: "Verify packaged executables and signatures"
-        run: uv run scripts/verify-release-wheels-macos.py ./signed ./wheels
+        run: uv run scripts/verify-release-wheels-macos.py "./signed/$TARGET" "./wheels/$TARGET"
 
       - name: "Download signed GitHub release archives"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -371,17 +449,23 @@ jobs:
           merge-multiple: true
 
       - name: "Verify GitHub release archive"
-        run: uv run scripts/verify-github-release-macos.py ./signed ./github-archives/uv-aarch64-apple-darwin.tar.gz
+        run: uv run scripts/verify-github-release-macos.py "./signed/$TARGET" "./github-archives/uv-$TARGET.tar.gz"
 
       - name: "Install and run the signed wheels"
-        run: ./scripts/test-release-wheels-macos.sh ./wheels
+        run: ./scripts/test-release-wheels-macos.sh "./wheels/$TARGET"
 
   verify-windows:
-    name: "verify signed windows artifacts"
-    needs: [sign-windows, assemble]
-    runs-on: namespace-profile-windows-2022-x86-64-16x32
+    name: "verify signed ${{ matrix.platform.target }} artifacts"
+    needs: [prepare, sign-windows, assemble]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(needs.prepare.outputs.targets).windows }}
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
+    env:
+      TARGET: ${{ matrix.platform.target }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -389,13 +473,15 @@ jobs:
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
+          cache: ""
           python-version: "3.13"
+          architecture: ${{ matrix.platform.python-architecture }}
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.10"
-          checksum: "f65744f94072152b1f86ba2aace4d01f1124d9a8ecb235805039e3718c36cac2"
+          checksum: ${{ matrix.platform.uv-checksum }}
           enable-cache: false
 
       - name: "Download signed executables"
@@ -414,7 +500,7 @@ jobs:
 
       - name: "Verify packaged executables and signatures"
         shell: pwsh
-        run: ./scripts/verify-release-wheels-windows.ps1 ./signed ./wheels
+        run: ./scripts/verify-release-wheels-windows.ps1 "./signed/$env:TARGET" "./wheels/$env:TARGET"
 
       - name: "Download signed GitHub release archives"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -425,8 +511,34 @@ jobs:
 
       - name: "Verify GitHub release archive"
         shell: pwsh
-        run: ./scripts/verify-github-release-windows.ps1 ./signed ./github-archives/uv-x86_64-pc-windows-msvc.zip
+        run: ./scripts/verify-github-release-windows.ps1 "./signed/$env:TARGET" "./github-archives/uv-${env:TARGET}.zip"
 
       - name: "Install and run the signed wheels"
         shell: pwsh
-        run: ./scripts/test-release-wheels-windows.ps1 ./wheels
+        run: ./scripts/test-release-wheels-windows.ps1 "./wheels/$env:TARGET"
+
+  complete:
+    name: "require verified signing outputs"
+    needs: [assemble, verify-macos, verify-windows]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-slim
+    outputs:
+      uv-wheels: ${{ needs.assemble.outputs.uv-wheels }}
+      uv-build-wheels: ${{ needs.assemble.outputs.uv-build-wheels }}
+      github-archives: ${{ needs.assemble.outputs.github-archives }}
+    steps:
+      - name: "Require every package to have passed verification"
+        env:
+          ASSEMBLY: ${{ needs.assemble.result }}
+          MACOS: ${{ needs.verify-macos.result }}
+          WINDOWS: ${{ needs.verify-windows.result }}
+          UV_WHEELS: ${{ needs.assemble.outputs.uv-wheels }}
+          UV_BUILD_WHEELS: ${{ needs.assemble.outputs.uv-build-wheels }}
+          GITHUB_ARCHIVES: ${{ needs.assemble.outputs.github-archives }}
+        run: |
+          test "$ASSEMBLY" = success
+          test "$MACOS" = success
+          test "$WINDOWS" = success
+          test -n "$UV_WHEELS"
+          test -n "$UV_BUILD_WHEELS"
+          test -n "$GITHUB_ARCHIVES"

--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -421,7 +421,7 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.10"
-          checksum: ${{ matrix.platform.uv-checksum }}
+          checksum: "51c6170e8e3a01cef9f33b94f582b7b81ac65046f55d40afb35f9cff5a68c179"
           enable-cache: false
 
       - name: "Download signed executables"
@@ -477,11 +477,21 @@ jobs:
           python-version: "3.13"
           architecture: ${{ matrix.platform.python-architecture }}
 
-      - name: "Install uv"
+      # setup-uv downloads for the runner architecture, not the wheel target.
+      - name: "Install uv on Windows x64"
+        if: ${{ runner.arch == 'X64' }}
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.10"
-          checksum: ${{ matrix.platform.uv-checksum }}
+          checksum: "f65744f94072152b1f86ba2aace4d01f1124d9a8ecb235805039e3718c36cac2"
+          enable-cache: false
+
+      - name: "Install uv on Windows ARM64"
+        if: ${{ runner.arch == 'ARM64' }}
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.10"
+          checksum: "ee985c51c0c9c1f82267a5d80f959b34a7ff888c109182bd3b2b35c4661bbcde"
           enable-cache: false
 
       - name: "Download signed executables"

--- a/scripts/plan-release-signing.py
+++ b/scripts/plan-release-signing.py
@@ -63,8 +63,9 @@ def signing_plan() -> dict[str, list[dict[str, str]]]:
 
 
 def main() -> None:
-    """Print the signing matrices as one JSON workflow output."""
-    print(json.dumps(signing_plan(), separators=(",", ":")))
+    """Print one GitHub Actions output for each signing matrix."""
+    for system, platforms in signing_plan().items():
+        print(f"{system}={json.dumps(platforms, separators=(',', ':'))}")
 
 
 if __name__ == "__main__":

--- a/scripts/plan-release-signing.py
+++ b/scripts/plan-release-signing.py
@@ -1,0 +1,80 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+#
+# [tool.uv]
+# no-build = true
+# exclude-newer = "P7D"
+# ///
+"""Describe the native verification jobs for every signed release target."""
+
+import json
+import tomllib
+from pathlib import Path
+
+MACOS_RUNNER = "namespace-profile-macos-15"
+WINDOWS_X64_RUNNER = "namespace-profile-windows-2022-x86-64-16x32"
+WINDOWS_ARM64_RUNNER = "github-windows-11-aarch64-8"
+
+# These checksums are for setup-uv's pinned uv 0.12.10 on the runner, not the
+# architecture of the release binary being checked.
+MACOS_UV_CHECKSUM = "51c6170e8e3a01cef9f33b94f582b7b81ac65046f55d40afb35f9cff5a68c179"
+WINDOWS_X64_UV_CHECKSUM = (
+    "f65744f94072152b1f86ba2aace4d01f1124d9a8ecb235805039e3718c36cac2"
+)
+WINDOWS_ARM64_UV_CHECKSUM = (
+    "ee985c51c0c9c1f82267a5d80f959b34a7ff888c109182bd3b2b35c4661bbcde"
+)
+
+PLATFORMS = {
+    "macos": {
+        "aarch64-apple-darwin": (MACOS_RUNNER, "arm64", MACOS_UV_CHECKSUM),
+        "x86_64-apple-darwin": (MACOS_RUNNER, "x64", MACOS_UV_CHECKSUM),
+    },
+    "windows": {
+        "aarch64-pc-windows-msvc": (
+            WINDOWS_ARM64_RUNNER,
+            "arm64",
+            WINDOWS_ARM64_UV_CHECKSUM,
+        ),
+        "i686-pc-windows-msvc": (WINDOWS_X64_RUNNER, "x86", WINDOWS_X64_UV_CHECKSUM),
+        "x86_64-pc-windows-msvc": (WINDOWS_X64_RUNNER, "x64", WINDOWS_X64_UV_CHECKSUM),
+    },
+}
+
+
+def signing_plan() -> dict[str, list[dict[str, str]]]:
+    """Require every macOS and Windows release target to have a verification job."""
+    workspace = Path(__file__).resolve().parent.parent / "dist-workspace.toml"
+    targets = tomllib.loads(workspace.read_text(encoding="utf-8"))["dist"]["targets"]
+    expected = {
+        target
+        for target in targets
+        if target.endswith(("-apple-darwin", "-pc-windows-msvc"))
+    }
+    configured = {target for platforms in PLATFORMS.values() for target in platforms}
+    if configured != expected:
+        raise ValueError(
+            f"Signing targets differ from dist-workspace.toml: {configured ^ expected}"
+        )
+    return {
+        system: [
+            {
+                "target": target,
+                "runner": runner,
+                "python-architecture": architecture,
+                "uv-checksum": checksum,
+            }
+            for target, (runner, architecture, checksum) in platforms.items()
+        ]
+        for system, platforms in PLATFORMS.items()
+    }
+
+
+def main() -> None:
+    """Print the signing matrices as one JSON workflow output."""
+    print(json.dumps(signing_plan(), separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plan-release-signing.py
+++ b/scripts/plan-release-signing.py
@@ -6,7 +6,12 @@
 # no-build = true
 # exclude-newer = "P7D"
 # ///
-"""Describe the native verification jobs for every signed release target."""
+"""Build native verification matrices for signed release artifacts.
+
+Every macOS and Windows target in `dist-workspace.toml` needs a runner to check
+its signed wheels and GitHub archive. Fail if the runner table falls out of sync
+so a new release target cannot bypass verification.
+"""
 
 import json
 import tomllib
@@ -16,29 +21,16 @@ MACOS_RUNNER = "namespace-profile-macos-15"
 WINDOWS_X64_RUNNER = "namespace-profile-windows-2022-x86-64-16x32"
 WINDOWS_ARM64_RUNNER = "github-windows-11-aarch64-8"
 
-# These checksums are for setup-uv's pinned uv 0.12.10 on the runner, not the
-# architecture of the release binary being checked.
-MACOS_UV_CHECKSUM = "51c6170e8e3a01cef9f33b94f582b7b81ac65046f55d40afb35f9cff5a68c179"
-WINDOWS_X64_UV_CHECKSUM = (
-    "f65744f94072152b1f86ba2aace4d01f1124d9a8ecb235805039e3718c36cac2"
-)
-WINDOWS_ARM64_UV_CHECKSUM = (
-    "ee985c51c0c9c1f82267a5d80f959b34a7ff888c109182bd3b2b35c4661bbcde"
-)
-
+# Runner assignment is explicit: adding a release target needs a native verifier.
 PLATFORMS = {
     "macos": {
-        "aarch64-apple-darwin": (MACOS_RUNNER, "arm64", MACOS_UV_CHECKSUM),
-        "x86_64-apple-darwin": (MACOS_RUNNER, "x64", MACOS_UV_CHECKSUM),
+        "aarch64-apple-darwin": (MACOS_RUNNER, "arm64"),
+        "x86_64-apple-darwin": (MACOS_RUNNER, "x64"),
     },
     "windows": {
-        "aarch64-pc-windows-msvc": (
-            WINDOWS_ARM64_RUNNER,
-            "arm64",
-            WINDOWS_ARM64_UV_CHECKSUM,
-        ),
-        "i686-pc-windows-msvc": (WINDOWS_X64_RUNNER, "x86", WINDOWS_X64_UV_CHECKSUM),
-        "x86_64-pc-windows-msvc": (WINDOWS_X64_RUNNER, "x64", WINDOWS_X64_UV_CHECKSUM),
+        "aarch64-pc-windows-msvc": (WINDOWS_ARM64_RUNNER, "arm64"),
+        "i686-pc-windows-msvc": (WINDOWS_X64_RUNNER, "x86"),
+        "x86_64-pc-windows-msvc": (WINDOWS_X64_RUNNER, "x64"),
     },
 }
 
@@ -63,9 +55,8 @@ def signing_plan() -> dict[str, list[dict[str, str]]]:
                 "target": target,
                 "runner": runner,
                 "python-architecture": architecture,
-                "uv-checksum": checksum,
             }
-            for target, (runner, architecture, checksum) in platforms.items()
+            for target, (runner, architecture) in platforms.items()
         ]
         for system, platforms in PLATFORMS.items()
     }

--- a/scripts/plan-release-signing.py.lock
+++ b/scripts/plan-release-signing.py.lock
@@ -1,0 +1,11 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+astral-dev-toolchain-cargo-shear = "2026-08-27T04:00:00Z"
+astral-dev-toolchain-cargo-dist = "2026-08-28T04:00:00Z"

--- a/scripts/verify-release-binaries-windows.ps1
+++ b/scripts/verify-release-binaries-windows.ps1
@@ -15,7 +15,8 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" |
+$architecture = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+$signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\$architecture\signtool.exe" |
     Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
 if (-not $signtool) { throw 'signtool.exe not found in Windows SDK' }
 


### PR DESCRIPTION
The release dry-run currently signs and verifies only arm64 macOS and x64 Windows binaries. Extend it to both macOS and all three Windows release targets, and align the Intel macOS artifact names with their Rust target. The signing plan requires every target in `dist-workspace.toml` to have a native verification runner.

This leaves release publishing unchanged. The signing workflow still runs only on an approved main-branch `dry-run`; the signed artifacts are assembled and verified but not substituted into PyPI or GitHub releases. The publishing switch remains in astral-sh/uv#21447.
