### PR TITLE
Default missing system site packages setting to false

### DIFF
--- a/crates/uv-python/src/virtualenv.rs
+++ b/crates/uv-python/src/virtualenv.rs
@@ -229,7 +229,7 @@ impl PyVenvConfiguration {
         let mut uv = false;
         let mut relocatable = false;
         let mut seed = false;
-        let mut include_system_site_packages = true;
+        let mut include_system_site_packages = false;
         let mut version = None;
 
         // Per https://snarky.ca/how-virtual-environments-work/, the `pyvenv.cfg` file is not a
@@ -441,5 +441,31 @@ mod tests {
                 version = 3.9.0
             "}
         );
+    }
+
+    #[test]
+    fn test_parse_include_system_site_packages() {
+        let tempdir = tempdir().unwrap();
+        let cfg = tempdir.path().join("pyvenv.cfg");
+
+        for (content, expected) in [
+            ("home = /path/to/python\nversion = 3.9.0\n", false),
+            (
+                "home = /path/to/python\nversion = 3.9.0\ninclude-system-site-packages = false\n",
+                false,
+            ),
+            (
+                "home = /path/to/python\nversion = 3.9.0\ninclude-system-site-packages = true\n",
+                true,
+            ),
+        ] {
+            fs::write(&cfg, content).unwrap();
+            let configuration = PyVenvConfiguration::parse(&cfg).unwrap();
+            assert_eq!(
+                configuration.include_system_site_packages(),
+                expected,
+                "unexpected include-system-site-packages value for {content:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->




## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix the default value for `include-system-site-packages` when parsing `pyvenv.cfg`.

The parser previously initialized the value to `true`, causing incomplete or manually-created virtual environment configurations to be interpreted differently from CPython. The default is now `false`, matching CPython's behavior when the configuration key is absent.


## Test Plan

<!-- How was it tested? -->


- `cargo test -p uv-python test_parse_include_system_site_packages`
- `cargo clippy -p uv-python --tests --locked -- -D warnings`