### PR TITLE
Remove the unimplemented `mkdocs` target from `transform_readme.py`

### DIFF
--- a/scripts/transform_readme.py
+++ b/scripts/transform_readme.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
         "--target",
         type=str,
         required=True,
-        choices=("pypi", "mkdocs"),
+        choices=("pypi",),
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

`scripts/transform_readme.py` lists `mkdocs` in its `--target` choices, but `main()` only implements the `pypi` branch and raises `ValueError: Unknown target: mkdocs` for anything else. The one documented alternative to `pypi` exits 1 with a traceback.

Nothing implements or invokes it: all eight call sites in `build-release-binaries.yml` pass `--target pypi`, and `mkdocs` does not appear anywhere else under `scripts/`. Dropping the choice lets argparse reject it instead.

## Test Plan

```console
$ python scripts/transform_readme.py --target mkdocs
usage: transform_readme.py [-h] --target {pypi}
transform_readme.py: error: argument --target: invalid choice: 'mkdocs' (choose from pypi)

$ python scripts/transform_readme.py --target pypi
$ echo $?
0
```

Before the change, the first command exited 1 with `ValueError: Unknown target: mkdocs`.
