### PR TITLE
Fix syntax highlighting in `exclude-newer` docs

### DIFF
--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -778,7 +778,7 @@ as if they do not exist.
 
 This option is also supported in the `pyproject.toml`, e.g.:
 
-```pyproject.toml
+```toml title="pyproject.toml"
 [tool.uv]
 exclude-newer = "2006-12-02T02:07:43Z"
 ```
@@ -792,7 +792,7 @@ When specified in persistent configuration, local date times are not allowed.
 Values may also be specified for specific packages, e.g.,
 `--exclude-newer-package setuptools=2006-12-02`, or:
 
-```pyproject.toml
+```toml title="pyproject.toml"
 [tool.uv]
 exclude-newer-package = { setuptools = "2006-12-02T02:07:43Z" }
 ```
@@ -800,7 +800,7 @@ exclude-newer-package = { setuptools = "2006-12-02T02:07:43Z" }
 The package option also accepts `<package>=false` to opt a package out of the restriction, e.g.,
 `--exclude-newer-package setuptools=false`, or:
 
-```pyproject.toml
+```toml title="pyproject.toml"
 [tool.uv]
 exclude-newer-package = { setuptools = false }
 ```
@@ -812,7 +812,7 @@ Package-specific values will take precedence over both global and index-specific
 
 Likewise, an individual index can override the global cutoff:
 
-```pyproject.toml
+```toml title="pyproject.toml"
 [tool.uv]
 exclude-newer = "2006-12-02T02:07:43Z"
 
@@ -824,7 +824,7 @@ exclude-newer = "7 days"
 
 Or disable it entirely for that index:
 
-```pyproject.toml
+```toml title="pyproject.toml"
 [[tool.uv.index]]
 name = "internal"
 url = "https://internal.example.com/simple"
@@ -860,7 +860,7 @@ performed, e.g., when `--upgrade` or `--refresh` is used.
 
 This option is also supported in the `pyproject.toml`, e.g.:
 
-```pyproject.toml
+```toml title="pyproject.toml"
 [tool.uv]
 exclude-newer = "1 week"
 ```
@@ -868,7 +868,7 @@ exclude-newer = "1 week"
 Values may also be specified for specific packages, e.g.,
 `--exclude-newer-package "setuptools=30 days"`, or:
 
-```pyproject.toml
+```toml title="pyproject.toml"
 [tool.uv]
 exclude-newer = "1 week"
 exclude-newer-package = { setuptools = "30 days" }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix TOML syntax highlighting in `resolution.md` docs for `exclude-newer` examples

### Details

- unlike the rest of the docs above this that [used](https://github.com/astral-sh/uv/blob/faad6dc3a89cc39a42cb36b2eb62c00911a86bf2/docs/concepts/resolution.md?plain=1#L721) `toml title="pyproject.toml"` for the config syntax highlighting, these areas just had `pyproject.toml`
  - this resulted in no syntax highlighting at all on the website at https://docs.astral.sh/uv/concepts/resolution/#reproducible-resolutions
  - these originate from d0a6f5d13fb5a7c569db9f9deddadc106f9aa1cb, 39b83c30e0cdaed833e88564878376f9361987d2, 08577895aece6db3b461a333f35ec8cb192fe287

## Test Plan

<!-- How was it tested? -->

Ran the [docs dev server](https://github.com/astral-sh/uv/blob/d28a3ee3d0f7122b0da64b0226d2e173e7d23747/CONTRIBUTING.md?plain=1#L285) and compared the before/after results. Screenshots:

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img width="767" height="122" alt="Screenshot 2026-09-07 at 11 38 37 PM" src="https://github.com/user-attachments/assets/c001bb0f-a9ec-42b7-9e22-64012261221e" />
    </td>
    <td>
      <img width="770" height="158" alt="Screenshot 2026-09-07 at 11 38 12 PM" src="https://github.com/user-attachments/assets/177f3369-c633-4b6d-9078-90bd4494d4ec" />
    </td>
  </tr>
</table>

