### PR TITLE
Prefer post-quantum X25519MLKEM768 key exchange

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,7 +332,7 @@ rcgen = { version = "0.14.5", features = [
   "pem",
   "ring",
 ], default-features = false }
-rustls = { version = "0.23.36" }
+rustls = { version = "0.23.36", features = ["prefer-post-quantum"] }
 similar = { version = "3.0.0" }
 webpki = { package = "rustls-webpki", version = "0.103.10" }
 x509-parser = { version = "0.18.0" }

--- a/crates/uv-client/tests/it/http_util.rs
+++ b/crates/uv-client/tests/it/http_util.rs
@@ -17,8 +17,9 @@ use rcgen::{
 };
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
-use rustls::{RootCertStore, ServerConfig};
+use rustls::{NamedGroup, RootCertStore, ServerConfig};
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
 
@@ -184,6 +185,8 @@ pub(crate) struct TestServerBuilder<'a> {
     server_cert: Option<&'a SelfSigned>,
     // Enable mTLS Verification
     mutual_tls: bool,
+    // Reports the negotiated key exchange group
+    kx_group_tx: Option<oneshot::Sender<NamedGroup>>,
 }
 
 impl<'a> TestServerBuilder<'a> {
@@ -192,6 +195,7 @@ impl<'a> TestServerBuilder<'a> {
             server_cert: None,
             ca_cert: None,
             mutual_tls: false,
+            kx_group_tx: None,
         }
     }
 
@@ -212,6 +216,13 @@ impl<'a> TestServerBuilder<'a> {
     /// Requires `with_server_cert` and `with_ca_cert`.
     fn with_mutual_tls(mut self, mutual: bool) -> Self {
         self.mutual_tls = mutual;
+        self
+    }
+
+    /// Report the negotiated key exchange group over `tx` once the handshake
+    /// completes. Requires `with_server_cert`.
+    fn with_kx_group_capture(mut self, tx: oneshot::Sender<NamedGroup>) -> Self {
+        self.kx_group_tx = Some(tx);
         self
     }
 
@@ -285,6 +296,8 @@ impl<'a> TestServerBuilder<'a> {
             future::ok::<_, hyper::Error>(Response::new(response_content))
         };
 
+        let kx_group_tx = self.kx_group_tx;
+
         // Spawn the server loop in a background task
         let server_task = tokio::spawn(async move {
             let svc = service_fn(move |req: Request<Incoming>| svc_fn(req));
@@ -303,6 +316,11 @@ impl<'a> TestServerBuilder<'a> {
                     .accept(tcp_stream)
                     .await
                     .context("Failed to accept TLS connection")?;
+                if let Some(kx_group_tx) = kx_group_tx
+                    && let Some(kx_group) = tls_stream.get_ref().1.negotiated_key_exchange_group()
+                {
+                    let _ = kx_group_tx.send(kx_group.name());
+                }
                 let socket = TokioIo::new(tls_stream);
                 tokio::task::spawn(async move {
                     Builder::new(TokioExecutor::new())
@@ -353,4 +371,21 @@ pub(crate) async fn start_https_mtls_user_agent_server(
         .with_mutual_tls(true)
         .start()
         .await
+}
+
+/// Single Request HTTPS server that reports the negotiated key exchange group.
+pub(crate) async fn start_https_negotiated_kx_group_server(
+    server_cert: &SelfSigned,
+) -> Result<(
+    JoinHandle<Result<()>>,
+    SocketAddr,
+    oneshot::Receiver<NamedGroup>,
+)> {
+    let (kx_group_tx, kx_group_rx) = oneshot::channel();
+    let (server_task, addr) = TestServerBuilder::new()
+        .with_server_cert(server_cert)
+        .with_kx_group_capture(kx_group_tx)
+        .start()
+        .await?;
+    Ok((server_task, addr, kx_group_rx))
 }

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -22,7 +22,7 @@ use uv_static::EnvVars;
 use crate::http_util::{
     SelfSigned, generate_expired_self_signed_certs_with_ca, generate_self_signed_certs_with_ca,
     generate_self_signed_certs_with_ca_custom_extensions, start_https_mtls_user_agent_server,
-    start_https_user_agent_server, test_cert_dir,
+    start_https_negotiated_kx_group_server, start_https_user_agent_server, test_cert_dir,
 };
 
 /// A self-signed CA together with a server certificate and a client certificate
@@ -909,6 +909,37 @@ async fn test_system_certs_with_ssl_cert_dir_valid() -> Result<()> {
         .ssl_cert_dir(dir.path())
         .expect_https_connect_succeeds(&cert)
         .await;
+    Ok(())
+}
+
+/// uv client prefers the PQ-safe hybrid X25519MLKEM768 kx over ECDH.
+#[tokio::test]
+async fn test_prefers_post_quantum_key_exchange() -> Result<()> {
+    let cert = TestCertificate::new()?;
+    let vars: Vec<(&'static str, Option<&str>)> = vec![
+        (EnvVars::UV_NATIVE_TLS, None),
+        (EnvVars::UV_SYSTEM_CERTS, None),
+        (EnvVars::SSL_CERT_FILE, None),
+        (EnvVars::SSL_CERT_DIR, None),
+        (EnvVars::SSL_CLIENT_CERT, None),
+    ];
+    let negotiated_kx_group = async_with_vars(vars, async {
+        let (_server_task, addr, kx_group_rx) =
+            start_https_negotiated_kx_group_server(&cert.server)
+                .await
+                .unwrap();
+        let response = send_request(addr, false, Some(&cert.trust_path)).await;
+        assert!(
+            response.is_ok(),
+            "expected successful response, got: {:?}",
+            response.err()
+        );
+        kx_group_rx
+            .await
+            .expect("server did not report a negotiated key exchange group")
+    })
+    .await;
+    assert_eq!(negotiated_kx_group, rustls::NamedGroup::X25519MLKEM768);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Enable rustls's `prefer-post-quantum` feature so uv's HTTPS client offers and prefers the X25519MLKEM768 hybrid key exchange group. Hybrid PQC protects against "harvest now, decrypt later" attacks.

References:
- https://www.memorysafety.org/blog/pq-key-exchange/
- https://blog.cloudflare.com/pq-2024/
- https://rustls.dev/perf/2024-12-17-pq-kx/

## Test Plan

PR includes a test case to verify that clients prefer hybrid X25519 + ML-KEM over ECDH.
