### PR TITLE
Document `--torch-backend` support in `uv tool run` and `uv tool install`

### DIFF
--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -527,4 +527,5 @@ $ # With an environment variable.
 $ UV_TORCH_BACKEND=cu130 uv pip install torch torchvision
 ```
 
-At present, `--torch-backend` is only available in the `uv pip` interface.
+At present, `--torch-backend` is available in the `uv pip` interface and in `uv tool run` and
+`uv tool install`, but not in the project interface (`uv lock`, `uv sync`, `uv run`, etc.).


### PR DESCRIPTION
## Summary

`docs/guides/integration/pytorch.md` ends with "At present, `--torch-backend` is only available in the `uv pip` interface." That stopped being true in #17117, which added the flag to `uv tool run` and `uv tool install`.

It is still absent from the project interface, so this names both halves rather than dropping the caveat. `torch_backend` appears on `PipCompileArgs`, `PipSyncArgs`, `PipInstallArgs`, `ToolRunArgs` and `ToolInstallArgs` and nowhere else; `lock.rs` discards the field and `sync.rs` sets it to `None`.

## Test Plan

Documentation only, one sentence. Ran `npx prettier@3.9.0 --check docs/guides/integration/pytorch.md`, which passes. I did not build the docs site locally.
