### PR TITLE
Respect ty exclusions in `uv check`

### DIFF
--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -175,6 +175,13 @@ pub(crate) async fn check(
         .as_ref()
         .is_some_and(|project| project.project_name().is_none());
     let defacto_all_packages = all_packages || (is_virtual_workspace && package.is_empty());
+    // Running within a project selects that project, even if workspace configuration excludes it.
+    let explicit_targets = all_packages
+        || !package.is_empty()
+        || script.is_some()
+        || project
+            .as_ref()
+            .is_some_and(|project| project.project_name().is_some());
 
     let target_dir = script
         .as_ref()
@@ -746,6 +753,7 @@ pub(crate) async fn check(
             .map(|project| project.workspace().install_path().as_path()),
         &check_targets,
         &excluded_targets,
+        explicit_targets,
         venv_path.as_deref(),
         exclude_newer,
         show_version,

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -21,6 +21,7 @@ use crate::commands::workspace::list::{ScriptDiscoveryError, find_scripts};
 use crate::printer::Printer;
 
 /// Run a type check powered by ty.
+#[expect(clippy::fn_params_excessive_bools)]
 pub(super) async fn run(
     version: Option<String>,
     ty_path: Option<PathBuf>,
@@ -29,6 +30,7 @@ pub(super) async fn run(
     workspace_root: Option<&Path>,
     check_targets: &[PathBuf],
     excluded_targets: &[PathBuf],
+    explicit_targets: bool,
     venv_path: Option<&Path>,
     exclude_newer: Option<jiff::Timestamp>,
     show_version: bool,
@@ -199,8 +201,10 @@ pub(super) async fn run(
         );
     }
     if !check_targets.is_empty() {
-        // Respect configured exclusions even though the paths are passed explicitly.
-        command.arg("--force-exclude");
+        // Respect configured exclusions when automatically selecting members of a virtual workspace.
+        if !explicit_targets {
+            command.arg("--force-exclude");
+        }
         // Keep paths relative to the working directory for stable diagnostics, and use `--` so
         // option-like filenames are treated as paths.
         command.arg("--");

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -199,6 +199,8 @@ pub(super) async fn run(
         );
     }
     if !check_targets.is_empty() {
+        // Respect configured exclusions even though the paths are passed explicitly.
+        command.arg("--force-exclude");
         // Keep paths relative to the working directory for stable diagnostics, and use `--` so
         // option-like filenames are treated as paths.
         command.arg("--");

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -191,7 +191,7 @@ fn check_show_command_quotes_script_path() -> Result<()> {
     All checks passed!
 
     ----- stderr -----
-    Running `ty check --color auto --force-exclude -- 'script with spaces.py'`
+    Running `ty check --color auto -- 'script with spaces.py'`
     "
     );
 
@@ -681,7 +681,7 @@ fn check_fix_script_does_not_fix_unselected_script() -> Result<()> {
     Ok(())
 }
 
-/// Check only the selected workspace member, whether selected implicitly or explicitly.
+/// Respect workspace exclusions unless packages are selected explicitly.
 #[test]
 fn check_workspace_member_selection() -> Result<()> {
     let context =
@@ -692,11 +692,15 @@ fn check_workspace_member_selection() -> Result<()> {
         .write_str(indoc! {r#"
             [tool.uv.workspace]
             members = ["packages/*"]
+
+            [tool.ty.src]
+            exclude = ["packages/member-a"]
         "#})?;
     write_workspace_member(&context, "member-a", "value: int = 'selected'\n")?;
     write_workspace_member(&context, "member-b", "value: int = 'excluded'\n")?;
 
     let member_a = context.temp_dir.child("packages").child("member-a");
+    // The current directory explicitly selects the member, overriding its exclusion.
     uv_snapshot!(context.filters(), workspace_check(&context).current_dir(&member_a), @r#"
     exit_code: 1 (failure)
     ----- stdout -----
@@ -712,6 +716,18 @@ fn check_workspace_member_selection() -> Result<()> {
     ----- stdout -----
     main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
     Found 1 diagnostic
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "#);
+
+    // Explicitly selecting all packages overrides the configured exclusion.
+    uv_snapshot!(context.filters(), workspace_check(&context).arg("--all-packages"), @r#"
+    exit_code: 1 (failure)
+    ----- stdout -----
+    packages/member-a/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected"]` is not assignable to `int`
+    packages/member-b/main.py:1:14: error[invalid-assignment] Object of type `Literal["excluded"]` is not assignable to `int`
+    Found 2 diagnostics
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -16,9 +16,9 @@ use uv_test::{diff_snapshot, uv_snapshot};
 fn workspace_check(context: &uv_test::TestContext) -> Command {
     let mut command = context.check();
     command.env("TY_OUTPUT_FORMAT", "concise");
-    // Select ty 0.0.64 independently of the suite-wide cutoff so these checks can
-    // exercise `--exclude-scripts` and track newer ty versions without disrupting other tests.
-    command.env(EnvVars::UV_EXCLUDE_NEWER, "2026-07-28T00:00:00Z");
+    // Select ty 0.0.80 independently of the suite-wide cutoff so these checks
+    // can exercise new ty features without disrupting other tests.
+    command.env(EnvVars::UV_EXCLUDE_NEWER, "2026-09-10T00:00:00Z");
     command
 }
 

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -191,7 +191,7 @@ fn check_show_command_quotes_script_path() -> Result<()> {
     All checks passed!
 
     ----- stderr -----
-    Running `ty check --color auto -- 'script with spaces.py'`
+    Running `ty check --color auto --force-exclude -- 'script with spaces.py'`
     "
     );
 
@@ -720,9 +720,9 @@ fn check_workspace_member_selection() -> Result<()> {
     Ok(())
 }
 
-/// Check every member when invoked from the root of a virtual workspace.
+/// Respect ty exclusions when automatically selecting members of a virtual workspace.
 #[test]
-fn check_virtual_workspace_checks_all_members_by_default() -> Result<()> {
+fn check_virtual_workspace_respects_exclusions() -> Result<()> {
     let context =
         uv_test::test_context!("3.12").with_filter((r"WARN Failed to fetch `ty`[^\n]*\n", ""));
     context
@@ -750,14 +750,12 @@ fn check_virtual_workspace_checks_all_members_by_default() -> Result<()> {
         .child("main.py")
         .write_str("value: int = 'selected-vendored'\n")?;
 
-    // Automatically selecting the vendored member overrides ty's exclusion, which is undesirable
-    // because configured exclusions should still apply. See astral-sh/uv#21551.
+    // Configured exclusions still apply to automatically selected members. See astral-sh/uv#21551.
     uv_snapshot!(context.filters(), workspace_check(&context), @r#"
     exit_code: 1 (failure)
     ----- stdout -----
     packages/member-a/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected-a"]` is not assignable to `int`
-    vendor/vendored/main.py:1:14: error[invalid-assignment] Object of type `Literal["selected-vendored"]` is not assignable to `int`
-    Found 2 diagnostics
+    Found 1 diagnostic
 
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.


### PR DESCRIPTION
`uv check` passes workspace members to ty as explicit paths, which override configured exclusions. Pass `--force-exclude` when automatically selecting members of a virtual workspace.

The rule is to honor user intent over implicit behavior:

1. Plain `uv check` from within an excluded workspace member: *still check that member*. The current directory selects the enclosing project, even when run from a subdirectory.
2. Plain `uv check` at a virtual workspace root: *check only non-excluded members*. This includes respecting exclusions of ancestor directories, e.g. excluding `vendor` also excludes `vendor/some-member`.
3. Plain `uv check` at a workspace root that defines a project: *check the root project*, even if excluded.
4. `uv check --all-packages`: *check all members, including excluded ones*.
5. `uv check --package $excluded_member`: *check the selected member, even if excluded*.
6. `uv check --script script.py`: *check the selected script, even if excluded*.
7. `uv check --no-project`, or outside a project: *leave file discovery and exclusions to ty*. uv passes no target paths.

For selected project directories, exclusions still apply to files and subdirectories discovered inside them. uv also continues to exclude nested workspace members that weren't selected.

The workspace tests now use ty 0.0.80, which includes the ancestor-exclusion fix in [astral-sh/ruff#28451](https://github.com/astral-sh/ruff/pull/28451).

Fixes #21551.
