### PR TITLE
Sign release binaries from the wheel inventory

### DIFF
--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -219,11 +219,12 @@ jobs:
         env:
           TARGETS: ${{ needs.prepare.outputs.windows }}
         run: |
+          $ErrorActionPreference = 'Stop'
           foreach ($platform in ($env:TARGETS | ConvertFrom-Json)) {
             $target = $platform.target
             New-Item "signed/$target" -ItemType Directory -Force | Out-Null
-            foreach ($binary in @('uv.exe', 'uvx.exe', 'uvw.exe', 'uv-build.exe')) {
-              Copy-Item "unsigned/$target/$binary" "signed/$target/$binary"
+            foreach ($binary in (Get-ChildItem "unsigned/$target" -File)) {
+              Copy-Item $binary.FullName "signed/$target/$($binary.Name)"
             }
           }
 
@@ -253,8 +254,8 @@ jobs:
           $ErrorActionPreference = 'Stop'
           if (-not $env:CERTIFICATE_SUBJECT) { throw 'Missing signing certificate subject' }
           foreach ($platform in ($env:TARGETS | ConvertFrom-Json)) {
-            foreach ($binary in @('uv.exe', 'uvx.exe', 'uvw.exe', 'uv-build.exe')) {
-              $path = "signed/$($platform.target)/$binary"
+            foreach ($binary in (Get-ChildItem "signed/$($platform.target)" -File)) {
+              $path = $binary.FullName
               $signature = Get-AuthenticodeSignature $path
               if ($signature.Status -ne 'Valid' -or $null -eq $signature.TimeStamperCertificate -or
                   $signature.SignerCertificate.Subject -ne $env:CERTIFICATE_SUBJECT) {

--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -223,7 +223,7 @@ jobs:
           foreach ($platform in ($env:TARGETS | ConvertFrom-Json)) {
             $target = $platform.target
             New-Item "signed/$target" -ItemType Directory -Force | Out-Null
-            foreach ($binary in (Get-ChildItem "unsigned/$target" -File)) {
+            foreach ($binary in (Get-ChildItem "unsigned/$target" -File -Force)) {
               Copy-Item $binary.FullName "signed/$target/$($binary.Name)"
             }
           }
@@ -254,7 +254,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           if (-not $env:CERTIFICATE_SUBJECT) { throw 'Missing signing certificate subject' }
           foreach ($platform in ($env:TARGETS | ConvertFrom-Json)) {
-            foreach ($binary in (Get-ChildItem "signed/$($platform.target)" -File)) {
+            foreach ($binary in (Get-ChildItem "signed/$($platform.target)" -File -Force)) {
               $path = $binary.FullName
               $signature = Get-AuthenticodeSignature $path
               if ($signature.Status -ne 'Valid' -or $null -eq $signature.TimeStamperCertificate -or

--- a/scripts/sign-release-macos.py
+++ b/scripts/sign-release-macos.py
@@ -20,9 +20,6 @@ from pathlib import Path
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 
-BINARIES = ("uv", "uvx", "uv-build")
-
-
 class SigningComponent(Enum):
     """The components needed to sign uv's macOS executables."""
 
@@ -147,7 +144,8 @@ def sign_binaries(unsigned: Path, signed: Path) -> None:
 
         signed.mkdir()
         shutil.copyfile(certificate, signed / "certificate.pem")
-        for binary in BINARIES:
+        for source in sorted(unsigned.iterdir()):
+            binary = source.name
             try:
                 subprocess.run(
                     [
@@ -163,7 +161,7 @@ def sign_binaries(unsigned: Path, signed: Path) -> None:
                         os.environ["KEY_NAME"],
                         "--code-signature-flags",
                         "runtime",
-                        unsigned / binary,
+                        source,
                         signed / binary,
                     ],
                     check=True,

--- a/scripts/sign-release-macos.py
+++ b/scripts/sign-release-macos.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 
+
 class SigningComponent(Enum):
     """The components needed to sign uv's macOS executables."""
 

--- a/scripts/verify-github-release-macos.py
+++ b/scripts/verify-github-release-macos.py
@@ -19,6 +19,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+
 def verify_archive(signed: Path, archive: Path) -> None:
     """Extract the GitHub archive and invoke the shared macOS executable verifier."""
     with tempfile.TemporaryDirectory() as temporary:

--- a/scripts/verify-github-release-macos.py
+++ b/scripts/verify-github-release-macos.py
@@ -19,9 +19,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-BINARIES = ("uv", "uvx")
-
-
 def verify_archive(signed: Path, archive: Path) -> None:
     """Extract the GitHub archive and invoke the shared macOS executable verifier."""
     with tempfile.TemporaryDirectory() as temporary:
@@ -43,7 +40,7 @@ def verify_archive(signed: Path, archive: Path) -> None:
                 Path(__file__).with_name("verify-release-binaries-macos.py"),
                 signed,
                 archive_binaries,
-                *BINARIES,
+                *sorted(path.name for path in archive_binaries.iterdir()),
             ],
             check=True,
         )

--- a/scripts/verify-github-release-windows.ps1
+++ b/scripts/verify-github-release-windows.ps1
@@ -20,7 +20,7 @@ try {
     if ($LASTEXITCODE -ne 0) { throw 'GitHub release archive extraction failed' }
 
     & "$PSScriptRoot/verify-release-binaries-windows.ps1" -Signed $Signed `
-        -BinaryDirectory $archiveBinaries -Binaries @('uv.exe', 'uvx.exe', 'uvw.exe')
+        -BinaryDirectory $archiveBinaries -Binaries @(Get-ChildItem $archiveBinaries -Name)
 }
 finally {
     Remove-Item $archiveBinaries -Recurse -Force

--- a/scripts/verify-github-release-windows.ps1
+++ b/scripts/verify-github-release-windows.ps1
@@ -20,7 +20,7 @@ try {
     if ($LASTEXITCODE -ne 0) { throw 'GitHub release archive extraction failed' }
 
     & "$PSScriptRoot/verify-release-binaries-windows.ps1" -Signed $Signed `
-        -BinaryDirectory $archiveBinaries -Binaries @(Get-ChildItem $archiveBinaries -Name)
+        -BinaryDirectory $archiveBinaries -Binaries @(Get-ChildItem $archiveBinaries -Name -Force)
 }
 finally {
     Remove-Item $archiveBinaries -Recurse -Force

--- a/scripts/verify-release-binaries-macos.py
+++ b/scripts/verify-release-binaries-macos.py
@@ -26,6 +26,9 @@ from cryptography.hazmat.primitives import hashes
 
 def verify_binaries(signed: Path, directory: Path, binaries: list[str]) -> None:
     """Check packaged bytes, Apple trust, timestamps, and the signing certificate."""
+    found = {path.name for path in directory.iterdir()}
+    if found != set(binaries):
+        raise ValueError(f"Unexpected packaged executables: {sorted(found)}")
     certificate = x509.load_pem_x509_certificate(
         (signed / "certificate.pem").read_bytes()
     )

--- a/scripts/verify-release-binaries-windows.ps1
+++ b/scripts/verify-release-binaries-windows.ps1
@@ -20,6 +20,11 @@ $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\$archi
     Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
 if (-not $signtool) { throw 'signtool.exe not found in Windows SDK' }
 
+$found = @(Get-ChildItem $BinaryDirectory | Select-Object -ExpandProperty Name)
+if ($found.Count -ne $Binaries.Count -or @($found | Where-Object { $_ -notin $Binaries }).Count -ne 0) {
+    throw "Unexpected packaged executables: $($found -join ', ')"
+}
+
 foreach ($binary in $Binaries) {
     $binaryPath = (Get-Item "$BinaryDirectory/$binary").FullName
     if ((Get-FileHash "$Signed/$binary").Hash -ne (Get-FileHash $binaryPath).Hash) {

--- a/scripts/verify-release-binaries-windows.ps1
+++ b/scripts/verify-release-binaries-windows.ps1
@@ -20,7 +20,7 @@ $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\$archi
     Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
 if (-not $signtool) { throw 'signtool.exe not found in Windows SDK' }
 
-$found = @(Get-ChildItem $BinaryDirectory | Select-Object -ExpandProperty Name)
+$found = @(Get-ChildItem $BinaryDirectory -Force | Select-Object -ExpandProperty Name)
 if ($found.Count -ne $Binaries.Count -or @($found | Where-Object { $_ -notin $Binaries }).Count -ne 0) {
     throw "Unexpected packaged executables: $($found -join ', ')"
 }


### PR DESCRIPTION
The release signing jobs repeat uv's executable names even though they already receive the executables extracted from the wheels. Sign that input inventory instead, then require the packaged wheels and GitHub archives to have their exact expected executable sets during verification. This keeps the signing target plan focused on native runner assignment.

Depends on #21525.
