### PR TITLE
Support `uv init --build-backend meson` for Meson.

### DIFF
--- a/crates/uv-configuration/src/project_build_backend.rs
+++ b/crates/uv-configuration/src/project_build_backend.rs
@@ -27,6 +27,13 @@ pub enum ProjectBuildBackend {
     Setuptools,
     /// Use [maturin](https://pypi.org/project/maturin) as the project build backend.
     Maturin,
+    /// Use [meson-python](https://pypi.org/project/meson-python) as the project build backend.
+    #[serde(alias = "meson-python")]
+    #[cfg_attr(
+        feature = "clap",
+        value(alias = "meson-python", alias = "meson_python")
+    )]
+    Meson,
     /// Use [scikit-build-core](https://pypi.org/project/scikit-build-core) as the project build backend.
     #[serde(alias = "scikit-build-core")]
     #[cfg_attr(feature = "clap", value(alias = "scikit-build-core"))]

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -962,6 +962,19 @@ fn pyproject_build_system(package: &PackageName, build_backend: ProjectBuildBack
                 requires = ["maturin>=1.0,<2.0"]
                 build-backend = "maturin"
             "#},
+        ProjectBuildBackend::Meson => indoc::formatdoc! {r#"
+                [tool.uv]
+                cache-keys = [{{ file = "pyproject.toml" }}, {{ file = "src/**/*.{{h,c,hpp,cpp}}" }}, {{ file = "meson.build" }}]
+                no-build-isolation-package = ["{module_name}"]
+
+                [build-system]
+                requires = ["meson-python>=0.20.0"]
+                build-backend = "mesonpy"
+
+                [dependency-groups]
+                dev = ["meson-python", "ninja"]
+            "#}
+        .to_string(),
         ProjectBuildBackend::Scikit => indoc::indoc! {r#"
                 [tool.scikit-build]
                 minimum-version = "build-system.requires"
@@ -1017,6 +1030,32 @@ fn pyproject_build_backend_prerequisites(
                     # "abi3-py39" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.9
                     pyo3 = {{ version = "0.28.2", features = ["extension-module", "abi3-py39"] }}
                 "#},
+                )?;
+            }
+        }
+        ProjectBuildBackend::Meson => {
+            // Generate Cargo.toml
+            let build_file = path.join("meson.build");
+            if !build_file.try_exists()? {
+                fs_err::write(
+                    build_file,
+                    indoc::formatdoc! {r"
+                    project('{module_name}', 'c')
+
+                    py = import('python').find_installation(pure: false)
+
+                    py.extension_module(
+                      '_core',
+                      'src/_core.c',
+                      install: true,
+                      subdir: '{module_name}'
+                    )
+
+                    py.install_sources(
+                      ['src/{module_name}/__init__.py'],
+                      subdir: '{module_name}'
+                    )
+                "},
                 )?;
             }
         }
@@ -1113,6 +1152,48 @@ fn generate_package_scripts(
                         fn hello_from_bin() -> String {{
                             "Hello from {package}!".to_string()
                         }}
+                    }}
+                "#},
+                )?;
+            }
+            // Generate .pyi file
+            let pyi_file = pkg_dir.join("_core.pyi");
+            if !pyi_file.try_exists()? {
+                fs_err::write(pyi_file, pyi_contents)?;
+            }
+            // Return python script calling binary
+            binary_call_script
+        }
+        ProjectBuildBackend::Meson => {
+            // Generate lib.rs
+            let native_src = src_dir.join("_core.c");
+            if !native_src.try_exists()? {
+                fs_err::write(
+                    native_src,
+                    indoc::formatdoc! {r#"
+                    #include <Python.h>
+
+                    static PyObject* hello_from_bin(PyObject *self)
+                    {{
+                    	return PyUnicode_FromString("Hello from {package}!");
+                    }}
+
+                    static PyMethodDef methods[] = {{
+                    	{{"hello_from_bin", (PyCFunction)hello_from_bin, METH_NOARGS, NULL}},
+                    	{{NULL, NULL, 0, NULL}},
+                    }};
+
+                    static struct PyModuleDef module = {{
+                    	PyModuleDef_HEAD_INIT,
+                    	"_core",
+                    	NULL,
+                    	-1,
+                    	methods,
+                    }};
+
+                    PyMODINIT_FUNC PyInit__core(void)
+                    {{
+                    	return PyModule_Create(&module);
                     }}
                 "#},
                 )?;

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -3457,6 +3457,144 @@ fn init_app_build_backend_maturin() -> Result<()> {
     Ok(())
 }
 
+/// Run `uv init --app --package --build-backend meson` to create a packaged application project
+#[test]
+#[cfg(feature = "test-crates-io")]
+fn init_app_build_backend_meson() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let child = context.temp_dir.child("foo");
+    child.create_dir_all()?;
+
+    let pyproject_toml = child.join("pyproject.toml");
+    let init_py = child.join("src").join("foo").join("__init__.py");
+    let pyi_file = child.join("src").join("foo").join("_core.pyi");
+    let lib_core = child.join("src").join("_core.c");
+    let build_file = child.join("meson.build");
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app").arg("--package").arg("--build-backend").arg("meson"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Initialized project `foo`
+    ");
+
+    let pyproject = fs_err::read_to_string(&pyproject_toml)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        description = "Add your description here"
+        readme = "README.md"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [project.scripts]
+        foo = "foo:main"
+
+        [tool.uv]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.{h,c,hpp,cpp}" }, { file = "meson.build" }]
+        no-build-isolation-package = ["foo"]
+
+        [build-system]
+        requires = ["meson-python>=0.20.0"]
+        build-backend = "mesonpy"
+
+        [dependency-groups]
+        dev = ["meson-python", "ninja"]
+        "#
+        );
+    });
+
+    let init = fs_err::read_to_string(init_py)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            init, @"
+        from foo._core import hello_from_bin
+
+
+        def main() -> None:
+            print(hello_from_bin())
+        "
+        );
+    });
+
+    let pyi_contents = fs_err::read_to_string(pyi_file)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyi_contents, @"def hello_from_bin() -> str: ..."
+        );
+    });
+
+    let lib_core_contents = fs_err::read_to_string(lib_core)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lib_core_contents, @r#"
+            #include <Python.h>
+
+            static PyObject* hello_from_bin(PyObject *self)
+            {
+            	return PyUnicode_FromString("Hello from foo!");
+            }
+
+            static PyMethodDef methods[] = {
+            	{"hello_from_bin", (PyCFunction)hello_from_bin, METH_NOARGS, NULL},
+            	{NULL, NULL, 0, NULL},
+            };
+
+            static struct PyModuleDef module = {
+            	PyModuleDef_HEAD_INIT,
+            	"_core",
+            	NULL,
+            	-1,
+            	methods,
+            };
+
+            PyMODINIT_FUNC PyInit__core(void)
+            {
+            	return PyModule_Create(&module);
+            }
+        "#
+        );
+    });
+
+    let build_file_contents = fs_err::read_to_string(build_file)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            build_file_contents, @r#"
+            project('foo', 'c')
+
+            py = import('python').find_installation(pure: false)
+
+            py.extension_module(
+              '_core',
+              'src/_core.c',
+              install: true,
+              subdir: 'foo'
+            )
+
+            py.install_sources(
+              ['src/foo/__init__.py'],
+              subdir: 'foo'
+            )
+        "#
+        );
+    });
+
+    Ok(())
+}
+
 /// Run `uv init --app --package --build-backend scikit` to create a packaged application project
 #[test]
 fn init_app_build_backend_scikit() -> Result<()> {
@@ -3698,6 +3836,142 @@ fn init_lib_build_backend_maturin() -> Result<()> {
         "#
         );
     });
+
+    Ok(())
+}
+
+/// Run `uv init --lib --build-backend meson` to create a packaged application project
+#[test]
+fn init_lib_build_backend_meson() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let child = context.temp_dir.child("foo");
+    child.create_dir_all()?;
+
+    let pyproject_toml = child.join("pyproject.toml");
+    let init_py = child.join("src").join("foo").join("__init__.py");
+    let pyi_file = child.join("src").join("foo").join("_core.pyi");
+    let lib_core = child.join("src").join("_core.c");
+    let build_file = child.join("meson.build");
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--lib").arg("--build-backend").arg("meson"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Initialized project `foo`
+    ");
+
+    let pyproject = fs_err::read_to_string(&pyproject_toml)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        description = "Add your description here"
+        readme = "README.md"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        cache-keys = [{ file = "pyproject.toml" }, { file = "src/**/*.{h,c,hpp,cpp}" }, { file = "meson.build" }]
+        no-build-isolation-package = ["foo"]
+
+        [build-system]
+        requires = ["meson-python>=0.20.0"]
+        build-backend = "mesonpy"
+
+        [dependency-groups]
+        dev = ["meson-python", "ninja"]
+        "#
+        );
+    });
+
+    let init = fs_err::read_to_string(init_py)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            init, @"
+        from foo._core import hello_from_bin
+
+
+        def hello() -> str:
+            return hello_from_bin()
+        "
+        );
+    });
+
+    let pyi_contents = fs_err::read_to_string(pyi_file)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyi_contents, @"def hello_from_bin() -> str: ..."
+        );
+    });
+
+    let lib_core_contents = fs_err::read_to_string(lib_core)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lib_core_contents, @r#"
+            #include <Python.h>
+
+            static PyObject* hello_from_bin(PyObject *self)
+            {
+            	return PyUnicode_FromString("Hello from foo!");
+            }
+
+            static PyMethodDef methods[] = {
+            	{"hello_from_bin", (PyCFunction)hello_from_bin, METH_NOARGS, NULL},
+            	{NULL, NULL, 0, NULL},
+            };
+
+            static struct PyModuleDef module = {
+            	PyModuleDef_HEAD_INIT,
+            	"_core",
+            	NULL,
+            	-1,
+            	methods,
+            };
+
+            PyMODINIT_FUNC PyInit__core(void)
+            {
+            	return PyModule_Create(&module);
+            }
+        "#
+        );
+    });
+
+    let build_file_contents = fs_err::read_to_string(build_file)?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            build_file_contents, @"
+            project('foo', 'c')
+
+            py = import('python').find_installation(pure: false)
+
+            py.extension_module(
+              '_core',
+              'src/_core.c',
+              install: true,
+              subdir: 'foo'
+            )
+
+            py.install_sources(
+              ['src/foo/__init__.py'],
+              subdir: 'foo'
+            )
+        "
+        );
+    });
+
+    // We do not test with uv run since it would otherwise require specific CXX build tooling
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds support for `meson-python` to  `uv init`. Comes from [this issue](https://github.com/astral-sh/uv/issues/16093).

One important thing that distinguishes `meson-python` from `scikit-build-core` or `setuptools` is that within a development environment, it obtains a temporary `ninja` executable at build-time and hard codes the path thereto in an import-time rebuild hook. By setting both `no-build-isolation-package` and the dev `dependency-groups`, we ensure that the same `ninja` used for the hook is installed within the development environment.

## Test Plan

The unit tests `init_app_build_backend_meson` and `init_lib_build_backend_meson` are both present to verify correct deployment. I have also smoke tested locally that these are built successfully and `hello_from_bin` works.