### PR TITLE
Separate metadata and archive hash policies

### DIFF
--- a/crates/uv-distribution-types/src/hash.rs
+++ b/crates/uv-distribution-types/src/hash.rs
@@ -107,7 +107,7 @@ impl ArchiveHashPolicy<'_> {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct MetadataHashPolicy<'a> {
     /// Which missing hashes to collect for the resolution.
-    pub collection: Option<HashCollection>,
+    pub collection: HashCollection,
     /// Expected hashes to validate before source builds. Wheel validation is deferred to installation.
     pub validation: HashValidation<'a>,
 }
@@ -137,8 +137,11 @@ impl<'a> From<HashValidation<'a>> for ArchiveHashPolicy<'a> {
 /// Which distributions should have hashes collected during resolution.
 ///
 /// Use index-provided hashes when available; otherwise, compute a SHA-256 hash from the archive.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum HashCollection {
+    /// Do not collect hashes during resolution.
+    #[default]
+    None,
     /// Supply hashes for non-registry distributions. Registry hashes come from index metadata.
     Url,
     /// Also compute missing registry hashes when the index metadata does not provide them.

--- a/crates/uv-distribution-types/src/hash.rs
+++ b/crates/uv-distribution-types/src/hash.rs
@@ -1,49 +1,34 @@
 use uv_pypi_types::{HashAlgorithm, HashDigest};
 
+/// Hash requirements for an archive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HashPolicy<'a> {
-    /// No hash policy is specified.
+pub enum ArchiveHashRequest<'a> {
+    /// No hash requirements.
     None,
-    /// Hashes should be generated (specifically, a SHA-256 hash), but not validated.
-    Generate(HashGeneration),
-    /// Hashes should be validated against a pre-defined list of hashes, and any matching digest is
-    /// sufficient. If necessary, hashes should be generated so as to ensure that the archive is
-    /// valid.
+    /// Generate a SHA-256 hash without validation.
+    Generate,
+    /// Require at least one expected hash to match.
     Any(&'a [HashDigest]),
-    /// Hashes should be validated against a pre-defined list of hashes, and every digest must
-    /// match. If necessary, hashes should be generated so as to ensure that the archive is valid.
+    /// Require every expected hash to match. An empty list rejects all archives.
     All(&'a [HashDigest]),
 }
 
-impl HashPolicy<'_> {
-    /// Returns `true` if the hash policy is `None`.
+impl ArchiveHashRequest<'_> {
+    /// Returns `true` if the hash request is `None`.
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
     }
 
-    /// Returns `true` if the hash policy is `Any` or `All`.
+    /// Returns `true` if the hash request is `Any` or `All`.
     pub fn requires_validation(&self) -> bool {
         matches!(self, Self::Any(_) | Self::All(_))
     }
 
-    /// Returns `true` if the hash policy indicates that hashes should be generated.
-    pub fn is_generate(&self, dist: &crate::BuiltDist) -> bool {
-        match self {
-            Self::Generate(HashGeneration::Url) => dist.file().is_none(),
-            Self::Generate(HashGeneration::All) => {
-                dist.file().is_none_or(|file| file.hashes.is_empty())
-            }
-            Self::Any(_) => false,
-            Self::All(_) => false,
-            Self::None => false,
-        }
-    }
-
-    /// Return the algorithms used in the hash policy.
+    /// Return the algorithms used in the hash request.
     pub fn algorithms(&self) -> Vec<HashAlgorithm> {
         match self {
             Self::None => vec![],
-            Self::Generate(_) => vec![HashAlgorithm::Sha256],
+            Self::Generate => vec![HashAlgorithm::Sha256],
             Self::Any(hashes) | Self::All(hashes) => {
                 let mut algorithms = hashes.iter().map(HashDigest::algorithm).collect::<Vec<_>>();
                 algorithms.sort();
@@ -53,20 +38,20 @@ impl HashPolicy<'_> {
         }
     }
 
-    /// Return the digests used in the hash policy.
+    /// Return the digests used in the hash request.
     pub fn digests(&self) -> &[HashDigest] {
         match self {
             Self::None => &[],
-            Self::Generate(_) => &[],
+            Self::Generate => &[],
             Self::Any(hashes) | Self::All(hashes) => hashes,
         }
     }
 
-    /// Returns `true` if the given hashes satisfy the policy.
+    /// Returns `true` if the given hashes satisfy the request.
     pub fn matches(&self, hashes: &[HashDigest]) -> bool {
         match self {
             Self::None => true,
-            Self::Generate(_) => hashes
+            Self::Generate => hashes
                 .iter()
                 .any(|hash| hash.algorithm == HashAlgorithm::Sha256),
             Self::Any(required) => {
@@ -78,11 +63,11 @@ impl HashPolicy<'_> {
         }
     }
 
-    /// Returns `true` if the given hashes include the algorithms required by the policy.
+    /// Returns `true` if the given hashes include the algorithms required by the request.
     fn has_required_algorithms(&self, hashes: &[HashDigest]) -> bool {
         match self {
             Self::None => true,
-            Self::Generate(_) => hashes
+            Self::Generate => hashes
                 .iter()
                 .any(|hash| hash.algorithm == HashAlgorithm::Sha256),
             Self::Any(required) => {
@@ -103,13 +88,57 @@ impl HashPolicy<'_> {
     }
 }
 
-/// The context in which hashes should be generated.
+/// Archive hashes to collect or validate when fetching distribution metadata.
+///
+/// For example, `uv pip compile --generate-hashes` requests [`HashCollection::All`] with
+/// [`HashValidation::None`]:
+///
+/// - If the index provides a wheel's hash, metadata lookup uses [`ArchiveHashRequest::None`].
+///   The resolver can record the index-provided hash without hashing the wheel.
+/// - If the index provides no hashes, metadata lookup uses [`ArchiveHashRequest::Generate`]
+///   to obtain a SHA-256 hash of the wheel.
+///
+/// If source metadata requires a build and `validation` contains expected hashes, the fetcher
+/// instead uses [`ArchiveHashRequest::Any`] or [`ArchiveHashRequest::All`] to check the archive
+/// before running the backend. Those expected hashes take precedence over collection.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct MetadataHashRequest<'a> {
+    /// Which missing hashes to collect for the resolution.
+    pub collection: Option<HashCollection>,
+    /// Expected hashes to validate before source builds. Wheel validation is deferred to installation.
+    pub validation: HashValidation<'a>,
+}
+
+/// Expected digests for an archive, without requesting hash generation.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum HashValidation<'a> {
+    /// No expected digests are specified.
+    #[default]
+    None,
+    /// Require at least one expected digest to match.
+    Any(&'a [HashDigest]),
+    /// Require every expected digest to match. An empty slice rejects all archives.
+    All(&'a [HashDigest]),
+}
+
+impl<'a> From<HashValidation<'a>> for ArchiveHashRequest<'a> {
+    fn from(validation: HashValidation<'a>) -> Self {
+        match validation {
+            HashValidation::None => Self::None,
+            HashValidation::Any(hashes) => Self::Any(hashes),
+            HashValidation::All(hashes) => Self::All(hashes),
+        }
+    }
+}
+
+/// Which distributions should have hashes collected during resolution.
+///
+/// Use index-provided hashes when available; otherwise, compute a SHA-256 hash from the archive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HashGeneration {
-    /// Generate hashes for direct URL distributions.
+pub enum HashCollection {
+    /// Supply hashes for non-registry distributions. Registry hashes come from index metadata.
     Url,
-    /// Generate hashes for direct URL distributions, along with any distributions that are hosted
-    /// on a registry that does _not_ provide hashes.
+    /// Also compute missing registry hashes when the index metadata does not provide them.
     All,
 }
 
@@ -117,13 +146,13 @@ pub trait Hashed {
     /// Return the [`HashDigest`]s for the archive.
     fn hashes(&self) -> &[HashDigest];
 
-    /// Returns `true` if the archive satisfies the given hash policy.
-    fn satisfies(&self, hashes: HashPolicy) -> bool {
+    /// Returns `true` if the archive satisfies the given hash request.
+    fn satisfies(&self, hashes: ArchiveHashRequest) -> bool {
         hashes.matches(self.hashes())
     }
 
-    /// Returns `true` if the archive includes the algorithms required by the given hash policy.
-    fn has_digests(&self, hashes: HashPolicy) -> bool {
+    /// Returns `true` if the archive includes the algorithms required by the given hash request.
+    fn has_digests(&self, hashes: ArchiveHashRequest) -> bool {
         hashes.has_required_algorithms(self.hashes())
     }
 }
@@ -146,7 +175,7 @@ mod tests {
 
     use uv_pypi_types::HashDigest;
 
-    use super::HashPolicy;
+    use super::ArchiveHashRequest;
 
     #[test]
     fn validate_all_requires_every_digest() {
@@ -163,10 +192,10 @@ mod tests {
         )
         .unwrap();
 
-        let policy = HashPolicy::All(&[sha256.clone(), sha512.clone()]);
-        assert!(policy.matches(&[sha256.clone(), sha512]));
-        assert!(!policy.matches(std::slice::from_ref(&sha256)));
-        assert!(!policy.matches(&[sha256, wrong_sha512]));
+        let request = ArchiveHashRequest::All(&[sha256.clone(), sha512.clone()]);
+        assert!(request.matches(&[sha256.clone(), sha512]));
+        assert!(!request.matches(std::slice::from_ref(&sha256)));
+        assert!(!request.matches(&[sha256, wrong_sha512]));
     }
 
     #[test]
@@ -184,8 +213,8 @@ mod tests {
         )
         .unwrap();
 
-        let policy = HashPolicy::Any(&[sha256.clone(), sha512]);
-        assert!(policy.matches(&[sha256]));
-        assert!(!policy.matches(&[wrong_sha512]));
+        let request = ArchiveHashRequest::Any(&[sha256.clone(), sha512]);
+        assert!(request.matches(&[sha256]));
+        assert!(!request.matches(&[wrong_sha512]));
     }
 }

--- a/crates/uv-distribution-types/src/hash.rs
+++ b/crates/uv-distribution-types/src/hash.rs
@@ -1,30 +1,33 @@
 use uv_pypi_types::{HashAlgorithm, HashDigest};
 
-/// Hash requirements for an archive.
+/// Hash generation and validation policy for an archive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArchiveHashRequest<'a> {
-    /// No hash requirements.
+pub enum ArchiveHashPolicy<'a> {
+    /// No hash policy is specified.
     None,
-    /// Generate a SHA-256 hash without validation.
+    /// Hashes should be generated (specifically, a SHA-256 hash), but not validated.
     Generate,
-    /// Require at least one expected hash to match.
+    /// Hashes should be validated against a pre-defined list of hashes, and any matching digest is
+    /// sufficient. If necessary, hashes should be generated so as to ensure that the archive is
+    /// valid.
     Any(&'a [HashDigest]),
-    /// Require every expected hash to match. An empty list rejects all archives.
+    /// Hashes should be validated against a pre-defined list of hashes, and every digest must
+    /// match. If necessary, hashes should be generated so as to ensure that the archive is valid.
     All(&'a [HashDigest]),
 }
 
-impl ArchiveHashRequest<'_> {
-    /// Returns `true` if the hash request is `None`.
+impl ArchiveHashPolicy<'_> {
+    /// Returns `true` if the hash policy is `None`.
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
     }
 
-    /// Returns `true` if the hash request is `Any` or `All`.
+    /// Returns `true` if the hash policy is `Any` or `All`.
     pub fn requires_validation(&self) -> bool {
         matches!(self, Self::Any(_) | Self::All(_))
     }
 
-    /// Return the algorithms used in the hash request.
+    /// Return the algorithms used in the hash policy.
     pub fn algorithms(&self) -> Vec<HashAlgorithm> {
         match self {
             Self::None => vec![],
@@ -38,7 +41,7 @@ impl ArchiveHashRequest<'_> {
         }
     }
 
-    /// Return the digests used in the hash request.
+    /// Return the digests used in the hash policy.
     pub fn digests(&self) -> &[HashDigest] {
         match self {
             Self::None => &[],
@@ -47,7 +50,7 @@ impl ArchiveHashRequest<'_> {
         }
     }
 
-    /// Returns `true` if the given hashes satisfy the request.
+    /// Returns `true` if the given hashes satisfy the policy.
     pub fn matches(&self, hashes: &[HashDigest]) -> bool {
         match self {
             Self::None => true,
@@ -63,7 +66,7 @@ impl ArchiveHashRequest<'_> {
         }
     }
 
-    /// Returns `true` if the given hashes include the algorithms required by the request.
+    /// Returns `true` if the given hashes include the algorithms required by the policy.
     fn has_required_algorithms(&self, hashes: &[HashDigest]) -> bool {
         match self {
             Self::None => true,
@@ -93,23 +96,23 @@ impl ArchiveHashRequest<'_> {
 /// For example, `uv pip compile --generate-hashes` requests [`HashCollection::All`] with
 /// [`HashValidation::None`]:
 ///
-/// - If the index provides a wheel's hash, metadata lookup uses [`ArchiveHashRequest::None`].
+/// - If the index provides a wheel's hash, metadata lookup uses [`ArchiveHashPolicy::None`].
 ///   The resolver can record the index-provided hash without hashing the wheel.
-/// - If the index provides no hashes, metadata lookup uses [`ArchiveHashRequest::Generate`]
+/// - If the index provides no hashes, metadata lookup uses [`ArchiveHashPolicy::Generate`]
 ///   to obtain a SHA-256 hash of the wheel.
 ///
 /// If source metadata requires a build and `validation` contains expected hashes, the fetcher
-/// instead uses [`ArchiveHashRequest::Any`] or [`ArchiveHashRequest::All`] to check the archive
+/// instead uses [`ArchiveHashPolicy::Any`] or [`ArchiveHashPolicy::All`] to check the archive
 /// before running the backend. Those expected hashes take precedence over collection.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct MetadataHashRequest<'a> {
+pub struct MetadataHashPolicy<'a> {
     /// Which missing hashes to collect for the resolution.
     pub collection: Option<HashCollection>,
     /// Expected hashes to validate before source builds. Wheel validation is deferred to installation.
     pub validation: HashValidation<'a>,
 }
 
-/// Expected digests for an archive, without requesting hash generation.
+/// Expected digests to validate against an archive.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum HashValidation<'a> {
     /// No expected digests are specified.
@@ -121,7 +124,7 @@ pub enum HashValidation<'a> {
     All(&'a [HashDigest]),
 }
 
-impl<'a> From<HashValidation<'a>> for ArchiveHashRequest<'a> {
+impl<'a> From<HashValidation<'a>> for ArchiveHashPolicy<'a> {
     fn from(validation: HashValidation<'a>) -> Self {
         match validation {
             HashValidation::None => Self::None,
@@ -146,13 +149,13 @@ pub trait Hashed {
     /// Return the [`HashDigest`]s for the archive.
     fn hashes(&self) -> &[HashDigest];
 
-    /// Returns `true` if the archive satisfies the given hash request.
-    fn satisfies(&self, hashes: ArchiveHashRequest) -> bool {
+    /// Returns `true` if the archive satisfies the given hash policy.
+    fn satisfies(&self, hashes: ArchiveHashPolicy) -> bool {
         hashes.matches(self.hashes())
     }
 
-    /// Returns `true` if the archive includes the algorithms required by the given hash request.
-    fn has_digests(&self, hashes: ArchiveHashRequest) -> bool {
+    /// Returns `true` if the archive includes the algorithms required by the given hash policy.
+    fn has_digests(&self, hashes: ArchiveHashPolicy) -> bool {
         hashes.has_required_algorithms(self.hashes())
     }
 }
@@ -175,7 +178,7 @@ mod tests {
 
     use uv_pypi_types::HashDigest;
 
-    use super::ArchiveHashRequest;
+    use super::ArchiveHashPolicy;
 
     #[test]
     fn validate_all_requires_every_digest() {
@@ -192,10 +195,10 @@ mod tests {
         )
         .unwrap();
 
-        let request = ArchiveHashRequest::All(&[sha256.clone(), sha512.clone()]);
-        assert!(request.matches(&[sha256.clone(), sha512]));
-        assert!(!request.matches(std::slice::from_ref(&sha256)));
-        assert!(!request.matches(&[sha256, wrong_sha512]));
+        let policy = ArchiveHashPolicy::All(&[sha256.clone(), sha512.clone()]);
+        assert!(policy.matches(&[sha256.clone(), sha512]));
+        assert!(!policy.matches(std::slice::from_ref(&sha256)));
+        assert!(!policy.matches(&[sha256, wrong_sha512]));
     }
 
     #[test]
@@ -213,8 +216,8 @@ mod tests {
         )
         .unwrap();
 
-        let request = ArchiveHashRequest::Any(&[sha256.clone(), sha512]);
-        assert!(request.matches(&[sha256]));
-        assert!(!request.matches(&[wrong_sha512]));
+        let policy = ArchiveHashPolicy::Any(&[sha256.clone(), sha512]);
+        assert!(policy.matches(&[sha256]));
+        assert!(!policy.matches(&[wrong_sha512]));
     }
 }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -193,8 +193,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
     /// Retrieve distribution metadata and any hashes requested for resolution.
     ///
-    /// Source archives are validated before executing build backends; wheel validation is deferred
-    /// to installation.
+    /// Source archive hashes are validated before executing build backends; wheel archive hash
+    /// validation is deferred to installation.
     #[instrument(skip_all, fields(%dist))]
     pub async fn get_or_build_wheel_metadata(
         &self,
@@ -535,8 +535,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
     /// Fetch wheel metadata, along with any hashes requested for resolution.
     ///
-    /// Hash-checking is _not_ enforced here; callers must enforce it when retrieving the wheel for
-    /// installation.
+    /// Wheel archive hash validation is deferred to installation. Metadata sidecar hashes are
+    /// checked by the client when downloading sidecars with index-provided hashes.
     async fn get_wheel_metadata(
         &self,
         dist: &BuiltDist,
@@ -548,7 +548,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     HashCollection::None => false,
                     HashCollection::Url | HashCollection::All => match dist {
                         BuiltDist::Registry(dist) => {
-                            // Preserve the fallback for indexes and `--find-links` without hashes.
+                            // Generate missing hashes for indexes and `--find-links` without hashes.
                             // This hashes only the selected wheel, not every distribution for the version.
                             hashes.collection == HashCollection::All
                                 && dist.best_wheel().file.hashes.is_empty()

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -24,8 +24,8 @@ use uv_client::{
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
-    BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, HashPolicy, Hashed, IndexUrl,
-    InstalledDist, Name, SourceDist,
+    ArchiveHashRequest, BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, HashCollection,
+    HashValidation, Hashed, IndexUrl, InstalledDist, MetadataHashRequest, Name, SourceDist,
 };
 use uv_extract::dirhash::{DirectoryDigest, HashedFile};
 use uv_extract::hash::Hasher;
@@ -157,7 +157,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         &self,
         dist: &Dist,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<LocalWheel, Error> {
         match dist {
             Dist::Built(built) => self.get_wheel(built, hashes).await,
@@ -191,16 +191,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         Ok(ArchiveMetadata::from_metadata23(metadata.clone()))
     }
 
-    /// Either fetch the only wheel metadata (directly from the index or with range requests) or
-    /// fetch and build the source distribution.
+    /// Retrieve distribution metadata and any hashes requested for resolution.
     ///
-    /// While hashes will be generated in some cases, hash-checking is only enforced for source
-    /// distributions, and should be enforced by the caller for wheels.
+    /// Source archives are validated before executing build backends; wheel validation is deferred
+    /// to installation.
     #[instrument(skip_all, fields(%dist))]
     pub async fn get_or_build_wheel_metadata(
         &self,
         dist: &Dist,
-        hashes: HashPolicy<'_>,
+        hashes: MetadataHashRequest<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         match dist {
             Dist::Built(built) => self.get_wheel_metadata(built, hashes).await,
@@ -218,7 +217,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     async fn get_wheel(
         &self,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<LocalWheel, Error> {
         match dist {
             BuiltDist::Registry(wheels) => {
@@ -451,7 +450,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         &self,
         dist: &SourceDist,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<LocalWheel, Error> {
         let built_wheel = self
             .builder
@@ -534,31 +533,39 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         })
     }
 
-    /// Fetch the wheel metadata from the index, or from the cache if possible.
+    /// Fetch wheel metadata, along with any hashes requested for resolution.
     ///
-    /// While hashes will be generated in some cases, hash-checking is _not_ enforced and should
-    /// instead be enforced by the caller.
+    /// Hash-checking is _not_ enforced here; callers must enforce it when retrieving the wheel for
+    /// installation.
     async fn get_wheel_metadata(
         &self,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: MetadataHashRequest<'_>,
     ) -> Result<ArchiveMetadata, Error> {
-        // If hash generation is enabled, and the distribution isn't hosted on a registry, get the
-        // entire wheel to ensure that the hashes are included in the response. If the distribution
-        // is hosted on an index, the hashes will be included in the simple metadata response.
-        // For hash _validation_, callers are expected to enforce the policy when retrieving the
-        // wheel.
-        //
-        // Historically, for `uv pip compile --universal`, we also generate hashes for
-        // registry-based distributions when the relevant registry doesn't provide them. This was
-        // motivated by `--find-links`. We continue that behavior (under `HashGeneration::All`) for
-        // backwards compatibility, but it's a little dubious, since we're only hashing _one_
-        // distribution here (as opposed to hashing all distributions for the version), and it may
-        // not even be a compatible distribution!
-        //
+        let hash_request = match hashes.validation {
+            HashValidation::None => {
+                let compute_hashes = hashes.collection.is_some_and(|collection| match dist {
+                    BuiltDist::Registry(dist) => {
+                        // Preserve the fallback for indexes and `--find-links` without hashes.
+                        // This hashes only the selected wheel, not every distribution for the version.
+                        collection == HashCollection::All
+                            && dist.best_wheel().file.hashes.is_empty()
+                    }
+                    BuiltDist::DirectUrl(_) | BuiltDist::Path(_) | BuiltDist::GitPath(_) => true,
+                });
+                if compute_hashes {
+                    ArchiveHashRequest::Generate
+                } else {
+                    ArchiveHashRequest::None
+                }
+            }
+            HashValidation::Any(_) | HashValidation::All(_) => hashes.validation.into(),
+        };
+
+        // Fetch the entire wheel only when we need to compute a hash for resolution.
         // TODO(charlie): Request the hashes via a separate method, to reduce the coupling in this API.
-        if hashes.is_generate(dist) {
-            let wheel = self.get_wheel(dist, hashes).await?;
+        if hash_request == ArchiveHashRequest::Generate {
+            let wheel = self.get_wheel(dist, hash_request).await?;
             // If the metadata was provided by the user directly, prefer it.
             let metadata = if let Some(metadata) = self
                 .build_context
@@ -611,7 +618,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 // If the request failed due to an error that could be resolved by
                 // downloading the wheel directly, try that.
-                let wheel = self.get_wheel(dist, hashes).await?;
+                let wheel = self.get_wheel(dist, hash_request).await?;
                 let metadata = wheel.metadata()?;
                 let hashes = wheel.hashes;
                 Ok(ArchiveMetadata {
@@ -625,12 +632,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
     /// Build the wheel metadata for a source distribution, or fetch it from the cache if possible.
     ///
-    /// The returned metadata is guaranteed to come from a distribution with a matching hash, and
-    /// no build processes will be executed for distributions with mismatched hashes.
+    /// Requested hashes are validated before executing a build backend. User-provided metadata
+    /// can avoid downloading or validating the source archive.
     pub async fn build_wheel_metadata(
         &self,
         source: &BuildableSource<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: MetadataHashRequest<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         // If the metadata was provided by the user directly, prefer it.
         if let Some(dist) = source.as_dist() {
@@ -647,9 +654,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             }
         }
 
+        let build_hash_request = match hashes.validation {
+            HashValidation::None => hashes
+                .collection
+                .map_or(ArchiveHashRequest::None, |_| ArchiveHashRequest::Generate),
+            HashValidation::Any(_) | HashValidation::All(_) => hashes.validation.into(),
+        };
         let metadata = self
             .builder
-            .download_and_build_metadata(source, hashes, &self.client)
+            .download_and_build_metadata(source, build_hash_request, &self.client)
             .boxed_local()
             .await?;
 
@@ -680,7 +693,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<Archive, Error> {
         let expected_size = match dist {
             BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
@@ -860,7 +873,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<Archive, Error> {
         let expected_size = match dist {
             BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
@@ -1058,7 +1071,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         filename: &WheelFilename,
         wheel_entry: CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<LocalWheel, Error> {
         // Acquire an advisory lock, to guard against concurrent writes.
         let _lock = Self::lock_wheel(&wheel_entry, filename).await?;

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -544,15 +544,20 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     ) -> Result<ArchiveMetadata, Error> {
         let hash_policy = match hashes.validation {
             HashValidation::None => {
-                let compute_hashes = hashes.collection.is_some_and(|collection| match dist {
-                    BuiltDist::Registry(dist) => {
-                        // Preserve the fallback for indexes and `--find-links` without hashes.
-                        // This hashes only the selected wheel, not every distribution for the version.
-                        collection == HashCollection::All
-                            && dist.best_wheel().file.hashes.is_empty()
-                    }
-                    BuiltDist::DirectUrl(_) | BuiltDist::Path(_) | BuiltDist::GitPath(_) => true,
-                });
+                let compute_hashes = match hashes.collection {
+                    HashCollection::None => false,
+                    HashCollection::Url | HashCollection::All => match dist {
+                        BuiltDist::Registry(dist) => {
+                            // Preserve the fallback for indexes and `--find-links` without hashes.
+                            // This hashes only the selected wheel, not every distribution for the version.
+                            hashes.collection == HashCollection::All
+                                && dist.best_wheel().file.hashes.is_empty()
+                        }
+                        BuiltDist::DirectUrl(_) | BuiltDist::Path(_) | BuiltDist::GitPath(_) => {
+                            true
+                        }
+                    },
+                };
                 if compute_hashes {
                     ArchiveHashPolicy::Generate
                 } else {
@@ -655,9 +660,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         }
 
         let build_hash_policy = match hashes.validation {
-            HashValidation::None => hashes
-                .collection
-                .map_or(ArchiveHashPolicy::None, |_| ArchiveHashPolicy::Generate),
+            HashValidation::None => match hashes.collection {
+                HashCollection::None => ArchiveHashPolicy::None,
+                HashCollection::Url | HashCollection::All => ArchiveHashPolicy::Generate,
+            },
             HashValidation::Any(_) | HashValidation::All(_) => hashes.validation.into(),
         };
         let metadata = self

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -24,8 +24,8 @@ use uv_client::{
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
-    ArchiveHashRequest, BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, HashCollection,
-    HashValidation, Hashed, IndexUrl, InstalledDist, MetadataHashRequest, Name, SourceDist,
+    ArchiveHashPolicy, BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, HashCollection,
+    HashValidation, Hashed, IndexUrl, InstalledDist, MetadataHashPolicy, Name, SourceDist,
 };
 use uv_extract::dirhash::{DirectoryDigest, HashedFile};
 use uv_extract::hash::Hasher;
@@ -157,7 +157,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         &self,
         dist: &Dist,
         tags: &Tags,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         match dist {
             Dist::Built(built) => self.get_wheel(built, hashes).await,
@@ -199,7 +199,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     pub async fn get_or_build_wheel_metadata(
         &self,
         dist: &Dist,
-        hashes: MetadataHashRequest<'_>,
+        hashes: MetadataHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         match dist {
             Dist::Built(built) => self.get_wheel_metadata(built, hashes).await,
@@ -217,7 +217,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     async fn get_wheel(
         &self,
         dist: &BuiltDist,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         match dist {
             BuiltDist::Registry(wheels) => {
@@ -450,7 +450,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         &self,
         dist: &SourceDist,
         tags: &Tags,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         let built_wheel = self
             .builder
@@ -540,9 +540,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     async fn get_wheel_metadata(
         &self,
         dist: &BuiltDist,
-        hashes: MetadataHashRequest<'_>,
+        hashes: MetadataHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
-        let hash_request = match hashes.validation {
+        let hash_policy = match hashes.validation {
             HashValidation::None => {
                 let compute_hashes = hashes.collection.is_some_and(|collection| match dist {
                     BuiltDist::Registry(dist) => {
@@ -554,9 +554,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     BuiltDist::DirectUrl(_) | BuiltDist::Path(_) | BuiltDist::GitPath(_) => true,
                 });
                 if compute_hashes {
-                    ArchiveHashRequest::Generate
+                    ArchiveHashPolicy::Generate
                 } else {
-                    ArchiveHashRequest::None
+                    ArchiveHashPolicy::None
                 }
             }
             HashValidation::Any(_) | HashValidation::All(_) => hashes.validation.into(),
@@ -564,8 +564,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // Fetch the entire wheel only when we need to compute a hash for resolution.
         // TODO(charlie): Request the hashes via a separate method, to reduce the coupling in this API.
-        if hash_request == ArchiveHashRequest::Generate {
-            let wheel = self.get_wheel(dist, hash_request).await?;
+        if hash_policy == ArchiveHashPolicy::Generate {
+            let wheel = self.get_wheel(dist, hash_policy).await?;
             // If the metadata was provided by the user directly, prefer it.
             let metadata = if let Some(metadata) = self
                 .build_context
@@ -618,7 +618,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 // If the request failed due to an error that could be resolved by
                 // downloading the wheel directly, try that.
-                let wheel = self.get_wheel(dist, hash_request).await?;
+                let wheel = self.get_wheel(dist, hash_policy).await?;
                 let metadata = wheel.metadata()?;
                 let hashes = wheel.hashes;
                 Ok(ArchiveMetadata {
@@ -637,7 +637,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     pub async fn build_wheel_metadata(
         &self,
         source: &BuildableSource<'_>,
-        hashes: MetadataHashRequest<'_>,
+        hashes: MetadataHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         // If the metadata was provided by the user directly, prefer it.
         if let Some(dist) = source.as_dist() {
@@ -654,15 +654,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             }
         }
 
-        let build_hash_request = match hashes.validation {
+        let build_hash_policy = match hashes.validation {
             HashValidation::None => hashes
                 .collection
-                .map_or(ArchiveHashRequest::None, |_| ArchiveHashRequest::Generate),
+                .map_or(ArchiveHashPolicy::None, |_| ArchiveHashPolicy::Generate),
             HashValidation::Any(_) | HashValidation::All(_) => hashes.validation.into(),
         };
         let metadata = self
             .builder
-            .download_and_build_metadata(source, build_hash_request, &self.client)
+            .download_and_build_metadata(source, build_hash_policy, &self.client)
             .boxed_local()
             .await?;
 
@@ -693,7 +693,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<Archive, Error> {
         let expected_size = match dist {
             BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
@@ -873,7 +873,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<Archive, Error> {
         let expected_size = match dist {
             BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
@@ -1071,7 +1071,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         filename: &WheelFilename,
         wheel_entry: CacheEntry,
         dist: &BuiltDist,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
         // Acquire an advisory lock, to guard against concurrent writes.
         let _lock = Self::lock_wheel(&wheel_entry, filename).await?;

--- a/crates/uv-distribution/src/hash.rs
+++ b/crates/uv-distribution/src/hash.rs
@@ -1,8 +1,8 @@
-use uv_distribution_types::HashPolicy;
+use uv_distribution_types::ArchiveHashRequest;
 use uv_pypi_types::HashAlgorithm;
 
 /// Return the algorithms to compute for an HTTP distribution.
-pub(crate) fn http_hash_algorithms(hashes: HashPolicy<'_>) -> Vec<HashAlgorithm> {
+pub(crate) fn http_hash_algorithms(hashes: ArchiveHashRequest<'_>) -> Vec<HashAlgorithm> {
     let mut algorithms = hashes.algorithms();
     algorithms.push(HashAlgorithm::Sha256);
     algorithms.sort();

--- a/crates/uv-distribution/src/hash.rs
+++ b/crates/uv-distribution/src/hash.rs
@@ -1,8 +1,8 @@
-use uv_distribution_types::ArchiveHashRequest;
+use uv_distribution_types::ArchiveHashPolicy;
 use uv_pypi_types::HashAlgorithm;
 
 /// Return the algorithms to compute for an HTTP distribution.
-pub(crate) fn http_hash_algorithms(hashes: ArchiveHashRequest<'_>) -> Vec<HashAlgorithm> {
+pub(crate) fn http_hash_algorithms(hashes: ArchiveHashPolicy<'_>) -> Vec<HashAlgorithm> {
     let mut algorithms = hashes.algorithms();
     algorithms.push(HashAlgorithm::Sha256);
     algorithms.sort();

--- a/crates/uv-distribution/src/index/built_wheel_index.rs
+++ b/crates/uv-distribution/src/index/built_wheel_index.rs
@@ -72,7 +72,7 @@ impl<'a> BuiltWheelIndex<'a> {
 
         // Enforce hash-checking by omitting any wheels that don't satisfy the required hashes.
         let revision = pointer.into_revision();
-        if !revision.satisfies(self.hasher.get(source_dist)) {
+        if !revision.satisfies(self.hasher.archive_policy(source_dist)) {
             return Ok(None);
         }
 
@@ -124,7 +124,7 @@ impl<'a> BuiltWheelIndex<'a> {
 
         // Enforce hash-checking by omitting any wheels that don't satisfy the required hashes.
         let revision = pointer.into_revision();
-        if !revision.satisfies(self.hasher.get(source_dist)) {
+        if !revision.satisfies(self.hasher.archive_policy(source_dist)) {
             return Ok(None);
         }
 
@@ -178,7 +178,7 @@ impl<'a> BuiltWheelIndex<'a> {
 
         // Enforce hash-checking by omitting any wheels that don't satisfy the required hashes.
         let revision = pointer.into_revision();
-        if !revision.satisfies(self.hasher.get(source_dist)) {
+        if !revision.satisfies(self.hasher.archive_policy(source_dist)) {
             return Ok(None);
         }
 
@@ -206,7 +206,11 @@ impl<'a> BuiltWheelIndex<'a> {
     /// Return the most compatible [`CachedWheel`] for a given source distribution at a git URL.
     pub fn git_directory(&self, source_dist: &GitDirectorySourceDist) -> Option<CachedWheel> {
         // Enforce hash-checking, which isn't supported for Git distributions.
-        if self.hasher.get(source_dist).requires_validation() {
+        if self
+            .hasher
+            .archive_policy(source_dist)
+            .requires_validation()
+        {
             return None;
         }
 
@@ -258,7 +262,7 @@ impl<'a> BuiltWheelIndex<'a> {
         };
 
         // Enforce hash-checking by omitting any wheels that don't satisfy the required hashes.
-        if !revision.satisfies(self.hasher.get(source_dist)) {
+        if !revision.satisfies(self.hasher.archive_policy(source_dist)) {
             return Ok(None);
         }
 

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -224,12 +224,10 @@ impl<'a> RegistryWheelIndex<'a> {
                             {
                                 if wheel.filename.compatibility(tags).is_compatible() {
                                     // Enforce hash-checking based on the built distribution.
-                                    if wheel.satisfies(
-                                        hasher.get_package(
-                                            &wheel.filename.name,
-                                            &wheel.filename.version,
-                                        ),
-                                    ) {
+                                    if wheel.satisfies(hasher.archive_policy_for_package(
+                                        &wheel.filename.name,
+                                        &wheel.filename.version,
+                                    )) {
                                         entries.push(IndexEntry {
                                             dist: wheel.into_registry_dist(),
                                             index,
@@ -251,12 +249,10 @@ impl<'a> RegistryWheelIndex<'a> {
                             {
                                 if wheel.filename.compatibility(tags).is_compatible() {
                                     // Enforce hash-checking based on the built distribution.
-                                    if wheel.satisfies(
-                                        hasher.get_package(
-                                            &wheel.filename.name,
-                                            &wheel.filename.version,
-                                        ),
-                                    ) {
+                                    if wheel.satisfies(hasher.archive_policy_for_package(
+                                        &wheel.filename.name,
+                                        &wheel.filename.version,
+                                    )) {
                                         entries.push(IndexEntry {
                                             dist: wheel.into_registry_dist(),
                                             index,
@@ -338,10 +334,10 @@ impl<'a> RegistryWheelIndex<'a> {
                         if let Some(wheel) = ResolvedWheel::from_built_source(wheel_dir, cache) {
                             if wheel.filename.compatibility(tags).is_compatible() {
                                 // Enforce hash-checking based on the source distribution.
-                                if revision.satisfies(
-                                    hasher
-                                        .get_package(&wheel.filename.name, &wheel.filename.version),
-                                ) {
+                                if revision.satisfies(hasher.archive_policy_for_package(
+                                    &wheel.filename.name,
+                                    &wheel.filename.version,
+                                )) {
                                     let wheel = CachedWheel::from_entry(
                                         wheel,
                                         revision.hashes().into(),

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -31,7 +31,7 @@ use uv_client::{
 use uv_configuration::{BuildKind, BuildOutput, NoSources};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::{
-    ArchiveHashRequest, BuildInfo, BuildVariables, BuildableSource, ConfigSettings,
+    ArchiveHashPolicy, BuildInfo, BuildVariables, BuildableSource, ConfigSettings,
     DirectorySourceUrl, ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, Hashed,
     IndexUrl, PathSourceUrl, RemoteSource, RequirementSource, RequiresPython, SourceDist,
     SourceUrl,
@@ -262,7 +262,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         tags: &Tags,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let built_wheel_metadata = match &source {
@@ -426,7 +426,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     pub(crate) async fn download_and_build_metadata(
         &self,
         source: &BuildableSource<'_>,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let metadata = match &source {
@@ -632,7 +632,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         subdirectory: Option<&'data Path>,
         ext: SourceDistExtension,
         tags: &Tags,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
@@ -765,7 +765,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         cache_shard: &CacheShard,
         subdirectory: Option<&'data Path>,
         ext: SourceDistExtension,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
@@ -949,7 +949,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         url: &DisplaySafeUrl,
         index: Option<&IndexUrl>,
         cache_shard: &CacheShard,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<Revision, Error> {
         let cache_entry = cache_shard.entry(HTTP_REVISION);
@@ -1058,7 +1058,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
         tags: &Tags,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
@@ -1166,7 +1166,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
@@ -1321,7 +1321,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<LocalRevisionPointer, Error> {
         // Verify that the archive exists.
         if !resource.path.is_file() {
@@ -1381,7 +1381,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &DirectorySourceUrl<'_>,
         tags: &Tags,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Before running the build, check that the hashes match.
         if hashes.requires_validation() {
@@ -1487,7 +1487,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &DirectorySourceUrl<'_>,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         credentials_cache: &CredentialsCache,
     ) -> Result<ArchiveMetadata, Error> {
         // Before running the build, check that the hashes match.
@@ -1799,7 +1799,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &GitPathSourceUrl<'_>,
         fetch: &Fetch,
         cache_shard: &CacheShard,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<RevisionHashes, Error> {
         // Validate that LFS artifacts were fully initialized.
         if resource.git.lfs().enabled() && !fetch.lfs_ready() {
@@ -1859,7 +1859,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &GitPathSourceUrl<'_>,
         tags: &Tags,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Fetch the Git repository.
@@ -1969,7 +1969,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &GitPathSourceUrl<'_>,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         // Fetch the Git repository.
@@ -2132,7 +2132,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &GitDirectorySourceUrl<'_>,
         tags: &Tags,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Before running the build, check that the hashes match.
@@ -2240,7 +2240,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &GitDirectorySourceUrl<'_>,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
         credentials_cache: &CredentialsCache,
     ) -> Result<ArchiveMetadata, Error> {
@@ -2716,7 +2716,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &PathSourceUrl<'_>,
         entry: &CacheEntry,
         revision: Revision,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<Revision, Error> {
         warn!("Re-extracting missing source distribution: {source}");
 
@@ -2742,7 +2742,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         index: Option<&IndexUrl>,
         entry: &CacheEntry,
         revision: Revision,
-        hashes: ArchiveHashRequest<'_>,
+        hashes: ArchiveHashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<Revision, Error> {
         warn!("Re-downloading missing source distribution: {source}");
@@ -2814,7 +2814,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         ext: SourceDistExtension,
         target: &Path,
-        hash_request: ArchiveHashRequest<'_>,
+        hash_request: ArchiveHashPolicy<'_>,
         existing_hashes: &[HashDigest],
     ) -> Result<(Vec<HashDigest>, u64), Error> {
         let reader = response
@@ -2854,7 +2854,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         path: &Path,
         ext: SourceDistExtension,
         target: &Path,
-        hash_request: ArchiveHashRequest<'_>,
+        hash_request: ArchiveHashPolicy<'_>,
         existing_hashes: &[HashDigest],
     ) -> Result<Vec<HashDigest>, Error> {
         debug!("Unpacking for build: {}", path.display());

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -31,9 +31,10 @@ use uv_client::{
 use uv_configuration::{BuildKind, BuildOutput, NoSources};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::{
-    BuildInfo, BuildVariables, BuildableSource, ConfigSettings, DirectorySourceUrl,
-    ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, HashPolicy, Hashed, IndexUrl,
-    PathSourceUrl, RemoteSource, RequirementSource, RequiresPython, SourceDist, SourceUrl,
+    ArchiveHashRequest, BuildInfo, BuildVariables, BuildableSource, ConfigSettings,
+    DirectorySourceUrl, ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, Hashed,
+    IndexUrl, PathSourceUrl, RemoteSource, RequirementSource, RequiresPython, SourceDist,
+    SourceUrl,
 };
 use uv_fs::{Simplified, rename_with_retry, write_atomic};
 use uv_git::{Fetch, GIT_LFS, GitError, GitHttpSettings, GitResolver};
@@ -261,7 +262,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let built_wheel_metadata = match &source {
@@ -425,7 +426,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     pub(crate) async fn download_and_build_metadata(
         &self,
         source: &BuildableSource<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let metadata = match &source {
@@ -631,7 +632,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         subdirectory: Option<&'data Path>,
         ext: SourceDistExtension,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
@@ -764,7 +765,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         cache_shard: &CacheShard,
         subdirectory: Option<&'data Path>,
         ext: SourceDistExtension,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
@@ -948,7 +949,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         url: &DisplaySafeUrl,
         index: Option<&IndexUrl>,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<Revision, Error> {
         let cache_entry = cache_shard.entry(HTTP_REVISION);
@@ -1057,7 +1058,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
@@ -1165,7 +1166,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
@@ -1320,7 +1321,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &PathSourceUrl<'_>,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<LocalRevisionPointer, Error> {
         // Verify that the archive exists.
         if !resource.path.is_file() {
@@ -1380,7 +1381,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &DirectorySourceUrl<'_>,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Before running the build, check that the hashes match.
         if hashes.requires_validation() {
@@ -1486,7 +1487,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &DirectorySourceUrl<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         credentials_cache: &CredentialsCache,
     ) -> Result<ArchiveMetadata, Error> {
         // Before running the build, check that the hashes match.
@@ -1798,7 +1799,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &GitPathSourceUrl<'_>,
         fetch: &Fetch,
         cache_shard: &CacheShard,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<RevisionHashes, Error> {
         // Validate that LFS artifacts were fully initialized.
         if resource.git.lfs().enabled() && !fetch.lfs_ready() {
@@ -1858,7 +1859,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &GitPathSourceUrl<'_>,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Fetch the Git repository.
@@ -1968,7 +1969,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &GitPathSourceUrl<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         // Fetch the Git repository.
@@ -2131,7 +2132,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         resource: &GitDirectorySourceUrl<'_>,
         tags: &Tags,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Before running the build, check that the hashes match.
@@ -2239,7 +2240,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         &self,
         source: &BuildableSource<'_>,
         resource: &GitDirectorySourceUrl<'_>,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
         credentials_cache: &CredentialsCache,
     ) -> Result<ArchiveMetadata, Error> {
@@ -2715,7 +2716,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         resource: &PathSourceUrl<'_>,
         entry: &CacheEntry,
         revision: Revision,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
     ) -> Result<Revision, Error> {
         warn!("Re-extracting missing source distribution: {source}");
 
@@ -2741,7 +2742,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         index: Option<&IndexUrl>,
         entry: &CacheEntry,
         revision: Revision,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashRequest<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<Revision, Error> {
         warn!("Re-downloading missing source distribution: {source}");
@@ -2813,7 +2814,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         ext: SourceDistExtension,
         target: &Path,
-        hash_policy: HashPolicy<'_>,
+        hash_request: ArchiveHashRequest<'_>,
         existing_hashes: &[HashDigest],
     ) -> Result<(Vec<HashDigest>, u64), Error> {
         let reader = response
@@ -2835,7 +2836,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             self.build_context.cache(),
             ArchiveValidation {
                 extra_algorithms: &[HashAlgorithm::Sha256],
-                hash_policy,
+                hash_request,
                 existing_hashes,
                 expected_size,
             },
@@ -2853,7 +2854,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         path: &Path,
         ext: SourceDistExtension,
         target: &Path,
-        hash_policy: HashPolicy<'_>,
+        hash_request: ArchiveHashRequest<'_>,
         existing_hashes: &[HashDigest],
     ) -> Result<Vec<HashDigest>, Error> {
         debug!("Unpacking for build: {}", path.display());
@@ -2867,7 +2868,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             self.build_context.cache(),
             ArchiveValidation {
                 extra_algorithms: &[],
-                hash_policy,
+                hash_request,
                 existing_hashes,
                 expected_size: None,
             },

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -2814,7 +2814,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         source: &BuildableSource<'_>,
         ext: SourceDistExtension,
         target: &Path,
-        hash_request: ArchiveHashPolicy<'_>,
+        hash_policy: ArchiveHashPolicy<'_>,
         existing_hashes: &[HashDigest],
     ) -> Result<(Vec<HashDigest>, u64), Error> {
         let reader = response
@@ -2836,7 +2836,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             self.build_context.cache(),
             ArchiveValidation {
                 extra_algorithms: &[HashAlgorithm::Sha256],
-                hash_request,
+                hash_policy,
                 existing_hashes,
                 expected_size,
             },
@@ -2854,7 +2854,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         path: &Path,
         ext: SourceDistExtension,
         target: &Path,
-        hash_request: ArchiveHashPolicy<'_>,
+        hash_policy: ArchiveHashPolicy<'_>,
         existing_hashes: &[HashDigest],
     ) -> Result<Vec<HashDigest>, Error> {
         debug!("Unpacking for build: {}", path.display());
@@ -2868,7 +2868,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             self.build_context.cache(),
             ArchiveValidation {
                 extra_algorithms: &[],
-                hash_request,
+                hash_policy,
                 existing_hashes,
                 expected_size: None,
             },

--- a/crates/uv-distribution/src/source/validated_archive.rs
+++ b/crates/uv-distribution/src/source/validated_archive.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 
 use uv_cache::{Cache, CacheBucket};
 use uv_distribution_filename::SourceDistExtension;
-use uv_distribution_types::{ArchiveHashRequest, BuildableSource};
+use uv_distribution_types::{ArchiveHashPolicy, BuildableSource};
 use uv_extract::hash::{HashReader, Hasher};
 use uv_fs::rename_with_retry;
 use uv_pypi_types::{HashAlgorithm, HashDigest};
@@ -19,7 +19,7 @@ pub(super) struct ArchiveValidation<'a> {
     /// Additional hashes to generate beyond those required for validation.
     pub(super) extra_algorithms: &'a [HashAlgorithm],
     /// The caller's hash requirements.
-    pub(super) hash_request: ArchiveHashRequest<'a>,
+    pub(super) hash_request: ArchiveHashPolicy<'a>,
     /// Every digest from a cache revision being repaired must remain unchanged.
     pub(super) existing_hashes: &'a [HashDigest],
     pub(super) expected_size: Option<u64>,
@@ -160,7 +160,7 @@ mod tests {
 
     const NO_VALIDATION: ArchiveValidation<'static> = ArchiveValidation {
         extra_algorithms: &[],
-        hash_request: ArchiveHashRequest::None,
+        hash_request: ArchiveHashPolicy::None,
         existing_hashes: &[],
         expected_size: None,
     };
@@ -222,7 +222,7 @@ mod tests {
                 ..NO_VALIDATION
             },
             ArchiveValidation {
-                hash_request: ArchiveHashRequest::Generate,
+                hash_request: ArchiveHashPolicy::Generate,
                 ..NO_VALIDATION
             },
             ArchiveValidation {
@@ -278,7 +278,7 @@ mod tests {
             &cache,
             &bytes[..],
             ArchiveValidation {
-                hash_request: ArchiveHashRequest::All(&[wrong_hash]),
+                hash_request: ArchiveHashPolicy::All(&[wrong_hash]),
                 ..NO_VALIDATION
             },
         )

--- a/crates/uv-distribution/src/source/validated_archive.rs
+++ b/crates/uv-distribution/src/source/validated_archive.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 
 use uv_cache::{Cache, CacheBucket};
 use uv_distribution_filename::SourceDistExtension;
-use uv_distribution_types::{BuildableSource, HashPolicy};
+use uv_distribution_types::{ArchiveHashRequest, BuildableSource};
 use uv_extract::hash::{HashReader, Hasher};
 use uv_fs::rename_with_retry;
 use uv_pypi_types::{HashAlgorithm, HashDigest};
@@ -18,8 +18,8 @@ use crate::error::Error;
 pub(super) struct ArchiveValidation<'a> {
     /// Additional hashes to generate beyond those required for validation.
     pub(super) extra_algorithms: &'a [HashAlgorithm],
-    /// The caller's trusted hash policy.
-    pub(super) hash_policy: HashPolicy<'a>,
+    /// The caller's hash requirements.
+    pub(super) hash_request: ArchiveHashRequest<'a>,
     /// Every digest from a cache revision being repaired must remain unchanged.
     pub(super) existing_hashes: &'a [HashDigest],
     pub(super) expected_size: Option<u64>,
@@ -53,8 +53,8 @@ impl ValidatedSourceArchive {
         let staging_dir = tempfile::tempdir_in(cache.bucket(CacheBucket::SourceDistributions))
             .map_err(Error::CacheWrite)?;
 
-        // Include every algorithm needed to validate the caller's policy or repair an old revision.
-        let mut algorithms = validation.hash_policy.algorithms();
+        // Include every algorithm needed to satisfy the hash request or repair an old revision.
+        let mut algorithms = validation.hash_request.algorithms();
         algorithms.extend_from_slice(validation.extra_algorithms);
         algorithms.extend(validation.existing_hashes.iter().map(HashDigest::algorithm));
         algorithms.sort();
@@ -88,11 +88,12 @@ impl ValidatedSourceArchive {
             .into_iter()
             .map(HashDigest::from)
             .collect::<Vec<_>>();
-        if validation.hash_policy.requires_validation() && !validation.hash_policy.matches(&hashes)
+        if validation.hash_request.requires_validation()
+            && !validation.hash_request.matches(&hashes)
         {
             return Err(Error::hash_mismatch(
                 source.to_string(),
-                validation.hash_policy.digests(),
+                validation.hash_request.digests(),
                 &hashes,
             ));
         }
@@ -152,14 +153,14 @@ mod tests {
     use futures::TryStreamExt;
     use tokio_util::compat::FuturesAsyncReadCompatExt;
 
-    use uv_distribution_types::{DirectSourceUrl, HashGeneration, SourceUrl};
+    use uv_distribution_types::{DirectSourceUrl, SourceUrl};
     use uv_redacted::DisplaySafeUrl;
 
     use super::*;
 
     const NO_VALIDATION: ArchiveValidation<'static> = ArchiveValidation {
         extra_algorithms: &[],
-        hash_policy: HashPolicy::None,
+        hash_request: ArchiveHashRequest::None,
         existing_hashes: &[],
         expected_size: None,
     };
@@ -221,7 +222,7 @@ mod tests {
                 ..NO_VALIDATION
             },
             ArchiveValidation {
-                hash_policy: HashPolicy::Generate(HashGeneration::All),
+                hash_request: ArchiveHashRequest::Generate,
                 ..NO_VALIDATION
             },
             ArchiveValidation {
@@ -277,7 +278,7 @@ mod tests {
             &cache,
             &bytes[..],
             ArchiveValidation {
-                hash_policy: HashPolicy::All(&[wrong_hash]),
+                hash_request: ArchiveHashRequest::All(&[wrong_hash]),
                 ..NO_VALIDATION
             },
         )

--- a/crates/uv-distribution/src/source/validated_archive.rs
+++ b/crates/uv-distribution/src/source/validated_archive.rs
@@ -18,8 +18,8 @@ use crate::error::Error;
 pub(super) struct ArchiveValidation<'a> {
     /// Additional hashes to generate beyond those required for validation.
     pub(super) extra_algorithms: &'a [HashAlgorithm],
-    /// The caller's hash requirements.
-    pub(super) hash_request: ArchiveHashPolicy<'a>,
+    /// The caller's trusted hash policy.
+    pub(super) hash_policy: ArchiveHashPolicy<'a>,
     /// Every digest from a cache revision being repaired must remain unchanged.
     pub(super) existing_hashes: &'a [HashDigest],
     pub(super) expected_size: Option<u64>,
@@ -53,8 +53,8 @@ impl ValidatedSourceArchive {
         let staging_dir = tempfile::tempdir_in(cache.bucket(CacheBucket::SourceDistributions))
             .map_err(Error::CacheWrite)?;
 
-        // Include every algorithm needed to satisfy the hash request or repair an old revision.
-        let mut algorithms = validation.hash_request.algorithms();
+        // Include every algorithm needed to validate the caller's policy or repair an old revision.
+        let mut algorithms = validation.hash_policy.algorithms();
         algorithms.extend_from_slice(validation.extra_algorithms);
         algorithms.extend(validation.existing_hashes.iter().map(HashDigest::algorithm));
         algorithms.sort();
@@ -88,12 +88,11 @@ impl ValidatedSourceArchive {
             .into_iter()
             .map(HashDigest::from)
             .collect::<Vec<_>>();
-        if validation.hash_request.requires_validation()
-            && !validation.hash_request.matches(&hashes)
+        if validation.hash_policy.requires_validation() && !validation.hash_policy.matches(&hashes)
         {
             return Err(Error::hash_mismatch(
                 source.to_string(),
-                validation.hash_request.digests(),
+                validation.hash_policy.digests(),
                 &hashes,
             ));
         }
@@ -160,7 +159,7 @@ mod tests {
 
     const NO_VALIDATION: ArchiveValidation<'static> = ArchiveValidation {
         extra_algorithms: &[],
-        hash_request: ArchiveHashPolicy::None,
+        hash_policy: ArchiveHashPolicy::None,
         existing_hashes: &[],
         expected_size: None,
     };
@@ -222,7 +221,7 @@ mod tests {
                 ..NO_VALIDATION
             },
             ArchiveValidation {
-                hash_request: ArchiveHashPolicy::Generate,
+                hash_policy: ArchiveHashPolicy::Generate,
                 ..NO_VALIDATION
             },
             ArchiveValidation {
@@ -278,7 +277,7 @@ mod tests {
             &cache,
             &bytes[..],
             ArchiveValidation {
-                hash_request: ArchiveHashPolicy::All(&[wrong_hash]),
+                hash_policy: ArchiveHashPolicy::All(&[wrong_hash]),
                 ..NO_VALIDATION
             },
         )

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -439,7 +439,7 @@ impl<'a> Planner<'a> {
                             let cache_info = pointer.to_cache_info();
                             let build_info = pointer.to_build_info();
                             let archive = pointer.into_archive();
-                            if archive.satisfies(hasher.get(dist.as_ref())) {
+                            if archive.satisfies(hasher.archive_policy(dist.as_ref())) {
                                 let cached_dist = CachedDirectUrlDist {
                                     filename: wheel.filename.clone(),
                                     url: VerbatimParsedUrl {
@@ -508,7 +508,7 @@ impl<'a> Planner<'a> {
                                     let cache_info = pointer.to_cache_info();
                                     let build_info = pointer.to_build_info();
                                     let archive = pointer.into_archive();
-                                    if archive.satisfies(hasher.get(dist.as_ref())) {
+                                    if archive.satisfies(hasher.archive_policy(dist.as_ref())) {
                                         let cached_dist = CachedDirectUrlDist {
                                             filename: wheel.filename.clone(),
                                             url: VerbatimParsedUrl {
@@ -572,7 +572,7 @@ impl<'a> Planner<'a> {
                             let cache_info = pointer.to_cache_info();
                             let build_info = pointer.to_build_info();
                             let archive = pointer.into_archive();
-                            if archive.satisfies(hasher.get(dist.as_ref())) {
+                            if archive.satisfies(hasher.archive_policy(dist.as_ref())) {
                                 let cached_dist = CachedDirectUrlDist {
                                     filename: wheel.filename.clone(),
                                     url: VerbatimParsedUrl {

--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -171,7 +171,7 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                 Err(err) => Err(Error::Thread(err.to_owned())),
             }
         } else {
-            let policy = self.hashes.get(&dist);
+            let policy = self.hashes.archive_policy(&dist);
 
             let result = self
                 .database

--- a/crates/uv-requirements/src/extras.rs
+++ b/crates/uv-requirements/src/extras.rs
@@ -101,7 +101,7 @@ impl<'a, Context: BuildContext> ExtrasResolver<'a, Context> {
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let archive = database
-                    .get_or_build_wheel_metadata(&dist, hasher.get_metadata(&dist))
+                    .get_or_build_wheel_metadata(&dist, hasher.metadata_policy(&dist))
                     .await
                     .map_err(|err| Error::from_dist(dist, err))?;
 

--- a/crates/uv-requirements/src/extras.rs
+++ b/crates/uv-requirements/src/extras.rs
@@ -101,7 +101,7 @@ impl<'a, Context: BuildContext> ExtrasResolver<'a, Context> {
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let archive = database
-                    .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
+                    .get_or_build_wheel_metadata(&dist, hasher.get_metadata(&dist))
                     .await
                     .map_err(|err| Error::from_dist(dist, err))?;
 

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -203,7 +203,7 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let archive = self
                     .database
-                    .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
+                    .get_or_build_wheel_metadata(&dist, hasher.get_metadata(&dist))
                     .await
                     .map_err(|err| Error::from_dist(dist, err))?;
 

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -203,7 +203,7 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let archive = self
                     .database
-                    .get_or_build_wheel_metadata(&dist, hasher.get_metadata(&dist))
+                    .get_or_build_wheel_metadata(&dist, hasher.metadata_policy(&dist))
                     .await
                     .map_err(|err| Error::from_dist(dist, err))?;
 

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -10,7 +10,8 @@ use uv_configuration::ExtrasSpecification;
 use uv_distribution::{DistributionDatabase, FlatRequiresDist, Reporter, RequiresDist};
 use uv_distribution_types::Requirement;
 use uv_distribution_types::{
-    BuildableSource, DirectorySourceUrl, HashGeneration, HashPolicy, Identifier, SourceUrl,
+    BuildableSource, DirectorySourceUrl, HashCollection, HashValidation, Identifier,
+    MetadataHashRequest, SourceUrl,
 };
 use uv_fs::Simplified;
 use uv_normalize::{ExtraName, PackageName};
@@ -203,9 +204,9 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
             editable: None,
         });
 
-        // Determine the hash policy. Since we don't have a package name, we perform a
+        // Determine the hash request. Since we don't have a package name, we perform a
         // manual match.
-        let hashes = match self.hasher.verification() {
+        let collection = match self.hasher.verification() {
             HashVerification::Required(_) => {
                 return Err(anyhow::anyhow!(
                     "Hash-checking is not supported for local directories: {}",
@@ -213,12 +214,13 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
                 ));
             }
             HashVerification::IfPresent(_) => {
-                HashPolicy::Generate(self.hasher.generation().unwrap_or(HashGeneration::All))
+                Some(self.hasher.collection().unwrap_or(HashCollection::All))
             }
-            HashVerification::None => self
-                .hasher
-                .generation()
-                .map_or(HashPolicy::None, HashPolicy::Generate),
+            HashVerification::None => self.hasher.collection(),
+        };
+        let hashes = MetadataHashRequest {
+            collection,
+            validation: HashValidation::None,
         };
 
         // Fetch the metadata for the distribution.

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -213,9 +213,10 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
                     path.user_display()
                 ));
             }
-            HashVerification::IfPresent(_) => {
-                Some(self.hasher.collection().unwrap_or(HashCollection::All))
-            }
+            HashVerification::IfPresent(_) => match self.hasher.collection() {
+                HashCollection::None => HashCollection::All,
+                collection @ (HashCollection::Url | HashCollection::All) => collection,
+            },
             HashVerification::None => self.hasher.collection(),
         };
         let hashes = MetadataHashPolicy {

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -204,7 +204,7 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
             editable: None,
         });
 
-        // Determine the hash request. Since we don't have a package name, we perform a
+        // Determine the hash policy. Since we don't have a package name, we perform a
         // manual match.
         let collection = match self.hasher.verification() {
             HashVerification::Required(_) => {

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -11,7 +11,7 @@ use uv_distribution::{DistributionDatabase, FlatRequiresDist, Reporter, Requires
 use uv_distribution_types::Requirement;
 use uv_distribution_types::{
     BuildableSource, DirectorySourceUrl, HashCollection, HashValidation, Identifier,
-    MetadataHashRequest, SourceUrl,
+    MetadataHashPolicy, SourceUrl,
 };
 use uv_fs::Simplified;
 use uv_normalize::{ExtraName, PackageName};
@@ -218,7 +218,7 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
             }
             HashVerification::None => self.hasher.collection(),
         };
-        let hashes = MetadataHashRequest {
+        let hashes = MetadataHashPolicy {
             collection,
             validation: HashValidation::None,
         };

--- a/crates/uv-requirements/src/unnamed.rs
+++ b/crates/uv-requirements/src/unnamed.rs
@@ -306,7 +306,7 @@ impl<'a, Context: BuildContext> NamedRequirementsResolver<'a, Context> {
                 archive.metadata.name.clone()
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
-                let hashes = hasher.get_url(source.url());
+                let hashes = hasher.get_url_metadata(source.url());
                 let source = BuildableSource::Url(source);
                 let archive = database
                     .build_wheel_metadata(&source, hashes)

--- a/crates/uv-requirements/src/unnamed.rs
+++ b/crates/uv-requirements/src/unnamed.rs
@@ -306,7 +306,7 @@ impl<'a, Context: BuildContext> NamedRequirementsResolver<'a, Context> {
                 archive.metadata.name.clone()
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
-                let hashes = hasher.get_url_metadata(source.url());
+                let hashes = hasher.metadata_policy_for_url(source.url());
                 let source = BuildableSource::Url(source);
                 let archive = database
                     .build_wheel_metadata(&source, hashes)

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -169,11 +169,11 @@ impl FlatDistributions {
         }
 
         // Check if hashes line up
-        let hash_policy = hasher.get_package(&filename.name, &filename.version);
-        let hash = if hash_policy.requires_validation() {
+        let hash_request = hasher.get_package(&filename.name, &filename.version);
+        let hash = if hash_request.requires_validation() {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hash_policy.matches(hashes) {
+            } else if hash_request.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched
@@ -209,11 +209,11 @@ impl FlatDistributions {
         };
 
         // Check if hashes line up.
-        let hash_policy = hasher.get_package(&filename.name, &filename.version);
-        let hash = if hash_policy.requires_validation() {
+        let hash_request = hasher.get_package(&filename.name, &filename.version);
+        let hash = if hash_request.requires_validation() {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hash_policy.matches(hashes) {
+            } else if hash_request.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -169,7 +169,7 @@ impl FlatDistributions {
         }
 
         // Check if hashes line up
-        let hash_policy = hasher.get_package(&filename.name, &filename.version);
+        let hash_policy = hasher.archive_policy_for_package(&filename.name, &filename.version);
         let hash = if hash_policy.requires_validation() {
             if hashes.is_empty() {
                 HashComparison::Missing
@@ -209,7 +209,7 @@ impl FlatDistributions {
         };
 
         // Check if hashes line up.
-        let hash_policy = hasher.get_package(&filename.name, &filename.version);
+        let hash_policy = hasher.archive_policy_for_package(&filename.name, &filename.version);
         let hash = if hash_policy.requires_validation() {
             if hashes.is_empty() {
                 HashComparison::Missing

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -169,11 +169,11 @@ impl FlatDistributions {
         }
 
         // Check if hashes line up
-        let hash_request = hasher.get_package(&filename.name, &filename.version);
-        let hash = if hash_request.requires_validation() {
+        let hash_policy = hasher.get_package(&filename.name, &filename.version);
+        let hash = if hash_policy.requires_validation() {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hash_request.matches(hashes) {
+            } else if hash_policy.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched
@@ -209,11 +209,11 @@ impl FlatDistributions {
         };
 
         // Check if hashes line up.
-        let hash_request = hasher.get_package(&filename.name, &filename.version);
-        let hash = if hash_request.requires_validation() {
+        let hash_policy = hasher.get_package(&filename.name, &filename.version);
+        let hash = if hash_policy.requires_validation() {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hash_request.matches(hashes) {
+            } else if hash_policy.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -32,12 +32,13 @@ use uv_distribution_filename::{
     BuildTag, DistExtension, ExtensionError, SourceDistExtension, WheelFilename,
 };
 use uv_distribution_types::{
-    BuiltDist, DependencyMetadata, DirectUrlBuiltDist, DirectUrlSourceDist, DirectorySourceDist,
-    Dist, FileLocation, FirstParty, GitDirectorySourceDist, GitPathBuiltDist, GitPathSourceDist,
-    HashPolicy, Identifier, IndexLocations, IndexMetadata, IndexUrl, Name, PYPI_URL, PathBuiltDist,
-    PathSourceDist, RegistryBuiltDist, RegistryBuiltWheel, RegistrySourceDist, RemoteSource,
-    Requirement, RequirementSource, RequiresPython, ResolvedDist, SimplifiedMarkerTree,
-    StaticMetadata, ToUrlError, UrlString, VersionId,
+    ArchiveHashRequest, BuiltDist, DependencyMetadata, DirectUrlBuiltDist, DirectUrlSourceDist,
+    DirectorySourceDist, Dist, FileLocation, FirstParty, GitDirectorySourceDist, GitPathBuiltDist,
+    GitPathSourceDist, HashValidation, Identifier, IndexLocations, IndexMetadata, IndexUrl,
+    MetadataHashRequest, Name, PYPI_URL, PathBuiltDist, PathSourceDist, RegistryBuiltDist,
+    RegistryBuiltWheel, RegistrySourceDist, RemoteSource, Requirement, RequirementSource,
+    RequiresPython, ResolvedDist, SimplifiedMarkerTree, StaticMetadata, ToUrlError, UrlString,
+    VersionId,
 };
 use uv_fs::{PortablePath, PortablePathBuf, Simplified, normalize_path, try_relative_to_if};
 use uv_git::{RepositoryReference, ResolvedRepositoryReference};
@@ -3273,10 +3274,10 @@ impl Lock {
         )?;
         let locked_hashes = match (&package.id.source, &dist) {
             (Source::Direct(..) | Source::Path(_), Dist::Source(_)) if !hashes.is_empty() => {
-                Some(HashPolicy::All(hashes.as_slice()))
+                Some(HashValidation::All(hashes.as_slice()))
             }
             (Source::Registry(_), Dist::Source(_)) if !hashes.is_empty() => {
-                Some(HashPolicy::Any(hashes.as_slice()))
+                Some(HashValidation::Any(hashes.as_slice()))
             }
             _ => None,
         };
@@ -3292,13 +3293,23 @@ impl Lock {
                     None
                 }
             })
-            && locked_hashes.is_none_or(|policy| policy.matches(archive.hashes.as_slice()))
+            && locked_hashes.is_none_or(|validation| {
+                ArchiveHashRequest::from(validation).matches(archive.hashes.as_slice())
+            })
         {
             return Ok(archive.metadata.clone());
         }
 
+        let metadata_hashes = if let Some(validation) = locked_hashes {
+            MetadataHashRequest {
+                collection: hasher.collection(),
+                validation,
+            }
+        } else {
+            hasher.get_metadata(&dist)
+        };
         let archive = database
-            .get_or_build_wheel_metadata(&dist, locked_hashes.unwrap_or_else(|| hasher.get(&dist)))
+            .get_or_build_wheel_metadata(&dist, metadata_hashes)
             .await
             .map_err(|err| LockErrorKind::Resolution {
                 id: package.id.clone(),
@@ -8145,16 +8156,16 @@ wheels = [{ filename = "local-1.0.0-py3-none-any.whl", hash = "sha256:53a42340ae
         let unknown = "https://example.com/unknown-1.0.0-py3-none-any.whl"
             .parse()
             .expect("valid URL");
-        assert_eq!(hasher.generation(), None);
+        assert_eq!(hasher.collection(), None);
         assert_eq!(
             hasher.get_url(&remote),
-            HashPolicy::All(slice::from_ref(&digest))
+            ArchiveHashRequest::All(slice::from_ref(&digest))
         );
         assert_eq!(
             hasher.get_url(&local),
-            HashPolicy::All(slice::from_ref(&digest))
+            ArchiveHashRequest::All(slice::from_ref(&digest))
         );
-        assert_eq!(hasher.get_url(&unknown), HashPolicy::None);
+        assert_eq!(hasher.get_url(&unknown), ArchiveHashRequest::None);
     }
 
     #[test]

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3306,7 +3306,7 @@ impl Lock {
                 validation,
             }
         } else {
-            hasher.get_metadata(&dist)
+            hasher.metadata_policy(&dist)
         };
         let archive = database
             .get_or_build_wheel_metadata(&dist, metadata_hashes)
@@ -8158,14 +8158,17 @@ wheels = [{ filename = "local-1.0.0-py3-none-any.whl", hash = "sha256:53a42340ae
             .expect("valid URL");
         assert_eq!(hasher.collection(), None);
         assert_eq!(
-            hasher.get_url(&remote),
+            hasher.archive_policy_for_url(&remote),
             ArchiveHashPolicy::All(slice::from_ref(&digest))
         );
         assert_eq!(
-            hasher.get_url(&local),
+            hasher.archive_policy_for_url(&local),
             ArchiveHashPolicy::All(slice::from_ref(&digest))
         );
-        assert_eq!(hasher.get_url(&unknown), ArchiveHashPolicy::None);
+        assert_eq!(
+            hasher.archive_policy_for_url(&unknown),
+            ArchiveHashPolicy::None
+        );
     }
 
     #[test]

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -8057,6 +8057,7 @@ pub(crate) fn is_wheel_unreachable(
 
 #[cfg(test)]
 mod tests {
+    use uv_distribution_types::HashCollection;
     use uv_pep440::VersionSpecifiers;
     use uv_pep508::MarkerEnvironmentBuilder;
     use uv_warnings::anstream;
@@ -8156,7 +8157,7 @@ wheels = [{ filename = "local-1.0.0-py3-none-any.whl", hash = "sha256:53a42340ae
         let unknown = "https://example.com/unknown-1.0.0-py3-none-any.whl"
             .parse()
             .expect("valid URL");
-        assert_eq!(hasher.collection(), None);
+        assert_eq!(hasher.collection(), HashCollection::None);
         assert_eq!(
             hasher.archive_policy_for_url(&remote),
             ArchiveHashPolicy::All(slice::from_ref(&digest))

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -32,10 +32,10 @@ use uv_distribution_filename::{
     BuildTag, DistExtension, ExtensionError, SourceDistExtension, WheelFilename,
 };
 use uv_distribution_types::{
-    ArchiveHashRequest, BuiltDist, DependencyMetadata, DirectUrlBuiltDist, DirectUrlSourceDist,
+    ArchiveHashPolicy, BuiltDist, DependencyMetadata, DirectUrlBuiltDist, DirectUrlSourceDist,
     DirectorySourceDist, Dist, FileLocation, FirstParty, GitDirectorySourceDist, GitPathBuiltDist,
     GitPathSourceDist, HashValidation, Identifier, IndexLocations, IndexMetadata, IndexUrl,
-    MetadataHashRequest, Name, PYPI_URL, PathBuiltDist, PathSourceDist, RegistryBuiltDist,
+    MetadataHashPolicy, Name, PYPI_URL, PathBuiltDist, PathSourceDist, RegistryBuiltDist,
     RegistryBuiltWheel, RegistrySourceDist, RemoteSource, Requirement, RequirementSource,
     RequiresPython, ResolvedDist, SimplifiedMarkerTree, StaticMetadata, ToUrlError, UrlString,
     VersionId,
@@ -3294,14 +3294,14 @@ impl Lock {
                 }
             })
             && locked_hashes.is_none_or(|validation| {
-                ArchiveHashRequest::from(validation).matches(archive.hashes.as_slice())
+                ArchiveHashPolicy::from(validation).matches(archive.hashes.as_slice())
             })
         {
             return Ok(archive.metadata.clone());
         }
 
         let metadata_hashes = if let Some(validation) = locked_hashes {
-            MetadataHashRequest {
+            MetadataHashPolicy {
                 collection: hasher.collection(),
                 validation,
             }
@@ -8159,13 +8159,13 @@ wheels = [{ filename = "local-1.0.0-py3-none-any.whl", hash = "sha256:53a42340ae
         assert_eq!(hasher.collection(), None);
         assert_eq!(
             hasher.get_url(&remote),
-            ArchiveHashRequest::All(slice::from_ref(&digest))
+            ArchiveHashPolicy::All(slice::from_ref(&digest))
         );
         assert_eq!(
             hasher.get_url(&local),
-            ArchiveHashRequest::All(slice::from_ref(&digest))
+            ArchiveHashPolicy::All(slice::from_ref(&digest))
         );
-        assert_eq!(hasher.get_url(&unknown), ArchiveHashRequest::None);
+        assert_eq!(hasher.get_url(&unknown), ArchiveHashPolicy::None);
     }
 
     #[test]

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -274,7 +274,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
     async fn get_or_build_wheel_metadata<'io>(&'io self, dist: &'io Dist) -> WheelMetadataResult {
         match self
             .fetcher
-            .get_or_build_wheel_metadata(dist, self.hasher.get_metadata(dist))
+            .get_or_build_wheel_metadata(dist, self.hasher.metadata_policy(dist))
             .await
         {
             Ok(metadata) => Ok(MetadataResponse::Found(metadata)),

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -274,7 +274,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
     async fn get_or_build_wheel_metadata<'io>(&'io self, dist: &'io Dist) -> WheelMetadataResult {
         match self
             .fetcher
-            .get_or_build_wheel_metadata(dist, self.hasher.get(dist))
+            .get_or_build_wheel_metadata(dist, self.hasher.get_metadata(dist))
             .await
         {
             Ok(metadata) => Ok(MetadataResponse::Found(metadata)),

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -763,14 +763,14 @@ impl VersionMapLazy {
         }
 
         // Check if hashes line up. If hashes aren't required, they're considered matching.
-        let hash_policy = self.hasher.get_package(&filename.name, &filename.version);
-        let required_hashes = hash_policy.digests();
+        let hash_request = self.hasher.get_package(&filename.name, &filename.version);
+        let required_hashes = hash_request.digests();
         let hash = if required_hashes.is_empty() {
             HashComparison::Matched
         } else {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hash_policy.matches(hashes) {
+            } else if hash_request.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched
@@ -827,14 +827,14 @@ impl VersionMapLazy {
         };
 
         // Check if hashes line up. If hashes aren't required, they're considered matching.
-        let hash_policy = self.hasher.get_package(name, version);
-        let required_hashes = hash_policy.digests();
+        let hash_request = self.hasher.get_package(name, version);
+        let required_hashes = hash_request.digests();
         let hash = if required_hashes.is_empty() {
             HashComparison::Matched
         } else {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hash_policy.matches(hashes) {
+            } else if hash_request.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -763,7 +763,9 @@ impl VersionMapLazy {
         }
 
         // Check if hashes line up. If hashes aren't required, they're considered matching.
-        let hash_policy = self.hasher.get_package(&filename.name, &filename.version);
+        let hash_policy = self
+            .hasher
+            .archive_policy_for_package(&filename.name, &filename.version);
         let required_hashes = hash_policy.digests();
         let hash = if required_hashes.is_empty() {
             HashComparison::Matched
@@ -827,7 +829,7 @@ impl VersionMapLazy {
         };
 
         // Check if hashes line up. If hashes aren't required, they're considered matching.
-        let hash_policy = self.hasher.get_package(name, version);
+        let hash_policy = self.hasher.archive_policy_for_package(name, version);
         let required_hashes = hash_policy.digests();
         let hash = if required_hashes.is_empty() {
             HashComparison::Matched

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -763,14 +763,14 @@ impl VersionMapLazy {
         }
 
         // Check if hashes line up. If hashes aren't required, they're considered matching.
-        let hash_request = self.hasher.get_package(&filename.name, &filename.version);
-        let required_hashes = hash_request.digests();
+        let hash_policy = self.hasher.get_package(&filename.name, &filename.version);
+        let required_hashes = hash_policy.digests();
         let hash = if required_hashes.is_empty() {
             HashComparison::Matched
         } else {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hash_request.matches(hashes) {
+            } else if hash_policy.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched
@@ -827,14 +827,14 @@ impl VersionMapLazy {
         };
 
         // Check if hashes line up. If hashes aren't required, they're considered matching.
-        let hash_request = self.hasher.get_package(name, version);
-        let required_hashes = hash_request.digests();
+        let hash_policy = self.hasher.get_package(name, version);
+        let required_hashes = hash_policy.digests();
         let hash = if required_hashes.is_empty() {
             HashComparison::Matched
         } else {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hash_request.matches(hashes) {
+            } else if hash_policy.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -78,7 +78,7 @@ impl HashStrategy {
         &self,
         distribution: &T,
     ) -> ArchiveHashPolicy<'_> {
-        self.get_archive_request(|| distribution.version_id())
+        self.archive_policy_for_id(|| distribution.version_id())
     }
 
     /// Return the [`MetadataHashPolicy`] for retrieving the given distribution's metadata.
@@ -88,7 +88,7 @@ impl HashStrategy {
     ) -> MetadataHashPolicy<'_> {
         MetadataHashPolicy {
             collection: self.collection,
-            validation: self.get_validation(|| distribution.version_id()),
+            validation: self.validation_for_id(|| distribution.version_id()),
         }
     }
 
@@ -98,27 +98,27 @@ impl HashStrategy {
         name: &PackageName,
         version: &Version,
     ) -> ArchiveHashPolicy<'_> {
-        self.get_archive_request(|| VersionId::from_registry(name.clone(), version.clone()))
+        self.archive_policy_for_id(|| VersionId::from_registry(name.clone(), version.clone()))
     }
 
     /// Return the [`ArchiveHashPolicy`] for the given direct URL package.
     ///
     /// A direct URL identifies a single concrete artifact, so every provided digest must match.
     pub fn archive_policy_for_url(&self, url: &DisplaySafeUrl) -> ArchiveHashPolicy<'_> {
-        self.get_archive_request(|| VersionId::from_url(url))
+        self.archive_policy_for_id(|| VersionId::from_url(url))
     }
 
     /// Return the [`MetadataHashPolicy`] for a URL whose package name is not yet known.
     pub fn metadata_policy_for_url(&self, url: &DisplaySafeUrl) -> MetadataHashPolicy<'_> {
         MetadataHashPolicy {
             collection: self.collection,
-            validation: self.get_validation(|| VersionId::from_url(url)),
+            validation: self.validation_for_id(|| VersionId::from_url(url)),
         }
     }
 
-    /// Return the archive hash policy for a distribution.
-    fn get_archive_request(&self, id: impl FnOnce() -> VersionId) -> ArchiveHashPolicy<'_> {
-        let validation = self.get_validation(id);
+    /// Return the archive hash policy for a distribution identity.
+    fn archive_policy_for_id(&self, id: impl FnOnce() -> VersionId) -> ArchiveHashPolicy<'_> {
+        let validation = self.validation_for_id(id);
         match validation {
             HashValidation::None => self
                 .collection
@@ -128,7 +128,7 @@ impl HashStrategy {
     }
 
     /// Construct an identity only when verification requires a lookup.
-    fn get_validation(&self, id: impl FnOnce() -> VersionId) -> HashValidation<'_> {
+    fn validation_for_id(&self, id: impl FnOnce() -> VersionId) -> HashValidation<'_> {
         match &self.verification {
             HashVerification::IfPresent(hashes) => {
                 let id = id();

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -21,7 +21,7 @@ use uv_redacted::DisplaySafeUrl;
 /// applies to the remaining distributions.
 #[derive(Debug, Default, Clone)]
 pub struct HashStrategy {
-    collection: Option<HashCollection>,
+    collection: HashCollection,
     verification: HashVerification,
 }
 
@@ -41,7 +41,7 @@ impl HashStrategy {
     /// Collect declared hashes for resolution, computing missing hashes according to the policy.
     pub fn collect(collection: HashCollection) -> Self {
         Self {
-            collection: Some(collection),
+            collection,
             ..Self::default()
         }
     }
@@ -64,7 +64,7 @@ impl HashStrategy {
     }
 
     /// Return the hash collection policy.
-    pub fn collection(&self) -> Option<HashCollection> {
+    pub fn collection(&self) -> HashCollection {
         self.collection
     }
 
@@ -120,9 +120,10 @@ impl HashStrategy {
     fn archive_policy_for_id(&self, id: impl FnOnce() -> VersionId) -> ArchiveHashPolicy<'_> {
         let validation = self.validation_for_id(id);
         match validation {
-            HashValidation::None => self
-                .collection
-                .map_or(ArchiveHashPolicy::None, |_| ArchiveHashPolicy::Generate),
+            HashValidation::None => match self.collection {
+                HashCollection::None => ArchiveHashPolicy::None,
+                HashCollection::Url | HashCollection::All => ArchiveHashPolicy::Generate,
+            },
             HashValidation::Any(_) | HashValidation::All(_) => validation.into(),
         }
     }
@@ -705,14 +706,14 @@ mod tests {
         assert_eq!(
             strategy.metadata_policy_for_url(&unknown_url),
             MetadataHashPolicy {
-                collection: Some(HashCollection::All),
+                collection: HashCollection::All,
                 validation: HashValidation::None,
             }
         );
         assert_eq!(
             strategy.metadata_policy_for_url(&url),
             MetadataHashPolicy {
-                collection: Some(HashCollection::All),
+                collection: HashCollection::All,
                 validation: HashValidation::All(slice::from_ref(&digest)),
             }
         );
@@ -743,7 +744,7 @@ mod tests {
         assert_eq!(
             strategy.metadata_policy_for_url(&url),
             MetadataHashPolicy {
-                collection: Some(HashCollection::All),
+                collection: HashCollection::All,
                 validation: HashValidation::All(&[]),
             }
         );

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 
 use uv_configuration::HashCheckingMode;
 use uv_distribution_types::{
-    ArchiveHashRequest, DistributionMetadata, HashCollection, HashValidation, MetadataHashRequest,
+    ArchiveHashPolicy, DistributionMetadata, HashCollection, HashValidation, MetadataHashPolicy,
     Name, Requirement, RequirementSource, Resolution, UnresolvedRequirement, VersionId,
 };
 use uv_normalize::PackageName;
@@ -73,49 +73,49 @@ impl HashStrategy {
         &self.verification
     }
 
-    /// Return the [`ArchiveHashRequest`] for the given distribution.
-    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> ArchiveHashRequest<'_> {
+    /// Return the [`ArchiveHashPolicy`] for the given distribution.
+    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> ArchiveHashPolicy<'_> {
         self.get_archive_request(|| distribution.version_id())
     }
 
-    /// Return the [`MetadataHashRequest`] for retrieving the given distribution's metadata.
+    /// Return the [`MetadataHashPolicy`] for retrieving the given distribution's metadata.
     pub fn get_metadata<T: DistributionMetadata>(
         &self,
         distribution: &T,
-    ) -> MetadataHashRequest<'_> {
-        MetadataHashRequest {
+    ) -> MetadataHashPolicy<'_> {
+        MetadataHashPolicy {
             collection: self.collection,
             validation: self.get_validation(|| distribution.version_id()),
         }
     }
 
-    /// Return the [`ArchiveHashRequest`] for the given registry-based package.
-    pub fn get_package(&self, name: &PackageName, version: &Version) -> ArchiveHashRequest<'_> {
+    /// Return the [`ArchiveHashPolicy`] for the given registry-based package.
+    pub fn get_package(&self, name: &PackageName, version: &Version) -> ArchiveHashPolicy<'_> {
         self.get_archive_request(|| VersionId::from_registry(name.clone(), version.clone()))
     }
 
-    /// Return the [`ArchiveHashRequest`] for the given direct URL package.
+    /// Return the [`ArchiveHashPolicy`] for the given direct URL package.
     ///
     /// A direct URL identifies a single concrete artifact, so every provided digest must match.
-    pub fn get_url(&self, url: &DisplaySafeUrl) -> ArchiveHashRequest<'_> {
+    pub fn get_url(&self, url: &DisplaySafeUrl) -> ArchiveHashPolicy<'_> {
         self.get_archive_request(|| VersionId::from_url(url))
     }
 
-    /// Return the [`MetadataHashRequest`] for a URL whose package name is not yet known.
-    pub fn get_url_metadata(&self, url: &DisplaySafeUrl) -> MetadataHashRequest<'_> {
-        MetadataHashRequest {
+    /// Return the [`MetadataHashPolicy`] for a URL whose package name is not yet known.
+    pub fn get_url_metadata(&self, url: &DisplaySafeUrl) -> MetadataHashPolicy<'_> {
+        MetadataHashPolicy {
             collection: self.collection,
             validation: self.get_validation(|| VersionId::from_url(url)),
         }
     }
 
-    /// Return the archive hash request for a distribution.
-    fn get_archive_request(&self, id: impl FnOnce() -> VersionId) -> ArchiveHashRequest<'_> {
+    /// Return the archive hash policy for a distribution.
+    fn get_archive_request(&self, id: impl FnOnce() -> VersionId) -> ArchiveHashPolicy<'_> {
         let validation = self.get_validation(id);
         match validation {
             HashValidation::None => self
                 .collection
-                .map_or(ArchiveHashRequest::None, |_| ArchiveHashRequest::Generate),
+                .map_or(ArchiveHashPolicy::None, |_| ArchiveHashPolicy::Generate),
             HashValidation::Any(_) | HashValidation::All(_) => validation.into(),
         }
     }
@@ -583,7 +583,7 @@ mod tests {
     use uv_configuration::HashCheckingMode;
     use uv_distribution_filename::DistExtension;
     use uv_distribution_types::{
-        ArchiveHashRequest, HashCollection, HashValidation, MetadataHashRequest, Requirement,
+        ArchiveHashPolicy, HashCollection, HashValidation, MetadataHashPolicy, Requirement,
         RequirementSource, UnresolvedRequirement, VersionId,
     };
     use uv_normalize::PackageName;
@@ -649,7 +649,7 @@ mod tests {
             };
             assert_eq!(
                 hasher.get_url(url),
-                ArchiveHashRequest::All(expected.as_slice())
+                ArchiveHashPolicy::All(expected.as_slice())
             );
         }
     }
@@ -677,7 +677,7 @@ mod tests {
 
         assert_eq!(
             strategy.get_url(&url),
-            ArchiveHashRequest::All(slice::from_ref(&digest))
+            ArchiveHashPolicy::All(slice::from_ref(&digest))
         );
         for fragment in [
             "#subdirectory=.",
@@ -688,31 +688,31 @@ mod tests {
             let root_url = format!("{url}{fragment}").parse()?;
             assert_eq!(
                 strategy.get_url(&root_url),
-                ArchiveHashRequest::All(slice::from_ref(&digest))
+                ArchiveHashPolicy::All(slice::from_ref(&digest))
             );
         }
-        assert_eq!(strategy.get_url(&unknown_url), ArchiveHashRequest::Generate);
+        assert_eq!(strategy.get_url(&unknown_url), ArchiveHashPolicy::Generate);
         assert_eq!(
             strategy.get_url_metadata(&unknown_url),
-            MetadataHashRequest {
+            MetadataHashPolicy {
                 collection: Some(HashCollection::All),
                 validation: HashValidation::None,
             }
         );
         assert_eq!(
             strategy.get_url_metadata(&url),
-            MetadataHashRequest {
+            MetadataHashPolicy {
                 collection: Some(HashCollection::All),
                 validation: HashValidation::All(slice::from_ref(&digest)),
             }
         );
         assert_eq!(
             strategy.get_package(&name, &version),
-            ArchiveHashRequest::Any(slice::from_ref(&digest))
+            ArchiveHashPolicy::Any(slice::from_ref(&digest))
         );
         assert_eq!(
             strategy.get_package(&name, &unknown_version),
-            ArchiveHashRequest::Generate
+            ArchiveHashPolicy::Generate
         );
 
         Ok(())
@@ -726,17 +726,17 @@ mod tests {
         let strategy = HashStrategy::collect(HashCollection::All)
             .with_verification(HashVerification::Required(Arc::default()));
 
-        assert_eq!(strategy.get_url(&url), ArchiveHashRequest::All(&[]));
+        assert_eq!(strategy.get_url(&url), ArchiveHashPolicy::All(&[]));
         assert_eq!(
             strategy.get_url_metadata(&url),
-            MetadataHashRequest {
+            MetadataHashPolicy {
                 collection: Some(HashCollection::All),
                 validation: HashValidation::All(&[]),
             }
         );
         assert_eq!(
             strategy.get_package(&name, &version),
-            ArchiveHashRequest::Any(&[])
+            ArchiveHashPolicy::Any(&[])
         );
         assert!(!strategy.allows_url(&url));
         assert!(!strategy.allows_package(&name, &version));

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -7,21 +7,21 @@ use rustc_hash::FxHashMap;
 
 use uv_configuration::HashCheckingMode;
 use uv_distribution_types::{
-    DistributionMetadata, HashGeneration, HashPolicy, Name, Requirement, RequirementSource,
-    Resolution, UnresolvedRequirement, VersionId,
+    ArchiveHashRequest, DistributionMetadata, HashCollection, HashValidation, MetadataHashRequest,
+    Name, Requirement, RequirementSource, Resolution, UnresolvedRequirement, VersionId,
 };
 use uv_normalize::PackageName;
 use uv_pep440::{Operator, Version};
 use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, HashError, ResolverMarkerEnvironment};
 use uv_redacted::DisplaySafeUrl;
 
-/// Hash generation and verification policies for a resolution.
+/// Hash collection and verification policies for a resolution.
 ///
-/// Verification takes precedence for distributions with trusted hashes. The generation policy
+/// Verification takes precedence for distributions with trusted hashes. The collection policy
 /// applies to the remaining distributions.
 #[derive(Debug, Default, Clone)]
 pub struct HashStrategy {
-    generation: Option<HashGeneration>,
+    collection: Option<HashCollection>,
     verification: HashVerification,
 }
 
@@ -38,10 +38,10 @@ pub enum HashVerification {
 }
 
 impl HashStrategy {
-    /// Generate hashes according to the given policy.
-    pub fn generate(generation: HashGeneration) -> Self {
+    /// Collect declared hashes for resolution, computing missing hashes according to the policy.
+    pub fn collect(collection: HashCollection) -> Self {
         Self {
-            generation: Some(generation),
+            collection: Some(collection),
             ..Self::default()
         }
     }
@@ -56,16 +56,16 @@ impl HashStrategy {
         Self::default().with_verification(HashVerification::Required(hashes))
     }
 
-    /// Set verification independently of hash generation.
+    /// Set verification independently of hash collection.
     #[must_use]
     pub fn with_verification(mut self, verification: HashVerification) -> Self {
         self.verification = verification;
         self
     }
 
-    /// Return the hash generation policy.
-    pub fn generation(&self) -> Option<HashGeneration> {
-        self.generation
+    /// Return the hash collection policy.
+    pub fn collection(&self) -> Option<HashCollection> {
+        self.collection
     }
 
     /// Return the hash verification policy.
@@ -73,30 +73,60 @@ impl HashStrategy {
         &self.verification
     }
 
-    /// Return the [`HashPolicy`] for the given distribution.
-    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> HashPolicy<'_> {
-        self.get_id(|| distribution.version_id())
+    /// Return the [`ArchiveHashRequest`] for the given distribution.
+    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> ArchiveHashRequest<'_> {
+        self.get_archive_request(|| distribution.version_id())
     }
 
-    /// Return the [`HashPolicy`] for the given registry-based package.
-    pub fn get_package(&self, name: &PackageName, version: &Version) -> HashPolicy<'_> {
-        self.get_id(|| VersionId::from_registry(name.clone(), version.clone()))
+    /// Return the [`MetadataHashRequest`] for retrieving the given distribution's metadata.
+    pub fn get_metadata<T: DistributionMetadata>(
+        &self,
+        distribution: &T,
+    ) -> MetadataHashRequest<'_> {
+        MetadataHashRequest {
+            collection: self.collection,
+            validation: self.get_validation(|| distribution.version_id()),
+        }
     }
 
-    /// Return the [`HashPolicy`] for the given direct URL package.
+    /// Return the [`ArchiveHashRequest`] for the given registry-based package.
+    pub fn get_package(&self, name: &PackageName, version: &Version) -> ArchiveHashRequest<'_> {
+        self.get_archive_request(|| VersionId::from_registry(name.clone(), version.clone()))
+    }
+
+    /// Return the [`ArchiveHashRequest`] for the given direct URL package.
     ///
     /// A direct URL identifies a single concrete artifact, so every provided digest must match.
-    pub fn get_url(&self, url: &DisplaySafeUrl) -> HashPolicy<'_> {
-        self.get_id(|| VersionId::from_url(url))
+    pub fn get_url(&self, url: &DisplaySafeUrl) -> ArchiveHashRequest<'_> {
+        self.get_archive_request(|| VersionId::from_url(url))
+    }
+
+    /// Return the [`MetadataHashRequest`] for a URL whose package name is not yet known.
+    pub fn get_url_metadata(&self, url: &DisplaySafeUrl) -> MetadataHashRequest<'_> {
+        MetadataHashRequest {
+            collection: self.collection,
+            validation: self.get_validation(|| VersionId::from_url(url)),
+        }
+    }
+
+    /// Return the archive hash request for a distribution.
+    fn get_archive_request(&self, id: impl FnOnce() -> VersionId) -> ArchiveHashRequest<'_> {
+        let validation = self.get_validation(id);
+        match validation {
+            HashValidation::None => self
+                .collection
+                .map_or(ArchiveHashRequest::None, |_| ArchiveHashRequest::Generate),
+            HashValidation::Any(_) | HashValidation::All(_) => validation.into(),
+        }
     }
 
     /// Construct an identity only when verification requires a lookup.
-    fn get_id(&self, id: impl FnOnce() -> VersionId) -> HashPolicy<'_> {
+    fn get_validation(&self, id: impl FnOnce() -> VersionId) -> HashValidation<'_> {
         match &self.verification {
             HashVerification::IfPresent(hashes) => {
                 let id = id();
                 if let Some(hashes) = hashes.get(&id) {
-                    return hash_policy(&id, hashes);
+                    return hash_validation(&id, hashes);
                 }
                 // `==1.0.0` can also select `1.0.0+local`. If the local version has no hash
                 // of its own, check it against the hash for `1.0.0`.
@@ -107,17 +137,19 @@ impl HashStrategy {
                         version.clone().without_local(),
                     ))
                 {
-                    return HashPolicy::Any(hashes);
+                    return HashValidation::Any(hashes);
                 }
             }
             HashVerification::Required(hashes) => {
                 let id = id();
-                return hash_policy(&id, hashes.get(&id).map(Vec::as_slice).unwrap_or_default());
+                return hash_validation(
+                    &id,
+                    hashes.get(&id).map(Vec::as_slice).unwrap_or_default(),
+                );
             }
             HashVerification::None => {}
         }
-        self.generation
-            .map_or(HashPolicy::None, HashPolicy::Generate)
+        HashValidation::None
     }
 
     /// Returns `true` if the given registry-based package is allowed.
@@ -172,7 +204,7 @@ impl HashStrategy {
         self.augment_with_requirements(requirements)
     }
 
-    /// Generate the required hashes from a set of [`UnresolvedRequirement`] entries.
+    /// Read the required hashes from a set of [`UnresolvedRequirement`] entries.
     ///
     /// When the environment is not given, this treats all marker expressions
     /// that reference the environment as true. In other words, it does
@@ -333,7 +365,7 @@ impl HashStrategy {
         }
     }
 
-    /// Generate the required hashes from a [`Resolution`].
+    /// Read the required hashes from a [`Resolution`].
     pub fn from_resolution(
         resolution: &Resolution,
         mode: HashCheckingMode,
@@ -451,14 +483,14 @@ impl HashStrategy {
     }
 }
 
-fn hash_policy<'a>(id: &VersionId, digests: &'a [HashDigest]) -> HashPolicy<'a> {
+fn hash_validation<'a>(id: &VersionId, digests: &'a [HashDigest]) -> HashValidation<'a> {
     match id {
-        VersionId::NameVersion { .. } => HashPolicy::Any(digests),
+        VersionId::NameVersion { .. } => HashValidation::Any(digests),
         VersionId::ArchiveUrl { .. }
         | VersionId::Git { .. }
         | VersionId::Path { .. }
         | VersionId::Directory { .. }
-        | VersionId::Unknown { .. } => HashPolicy::All(digests),
+        | VersionId::Unknown { .. } => HashValidation::All(digests),
     }
 }
 
@@ -551,8 +583,8 @@ mod tests {
     use uv_configuration::HashCheckingMode;
     use uv_distribution_filename::DistExtension;
     use uv_distribution_types::{
-        HashGeneration, HashPolicy, Requirement, RequirementSource, UnresolvedRequirement,
-        VersionId,
+        ArchiveHashRequest, HashCollection, HashValidation, MetadataHashRequest, Requirement,
+        RequirementSource, UnresolvedRequirement, VersionId,
     };
     use uv_normalize::PackageName;
     use uv_pep440::Version;
@@ -615,7 +647,10 @@ mod tests {
             let RequirementSource::Url { url, .. } = &requirement.source else {
                 panic!("expected direct URL requirement");
             };
-            assert_eq!(hasher.get_url(url), HashPolicy::All(expected.as_slice()));
+            assert_eq!(
+                hasher.get_url(url),
+                ArchiveHashRequest::All(expected.as_slice())
+            );
         }
     }
 
@@ -637,12 +672,12 @@ mod tests {
                 vec![digest.clone()],
             ),
         ]);
-        let strategy = HashStrategy::generate(HashGeneration::All)
+        let strategy = HashStrategy::collect(HashCollection::All)
             .with_verification(HashVerification::IfPresent(Arc::new(hashes)));
 
         assert_eq!(
             strategy.get_url(&url),
-            HashPolicy::All(slice::from_ref(&digest))
+            ArchiveHashRequest::All(slice::from_ref(&digest))
         );
         for fragment in [
             "#subdirectory=.",
@@ -653,35 +688,56 @@ mod tests {
             let root_url = format!("{url}{fragment}").parse()?;
             assert_eq!(
                 strategy.get_url(&root_url),
-                HashPolicy::All(slice::from_ref(&digest))
+                ArchiveHashRequest::All(slice::from_ref(&digest))
             );
         }
+        assert_eq!(strategy.get_url(&unknown_url), ArchiveHashRequest::Generate);
         assert_eq!(
-            strategy.get_url(&unknown_url),
-            HashPolicy::Generate(HashGeneration::All)
+            strategy.get_url_metadata(&unknown_url),
+            MetadataHashRequest {
+                collection: Some(HashCollection::All),
+                validation: HashValidation::None,
+            }
+        );
+        assert_eq!(
+            strategy.get_url_metadata(&url),
+            MetadataHashRequest {
+                collection: Some(HashCollection::All),
+                validation: HashValidation::All(slice::from_ref(&digest)),
+            }
         );
         assert_eq!(
             strategy.get_package(&name, &version),
-            HashPolicy::Any(slice::from_ref(&digest))
+            ArchiveHashRequest::Any(slice::from_ref(&digest))
         );
         assert_eq!(
             strategy.get_package(&name, &unknown_version),
-            HashPolicy::Generate(HashGeneration::All)
+            ArchiveHashRequest::Generate
         );
 
         Ok(())
     }
 
     #[test]
-    fn required_hashes_take_precedence_over_generation() -> Result<(), Box<dyn std::error::Error>> {
+    fn required_hashes_take_precedence_over_collection() -> Result<(), Box<dyn std::error::Error>> {
         let url: DisplaySafeUrl = "https://example.com/anyio-4.0.0.tar.gz".parse()?;
         let name: PackageName = "anyio".parse()?;
         let version: Version = "4.0.0".parse()?;
-        let strategy = HashStrategy::generate(HashGeneration::All)
+        let strategy = HashStrategy::collect(HashCollection::All)
             .with_verification(HashVerification::Required(Arc::default()));
 
-        assert_eq!(strategy.get_url(&url), HashPolicy::All(&[]));
-        assert_eq!(strategy.get_package(&name, &version), HashPolicy::Any(&[]));
+        assert_eq!(strategy.get_url(&url), ArchiveHashRequest::All(&[]));
+        assert_eq!(
+            strategy.get_url_metadata(&url),
+            MetadataHashRequest {
+                collection: Some(HashCollection::All),
+                validation: HashValidation::All(&[]),
+            }
+        );
+        assert_eq!(
+            strategy.get_package(&name, &version),
+            ArchiveHashRequest::Any(&[])
+        );
         assert!(!strategy.allows_url(&url));
         assert!(!strategy.allows_package(&name, &version));
         Ok(())

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -74,12 +74,15 @@ impl HashStrategy {
     }
 
     /// Return the [`ArchiveHashPolicy`] for the given distribution.
-    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> ArchiveHashPolicy<'_> {
+    pub fn archive_policy<T: DistributionMetadata>(
+        &self,
+        distribution: &T,
+    ) -> ArchiveHashPolicy<'_> {
         self.get_archive_request(|| distribution.version_id())
     }
 
     /// Return the [`MetadataHashPolicy`] for retrieving the given distribution's metadata.
-    pub fn get_metadata<T: DistributionMetadata>(
+    pub fn metadata_policy<T: DistributionMetadata>(
         &self,
         distribution: &T,
     ) -> MetadataHashPolicy<'_> {
@@ -90,19 +93,23 @@ impl HashStrategy {
     }
 
     /// Return the [`ArchiveHashPolicy`] for the given registry-based package.
-    pub fn get_package(&self, name: &PackageName, version: &Version) -> ArchiveHashPolicy<'_> {
+    pub fn archive_policy_for_package(
+        &self,
+        name: &PackageName,
+        version: &Version,
+    ) -> ArchiveHashPolicy<'_> {
         self.get_archive_request(|| VersionId::from_registry(name.clone(), version.clone()))
     }
 
     /// Return the [`ArchiveHashPolicy`] for the given direct URL package.
     ///
     /// A direct URL identifies a single concrete artifact, so every provided digest must match.
-    pub fn get_url(&self, url: &DisplaySafeUrl) -> ArchiveHashPolicy<'_> {
+    pub fn archive_policy_for_url(&self, url: &DisplaySafeUrl) -> ArchiveHashPolicy<'_> {
         self.get_archive_request(|| VersionId::from_url(url))
     }
 
     /// Return the [`MetadataHashPolicy`] for a URL whose package name is not yet known.
-    pub fn get_url_metadata(&self, url: &DisplaySafeUrl) -> MetadataHashPolicy<'_> {
+    pub fn metadata_policy_for_url(&self, url: &DisplaySafeUrl) -> MetadataHashPolicy<'_> {
         MetadataHashPolicy {
             collection: self.collection,
             validation: self.get_validation(|| VersionId::from_url(url)),
@@ -648,7 +655,7 @@ mod tests {
                 panic!("expected direct URL requirement");
             };
             assert_eq!(
-                hasher.get_url(url),
+                hasher.archive_policy_for_url(url),
                 ArchiveHashPolicy::All(expected.as_slice())
             );
         }
@@ -676,7 +683,7 @@ mod tests {
             .with_verification(HashVerification::IfPresent(Arc::new(hashes)));
 
         assert_eq!(
-            strategy.get_url(&url),
+            strategy.archive_policy_for_url(&url),
             ArchiveHashPolicy::All(slice::from_ref(&digest))
         );
         for fragment in [
@@ -687,31 +694,34 @@ mod tests {
         ] {
             let root_url = format!("{url}{fragment}").parse()?;
             assert_eq!(
-                strategy.get_url(&root_url),
+                strategy.archive_policy_for_url(&root_url),
                 ArchiveHashPolicy::All(slice::from_ref(&digest))
             );
         }
-        assert_eq!(strategy.get_url(&unknown_url), ArchiveHashPolicy::Generate);
         assert_eq!(
-            strategy.get_url_metadata(&unknown_url),
+            strategy.archive_policy_for_url(&unknown_url),
+            ArchiveHashPolicy::Generate
+        );
+        assert_eq!(
+            strategy.metadata_policy_for_url(&unknown_url),
             MetadataHashPolicy {
                 collection: Some(HashCollection::All),
                 validation: HashValidation::None,
             }
         );
         assert_eq!(
-            strategy.get_url_metadata(&url),
+            strategy.metadata_policy_for_url(&url),
             MetadataHashPolicy {
                 collection: Some(HashCollection::All),
                 validation: HashValidation::All(slice::from_ref(&digest)),
             }
         );
         assert_eq!(
-            strategy.get_package(&name, &version),
+            strategy.archive_policy_for_package(&name, &version),
             ArchiveHashPolicy::Any(slice::from_ref(&digest))
         );
         assert_eq!(
-            strategy.get_package(&name, &unknown_version),
+            strategy.archive_policy_for_package(&name, &unknown_version),
             ArchiveHashPolicy::Generate
         );
 
@@ -726,16 +736,19 @@ mod tests {
         let strategy = HashStrategy::collect(HashCollection::All)
             .with_verification(HashVerification::Required(Arc::default()));
 
-        assert_eq!(strategy.get_url(&url), ArchiveHashPolicy::All(&[]));
         assert_eq!(
-            strategy.get_url_metadata(&url),
+            strategy.archive_policy_for_url(&url),
+            ArchiveHashPolicy::All(&[])
+        );
+        assert_eq!(
+            strategy.metadata_policy_for_url(&url),
             MetadataHashPolicy {
                 collection: Some(HashCollection::All),
                 validation: HashValidation::All(&[]),
             }
         );
         assert_eq!(
-            strategy.get_package(&name, &version),
+            strategy.archive_policy_for_package(&name, &version),
             ArchiveHashPolicy::Any(&[])
         );
         assert!(!strategy.allows_url(&url));

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -21,7 +21,7 @@ use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::LoweredExtraBuildDependencies;
 use uv_distribution_types::{
-    ConfigSettings, DependencyMetadata, ExtraBuildVariables, HashGeneration, Index, IndexLocations,
+    ConfigSettings, DependencyMetadata, ExtraBuildVariables, HashCollection, Index, IndexLocations,
     NameRequirementSpecification, Origin, PackageConfigSettings, Requirement, RequiresPython,
     Verbatim,
 };
@@ -411,10 +411,10 @@ pub(crate) async fn pip_compile(
         (Some(tags), ResolverEnvironment::specific(marker_env))
     };
 
-    // Generate, but don't enforce hashes for the requirements. PEP 751 _requires_ a hash to be
+    // Collect, but don't enforce hashes for the requirements. PEP 751 _requires_ a hash to be
     // present, but otherwise, we omit them by default.
     let hasher = if generate_hashes || matches!(format, PipCompileFormat::PylockToml) {
-        HashStrategy::generate(HashGeneration::All)
+        HashStrategy::collect(HashCollection::All)
     } else {
         HashStrategy::default()
     };

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -18,7 +18,7 @@ use uv_configuration::{
 use uv_dispatch::BuildDispatch;
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies};
 use uv_distribution_types::{
-    DependencyMetadata, HashGeneration, Index, IndexLocations, NameRequirementSpecification,
+    DependencyMetadata, HashCollection, Index, IndexLocations, NameRequirementSpecification,
     Requirement, RequiresPython, UnresolvedRequirementSpecification,
 };
 use uv_git::ResolvedRepositoryReference;
@@ -845,7 +845,7 @@ async fn do_lock(
         LockMode::Locked(..) => &locked_build_hasher,
         LockMode::Write(_) | LockMode::DryRun(_) | LockMode::Frozen(_) => &HashStrategy::default(),
     };
-    let hasher = HashStrategy::generate(HashGeneration::Url)
+    let hasher = HashStrategy::collect(HashCollection::Url)
         .with_verification(resolution_build_hasher.verification().clone());
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -21,7 +21,7 @@ use uv_configuration::{
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies, LoweredRequirement};
 use uv_distribution_types::{
-    ExtraBuildRequirement, ExtraBuildRequires, HashGeneration, Index, IndexCredentialsError,
+    ExtraBuildRequirement, ExtraBuildRequires, HashCollection, Index, IndexCredentialsError,
     IndexUrlError, Requirement, RequiresPython, Resolution, UnresolvedRequirement,
     UnresolvedRequirementSpecification,
 };
@@ -2617,7 +2617,7 @@ pub(crate) async fn resolve_environment(
     let groups = BTreeMap::new();
     let hasher = match resolution_scope {
         EnvironmentResolution::Specific => HashStrategy::default(),
-        EnvironmentResolution::Universal => HashStrategy::generate(HashGeneration::Url),
+        EnvironmentResolution::Universal => HashStrategy::collect(HashCollection::Url),
     };
     let build_hasher = HashStrategy::default();
 

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -22,7 +22,7 @@ use uv_distribution::{
     DistributionDatabase, LoweredExtraBuildDependencies, StaticMetadataDatabase,
 };
 use uv_distribution_types::{
-    DependencyMetadata, HashGeneration, Index, IndexLocations, InstalledDist, Name, Requirement,
+    DependencyMetadata, HashCollection, Index, IndexLocations, InstalledDist, Name, Requirement,
     RequiresPython, Resolution, UnresolvedRequirement,
 };
 use uv_errors::{ErrorWithHints, Hint, Hints};
@@ -463,7 +463,7 @@ impl ToolLock {
             .index_strategy(*index_strategy)
             .build_options(build_options.clone())
             .build();
-        let hasher = HashStrategy::generate(HashGeneration::Url);
+        let hasher = HashStrategy::collect(HashCollection::Url);
         let build_hasher = HashStrategy::default();
 
         let flat_index = {


### PR DESCRIPTION
## Summary

`HashPolicy` currently carries both resolution-wide hash collection settings and requirements for a specific archive. We split those into `MetadataHashPolicy`, with collection and validation fields, and `ArchiveHashPolicy`, which describes the hashes an archive must provide.

The distribution database selects the archive policy. Expected hashes continue to take precedence over collection.

Preparation for #21279, which adds URL-hash reuse on top of this refactor.
