### PR TITLE
Verify sidecar hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6381,6 +6381,7 @@ dependencies = [
  "uv-distribution-filename",
  "uv-distribution-types",
  "uv-errors",
+ "uv-extract",
  "uv-fs",
  "uv-git",
  "uv-metadata",

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -1303,12 +1303,12 @@ impl CacheBucket {
             Self::SourceDistributions => "sdists-v9",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/lock/lock.rs`.
-            Self::FlatIndex => "flat-index-v4",
+            Self::FlatIndex => "flat-index-v5",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_clean.rs`.
-            Self::Simple => "simple-v24",
+            Self::Simple => "simple-v25",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/build/cache_prune.rs`.
             Self::Wheels => "wheels-v6",

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -26,6 +26,7 @@ uv-configuration = { workspace = true }
 uv-distribution-filename = { workspace = true }
 uv-distribution-types = { workspace = true }
 uv-errors = { workspace = true }
+uv-extract = { workspace = true }
 uv-fs = { workspace = true, features = ["tokio"] }
 uv-git = { workspace = true }
 uv-metadata = { workspace = true }

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -19,6 +19,7 @@ use uv_distribution_types::IndexUrl;
 use uv_errors::{Hint, Hints};
 use uv_git::GitError;
 use uv_normalize::PackageName;
+use uv_pypi_types::HashDigest;
 use uv_redacted::DisplaySafeUrl;
 
 /// RFC 9457 Problem Details for HTTP APIs
@@ -438,6 +439,16 @@ pub enum ErrorKind {
     /// The root was not found in the local (file-based) index.
     #[error("Local index not found at: `{}`", _0.display())]
     LocalIndexNotFound(PathBuf),
+
+    /// The metadata file does not match a hash provided by its package index.
+    #[error(
+        "Hash mismatch for package metadata at `{url}`\n\nExpected:\n  {expected}\n\nComputed:\n  {actual}"
+    )]
+    MetadataHashMismatch {
+        url: DisplaySafeUrl,
+        expected: HashDigest,
+        actual: HashDigest,
+    },
 
     /// The metadata file could not be parsed.
     #[error("Couldn't parse metadata of {0} from {1}")]

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -299,9 +299,7 @@ impl<'a> FlatIndexClient<'a> {
     ) -> FlatIndexEntries {
         let entries = files
             .into_iter()
-            .filter_map(|mut file| {
-                // Ignore deprecated pyx-specific zstd wheel metadata from an older cache entry.
-                file.zstd = None;
+            .filter_map(|file| {
                 Some(FlatIndexEntry {
                     filename: DistFilename::try_from_normalized_filename(&file.filename)?,
                     file,
@@ -364,7 +362,6 @@ impl<'a> FlatIndexClient<'a> {
                 upload_time_utc_ms: None,
                 url: FileLocation::AbsoluteUrl(UrlString::from(url)),
                 yanked: None,
-                zstd: None,
             };
 
             let Some(filename) = DistFilename::try_from_normalized_filename(filename) else {
@@ -397,14 +394,12 @@ mod tests {
     use fs_err::File;
     use std::io::Write;
     use tempfile::tempdir;
-    use uv_distribution_types::Zstd;
 
-    /// Round-trip a synthetic flat-index cache entry, preserving sidecar hashes and discarding
-    /// deprecated pyx-specific zstd wheel metadata before the file is used.
+    /// Round-trip a synthetic flat-index cache entry and preserve sidecar hashes.
     #[test]
     fn cached_files_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         let url = DisplaySafeUrl::parse("https://example.com/flat/")?;
-        let mut files = FlatIndexClient::parse_html(
+        let files = FlatIndexClient::parse_html(
             r#"<a href="example-1.0.0-py3-none-any.whl" data-core-metadata="sha256=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef">example-1.0.0-py3-none-any.whl</a>"#,
             &url,
         )?;
@@ -415,18 +410,11 @@ mod tests {
                 .as_ref()
                 .is_some_and(|hashes| !hashes.is_empty())
         );
-        assert!(files[0].zstd.is_none());
-        files[0].zstd = Some(Box::new(Zstd {
-            hashes: HashDigests::empty(),
-            size: Some(42),
-        }));
-
         let archived = OwnedArchive::from_unarchived(&files)?;
         let files = OwnedArchive::deserialize(&archived);
         let entries =
             FlatIndexClient::entries_from_files(files, &IndexUrl::parse(url.as_str(), None)?);
         assert_eq!(entries.entries.len(), 1);
-        assert!(entries.entries[0].file.zstd.is_none());
         assert_eq!(entries.entries[0].file.dist_info_metadata, metadata_hashes);
         Ok(())
     }

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -356,7 +356,7 @@ impl<'a> FlatIndexClient<'a> {
             let url = DisplaySafeUrl::from_file_path(entry.path()).unwrap();
 
             let file = File {
-                dist_info_metadata: false,
+                dist_info_metadata: None,
                 filename: filename.into(),
                 hashes: HashDigests::empty(),
                 requires_python: None,
@@ -399,16 +399,22 @@ mod tests {
     use tempfile::tempdir;
     use uv_distribution_types::Zstd;
 
-    /// Round-trip a synthetic cache entry containing deprecated pyx-specific zstd wheel metadata
-    /// and verify that the metadata is discarded before the file is used.
+    /// Round-trip a synthetic flat-index cache entry, preserving sidecar hashes and discarding
+    /// deprecated pyx-specific zstd wheel metadata before the file is used.
     #[test]
-    fn cached_files_ignore_deprecated_zstd() -> Result<(), Box<dyn std::error::Error>> {
+    fn cached_files_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         let url = DisplaySafeUrl::parse("https://example.com/flat/")?;
         let mut files = FlatIndexClient::parse_html(
-            r#"<a href="example-1.0.0-py3-none-any.whl">example-1.0.0-py3-none-any.whl</a>"#,
+            r#"<a href="example-1.0.0-py3-none-any.whl" data-core-metadata="sha256=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef">example-1.0.0-py3-none-any.whl</a>"#,
             &url,
         )?;
         assert_eq!(files.len(), 1);
+        let metadata_hashes = files[0].dist_info_metadata.clone();
+        assert!(
+            metadata_hashes
+                .as_ref()
+                .is_some_and(|hashes| !hashes.is_empty())
+        );
         assert!(files[0].zstd.is_none());
         files[0].zstd = Some(Box::new(Zstd {
             hashes: HashDigests::empty(),
@@ -421,6 +427,7 @@ mod tests {
             FlatIndexClient::entries_from_files(files, &IndexUrl::parse(url.as_str(), None)?);
         assert_eq!(entries.entries.len(), 1);
         assert!(entries.entries[0].file.zstd.is_none());
+        assert_eq!(entries.entries[0].file.dist_info_metadata, metadata_hashes);
         Ok(())
     }
 

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -22,7 +22,7 @@ use uv_distribution_filename::{DistFilename, WheelFilename};
 use uv_distribution_types::{
     BuiltDist, File, FileLocation, IndexCapabilities, IndexFormat, IndexLocations,
     IndexMetadataRef, IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
-    RegistryBuiltWheel, Zstd,
+    RegistryBuiltWheel,
 };
 use uv_extract::hash::Hasher;
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
@@ -1380,11 +1380,6 @@ pub struct CachedFile {
     filename: Option<Box<SmallString>>,
     #[rkyv(with = rkyv::with::Niche)]
     yanked: Option<Box<Yanked>>,
-    /// Deprecated pyx-specific zstd wheel metadata, retained only for compatibility with the
-    /// Simple API cache layout.
-    // TODO: Remove this field when the Simple API cache format is next bumped.
-    #[rkyv(with = rkyv::with::Niche)]
-    zstd: Option<Box<Zstd>>,
     #[rkyv(with = rkyv::with::Niche)]
     metadata_hashes: Option<Box<CachedHashDigests>>,
     dist_info_metadata: bool,
@@ -1438,7 +1433,6 @@ impl From<File> for CachedFile {
             has_upload_time,
             url: file.url,
             yanked: file.yanked.filter(|yanked| yanked.is_yanked()),
-            zstd: None,
         }
     }
 }
@@ -1459,7 +1453,6 @@ impl From<CachedFile> for File {
             upload_time_utc_ms: file.has_upload_time.then_some(file.upload_time_utc_ms),
             url: file.url,
             yanked: file.yanked,
-            zstd: None,
         }
     }
 }
@@ -1829,8 +1822,8 @@ mod tests {
     };
     use uv_cache::Cache;
     use uv_distribution_types::{
-        File, FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations,
-        IndexMetadataRef, IndexUrl, ToUrlError, Zstd,
+        FileLocation, Index, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
+        IndexUrl, ToUrlError,
     };
     use uv_small_str::SmallString;
     use wiremock::matchers::{basic_auth, method, path_regex};
@@ -2196,19 +2189,12 @@ mod tests {
         let package_name = PackageName::from_str("example-1")?;
         let data: PypiSimpleDetail = serde_json::from_str(response)?;
         let base = DisplaySafeUrl::parse("https://pypi.org/simple/example-1/")?;
-        let mut simple_metadata = SimpleDetailMetadata::from_pypi_files(
+        let simple_metadata = SimpleDetailMetadata::from_pypi_files(
             data.files,
             &package_name,
             data.project_status,
             &base,
         );
-        let cached_wheel = &mut simple_metadata.versions[0].files.wheels[0];
-        assert!(cached_wheel.zstd.is_none());
-        // An entry written by an older uv may still contain pyx-specific zstd wheel metadata.
-        cached_wheel.zstd = Some(Box::new(Zstd {
-            hashes: HashDigests::empty(),
-            size: Some(42),
-        }));
         let archived = super::OwnedArchive::from_unarchived(&simple_metadata)?;
         let simple_metadata = super::OwnedArchive::deserialize(&archived);
 
@@ -2216,19 +2202,6 @@ mod tests {
             .versions
             .into_iter()
             .flat_map(|datum| datum.files.all(&package_name))
-            .map(|(filename, mut file)| {
-                assert!(file.zstd.is_none());
-                // New cache entries must not preserve pyx-specific zstd wheel metadata either.
-                file.zstd = Some(Box::new(Zstd {
-                    hashes: HashDigests::empty(),
-                    size: Some(42),
-                }));
-                let cached = super::CachedFile::from(file);
-                assert!(cached.zstd.is_none());
-                let file = File::from(cached);
-                assert!(file.zstd.is_none());
-                (filename, file)
-            })
             .collect();
         let filenames: Vec<_> = files
             .iter()
@@ -2331,7 +2304,6 @@ mod tests {
                                 ),
                                 filename: None,
                                 yanked: None,
-                                zstd: None,
                                 metadata_hashes: None,
                                 dist_info_metadata: false,
                                 has_size: true,
@@ -2404,7 +2376,6 @@ mod tests {
                                 ),
                                 filename: None,
                                 yanked: None,
-                                zstd: None,
                                 metadata_hashes: None,
                                 dist_info_metadata: false,
                                 has_size: false,

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -24,6 +24,7 @@ use uv_distribution_types::{
     IndexMetadataRef, IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, Name,
     RegistryBuiltWheel, Zstd,
 };
+use uv_extract::hash::Hasher;
 use uv_git::{GIT_LFS, GitError, GitHttpSettings, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
 use uv_normalize::PackageName;
@@ -1025,7 +1026,7 @@ impl RegistryClient {
         } = wheel;
 
         // If the metadata file is available at its own url (PEP 658), download it from there.
-        if file.dist_info_metadata.is_some() {
+        if let Some(hashes) = &file.dist_info_metadata {
             let mut url = url.clone();
             let path = format!("{}.metadata", url.path());
             url.set_path(&path);
@@ -1060,6 +1061,20 @@ impl RegistryClient {
                 let bytes = response.bytes().await.map_err(|err| {
                     ErrorKind::from_reqwest(url.clone(), err, self.client.certificate_source())
                 })?;
+
+                // Verify the downloaded bytes before parsing or caching the metadata.
+                for expected in hashes.iter() {
+                    let mut hasher = Hasher::from(expected.algorithm());
+                    hasher.update(&bytes);
+                    let actual = HashDigest::from(hasher);
+                    if !actual.digest.eq_ignore_ascii_case(expected.digest.as_ref()) {
+                        return Err(Error::from(ErrorKind::MetadataHashMismatch {
+                            url: url.clone(),
+                            expected: expected.clone(),
+                            actual,
+                        }));
+                    }
+                }
 
                 info_span!("parse_metadata21")
                     .in_scope(|| ResolutionMetadata::parse_metadata(bytes.as_ref()))

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1025,7 +1025,7 @@ impl RegistryClient {
         } = wheel;
 
         // If the metadata file is available at its own url (PEP 658), download it from there.
-        if file.dist_info_metadata {
+        if file.dist_info_metadata.is_some() {
             let mut url = url.clone();
             let path = format!("{}.metadata", url.path());
             url.set_path(&path);
@@ -1370,6 +1370,8 @@ pub struct CachedFile {
     // TODO: Remove this field when the Simple API cache format is next bumped.
     #[rkyv(with = rkyv::with::Niche)]
     zstd: Option<Box<Zstd>>,
+    #[rkyv(with = rkyv::with::Niche)]
+    metadata_hashes: Option<Box<CachedHashDigests>>,
     dist_info_metadata: bool,
     has_size: bool,
     has_upload_time: bool,
@@ -1403,8 +1405,15 @@ impl From<File> for CachedFile {
             (file.url.raw_filename() != file.filename.as_ref()).then(|| Box::new(file.filename));
         let has_size = file.size.is_some();
         let has_upload_time = file.upload_time_utc_ms.is_some();
+        let dist_info_metadata = file.dist_info_metadata.is_some();
+        let metadata_hashes = file
+            .dist_info_metadata
+            .filter(|hashes| !hashes.is_empty())
+            .map(CachedHashDigests::from)
+            .map(Box::new);
         Self {
-            dist_info_metadata: file.dist_info_metadata,
+            dist_info_metadata,
+            metadata_hashes,
             filename,
             hashes: CachedHashDigests::from(file.hashes),
             requires_python: file.requires_python,
@@ -1422,8 +1431,12 @@ impl From<File> for CachedFile {
 impl From<CachedFile> for File {
     fn from(file: CachedFile) -> Self {
         let filename = SmallString::from(file.filename());
+        let dist_info_metadata = file.dist_info_metadata.then(|| {
+            file.metadata_hashes
+                .map_or_else(HashDigests::empty, |hashes| HashDigests::from(*hashes))
+        });
         Self {
-            dist_info_metadata: file.dist_info_metadata,
+            dist_info_metadata,
             filename,
             hashes: HashDigests::from(file.hashes),
             requires_python: file.requires_python,
@@ -1791,7 +1804,7 @@ mod tests {
     use tokio::sync::Semaphore;
     use url::Url;
     use uv_normalize::PackageName;
-    use uv_pypi_types::{HashDigests, PypiSimpleDetail};
+    use uv_pypi_types::{HashDigest, HashDigests, PypiSimpleDetail};
     use uv_redacted::DisplaySafeUrl;
     use uv_torch::{TorchBackend, TorchStrategy};
 
@@ -2151,6 +2164,9 @@ mod tests {
             "files": [
                 {
                     "filename": "example_1-1.0.0-py3-none-any.whl",
+                    "core-metadata": {
+                        "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                    },
                     "hashes": {},
                     "url": "https://files.pythonhosted.org/example_1-1.0.0-py3-none-any.whl"
                 },
@@ -2181,7 +2197,7 @@ mod tests {
         let archived = super::OwnedArchive::from_unarchived(&simple_metadata)?;
         let simple_metadata = super::OwnedArchive::deserialize(&archived);
 
-        let filenames: Vec<_> = simple_metadata
+        let files: Vec<_> = simple_metadata
             .versions
             .into_iter()
             .flat_map(|datum| datum.files.all(&package_name))
@@ -2194,13 +2210,26 @@ mod tests {
                 }));
                 let cached = super::CachedFile::from(file);
                 assert!(cached.zstd.is_none());
-                assert!(File::from(cached).zstd.is_none());
-                filename.to_string()
+                let file = File::from(cached);
+                assert!(file.zstd.is_none());
+                (filename, file)
             })
+            .collect();
+        let filenames: Vec<_> = files
+            .iter()
+            .map(|(filename, _)| filename.to_string())
             .collect();
         assert_eq!(
             filenames,
             ["example_1-1.0.0.tar.gz", "example_1-1.0.0-py3-none-any.whl"]
+        );
+        assert!(files[0].1.dist_info_metadata.is_none());
+        let metadata_hashes = HashDigests::from(HashDigest::from_str(
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )?);
+        assert_eq!(
+            files[1].1.dist_info_metadata.as_ref(),
+            Some(&metadata_hashes)
         );
 
         Ok(())
@@ -2288,6 +2317,7 @@ mod tests {
                                 filename: None,
                                 yanked: None,
                                 zstd: None,
+                                metadata_hashes: None,
                                 dist_info_metadata: false,
                                 has_size: true,
                                 has_upload_time: true,
@@ -2360,6 +2390,7 @@ mod tests {
                                 filename: None,
                                 yanked: None,
                                 zstd: None,
+                                metadata_hashes: None,
                                 dist_info_metadata: false,
                                 has_size: false,
                                 has_upload_time: false,

--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -23,7 +23,8 @@ pub enum FileConversionError {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 pub struct File {
-    pub dist_info_metadata: bool,
+    /// Hashes for separately available metadata, or an empty list when no hashes were provided.
+    pub dist_info_metadata: Option<HashDigests>,
     pub filename: SmallString,
     pub hashes: HashDigests,
     pub requires_python: Option<Arc<VersionSpecifiers>>,
@@ -48,10 +49,7 @@ impl File {
         base: &SmallString,
     ) -> Result<Self, FileConversionError> {
         Ok(Self {
-            dist_info_metadata: file
-                .core_metadata
-                .as_ref()
-                .is_some_and(CoreMetadata::is_available),
+            dist_info_metadata: Self::dist_info_metadata(file.core_metadata),
             filename: file.filename,
             hashes: HashDigests::from(file.hashes),
             requires_python: file
@@ -64,6 +62,14 @@ impl File {
             yanked: file.yanked,
             zstd: None,
         })
+    }
+
+    fn dist_info_metadata(metadata: Option<CoreMetadata>) -> Option<HashDigests> {
+        match metadata? {
+            CoreMetadata::Bool(false) => None,
+            CoreMetadata::Bool(true) => Some(HashDigests::empty()),
+            CoreMetadata::Hashes(hashes) => Some(HashDigests::from(hashes)),
+        }
     }
 }
 

--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -36,10 +36,6 @@ pub struct File {
     pub upload_time_utc_ms: Option<i64>,
     pub url: FileLocation,
     pub yanked: Option<Box<Yanked>>,
-    /// Deprecated pyx-specific zstd wheel metadata, retained only for compatibility with the
-    /// flat-index cache layout.
-    // TODO: Remove this field when the flat-index cache format is next bumped.
-    pub zstd: Option<Box<Zstd>>,
 }
 
 impl File {
@@ -60,7 +56,6 @@ impl File {
             upload_time_utc_ms: file.upload_time.map(Timestamp::as_millisecond),
             url: FileLocation::new(file.url, base),
             yanked: file.yanked,
-            zstd: None,
         })
     }
 
@@ -260,15 +255,6 @@ pub enum ToUrlError {
         #[source]
         err: DisplaySafeUrlError,
     },
-}
-
-/// Deprecated pyx-specific zstd wheel metadata, retained only for compatibility with existing
-/// cache layouts.
-// TODO: Remove this type once the Simple API and flat-index cache formats are both bumped.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-pub struct Zstd {
-    pub hashes: HashDigests,
-    pub size: Option<u64>,
 }
 
 #[cfg(test)]

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -294,15 +294,6 @@ impl Serialize for CoreMetadata {
     }
 }
 
-impl CoreMetadata {
-    pub fn is_available(&self) -> bool {
-        match self {
-            Self::Bool(is_available) => *is_available,
-            Self::Hashes(_) => true,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
 #[rkyv(derive(Debug))]
 pub enum Yanked {

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -46,8 +46,9 @@ pub struct PypiFile {
 #[derive(Deserialize)]
 #[serde(field_identifier, rename_all = "kebab-case")]
 enum FileField {
-    #[serde(alias = "dist-info-metadata", alias = "data-dist-info-metadata")]
     CoreMetadata,
+    #[serde(alias = "data-dist-info-metadata")]
+    DistInfoMetadata,
     Filename,
     Hashes,
     RequiresPython,
@@ -215,6 +216,7 @@ impl<'de> Visitor<'de> for PypiFileVisitor<'_> {
         M: MapAccess<'de>,
     {
         let mut core_metadata = None;
+        let mut dist_info_metadata = None;
         let mut filename = None;
         let mut hashes = None;
         let mut requires_python = None;
@@ -227,6 +229,11 @@ impl<'de> Visitor<'de> for PypiFileVisitor<'_> {
             match key {
                 FileField::CoreMetadata if core_metadata.is_none() => {
                     core_metadata = access.next_value()?;
+                }
+                FileField::DistInfoMetadata
+                    if core_metadata.is_none() && dist_info_metadata.is_none() =>
+                {
+                    dist_info_metadata = access.next_value()?;
                 }
                 FileField::Filename => filename = Some(access.next_value()?),
                 FileField::Hashes => hashes = Some(access.next_value()?),
@@ -245,7 +252,7 @@ impl<'de> Visitor<'de> for PypiFileVisitor<'_> {
         }
 
         Ok(PypiFile {
-            core_metadata,
+            core_metadata: core_metadata.or(dist_info_metadata),
             filename: filename.ok_or_else(|| serde::de::Error::missing_field("filename"))?,
             hashes: hashes.ok_or_else(|| serde::de::Error::missing_field("hashes"))?,
             requires_python,
@@ -788,7 +795,48 @@ pub enum HashError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{HashError, Hashes};
+    use crate::{CoreMetadata, HashError, Hashes, PypiFile};
+
+    #[test]
+    fn pypi_core_metadata_precedence() -> Result<(), serde_json::Error> {
+        const SHA256: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+        for metadata_fields in [
+            format!(r#""dist-info-metadata": true, "core-metadata": {{"sha256": "{SHA256}"}}"#),
+            format!(r#""core-metadata": {{"sha256": "{SHA256}"}}, "dist-info-metadata": true"#),
+            format!(
+                r#""core-metadata": {{"sha256": "{SHA256}"}}, "dist-info-metadata": "ignored""#
+            ),
+            format!(
+                r#""data-dist-info-metadata": true, "core-metadata": {{"sha256": "{SHA256}"}}"#
+            ),
+        ] {
+            // Use raw JSON to control field order.
+            let document = format!(
+                r#"{{"filename": "example-1.0-py3-none-any.whl", "hashes": {{}}, "url": "example.whl", {metadata_fields}}}"#
+            );
+            let pypi_file: PypiFile = serde_json::from_str(&document)?;
+
+            assert!(matches!(
+                pypi_file.core_metadata,
+                Some(CoreMetadata::Hashes(hashes)) if hashes.sha256.as_deref() == Some(SHA256)
+            ));
+        }
+
+        for alias in ["dist-info-metadata", "data-dist-info-metadata"] {
+            let document = format!(
+                r#"{{"filename": "example-1.0-py3-none-any.whl", "hashes": {{}}, "url": "example.whl", "{alias}": true}}"#
+            );
+            let pypi_file: PypiFile = serde_json::from_str(&document)?;
+
+            assert!(matches!(
+                pypi_file.core_metadata,
+                Some(CoreMetadata::Bool(true))
+            ));
+        }
+
+        Ok(())
+    }
 
     #[test]
     fn parse_hashes() -> Result<(), HashError> {

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1716,7 +1716,6 @@ impl PylockTomlWheel {
             upload_time_utc_ms: self.upload_time.map(Timestamp::as_millisecond),
             url: FileLocation::AbsoluteUrl(file_url),
             yanked: None,
-            zstd: None,
         });
 
         Ok(RegistryBuiltWheel {
@@ -1880,7 +1879,6 @@ impl PylockTomlSdist {
             upload_time_utc_ms: self.upload_time.map(Timestamp::as_millisecond),
             url: FileLocation::AbsoluteUrl(file_url),
             yanked: None,
-            zstd: None,
         });
 
         Ok(RegistrySourceDist {

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1708,7 +1708,7 @@ impl PylockTomlWheel {
         };
 
         let file = Box::new(uv_distribution_types::File {
-            dist_info_metadata: false,
+            dist_info_metadata: None,
             filename: SmallString::from(filename.to_string()),
             hashes: HashDigests::from(self.hashes.clone()),
             requires_python: None,
@@ -1872,7 +1872,7 @@ impl PylockTomlSdist {
         };
 
         let file = Box::new(uv_distribution_types::File {
-            dist_info_metadata: false,
+            dist_info_metadata: None,
             filename,
             hashes: HashDigests::from(self.hashes.clone()),
             requires_python: None,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -4362,7 +4362,6 @@ impl Package {
                     upload_time_utc_ms: sdist.upload_time().map(Timestamp::as_millisecond),
                     url: FileLocation::AbsoluteUrl(file_url.clone()),
                     yanked: None,
-                    zstd: None,
                 });
 
                 let index = IndexUrl::from(VerbatimUrl::from_url(
@@ -4438,7 +4437,6 @@ impl Package {
                     upload_time_utc_ms: sdist.upload_time().map(Timestamp::as_millisecond),
                     url: file_url,
                     yanked: None,
-                    zstd: None,
                 });
 
                 let index = IndexUrl::from(
@@ -6216,7 +6214,6 @@ impl Wheel {
                     upload_time_utc_ms: self.upload_time.map(Timestamp::as_millisecond),
                     url: file_location,
                     yanked: None,
-                    zstd: None,
                 });
                 let index = IndexUrl::from(VerbatimUrl::from_url(
                     url.to_url().map_err(LockErrorKind::InvalidUrl)?,
@@ -6260,7 +6257,6 @@ impl Wheel {
                     upload_time_utc_ms: self.upload_time.map(Timestamp::as_millisecond),
                     url: file_location,
                     yanked: None,
-                    zstd: None,
                 });
                 let index = IndexUrl::from(
                     VerbatimUrl::from_absolute_path(root.join(index_path))

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -4352,7 +4352,7 @@ impl Package {
                     }
                 })?;
                 let file = Box::new(uv_distribution_types::File {
-                    dist_info_metadata: false,
+                    dist_info_metadata: None,
                     filename: SmallString::from(filename),
                     hashes: sdist.hash().map_or(HashDigests::empty(), |hash| {
                         HashDigests::from(hash.0.clone())
@@ -4428,7 +4428,7 @@ impl Package {
                     }
                 })?;
                 let file = Box::new(uv_distribution_types::File {
-                    dist_info_metadata: false,
+                    dist_info_metadata: None,
                     filename: SmallString::from(filename),
                     hashes: sdist.hash().map_or(HashDigests::empty(), |hash| {
                         HashDigests::from(hash.0.clone())
@@ -6208,7 +6208,7 @@ impl Wheel {
                     }
                 };
                 let file = Box::new(uv_distribution_types::File {
-                    dist_info_metadata: false,
+                    dist_info_metadata: None,
                     filename: SmallString::from(filename.to_string()),
                     hashes: self.hash.iter().map(|h| h.0.clone()).collect(),
                     requires_python: None,
@@ -6252,7 +6252,7 @@ impl Wheel {
                     }
                 };
                 let file = Box::new(uv_distribution_types::File {
-                    dist_info_metadata: false,
+                    dist_info_metadata: None,
                     filename: SmallString::from(filename.to_string()),
                     hashes: self.hash.iter().map(|h| h.0.clone()).collect(),
                     requires_python: None,

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -287,7 +287,7 @@ impl BatchPrefetcherRunner {
 
             // Avoid prefetching built distributions that don't support _either_ PEP 658 (`.metadata`)
             // or range requests.
-            if !(wheel.file.dist_info_metadata
+            if !(wheel.file.dist_info_metadata.is_some()
                 || self.capabilities.supports_range_requests(&wheel.index))
             {
                 debug!("Abandoning prefetch for {wheel} due to missing registry capabilities");

--- a/crates/uv/tests/build/cache_clean.rs
+++ b/crates/uv/tests/build/cache_clean.rs
@@ -354,7 +354,7 @@ fn clean_package_pypi() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v24")
+        .child("simple-v25")
         .child("pypi")
         .child("iniconfig.rkyv");
     assert!(
@@ -417,7 +417,7 @@ fn clean_package_index() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v24")
+        .child("simple-v25")
         .child("index")
         .child("e8208120cae3ba69")
         .child("iniconfig.rkyv");

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -11732,6 +11732,122 @@ fn lock_mixed_hashes() -> Result<()> {
     Ok(())
 }
 
+/// Verify sidecar downloads using both fresh and cached index responses.
+#[cfg(feature = "test-universal")]
+#[tokio::test]
+async fn lock_core_metadata_hash() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let index_server = MockServer::start().await;
+    let artifact_server = MockServer::start().await;
+
+    let metadata = indoc! {"
+        Metadata-Version: 2.1
+        Name: basic-package
+        Version: 0.1.0
+    "};
+    let metadata_hash = hex::encode(Sha256::digest(metadata.as_bytes())).to_ascii_uppercase();
+    let forged_metadata = indoc! {"
+        Metadata-Version: 2.1
+        Name: basic-package
+        Version: 0.1.0
+        Summary: forged metadata
+    "};
+    let simple_index = json!({
+        "meta": {
+            "api-version": "1.1"
+        },
+        "name": "basic-package",
+        "files": [{
+            "filename": "basic_package-0.1.0-py3-none-any.whl",
+            "url": format!("{}/files/basic_package-0.1.0-py3-none-any.whl", artifact_server.uri()),
+            "hashes": {
+                "sha256": "7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82"
+            },
+            "core-metadata": { "sha256": metadata_hash },
+            "upload-time": "2024-03-24T00:00:00Z"
+        }]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/simple/basic-package/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            simple_index.to_string(),
+            "application/vnd.pypi.simple.v1+json",
+        ))
+        .expect(1)
+        .mount(&index_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/files/basic_package-0.1.0-py3-none-any.whl.metadata"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(forged_metadata))
+        .expect(2)
+        .mount(&artifact_server)
+        .await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["basic-package"]
+
+        [[tool.uv.index]]
+        name = "test-registry"
+        url = "{}/simple"
+        default = true
+        cache-control = {{ api = "max-age=3600, immutable", files = "max-age=3600, immutable" }}
+    "#, index_server.uri()})?;
+
+    // Reject sidecar bytes that do not match the index's advertised hash.
+    uv_snapshot!(context.filters(), context.lock(), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Hash mismatch for package metadata at `http://[LOCALHOST]/files/basic_package-0.1.0-py3-none-any.whl.metadata`
+
+    Expected:
+      sha256:1C9F243A45631766EACD673AD9F6A1672AD847C7495A387C3B8D6C9B0572E00B
+
+    Computed:
+      sha256:987ad54f0d53537fb7157c700260deaa18346f43db7968cf0327de594d631205
+    ");
+
+    // The cached index response must retain the expected sidecar hashes.
+    uv_snapshot!(context.filters(), context.lock(), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Hash mismatch for package metadata at `http://[LOCALHOST]/files/basic_package-0.1.0-py3-none-any.whl.metadata`
+
+    Expected:
+      sha256:1C9F243A45631766EACD673AD9F6A1672AD847C7495A387C3B8D6C9B0572E00B
+
+    Computed:
+      sha256:987ad54f0d53537fb7157c700260deaa18346f43db7968cf0327de594d631205
+    ");
+
+    // Serve the genuine metadata without refreshing the sidecar cache.
+    artifact_server.verify().await;
+    artifact_server.reset().await;
+
+    Mock::given(method("GET"))
+        .and(path("/files/basic_package-0.1.0-py3-none-any.whl.metadata"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(metadata))
+        .expect(1)
+        .mount(&artifact_server)
+        .await;
+
+    context.lock().assert().success();
+    // The rejected metadata must not be reused from the cache.
+    artifact_server.verify().await;
+
+    fs_err::remove_file(context.temp_dir.join("uv.lock"))?;
+    context.lock().assert().success();
+    // The verified metadata must be reused without another download.
+    artifact_server.verify().await;
+
+    Ok(())
+}
+
 /// Lock with an index that advertises multiple hashes, then require SHA256 for that index.
 #[cfg(feature = "test-universal")]
 #[tokio::test]

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -15996,7 +15996,7 @@ fn lock_find_links_http_wheel() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
-    assert!(context.cache_dir.child("flat-index-v4").is_dir());
+    assert!(context.cache_dir.child("flat-index-v5").is_dir());
 
     let lock = context.read("uv.lock");
 


### PR DESCRIPTION
Previously we ignored index-provided hashes when downloading PEP 658 metadata sidecars. This PR stores those hashes in cached index responses (necessitating a bump of the simple and flat-index cache buckets) so we can reference them when downloading a sidecar, and verifies the sidecar bytes if the index provided a hash.

This also includes a fix for PEP 714 compliance where we could previously incorrectly pick dist-info-metadata or data-dist-info-metadata over core-metadata depending on the order in the json (HTML was already correct).

Existing cached sidecars are reused without hash verification; only freshly downloaded sidecars are checked against index-provided hashes.

Since this bumps `cache`, there's a commit removing the legacy `zstd` fields from `CachedFile` and `File`.