### PR TITLE
Route Python upgrade request errors through `UvError`

### DIFF
--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -18,6 +18,7 @@ use crate::commands::project::add::AddDependencyError;
 use crate::commands::project::remove::DependencyNotFoundError;
 use crate::commands::project::run::RecursionLimitError;
 use crate::commands::project::version::MissingProjectVersionError;
+use crate::commands::python::install::InvalidUpgradeRequestError;
 use crate::commands::tool::common::NoExecutablesError;
 use crate::commands::tool::run::{ToolRunScriptError, ToolRunUsageError};
 use crate::printer::Printer;
@@ -68,6 +69,7 @@ pub(crate) fn hints_for_error(err: &anyhow::Error) -> Hints<'static> {
         collect_hint::<NoExecutablesError>(cause, &mut hints);
         collect_hint::<ExternallyManagedError>(cause, &mut hints);
         collect_hint::<MissingProjectVersionError>(cause, &mut hints);
+        collect_hint::<InvalidUpgradeRequestError>(cause, &mut hints);
         collect_hint::<crate::commands::build_frontend::Error>(cause, &mut hints);
         collect_hint::<uv_build_backend::Error>(cause, &mut hints);
         collect_hint::<uv_build_frontend::Error>(cause, &mut hints);

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -41,7 +41,7 @@ use uv_warnings::warn_user;
 
 use crate::commands::python::{ChangeEvent, ChangeEventKind};
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::{ExitStatus, conjunction, elapsed};
+use crate::commands::{ExitStatus, UvError, conjunction, elapsed};
 use crate::printer::Printer;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -166,6 +166,26 @@ impl std::fmt::Display for PythonUpgradeSource {
         match self {
             Self::Install => write!(f, "uv python install --upgrade"),
             Self::Upgrade => write!(f, "uv python upgrade"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("`{command}` only accepts minor versions, got: {request}")]
+pub(crate) struct InvalidUpgradeRequestError {
+    command: PythonUpgradeSource,
+    request: String,
+    from_version_file: bool,
+}
+
+impl uv_errors::Hinted for InvalidUpgradeRequestError {
+    fn hints(&self) -> Hints<'_> {
+        if self.from_version_file {
+            Hints::from(
+                "The version request came from a `.python-version` file; change the patch version in the file to upgrade instead",
+            )
+        } else {
+            Hints::none()
         }
     }
 }
@@ -446,22 +466,12 @@ async fn perform_install(
         if let Some(request) = requests.iter().find(|request| {
             request.request.includes_patch() || request.request.includes_prerelease()
         }) {
-            writeln!(
-                printer.stderr(),
-                "error: `{source}` only accepts minor versions, got: {}",
-                request.request.to_canonical_string()
-            )?;
-            if is_from_python_version_file {
-                // TODO(zanieb): Consider refactoring this to use an error type.
-                write!(
-                    printer.stderr(),
-                    "{}",
-                    uv_errors::Hints::from(
-                        "The version request came from a `.python-version` file; change the patch version in the file to upgrade instead",
-                    ),
-                )?;
-            }
-            return Ok(ExitStatus::Failure);
+            return Err(UvError::user(InvalidUpgradeRequestError {
+                command: source,
+                request: request.request.to_canonical_string().into_owned(),
+                from_version_file: is_from_python_version_file,
+            })
+            .into());
         }
     }
 


### PR DESCRIPTION
Python upgrade rejects patch and prerelease requests by printing directly to ordinary stderr, so `-q` hides the error and its `.python-version` guidance. Represent this as a typed user error and collect the version-file hint through `Hinted`. The message remains visible with `-q`, is suppressed with `-qq`, and keeps exit code 1. Explicit command-line version requests do not receive the version-file hint.

Prior work:

- #20188 introduced the explicit `UvError` model.
- #20163 defines the final-error behavior for `-q` and `-qq`.
- #17110 consolidates the remaining operation-error rendering.
