### PR TITLE
Borrow hash strategies in lock setup and the resolver provider

### DIFF
--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -121,7 +121,7 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext> {
     tags: Option<Tags>,
     requires_python: RequiresPython,
     allowed_yanks: AllowedYanks,
-    hasher: HashStrategy,
+    hasher: &'a HashStrategy,
     exclude_newer: ExcludeNewer,
     available_version_cutoff: Option<jiff::Timestamp>,
     index_locations: &'a IndexLocations,
@@ -149,7 +149,7 @@ impl<'a, Context: BuildContext> DefaultResolverProvider<'a, Context> {
             tags: tags.cloned(),
             requires_python: requires_python.clone(),
             allowed_yanks,
-            hasher: hasher.clone(),
+            hasher,
             exclude_newer,
             available_version_cutoff: std::env::var(EnvVars::UV_TEST_AVAILABLE_VERSION_CUTOFF)
                 .ok()
@@ -200,7 +200,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                 FlatDistributions::from_entries(
                     entries.iter().cloned(),
                     self.tags.as_ref(),
-                    &self.hasher,
+                    self.hasher,
                     self.build_options,
                 )
             });
@@ -234,7 +234,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                             MetadataFormat::Flat(metadata) => VersionMap::from_flat_metadata(
                                 metadata,
                                 self.tags.as_ref(),
-                                &self.hasher,
+                                self.hasher,
                                 self.build_options,
                             ),
                         }

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -841,10 +841,9 @@ async fn do_lock(
     // A fresh resolution retains those hashes under `--locked`, but an explicitly unlocked update
     // must be able to replace them. Build dependencies follow the same choice without generating
     // hashes for artifacts absent from the lockfile.
-    let resolution_build_hasher = if matches!(mode, LockMode::Locked(..)) {
-        locked_build_hasher.clone()
-    } else {
-        HashStrategy::default()
+    let resolution_build_hasher = match mode {
+        LockMode::Locked(..) => &locked_build_hasher,
+        LockMode::Write(_) | LockMode::DryRun(_) | LockMode::Frozen(_) => &HashStrategy::default(),
     };
     let hasher = HashStrategy::generate(HashGeneration::Url)
         .with_verification(resolution_build_hasher.verification().clone());
@@ -912,7 +911,7 @@ async fn do_lock(
         extra_build_variables,
         *link_mode,
         build_options,
-        &resolution_build_hasher,
+        resolution_build_hasher,
         exclude_newer.clone(),
         sources.clone(),
         SourceTreeEditablePolicy::Project,


### PR DESCRIPTION
We borrow the selected build hash strategy in `do_lock` and the caller's strategy in `DefaultResolverProvider`, avoiding unnecessary strategy clones and hash-map reference-count updates. The resolver thread, lookahead results, and cached version maps retain owned policy snapshots.

Stacked on #21540. Follows up on https://github.com/astral-sh/uv/pull/21223#discussion_r3872300482.
