### PR TITLE
Use xhigh effort for PR security review

### DIFF
--- a/.github/workflows/pull-request-security-review.yml
+++ b/.github/workflows/pull-request-security-review.yml
@@ -129,7 +129,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           codex-version: "0.153.4"
           codex-home: "agents/codex"
-          effort: high
+          effort: xhigh
           permission-profile: "pull-request-review"
           safety-strategy: drop-sudo
           allow-bot-users: "astral-automations-bot[bot],renovate[bot]"


### PR DESCRIPTION
Increase the PR security review's `codex-action` reasoning effort from `high` to `xhigh`.

Stacked on #21528.
