### PR TITLE
Use x86_64 Python to smoke-test Intel macOS wheels

### DIFF
--- a/scripts/test-release-wheels-macos.sh
+++ b/scripts/test-release-wheels-macos.sh
@@ -7,7 +7,12 @@ virtual_environment=$(mktemp -d "${TMPDIR:-/tmp}/uv-release-wheels.XXXXXX")
 trap 'rm -rf "$virtual_environment"' EXIT
 
 python3 -m venv "$virtual_environment"
-"$virtual_environment/bin/python" -m pip install --no-index --no-deps "$wheel_directory"/*.whl
+python=("$virtual_environment/bin/python")
+# The Intel wheels are verified on an ARM runner; pip needs the Intel Python slice.
+if [[ "$wheel_directory" == *x86_64-apple-darwin ]]; then
+  python=(arch -x86_64 "$virtual_environment/bin/python")
+fi
+"${python[@]}" -m pip install --no-index --no-deps "$wheel_directory"/*.whl
 for binary in uv uvx uv-build; do
   "$virtual_environment/bin/$binary" --help
 done


### PR DESCRIPTION
The Intel macOS wheel smoke test in the [release dry-run](https://github.com/astral-sh/uv/actions/runs/34133357091) runs on an ARM64 runner. Although `setup-python` selects `x64`, the universal Python interpreter defaults to its ARM64 slice, so `pip` rejects the Intel wheel as unsupported. Run the wheel install through the x86_64 Python slice for that target; the ARM64 path is unchanged.
