### PR TITLE
Add optional native-tls (OpenSSL) backend

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -127,6 +127,10 @@ jobs:
         run: rustup component add clippy
       - name: "Clippy"
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+      - name: "Install OpenSSL headers"
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends pkg-config libssl-dev
+      - name: "Clippy (native-tls)"
+        run: cargo clippy -p uv-client --no-default-features --features native-tls --all-targets --locked -- -D warnings
 
   clippy-windows:
     name: "clippy on windows"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,64 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  cargo-test-native-tls:
+    timeout-minutes: 10
+    runs-on: depot-ubuntu-24.04-16
+    name: "cargo test native-tls"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Install OpenSSL headers"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pkg-config libssl-dev
+
+      - name: "Install mold"
+        run: ./scripts/install-mold.sh
+
+      - name: "Install Rust toolchain"
+        run: rustup toolchain install --profile minimal
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        id: rust-cache
+        with:
+          # Separate cache from the default-backend jobs: native-tls builds a
+          # different dependency graph (OpenSSL instead of rustls/aws-lc-rs).
+          prefix-key: v1-rust-native-tls
+          key: ${{ hashFiles('Cargo.toml') }}
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
+
+      - name: "Install cargo nextest"
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        with:
+          tool: cargo-nextest
+
+      - name: "Cargo test"
+        env:
+          RUST_BACKTRACE: 1
+        # All backend-specific code lives in `uv-client`; run its unit and
+        # integration tests against the native-tls (OpenSSL) backend.
+        run: |
+          cargo nextest run \
+            --cargo-profile fast-build-nightly \
+            -Z panic-abort-tests \
+            -Z checksum-freshness \
+            -p uv-client \
+            --no-default-features \
+            --features native-tls \
+            --profile ci-linux
+
+      - name: "Upload JUnit results"
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-results-native-tls
+          path: target/nextest/ci*/junit.xml
+          if-no-files-found: ignore
+          retention-days: 14
+
   cargo-test-macos:
     timeout-minutes: 20
     # Only run macOS tests on main without opt-in
@@ -227,7 +285,7 @@ jobs:
             -Z panic-abort-tests \
             -Z checksum-freshness \
             --no-default-features \
-            --features test-python,test-python-managed,test-pypi,test-git,test-git-lfs,performance,test-crates-io,native-auth,apple-native \
+            --features rustls-tls,test-python,test-python-managed,test-pypi,test-git,test-git-lfs,performance,test-crates-io,native-auth,apple-native \
             --workspace \
             --profile ci-macos
 
@@ -338,7 +396,7 @@ jobs:
             -Z panic-abort-tests \
             -Z checksum-freshness \
             --no-default-features \
-            --features test-python,test-pypi,test-python-managed,test-windows-registry,native-auth,windows-native \
+            --features rustls-tls,test-python,test-pypi,test-python-managed,test-windows-registry,native-auth,windows-native \
             --workspace \
             --profile ci-windows \
             --partition hash:${{ matrix.partition }}/3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,24 @@ winget install NASM.NASM
 After installation, add `C:\Program Files\NASM` to your `PATH`. While the prebuilt blob will not be
 used when NASM is found, you can guarantee this behavior by setting `AWS_LC_SYS_PREBUILT_NASM=0`.
 
+### Building against OpenSSL
+
+By default, uv uses `rustls` (with `aws-lc-rs`) for TLS. It can instead be built against the
+system's native TLS stack (OpenSSL), for example to inherit the system crypto policy for FIPS or
+post-quantum requirements:
+
+```shell
+cargo build -p uv --no-default-features --features native-tls
+```
+
+This backend links against OpenSSL through the [`openssl`](https://docs.rs/openssl/latest/openssl/)
+crate. By default it uses the system OpenSSL, which needs the OpenSSL headers and `pkg-config` (e.g.
+`sudo apt install pkg-config libssl-dev` or `sudo dnf install pkg-config openssl-devel`).
+Alternatively, `openssl-sys` can build a vendored copy of OpenSSL, which is compiled from source and
+therefore requires a C compiler and Perl (and NASM on Windows); see the
+[`openssl` crate documentation](https://docs.rs/openssl/latest/openssl/) for system-versus-vendored
+builds and the relevant environment variables.
+
 ## Testing
 
 For running tests, we recommend [nextest](https://nexte.st/).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2254,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2963,6 +2994,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,10 +3208,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -4113,10 +4198,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4128,6 +4215,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5413,6 +5501,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6351,6 +6449,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "jiff",
+ "openssl",
  "owo-colors",
  "percent-encoding",
  "rcgen",
@@ -7736,6 +7835,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ uv-cache = { version = "0.0.78", path = "crates/uv-cache" }
 uv-cache-info = { version = "0.0.78", path = "crates/uv-cache-info" }
 uv-cache-key = { version = "0.0.78", path = "crates/uv-cache-key" }
 uv-cli = { version = "0.0.78", path = "crates/uv-cli" }
-uv-client = { version = "0.0.78", path = "crates/uv-client" }
+uv-client = { version = "0.0.78", path = "crates/uv-client", default-features = false }
 uv-configuration = { version = "0.0.78", path = "crates/uv-configuration" }
 uv-console = { version = "0.0.78", path = "crates/uv-console" }
 uv-dirs = { version = "0.0.78", path = "crates/uv-dirs" }
@@ -179,6 +179,7 @@ md-5 = { version = "0.11.0" }
 memchr = { version = "2.7.4" }
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 nix = { version = "0.31.2", features = ["resource", "signal"] }
+openssl = { version = "0.10.81" }
 owo-colors = { version = "4.1.0" }
 papaya = { version = "0.2.5" , default-features = false }
 path-slash = { version = "0.2.1" }
@@ -214,7 +215,7 @@ reqwest = { version = "0.13.1", default-features = false, features = [
   "zstd",
   "stream",
   "system-proxy",
-  "rustls",
+  # TLS backend is selected by uv-client features: `rustls-tls` (default) or `native-tls`.
   "socks",
   "multipart",
   "http2",

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -39,7 +39,8 @@ path = "benches/uv_pypi_types.rs"
 harness = false
 
 [dev-dependencies]
-uv = { workspace = true }
+# `uv` is `default-features = false` at the workspace level; select a TLS backend explicitly.
+uv = { workspace = true, features = ["rustls-tls"] }
 uv-cache = { workspace = true }
 uv-cli = { workspace = true }
 uv-client = { workspace = true }

--- a/crates/uv-cli/Cargo.toml
+++ b/crates/uv-cli/Cargo.toml
@@ -49,6 +49,11 @@ insta = { workspace = true }
 [features]
 default = []
 self-update = []
+# TLS backend selection, forwarded from the `uv` binary. These features only gate the
+# `--system-certs` help text so it describes the actual runtime behavior; `uv-cli` itself
+# does not link a TLS stack. `rustls-tls` takes precedence when both are enabled.
+rustls-tls = []
+native-tls = []
 
 [build-dependencies]
 uv-static = { workspace = true }

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -289,6 +289,17 @@ pub struct GlobalArgs {
     /// However, in some cases, you may want to use the platform's native certificate store,
     /// especially if you're relying on a corporate trust root (e.g., for a mandatory proxy) that's
     /// included in your system's certificate store.
+    #[cfg(feature = "rustls-tls")]
+    #[arg(global = true, long, value_parser = clap::builder::BoolishValueParser::new(), overrides_with_all = ["no_system_certs", "native_tls", "no_native_tls"])]
+    pub system_certs: bool,
+
+    /// Accepted for compatibility; this build of uv (OpenSSL) always uses the platform's native certificate store [env: UV_SYSTEM_CERTS=]
+    ///
+    /// This build of uv links against the system's native TLS stack (e.g., OpenSSL), which always
+    /// uses the platform's native certificate store (honoring `SSL_CERT_FILE` and `SSL_CERT_DIR`).
+    /// The system certificate store is therefore always in effect, so this flag is accepted for
+    /// compatibility but has no effect.
+    #[cfg(not(feature = "rustls-tls"))]
     #[arg(global = true, long, value_parser = clap::builder::BoolishValueParser::new(), overrides_with_all = ["no_system_certs", "native_tls", "no_native_tls"])]
     pub system_certs: bool,
 

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -10,6 +10,17 @@ authors = { workspace = true }
 license = { workspace = true }
 
 [features]
+default = ["rustls-tls"]
+rustls-tls = [
+  "dep:rustls",
+  "dep:rustls-native-certs",
+  "dep:rustls-pki-types",
+  "dep:webpki",
+  "dep:webpki-root-certs",
+  "dep:x509-parser",
+  "reqwest/rustls",
+]
+native-tls = ["dep:openssl", "reqwest/native-tls"]
 test-pypi = []
 
 [lib]
@@ -64,12 +75,12 @@ reqwest-retry = { workspace = true }
 rkyv = { workspace = true }
 rmp-serde = { workspace = true }
 rustc-hash = { workspace = true }
-rustls = { workspace = true }
-rustls-native-certs = { workspace = true }
-rustls-pki-types = { workspace = true }
+rustls = { workspace = true, optional = true }
+rustls-native-certs = { workspace = true, optional = true }
+rustls-pki-types = { workspace = true, optional = true }
 serde = { workspace = true }
-webpki = { workspace = true }
-x509-parser = { workspace = true }
+webpki = { workspace = true, optional = true }
+x509-parser = { workspace = true, optional = true }
 serde_json = { workspace = true }
 uv-platform = { workspace = true }
 thiserror = { workspace = true }
@@ -77,7 +88,11 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-webpki-root-certs = { workspace = true }
+webpki-root-certs = { workspace = true, optional = true }
+
+# `native-tls` uses OpenSSL only off Apple (SecureTransport) and Windows (SChannel).
+[target.'cfg(not(any(target_vendor = "apple", target_os = "windows")))'.dependencies]
+openssl = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -10,9 +10,13 @@ use http::header::{
     PROXY_AUTHORIZATION, REFERER, TRANSFER_ENCODING, WWW_AUTHENTICATE,
 };
 use http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
-use reqwest::{
-    Certificate, Client, ClientBuilder, IntoUrl, NoProxy, Proxy, Request, Response, multipart,
-};
+use reqwest::{Client, ClientBuilder, IntoUrl, NoProxy, Proxy, Request, Response, multipart};
+// `reqwest::Certificate` only exists when a TLS backend is enabled. Without one it is aliased to an
+// uninhabited type so signatures still resolve; a certificate value can never be constructed.
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+use reqwest::Certificate;
+#[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+type Certificate = std::convert::Infallible;
 use reqwest_middleware::{ClientWithMiddleware, Middleware};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{Jitter, RetryTransientMiddleware};
@@ -35,11 +39,15 @@ use uv_redacted::DisplaySafeUrl;
 use uv_redacted::DisplaySafeUrlError;
 use uv_static::EnvVars;
 use uv_version::version;
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
 use uv_warnings::warn_user_once;
 
 use crate::linehaul::LineHaul;
 use crate::middleware::{AzureStorageMiddleware, OfflineMiddleware};
-use crate::tls::{Certificates, read_identity};
+#[cfg(feature = "rustls-tls")]
+use crate::tls::Certificates;
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+use crate::tls::read_identity;
 use crate::{Connectivity, MetadataRangeRequest, RetriableError, RetryState, UvRetryableStrategy};
 
 pub const DEFAULT_RETRIES: u32 = 3;
@@ -93,6 +101,7 @@ pub struct BaseClientBuilder<'a> {
     preview: Preview,
     allow_insecure_host: Vec<TrustedHost>,
     system_certs: bool,
+    #[cfg(feature = "rustls-tls")]
     custom_certificates: Option<Certificates>,
     retries: u32,
     pub connectivity: Connectivity,
@@ -205,6 +214,7 @@ impl Default for BaseClientBuilder<'_> {
             preview: Preview::default(),
             allow_insecure_host: vec![],
             system_certs: false,
+            #[cfg(feature = "rustls-tls")]
             custom_certificates: None,
             connectivity: Connectivity::Online,
             retries: DEFAULT_RETRIES,
@@ -321,6 +331,9 @@ impl<'a> BaseClientBuilder<'a> {
     }
 
     /// Use custom certificate authorities for TLS verification.
+    ///
+    /// Only available with the `rustls-tls` backend.
+    #[cfg(feature = "rustls-tls")]
     #[must_use]
     pub fn custom_certificates(mut self, certificates: Certificates) -> Self {
         self.custom_certificates = Some(certificates);
@@ -547,17 +560,28 @@ impl<'a> BaseClientBuilder<'a> {
             let _ = write!(user_agent_string, " {output}");
         }
 
-        let custom_certs = self
-            .custom_certificates
-            .as_ref()
-            .map(Certificates::to_reqwest_certs);
-        let certificate_source = if custom_certs.is_some() {
-            CertificateSource::Custom
-        } else if self.system_certs {
-            CertificateSource::System
-        } else {
-            CertificateSource::WebPki
+        // Only rustls selects a certificate source; other backends use the system trust store.
+        #[cfg(feature = "rustls-tls")]
+        let (custom_certs, certificate_source) = {
+            let custom_certs = self
+                .custom_certificates
+                .as_ref()
+                .map(Certificates::to_reqwest_certs);
+            let certificate_source = if custom_certs.is_some() {
+                CertificateSource::Custom
+            } else if self.system_certs {
+                CertificateSource::System
+            } else {
+                CertificateSource::WebPki
+            };
+            (custom_certs, certificate_source)
         };
+        #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
+        let (custom_certs, certificate_source) =
+            (None::<Vec<Certificate>>, CertificateSource::System);
+        #[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+        let (custom_certs, certificate_source) =
+            (None::<Vec<Certificate>>, CertificateSource::Unknown);
 
         // Create a secure client that validates certificates.
         let raw_client = self.create_client(
@@ -582,6 +606,9 @@ impl<'a> BaseClientBuilder<'a> {
         Ok((raw_client, raw_dangerous_client, certificate_source))
     }
 
+    // `custom_certs` is consumed only by the rustls backend (which takes ownership); with any other
+    // backend it is intentionally unused, so silence the by-value lint there.
+    #[cfg_attr(not(feature = "rustls-tls"), allow(clippy::needless_pass_by_value))]
     fn create_client(
         &self,
         user_agent: &str,
@@ -601,17 +628,24 @@ impl<'a> BaseClientBuilder<'a> {
             .redirect(redirect_policy.reqwest_policy());
 
         // If necessary, accept invalid certificates.
+        #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
         let client_builder = match security {
             Security::Secure => client_builder,
             Security::Insecure => client_builder.danger_accept_invalid_certs(true),
         };
+        // Without a TLS backend there are no certificates to accept or reject.
+        #[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+        let _ = security;
 
+        // Select the TLS backend.
+        #[cfg(feature = "rustls-tls")]
         let client_builder = client_builder.tls_backend_rustls();
 
         // Configure the certificate source.
         //
         // Non-empty `SSL_CERT_FILE` and `SSL_CERT_DIR` values override the default certificate
         // source, even when no valid certificates can be loaded from their configured paths.
+        #[cfg(feature = "rustls-tls")]
         let client_builder = if let Some(custom_certs) = custom_certs {
             client_builder.tls_certs_only(custom_certs)
         } else if self.system_certs {
@@ -619,8 +653,12 @@ impl<'a> BaseClientBuilder<'a> {
         } else {
             client_builder.tls_certs_only(Certificates::webpki_roots().to_reqwest_certs())
         };
+        // Only rustls consumes `custom_certs`; other backends leave it unused.
+        #[cfg(not(feature = "rustls-tls"))]
+        let _ = custom_certs;
 
-        // Configure mTLS.
+        // Configure mTLS. Client identities require a TLS backend.
+        #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
         let client_builder = if let Some(ssl_client_cert) = env::var_os(EnvVars::SSL_CLIENT_CERT) {
             match read_identity(&ssl_client_cert) {
                 Ok(identity) => client_builder.identity(identity),
@@ -753,10 +791,13 @@ pub struct BaseClient {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum CertificateSource {
     /// The system certificate roots.
+    #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
     System,
-    /// The bundled `WebPKI` certificate roots.
+    /// The bundled `WebPKI` certificate roots (rustls-tls only).
+    #[cfg(feature = "rustls-tls")]
     WebPki,
-    /// Custom certificate roots.
+    /// Custom certificate roots (rustls-tls only).
+    #[cfg(feature = "rustls-tls")]
     Custom,
     /// An externally constructed client whose certificate roots are unknown.
     Unknown,

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -557,6 +557,7 @@ pub struct WrappedReqwestError {
 #[derive(Debug)]
 enum WrappedReqwestErrorContext {
     ProblemDetails(ProblemDetails),
+    #[cfg(feature = "rustls-tls")]
     TlsCertificateSource(CertificateSource),
 }
 
@@ -575,22 +576,35 @@ impl WrappedReqwestError {
     }
 
     #[must_use]
+    #[cfg_attr(not(feature = "rustls-tls"), allow(unused_mut))]
     fn with_certificate_source(mut self, certificate_source: CertificateSource) -> Self {
+        #[cfg(feature = "rustls-tls")]
         if self.is_ssl() {
             self.context = Some(Box::new(WrappedReqwestErrorContext::TlsCertificateSource(
                 certificate_source,
             )));
         }
+        #[cfg(not(feature = "rustls-tls"))]
+        let _ = certificate_source;
         self
     }
 
+    #[cfg_attr(not(feature = "rustls-tls"), allow(clippy::unused_self))]
     fn suggests_system_certs(&self) -> bool {
-        matches!(
-            self.context.as_deref(),
-            Some(WrappedReqwestErrorContext::TlsCertificateSource(
-                CertificateSource::WebPki
-            ))
-        )
+        #[cfg(feature = "rustls-tls")]
+        {
+            matches!(
+                self.context.as_deref(),
+                Some(WrappedReqwestErrorContext::TlsCertificateSource(
+                    CertificateSource::WebPki
+                ))
+            )
+        }
+        // Other backends always use the system trust store, so there is nothing to suggest.
+        #[cfg(not(feature = "rustls-tls"))]
+        {
+            false
+        }
     }
 
     /// Drop `RetryError::WithRetries` to avoid reporting the number of retries twice.
@@ -656,6 +670,7 @@ impl WrappedReqwestError {
 
     /// Check if the error chain contains a `reqwest` error that looks like this:
     /// * invalid peer certificate: `UnknownIssuer`
+    #[cfg(feature = "rustls-tls")]
     fn is_ssl(&self) -> bool {
         if let Some(reqwest_err) = self.inner() {
             if !reqwest_err.is_connect() {

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -14,6 +14,8 @@ pub use registry_client::{
 pub(crate) use retry::UvRetryableStrategy;
 pub use retry::{RetriableError, RetryState, retryable_on_request_failure};
 pub use rkyvutil::OwnedArchive;
+pub use tls::tls_stack;
+#[cfg(feature = "rustls-tls")]
 pub use tls::{CertificateFileError, Certificates};
 
 mod base_client;

--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -4,11 +4,18 @@ use std::{io, iter};
 
 use http::status::StatusCode;
 use itertools::Itertools;
+#[cfg(all(
+    feature = "native-tls",
+    not(feature = "rustls-tls"),
+    not(any(target_vendor = "apple", target_os = "windows"))
+))]
+use openssl::error::ErrorStack;
 use reqwest::Response;
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{
     RetryPolicy, Retryable, RetryableStrategy, default_on_request_error, default_on_request_success,
 };
+#[cfg(feature = "rustls-tls")]
 use rustls::{AlertDescription, Error as RustlsError};
 use tracing::{debug, trace};
 use url::Url;
@@ -273,31 +280,136 @@ fn is_retryable_status_error(reqwest_err: &reqwest::Error) -> bool {
         || status == StatusCode::TOO_MANY_REQUESTS
 }
 
-fn is_tls_certificate_error(reqwest_err: &reqwest::Error) -> bool {
-    let Some(rustls_error) = find_source::<RustlsError>(reqwest_err) else {
-        return false;
-    };
+/// OpenSSL library code for the TLS/SSL layer (`ERR_LIB_SSL`). Not re-exported by
+/// `openssl-sys`; the value is stable across OpenSSL 1.1.1 and 3.x.
+#[cfg(all(
+    feature = "native-tls",
+    not(feature = "rustls-tls"),
+    not(any(target_vendor = "apple", target_os = "windows"))
+))]
+const ERR_LIB_SSL: i32 = 20;
 
-    // TODO(konsti): https://github.com/seanmonstar/reqwest/issues/2819#issuecomment-5032072023
-    match rustls_error {
-        RustlsError::InvalidCertificate(_) | RustlsError::NoCertificatesPresented => true,
-        RustlsError::AlertReceived(alert) => matches!(
-            alert,
-            AlertDescription::AccessDenied
-                | AlertDescription::BadCertificate
-                | AlertDescription::BadCertificateHashValue
-                | AlertDescription::BadCertificateStatusResponse
-                | AlertDescription::CertificateExpired
-                | AlertDescription::CertificateRequired
-                | AlertDescription::CertificateRevoked
-                | AlertDescription::CertificateUnknown
-                | AlertDescription::CertificateUnobtainable
-                | AlertDescription::DecryptError
-                | AlertDescription::NoCertificate
-                | AlertDescription::UnknownCA
-                | AlertDescription::UnsupportedCertificate
-        ),
-        _ => false,
+/// OpenSSL reason code for a failed local certificate verification
+/// (`SSL_R_CERTIFICATE_VERIFY_FAILED`).
+#[cfg(all(
+    feature = "native-tls",
+    not(feature = "rustls-tls"),
+    not(any(target_vendor = "apple", target_os = "windows"))
+))]
+const SSL_R_CERTIFICATE_VERIFY_FAILED: i32 = 134;
+
+// TODO(tiran): Once a released `openssl` crate exposes the typed `SslAlert`
+// (sfackler/rust-openssl#2684), replace this manual `SSL_AD_REASON_OFFSET` arithmetic and the
+// `CERTIFICATE_ALERT_DESCRIPTIONS` table below with `SslAlert::from_reason_code` and its variants.
+
+/// OpenSSL encodes a received or sent TLS alert as the reason code
+/// `SSL_AD_REASON_OFFSET + <alert description>` (see OpenSSL's `ssl.h`).
+#[cfg(all(
+    feature = "native-tls",
+    not(feature = "rustls-tls"),
+    not(any(target_vendor = "apple", target_os = "windows"))
+))]
+const SSL_AD_REASON_OFFSET: i32 = 1000;
+
+/// TLS alert descriptions (per the IANA registry) that indicate a certificate
+/// problem. This mirrors the [`AlertDescription`] set matched by the rustls
+/// backend.
+#[cfg(all(
+    feature = "native-tls",
+    not(feature = "rustls-tls"),
+    not(any(target_vendor = "apple", target_os = "windows"))
+))]
+const CERTIFICATE_ALERT_DESCRIPTIONS: &[i32] = &[
+    41,  // no_certificate (SSLv3)
+    42,  // bad_certificate
+    43,  // unsupported_certificate
+    44,  // certificate_revoked
+    45,  // certificate_expired
+    46,  // certificate_unknown
+    48,  // unknown_ca
+    49,  // access_denied
+    51,  // decrypt_error
+    111, // certificate_unobtainable
+    113, // bad_certificate_status_response
+    114, // bad_certificate_hash_value
+    116, // certificate_required
+];
+
+/// Whether a request failed because the TLS handshake produced a fatal verdict: uv rejected the
+/// peer's certificate, or the peer sent an alert to abort the handshake. These are deterministic,
+/// so we treat them as fatal rather than retrying. Transient handshake failures instead surface as
+/// [`io::Error`]s, handled by [`retryable_on_request_failure`].
+fn is_tls_certificate_error(reqwest_err: &reqwest::Error) -> bool {
+    #[cfg(feature = "rustls-tls")]
+    {
+        let Some(rustls_error) = find_source::<RustlsError>(reqwest_err) else {
+            return false;
+        };
+
+        // TODO(konsti): https://github.com/seanmonstar/reqwest/issues/2819#issuecomment-5032072023
+        match rustls_error {
+            RustlsError::InvalidCertificate(_) | RustlsError::NoCertificatesPresented => true,
+            RustlsError::AlertReceived(alert) => matches!(
+                alert,
+                AlertDescription::AccessDenied
+                    | AlertDescription::BadCertificate
+                    | AlertDescription::BadCertificateHashValue
+                    | AlertDescription::BadCertificateStatusResponse
+                    | AlertDescription::CertificateExpired
+                    | AlertDescription::CertificateRequired
+                    | AlertDescription::CertificateRevoked
+                    | AlertDescription::CertificateUnknown
+                    | AlertDescription::CertificateUnobtainable
+                    | AlertDescription::DecryptError
+                    | AlertDescription::NoCertificate
+                    | AlertDescription::UnknownCA
+                    | AlertDescription::UnsupportedCertificate
+            ),
+            _ => false,
+        }
+    }
+    // `native-tls` uses OpenSSL off Apple and Windows.
+    #[cfg(all(
+        feature = "native-tls",
+        not(feature = "rustls-tls"),
+        not(any(target_vendor = "apple", target_os = "windows"))
+    ))]
+    {
+        // With the native-tls (OpenSSL) backend, a certificate failure surfaces as an
+        // [`ErrorStack`] nested in the error source chain. Both local verification failures
+        // and received certificate-related TLS alerts are treated as fatal, matching the
+        // rustls backend. Non-certificate TLS failures (for example, a received
+        // `internal_error` alert) are left retryable.
+        let Some(error_stack) = find_source::<ErrorStack>(reqwest_err) else {
+            return false;
+        };
+
+        error_stack.errors().iter().any(|error| {
+            if error.library_code() != ERR_LIB_SSL {
+                return false;
+            }
+            let reason = error.reason_code();
+            reason == SSL_R_CERTIFICATE_VERIFY_FAILED
+                || CERTIFICATE_ALERT_DESCRIPTIONS.contains(&(reason - SSL_AD_REASON_OFFSET))
+        })
+    }
+    // SecureTransport (Apple) and SChannel (Windows) expose no typed certificate error; fall back to
+    // generic retry. The default build on these platforms uses rustls anyway.
+    #[cfg(all(
+        feature = "native-tls",
+        not(feature = "rustls-tls"),
+        any(target_vendor = "apple", target_os = "windows")
+    ))]
+    {
+        let _ = reqwest_err;
+        false
+    }
+    // Without a TLS backend the client cannot establish secure connections, so there are no TLS
+    // certificate errors to classify.
+    #[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+    {
+        let _ = reqwest_err;
+        false
     }
 }
 

--- a/crates/uv-client/src/tls/mod.rs
+++ b/crates/uv-client/src/tls/mod.rs
@@ -1,0 +1,103 @@
+// TLS backend selection.
+//
+// TLS backend selection: `rustls-tls` (default) or `native-tls`, as additive Cargo features.
+// `rustls-tls` wins when both are on (e.g. `--all-features`), so `native-tls` code is gated on
+// `all(feature = "native-tls", not(feature = "rustls-tls"))`. With neither, the crate still builds
+// (for `--no-default-features` checks) but has no working TLS.
+
+/// A human-readable description of the TLS backend, for diagnostic logging (`uv -vv`).
+pub fn tls_stack() -> String {
+    #[cfg(feature = "rustls-tls")]
+    {
+        "rustls (aws-lc-rs)".to_string()
+    }
+
+    #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
+    {
+        native_tls_stack()
+    }
+
+    #[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+    {
+        "none".to_string()
+    }
+}
+
+/// Describe the `native-tls` backend for the current target platform.
+#[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
+fn native_tls_stack() -> String {
+    // Apple/Windows use the OS TLS stack (no version); elsewhere OpenSSL (has one).
+    #[cfg(target_vendor = "apple")]
+    {
+        "native-tls (SecureTransport)".to_string()
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        "native-tls (SChannel)".to_string()
+    }
+
+    #[cfg(not(any(target_vendor = "apple", target_os = "windows")))]
+    {
+        format!("native-tls ({})", openssl::version::version())
+    }
+}
+
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+use std::io::{self, Read};
+
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+use reqwest::Identity;
+
+#[cfg(feature = "rustls-tls")]
+mod rustls;
+
+#[cfg(feature = "rustls-tls")]
+pub use self::rustls::{CertificateFileError, Certificates};
+
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum CertificateError {
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Reqwest(reqwest::Error),
+}
+
+/// Return the [`Identity`] from the provided file.
+///
+/// The file is expected to contain a PEM-encoded certificate chain and private key.
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+pub(crate) fn read_identity(
+    ssl_client_cert: &std::ffi::OsStr,
+) -> Result<Identity, CertificateError> {
+    let mut buf = Vec::new();
+    fs_err::File::open(ssl_client_cert)?.read_to_end(&mut buf)?;
+
+    #[cfg(feature = "rustls-tls")]
+    {
+        Identity::from_pem(&buf).map_err(|tls_err| {
+            debug_assert!(tls_err.is_builder(), "must be a rustls::Error internally");
+            CertificateError::Reqwest(tls_err)
+        })
+    }
+
+    #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
+    {
+        // `Identity::from_pkcs8_pem` requires the key argument to begin with the
+        // PKCS#8 PEM header. The certificate argument is parsed by OpenSSL's
+        // `X509::stack_from_pem`, which only extracts certificate blocks and ignores
+        // private key blocks, so we can pass the full buffer as-is.
+        const KEY_MARKER: &[u8] = b"-----BEGIN PRIVATE KEY-----";
+        let key_start = buf
+            .windows(KEY_MARKER.len())
+            .position(|window| window == KEY_MARKER)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "no PKCS#8 private key found in client certificate file",
+                )
+            })?;
+        Identity::from_pkcs8_pem(&buf, &buf[key_start..]).map_err(CertificateError::Reqwest)
+    }
+}

--- a/crates/uv-client/src/tls/rustls.rs
+++ b/crates/uv-client/src/tls/rustls.rs
@@ -1,10 +1,10 @@
 use std::env;
 use std::fmt::{Display, Formatter};
-use std::io::{self, Read};
+use std::io;
 use std::path::{Path, PathBuf};
 
 use itertools::Itertools;
-use reqwest::{Certificate, Identity};
+use reqwest::Certificate;
 use rustls_native_certs::{CertificateResult, load_certs_from_paths};
 use rustls_pki_types::CertificateDer;
 use tracing::{debug, warn};
@@ -470,14 +470,6 @@ impl From<CertificateResult> for Certificates {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum CertificateError {
-    #[error(transparent)]
-    Io(#[from] io::Error),
-    #[error(transparent)]
-    Reqwest(reqwest::Error),
-}
-
-#[derive(thiserror::Error, Debug)]
 pub enum CertificateFileError {
     #[error("Failed to read certificate file `{}`", .0.simplified_display())]
     Io(PathBuf, #[source] io::Error),
@@ -485,18 +477,6 @@ pub enum CertificateFileError {
     NotFile(PathBuf),
     #[error("No valid certificates found in: `{}`", .0.simplified_display())]
     NoValidCertificates(PathBuf),
-}
-
-/// Return the `Identity` from the provided file.
-pub(crate) fn read_identity(
-    ssl_client_cert: &std::ffi::OsStr,
-) -> Result<Identity, CertificateError> {
-    let mut buf = Vec::new();
-    fs_err::File::open(ssl_client_cert)?.read_to_end(&mut buf)?;
-    Identity::from_pem(&buf).map_err(|tls_err| {
-        debug_assert!(tls_err.is_builder(), "must be a rustls::Error internally");
-        CertificateError::Reqwest(tls_err)
-    })
 }
 
 #[cfg(test)]

--- a/crates/uv-client/tests/it/http_util.rs
+++ b/crates/uv-client/tests/it/http_util.rs
@@ -1,9 +1,12 @@
 use std::net::SocketAddr;
+#[cfg(feature = "rustls-tls")]
 use std::path::PathBuf;
+#[cfg(feature = "rustls-tls")]
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use futures::future;
+use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
 use hyper::header::USER_AGENT;
@@ -11,20 +14,71 @@ use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
+#[cfg(feature = "rustls-tls")]
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, CustomExtension, DnType,
     ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType, date_time_ymd,
 };
+#[cfg(feature = "rustls-tls")]
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+#[cfg(feature = "rustls-tls")]
 use rustls::server::WebPkiClientVerifier;
+#[cfg(feature = "rustls-tls")]
 use rustls::{RootCertStore, ServerConfig};
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
+#[cfg(feature = "rustls-tls")]
 use tokio_rustls::TlsAcceptor;
 
+#[cfg(feature = "rustls-tls")]
 use uv_fs::Simplified;
 
+/// Handles a single request by echoing back the `User-Agent` header.
+fn echo_user_agent(
+    req: &Request<Incoming>,
+) -> future::Ready<Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error>> {
+    // Get User Agent Header and send it back in the response
+    let user_agent = req
+        .headers()
+        .get(USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .map(ToString::to_string)
+        .unwrap_or_default(); // Empty Default
+    let response_content = Full::new(Bytes::from(user_agent))
+        .map_err(|_| unreachable!())
+        .boxed();
+    future::ok::<_, hyper::Error>(Response::new(response_content))
+}
+
+/// Single Request HTTP server that echoes the User Agent Header.
+pub(crate) async fn start_http_user_agent_server() -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+
+    let server_task = tokio::spawn(async move {
+        let svc = service_fn(|req: Request<Incoming>| echo_user_agent(&req));
+
+        let (tcp_stream, _remote_addr) = listener
+            .accept()
+            .await
+            .context("Failed to accept TCP connection")?;
+
+        let socket = TokioIo::new(tcp_stream);
+        tokio::task::spawn(async move {
+            Builder::new(TokioExecutor::new())
+                .serve_connection(socket, svc)
+                .await
+                .expect("HTTP Server Started");
+        });
+
+        Ok(())
+    });
+
+    Ok((server_task, addr))
+}
+
 /// An issued certificate, together with the subject keypair.
+#[cfg(feature = "rustls-tls")]
 #[derive(Debug)]
 pub(crate) struct SelfSigned {
     /// An issued certificate.
@@ -36,6 +90,7 @@ pub(crate) struct SelfSigned {
 /// Defines the base location for temporary generated certs.
 ///
 /// See [`TestContext::test_bucket_dir`] for implementation rationale.
+#[cfg(feature = "rustls-tls")]
 pub(crate) fn test_cert_dir() -> PathBuf {
     std::env::temp_dir()
         .simple_canonicalize()
@@ -51,12 +106,14 @@ pub(crate) fn test_cert_dir() -> PathBuf {
 /// The client certificate is for `uv-test-client` issued by this CA.
 ///
 /// Use sparingly as generation of these certs is a very slow operation.
+#[cfg(feature = "rustls-tls")]
 pub(crate) fn generate_self_signed_certs_with_ca() -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
     generate_self_signed_certs_with_ca_custom_extensions(Vec::new())
 }
 
 /// Like [`generate_self_signed_certs_with_ca`], but the server certificate is
 /// already expired (`not_after` is in the past).
+#[cfg(feature = "rustls-tls")]
 pub(crate) fn generate_expired_self_signed_certs_with_ca()
 -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
     generate_self_signed_certs_with_ca_impl(Vec::new(), (2020, 1, 1), (2021, 1, 1))
@@ -64,6 +121,7 @@ pub(crate) fn generate_expired_self_signed_certs_with_ca()
 
 /// Like [`generate_self_signed_certs_with_ca`], but the CA certificate contains
 /// additional custom extensions.
+#[cfg(feature = "rustls-tls")]
 pub(crate) fn generate_self_signed_certs_with_ca_custom_extensions(
     custom_extensions: Vec<CustomExtension>,
 ) -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
@@ -72,6 +130,7 @@ pub(crate) fn generate_self_signed_certs_with_ca_custom_extensions(
 
 /// Generates a self-signed root CA, server certificate, and client certificate,
 /// with a configurable validity period for the server certificate.
+#[cfg(feature = "rustls-tls")]
 fn generate_self_signed_certs_with_ca_impl(
     ca_custom_extensions: Vec<CustomExtension>,
     server_not_before: (i32, u8, u8),
@@ -176,6 +235,7 @@ fn generate_self_signed_certs_with_ca_impl(
     Ok((ca_self_signed, server_self_signed, client_self_signed))
 }
 
+#[cfg(feature = "rustls-tls")]
 #[derive(Default)]
 pub(crate) struct TestServerBuilder<'a> {
     // CA certificate
@@ -186,6 +246,7 @@ pub(crate) struct TestServerBuilder<'a> {
     mutual_tls: bool,
 }
 
+#[cfg(feature = "rustls-tls")]
 impl<'a> TestServerBuilder<'a> {
     pub(crate) fn new() -> Self {
         Self {
@@ -215,7 +276,7 @@ impl<'a> TestServerBuilder<'a> {
         self
     }
 
-    /// Starts the HTTP(S) server with optional mTLS enforcement.
+    /// Starts the HTTPS server with optional mTLS enforcement.
     pub(crate) async fn start(self) -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
         // Validate builder input combinations
         if self.ca_cert.is_some() && self.server_cert.is_none() {
@@ -267,27 +328,9 @@ impl<'a> TestServerBuilder<'a> {
             None
         };
 
-        // Setup Response Handler
-        let svc_fn = |req: Request<Incoming>| {
-            // Get User Agent Header and send it back in the response
-            let user_agent = req
-                .headers()
-                .get(USER_AGENT)
-                .and_then(|v| v.to_str().ok())
-                .map(ToString::to_string)
-                .unwrap_or_default(); // Empty Default
-            let response_content = Full::new(Bytes::from(user_agent))
-                .map_err(|_| unreachable!())
-                .boxed();
-            // If we ever want a true echo server, we can use instead
-            // let response_content = req.into_body().boxed();
-            // although uv-client doesn't expose post currently.
-            future::ok::<_, hyper::Error>(Response::new(response_content))
-        };
-
         // Spawn the server loop in a background task
         let server_task = tokio::spawn(async move {
-            let svc = service_fn(move |req: Request<Incoming>| svc_fn(req));
+            let svc = service_fn(|req: Request<Incoming>| echo_user_agent(&req));
 
             let (tcp_stream, _remote_addr) = listener
                 .accept()
@@ -327,12 +370,8 @@ impl<'a> TestServerBuilder<'a> {
     }
 }
 
-/// Single Request HTTP server that echoes the User Agent Header.
-pub(crate) async fn start_http_user_agent_server() -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
-    TestServerBuilder::new().start().await
-}
-
 /// Single Request HTTPS server that echoes the User Agent Header.
+#[cfg(feature = "rustls-tls")]
 pub(crate) async fn start_https_user_agent_server(
     server_cert: &SelfSigned,
 ) -> Result<(JoinHandle<Result<()>>, SocketAddr)> {
@@ -343,6 +382,7 @@ pub(crate) async fn start_https_user_agent_server(
 }
 
 /// Single Request HTTPS mTLS server that echoes the User Agent Header.
+#[cfg(feature = "rustls-tls")]
 pub(crate) async fn start_https_mtls_user_agent_server(
     ca_cert: &SelfSigned,
     server_cert: &SelfSigned,

--- a/crates/uv-client/tests/it/main.rs
+++ b/crates/uv-client/tests/it/main.rs
@@ -2,5 +2,8 @@ mod cached_client;
 mod http_util;
 mod proxy;
 mod remote_metadata;
+// The certificate tests exercise uv's custom-certificate handling and a rustls-based test server,
+// both of which are only available with the `rustls-tls` backend.
+#[cfg(feature = "rustls-tls")]
 mod ssl_certs;
 mod user_agent_version;

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -81,9 +81,14 @@ name = "uv-dev"
 required-features = ["dev"]
 
 [features]
-default = ["performance"]
+# `uv-client` is declared with `default-features = false` at the workspace level, so a TLS
+# backend has to be re-enabled here for the dev CLI to make HTTPS requests (e.g. `generate-all`
+# fetches Python build metadata). Default to `rustls-tls`, matching the `uv` binary.
+default = ["performance", "rustls-tls"]
 # Actually build the dev CLI.
 dev = []
+rustls-tls = ["uv-client/rustls-tls", "uv-cli/rustls-tls"]
+native-tls = ["uv-client/native-tls", "uv-cli/native-tls"]
 performance = ["performance-memory-allocator"]
 performance-memory-allocator = ["dep:uv-performance-memory-allocator"]
 render = ["poloto", "resvg", "tagu"]

--- a/crates/uv-dev/src/lib.rs
+++ b/crates/uv-dev/src/lib.rs
@@ -1,3 +1,12 @@
+// The `uv-dev` binary makes HTTPS requests (e.g. `generate-all`), so it must link a TLS backend.
+// `rustls-tls` is the default; downstream rebuilds can swap in the native stack via
+// `--no-default-features --features native-tls`. Reject a build that would link no TLS stack at all.
+#[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+compile_error!(
+    "a TLS backend is required: build with the default `rustls-tls` feature, \
+     or `--no-default-features --features native-tls`"
+);
+
 use std::env;
 
 use anyhow::Result;

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -157,8 +157,12 @@ nix = { workspace = true }
 uv-unix = { workspace = true }
 
 [features]
-default = ["performance", "test-defaults"]
+default = ["rustls-tls", "performance", "test-defaults"]
+rustls-tls = ["uv-client/rustls-tls", "uv-cli/rustls-tls"]
 native-auth = []
+# Use the system's native TLS stack (e.g., OpenSSL) instead of rustls.
+# Intended for downstream rebuilds that require FIPS compliance or PQC support.
+native-tls = ["uv-client/native-tls", "uv-cli/native-tls"]
 # Use better memory allocators, etc.
 performance = ["performance-memory-allocator"]
 performance-memory-allocator = ["dep:uv-performance-memory-allocator"]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1,5 +1,14 @@
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
+// The `uv` binary must link a TLS backend. `rustls-tls` is the default; downstream rebuilds can swap
+// in the system's native stack via `--no-default-features --features native-tls`. Reject a
+// `--no-default-features` build that would link no TLS stack at all.
+#[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+compile_error!(
+    "a TLS backend is required: build with the default `rustls-tls` feature, \
+     or `--no-default-features --features native-tls`"
+);
+
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::fmt::Write;
@@ -85,11 +94,15 @@ pub(crate) fn base_client_builder<'a>(globals: &GlobalSettings) -> BaseClientBui
     .https_proxy(globals.network_settings.https_proxy.clone())
     .no_proxy(globals.network_settings.no_proxy.clone());
 
-    if let Some(certificates) = &globals.network_settings.custom_certificates {
+    // Only rustls consumes uv's custom certificates; other backends use the system store.
+    #[cfg(feature = "rustls-tls")]
+    let client_builder = if let Some(certificates) = &globals.network_settings.custom_certificates {
         client_builder.custom_certificates(certificates.clone())
     } else {
         client_builder
-    }
+    };
+
+    client_builder
 }
 
 /// Whether to initialize process-global state.
@@ -513,6 +526,7 @@ pub async fn run(cli: Cli, global_initialization: GlobalInitialization) -> Resul
     }
 
     debug!("uv {}", uv_cli::version::uv_self_version());
+    trace!("TLS backend: {}", uv_client::tls_stack());
     if let Some(config_file) = cli.top_level.config_file.as_ref() {
         debug!("Using configuration file: {}", config_file.user_display());
     }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -32,7 +32,9 @@ use uv_cli::{
         resolver_installer_options, resolver_options,
     },
 };
-use uv_client::{Certificates, Connectivity, MetadataRangeRequest};
+#[cfg(feature = "rustls-tls")]
+use uv_client::Certificates;
+use uv_client::{Connectivity, MetadataRangeRequest};
 use uv_configuration::{
     ActiveEnvironment, BuildIsolation, BuildOptions, Concurrency, DependencyGroups, DevMode,
     DryRun, EditableMode, EnvFile, ExcludeDependency, ExportFormat, ExtrasSpecification,
@@ -276,6 +278,7 @@ pub(crate) struct NetworkSettings {
     pub(super) connectivity: Connectivity,
     pub(super) offline: Flag,
     pub(super) system_certs: bool,
+    #[cfg(feature = "rustls-tls")]
     pub(super) custom_certificates: Option<Certificates>,
     pub(super) http_proxy: Option<ProxyUrl>,
     pub(super) https_proxy: Option<ProxyUrl>,
@@ -394,15 +397,20 @@ impl NetworkSettings {
         let https_proxy = workspace.and_then(|workspace| workspace.globals.https_proxy.clone());
         let no_proxy = workspace.and_then(|workspace| workspace.globals.no_proxy.clone());
 
+        // Only rustls consumes uv's custom certificates; other backends use the system store.
+        #[cfg(feature = "rustls-tls")]
         let custom_certificates = custom_certificate_file
             .map(Certificates::from_file)
             .transpose()?
             .or_else(Certificates::from_env);
+        #[cfg(not(feature = "rustls-tls"))]
+        let _ = custom_certificate_file;
 
         Ok(Self {
             connectivity,
             offline,
             system_certs,
+            #[cfg(feature = "rustls-tls")]
             custom_certificates,
             http_proxy,
             https_proxy,

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -14742,6 +14742,7 @@ fn offline_refresh_conflict_verbose() {
     ----- stderr -----
     DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    TRACE TLS backend: rustls (aws-lc-rs)
     error: the argument `--offline` cannot be used with `--refresh`
     ");
 }

--- a/docs/concepts/authentication/certificates.md
+++ b/docs/concepts/authentication/certificates.md
@@ -8,6 +8,12 @@ are used to verify the identity of these servers, ensuring that connections are 
 uv uses [`rustls`](https://github.com/rustls/rustls), a memory-safe TLS implementation written in
 Rust, with [`aws-lc-rs`](https://github.com/aws/aws-lc-rs) as the cryptography provider.
 
+!!! note
+
+    uv can also be built against the system's native TLS stack (OpenSSL) instead of `rustls` — for
+    example, to meet FIPS or post-quantum cryptography requirements. This changes how certificates
+    are configured; see [System certificates](#system-certificates).
+
 uv supports the following X.509 certificate signature algorithms:
 
 - ECDSA (P-256, P-384, P-521) with SHA-256, SHA-384, or SHA-512
@@ -29,6 +35,17 @@ or set [`system-certs = true`](../../reference/settings.md#system-certs) in `uv.
 When using system certificates, certificate verification is performed by
 [`rustls-platform-verifier`](https://github.com/rustls/rustls-platform-verifier), which delegates to
 the operating system's certificate verifier.
+
+!!! note "OpenSSL builds"
+
+    When uv is built against the system's native TLS stack (OpenSSL) rather than the default
+    `rustls` backend, the platform's native certificate store is **always** used. Because there is
+    no bundled-certificate mode to switch away from, the
+    [`--system-certs`](../../reference/cli.md#uv) option, the
+    [`UV_SYSTEM_CERTS`](../../reference/environment.md#uv_system_certs) environment variable, and the
+    [`system-certs`](../../reference/settings.md#system-certs) setting all behave differently than on
+    the default build: they are accepted for compatibility but have no effect. Custom certificates
+    (`SSL_CERT_FILE`/`SSL_CERT_DIR`) and mTLS (`SSL_CLIENT_CERT`) continue to work on all builds.
 
 ## Custom certificates
 


### PR DESCRIPTION
## Summary

Add a compile-time `native-tls` feature to `uv-client` as an alternative to the default `rustls-tls` backend, selected by the top-level `uv` binary. Downstream rebuilders can now link uv against the system's OpenSSL and inherit the system crypto policy to meet FIPS or post-quantum requirements. The default build is `rustls`.

The two backends are additive Cargo features rather than mutually exclusive, so the crate builds under every feature combination CI exercises:

* Default and `--all-features`: `rustls-tls` always wins, so the default build is unchanged. Rustls-specific certificate handling moves to `tls/rustls.rs`.
* `native-tls` only: OpenSSL owns certificate validation and trust-store access, including `SSL_CERT_FILE`/`SSL_CERT_DIR` and client certificates (mTLS).
* Neither: the crate still compiles with no TLS backend, keeping `uv-client` publishable in isolation, where dependents pull it in with `default-features = false`.

OpenSSL builds always use the platform certificate store and read env vars `SSL_CERT_FILE`, `SSL_CERT_DIR`, and `SSL_CLIENT_CERT`. The bundled-roots controls (`--system-certs`, `UV_SYSTEM_CERTS`, `system-certs`) are accepted for compatibility but have no effect there. Custom certificates and mTLS continue to work on all builds. Retry classification is kept equivalent across backends, so retry behavior does not depend on the TLS backend.

Build with:

```console
cargo build -p uv --no-default-features --features native-tls
```

Fixes: astral-sh/uv#11595

## Test Plan

CI gains a `cargo test native-tls` job that runs uv-client's unit and integration tests against the OpenSSL backend, alongside the existing default-backend coverage.

I have performed local testing as well:

```console
$ cargo build -p uv --profile fast-build --no-default-features --features native-tls
$ ldd target/fast-build/uv
        linux-vdso.so.1 (0x00007fffbcde7000)
        libssl.so.3 => /lib64/libssl.so.3 (0x00007fcfb01bf000)
        libcrypto.so.3 => /lib64/libcrypto.so.3 (0x00007fcfaaa3b000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fcfb01a2000)
        libm.so.6 => /lib64/libm.so.6 (0x00007fcfaa95e000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fcfaa754000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fcfb02c5000)
        libz.so.1 => /lib64/libz.so.1 (0x00007fcfb0186000)
```

In tracing mode, uv now reports TLS backend:

```console
$ echo ruff | target/fast-build/uv -vv --no-cache pip compile -
...
DEBUG uv 0.12.10+35 (11cd71d76 2026-09-08 x86_64-unknown-linux-gnu)
TRACE TLS backend: native-tls (OpenSSL 3.5.5 27 Jan 2026)
...
Resolved 1 package in 178ms
# This file was autogenerated by uv via the following command:
#    uv --no-cache pip compile -
ruff==0.16.5
```

A native `uv` build uses system's crypto policy (tested on Fedora + RHEL):

```console
$ update-crypto-policies --set FUTURE
$ echo ruff | target/fast-build/uv --no-cache pip compile -
  Resolving dependencies...                                                                                                                                                                                    
error: Failed to fetch: `https://pypi.org/simple/ruff/`
  Caused by: error sending request for url (https://pypi.org/simple/ruff/)
  Caused by: client error (Connect)
  Caused by: error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2124: (EE certificate key too weak)
  Caused by: error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2124:
```