### PR TITLE
Preserve hints in tool upgrade failures

### DIFF
--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -12,7 +12,6 @@ use uv_client::BaseClientBuilder;
 use uv_configuration::{Concurrency, Constraints, DryRun, HashCheckingMode, TargetTriple};
 use uv_distribution::LoweredExtraBuildDependencies;
 use uv_distribution_types::{ExtraBuildRequires, Index, Name, Requirement, RequirementSource};
-use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
 use uv_fs::{CWD, Simplified};
 use uv_installer::{InstallationStrategy, Planner, SitePackages};
 use uv_normalize::PackageName;
@@ -179,11 +178,9 @@ pub(crate) async fn upgrade(
             .sorted_unstable_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b))
         {
             trace!("Error trace: {err:?}");
-            write_error_chain_with_options(
-                err.context(format!("Failed to upgrade {}", name.green()))
-                    .as_ref(),
-                &Hints::none(),
-                ErrorOptions::default().with_stream(printer.stderr()),
+            crate::commands::diagnostics::write_error_chain(
+                &err.context(format!("Failed to upgrade {}", name.green())),
+                printer,
             )?;
         }
         return Ok(ExitStatus::Failure);

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -1651,6 +1651,66 @@ async fn mount_simple_launcher_index(server: &MockServer, hash: &str, wheel: &[u
         .await;
 }
 
+#[tokio::test]
+async fn tool_upgrade_resolution_hints_quiet_modes() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_tool_dirs();
+    let bin_dir = context.temp_dir.child("bin");
+    let wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/simple_launcher-0.1.0-py3-none-any.whl"),
+    )?;
+    let server = MockServer::start().await;
+    mount_simple_launcher_index(
+        &server,
+        "5327e0bb67cdb46800999de6dcf034bf0a5335702883494af0d8b7f6ca48cee4",
+        &wheel,
+    )
+    .await;
+    let index_url = format!("{}/simple", server.uri());
+    context
+        .tool_install()
+        .arg("simple-launcher")
+        .arg("--index-url")
+        .arg(&index_url)
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    server.reset().await;
+    Mock::given(method("GET"))
+        .and(path("/simple/simple-launcher/"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    for quiet in [None, Some("-q"), Some("-qq")] {
+        let mut command = context.tool_upgrade();
+        command
+            .arg("simple-launcher>0.1.0")
+            .arg("--index-url")
+            .arg(&index_url)
+            .arg("--no-cache")
+            .env(EnvVars::PATH, bin_dir.as_os_str());
+        if let Some(quiet) = quiet {
+            command.arg(quiet);
+        }
+        let assertion = command.assert().code(1);
+        if quiet == Some("-qq") {
+            assertion.stderr("");
+        } else {
+            assertion
+                .stderr(predicate::str::contains(
+                    "error: Failed to upgrade simple-launcher",
+                ))
+                .stderr(predicate::str::contains("hint: An index URL"))
+                .stderr(predicate::str::contains("401 Unauthorized"));
+        }
+    }
+
+    Ok(())
+}
+
 /// Ensure that `tool upgrade` verifies distributions against its newly generated tool lock.
 ///
 /// The initial install and upgrade use the same index URL so that the installed distribution's

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -1652,7 +1652,7 @@ async fn mount_simple_launcher_index(server: &MockServer, hash: &str, wheel: &[u
 }
 
 #[tokio::test]
-async fn tool_upgrade_resolution_hints_quiet_modes() -> Result<()> {
+async fn tool_upgrade_resolution_hints() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_tool_dirs();
     let bin_dir = context.temp_dir.child("bin");
     let wheel = fs_err::read(
@@ -1684,29 +1684,19 @@ async fn tool_upgrade_resolution_hints_quiet_modes() -> Result<()> {
         .mount(&server)
         .await;
 
-    for quiet in [None, Some("-q"), Some("-qq")] {
-        let mut command = context.tool_upgrade();
-        command
-            .arg("simple-launcher>0.1.0")
-            .arg("--index-url")
-            .arg(&index_url)
-            .arg("--no-cache")
-            .env(EnvVars::PATH, bin_dir.as_os_str());
-        if let Some(quiet) = quiet {
-            command.arg(quiet);
-        }
-        let assertion = command.assert().code(1);
-        if quiet == Some("-qq") {
-            assertion.stderr("");
-        } else {
-            assertion
-                .stderr(predicate::str::contains(
-                    "error: Failed to upgrade simple-launcher",
-                ))
-                .stderr(predicate::str::contains("hint: An index URL"))
-                .stderr(predicate::str::contains("401 Unauthorized"));
-        }
-    }
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("simple-launcher>0.1.0")
+        .arg("--index-url")
+        .arg(&index_url)
+        .arg("--no-cache")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    error: Failed to upgrade simple-launcher
+      Caused by: Because simple-launcher was not found in the package registry and you require simple-launcher>0.1.0, we can conclude that your requirements are unsatisfiable.
+
+    hint: An index URL (http://[LOCALHOST]/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
`uv tool upgrade` renders each failed upgrade with an empty hint list, so resolver guidance such as missing registry credentials is lost. It also uses ordinary stderr, which hides the final failure under `-q`.

Use the command-layer error renderer for each failure. This collects hints from the error chain and keeps final errors visible with `-q` while suppressing them with `-qq`. Upgrading other requested tools still continues after an error, and the aggregate failure status remains 1.

Prior work:

- #17110 moves operation errors and hints onto the standard rendering path.
- #20163 defines the final-error behavior for `-q` and `-qq`.
