### PR TITLE
Apply flat index policies in each resolver

### DIFF
--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -50,7 +50,7 @@ pub struct FlatIndexEntry {
 
 impl FlatIndexEntry {
     /// Return the distribution filename.
-    pub(crate) fn filename(&self) -> &DistFilename {
+    pub fn filename(&self) -> &DistFilename {
         &self.filename
     }
 

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -191,19 +191,14 @@ impl<'a> BuildDispatch<'a> {
         }
     }
 
-    /// Fork the dispatch with a different hash strategy and its corresponding flat index.
+    /// Fork the dispatch with a different hash strategy.
     ///
-    /// The flat index must use the same hash verification policy as `hasher`. In-memory resolution,
-    /// download, and build caches are reset, since they may depend on the previous policy.
+    /// In-memory resolution, download, and build caches are reset, since they may depend on the
+    /// previous policy.
     #[must_use]
-    pub fn fork<'fork>(
-        &'fork self,
-        hasher: &'fork HashStrategy,
-        flat_index: &'fork FlatIndex,
-    ) -> BuildDispatch<'fork> {
+    pub fn fork<'fork>(&'fork self, hasher: &'fork HashStrategy) -> BuildDispatch<'fork> {
         BuildDispatch {
             hasher,
-            flat_index,
             shared_state: SharedState {
                 build_arena: BuildArena::default(),
                 ..self.shared_state.fork()

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -17,12 +17,11 @@ use uv_platform_tags::{TagCompatibility, Tags};
 use uv_pypi_types::HashDigest;
 use uv_types::HashStrategy;
 
-/// A set of [`PrioritizedDist`] from a `--find-links` entry, indexed by [`PackageName`]
-/// and [`Version`].
+/// Unfiltered entries from `--find-links`, indexed by [`PackageName`].
 #[derive(Debug, Clone, Default)]
 pub struct FlatIndex {
-    /// The list of [`FlatDistributions`] from the `--find-links` entries, indexed by package name.
-    index: FxHashMap<PackageName, FlatDistributions>,
+    /// Entries are ranked using each resolver's platform and hash policies when requested.
+    index: FxHashMap<PackageName, Vec<FlatIndexEntry>>,
     /// Whether any `--find-links` entries could not be resolved due to a lack of network
     /// connectivity.
     offline: bool,
@@ -31,28 +30,23 @@ pub struct FlatIndex {
 impl FlatIndex {
     /// Collect all files from a `--find-links` target into a [`FlatIndex`].
     #[instrument(skip_all)]
-    pub fn from_entries(
-        entries: FlatIndexEntries,
-        tags: Option<&Tags>,
-        hasher: &HashStrategy,
-        build_options: &BuildOptions,
-    ) -> Self {
-        // Collect compatible distributions.
-        let mut index = FxHashMap::<PackageName, FlatDistributions>::default();
+    pub fn from_entries(entries: FlatIndexEntries) -> Self {
+        let mut index = FxHashMap::<PackageName, Vec<FlatIndexEntry>>::default();
         let (entries, offline) = entries.into_parts();
 
         for entry in entries {
-            let (filename, file, index_url) = entry.into_parts();
-            let distributions = index.entry(filename.name().clone()).or_default();
-            distributions.add_file(file, filename, tags, hasher, build_options, index_url);
+            index
+                .entry(entry.filename().name().clone())
+                .or_default()
+                .push(entry);
         }
 
         Self { index, offline }
     }
 
-    /// Get the [`FlatDistributions`] for the given package name.
-    pub(crate) fn get(&self, package_name: &PackageName) -> Option<&FlatDistributions> {
-        self.index.get(package_name)
+    /// Get the unfiltered entries for the given package name.
+    pub(crate) fn get(&self, package_name: &PackageName) -> Option<&[FlatIndexEntry]> {
+        self.index.get(package_name).map(Vec::as_slice)
     }
 
     /// Whether any `--find-links` entries could not be resolved due to a lack of network
@@ -68,10 +62,10 @@ impl FlatIndex {
 pub struct FlatDistributions(BTreeMap<Version, PrioritizedDist>);
 
 impl FlatDistributions {
-    /// Collect all files from a `--find-links` target into a [`FlatIndex`].
+    /// Rank the entries for a package using the resolver's platform and hash policies.
     #[instrument(skip_all)]
     pub(crate) fn from_entries(
-        entries: Vec<FlatIndexEntry>,
+        entries: impl IntoIterator<Item = FlatIndexEntry>,
         tags: Option<&Tags>,
         hasher: &HashStrategy,
         build_options: &BuildOptions,

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -59,7 +59,7 @@ impl FlatIndex {
 /// A set of [`PrioritizedDist`] from a `--find-links` entry for a single package, indexed
 /// by [`Version`].
 #[derive(Debug, Clone, Default)]
-pub struct FlatDistributions(BTreeMap<Version, PrioritizedDist>);
+pub(crate) struct FlatDistributions(BTreeMap<Version, PrioritizedDist>);
 
 impl FlatDistributions {
     /// Rank the entries for a package using the resolver's platform and hash policies.
@@ -241,12 +241,5 @@ impl IntoIterator for FlatDistributions {
 impl From<FlatDistributions> for BTreeMap<Version, PrioritizedDist> {
     fn from(distributions: FlatDistributions) -> Self {
         distributions.0
-    }
-}
-
-/// For external users.
-impl From<BTreeMap<Version, PrioritizedDist>> for FlatDistributions {
-    fn from(distributions: BTreeMap<Version, PrioritizedDist>) -> Self {
-        Self(distributions)
     }
 }

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -5,7 +5,7 @@ pub use exclude_newer::{
     ExcludeNewerValueWithSpanRef, serialize_exclude_newer_package_with_spans,
 };
 pub use exclusions::Exclusions;
-pub use flat_index::{FlatDistributions, FlatIndex};
+pub use flat_index::FlatIndex;
 pub use fork_strategy::ForkStrategy;
 pub use lock::{
     CanonicalLockError, DependencySelection, Installable, InstallableRootKind, Lock, LockError,

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -17,7 +17,7 @@ use uv_static::EnvVars;
 use uv_types::{BuildContext, HashStrategy};
 
 use crate::ExcludeNewer;
-use crate::flat_index::FlatIndex;
+use crate::flat_index::{FlatDistributions, FlatIndex};
 use crate::version_map::VersionMap;
 use crate::yanks::AllowedYanks;
 
@@ -117,7 +117,7 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext> {
     /// The [`DistributionDatabase`] used to build source distributions.
     fetcher: DistributionDatabase<'a, Context>,
     /// These are the entries from `--find-links` that act as overrides for index responses.
-    flat_index: FlatIndex,
+    flat_index: &'a FlatIndex,
     tags: Option<Tags>,
     requires_python: RequiresPython,
     allowed_yanks: AllowedYanks,
@@ -145,7 +145,7 @@ impl<'a, Context: BuildContext> DefaultResolverProvider<'a, Context> {
     ) -> Self {
         Self {
             fetcher,
-            flat_index: flat_index.clone(),
+            flat_index,
             tags: tags.cloned(),
             requires_python: requires_python.clone(),
             allowed_yanks,
@@ -193,7 +193,17 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
             .await;
 
         // If a package is pinned to an explicit index, ignore any `--find-links` entries.
-        let flat_index = index.is_none().then_some(&self.flat_index);
+        let flat_index = index.is_none().then_some(self.flat_index);
+        let flat_distributions = flat_index
+            .and_then(|flat_index| flat_index.get(package_name))
+            .map(|entries| {
+                FlatDistributions::from_entries(
+                    entries.iter().cloned(),
+                    self.tags.as_ref(),
+                    &self.hasher,
+                    self.build_options,
+                )
+            });
 
         match result {
             Ok(results) => Ok(VersionsResponse::Found(
@@ -218,9 +228,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                                 self.hasher.clone(),
                                 included_version_cutoff,
                                 available_version_cutoff,
-                                flat_index
-                                    .and_then(|flat_index| flat_index.get(package_name))
-                                    .cloned(),
+                                flat_distributions.clone(),
                                 self.build_options,
                             ),
                             MetadataFormat::Flat(metadata) => VersionMap::from_flat_metadata(
@@ -235,20 +243,14 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
             )),
             Err(err) => match err.kind() {
                 uv_client::ErrorKind::RemotePackageNotFound(_) => {
-                    if let Some(flat_index) = flat_index
-                        .and_then(|flat_index| flat_index.get(package_name))
-                        .cloned()
-                    {
+                    if let Some(flat_index) = flat_distributions {
                         Ok(VersionsResponse::Found(vec![VersionMap::from(flat_index)]))
                     } else {
                         Ok(VersionsResponse::NotFound)
                     }
                 }
                 uv_client::ErrorKind::NoIndex(_) => {
-                    if let Some(flat_index) = flat_index
-                        .and_then(|flat_index| flat_index.get(package_name))
-                        .cloned()
-                    {
+                    if let Some(flat_index) = flat_distributions {
                         Ok(VersionsResponse::Found(vec![VersionMap::from(flat_index)]))
                     } else if flat_index.is_some_and(FlatIndex::offline) {
                         Ok(VersionsResponse::Offline)
@@ -257,10 +259,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                     }
                 }
                 uv_client::ErrorKind::Offline(_) => {
-                    if let Some(flat_index) = flat_index
-                        .and_then(|flat_index| flat_index.get(package_name))
-                        .cloned()
-                    {
+                    if let Some(flat_index) = flat_distributions {
                         Ok(VersionsResponse::Found(vec![VersionMap::from(flat_index)]))
                     } else {
                         Ok(VersionsResponse::Offline)

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -688,7 +688,7 @@ async fn build_package(
         let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
             .await?;
-        FlatIndex::from_entries(entries, None, &hasher, build_options)
+        FlatIndex::from_entries(entries)
     };
 
     // Initialize any shared state.

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -490,7 +490,7 @@ pub(crate) async fn pip_compile(
         let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
             .await?;
-        FlatIndex::from_entries(entries, tags.as_deref(), &hasher, &build_options)
+        FlatIndex::from_entries(entries)
     };
 
     // Determine whether to enable build isolation.

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -461,7 +461,7 @@ pub(crate) async fn pip_install(
         let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
             .await?;
-        FlatIndex::from_entries(entries, Some(&tags), &hasher, &build_options)
+        FlatIndex::from_entries(entries)
     };
 
     // Determine whether to enable build isolation.

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -332,7 +332,7 @@ pub(crate) async fn pip_sync(
         let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
             .await?;
-        FlatIndex::from_entries(entries, Some(&tags), &hasher, &build_options)
+        FlatIndex::from_entries(entries)
     };
 
     // Determine whether to enable build isolation.

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -428,7 +428,7 @@ pub(crate) async fn add(
                             .map(Index::url),
                     )
                     .await?;
-                FlatIndex::from_entries(entries, None, &hasher, &settings.resolver.build_options)
+                FlatIndex::from_entries(entries)
             };
 
             // Lower the extra build dependencies, if any.

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -855,14 +855,13 @@ async fn do_lock(
     let groups = BTreeMap::new();
 
     // Resolve the flat indexes from `--find-links`.
-    let flat_index_entries = {
+    let flat_index = {
         let client = FlatIndexClient::new(client.cached_client(), client.connectivity(), cache);
-        client
+        let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
-            .await?
+            .await?;
+        FlatIndex::from_entries(entries)
     };
-    let flat_index =
-        FlatIndex::from_entries(flat_index_entries.clone(), None, &hasher, build_options);
 
     // Lower the extra build dependencies.
     let extra_build_requires = match &target {
@@ -924,15 +923,7 @@ async fn do_lock(
 
     // If any of the resolution-determining settings changed, invalidate the lock.
     let existing_lock = if let Some(existing_lock) = existing_lock {
-        // Rank build dependencies using the same hashes that validation will enforce.
-        let locked_flat_index = FlatIndex::from_entries(
-            flat_index_entries,
-            None,
-            &locked_build_hasher,
-            build_options,
-        );
-        let validation_build_dispatch =
-            build_dispatch.fork(&locked_build_hasher, &locked_flat_index);
+        let validation_build_dispatch = build_dispatch.fork(&locked_build_hasher);
         let database = DistributionDatabase::new(
             &client,
             &validation_build_dispatch,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -2654,7 +2654,7 @@ pub(crate) async fn resolve_environment(
         let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
             .await?;
-        FlatIndex::from_entries(entries, tags.as_deref(), &hasher, build_options)
+        FlatIndex::from_entries(entries)
     };
 
     // Lower the extra build dependencies, if any.
@@ -2796,7 +2796,7 @@ pub(crate) async fn sync_environment(
         let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
             .await?;
-        FlatIndex::from_entries(entries, Some(tags), &hasher, build_options)
+        FlatIndex::from_entries(entries)
     };
 
     // Lower the extra build dependencies, if any.
@@ -3059,7 +3059,7 @@ pub(crate) async fn update_environment(
         let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
             .await?;
-        FlatIndex::from_entries(entries, Some(&tags), &hasher, build_options)
+        FlatIndex::from_entries(entries)
     };
 
     // Create a build dispatch.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -883,7 +883,7 @@ pub(crate) async fn do_sync<'a>(
         let entries = client
             .fetch_all(index_locations.flat_indexes().map(Index::url))
             .await?;
-        FlatIndex::from_entries(entries, Some(&tags), &build_hasher, build_options)
+        FlatIndex::from_entries(entries)
     };
 
     // Create a build dispatch.

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -471,7 +471,7 @@ impl ToolLock {
             let entries = client
                 .fetch_all(index_locations.flat_indexes().map(Index::url))
                 .await?;
-            FlatIndex::from_entries(entries, None, &hasher, build_options)
+            FlatIndex::from_entries(entries)
         };
 
         let extra_build_requires =

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -58,9 +58,6 @@ enum VenvError {
     #[error("Failed to install seed packages into virtual environment")]
     Seed(#[source] AnyErrorBuild),
 
-    #[error("Failed to extract interpreter tags for installing seed packages")]
-    Tags(#[source] uv_platform_tags::TagsError),
-
     #[error("Failed to resolve `--find-links` entry")]
     FlatIndex(#[source] uv_client::FlatIndexError),
 }
@@ -304,18 +301,12 @@ pub(crate) async fn venv(
 
         // Resolve the flat indexes from `--find-links`.
         let flat_index = {
-            let tags = interpreter.tags().map_err(VenvError::Tags)?;
             let client = FlatIndexClient::new(client.cached_client(), client.connectivity(), cache);
             let entries = client
                 .fetch_all(index_locations.flat_indexes().map(Index::url))
                 .await
                 .map_err(VenvError::FlatIndex)?;
-            FlatIndex::from_entries(
-                entries,
-                Some(tags),
-                &HashStrategy::default(),
-                &BuildOptions::new(NoBinary::None, NoBuild::All),
-            )
+            FlatIndex::from_entries(entries)
         };
 
         // Initialize any shared state.


### PR DESCRIPTION
`FlatIndex` currently ranks `--find-links` entries using the caller's hash policy, platform tags, and build options. Reusing that index in a build resolver requires callers to construct a separate index whenever those policies differ.

We now keep the raw entries in `FlatIndex` and rank each requested package inside `DefaultResolverProvider`. This lets build dispatches share an index and reduces `BuildDispatch::fork` to a hash-strategy argument.

Follow-up to #21223.
