### PR TITLE
Retry failed partial downloads with HTTP Range header when supported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6576,6 +6576,7 @@ dependencies = [
  "either",
  "fs-err",
  "futures",
+ "http-content-range",
  "indoc",
  "insta",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ hashbrown = { version = "0.17.0" }
 hex = { version = "0.4.3" }
 html-escape = { version = "0.2.13" }
 http = { version = "1.1.0" }
+http-content-range = { version = "0.2.4" }
 indexmap = { version = "2.5.0" }
 indicatif = { version = "0.18.0" }
 indoc = { version = "2.0.5" }

--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -413,7 +413,7 @@ impl Osv {
                 req,
                 &cache_entry,
                 CacheControl::Override(VULN_CACHE_CONTROL.clone()),
-                async |response| response.json::<Vulnerability>().await,
+                async |response, _| response.json::<Vulnerability>().await,
             )
             .await
             .map_err(|err| match err {

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -99,8 +99,7 @@ where
 pub enum CachedClientError<CallbackError: std::error::Error + 'static> {
     /// The client tracks retries internally.
     Client(Error),
-    /// Track retries before a callback explicitly, as we can't attach them to the callback error
-    /// type.
+    /// The callback error, with retry context attached by the outer request loop.
     Callback {
         retries: u32,
         err: CallbackError,
@@ -238,7 +237,7 @@ impl CachedClient {
     async fn get_cacheable<
         Payload: Cacheable + 'static,
         CallBackError: std::error::Error + 'static,
-        Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+        Callback: AsyncFnOnce(Response) -> Result<Payload, CallBackError>,
     >(
         &self,
         req: Request,
@@ -451,17 +450,13 @@ impl CachedClient {
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let new_cache = info_span!("new_cache", file = %cache_entry.path().display());
-        // Capture retries from the retry middleware
-        let retries = response
-            .extensions()
-            .get::<reqwest_retry::RetryCount>()
-            .map(|retries| retries.value())
-            .unwrap_or_default();
         let data = response_callback(response)
             .boxed_local()
             .await
             .map_err(|err| CachedClientError::Callback {
-                retries,
+                // These retries are already counted in RetryState, so don't count them again.
+                // The outer loop fills in the total before returning the error to the caller.
+                retries: 0,
                 err,
                 duration: start.elapsed(),
             })?;
@@ -701,11 +696,14 @@ impl CachedClient {
     }
 
     /// Perform a [`CachedClient::get_serde`] request with a default retry strategy.
+    ///
+    /// The callback shares the request's [`RetryState`]. It must use that state for any retries
+    /// it performs and send subsequent requests through [`RetryState::send`].
     #[instrument(skip_all)]
     pub async fn get_serde_with_retry<
         Payload: Serialize + DeserializeOwned + Send + 'static,
         CallBackError: std::error::Error + 'static,
-        Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+        Callback: AsyncFn(Response, &mut RetryState) -> Result<Payload, CallBackError>,
     >(
         &self,
         req: Request,
@@ -714,10 +712,15 @@ impl CachedClient {
         response_callback: Callback,
     ) -> Result<Payload, CachedClientError<CallBackError>> {
         let payload = self
-            .get_cacheable_with_retry(req, cache_entry, cache_control, async |resp| {
-                let payload = response_callback(resp).await?;
-                Ok(SerdeCacheable { inner: payload })
-            })
+            .get_cacheable_with_retry(
+                req,
+                cache_entry,
+                cache_control,
+                async |resp, retry_state| {
+                    let payload = response_callback(resp, retry_state).await?;
+                    Ok(SerdeCacheable { inner: payload })
+                },
+            )
             .await?;
         Ok(payload)
     }
@@ -729,7 +732,7 @@ impl CachedClient {
     pub(crate) async fn get_cacheable_with_retry<
         Payload: Cacheable + 'static,
         CallBackError: std::error::Error + 'static,
-        Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+        Callback: AsyncFn(Response, &mut RetryState) -> Result<Payload, CallBackError>,
     >(
         &self,
         req: Request,
@@ -745,7 +748,11 @@ impl CachedClient {
                     fresh_req,
                     cache_entry,
                     cache_control.clone(),
-                    &response_callback,
+                    async |response| {
+                        retry_state
+                            .handle_response(response, &response_callback)
+                            .await
+                    },
                 )
                 .await;
 
@@ -763,11 +770,13 @@ impl CachedClient {
 
     /// Perform a [`CachedClient::skip_cache`] request with a default retry strategy.
     ///
+    /// The callback shares the request's [`RetryState`], as in [`Self::get_serde_with_retry`].
+    ///
     /// See: <https://github.com/TrueLayer/reqwest-middleware/blob/8a494c165734e24c62823714843e1c9347027e8a/reqwest-retry/src/middleware.rs#L137>
     pub async fn skip_cache_with_retry<
         Payload: Serialize + DeserializeOwned + Send + 'static,
         CallBackError: std::error::Error + 'static,
-        Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+        Callback: AsyncFn(Response, &mut RetryState) -> Result<Payload, CallBackError>,
     >(
         &self,
         req: Request,
@@ -783,7 +792,11 @@ impl CachedClient {
                     fresh_req,
                     cache_entry,
                     cache_control.clone(),
-                    &response_callback,
+                    async |response| {
+                        retry_state
+                            .handle_response(response, &response_callback)
+                            .await
+                    },
                 )
                 .await;
 

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -15,7 +15,7 @@ use uv_small_str::SmallString;
 
 use crate::cached_client::{CacheControl, CachedClientError};
 use crate::html::SimpleDetailHTML;
-use crate::{CachedClient, Connectivity, Error, ErrorKind, OwnedArchive};
+use crate::{CachedClient, Connectivity, Error, ErrorKind, OwnedArchive, RetryState};
 
 #[derive(Debug, thiserror::Error)]
 pub enum FlatIndexError {
@@ -216,7 +216,7 @@ impl<'a> FlatIndexClient<'a> {
             .map_err(|err| {
                 ErrorKind::from_reqwest(url.clone(), err, self.client.certificate_source())
             })?;
-        let parse_simple_response = |response: Response| {
+        let parse_simple_response = |response: Response, _: &mut RetryState| {
             async {
                 // Use the response URL, rather than the request URL, as the base for relative URLs.
                 // This ensures that we handle redirects and other URL transformations correctly.

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -45,6 +45,7 @@ use crate::remote_metadata::wheel_metadata_from_remote_zip;
 use crate::rkyvutil::OwnedArchive;
 use crate::{
     BaseClient, CachedClient, Error, ErrorKind, FlatIndexClient, RedirectClientWithMiddleware,
+    RetryState,
 };
 
 /// A builder for an [`RegistryClient`].
@@ -624,7 +625,7 @@ impl RegistryClient {
             .map_err(|err| {
                 ErrorKind::from_reqwest(url.clone(), err, self.client.certificate_source())
             })?;
-        let parse_simple_response = |response: Response| {
+        let parse_simple_response = |response: Response, _: &mut RetryState| {
             async {
                 // Use the response URL, rather than the request URL, as the base for relative URLs.
                 // This ensures that we handle redirects and other URL transformations correctly.
@@ -770,7 +771,7 @@ impl RegistryClient {
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
-        let parse_simple_response = |response: Response| {
+        let parse_simple_response = |response: Response, _: &mut RetryState| {
             async {
                 // Use the response URL, rather than the request URL, as the base for relative URLs.
                 // This ensures that we handle redirects and other URL transformations correctly.
@@ -1057,7 +1058,7 @@ impl RegistryClient {
                 lock_entry.lock().await.map_err(ErrorKind::CacheLock)?
             };
 
-            let response_callback = async |response: Response| {
+            let response_callback = async |response: Response, _: &mut RetryState| {
                 let bytes = response.bytes().await.map_err(|err| {
                     ErrorKind::from_reqwest(url.clone(), err, self.client.certificate_source())
                 })?;
@@ -1181,7 +1182,7 @@ impl RegistryClient {
             );
             // This response callback is special, we actually make a number of subsequent requests to
             // fetch the file from the remote zip.
-            let read_metadata_range_request = |response: Response| {
+            let read_metadata_range_request = |response: Response, _: &mut RetryState| {
                 async {
                     let mut reader = AsyncHttpRangeReader::from_head_response(
                         self.uncached_client(url).clone(),
@@ -1260,7 +1261,7 @@ impl RegistryClient {
             })?;
 
         // Stream the file, searching for the METADATA.
-        let read_metadata_stream = |response: Response| {
+        let read_metadata_stream = |response: Response, _: &mut RetryState| {
             async {
                 let reader = response
                     .bytes_stream()

--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 use uv_redacted::DisplaySafeUrl;
 
-use crate::WrappedReqwestError;
+use crate::{RequestBuilder, WrappedReqwestError};
 
 /// An extension over [`DefaultRetryableStrategy`] that logs transient request failures and
 /// adds additional retry cases.
@@ -78,7 +78,7 @@ impl RetryState {
 
     /// The number of retries across all requests.
     ///
-    /// After a failed retryable request, this equals the maximum number of retries.
+    /// Includes retries reported by the HTTP middleware.
     pub(crate) fn total_retries(&self) -> u32 {
         self.total_retries
     }
@@ -86,6 +86,49 @@ impl RetryState {
     /// The total duration from the first request to the (failure) of the last request.
     pub(crate) fn duration(&self) -> Result<Duration, SystemTimeError> {
         self.start_time.elapsed()
+    }
+
+    /// Send a request and count any retries performed by the middleware.
+    pub async fn send(
+        &mut self,
+        request: RequestBuilder<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        let result = request.send().await;
+        self.record_request_retries(result.as_ref());
+        result
+    }
+
+    /// Count middleware retries before invoking the callback with the updated [`RetryState`].
+    pub(crate) async fn handle_response<Payload, CallbackError, Callback>(
+        &mut self,
+        response: Response,
+        callback: Callback,
+    ) -> Result<Payload, CallbackError>
+    where
+        Callback: AsyncFnOnce(Response, &mut Self) -> Result<Payload, CallbackError>,
+    {
+        self.record_request_retries(Ok(&response));
+        callback(response, self).await
+    }
+
+    /// Account for retries performed by the middleware before handling a response or error.
+    ///
+    /// Call once per request, including successful requests whose bodies may later fail.
+    fn record_request_retries(&mut self, result: Result<&Response, &reqwest_middleware::Error>) {
+        let retries = match result {
+            Ok(response) => response
+                .extensions()
+                .get::<reqwest_retry::RetryCount>()
+                .map_or(0, |retries| retries.value()),
+            Err(reqwest_middleware::Error::Middleware(err)) => {
+                match err.downcast_ref::<reqwest_retry::RetryError>() {
+                    Some(reqwest_retry::RetryError::WithRetries { retries, .. }) => *retries,
+                    Some(reqwest_retry::RetryError::Error(_)) | None => 0,
+                }
+            }
+            Err(reqwest_middleware::Error::Reqwest(_)) => 0,
+        };
+        self.total_retries += retries;
     }
 
     /// Determines whether request should be retried.

--- a/crates/uv-client/tests/it/cached_client.rs
+++ b/crates/uv-client/tests/it/cached_client.rs
@@ -1,9 +1,141 @@
-use std::assert_matches;
-use uv_client::{DataWithCachePolicy, ErrorKind};
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{assert_matches, io};
+
+use anyhow::Result;
+use reqwest::Response;
+use wiremock::matchers::any;
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+use uv_cache::CacheEntry;
+use uv_client::{
+    BaseClientBuilder, CacheControl, CachedClient, CachedClientError, DataWithCachePolicy,
+    ErrorKind, RetryState,
+};
 
 #[test]
 fn reject_overflowing_cache_policy_length() {
     let error = DataWithCachePolicy::from_reader(&[u8::MAX; 8][..]).unwrap_err();
 
     assert_matches!(error.kind(), ErrorKind::ArchiveRead(_));
+}
+
+/// Exercise the shared budget through both cached and forced-refresh requests.
+async fn assert_retry_budget(
+    middleware_failures: usize,
+    retry_in_callback: bool,
+    expected_callback_retries: &[bool],
+) -> Result<()> {
+    for skip_cache in [false, true] {
+        let server = MockServer::start().await;
+        let requests = AtomicUsize::new(0);
+        Mock::given(any())
+            .respond_with(move |_: &Request| {
+                if requests.fetch_add(1, Ordering::Relaxed) < middleware_failures {
+                    ResponseTemplate::new(503)
+                } else {
+                    ResponseTemplate::new(200).set_body_string("response")
+                }
+            })
+            .expect((middleware_failures + expected_callback_retries.len()) as u64)
+            .mount(&server)
+            .await;
+
+        let cache = tempfile::tempdir()?;
+        let entry = CacheEntry::new(cache.path(), "response.msgpack");
+        let client = CachedClient::new(
+            BaseClientBuilder::default()
+                .retries(2)
+                .no_retry_delay(true)
+                .build()?,
+        );
+        let url = server.uri().parse()?;
+        let request = client.uncached().for_host(&url).get(server.uri()).build()?;
+        let callback_retries = RefCell::new(Vec::new());
+        let callback = async |response: Response, retry_state: &mut RetryState| {
+            response.bytes().await.map_err(io::Error::other)?;
+            let error = io::Error::new(io::ErrorKind::TimedOut, "interrupted response");
+            callback_retries
+                .borrow_mut()
+                .push(retry_in_callback && retry_state.should_retry(&error, 0).is_some());
+            Err::<String, _>(error)
+        };
+        let result = if skip_cache {
+            client
+                .skip_cache_with_retry(request, &entry, CacheControl::None, callback)
+                .await
+        } else {
+            client
+                .get_serde_with_retry(request, &entry, CacheControl::None, callback)
+                .await
+        };
+
+        assert_matches!(result, Err(CachedClientError::Callback { retries: 2, .. }));
+        assert_eq!(callback_retries.into_inner(), expected_callback_retries);
+        server.verify().await;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn callback_and_outer_retries_share_budget() -> Result<()> {
+    // One retry in the callback leaves one full restart, whose callback has no budget left.
+    assert_retry_budget(0, true, &[true, false]).await
+}
+
+#[tokio::test]
+async fn middleware_retries_are_counted_before_callback() -> Result<()> {
+    // The middleware exhausts the budget before delivering a response to the callback.
+    assert_retry_budget(2, true, &[false]).await
+}
+
+#[tokio::test]
+async fn middleware_retries_are_not_counted_twice() -> Result<()> {
+    // One middleware retry leaves one full restart after the callback fails.
+    assert_retry_budget(1, false, &[false, false]).await
+}
+
+#[tokio::test]
+async fn send_counts_middleware_retries() -> Result<()> {
+    for network_error in [false, true] {
+        let server = MockServer::start().await;
+        let mock = if network_error {
+            Mock::given(any())
+                .respond_with_err(|_: &Request| {
+                    io::Error::new(io::ErrorKind::ConnectionReset, "connection reset")
+                })
+                .expect(3)
+        } else {
+            let requests = AtomicUsize::new(0);
+            Mock::given(any())
+                .respond_with(move |_: &Request| {
+                    if requests.fetch_add(1, Ordering::Relaxed) == 0 {
+                        ResponseTemplate::new(503)
+                    } else {
+                        ResponseTemplate::new(200)
+                    }
+                })
+                .expect(2)
+        };
+        mock.mount(&server).await;
+
+        let client = BaseClientBuilder::default()
+            .retries(2)
+            .no_retry_delay(true)
+            .build()?;
+        let url = server.uri().parse()?;
+        let request = client.for_host(&url).get(server.uri());
+        let mut retry_state = RetryState::start(client.retry_policy(), url);
+        let result = retry_state.send(request).await;
+        assert_eq!(result.is_err(), network_error);
+
+        let error = io::Error::new(io::ErrorKind::TimedOut, "interrupted response");
+        if !network_error {
+            // The successful request used one retry, leaving one for a body failure.
+            assert!(retry_state.should_retry(&error, 0).is_some());
+        }
+        assert!(retry_state.should_retry(&error, 0).is_none());
+        server.verify().await;
+    }
+    Ok(())
 }

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -47,6 +47,7 @@ anyhow = { workspace = true }
 either = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }
+http-content-range = { workspace = true }
 owo-colors = { workspace = true }
 rayon = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -10,7 +10,6 @@ use futures::{FutureExt, TryStreamExt};
 use http_content_range::{ContentRange, ContentRangeBytes, ContentRangeUnbound};
 use rayon::in_place_scope;
 use rayon::prelude::*;
-use reqwest::header::{ETAG, HeaderValue, IF_RANGE};
 use rustc_hash::FxHashMap;
 use tokio::io::{AsyncRead, AsyncSeekExt, AsyncWriteExt, ReadBuf};
 use tokio::sync::Semaphore;
@@ -1038,7 +1037,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     ) -> Result<Archive, Error> {
         let progress_size_hint = progress_size_hint.or_else(|| content_length(&response));
         let mut download_size = content_length(&response).or(expected_size);
-        let etag = strong_etag(&response).cloned();
 
         let progress = self.reporter.as_ref().map(|reporter| {
             (
@@ -1198,12 +1196,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 return Err(err);
             }
 
-            // We expect any partial response to have an ETag, so that we can detect
-            // when an (honest) origin changes its representation beneath us.
-            let Some(etag) = etag.as_ref() else {
-                return Err(err);
-            };
-
             // Some sanity checks: we should have made *some* progress as part of
             // partial response, plus our writer's offset should agree with the number
             // of bytes retrieved, *and* we should be making forward progress (i.e. not
@@ -1223,7 +1215,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
             // Finally our resumption, which is a range request.
             debug!("Resuming download of {url} at byte {offset}");
-            let resumed_response = self.request_with_offset(url.clone(), offset, etag).await?;
+            let resumed_response = self.request_with_offset(url.clone(), offset).await?;
 
             // A chunked response can fail after all wheel bytes arrive, leaving no satisfiable
             // range. Return the original error so the outer retry policy can restart in full.
@@ -1232,14 +1224,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 return Err(err);
             }
             resumed_response.error_for_status_ref()?;
-
-            // Sanity check with the ETag above: the origin might have changed
-            // the download underneath us, in which case we need to kick back to the retry
-            // stack and do an entirely fresh request for consistency.
-            if strong_etag(&resumed_response) != Some(etag) {
-                debug!("Download changed while resuming {url}; retrying in full");
-                return Err(err);
-            }
 
             resumed_range = if resumed_response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
                 // The origin honored our range request, so we update `resumed_range`
@@ -1523,14 +1507,13 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .build()
     }
 
-    /// Send a GET request with a `Range: bytes=<offset>-` header and an `If-Range` validator.
+    /// Send a GET request with a `Range: bytes=<offset>-` header.
     ///
     /// Used to resume an interrupted download from `offset` bytes into the file.
     async fn request_with_offset(
         &self,
         url: DisplaySafeUrl,
         offset: u64,
-        etag: &HeaderValue,
     ) -> Result<reqwest::Response, reqwest_middleware::Error> {
         self.client
             .unmanaged
@@ -1541,7 +1524,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 reqwest::header::HeaderValue::from_static("identity"),
             )
             .header(reqwest::header::RANGE, format!("bytes={offset}-"))
-            .header(IF_RANGE, etag.clone())
             .send()
             .await
     }
@@ -1671,21 +1653,6 @@ fn content_length(response: &reqwest::Response) -> Option<u64> {
         .get(reqwest::header::CONTENT_LENGTH)
         .and_then(|val| val.to_str().ok())
         .and_then(|val| val.parse::<u64>().ok())
-}
-
-/// Return a syntactically valid strong `ETag` that can validate a byte range.
-///
-/// TODO: De-dupe with `uv_client::httpcache::ETag::parse`?
-fn strong_etag(response: &reqwest::Response) -> Option<&HeaderValue> {
-    let etag = response.headers().get(ETAG)?;
-    let value = etag.as_bytes().strip_prefix(b"\"")?.strip_suffix(b"\"")?;
-    if !value
-        .iter()
-        .all(|byte| *byte == b'!' || (b'#'..=b'~').contains(byte) || *byte >= 0x80)
-    {
-        return None;
-    }
-    Some(etag)
 }
 
 /// Return the bounds of a range response starting at `offset` with a known complete length.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
+use http_content_range::{ContentRange, ContentRangeBytes, ContentRangeUnbound};
 use rayon::in_place_scope;
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
@@ -935,20 +936,22 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 let mut resumed_at = None;
                 let mut supports_range_requests = false;
+                let mut can_resume = true;
 
                 loop {
-                    supports_range_requests |= response.status()
-                        == reqwest::StatusCode::PARTIAL_CONTENT
-                        || response
-                            .headers()
-                            .get(reqwest::header::ACCEPT_RANGES)
-                            .is_some_and(|value| value == "bytes");
+                    supports_range_requests |= can_resume
+                        && (response.status() == reqwest::StatusCode::PARTIAL_CONTENT
+                            || response
+                                .headers()
+                                .get(reqwest::header::ACCEPT_RANGES)
+                                .is_some_and(|value| value == "bytes"));
 
                     // A server can advertise range requests but ignore one. In that case, the
                     // response is a complete download and must replace the partial bytes.
                     if resumed_at.is_some()
                         && response.status() != reqwest::StatusCode::PARTIAL_CONTENT
                     {
+                        can_resume = false;
                         writer
                             .get_mut()
                             .set_len(0)
@@ -993,7 +996,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     let Err(err) = copy_result else {
                         break;
                     };
-                    if !supports_range_requests {
+                    if !can_resume || !supports_range_requests {
                         return Err(err);
                     }
 
@@ -1011,13 +1014,32 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     }
 
                     debug!("Resuming download of {download_url} at byte {offset}");
-                    response = self
+                    let resumed_response = self
                         .client
                         .unmanaged
                         .uncached_client(&download_url)
                         .execute(self.request_with_offset(download_url.clone(), offset)?)
                         .await?;
-                    response.error_for_status_ref()?;
+                    resumed_response.error_for_status_ref()?;
+
+                    if resumed_response.status() == reqwest::StatusCode::PARTIAL_CONTENT
+                        && !content_range_starts_at(&resumed_response, offset)
+                    {
+                        warn!(
+                            "Invalid range request response from server that declares HTTP range \
+                             request support, restarting download: {download_url}"
+                        );
+                        response = self
+                            .client
+                            .unmanaged
+                            .uncached_client(&download_url)
+                            .execute(self.request(download_url.clone())?)
+                            .await?;
+                        response.error_for_status_ref()?;
+                    } else {
+                        response = resumed_response;
+                    }
+
                     resumed_at = Some(offset);
                 }
 
@@ -1505,6 +1527,25 @@ fn content_length(response: &reqwest::Response) -> Option<u64> {
         .get(reqwest::header::CONTENT_LENGTH)
         .and_then(|val| val.to_str().ok())
         .and_then(|val| val.parse::<u64>().ok())
+}
+
+/// Returns `true` if `response` is a range response starting at `offset`.
+fn content_range_starts_at(response: &reqwest::Response, offset: u64) -> bool {
+    let Some(content_range) = response
+        .headers()
+        .get(reqwest::header::CONTENT_RANGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(ContentRange::parse)
+    else {
+        return false;
+    };
+
+    matches!(
+        content_range,
+        ContentRange::Bytes(ContentRangeBytes { first_byte, .. })
+            | ContentRange::UnboundBytes(ContentRangeUnbound { first_byte, .. })
+            if first_byte == offset
+    )
 }
 
 /// An asynchronous reader that reports progress as bytes are read.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1565,6 +1565,8 @@ fn content_length(response: &reqwest::Response) -> Option<u64> {
 }
 
 /// Return a syntactically valid strong `ETag` that can validate a byte range.
+///
+/// TODO: De-dupe with `uv_client::httpcache::ETag::parse`?
 fn strong_etag(response: &reqwest::Response) -> Option<&HeaderValue> {
     let etag = response.headers().get(ETAG)?;
     let value = etag.as_bytes().strip_prefix(b"\"")?.strip_suffix(b"\"")?;

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1034,7 +1034,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         expected_size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
-        hashes: HashPolicy<'_>,
+        hashes: ArchiveHashPolicy<'_>,
     ) -> Result<Archive, Error> {
         let progress_size_hint = progress_size_hint.or_else(|| content_length(&response));
         let mut download_size = content_length(&response).or(expected_size);
@@ -1243,7 +1243,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             } else {
                 // The origin is allowed to ignore our range request and send a full response instead.
                 // That means we have no `resumed_range` to honor on the next iteration.
-                download_size = content_length(&resumed_response).or(expected_size);
                 None
             };
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::cmp::Reverse;
 use std::future::Future;
 use std::io;
@@ -10,10 +11,10 @@ use futures::{FutureExt, TryStreamExt};
 use rayon::in_place_scope;
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
-use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
+use tokio::io::{AsyncRead, AsyncSeekExt, AsyncWriteExt, ReadBuf};
 use tokio::sync::Semaphore;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
-use tracing::{Instrument, info_span, instrument, warn};
+use tracing::{Instrument, debug, info_span, instrument, warn};
 use url::Url;
 
 use uv_cache::{ArchiveFileId, ArchiveId, Cache, CacheBucket, CacheEntry, WheelCache};
@@ -905,9 +906,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Acquire an advisory lock, to guard against concurrent writes.
         let _lock = Self::lock_wheel(wheel_entry, filename).await?;
 
-        // Create an entry for the HTTP cache.
+        // Create an entry for the HTTP cache and ensure the cache dir exists
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
-        // Ensure the cache dir exists so we can rename the completed download into it.
         fs_err::create_dir_all(wheel_entry.dir()).map_err(Error::CacheWrite)?;
 
         // A NamedTempFile in the cache dir holds the completed .whl between download and
@@ -923,11 +923,26 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .tempfile_in(self.build_context.cache().root())
             .map_err(Error::CacheWrite)?;
 
+        // Position for Range header retries
+        let use_range = Cell::new(false);
+        let bytes_on_disk = Cell::new(0u64);
+
         let download = |response: reqwest::Response| {
             async {
                 // Resume when the server honored the Range header and returned 206.
                 // Otherwise, truncate and start fresh.
                 let resuming = response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
+                // Confirm Range support so the retry loop can choose between a free
+                // byte-level resume and a retry that re-downloads from scratch.
+                if resuming
+                    || response
+                        .headers()
+                        .get("accept-ranges")
+                        .and_then(|v| v.to_str().ok())
+                        .is_some_and(|v| v != "none")
+                {
+                    use_range.set(true);
+                }
                 let progress_size = size.or_else(|| content_length(&response));
 
                 let progress = self.reporter.as_ref().map(|reporter| {
@@ -957,7 +972,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     fs_err::File::from_parts(temp_file.into(), partial_entry.path()),
                 ));
 
-                match progress {
+                let copy_result = match progress {
                     Some((reporter, progress)) => {
                         // Wrap the reader in a progress reporter. This will report 100% progress once
                         // the download is complete, before the wheel is unzipped.
@@ -965,14 +980,22 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                         tokio::io::copy(&mut reader, &mut writer)
                             .await
-                            .map_err(Error::CacheWrite)?;
+                            .map_err(Error::CacheWrite)
                     }
-                    None => {
-                        tokio::io::copy(&mut hasher, &mut writer)
-                            .await
-                            .map_err(Error::CacheWrite)?;
-                    }
+                    None => tokio::io::copy(&mut hasher, &mut writer)
+                        .await
+                        .map_err(Error::CacheWrite),
+                };
+
+                // Flush before propagating any copy error. On partial downloads this
+                // ensures bytes land on disk so the retry loop can resume via Range.
+                let _ = writer.flush().await;
+                if copy_result.is_err() {
+                    let pos = writer.get_mut().stream_position().await.unwrap_or(0);
+                    bytes_on_disk.set(pos);
                 }
+
+                copy_result?;
 
                 if let Some(expected) = expected_size
                     && hasher.bytes_read() != expected
@@ -1052,12 +1075,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
-        let partial_len = || {
-            fs_err::metadata(partial_entry.path())
-                .map(|m| m.len())
-                .unwrap_or(0)
-        };
-
         let mut retry_state = RetryState::start(
             self.client
                 .unmanaged
@@ -1066,12 +1083,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 .retry_policy(),
             url.clone(),
         );
-        let mut use_range = true;
 
         let archive = loop {
-            let bytes_written = partial_len();
+            let bytes_written = bytes_on_disk.get();
+            // Send a Range header only when the server previously confirmed support and we have
+            // bytes on disk to resume from.
+            let sent_range = use_range.get() && bytes_written > 0;
 
-            let req = if use_range && bytes_written > 0 {
+            let req = if sent_range {
+                debug!("Resuming download of {url} at byte {bytes_written}");
                 self.request_with_offset(url.clone(), bytes_written)?
             } else {
                 self.request(url.clone())?
@@ -1089,27 +1109,38 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 })
                 .await;
 
+            let new_partial_len = bytes_on_disk.get();
+            // Forward progress with Range confirmed means the next request can resume for free.
+            let can_resume = use_range.get() && new_partial_len > bytes_written;
+
             match result {
                 Ok(archive) => break archive,
                 Err(CachedClientError::Client(err)) => {
-                    let new_partial_len = partial_len();
-                    // If the download made forward progress before being cut off, don't
-                    // consume a retry—the next attempt will resume via Range header.
-                    if use_range && new_partial_len > bytes_written {
+                    if can_resume {
                         continue;
                     }
                     if let Some(backoff) = retry_state.should_retry(&err, err.retries()) {
                         // Server ignored our Range header (returned 200, truncating the file);
                         // fall back to plain GET for remaining retries.
-                        if use_range && bytes_written > 0 && new_partial_len == 0 {
-                            use_range = false;
+                        if sent_range && new_partial_len == 0 {
+                            use_range.set(false);
                         }
                         retry_state.sleep_backoff(backoff).await;
                     } else {
                         return Err(Error::Client(err));
                     }
                 }
-                Err(CachedClientError::Callback { err, .. }) => return Err(err),
+                Err(CachedClientError::Callback { err, .. }) => {
+                    if can_resume {
+                        continue;
+                    }
+                    // Not on the Range resume path; consume a retry for a plain re-download.
+                    if let Some(backoff) = retry_state.should_retry(&err, 0) {
+                        retry_state.sleep_backoff(backoff).await;
+                    } else {
+                        return Err(err);
+                    }
+                }
             }
         };
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -21,6 +21,7 @@ use uv_cache::{ArchiveFileId, ArchiveId, Cache, CacheBucket, CacheEntry, WheelCa
 use uv_cache_info::{CacheInfo, Timestamp};
 use uv_client::{
     CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient,
+    RequestBuilder, RetryState,
 };
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
@@ -734,7 +735,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
 
-        let download = |response: reqwest::Response| {
+        let download = |response: reqwest::Response, _: &mut RetryState| {
             async {
                 let progress_size_hint = progress_size_hint.or_else(|| content_length(&response));
 
@@ -923,10 +924,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let download_url = url.clone();
 
-        let download = |response| {
+        let download = async |response, retry_state: &mut RetryState| {
             self.download_wheel_response(
                 response,
                 &download_url,
+                retry_state,
                 filename,
                 progress_size_hint,
                 expected_size,
@@ -935,6 +937,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 hashes,
             )
             .instrument(info_span!("wheel", wheel = %dist))
+            .await
         };
 
         // Fetch the archive from the cache, or download it if necessary.
@@ -1028,6 +1031,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         &self,
         mut response: reqwest::Response,
         url: &DisplaySafeUrl,
+        retry_state: &mut RetryState,
         filename: &WheelFilename,
         progress_size_hint: Option<u64>,
         expected_size: Option<u64>,
@@ -1140,6 +1144,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
             bytes_retrieved += hasher.bytes_read();
 
+            let interrupted = copy_result.is_err();
             let err = match copy_result {
                 // Draining the response succeeded. However, the response could be a `206 Partial Content`,
                 // so we can't assume that we're done.
@@ -1213,9 +1218,20 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 return Err(err);
             }
 
+            // Recovering from a failed body consumes the same budget as a full restart.
+            // A successfully completed range needs no retry, even if more bytes remain.
+            if interrupted {
+                let Some(backoff) = retry_state.should_retry(&err, 0) else {
+                    return Err(err);
+                };
+                retry_state.sleep_backoff(backoff).await;
+            }
+
             // Finally our resumption, which is a range request.
             debug!("Resuming download of {url} at byte {offset}");
-            let resumed_response = self.request_with_offset(url.clone(), offset).await?;
+            let resumed_response = retry_state
+                .send(self.request_with_offset(url.clone(), offset))
+                .await?;
 
             // A chunked response can fail after all wheel bytes arrive, leaving no satisfiable
             // range. Return the original error so the outer retry policy can restart in full.
@@ -1507,14 +1523,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .build()
     }
 
-    /// Send a GET request with a `Range: bytes=<offset>-` header.
+    /// Build a GET request with a `Range: bytes=<offset>-` header.
     ///
     /// Used to resume an interrupted download from `offset` bytes into the file.
-    async fn request_with_offset(
-        &self,
-        url: DisplaySafeUrl,
-        offset: u64,
-    ) -> Result<reqwest::Response, reqwest_middleware::Error> {
+    fn request_with_offset(&self, url: DisplaySafeUrl, offset: u64) -> RequestBuilder<'_> {
         self.client
             .unmanaged
             .uncached_client(&url)
@@ -1524,8 +1536,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 reqwest::header::HeaderValue::from_static("identity"),
             )
             .header(reqwest::header::RANGE, format!("bytes={offset}-"))
-            .send()
-            .await
     }
 
     /// Return the [`ManagedClient`] used by this resolver.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1052,11 +1052,18 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
-        let partial_len =
-            || std::fs::metadata(partial_entry.path()).map(|m| m.len()).unwrap_or(0);
+        let partial_len = || {
+            std::fs::metadata(partial_entry.path())
+                .map(|m| m.len())
+                .unwrap_or(0)
+        };
 
         let mut retry_state = RetryState::start(
-            self.client.unmanaged.cached_client().uncached().retry_policy(),
+            self.client
+                .unmanaged
+                .cached_client()
+                .uncached()
+                .retry_policy(),
             url.clone(),
         );
         let mut use_range = true;
@@ -1073,9 +1080,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             let result = self
                 .client
                 .managed(|client| {
-                    client
-                        .cached_client()
-                        .get_serde(req, &http_entry, cache_control.clone(), &download)
+                    client.cached_client().get_serde(
+                        req,
+                        &http_entry,
+                        cache_control.clone(),
+                        &download,
+                    )
                 })
                 .await;
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1074,6 +1074,19 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Errors returned from this loop reach the outer retry classifier, which may restart
         // the full download.
         loop {
+            // Reject conflicting full-response lengths before reading the body. A range response's
+            // Content-Length describes only that range, so it cannot be compared to the wheel size.
+            if response.status() == reqwest::StatusCode::OK
+                && let (Some(expected), Some(actual)) = (expected_size, content_length(&response))
+                && expected != actual
+            {
+                return Err(Error::MismatchedContentLength {
+                    distribution: dist.to_string(),
+                    expected,
+                    actual,
+                });
+            }
+
             // Check whether the response indicates range request support. A `206 Partial Content`
             // implies range support while an `Accept-Ranges: bytes` header explicitly advertises it.
             let supports_range_requests = response.status() == reqwest::StatusCode::PARTIAL_CONTENT

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -993,6 +993,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     let Err(err) = copy_result else {
                         break;
                     };
+                    // Only resume inline when range support is usable; otherwise let the outer
+                    // retry machinery retry the full download.
                     if replaces_partial_download || !supports_range_requests {
                         return Err(err);
                     }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1211,6 +1211,13 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             // Finally our resumption, which is a range request.
             debug!("Resuming download of {url} at byte {offset}");
             let resumed_response = self.request_with_offset(url.clone(), offset, etag).await?;
+
+            // A chunked response can fail after all wheel bytes arrive, leaving no satisfiable
+            // range. Return the original error so the outer retry policy can restart in full.
+            if resumed_response.status() == reqwest::StatusCode::RANGE_NOT_SATISFIABLE {
+                debug!("Range not satisfiable while resuming {url}; abandoning resumed download");
+                return Err(err);
+            }
             resumed_response.error_for_status_ref()?;
 
             // Sanity check with the ETag above: the origin might have changed

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -946,7 +946,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
                 // Open the partial entry (temp file), truncating if not resuming.
-                let temp_file = std::fs::OpenOptions::new()
+                let temp_file = fs_err::OpenOptions::new()
                     .create(true)
                     .write(true)
                     .append(resuming)
@@ -954,7 +954,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .open(partial_entry.path())
                     .map_err(Error::CacheWrite)?;
                 let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
-                    fs_err::File::from_parts(temp_file, partial_entry.path()),
+                    fs_err::File::from_parts(temp_file.into(), partial_entry.path()),
                 ));
 
                 match progress {
@@ -1053,7 +1053,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         };
 
         let partial_len = || {
-            std::fs::metadata(partial_entry.path())
+            fs_err::metadata(partial_entry.path())
                 .map(|m| m.len())
                 .unwrap_or(0)
         };

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -10,6 +10,7 @@ use futures::{FutureExt, TryStreamExt};
 use http_content_range::{ContentRange, ContentRangeBytes, ContentRangeUnbound};
 use rayon::in_place_scope;
 use rayon::prelude::*;
+use reqwest::header::{ETAG, HeaderValue, IF_RANGE};
 use rustc_hash::FxHashMap;
 use tokio::io::{AsyncRead, AsyncSeekExt, AsyncWriteExt, ReadBuf};
 use tokio::sync::Semaphore;
@@ -915,6 +916,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             async {
                 let progress_size = size.or_else(|| content_length(&response));
                 let mut download_size = content_length(&response).or(expected_size);
+                let etag = strong_etag(&response).cloned();
 
                 let progress = self.reporter.as_ref().map(|reporter| {
                     (
@@ -1020,6 +1022,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     if replaces_partial_download || !supports_range_requests {
                         return Err(err);
                     }
+                    let Some(etag) = etag.as_ref() else {
+                        return Err(err);
+                    };
 
                     writer.flush().await.map_err(Error::CacheWrite)?;
                     let offset = writer
@@ -1036,9 +1041,17 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                     debug!("Resuming download of {download_url} at byte {offset}");
                     let resumed_response = self
-                        .request_with_offset(download_url.clone(), offset)
+                        .request_with_offset(download_url.clone(), offset, etag)
                         .await?;
                     resumed_response.error_for_status_ref()?;
+
+                    if strong_etag(&resumed_response) != Some(etag) {
+                        // The callback is cached with the original response's headers. A changed
+                        // representation needs a fresh request through the cached client so its
+                        // bytes and cache metadata come from the same response.
+                        debug!("Download changed while resuming {download_url}; retrying in full");
+                        return Err(err);
+                    }
 
                     resumed_range = if resumed_response.status()
                         == reqwest::StatusCode::PARTIAL_CONTENT
@@ -1401,13 +1414,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .build()
     }
 
-    /// Send a GET request with a `Range: bytes=<offset>-` header.
+    /// Send a GET request with a `Range: bytes=<offset>-` header and an `If-Range` validator.
     ///
     /// Used to resume an interrupted download from `offset` bytes into the file.
     async fn request_with_offset(
         &self,
         url: DisplaySafeUrl,
         offset: u64,
+        etag: &HeaderValue,
     ) -> Result<reqwest::Response, reqwest_middleware::Error> {
         self.client
             .unmanaged
@@ -1418,6 +1432,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 reqwest::header::HeaderValue::from_static("identity"),
             )
             .header(reqwest::header::RANGE, format!("bytes={offset}-"))
+            .header(IF_RANGE, etag.clone())
             .send()
             .await
     }
@@ -1547,6 +1562,19 @@ fn content_length(response: &reqwest::Response) -> Option<u64> {
         .get(reqwest::header::CONTENT_LENGTH)
         .and_then(|val| val.to_str().ok())
         .and_then(|val| val.parse::<u64>().ok())
+}
+
+/// Return a syntactically valid strong `ETag` that can validate a byte range.
+fn strong_etag(response: &reqwest::Response) -> Option<&HeaderValue> {
+    let etag = response.headers().get(ETAG)?;
+    let value = etag.as_bytes().strip_prefix(b"\"")?.strip_suffix(b"\"")?;
+    if !value
+        .iter()
+        .all(|byte| *byte == b'!' || (b'#'..=b'~').contains(byte) || *byte >= 0x80)
+    {
+        return None;
+    }
+    Some(etag)
 }
 
 /// Return the bounds of a range response starting at `offset` with a known complete length.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1,4 +1,3 @@
-use std::cell::Cell;
 use std::cmp::Reverse;
 use std::future::Future;
 use std::io;
@@ -20,7 +19,7 @@ use url::Url;
 use uv_cache::{ArchiveFileId, ArchiveId, Cache, CacheBucket, CacheEntry, WheelCache};
 use uv_cache_info::{CacheInfo, Timestamp};
 use uv_client::{
-    CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient, RetryState,
+    CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient,
 };
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
@@ -906,43 +905,13 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Acquire an advisory lock, to guard against concurrent writes.
         let _lock = Self::lock_wheel(wheel_entry, filename).await?;
 
-        // Create an entry for the HTTP cache and ensure the cache dir exists
+        // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
-        fs_err::create_dir_all(wheel_entry.dir()).map_err(Error::CacheWrite)?;
 
-        // A NamedTempFile in the cache dir holds the completed .whl between download and
-        // extraction; auto-deleted on drop if extraction fails or the process is interrupted.
-        let complete_entry = tempfile::Builder::new()
-            .suffix(".whl")
-            .tempfile_in(wheel_entry.dir())
-            .map_err(Error::CacheWrite)?;
+        let download_url = url.clone();
 
-        // A tempfile in the cache root accumulates bytes across retries. Using a NamedTempFile
-        // means it is cleaned up automatically on drop if the download fails.
-        let partial_entry = tempfile::Builder::new()
-            .tempfile_in(self.build_context.cache().root())
-            .map_err(Error::CacheWrite)?;
-
-        // Position for Range header retries
-        let use_range = Cell::new(false);
-        let bytes_on_disk = Cell::new(0u64);
-
-        let download = |response: reqwest::Response| {
+        let download = |mut response: reqwest::Response| {
             async {
-                // Resume when the server honored the Range header and returned 206.
-                // Otherwise, truncate and start fresh.
-                let resuming = response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
-                // Confirm Range support so the retry loop can choose between a free
-                // byte-level resume and a retry that re-downloads from scratch.
-                if resuming
-                    || response
-                        .headers()
-                        .get("accept-ranges")
-                        .and_then(|v| v.to_str().ok())
-                        .is_some_and(|v| v != "none")
-                {
-                    use_range.set(true);
-                }
                 let progress_size = size.or_else(|| content_length(&response));
 
                 let progress = self.reporter.as_ref().map(|reporter| {
@@ -952,75 +921,121 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     )
                 });
 
-                let reader = response
-                    .bytes_stream()
-                    .map_err(|err| self.handle_response_errors(err))
-                    .into_async_read();
                 let algorithms = http_hash_algorithms(hashes);
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
-                let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
+                let mut actual_size = 0;
 
-                // Open the partial entry (temp file), truncating if not resuming.
-                let temp_file = fs_err::OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .append(resuming)
-                    .truncate(!resuming)
-                    .open(partial_entry.path())
+                // Download the wheel to a temporary file.
+                let temp_file = tempfile::tempfile_in(self.build_context.cache().root())
                     .map_err(Error::CacheWrite)?;
                 let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
-                    fs_err::File::from_parts(temp_file.into(), partial_entry.path()),
+                    // It's an unnamed file on Linux so that's the best approximation.
+                    fs_err::File::from_parts(temp_file, self.build_context.cache().root()),
                 ));
 
-                let copy_result = match progress {
-                    Some((reporter, progress)) => {
-                        // Wrap the reader in a progress reporter. This will report 100% progress once
-                        // the download is complete, before the wheel is unzipped.
-                        let mut reader = ProgressReader::new(&mut hasher, progress, &**reporter);
+                let mut resumed_at = None;
+                let mut supports_range_requests = false;
 
-                        tokio::io::copy(&mut reader, &mut writer)
+                loop {
+                    supports_range_requests |= response.status()
+                        == reqwest::StatusCode::PARTIAL_CONTENT
+                        || response
+                            .headers()
+                            .get(reqwest::header::ACCEPT_RANGES)
+                            .is_some_and(|value| value == "bytes");
+
+                    // A server can advertise range requests but ignore one. In that case, the
+                    // response is a complete download and must replace the partial bytes.
+                    if resumed_at.is_some()
+                        && response.status() != reqwest::StatusCode::PARTIAL_CONTENT
+                    {
+                        writer
+                            .get_mut()
+                            .set_len(0)
                             .await
-                            .map_err(Error::CacheWrite)
+                            .map_err(Error::CacheWrite)?;
+                        writer
+                            .seek(io::SeekFrom::Start(0))
+                            .await
+                            .map_err(Error::CacheWrite)?;
+                        hashers = http_hash_algorithms(hashes)
+                            .into_iter()
+                            .map(Hasher::from)
+                            .collect();
+                        actual_size = 0;
                     }
-                    None => tokio::io::copy(&mut hasher, &mut writer)
-                        .await
-                        .map_err(Error::CacheWrite),
-                };
 
-                // Flush before propagating any copy error. On partial downloads this
-                // ensures bytes land on disk so the retry loop can resume via Range.
-                let _ = writer.flush().await;
-                if copy_result.is_err() {
-                    let pos = writer.get_mut().stream_position().await.unwrap_or(0);
-                    bytes_on_disk.set(pos);
+                    let reader = response
+                        .bytes_stream()
+                        .map_err(|err| self.handle_response_errors(err))
+                        .into_async_read();
+                    let mut hasher =
+                        uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
+
+                    let copy_result = match progress {
+                        Some((reporter, progress)) => {
+                            // Wrap the reader in a progress reporter. This will report 100%
+                            // progress once the download is complete, before the wheel is unzipped.
+                            let mut reader =
+                                ProgressReader::new(&mut hasher, progress, &**reporter);
+
+                            tokio::io::copy(&mut reader, &mut writer)
+                                .await
+                                .map_err(Error::CacheWrite)
+                        }
+                        None => tokio::io::copy(&mut hasher, &mut writer)
+                            .await
+                            .map_err(Error::CacheWrite),
+                    };
+
+                    actual_size += hasher.bytes_read();
+
+                    let Err(err) = copy_result else {
+                        break;
+                    };
+                    if !supports_range_requests {
+                        return Err(err);
+                    }
+
+                    writer.flush().await.map_err(Error::CacheWrite)?;
+                    let offset = writer
+                        .get_mut()
+                        .stream_position()
+                        .await
+                        .map_err(Error::CacheWrite)?;
+                    if offset == 0
+                        || offset != actual_size
+                        || resumed_at.is_some_and(|previous| offset <= previous)
+                    {
+                        return Err(err);
+                    }
+
+                    debug!("Resuming download of {download_url} at byte {offset}");
+                    response = self
+                        .client
+                        .unmanaged
+                        .uncached_client(&download_url)
+                        .execute(self.request_with_offset(download_url.clone(), offset)?)
+                        .await?;
+                    response.error_for_status_ref()?;
+                    resumed_at = Some(offset);
                 }
 
-                copy_result?;
-
                 if let Some(expected) = expected_size
-                    && hasher.bytes_read() != expected
+                    && actual_size != expected
                 {
                     return Err(Error::MismatchedSize {
                         distribution: dist.to_string(),
                         expected,
-                        actual: hasher.bytes_read(),
+                        actual: actual_size,
                     });
                 }
-
-                let actual_size = hasher.bytes_read();
 
                 // Unzip the wheel to a temporary directory.
                 let extractor =
                     WheelExtractor::new(self.build_context.cache().root(), content_addressed_cache)
                         .map_err(Error::CacheWrite)?;
-                // Download is complete, atomically rename into place.
-                fs_err::rename(partial_entry.path(), complete_entry.path())
-                    .map_err(Error::CacheWrite)?;
-
-                // Re-open the renamed file for extraction.
-                let mut file = fs_err::tokio::File::open(complete_entry.path())
-                    .await
-                    .map_err(Error::CacheWrite)?;
+                let mut file = writer.into_inner();
                 file.seek(io::SeekFrom::Start(0))
                     .await
                     .map_err(Error::CacheWrite)?;
@@ -1055,6 +1070,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .instrument(info_span!("wheel", wheel = %dist))
         };
 
+        // Fetch the archive from the cache, or download it if necessary.
+        let req = self.request(url.clone())?;
+
         // Determine the cache control policy for the URL.
         let cache_control = match self.client.unmanaged.connectivity() {
             Connectivity::Online
@@ -1075,74 +1093,21 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
-        let mut retry_state = RetryState::start(
-            self.client
-                .unmanaged
-                .cached_client()
-                .uncached()
-                .retry_policy(),
-            url.clone(),
-        );
-
-        let archive = loop {
-            let bytes_written = bytes_on_disk.get();
-            // Send a Range header only when the server previously confirmed support and we have
-            // bytes on disk to resume from.
-            let sent_range = use_range.get() && bytes_written > 0;
-
-            let req = if sent_range {
-                debug!("Resuming download of {url} at byte {bytes_written}");
-                self.request_with_offset(url.clone(), bytes_written)?
-            } else {
-                self.request(url.clone())?
-            };
-
-            let result = self
-                .client
-                .managed(|client| {
-                    client.cached_client().get_serde(
-                        req,
-                        &http_entry,
-                        cache_control.clone(),
-                        &download,
-                    )
-                })
-                .await;
-
-            let new_partial_len = bytes_on_disk.get();
-            // Forward progress with Range confirmed means the next request can resume for free.
-            let can_resume = use_range.get() && new_partial_len > bytes_written;
-
-            match result {
-                Ok(archive) => break archive,
-                Err(CachedClientError::Client(err)) => {
-                    if can_resume {
-                        continue;
-                    }
-                    if let Some(backoff) = retry_state.should_retry(&err, err.retries()) {
-                        // Server ignored our Range header (returned 200, truncating the file);
-                        // fall back to plain GET for remaining retries.
-                        if sent_range && new_partial_len == 0 {
-                            use_range.set(false);
-                        }
-                        retry_state.sleep_backoff(backoff).await;
-                    } else {
-                        return Err(Error::Client(err));
-                    }
-                }
-                Err(CachedClientError::Callback { err, .. }) => {
-                    if can_resume {
-                        continue;
-                    }
-                    // Not on the Range resume path; consume a retry for a plain re-download.
-                    if let Some(backoff) = retry_state.should_retry(&err, 0) {
-                        retry_state.sleep_backoff(backoff).await;
-                    } else {
-                        return Err(err);
-                    }
-                }
-            }
-        };
+        let archive = self
+            .client
+            .managed(|client| {
+                client.cached_client().get_serde_with_retry(
+                    req,
+                    &http_entry,
+                    cache_control.clone(),
+                    download,
+                )
+            })
+            .await
+            .map_err(|err| match err {
+                CachedClientError::Callback { err, .. } => err,
+                CachedClientError::Client(err) => Error::Client(err),
+            })?;
 
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
@@ -1411,11 +1376,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 "accept-encoding",
                 reqwest::header::HeaderValue::from_static("identity"),
             )
-            .header(
-                reqwest::header::RANGE,
-                reqwest::header::HeaderValue::from_str(&format!("bytes={offset}-"))
-                    .expect("valid range header value"),
-            )
+            .header(reqwest::header::RANGE, format!("bytes={offset}-"))
             .build()
     }
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -902,8 +902,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             _ => None,
         };
 
-        let content_addressed_cache = self.content_addressed_cache;
-
         // Acquire an advisory lock, to guard against concurrent writes.
         let _lock = Self::lock_wheel(wheel_entry, filename).await?;
 
@@ -912,215 +910,17 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let download_url = url.clone();
 
-        let download = |mut response: reqwest::Response| {
-            async {
-                let progress_size = size.or_else(|| content_length(&response));
-                let mut download_size = content_length(&response).or(expected_size);
-                let etag = strong_etag(&response).cloned();
-
-                let progress = self.reporter.as_ref().map(|reporter| {
-                    (
-                        reporter,
-                        reporter.on_download_start(dist.name(), progress_size),
-                    )
-                });
-
-                let algorithms = http_hash_algorithms(hashes);
-                let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
-                let mut actual_size = 0;
-
-                // Download the wheel to a temporary file.
-                let temp_file = tempfile::tempfile_in(self.build_context.cache().root())
-                    .map_err(Error::CacheWrite)?;
-                let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
-                    // It's an unnamed file on Linux so that's the best approximation.
-                    fs_err::File::from_parts(temp_file, self.build_context.cache().root()),
-                ));
-
-                let mut resumed_at = None;
-                let mut resumed_range: Option<ContentRangeBytes> = None;
-
-                loop {
-                    let supports_range_requests = response.status()
-                        == reqwest::StatusCode::PARTIAL_CONTENT
-                        || response
-                            .headers()
-                            .get(reqwest::header::ACCEPT_RANGES)
-                            .is_some_and(|value| value == "bytes");
-
-                    // A server can advertise range requests but ignore one. In that case, the
-                    // response is a complete download and must replace the partial bytes.
-                    let replaces_partial_download = resumed_at.is_some()
-                        && response.status() != reqwest::StatusCode::PARTIAL_CONTENT;
-                    if replaces_partial_download {
-                        writer
-                            .get_mut()
-                            .set_len(0)
-                            .await
-                            .map_err(Error::CacheWrite)?;
-                        writer
-                            .seek(io::SeekFrom::Start(0))
-                            .await
-                            .map_err(Error::CacheWrite)?;
-                        hashers = http_hash_algorithms(hashes)
-                            .into_iter()
-                            .map(Hasher::from)
-                            .collect();
-                        actual_size = 0;
-                    }
-
-                    let reader = response
-                        .bytes_stream()
-                        .map_err(|err| self.handle_response_errors(err))
-                        .into_async_read();
-                    let mut hasher =
-                        uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
-
-                    let copy_result = match progress {
-                        Some((reporter, progress)) => {
-                            // Wrap the reader in a progress reporter. This will report 100%
-                            // progress once the download is complete, before the wheel is unzipped.
-                            let mut reader =
-                                ProgressReader::new(&mut hasher, progress, &**reporter);
-
-                            tokio::io::copy(&mut reader, &mut writer)
-                                .await
-                                .map_err(Error::CacheWrite)
-                        }
-                        None => tokio::io::copy(&mut hasher, &mut writer)
-                            .await
-                            .map_err(Error::CacheWrite),
-                    };
-
-                    actual_size += hasher.bytes_read();
-
-                    let err = match copy_result {
-                        Ok(_) => {
-                            let Some(range) = resumed_range else {
-                                break;
-                            };
-                            if actual_size != range.last_byte + 1 {
-                                return Err(Error::CacheWrite(io::Error::new(
-                                    io::ErrorKind::UnexpectedEof,
-                                    "Range response length does not match Content-Range",
-                                )));
-                            }
-                            if actual_size == range.complete_length {
-                                break;
-                            }
-                            // A successful range response may cover only part of the requested
-                            // bytes. Keep requesting the remainder before extracting the wheel.
-                            Error::CacheWrite(io::Error::new(
-                                io::ErrorKind::UnexpectedEof,
-                                "Range response did not complete the download",
-                            ))
-                        }
-                        Err(err) => err,
-                    };
-                    // Only resume inline when range support is usable; otherwise let the outer
-                    // retry machinery retry the full download.
-                    if replaces_partial_download || !supports_range_requests {
-                        return Err(err);
-                    }
-                    let Some(etag) = etag.as_ref() else {
-                        return Err(err);
-                    };
-
-                    writer.flush().await.map_err(Error::CacheWrite)?;
-                    let offset = writer
-                        .get_mut()
-                        .stream_position()
-                        .await
-                        .map_err(Error::CacheWrite)?;
-                    if offset == 0
-                        || offset != actual_size
-                        || resumed_at.is_some_and(|previous| offset <= previous)
-                    {
-                        return Err(err);
-                    }
-
-                    debug!("Resuming download of {download_url} at byte {offset}");
-                    let resumed_response = self
-                        .request_with_offset(download_url.clone(), offset, etag)
-                        .await?;
-                    resumed_response.error_for_status_ref()?;
-
-                    if strong_etag(&resumed_response) != Some(etag) {
-                        // The callback is cached with the original response's headers. A changed
-                        // representation needs a fresh request through the cached client so its
-                        // bytes and cache metadata come from the same response.
-                        debug!("Download changed while resuming {download_url}; retrying in full");
-                        return Err(err);
-                    }
-
-                    resumed_range = if resumed_response.status()
-                        == reqwest::StatusCode::PARTIAL_CONTENT
-                    {
-                        let Some(range) = content_range(&resumed_response, offset, download_size)
-                        else {
-                            warn!(
-                                "Invalid range request response from server that declares HTTP range \
-                                 request support, abandoning resumed download: {download_url}"
-                            );
-                            return Err(err);
-                        };
-                        download_size = Some(range.complete_length);
-                        Some(range)
-                    } else {
-                        download_size = content_length(&resumed_response).or(expected_size);
-                        None
-                    };
-
-                    response = resumed_response;
-                    resumed_at = Some(offset);
-                }
-
-                if let Some(expected) = expected_size
-                    && actual_size != expected
-                {
-                    return Err(Error::MismatchedSize {
-                        distribution: dist.to_string(),
-                        expected,
-                        actual: actual_size,
-                    });
-                }
-
-                // Unzip the wheel to a temporary directory.
-                let extractor =
-                    WheelExtractor::new(self.build_context.cache().root(), content_addressed_cache)
-                        .map_err(Error::CacheWrite)?;
-                let mut file = writer.into_inner();
-                file.seek(io::SeekFrom::Start(0))
-                    .await
-                    .map_err(Error::CacheWrite)?;
-
-                let file = file.into_std().await;
-                let mut extracted =
-                    tokio::task::spawn_blocking(move || extractor.extract_seekable(file))
-                        .await?
-                        .map_err(|err| Error::Extract(filename.to_string(), err))?;
-                let hashes = hashers.into_iter().map(HashDigest::from).collect();
-
-                // Before we make the wheel accessible by persisting it, ensure that the RECORD is
-                // valid.
-                extracted.validate_and_heal_record(dist)?;
-
-                // Persist the temporary directory to the directory store.
-                let id = self
-                    .persist_extracted_wheel(extracted, wheel_entry.path())
-                    .await?;
-
-                if let Some((reporter, progress)) = progress {
-                    reporter.on_download_complete(dist.name(), progress);
-                }
-
-                Ok(Archive::new(
-                    id,
-                    hashes,
-                    filename.clone(),
-                    Some(actual_size),
-                ))
-            }
+        let download = |response| {
+            self.download_wheel_response(
+                response,
+                &download_url,
+                filename,
+                size,
+                expected_size,
+                wheel_entry,
+                dist,
+                hashes,
+            )
             .instrument(info_span!("wheel", wheel = %dist))
         };
 
@@ -1202,6 +1002,225 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         };
 
         Ok(archive)
+    }
+
+    /// Download and extract a wheel from an HTTP response.
+    ///
+    /// This helper is called by [`Self::download_wheel`] and handles partial content/resumptions
+    /// of interrupted downloads if the origin supports it. Hard failures are propagated
+    /// back to the caller and thus to our general retry machinery.
+    ///
+    /// The caller is responsible for obtaining a lock on the wheel cache.
+    async fn download_wheel_response(
+        &self,
+        mut response: reqwest::Response,
+        url: &DisplaySafeUrl,
+        filename: &WheelFilename,
+        size: Option<u64>,
+        expected_size: Option<u64>,
+        wheel_entry: &CacheEntry,
+        dist: &BuiltDist,
+        hashes: HashPolicy<'_>,
+    ) -> Result<Archive, Error> {
+        let progress_size = size.or_else(|| content_length(&response));
+        let mut download_size = content_length(&response).or(expected_size);
+        let etag = strong_etag(&response).cloned();
+
+        let progress = self.reporter.as_ref().map(|reporter| {
+            (
+                reporter,
+                reporter.on_download_start(dist.name(), progress_size),
+            )
+        });
+
+        let algorithms = http_hash_algorithms(hashes);
+        let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
+        let mut actual_size = 0;
+
+        // Download the wheel to a temporary file.
+        let temp_file =
+            tempfile::tempfile_in(self.build_context.cache().root()).map_err(Error::CacheWrite)?;
+        let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
+            // It's an unnamed file on Linux so that's the best approximation.
+            fs_err::File::from_parts(temp_file, self.build_context.cache().root()),
+        ));
+
+        let mut resumed_at = None;
+        let mut resumed_range: Option<ContentRangeBytes> = None;
+
+        loop {
+            let supports_range_requests = response.status() == reqwest::StatusCode::PARTIAL_CONTENT
+                || response
+                    .headers()
+                    .get(reqwest::header::ACCEPT_RANGES)
+                    .is_some_and(|value| value == "bytes");
+
+            // A server can advertise range requests but ignore one. In that case, the
+            // response is a complete download and must replace the partial bytes.
+            let replaces_partial_download =
+                resumed_at.is_some() && response.status() != reqwest::StatusCode::PARTIAL_CONTENT;
+            if replaces_partial_download {
+                writer
+                    .get_mut()
+                    .set_len(0)
+                    .await
+                    .map_err(Error::CacheWrite)?;
+                writer
+                    .seek(io::SeekFrom::Start(0))
+                    .await
+                    .map_err(Error::CacheWrite)?;
+                hashers = http_hash_algorithms(hashes)
+                    .into_iter()
+                    .map(Hasher::from)
+                    .collect();
+                actual_size = 0;
+            }
+
+            let reader = response
+                .bytes_stream()
+                .map_err(|err| self.handle_response_errors(err))
+                .into_async_read();
+            let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
+
+            let copy_result = match progress {
+                Some((reporter, progress)) => {
+                    // Wrap the reader in a progress reporter. This will report 100%
+                    // progress once the download is complete, before the wheel is unzipped.
+                    let mut reader = ProgressReader::new(&mut hasher, progress, &**reporter);
+
+                    tokio::io::copy(&mut reader, &mut writer)
+                        .await
+                        .map_err(Error::CacheWrite)
+                }
+                None => tokio::io::copy(&mut hasher, &mut writer)
+                    .await
+                    .map_err(Error::CacheWrite),
+            };
+
+            actual_size += hasher.bytes_read();
+
+            let err = match copy_result {
+                Ok(_) => {
+                    let Some(range) = resumed_range else {
+                        break;
+                    };
+                    if actual_size != range.last_byte + 1 {
+                        return Err(Error::CacheWrite(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "Range response length does not match Content-Range",
+                        )));
+                    }
+                    if actual_size == range.complete_length {
+                        break;
+                    }
+                    // A successful range response may cover only part of the requested
+                    // bytes. Keep requesting the remainder before extracting the wheel.
+                    Error::CacheWrite(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "Range response did not complete the download",
+                    ))
+                }
+                Err(err) => err,
+            };
+            // Only resume inline when range support is usable; otherwise let the outer
+            // retry machinery retry the full download.
+            if replaces_partial_download || !supports_range_requests {
+                return Err(err);
+            }
+            let Some(etag) = etag.as_ref() else {
+                return Err(err);
+            };
+
+            writer.flush().await.map_err(Error::CacheWrite)?;
+            let offset = writer
+                .get_mut()
+                .stream_position()
+                .await
+                .map_err(Error::CacheWrite)?;
+            if offset == 0
+                || offset != actual_size
+                || resumed_at.is_some_and(|previous| offset <= previous)
+            {
+                return Err(err);
+            }
+
+            debug!("Resuming download of {url} at byte {offset}");
+            let resumed_response = self.request_with_offset(url.clone(), offset, etag).await?;
+            resumed_response.error_for_status_ref()?;
+
+            if strong_etag(&resumed_response) != Some(etag) {
+                // The callback is cached with the original response's headers. A changed
+                // representation needs a fresh request through the cached client so its
+                // bytes and cache metadata come from the same response.
+                debug!("Download changed while resuming {url}; retrying in full");
+                return Err(err);
+            }
+
+            resumed_range = if resumed_response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
+                let Some(range) = content_range(&resumed_response, offset, download_size) else {
+                    warn!(
+                        "Invalid range request response from server that declares HTTP range \
+                         request support, abandoning resumed download: {url}"
+                    );
+                    return Err(err);
+                };
+                download_size = Some(range.complete_length);
+                Some(range)
+            } else {
+                download_size = content_length(&resumed_response).or(expected_size);
+                None
+            };
+
+            response = resumed_response;
+            resumed_at = Some(offset);
+        }
+
+        if let Some(expected) = expected_size
+            && actual_size != expected
+        {
+            return Err(Error::MismatchedSize {
+                distribution: dist.to_string(),
+                expected,
+                actual: actual_size,
+            });
+        }
+
+        // Unzip the wheel to a temporary directory.
+        let extractor = WheelExtractor::new(
+            self.build_context.cache().root(),
+            self.content_addressed_cache,
+        )
+        .map_err(Error::CacheWrite)?;
+        let mut file = writer.into_inner();
+        file.seek(io::SeekFrom::Start(0))
+            .await
+            .map_err(Error::CacheWrite)?;
+
+        let file = file.into_std().await;
+        let mut extracted = tokio::task::spawn_blocking(move || extractor.extract_seekable(file))
+            .await?
+            .map_err(|err| Error::Extract(filename.to_string(), err))?;
+        let hashes = hashers.into_iter().map(HashDigest::from).collect();
+
+        // Before we make the wheel accessible by persisting it, ensure that the RECORD is
+        // valid.
+        extracted.validate_and_heal_record(dist)?;
+
+        // Persist the temporary directory to the directory store.
+        let id = self
+            .persist_extracted_wheel(extracted, wheel_entry.path())
+            .await?;
+
+        if let Some((reporter, progress)) = progress {
+            reporter.on_download_complete(dist.name(), progress);
+        }
+
+        Ok(Archive::new(
+            id,
+            hashes,
+            filename.clone(),
+            Some(actual_size),
+        ))
     }
 
     /// Load a wheel from a local path.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -706,19 +706,26 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     }
 
     /// Stream a wheel from a URL, unzipping it into the cache as it's downloaded.
+    ///
+    /// Note that `progress_size_hint` is purely a size hint for the progress reporter,
+    /// and is not guaranteed to be the true size of the wheel if/when fetched from the
+    /// origin.
     async fn stream_wheel(
         &self,
         url: DisplaySafeUrl,
         index: Option<&IndexUrl>,
         filename: &WheelFilename,
-        size: Option<u64>,
+        progress_size_hint: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
         hashes: ArchiveHashPolicy<'_>,
     ) -> Result<Archive, Error> {
+        // Sometimes we can promote the size hint to a guaranteed size.
         let expected_size = match dist {
-            BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
-            BuiltDist::DirectUrl(_) => size,
+            BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => {
+                progress_size_hint
+            }
+            BuiltDist::DirectUrl(_) => progress_size_hint,
             _ => None,
         };
 
@@ -730,12 +737,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         let download = |response: reqwest::Response| {
             async {
-                let progress_size = size.or_else(|| content_length(&response));
+                let progress_size_hint = progress_size_hint.or_else(|| content_length(&response));
 
                 let progress = self.reporter.as_ref().map(|reporter| {
                     (
                         reporter,
-                        reporter.on_download_start(dist.name(), progress_size),
+                        reporter.on_download_start(dist.name(), progress_size_hint),
                     )
                 });
 
@@ -886,19 +893,26 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     }
 
     /// Download a wheel from a URL, then unzip it into the cache.
+    ///
+    /// Note that, like [`Self::stream_wheel`], `progress_size_hint` is purely
+    /// a size hint for the progress reporter, and is not guaranteed to be the size
+    /// of the wheel if/when fetched from the origin.
     async fn download_wheel(
         &self,
         url: DisplaySafeUrl,
         index: Option<&IndexUrl>,
         filename: &WheelFilename,
-        size: Option<u64>,
+        progress_size_hint: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
         hashes: ArchiveHashPolicy<'_>,
     ) -> Result<Archive, Error> {
+        // Sometimes we can promote the size hint to a guaranteed size.
         let expected_size = match dist {
-            BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => size,
-            BuiltDist::DirectUrl(_) => size,
+            BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => {
+                progress_size_hint
+            }
+            BuiltDist::DirectUrl(_) => progress_size_hint,
             _ => None,
         };
 
@@ -915,7 +929,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 response,
                 &download_url,
                 filename,
-                size,
+                progress_size_hint,
                 expected_size,
                 wheel_entry,
                 dist,
@@ -1016,26 +1030,24 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         mut response: reqwest::Response,
         url: &DisplaySafeUrl,
         filename: &WheelFilename,
-        size: Option<u64>,
+        progress_size_hint: Option<u64>,
         expected_size: Option<u64>,
         wheel_entry: &CacheEntry,
         dist: &BuiltDist,
         hashes: HashPolicy<'_>,
     ) -> Result<Archive, Error> {
-        let progress_size = size.or_else(|| content_length(&response));
+        let progress_size_hint = progress_size_hint.or_else(|| content_length(&response));
         let mut download_size = content_length(&response).or(expected_size);
         let etag = strong_etag(&response).cloned();
 
         let progress = self.reporter.as_ref().map(|reporter| {
             (
                 reporter,
-                reporter.on_download_start(dist.name(), progress_size),
+                reporter.on_download_start(dist.name(), progress_size_hint),
             )
         });
 
         let algorithms = http_hash_algorithms(hashes);
-        let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
-        let mut actual_size = 0;
 
         // Download the wheel to a temporary file.
         let temp_file =
@@ -1045,10 +1057,24 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             fs_err::File::from_parts(temp_file, self.build_context.cache().root()),
         ));
 
+        // States for the download loop below.
+        let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
+        // The total number of bytes written to the tempfile, accumulated over individual requests.
+        let mut bytes_written = 0;
+        // The current offset, i.e. where to resume a partial download from.
         let mut resumed_at = None;
+        // The `Content-Range` that the download was last resumed at.
         let mut resumed_range: Option<ContentRangeBytes> = None;
 
+        // This loop is where we handle resumption of interrupted downloads, as well as
+        // range requests (if the origin supports them).
+        //
+        // Note that this loop exists outside of our normal retry logic since it handles partial
+        // downloads rather than full restarts of downloads. Hard errors are returned back
+        // and may cause full retries (per the retry classifier).
         loop {
+            // Check whether the response indicates range request support. A `206 Partial Content`
+            // implies range support while an `Accept-Ranges: bytes` header explicitly advertises it.
             let supports_range_requests = response.status() == reqwest::StatusCode::PARTIAL_CONTENT
                 || response
                     .headers()
@@ -1073,7 +1099,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .into_iter()
                     .map(Hasher::from)
                     .collect();
-                actual_size = 0;
+                bytes_written = 0;
             }
 
             let reader = response
@@ -1082,6 +1108,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 .into_async_read();
             let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
+            // Drain the response. This could be a partial response or a full one.
+            // Note that the partial response here can take several forms: it can be an interrupted
+            // request *or* it can be a `206 Partial Content`.
             let copy_result = match progress {
                 Some((reporter, progress)) => {
                     // Wrap the reader in a progress reporter. This will report 100%
@@ -1097,40 +1126,76 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .map_err(Error::CacheWrite),
             };
 
-            actual_size += hasher.bytes_read();
+            bytes_written += hasher.bytes_read();
 
             let err = match copy_result {
+                // Draining the response succeeded. However, the response could be a `206 Partial Content`,
+                // so we can't assume that we're done.
                 Ok(_) => {
+                    // No `resumed_range` means this was a normal full response, so there's
+                    // no resumption to do. We can leave the loop.
                     let Some(range) = resumed_range else {
                         break;
                     };
-                    if actual_size != range.last_byte + 1 {
+
+                    // We should be in sync with the origin. Failure here means that the
+                    // origin actually sent us an under- or over-length response, which we
+                    // treat as a resumption error (and return back to the normal retry
+                    // stack). Note that this implies some kind of buggy origin.
+                    //
+                    // Byte ranges are inclusive, not exclusive.
+                    if bytes_written != range.last_byte + 1 {
                         return Err(Error::CacheWrite(io::Error::new(
                             io::ErrorKind::UnexpectedEof,
                             "Range response length does not match Content-Range",
                         )));
                     }
-                    if actual_size == range.complete_length {
+
+                    // We've successfully performed the download over one or more
+                    // range requests. We can leave the loop.
+                    if bytes_written == range.complete_length {
                         break;
                     }
+
                     // A successful range response may cover only part of the requested
                     // bytes. Keep requesting the remainder before extracting the wheel.
+                    //
+                    // Observe that we don't return this error; we bind it for handling
+                    // below.
                     Error::CacheWrite(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
                         "Range response did not complete the download",
                     ))
                 }
+                // Draining the response failed, potentially because the connection was interrupted.
+                // Like above, we don't return this error until we know how we want to treat it.
                 Err(err) => err,
             };
-            // Only resume inline when range support is usable; otherwise let the outer
-            // retry machinery retry the full download.
+
+            // At this point we have *some* error state: either a synthetic error (from a
+            // partial response that did not complete the download) or a real error (e.g.
+            // from an interrupted download). We can only resume if certain conditions
+            // below are met.
+
+            // If the response replaces an already in-flight partial download or
+            // indicates a lack of range-request support, then we can't resume.
+            // Return the error back to the retry stack.
             if replaces_partial_download || !supports_range_requests {
                 return Err(err);
             }
+
+            // We expect any partial response to have an ETag, so that we can detect
+            // when an (honest) origin changes its response beneath us. This is strictly
+            // an optimization, i.e. so that we don't continue requesting content for a
+            // download that will fail hash and/or size validation anyways.
             let Some(etag) = etag.as_ref() else {
                 return Err(err);
             };
 
+            // Some sanity checks: we should have made *some* progress as part of
+            // partial response, plus our writer's offset should agree with the number
+            // of bytes written, *and* we should be making forward progress (i.e. not
+            // resuming behind where we already are).
             writer.flush().await.map_err(Error::CacheWrite)?;
             let offset = writer
                 .get_mut()
@@ -1138,25 +1203,28 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 .await
                 .map_err(Error::CacheWrite)?;
             if offset == 0
-                || offset != actual_size
+                || offset != bytes_written
                 || resumed_at.is_some_and(|previous| offset <= previous)
             {
                 return Err(err);
             }
 
+            // Finally our resumption, which is a range request.
             debug!("Resuming download of {url} at byte {offset}");
             let resumed_response = self.request_with_offset(url.clone(), offset, etag).await?;
             resumed_response.error_for_status_ref()?;
 
+            // Sanity check with the ETag above: the origin might have changed
+            // the download underneath us, in which case we need to kick back to the retry
+            // stack and do an entirely fresh request for consistency.
             if strong_etag(&resumed_response) != Some(etag) {
-                // The callback is cached with the original response's headers. A changed
-                // representation needs a fresh request through the cached client so its
-                // bytes and cache metadata come from the same response.
                 debug!("Download changed while resuming {url}; retrying in full");
                 return Err(err);
             }
 
             resumed_range = if resumed_response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
+                // The origin honored our range request, so we update `resumed_range`
+                // for the next iteration.
                 let Some(range) = content_range(&resumed_response, offset, download_size) else {
                     warn!(
                         "Invalid range request response from server that declares HTTP range \
@@ -1167,6 +1235,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 download_size = Some(range.complete_length);
                 Some(range)
             } else {
+                // The origin is allowed to ignore our range request and send a full response instead.
+                // That means we have no `resumed_range` to honor on the next iteration.
                 download_size = content_length(&resumed_response).or(expected_size);
                 None
             };
@@ -1175,13 +1245,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             resumed_at = Some(offset);
         }
 
+        // We've left the resumption loop.
+        // Sanity check: we should have written as many bytes as we expected.
         if let Some(expected) = expected_size
-            && actual_size != expected
+            && bytes_written != expected
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
                 expected,
-                actual: actual_size,
+                actual: bytes_written,
             });
         }
 
@@ -1219,7 +1291,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             id,
             hashes,
             filename.clone(),
-            Some(actual_size),
+            Some(bytes_written),
         ))
     }
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1024,19 +1024,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     {
                         warn!(
                             "Invalid range request response from server that declares HTTP range \
-                             request support, restarting download: {download_url}"
+                             request support, abandoning resumed download: {download_url}"
                         );
-                        response = self
-                            .client
-                            .unmanaged
-                            .uncached_client(&download_url)
-                            .execute(self.request(download_url.clone())?)
-                            .await?;
-                        response.error_for_status_ref()?;
-                    } else {
-                        response = resumed_response;
+                        return Err(err);
                     }
 
+                    response = resumed_response;
                     resumed_at = Some(offset);
                 }
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1014,10 +1014,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                     debug!("Resuming download of {download_url} at byte {offset}");
                     let resumed_response = self
-                        .client
-                        .unmanaged
-                        .uncached_client(&download_url)
-                        .execute(self.request_with_offset(download_url.clone(), offset)?)
+                        .request_with_offset(download_url.clone(), offset)
                         .await?;
                     resumed_response.error_for_status_ref()?;
 
@@ -1374,14 +1371,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .build()
     }
 
-    /// Returns a GET [`reqwest::Request`] with a `Range: bytes=<offset>-` header.
+    /// Send a GET request with a `Range: bytes=<offset>-` header.
     ///
     /// Used to resume an interrupted download from `offset` bytes into the file.
-    fn request_with_offset(
+    async fn request_with_offset(
         &self,
         url: DisplaySafeUrl,
         offset: u64,
-    ) -> Result<reqwest::Request, reqwest::Error> {
+    ) -> Result<reqwest::Response, reqwest_middleware::Error> {
         self.client
             .unmanaged
             .uncached_client(&url)
@@ -1391,7 +1388,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 reqwest::header::HeaderValue::from_static("identity"),
             )
             .header(reqwest::header::RANGE, format!("bytes={offset}-"))
-            .build()
+            .send()
+            .await
     }
 
     /// Return the [`ManagedClient`] used by this resolver.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -19,7 +19,7 @@ use url::Url;
 use uv_cache::{ArchiveFileId, ArchiveId, Cache, CacheBucket, CacheEntry, WheelCache};
 use uv_cache_info::{CacheInfo, Timestamp};
 use uv_client::{
-    CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient,
+    CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient, RetryState,
 };
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
@@ -907,9 +907,27 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
+        // Ensure the cache dir exists so we can rename the completed download into it.
+        fs_err::create_dir_all(wheel_entry.dir()).map_err(Error::CacheWrite)?;
+
+        // A NamedTempFile in the cache dir holds the completed .whl between download and
+        // extraction; auto-deleted on drop if extraction fails or the process is interrupted.
+        let complete_entry = tempfile::Builder::new()
+            .suffix(".whl")
+            .tempfile_in(wheel_entry.dir())
+            .map_err(Error::CacheWrite)?;
+
+        // A tempfile in the cache root accumulates bytes across retries. Using a NamedTempFile
+        // means it is cleaned up automatically on drop if the download fails.
+        let partial_entry = tempfile::Builder::new()
+            .tempfile_in(self.build_context.cache().root())
+            .map_err(Error::CacheWrite)?;
 
         let download = |response: reqwest::Response| {
             async {
+                // Resume when the server honored the Range header and returned 206.
+                // Otherwise, truncate and start fresh.
+                let resuming = response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
                 let progress_size = size.or_else(|| content_length(&response));
 
                 let progress = self.reporter.as_ref().map(|reporter| {
@@ -927,12 +945,16 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
-                // Download the wheel to a temporary file.
-                let temp_file = tempfile::tempfile_in(self.build_context.cache().root())
+                // Open the partial entry (temp file), truncating if not resuming.
+                let temp_file = std::fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .append(resuming)
+                    .truncate(!resuming)
+                    .open(partial_entry.path())
                     .map_err(Error::CacheWrite)?;
                 let mut writer = tokio::io::BufWriter::new(fs_err::tokio::File::from_std(
-                    // It's an unnamed file on Linux so that's the best approximation.
-                    fs_err::File::from_parts(temp_file, self.build_context.cache().root()),
+                    fs_err::File::from_parts(temp_file, partial_entry.path()),
                 ));
 
                 match progress {
@@ -968,7 +990,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let extractor =
                     WheelExtractor::new(self.build_context.cache().root(), content_addressed_cache)
                         .map_err(Error::CacheWrite)?;
-                let mut file = writer.into_inner();
+                // Download is complete, atomically rename into place.
+                fs_err::rename(partial_entry.path(), complete_entry.path())
+                    .map_err(Error::CacheWrite)?;
+
+                // Re-open the renamed file for extraction.
+                let mut file = fs_err::tokio::File::open(complete_entry.path())
+                    .await
+                    .map_err(Error::CacheWrite)?;
                 file.seek(io::SeekFrom::Start(0))
                     .await
                     .map_err(Error::CacheWrite)?;
@@ -1003,9 +1032,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .instrument(info_span!("wheel", wheel = %dist))
         };
 
-        // Fetch the archive from the cache, or download it if necessary.
-        let req = self.request(url.clone())?;
-
         // Determine the cache control policy for the URL.
         let cache_control = match self.client.unmanaged.connectivity() {
             Connectivity::Online
@@ -1026,21 +1052,56 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
-        let archive = self
-            .client
-            .managed(|client| {
-                client.cached_client().get_serde_with_retry(
-                    req,
-                    &http_entry,
-                    cache_control.clone(),
-                    download,
-                )
-            })
-            .await
-            .map_err(|err| match err {
-                CachedClientError::Callback { err, .. } => err,
-                CachedClientError::Client(err) => Error::Client(err),
-            })?;
+        let partial_len =
+            || std::fs::metadata(partial_entry.path()).map(|m| m.len()).unwrap_or(0);
+
+        let mut retry_state = RetryState::start(
+            self.client.unmanaged.cached_client().uncached().retry_policy(),
+            url.clone(),
+        );
+        let mut use_range = true;
+
+        let archive = loop {
+            let bytes_written = partial_len();
+
+            let req = if use_range && bytes_written > 0 {
+                self.request_with_offset(url.clone(), bytes_written)?
+            } else {
+                self.request(url.clone())?
+            };
+
+            let result = self
+                .client
+                .managed(|client| {
+                    client
+                        .cached_client()
+                        .get_serde(req, &http_entry, cache_control.clone(), &download)
+                })
+                .await;
+
+            match result {
+                Ok(archive) => break archive,
+                Err(CachedClientError::Client(err)) => {
+                    let new_partial_len = partial_len();
+                    // If the download made forward progress before being cut off, don't
+                    // consume a retry—the next attempt will resume via Range header.
+                    if use_range && new_partial_len > bytes_written {
+                        continue;
+                    }
+                    if let Some(backoff) = retry_state.should_retry(&err, err.retries()) {
+                        // Server ignored our Range header (returned 200, truncating the file);
+                        // fall back to plain GET for remaining retries.
+                        if use_range && bytes_written > 0 && new_partial_len == 0 {
+                            use_range = false;
+                        }
+                        retry_state.sleep_backoff(backoff).await;
+                    } else {
+                        return Err(Error::Client(err));
+                    }
+                }
+                Err(CachedClientError::Callback { err, .. }) => return Err(err),
+            }
+        };
 
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
@@ -1289,6 +1350,30 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 // behavior from servers. ref: https://github.com/pypa/pip/pull/1688
                 "accept-encoding",
                 reqwest::header::HeaderValue::from_static("identity"),
+            )
+            .build()
+    }
+
+    /// Returns a GET [`reqwest::Request`] with a `Range: bytes=<offset>-` header.
+    ///
+    /// Used to resume an interrupted download from `offset` bytes into the file.
+    fn request_with_offset(
+        &self,
+        url: DisplaySafeUrl,
+        offset: u64,
+    ) -> Result<reqwest::Request, reqwest::Error> {
+        self.client
+            .unmanaged
+            .uncached_client(&url)
+            .get(Url::from(url))
+            .header(
+                "accept-encoding",
+                reqwest::header::HeaderValue::from_static("identity"),
+            )
+            .header(
+                reqwest::header::RANGE,
+                reqwest::header::HeaderValue::from_str(&format!("bytes={offset}-"))
+                    .expect("valid range header value"),
             )
             .build()
     }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -935,23 +935,20 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 ));
 
                 let mut resumed_at = None;
-                let mut supports_range_requests = false;
-                let mut can_resume = true;
 
                 loop {
-                    supports_range_requests |= can_resume
-                        && (response.status() == reqwest::StatusCode::PARTIAL_CONTENT
-                            || response
-                                .headers()
-                                .get(reqwest::header::ACCEPT_RANGES)
-                                .is_some_and(|value| value == "bytes"));
+                    let supports_range_requests = response.status()
+                        == reqwest::StatusCode::PARTIAL_CONTENT
+                        || response
+                            .headers()
+                            .get(reqwest::header::ACCEPT_RANGES)
+                            .is_some_and(|value| value == "bytes");
 
                     // A server can advertise range requests but ignore one. In that case, the
                     // response is a complete download and must replace the partial bytes.
-                    if resumed_at.is_some()
-                        && response.status() != reqwest::StatusCode::PARTIAL_CONTENT
-                    {
-                        can_resume = false;
+                    let replaces_partial_download = resumed_at.is_some()
+                        && response.status() != reqwest::StatusCode::PARTIAL_CONTENT;
+                    if replaces_partial_download {
                         writer
                             .get_mut()
                             .set_len(0)
@@ -996,7 +993,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     let Err(err) = copy_result else {
                         break;
                     };
-                    if !can_resume || !supports_range_requests {
+                    if replaces_partial_download || !supports_range_requests {
                         return Err(err);
                     }
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -707,7 +707,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
     /// Stream a wheel from a URL, unzipping it into the cache as it's downloaded.
     ///
-    /// Note that `progress_size_hint` is purely a size hint for the progress reporter,
+    /// Note that `progress_size_hint` is a size hint for the progress reporter,
     /// and is not guaranteed to be the true size of the wheel if/when fetched from the
     /// origin.
     async fn stream_wheel(
@@ -720,7 +720,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         dist: &BuiltDist,
         hashes: ArchiveHashPolicy<'_>,
     ) -> Result<Archive, Error> {
-        // Sometimes we can promote the size hint to a guaranteed size.
+        // Sometimes we can promote the size hint to a trusted effective size.
         let expected_size = match dist {
             BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => {
                 progress_size_hint
@@ -894,7 +894,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
     /// Download a wheel from a URL, then unzip it into the cache.
     ///
-    /// Note that, like [`Self::stream_wheel`], `progress_size_hint` is purely
+    /// Note that, like [`Self::stream_wheel`], `progress_size_hint` is
     /// a size hint for the progress reporter, and is not guaranteed to be the size
     /// of the wheel if/when fetched from the origin.
     async fn download_wheel(
@@ -907,7 +907,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         dist: &BuiltDist,
         hashes: ArchiveHashPolicy<'_>,
     ) -> Result<Archive, Error> {
-        // Sometimes we can promote the size hint to a guaranteed size.
+        // Sometimes we can promote the size hint to a trusted effective size.
         let expected_size = match dist {
             BuiltDist::Registry(dist) if dist.best_wheel().size_is_authoritative => {
                 progress_size_hint
@@ -1059,9 +1059,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // States for the download loop below.
         let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
-        // The total number of bytes written to the tempfile, accumulated over individual requests.
-        let mut bytes_written = 0;
-        // The current offset, i.e. where to resume a partial download from.
+        // The total number of bytes retrieved, accumulated over individual requests.
+        // Note that this is *not* the same as the number of bytes actually written
+        // to the temporary file, since a copy from the response to the file can fail.
+        let mut bytes_retrieved = 0;
+        // The most recent range request's starting offset.
         let mut resumed_at = None;
         // The `Content-Range` that the download was last resumed at.
         let mut resumed_range: Option<ContentRangeBytes> = None;
@@ -1069,9 +1071,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // This loop is where we handle resumption of interrupted downloads, as well as
         // range requests (if the origin supports them).
         //
-        // Note that this loop exists outside of our normal retry logic since it handles partial
-        // downloads rather than full restarts of downloads. Hard errors are returned back
-        // and may cause full retries (per the retry classifier).
+        // Errors returned from this loop reach the outer retry classifier, which may restart
+        // the full download.
         loop {
             // Check whether the response indicates range request support. A `206 Partial Content`
             // implies range support while an `Accept-Ranges: bytes` header explicitly advertises it.
@@ -1099,7 +1100,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .into_iter()
                     .map(Hasher::from)
                     .collect();
-                bytes_written = 0;
+                bytes_retrieved = 0;
             }
 
             let reader = response
@@ -1126,7 +1127,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .map_err(Error::CacheWrite),
             };
 
-            bytes_written += hasher.bytes_read();
+            bytes_retrieved += hasher.bytes_read();
 
             let err = match copy_result {
                 // Draining the response succeeded. However, the response could be a `206 Partial Content`,
@@ -1144,7 +1145,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     // stack). Note that this implies some kind of buggy origin.
                     //
                     // Byte ranges are inclusive, not exclusive.
-                    if bytes_written != range.last_byte + 1 {
+                    if bytes_retrieved != range.last_byte + 1 {
                         return Err(Error::CacheWrite(io::Error::new(
                             io::ErrorKind::UnexpectedEof,
                             "Range response length does not match Content-Range",
@@ -1153,7 +1154,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                     // We've successfully performed the download over one or more
                     // range requests. We can leave the loop.
-                    if bytes_written == range.complete_length {
+                    if bytes_retrieved == range.complete_length {
                         break;
                     }
 
@@ -1185,16 +1186,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             }
 
             // We expect any partial response to have an ETag, so that we can detect
-            // when an (honest) origin changes its response beneath us. This is strictly
-            // an optimization, i.e. so that we don't continue requesting content for a
-            // download that will fail hash and/or size validation anyways.
+            // when an (honest) origin changes its representation beneath us.
             let Some(etag) = etag.as_ref() else {
                 return Err(err);
             };
 
             // Some sanity checks: we should have made *some* progress as part of
             // partial response, plus our writer's offset should agree with the number
-            // of bytes written, *and* we should be making forward progress (i.e. not
+            // of bytes retrieved, *and* we should be making forward progress (i.e. not
             // resuming behind where we already are).
             writer.flush().await.map_err(Error::CacheWrite)?;
             let offset = writer
@@ -1203,7 +1202,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 .await
                 .map_err(Error::CacheWrite)?;
             if offset == 0
-                || offset != bytes_written
+                || offset != bytes_retrieved
                 || resumed_at.is_some_and(|previous| offset <= previous)
             {
                 return Err(err);
@@ -1248,12 +1247,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // We've left the resumption loop.
         // Sanity check: we should have written as many bytes as we expected.
         if let Some(expected) = expected_size
-            && bytes_written != expected
+            && bytes_retrieved != expected
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
                 expected,
-                actual: bytes_written,
+                actual: bytes_retrieved,
             });
         }
 
@@ -1291,7 +1290,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             id,
             hashes,
             filename.clone(),
-            Some(bytes_written),
+            Some(bytes_retrieved),
         ))
     }
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1140,16 +1140,16 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     };
 
                     // We should be in sync with the origin. Failure here means that the
-                    // origin actually sent us an under- or over-length response, which we
-                    // treat as a resumption error (and return back to the normal retry
-                    // stack). Note that this implies some kind of buggy origin.
+                    // origin actually sent us an under- or over-length response. Treat this
+                    // as a non-retryable error, since the HTTP body was received successfully.
                     //
                     // Byte ranges are inclusive, not exclusive.
                     if bytes_retrieved != range.last_byte + 1 {
-                        return Err(Error::CacheWrite(io::Error::new(
-                            io::ErrorKind::UnexpectedEof,
-                            "Range response length does not match Content-Range",
-                        )));
+                        return Err(Error::MismatchedRangeSize {
+                            distribution: dist.to_string(),
+                            expected: range.last_byte - range.first_byte + 1,
+                            actual: hasher.bytes_read(),
+                        });
                     }
 
                     // We've successfully performed the download over one or more

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -914,6 +914,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         let download = |mut response: reqwest::Response| {
             async {
                 let progress_size = size.or_else(|| content_length(&response));
+                let mut download_size = content_length(&response).or(expected_size);
 
                 let progress = self.reporter.as_ref().map(|reporter| {
                     (
@@ -935,6 +936,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 ));
 
                 let mut resumed_at = None;
+                let mut resumed_range: Option<ContentRangeBytes> = None;
 
                 loop {
                     let supports_range_requests = response.status()
@@ -990,8 +992,28 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                     actual_size += hasher.bytes_read();
 
-                    let Err(err) = copy_result else {
-                        break;
+                    let err = match copy_result {
+                        Ok(_) => {
+                            let Some(range) = resumed_range else {
+                                break;
+                            };
+                            if actual_size != range.last_byte + 1 {
+                                return Err(Error::CacheWrite(io::Error::new(
+                                    io::ErrorKind::UnexpectedEof,
+                                    "Range response length does not match Content-Range",
+                                )));
+                            }
+                            if actual_size == range.complete_length {
+                                break;
+                            }
+                            // A successful range response may cover only part of the requested
+                            // bytes. Keep requesting the remainder before extracting the wheel.
+                            Error::CacheWrite(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "Range response did not complete the download",
+                            ))
+                        }
+                        Err(err) => err,
                     };
                     // Only resume inline when range support is usable; otherwise let the outer
                     // retry machinery retry the full download.
@@ -1018,15 +1040,23 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         .await?;
                     resumed_response.error_for_status_ref()?;
 
-                    if resumed_response.status() == reqwest::StatusCode::PARTIAL_CONTENT
-                        && !content_range_starts_at(&resumed_response, offset)
+                    resumed_range = if resumed_response.status()
+                        == reqwest::StatusCode::PARTIAL_CONTENT
                     {
-                        warn!(
-                            "Invalid range request response from server that declares HTTP range \
-                             request support, abandoning resumed download: {download_url}"
-                        );
-                        return Err(err);
-                    }
+                        let Some(range) = content_range(&resumed_response, offset, download_size)
+                        else {
+                            warn!(
+                                "Invalid range request response from server that declares HTTP range \
+                                 request support, abandoning resumed download: {download_url}"
+                            );
+                            return Err(err);
+                        };
+                        download_size = Some(range.complete_length);
+                        Some(range)
+                    } else {
+                        download_size = content_length(&resumed_response).or(expected_size);
+                        None
+                    };
 
                     response = resumed_response;
                     resumed_at = Some(offset);
@@ -1519,23 +1549,39 @@ fn content_length(response: &reqwest::Response) -> Option<u64> {
         .and_then(|val| val.parse::<u64>().ok())
 }
 
-/// Returns `true` if `response` is a range response starting at `offset`.
-fn content_range_starts_at(response: &reqwest::Response, offset: u64) -> bool {
-    let Some(content_range) = response
+/// Return the bounds of a range response starting at `offset` with a known complete length.
+fn content_range(
+    response: &reqwest::Response,
+    offset: u64,
+    download_size: Option<u64>,
+) -> Option<ContentRangeBytes> {
+    let range = response
         .headers()
         .get(reqwest::header::CONTENT_RANGE)
         .and_then(|value| value.to_str().ok())
-        .and_then(ContentRange::parse)
-    else {
-        return false;
+        .and_then(ContentRange::parse)?;
+
+    let range = match range {
+        ContentRange::Bytes(range) => range,
+        ContentRange::UnboundBytes(ContentRangeUnbound {
+            first_byte,
+            last_byte,
+        }) => ContentRangeBytes {
+            first_byte,
+            last_byte,
+            complete_length: download_size?,
+        },
+        ContentRange::Unsatisfied(_) => return None,
     };
 
-    matches!(
-        content_range,
-        ContentRange::Bytes(ContentRangeBytes { first_byte, .. })
-            | ContentRange::UnboundBytes(ContentRangeUnbound { first_byte, .. })
-            if first_byte == offset
-    )
+    if range.first_byte != offset
+        || range.last_byte >= range.complete_length
+        || download_size.is_some_and(|size| size != range.complete_length)
+    {
+        return None;
+    }
+
+    Some(range)
 }
 
 /// An asynchronous reader that reports progress as bytes are read.

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -183,6 +183,15 @@ pub enum Error {
     },
 
     #[error(
+        "Content-Length mismatch for `{distribution}`: expected {expected} bytes, but the server advertised {actual} bytes"
+    )]
+    MismatchedContentLength {
+        distribution: String,
+        expected: u64,
+        actual: u64,
+    },
+
+    #[error(
         "Range response size mismatch for `{distribution}`: expected {expected} bytes from Content-Range, but received {actual} bytes"
     )]
     MismatchedRangeSize {

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -183,6 +183,15 @@ pub enum Error {
     },
 
     #[error(
+        "Range response size mismatch for `{distribution}`: expected {expected} bytes from Content-Range, but received {actual} bytes"
+    )]
+    MismatchedRangeSize {
+        distribution: String,
+        expected: u64,
+        actual: u64,
+    },
+
+    #[error(
         "Hash-checking is enabled, but no hashes were provided or computed for: `{distribution}`"
     )]
     MissingHashes { distribution: String },

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -26,7 +26,7 @@ use uv_cache::{Cache, CacheBucket, CacheEntry, CacheShard, Removal, WheelCache};
 use uv_cache_info::CacheInfo;
 use uv_client::{
     BaseClientBuilder, CacheControl, CachedClientError, Connectivity, DataWithCachePolicy,
-    RegistryClient,
+    RegistryClient, RetryState,
 };
 use uv_configuration::{BuildKind, BuildOutput, NoSources};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
@@ -974,7 +974,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
-        let download = |response| {
+        let download = |response, _: &mut RetryState| {
             async {
                 // At this point, we're seeing a new or updated source distribution. Initialize a
                 // new revision, to collect the source and built artifacts.
@@ -2768,7 +2768,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             Connectivity::Offline => CacheControl::AllowStale,
         };
 
-        let download = |response| {
+        let download = |response, _: &mut RetryState| {
             async {
                 let (hashes, size) = self
                     .download_archive(

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -27,7 +27,7 @@ use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::cache_digest;
 use uv_client::{
     BaseClient, BaseClientBuilder, CacheControl, CachedClient, CachedClientError, ClientBuildError,
-    Connectivity, RetriableError, WrappedReqwestError, fetch_with_url_fallback,
+    Connectivity, RetriableError, RetryState, WrappedReqwestError, fetch_with_url_fallback,
     retryable_on_request_failure,
 };
 use uv_distribution_filename::{ExtensionError, SourceDistExtension};
@@ -1143,7 +1143,7 @@ async fn fetch_downloads_from_url(
         .build()
         .map_err(|err| Error::NetworkError(url.clone(), WrappedReqwestError::from(err)))?;
 
-    let response_callback = async |response: Response| {
+    let response_callback = async |response: Response, _: &mut RetryState| {
         let bytes = response
             .bytes()
             .await

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -10,7 +10,6 @@ use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild};
 use async_zip::base::write::ZipFileWriter;
 use async_zip::{Compression, ZipEntryBuilder};
 use bytes::Bytes;
-use futures::io::AsyncWriteExt;
 use http::StatusCode;
 use http::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, ETAG, IF_RANGE, RANGE};
 use http_body_util::combinators::BoxBody;
@@ -191,12 +190,12 @@ async fn mixed_error_server() -> (MockServer, String) {
 
 type StreamingResponse = hyper::Response<BoxBody<Bytes, Infallible>>;
 
-/// Emit some bytes and then stall until the client times out.
-fn stalled_body(bytes: Bytes) -> BoxBody<Bytes, Infallible> {
+/// Emit some bytes, then wait before ending the response body.
+fn delayed_body(bytes: Bytes, delay: Duration) -> BoxBody<Bytes, Infallible> {
     let (tx, rx) = tokio::sync::mpsc::channel(1);
     tokio::spawn(async move {
         let _ = tx.send(Ok(Frame::data(bytes))).await;
-        tokio::time::sleep(Duration::from_mins(1)).await;
+        tokio::time::sleep(delay).await;
     });
     StreamBody::new(ReceiverStream::new(rx)).boxed()
 }
@@ -206,7 +205,7 @@ fn time_out_response(
 ) -> Result<StreamingResponse, http::Error> {
     hyper::Response::builder()
         .header("Content-Type", "text/html")
-        .body(stalled_body(Bytes::new()))
+        .body(delayed_body(Bytes::new(), Duration::from_mins(1)))
 }
 
 /// Run a streaming HTTP server on its own runtime so test subprocesses cannot starve it.
@@ -1106,8 +1105,8 @@ async fn retry_read_timeout_stream() {
     ");
 }
 
-/// A valid wheel whose stored entries and data descriptors require on-disk extraction.
-async fn wheel_requiring_download(generator: &str) -> Result<Bytes> {
+/// A wheel that supports both streaming and on-disk extraction.
+async fn test_wheel(generator: &str) -> Result<Bytes> {
     let wheel_metadata = format!(
         "Wheel-Version: 1.0\nGenerator: {generator}\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
     );
@@ -1123,10 +1122,8 @@ async fn wheel_requiring_download(generator: &str) -> Result<Bytes> {
             b"ok-1.0.0.dist-info/RECORD,,\n".as_slice(),
         ),
     ] {
-        let entry = ZipEntryBuilder::new(path.to_string().into(), Compression::Stored);
-        let mut entry_writer = writer.write_entry_stream(entry).await?;
-        entry_writer.write_all(contents).await?;
-        entry_writer.close().await?;
+        let entry = ZipEntryBuilder::new(path.to_string().into(), Compression::Deflate);
+        writer.write_entry_whole(entry, contents).await?;
     }
     Ok(writer.close().await?.into())
 }
@@ -1148,7 +1145,7 @@ struct DownloadCase {
     range: RangeResponse,
     etag: Option<&'static str>,
     replace: bool,
-    /// Number of full download retries expected and allowed.
+    /// Retry limit for both paths, and the number of retries expected after falling back.
     full_retries: usize,
 }
 
@@ -1163,7 +1160,8 @@ impl Default for DownloadCase {
     }
 }
 
-/// Serve metadata normally, then interrupt the second full GET after streaming extraction fails.
+/// Serve metadata normally, then truncate full responses until streaming retries are exhausted.
+/// Interrupt the first download-to-file response with a timeout.
 /// Subsequent requests exercise the configured continuation or full-download fallback.
 fn wheel_response(
     request: &hyper::Request<hyper::body::Incoming>,
@@ -1172,7 +1170,8 @@ fn wheel_response(
     case: DownloadCase,
     full_get_count: &AtomicUsize,
 ) -> Result<StreamingResponse, http::Error> {
-    let resuming = full_get_count.load(Ordering::Relaxed) >= 2;
+    let streaming_attempts = 1 + case.full_retries;
+    let resuming = full_get_count.load(Ordering::Relaxed) > streaming_attempts;
     let (wheel, etag) = if resuming && let Some(replacement) = replacement {
         (replacement, Some("\"replacement\""))
     } else {
@@ -1243,19 +1242,30 @@ fn wheel_response(
             .body(http_body_util::Full::new(bytes).boxed());
     }
     response = response.header(CONTENT_LENGTH, size);
-    if full_get_count.fetch_add(1, Ordering::Relaxed) != 1 {
+    let full_get = full_get_count.fetch_add(1, Ordering::Relaxed);
+    if full_get < streaming_attempts {
+        // Give Hyper time to flush the partial body before closing short of Content-Length.
+        return response.body(delayed_body(
+            wheel.slice(..size / 2),
+            Duration::from_millis(50),
+        ));
+    }
+    if full_get > streaming_attempts {
         return response.body(http_body_util::Full::new(wheel.clone()).boxed());
     }
     if !matches!(case.range, RangeResponse::NotAdvertised) {
         response = response.header(ACCEPT_RANGES, "bytes");
     }
-    response.body(stalled_body(wheel.slice(..size / 2)))
+    response.body(delayed_body(
+        wheel.slice(..size / 2),
+        Duration::from_mins(1),
+    ))
 }
 
 async fn wheel_server(case: DownloadCase) -> Result<(String, impl Drop, Arc<AtomicUsize>, String)> {
-    let wheel = wheel_requiring_download("test").await?;
+    let wheel = test_wheel("test").await?;
     let replacement = if case.replace {
-        Some(wheel_requiring_download("next").await?)
+        Some(test_wheel("next").await?)
     } else {
         None
     };
@@ -1293,16 +1303,16 @@ async fn assert_wheel_download(case: DownloadCase) -> Result<()> {
         exit_code: 0 (success)
         ----- stderr -----
         Resolved 1 package in [TIME]
-        WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+        WARN Streaming failed for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
         Prepared 1 package in [TIME]
         Installed 1 package in [TIME]
          + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
         ");
     }
-    // The first full GET reaches the extraction fallback; the second is interrupted.
+    // Both streaming and the download fallback use their configured full-request retry budgets.
     assert_eq!(
         full_get_count.load(Ordering::Relaxed),
-        2 + case.full_retries
+        2 * (1 + case.full_retries)
     );
     Ok(())
 }
@@ -1424,7 +1434,7 @@ async fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    WARN Streaming failed for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
     WARN Invalid range request response from server that declares HTTP range request support, abandoning resumed download: http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl
       × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
       ├─▶ Failed to write to the distribution cache

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1112,6 +1112,7 @@ enum RangeResponse {
     NotAdvertised,
     InvalidContentRange,
     ShortBody,
+    Unsatisfiable,
 }
 
 #[derive(Clone, Copy)]
@@ -1205,6 +1206,13 @@ fn wheel_response(
                 }
                 RangeResponse::InvalidContentRange => content_range_start = 0,
                 RangeResponse::ShortBody => body_end = Some(end - 1),
+                RangeResponse::Unsatisfiable => {
+                    assert_eq!(start, size);
+                    return response
+                        .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                        .header(CONTENT_RANGE, format!("bytes */{size}"))
+                        .body(http_body_util::Empty::new().boxed());
+                }
             }
         }
         let bytes = wheel.slice(start..=body_end.unwrap_or(end));
@@ -1217,22 +1225,27 @@ fn wheel_response(
             .header(CONTENT_LENGTH, bytes.len())
             .body(http_body_util::Full::new(bytes).boxed());
     }
-    response = response.header(CONTENT_LENGTH, size);
     let full_get = full_get_count.fetch_add(1, Ordering::Relaxed);
     if full_get < streaming_attempts {
         // Give Hyper time to flush the partial body before closing short of Content-Length.
-        return response.body(delayed_body(
+        return response.header(CONTENT_LENGTH, size).body(delayed_body(
             wheel.slice(..size / 2),
             Duration::from_millis(50),
         ));
     }
     if full_get > streaming_attempts {
-        return response.body(http_body_util::Full::new(wheel.clone()).boxed());
+        return response
+            .header(CONTENT_LENGTH, size)
+            .body(http_body_util::Full::new(wheel.clone()).boxed());
     }
     if !matches!(case.range, RangeResponse::NotAdvertised) {
         response = response.header(ACCEPT_RANGES, "bytes");
     }
-    response.body(delayed_body(
+    if let RangeResponse::Unsatisfiable = case.range {
+        // Send all wheel bytes, but stall before terminating the chunked response.
+        return response.body(delayed_body(wheel.clone(), Duration::from_mins(1)));
+    }
+    response.header(CONTENT_LENGTH, size).body(delayed_body(
         wheel.slice(..size / 2),
         Duration::from_mins(1),
     ))
@@ -1340,6 +1353,46 @@ fn direct_url_no_range_resume() -> Result<()> {
         full_retries: 1,
         ..DownloadCase::default()
     })
+}
+
+#[test]
+fn direct_url_unsatisfiable_range_retries_in_full() -> Result<()> {
+    assert_wheel_download(DownloadCase {
+        range: RangeResponse::Unsatisfiable,
+        full_retries: 1,
+        ..DownloadCase::default()
+    })
+}
+
+#[test]
+fn direct_url_unsatisfiable_range_does_not_bypass_retry() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let (server, _guard, full_get_count, _) = wheel_server(
+        &context,
+        DownloadCase {
+            range: RangeResponse::Unsatisfiable,
+            ..DownloadCase::default()
+        },
+    )?;
+
+    let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg(format!("build-tag @ {wheel_url}"))
+        .env(EnvVars::UV_HTTP_RETRIES, "0")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming failed for build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
+      × Failed to download `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`
+      ├─▶ Failed to write to the distribution cache
+      ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
+    ");
+    assert_eq!(full_get_count.load(Ordering::Relaxed), 2);
+    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1,13 +1,16 @@
 use std::convert::Infallible;
 use std::io;
-use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild};
+use async_zip::base::write::ZipFileWriter;
+use async_zip::{Compression, ZipEntryBuilder};
 use bytes::Bytes;
+use futures::io::AsyncWriteExt;
 use http::StatusCode;
+use http::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, RANGE};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, StreamBody};
 use hyper::body::Frame;
@@ -17,8 +20,6 @@ use serde_json::json;
 use tokio_stream::wrappers::ReceiverStream;
 use wiremock::matchers::{any, method};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
-use zip::ZipWriter;
-use zip::write::SimpleFileOptions;
 
 use uv_static::EnvVars;
 use uv_test::{TestContext, uv_snapshot};
@@ -1094,54 +1095,43 @@ async fn retry_read_timeout_stream() {
     ");
 }
 
-/// A minimal `iniconfig-2.0.0-py3-none-any.whl` with only dist-info files.
-///
-/// `validate_and_heal_record` fills in missing RECORD entries at install time, so we don't
-/// need correct hashes here.
-fn minimal_iniconfig_wheel() -> Vec<u8> {
-    let mut buf = std::io::Cursor::new(Vec::new());
-    let mut zip = ZipWriter::new(&mut buf);
-    let options = SimpleFileOptions::default();
-
-    zip.start_file("iniconfig-2.0.0.dist-info/WHEEL", options)
-        .unwrap();
-    zip.write_all(
-        b"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
-    )
-    .unwrap();
-
-    zip.start_file("iniconfig-2.0.0.dist-info/METADATA", options)
-        .unwrap();
-    zip.write_all(b"Metadata-Version: 2.1\nName: iniconfig\nVersion: 2.0.0\n")
-        .unwrap();
-
-    zip.start_file("iniconfig-2.0.0.dist-info/RECORD", options)
-        .unwrap();
-    zip.write_all(b"iniconfig-2.0.0.dist-info/RECORD,,\n")
-        .unwrap();
-
-    zip.finish().unwrap();
-    buf.into_inner()
+/// A valid wheel whose data descriptors require the on-disk extraction fallback.
+async fn wheel_requiring_download() -> Vec<u8> {
+    let mut writer = ZipFileWriter::new(Vec::new());
+    for (path, contents) in [
+        (
+            "ok-1.0.0.dist-info/WHEEL",
+            b"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+                .as_slice(),
+        ),
+        (
+            "ok-1.0.0.dist-info/METADATA",
+            b"Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\n".as_slice(),
+        ),
+        (
+            "ok-1.0.0.dist-info/RECORD",
+            b"ok-1.0.0.dist-info/RECORD,,\n".as_slice(),
+        ),
+    ] {
+        let entry = ZipEntryBuilder::new(path.to_string().into(), Compression::Stored);
+        let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
+        entry_writer.write_all(contents).await.unwrap();
+        entry_writer.close().await.unwrap();
+    }
+    writer.close().await.unwrap()
 }
 
 /// Returns a server URL and a drop guard that serves a wheel with mid-stream interruption.
 ///
-/// When `honor_range` is true:
-/// - HEAD → `Content-Length` + `Accept-Ranges: bytes`
-/// - Plain GET → first half, then hangs (timeout fires instead of TCP RST so bytes land on disk)
-/// - Range GET → 206 with the requested slice, enabling a free byte-level resume
-///
-/// When `honor_range` is false:
-/// - HEAD → `Content-Length` only (no `Accept-Ranges`)
-/// - Plain GET → first two requests hang (`stream_wheel` + first download attempt); the third
-///   serves the full wheel so the retry (which consumes one retry budget) succeeds
-/// - Range GET → 200 full content (ignored, but never sent by the client once Range is disabled)
-fn wheel_server(wheel: Vec<u8>, honor_range: bool) -> (String, impl Drop) {
+/// HEAD and range requests complete normally so metadata reads do not affect the download count.
+/// The first full GET reaches the streaming fallback, and the second is interrupted. When
+/// `advertise_range` is true, that interrupted download can be resumed.
+fn wheel_server(wheel: Vec<u8>, advertise_range: bool) -> (String, impl Drop) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     listener.set_nonblocking(true).unwrap();
     let server_url = format!("http://{}", listener.local_addr().unwrap());
     let wheel = Bytes::from(wheel);
-    let plain_get_count = Arc::new(AtomicUsize::new(0));
+    let full_get_count = Arc::new(AtomicUsize::new(0));
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -1155,79 +1145,70 @@ fn wheel_server(wheel: Vec<u8>, honor_range: bool) -> (String, impl Drop) {
                     loop {
                         let Ok((stream, _)) = listener.accept().await else { break };
                         let wheel = wheel.clone();
-                        let plain_get_count = plain_get_count.clone();
+                        let full_get_count = full_get_count.clone();
                         tokio::spawn(async move {
                             let _ = hyper_util::server::conn::auto::Builder::new(
                                 hyper_util::rt::TokioExecutor::new(),
                             )
                             .serve_connection(
                                 TokioIo::new(stream),
-                                service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+                                service_fn(move |request: hyper::Request<hyper::body::Incoming>| {
                                     let wheel = wheel.clone();
-                                    let plain_get_count = plain_get_count.clone();
+                                    let full_get_count = full_get_count.clone();
                                     async move {
-                                        let n = wheel.len();
-                                        if req.method() == hyper::Method::HEAD {
-                                            let mut builder = hyper::Response::builder()
-                                                .header("Content-Length", n.to_string());
-                                            if honor_range {
-                                                builder = builder.header("Accept-Ranges", "bytes");
-                                            }
-                                            Ok::<_, Infallible>(builder
+                                        let size = wheel.len();
+                                        if request.method() == hyper::Method::HEAD {
+                                            return Ok::<_, Infallible>(hyper::Response::builder()
+                                                .header(CONTENT_LENGTH, size.to_string())
+                                                .header(ACCEPT_RANGES, "bytes")
                                                 .body(http_body_util::Empty::new().boxed())
-                                                .unwrap())
-                                        } else if let Some(hdr) = req.headers().get("range") {
-                                            if honor_range {
-                                                let (start, end) = hdr.to_str().unwrap_or("bytes=0-")
-                                                    .trim_start_matches("bytes=")
-                                                    .split_once('-')
-                                                    .map(|(a, b)| (
-                                                        a.parse().unwrap_or(0),
-                                                        b.parse().unwrap_or(n - 1),
-                                                    ))
-                                                    .unwrap_or((0, n - 1));
-                                                let slice = wheel.slice(start..=end);
-                                                Ok::<_, Infallible>(hyper::Response::builder()
-                                                    .status(206)
-                                                    .header("Content-Range", format!("bytes {start}-{end}/{n}"))
-                                                    .header("Content-Length", slice.len().to_string())
-                                                    .body(http_body_util::Full::new(slice).boxed())
-                                                    .unwrap())
-                                            } else {
-                                                Ok::<_, Infallible>(hyper::Response::builder()
-                                                    .header("Content-Type", "application/zip")
-                                                    .header("Content-Length", n.to_string())
-                                                    .body(http_body_util::Full::new(wheel.clone()).boxed())
-                                                    .unwrap())
-                                            }
-                                        } else {
-                                            let count = plain_get_count.fetch_add(1, Ordering::Relaxed);
-                                            // First two plain GETs hang (stream_wheel + first
-                                            // download attempt); subsequent ones serve the full
-                                            // wheel for the retry.
-                                            if honor_range || count < 2 {
-                                                let (tx, rx) = tokio::sync::mpsc::channel(1);
-                                                tokio::spawn(async move {
-                                                    let _ = tx.send(Ok(Frame::data(wheel.slice(..n / 2)))).await;
-                                                    tokio::time::sleep(Duration::from_secs(60)).await;
-                                                });
-                                                let mut builder = hyper::Response::builder()
-                                                    .header("Content-Type", "application/zip")
-                                                    .header("Content-Length", n.to_string());
-                                                if honor_range {
-                                                    builder = builder.header("Accept-Ranges", "bytes");
-                                                }
-                                                Ok::<_, Infallible>(builder
-                                                    .body(StreamBody::new(ReceiverStream::new(rx)).boxed())
-                                                    .unwrap())
-                                            } else {
-                                                Ok::<_, Infallible>(hyper::Response::builder()
-                                                    .header("Content-Type", "application/zip")
-                                                    .header("Content-Length", n.to_string())
-                                                    .body(http_body_util::Full::new(wheel.clone()).boxed())
-                                                    .unwrap())
-                                            }
+                                                .unwrap());
                                         }
+
+                                        if let Some(range) = request.headers().get(RANGE) {
+                                            let (start, end) = range
+                                                .to_str()
+                                                .unwrap()
+                                                .trim_start_matches("bytes=")
+                                                .split_once('-')
+                                                .map(|(start, end)| {
+                                                    (
+                                                        start.parse().unwrap(),
+                                                        end.parse().unwrap_or(size - 1),
+                                                    )
+                                                })
+                                                .unwrap();
+                                            let bytes = wheel.slice(start..=end);
+                                            return Ok::<_, Infallible>(hyper::Response::builder()
+                                                .status(StatusCode::PARTIAL_CONTENT)
+                                                .header(CONTENT_RANGE, format!("bytes {start}-{end}/{size}"))
+                                                .header(CONTENT_LENGTH, bytes.len().to_string())
+                                                .body(http_body_util::Full::new(bytes).boxed())
+                                                .unwrap());
+                                        }
+
+                                        if full_get_count.fetch_add(1, Ordering::Relaxed) != 1 {
+                                            return Ok::<_, Infallible>(hyper::Response::builder()
+                                                .header(CONTENT_LENGTH, size.to_string())
+                                                .body(http_body_util::Full::new(wheel).boxed())
+                                                .unwrap());
+                                        }
+
+                                        let (tx, rx) = tokio::sync::mpsc::channel(1);
+                                        tokio::spawn(async move {
+                                            let _ = tx
+                                                .send(Ok(Frame::data(wheel.slice(..size / 2))))
+                                                .await;
+                                            tokio::time::sleep(Duration::from_mins(1)).await;
+                                        });
+                                        let mut response = hyper::Response::builder()
+                                            .header(CONTENT_LENGTH, size.to_string());
+                                        if advertise_range {
+                                            response = response.header(ACCEPT_RANGES, "bytes");
+                                        }
+                                        Ok::<_, Infallible>(response
+                                            .body(StreamBody::new(ReceiverStream::new(rx)).boxed())
+                                            .unwrap())
                                     }
                                 }),
                             )
@@ -1242,27 +1223,19 @@ fn wheel_server(wheel: Vec<u8>, honor_range: bool) -> (String, impl Drop) {
     (server_url, shutdown_tx)
 }
 
-/// A mid-stream interruption is transparently resumed via HTTP Range without consuming a retry.
-///
-/// The server sends the first half of the wheel then hangs. `UV_HTTP_TIMEOUT=1` causes the client
-/// to time out, but since bytes were written to disk, the retry loop resumes via a Range request
-/// rather than restarting from scratch. With `UV_HTTP_RETRIES=0`, a normal error would fail
-/// immediately; the Range-based resume is "free" (not counted as a retry), so the install
-/// succeeds.
+/// A mid-stream interruption is transparently resumed via HTTP range without consuming a retry.
 #[tokio::test]
 async fn direct_url_range_resume() {
     let context = uv_test::test_context!("3.12");
 
-    let wheel = minimal_iniconfig_wheel();
+    let wheel = wheel_requiring_download().await;
     let (server, _guard) = wheel_server(wheel, true);
 
-    let wheel_url = format!("{server}/iniconfig-2.0.0-py3-none-any.whl");
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
     uv_snapshot!(context.filters(), context
         .pip_install()
-        .arg(format!("iniconfig @ {wheel_url}"))
-        // Zero retries: the Range-based resume must not count as a retry.
+        .arg(format!("ok @ {wheel_url}"))
         .env(EnvVars::UV_HTTP_RETRIES, "0")
-        // Short timeout so the hanging body is interrupted quickly.
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
         .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true"), @"
     success: true
@@ -1271,29 +1244,26 @@ async fn direct_url_range_resume() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
-     + iniconfig==2.0.0 (from http://[LOCALHOST]/iniconfig-2.0.0-py3-none-any.whl)
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
     ");
 }
 
-/// When the server does not support Range requests, uv falls back to a plain re-download from
-/// scratch. Because the server does not advertise `Accept-Ranges`, the interruption is not a
-/// free Range-resume—it consumes one retry. With `UV_HTTP_RETRIES=1` the install succeeds.
+/// Without advertised range support, a mid-stream interruption uses a regular retry.
 #[tokio::test]
 async fn direct_url_no_range_resume() {
     let context = uv_test::test_context!("3.12");
 
-    let wheel = minimal_iniconfig_wheel();
+    let wheel = wheel_requiring_download().await;
     let (server, _guard) = wheel_server(wheel, false);
 
-    let wheel_url = format!("{server}/iniconfig-2.0.0-py3-none-any.whl");
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
     uv_snapshot!(context.filters(), context
         .pip_install()
-        .arg(format!("iniconfig @ {wheel_url}"))
-        // One retry: the re-download from scratch consumes one retry budget.
+        .arg(format!("ok @ {wheel_url}"))
         .env(EnvVars::UV_HTTP_RETRIES, "1")
-        // Short timeout so the hanging body is interrupted quickly.
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
         .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true"), @"
     success: true
@@ -1302,8 +1272,9 @@ async fn direct_url_no_range_resume() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
-     + iniconfig==2.0.0 (from http://[LOCALHOST]/iniconfig-2.0.0-py3-none-any.whl)
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
     ");
 }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1111,6 +1111,7 @@ enum RangeResponse {
     Ignored,
     NotAdvertised,
     InvalidContentRange,
+    ShortBody,
 }
 
 #[derive(Clone, Copy)]
@@ -1187,6 +1188,7 @@ fn wheel_response(
         };
         let mut content_range_start = start;
         let mut complete_length = size.to_string();
+        let mut body_end = None;
         if resuming {
             match case.range {
                 RangeResponse::Supported | RangeResponse::NotAdvertised => {}
@@ -1202,9 +1204,10 @@ fn wheel_response(
                     }
                 }
                 RangeResponse::InvalidContentRange => content_range_start = 0,
+                RangeResponse::ShortBody => body_end = Some(end - 1),
             }
         }
-        let bytes = wheel.slice(start..=end);
+        let bytes = wheel.slice(start..=body_end.unwrap_or(end));
         return response
             .status(StatusCode::PARTIAL_CONTENT)
             .header(
@@ -1415,5 +1418,38 @@ fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
       ├─▶ Failed to write to the distribution cache
       ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
     ");
+    Ok(())
+}
+
+/// A complete HTTP body with the wrong range length fails without retrying the full download.
+#[test]
+fn direct_url_range_size_mismatch() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let (server, _guard, full_get_count, _) = wheel_server(
+        &context,
+        DownloadCase {
+            range: RangeResponse::ShortBody,
+            full_retries: 1,
+            ..DownloadCase::default()
+        },
+    )?;
+
+    let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg(format!("build-tag @ {wheel_url}"))
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming failed for build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
+      × Failed to download `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`
+      ╰─▶ Range response size mismatch for `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`: expected 466 bytes from Content-Range, but received 465 bytes
+    ");
+    // Two streaming attempts precede the download fallback; the range mismatch ends the attempt.
+    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
     Ok(())
 }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -15,6 +15,7 @@ use http_body_util::{BodyExt, StreamBody};
 use hyper::body::Frame;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
+use indoc::formatdoc;
 use insta::{allow_duplicates, assert_snapshot};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -1285,22 +1286,18 @@ fn wheel_server(
 fn assert_wheel_download(case: DownloadCase) -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let (server, _guard, full_get_count, hash) = wheel_server(&context, case)?;
-    let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("build-tag @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    write_wheel_lockfile(&context, &server, 932, &hash)?;
     allow_duplicates! {
         uv_snapshot!(context.filters(), context
-            .pip_install()
-            .arg("-r")
-            .arg(requirements.path())
-            .arg("--require-hashes")
+            .pip_sync()
+            .arg("--preview")
+            .arg("pylock.toml")
             .env(EnvVars::UV_HTTP_RETRIES, case.full_retries.to_string())
             .env(EnvVars::UV_HTTP_TIMEOUT, "1")
             .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
             .env(EnvVars::RUST_LOG, "warn"), @"
         exit_code: 0 (success)
         ----- stderr -----
-        Resolved 1 package in [TIME]
         WARN Streaming failed for build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
         Prepared 1 package in [TIME]
         Installed 1 package in [TIME]
@@ -1336,6 +1333,53 @@ fn assert_wheel_download(case: DownloadCase) -> Result<()> {
         Tag: py3-none-any
         ");
     }
+    Ok(())
+}
+
+fn write_wheel_lockfile(context: &TestContext, server: &str, size: u64, hash: &str) -> Result<()> {
+    context.temp_dir.child("pylock.toml").write_str(&formatdoc! {
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "build-tag"
+        version = "1.0.0"
+        archive = {{ url = "{server}/build_tag-1.0.0-1-py2.py3-none-any.whl", size = {size}, hashes = {{ sha256 = "{hash}" }} }}
+        "#,
+    })?;
+    Ok(())
+}
+
+#[test]
+fn direct_url_content_length_mismatch() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let (server, _guard, full_get_count, hash) = wheel_server(
+        &context,
+        DownloadCase {
+            range: RangeResponse::NotAdvertised,
+            full_retries: 1,
+            ..DownloadCase::default()
+        },
+    )?;
+    write_wheel_lockfile(&context, &server, 1, &hash)?;
+
+    uv_snapshot!(context.filters(), context
+        .pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml")
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    WARN Streaming failed for build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
+      × Failed to download `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`
+      ╰─▶ Content-Length mismatch for `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`: expected 1 bytes, but the server advertised 932 bytes
+    ");
+    // The first fallback response fails on its headers without consuming a full-download retry.
+    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
     Ok(())
 }
 

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -209,12 +209,13 @@ fn time_out_response(
 
 /// Run a streaming HTTP server on its own runtime so test subprocesses cannot starve it.
 /// Dropping the guard shuts down the runtime and all connection tasks.
-fn streaming_server(
-    handler: impl Fn(hyper::Request<hyper::body::Incoming>) -> Result<StreamingResponse, http::Error>
-    + Send
-    + Sync
-    + 'static,
-) -> (String, impl Drop) {
+fn streaming_server<F>(handler: F) -> (String, impl Drop)
+where
+    F: Fn(hyper::Request<hyper::body::Incoming>) -> Result<StreamingResponse, http::Error>
+        + Send
+        + Sync
+        + 'static,
+{
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     listener.set_nonblocking(true).unwrap();
     let server = format!("http://{}", listener.local_addr().unwrap());

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -15,7 +15,7 @@ use http_body_util::{BodyExt, StreamBody};
 use hyper::body::Frame;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
-use insta::allow_duplicates;
+use insta::{allow_duplicates, assert_snapshot};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use tokio_stream::wrappers::ReceiverStream;
@@ -1312,6 +1312,30 @@ fn assert_wheel_download(case: DownloadCase) -> Result<()> {
         full_get_count.load(Ordering::Relaxed),
         2 * (1 + case.full_retries)
     );
+
+    let site_packages = context.site_packages();
+    let build = if case.replace { "3" } else { "1" };
+    assert_eq!(
+        fs_err::read_to_string(site_packages.join("build_tag/__init__.py"))?,
+        format!("def main():\n    print(\"{build}\")\n"),
+    );
+    let metadata =
+        fs_err::read_to_string(site_packages.join("build_tag-1.0.0.dist-info/METADATA"))?;
+    let wheel = fs_err::read_to_string(site_packages.join("build_tag-1.0.0.dist-info/WHEEL"))?;
+    allow_duplicates! {
+        assert_snapshot!(metadata, @"
+        Metadata-Version: 2.3
+        Name: build-tag
+        Version: 1.0.0
+        ");
+        assert_snapshot!(wheel, @"
+        Wheel-Version: 1.0
+        Generator: hatchling 1.26.3
+        Root-Is-Purelib: true
+        Tag: py2-none-any
+        Tag: py3-none-any
+        ");
+    }
     Ok(())
 }
 

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild};
 use bytes::Bytes;
 use http::StatusCode;
-use http::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, ETAG, IF_RANGE, RANGE};
+use http::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, RANGE};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, StreamBody};
 use hyper::body::Frame;
@@ -1117,24 +1117,11 @@ enum RangeResponse {
     Unsatisfiable,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 struct DownloadCase {
     range: RangeResponse,
-    etag: Option<&'static str>,
-    replace: bool,
     /// Retry limit for both paths, and the number of retries expected after falling back.
     full_retries: usize,
-}
-
-impl Default for DownloadCase {
-    fn default() -> Self {
-        Self {
-            range: RangeResponse::Supported,
-            etag: Some("\"wheel\""),
-            replace: false,
-            full_retries: 0,
-        }
-    }
 }
 
 /// Serve metadata normally, then truncate full responses until streaming retries are exhausted.
@@ -1143,22 +1130,13 @@ impl Default for DownloadCase {
 fn wheel_response(
     request: &hyper::Request<hyper::body::Incoming>,
     wheel: &Bytes,
-    replacement: Option<&Bytes>,
     case: DownloadCase,
     full_get_count: &AtomicUsize,
 ) -> Result<StreamingResponse, http::Error> {
     let streaming_attempts = 1 + case.full_retries;
     let resuming = full_get_count.load(Ordering::Relaxed) > streaming_attempts;
-    let (wheel, etag) = if resuming && let Some(replacement) = replacement {
-        (replacement, Some("\"replacement\""))
-    } else {
-        (wheel, case.etag)
-    };
     let size = wheel.len();
     let mut response = hyper::Response::builder();
-    if let Some(etag) = etag {
-        response = response.header(ETAG, etag);
-    }
     if request.method() == hyper::Method::HEAD {
         return response
             .header(CONTENT_LENGTH, size)
@@ -1166,16 +1144,6 @@ fn wheel_response(
             .body(http_body_util::Empty::new().boxed());
     }
     if let Some(range) = request.headers().get(RANGE) {
-        if resuming
-            && request
-                .headers()
-                .get(IF_RANGE)
-                .is_some_and(|validator| etag.is_none_or(|etag| validator != etag))
-        {
-            return response
-                .header(CONTENT_LENGTH, size)
-                .body(http_body_util::Full::new(wheel.clone()).boxed());
-        }
         let (start, end) = range
             .to_str()
             .expect("ASCII range")
@@ -1261,26 +1229,11 @@ fn wheel_server(
     let wheel = Bytes::from(fs_err::read(
         fixtures.join("build_tag-1.0.0-1-py2.py3-none-any.whl"),
     )?);
-    // These builds have the same package version and length, but different contents.
-    let replacement = if case.replace {
-        Some(Bytes::from(fs_err::read(
-            fixtures.join("build_tag-1.0.0-3-py2.py3-none-any.whl"),
-        )?))
-    } else {
-        None
-    };
-    let hash = hex::encode(Sha256::digest(replacement.as_ref().unwrap_or(&wheel)));
+    let hash = hex::encode(Sha256::digest(&wheel));
     let full_get_count = Arc::new(AtomicUsize::new(0));
     let requests = full_get_count.clone();
-    let (server, guard) = streaming_server(move |request| {
-        wheel_response(
-            &request,
-            &wheel,
-            replacement.as_ref(),
-            case,
-            &full_get_count,
-        )
-    });
+    let (server, guard) =
+        streaming_server(move |request| wheel_response(&request, &wheel, case, &full_get_count));
     Ok((server, guard, requests, hash))
 }
 
@@ -1312,10 +1265,9 @@ fn assert_wheel_download(case: DownloadCase) -> Result<()> {
     );
 
     let site_packages = context.site_packages();
-    let build = if case.replace { "3" } else { "1" };
     assert_eq!(
         fs_err::read_to_string(site_packages.join("build_tag/__init__.py"))?,
-        format!("def main():\n    print(\"{build}\")\n"),
+        "def main():\n    print(\"1\")\n",
     );
     let metadata =
         fs_err::read_to_string(site_packages.join("build_tag-1.0.0.dist-info/METADATA"))?;
@@ -1360,7 +1312,6 @@ fn direct_url_content_length_mismatch() -> Result<()> {
         DownloadCase {
             range: RangeResponse::NotAdvertised,
             full_retries: 1,
-            ..DownloadCase::default()
         },
     )?;
     write_wheel_lockfile(&context, &server, 1, &hash)?;
@@ -1420,7 +1371,6 @@ fn direct_url_no_range_resume() -> Result<()> {
     assert_wheel_download(DownloadCase {
         range: RangeResponse::NotAdvertised,
         full_retries: 1,
-        ..DownloadCase::default()
     })
 }
 
@@ -1429,7 +1379,6 @@ fn direct_url_unsatisfiable_range_retries_in_full() -> Result<()> {
     assert_wheel_download(DownloadCase {
         range: RangeResponse::Unsatisfiable,
         full_retries: 1,
-        ..DownloadCase::default()
     })
 }
 
@@ -1462,52 +1411,6 @@ fn direct_url_unsatisfiable_range_does_not_bypass_retry() -> Result<()> {
     ");
     assert_eq!(full_get_count.load(Ordering::Relaxed), 2);
     Ok(())
-}
-
-#[test]
-fn direct_url_range_validator_changed() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        replace: true,
-        full_retries: 1,
-        ..DownloadCase::default()
-    })
-}
-
-#[test]
-fn direct_url_range_validator_changed_full_response() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        range: RangeResponse::Ignored,
-        replace: true,
-        full_retries: 1,
-        ..DownloadCase::default()
-    })
-}
-
-#[test]
-fn direct_url_range_validator_missing() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        etag: None,
-        full_retries: 1,
-        ..DownloadCase::default()
-    })
-}
-
-#[test]
-fn direct_url_range_validator_weak() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        etag: Some("W/\"wheel\""),
-        full_retries: 1,
-        ..DownloadCase::default()
-    })
-}
-
-#[test]
-fn direct_url_range_validator_invalid() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        etag: Some("unquoted"),
-        full_retries: 1,
-        ..DownloadCase::default()
-    })
 }
 
 /// An invalid continuation response does not bypass regular retry handling.
@@ -1552,7 +1455,6 @@ fn direct_url_range_size_mismatch() -> Result<()> {
         DownloadCase {
             range: RangeResponse::ShortBody,
             full_retries: 1,
-            ..DownloadCase::default()
         },
     )?;
 

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1121,12 +1121,19 @@ async fn wheel_requiring_download() -> Vec<u8> {
     writer.close().await.unwrap()
 }
 
+#[derive(Clone, Copy)]
+enum RangeResponse {
+    Supported,
+    NotAdvertised,
+    InvalidContentRange,
+}
+
 /// Returns a server URL and a drop guard that serves a wheel with mid-stream interruption.
 ///
 /// HEAD and range requests complete normally so metadata reads do not affect the download count.
 /// The first full GET reaches the streaming fallback, and the second is interrupted. When
-/// `advertise_range` is true, that interrupted download can be resumed.
-fn wheel_server(wheel: Vec<u8>, advertise_range: bool) -> (String, impl Drop) {
+/// supported, that interrupted download can be resumed.
+fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl Drop) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     listener.set_nonblocking(true).unwrap();
     let server_url = format!("http://{}", listener.local_addr().unwrap());
@@ -1178,10 +1185,19 @@ fn wheel_server(wheel: Vec<u8>, advertise_range: bool) -> (String, impl Drop) {
                                                     )
                                                 })
                                                 .unwrap();
+                                            let content_range_start = if matches!(
+                                                range_response,
+                                                RangeResponse::InvalidContentRange
+                                            ) && full_get_count.load(Ordering::Relaxed) >= 2
+                                            {
+                                                0
+                                            } else {
+                                                start
+                                            };
                                             let bytes = wheel.slice(start..=end);
                                             return Ok::<_, Infallible>(hyper::Response::builder()
                                                 .status(StatusCode::PARTIAL_CONTENT)
-                                                .header(CONTENT_RANGE, format!("bytes {start}-{end}/{size}"))
+                                                .header(CONTENT_RANGE, format!("bytes {content_range_start}-{end}/{size}"))
                                                 .header(CONTENT_LENGTH, bytes.len().to_string())
                                                 .body(http_body_util::Full::new(bytes).boxed())
                                                 .unwrap());
@@ -1203,7 +1219,11 @@ fn wheel_server(wheel: Vec<u8>, advertise_range: bool) -> (String, impl Drop) {
                                         });
                                         let mut response = hyper::Response::builder()
                                             .header(CONTENT_LENGTH, size.to_string());
-                                        if advertise_range {
+                                        if matches!(
+                                            range_response,
+                                            RangeResponse::Supported
+                                                | RangeResponse::InvalidContentRange
+                                        ) {
                                             response = response.header(ACCEPT_RANGES, "bytes");
                                         }
                                         Ok::<_, Infallible>(response
@@ -1229,7 +1249,7 @@ async fn direct_url_range_resume() {
     let context = uv_test::test_context!("3.12");
 
     let wheel = wheel_requiring_download().await;
-    let (server, _guard) = wheel_server(wheel, true);
+    let (server, _guard) = wheel_server(wheel, RangeResponse::Supported);
 
     let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
     uv_snapshot!(context.filters(), context
@@ -1258,7 +1278,7 @@ async fn direct_url_no_range_resume() {
     let context = uv_test::test_context!("3.12");
 
     let wheel = wheel_requiring_download().await;
-    let (server, _guard) = wheel_server(wheel, false);
+    let (server, _guard) = wheel_server(wheel, RangeResponse::NotAdvertised);
 
     let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
     uv_snapshot!(context.filters(), context
@@ -1275,6 +1295,36 @@ async fn direct_url_no_range_resume() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+}
+
+/// An invalid continuation response is discarded before restarting the download.
+#[tokio::test]
+async fn direct_url_invalid_range_resume() {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let (server, _guard) = wheel_server(wheel, RangeResponse::InvalidContentRange);
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg(format!("ok @ {wheel_url}"))
+        .env(EnvVars::UV_HTTP_RETRIES, "0")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    WARN Invalid range request response from server that declares HTTP range request support, restarting download: http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1237,7 +1237,8 @@ async fn direct_url_range_resume() {
         .arg(format!("ok @ {wheel_url}"))
         .env(EnvVars::UV_HTTP_RETRIES, "0")
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true"), @"
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1265,7 +1266,8 @@ async fn direct_url_no_range_resume() {
         .arg(format!("ok @ {wheel_url}"))
         .env(EnvVars::UV_HTTP_RETRIES, "1")
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true"), @"
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -214,20 +214,18 @@ fn streaming_server(
     + Sync
     + 'static,
 ) -> (String, impl Drop) {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test server");
-    listener
-        .set_nonblocking(true)
-        .expect("nonblocking listener");
-    let server = format!("http://{}", listener.local_addr().expect("server address"));
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let server = format!("http://{}", listener.local_addr().unwrap());
     let handler = Arc::new(handler);
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .expect("test server runtime");
+            .unwrap();
         runtime.block_on(async move {
-            let listener = tokio::net::TcpListener::from_std(listener).expect("async listener");
+            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
             tokio::select! {
                 () = async {
                     while let Ok((stream, _)) = listener.accept().await {

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1,5 +1,8 @@
 use std::convert::Infallible;
 use std::io;
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild};
@@ -14,6 +17,8 @@ use serde_json::json;
 use tokio_stream::wrappers::ReceiverStream;
 use wiremock::matchers::{any, method};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+use zip::ZipWriter;
+use zip::write::SimpleFileOptions;
 
 use uv_static::EnvVars;
 use uv_test::{TestContext, uv_snapshot};
@@ -1086,5 +1091,219 @@ async fn retry_read_timeout_stream() {
       ├─▶ Failed to read from zip file
       ├─▶ an upstream reader returned an error: Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
       ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
+    ");
+}
+
+/// A minimal `iniconfig-2.0.0-py3-none-any.whl` with only dist-info files.
+///
+/// `validate_and_heal_record` fills in missing RECORD entries at install time, so we don't
+/// need correct hashes here.
+fn minimal_iniconfig_wheel() -> Vec<u8> {
+    let mut buf = std::io::Cursor::new(Vec::new());
+    let mut zip = ZipWriter::new(&mut buf);
+    let options = SimpleFileOptions::default();
+
+    zip.start_file("iniconfig-2.0.0.dist-info/WHEEL", options)
+        .unwrap();
+    zip.write_all(
+        b"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    )
+    .unwrap();
+
+    zip.start_file("iniconfig-2.0.0.dist-info/METADATA", options)
+        .unwrap();
+    zip.write_all(b"Metadata-Version: 2.1\nName: iniconfig\nVersion: 2.0.0\n")
+        .unwrap();
+
+    zip.start_file("iniconfig-2.0.0.dist-info/RECORD", options)
+        .unwrap();
+    zip.write_all(b"iniconfig-2.0.0.dist-info/RECORD,,\n")
+        .unwrap();
+
+    zip.finish().unwrap();
+    buf.into_inner()
+}
+
+/// Returns a server URL and a drop guard that serves a wheel with mid-stream interruption.
+///
+/// When `honor_range` is true:
+/// - HEAD → `Content-Length` + `Accept-Ranges: bytes`
+/// - Plain GET → first half, then hangs (timeout fires instead of TCP RST so bytes land on disk)
+/// - Range GET → 206 with the requested slice, enabling a free byte-level resume
+///
+/// When `honor_range` is false:
+/// - HEAD → `Content-Length` only (no `Accept-Ranges`)
+/// - Plain GET → first two requests hang (stream_wheel + first download attempt); the third
+///   serves the full wheel so the retry (which consumes one retry budget) succeeds
+/// - Range GET → 200 full content (ignored, but never sent by the client once Range is disabled)
+fn wheel_server(wheel: Vec<u8>, honor_range: bool) -> (String, impl Drop) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let server_url = format!("http://{}", listener.local_addr().unwrap());
+    let wheel = Bytes::from(wheel);
+    let plain_get_count = Arc::new(AtomicUsize::new(0));
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+            tokio::select! {
+                () = async {
+                    loop {
+                        let Ok((stream, _)) = listener.accept().await else { break };
+                        let wheel = wheel.clone();
+                        let plain_get_count = plain_get_count.clone();
+                        tokio::spawn(async move {
+                            let _ = hyper_util::server::conn::auto::Builder::new(
+                                hyper_util::rt::TokioExecutor::new(),
+                            )
+                            .serve_connection(
+                                TokioIo::new(stream),
+                                service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+                                    let wheel = wheel.clone();
+                                    let plain_get_count = plain_get_count.clone();
+                                    async move {
+                                        let n = wheel.len();
+                                        if req.method() == hyper::Method::HEAD {
+                                            let mut builder = hyper::Response::builder()
+                                                .header("Content-Length", n.to_string());
+                                            if honor_range {
+                                                builder = builder.header("Accept-Ranges", "bytes");
+                                            }
+                                            Ok::<_, Infallible>(builder
+                                                .body(http_body_util::Empty::new().boxed())
+                                                .unwrap())
+                                        } else if let Some(hdr) = req.headers().get("range") {
+                                            if honor_range {
+                                                let (start, end) = hdr.to_str().unwrap_or("bytes=0-")
+                                                    .trim_start_matches("bytes=")
+                                                    .split_once('-')
+                                                    .map(|(a, b)| (
+                                                        a.parse().unwrap_or(0),
+                                                        b.parse().unwrap_or(n - 1),
+                                                    ))
+                                                    .unwrap_or((0, n - 1));
+                                                let slice = wheel.slice(start..=end);
+                                                Ok::<_, Infallible>(hyper::Response::builder()
+                                                    .status(206)
+                                                    .header("Content-Range", format!("bytes {start}-{end}/{n}"))
+                                                    .header("Content-Length", slice.len().to_string())
+                                                    .body(http_body_util::Full::new(slice).boxed())
+                                                    .unwrap())
+                                            } else {
+                                                Ok::<_, Infallible>(hyper::Response::builder()
+                                                    .header("Content-Type", "application/zip")
+                                                    .header("Content-Length", n.to_string())
+                                                    .body(http_body_util::Full::new(wheel.clone()).boxed())
+                                                    .unwrap())
+                                            }
+                                        } else {
+                                            let count = plain_get_count.fetch_add(1, Ordering::Relaxed);
+                                            // First two plain GETs hang (stream_wheel + first
+                                            // download attempt); subsequent ones serve the full
+                                            // wheel for the retry.
+                                            if honor_range || count < 2 {
+                                                let (tx, rx) = tokio::sync::mpsc::channel(1);
+                                                tokio::spawn(async move {
+                                                    let _ = tx.send(Ok(Frame::data(wheel.slice(..n / 2)))).await;
+                                                    tokio::time::sleep(Duration::from_secs(60)).await;
+                                                });
+                                                let mut builder = hyper::Response::builder()
+                                                    .header("Content-Type", "application/zip")
+                                                    .header("Content-Length", n.to_string());
+                                                if honor_range {
+                                                    builder = builder.header("Accept-Ranges", "bytes");
+                                                }
+                                                Ok::<_, Infallible>(builder
+                                                    .body(StreamBody::new(ReceiverStream::new(rx)).boxed())
+                                                    .unwrap())
+                                            } else {
+                                                Ok::<_, Infallible>(hyper::Response::builder()
+                                                    .header("Content-Type", "application/zip")
+                                                    .header("Content-Length", n.to_string())
+                                                    .body(http_body_util::Full::new(wheel.clone()).boxed())
+                                                    .unwrap())
+                                            }
+                                        }
+                                    }
+                                }),
+                            )
+                            .await;
+                        });
+                    }
+                } => {}
+                _ = shutdown_rx => {}
+            }
+        });
+    });
+    (server_url, shutdown_tx)
+}
+
+/// A mid-stream interruption is transparently resumed via HTTP Range without consuming a retry.
+///
+/// The server sends the first half of the wheel then hangs. `UV_HTTP_TIMEOUT=1` causes the client
+/// to time out, but since bytes were written to disk, the retry loop resumes via a Range request
+/// rather than restarting from scratch. With `UV_HTTP_RETRIES=0`, a normal error would fail
+/// immediately; the Range-based resume is "free" (not counted as a retry), so the install
+/// succeeds.
+#[tokio::test]
+async fn direct_url_range_resume() {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = minimal_iniconfig_wheel();
+    let (server, _guard) = wheel_server(wheel, true);
+
+    let wheel_url = format!("{server}/iniconfig-2.0.0-py3-none-any.whl");
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg(format!("iniconfig @ {wheel_url}"))
+        // Zero retries: the Range-based resume must not count as a retry.
+        .env(EnvVars::UV_HTTP_RETRIES, "0")
+        // Short timeout so the hanging body is interrupted quickly.
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0 (from http://[LOCALHOST]/iniconfig-2.0.0-py3-none-any.whl)
+    ");
+}
+
+/// When the server does not support Range requests, uv falls back to a plain re-download from
+/// scratch. Because the server does not advertise `Accept-Ranges`, the interruption is not a
+/// free Range-resume—it consumes one retry. With `UV_HTTP_RETRIES=1` the install succeeds.
+#[tokio::test]
+async fn direct_url_no_range_resume() {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = minimal_iniconfig_wheel();
+    let (server, _guard) = wheel_server(wheel, false);
+
+    let wheel_url = format!("{server}/iniconfig-2.0.0-py3-none-any.whl");
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg(format!("iniconfig @ {wheel_url}"))
+        // One retry: the re-download from scratch consumes one retry budget.
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
+        // Short timeout so the hanging body is interrupted quickly.
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0 (from http://[LOCALHOST]/iniconfig-2.0.0-py3-none-any.whl)
     ");
 }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1126,6 +1126,8 @@ async fn wheel_requiring_download() -> Vec<u8> {
 #[derive(Clone, Copy)]
 enum RangeResponse {
     Supported,
+    Limited,
+    LimitedUnknownLength,
     Ignored,
     NotAdvertised,
     InvalidContentRange,
@@ -1196,6 +1198,29 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                                     )
                                                 })
                                                 .unwrap();
+                                            let end = match range_response {
+                                                RangeResponse::Limited | RangeResponse::LimitedUnknownLength
+                                                    if full_get_count.load(Ordering::Relaxed) >= 2 =>
+                                                {
+                                                    end.min(start + size / 4 - 1)
+                                                }
+                                                RangeResponse::Supported
+                                                | RangeResponse::Limited
+                                                | RangeResponse::LimitedUnknownLength
+                                                | RangeResponse::Ignored
+                                                | RangeResponse::NotAdvertised
+                                                | RangeResponse::InvalidContentRange => end,
+                                            };
+                                            let complete_length = match range_response {
+                                                RangeResponse::LimitedUnknownLength
+                                                    if full_get_count.load(Ordering::Relaxed) >= 2 => "*".to_string(),
+                                                RangeResponse::Supported
+                                                | RangeResponse::Limited
+                                                | RangeResponse::LimitedUnknownLength
+                                                | RangeResponse::Ignored
+                                                | RangeResponse::NotAdvertised
+                                                | RangeResponse::InvalidContentRange => size.to_string(),
+                                            };
                                             let content_range_start = if matches!(
                                                 range_response,
                                                 RangeResponse::InvalidContentRange
@@ -1208,7 +1233,7 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                             let bytes = wheel.slice(start..=end);
                                             return Ok::<_, Infallible>(hyper::Response::builder()
                                                 .status(StatusCode::PARTIAL_CONTENT)
-                                                .header(CONTENT_RANGE, format!("bytes {content_range_start}-{end}/{size}"))
+                                                .header(CONTENT_RANGE, format!("bytes {content_range_start}-{end}/{complete_length}"))
                                                 .header(CONTENT_LENGTH, bytes.len().to_string())
                                                 .body(http_body_util::Full::new(bytes).boxed())
                                                 .unwrap());
@@ -1233,6 +1258,8 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                         if matches!(
                                             range_response,
                                             RangeResponse::Supported
+                                                | RangeResponse::Limited
+                                                | RangeResponse::LimitedUnknownLength
                                                 | RangeResponse::Ignored
                                                 | RangeResponse::InvalidContentRange
                                         ) {
@@ -1263,6 +1290,72 @@ async fn direct_url_range_resume() -> Result<()> {
     let wheel = wheel_requiring_download().await;
     let hash = hex::encode(Sha256::digest(&wheel));
     let (server, _guard) = wheel_server(wheel, RangeResponse::Supported);
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
+        .env(EnvVars::UV_HTTP_RETRIES, "0")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    Ok(())
+}
+
+/// Complete the wheel when each range response supplies only part of the remaining bytes.
+#[tokio::test]
+async fn direct_url_partial_range_resume() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let hash = hex::encode(Sha256::digest(&wheel));
+    let (server, _guard) = wheel_server(wheel, RangeResponse::Limited);
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
+        .env(EnvVars::UV_HTTP_RETRIES, "0")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    Ok(())
+}
+
+/// Use the original content length when partial responses omit the complete length.
+#[tokio::test]
+async fn direct_url_partial_range_resume_unknown_length() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let hash = hex::encode(Sha256::digest(&wheel));
+    let (server, _guard) = wheel_server(wheel, RangeResponse::LimitedUnknownLength);
 
     let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
     let requirements = context.temp_dir.child("requirements.txt");

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1133,7 +1133,7 @@ fn minimal_iniconfig_wheel() -> Vec<u8> {
 ///
 /// When `honor_range` is false:
 /// - HEAD → `Content-Length` only (no `Accept-Ranges`)
-/// - Plain GET → first two requests hang (stream_wheel + first download attempt); the third
+/// - Plain GET → first two requests hang (`stream_wheel` + first download attempt); the third
 ///   serves the full wheel so the retry (which consumes one retry budget) succeeds
 /// - Range GET → 200 full content (ignored, but never sent by the client once Range is disabled)
 fn wheel_server(wheel: Vec<u8>, honor_range: bool) -> (String, impl Drop) {

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -11,7 +11,7 @@ use async_zip::{Compression, ZipEntryBuilder};
 use bytes::Bytes;
 use futures::io::AsyncWriteExt;
 use http::StatusCode;
-use http::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, RANGE};
+use http::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, ETAG, IF_RANGE, RANGE};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, StreamBody};
 use hyper::body::Frame;
@@ -1099,13 +1099,16 @@ async fn retry_read_timeout_stream() {
 
 /// A valid wheel whose data descriptors require the on-disk extraction fallback.
 async fn wheel_requiring_download() -> Vec<u8> {
+    wheel_requiring_download_with_generator("test").await
+}
+
+async fn wheel_requiring_download_with_generator(generator: &str) -> Vec<u8> {
+    let wheel_metadata = format!(
+        "Wheel-Version: 1.0\nGenerator: {generator}\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+    );
     let mut writer = ZipFileWriter::new(Vec::new());
     for (path, contents) in [
-        (
-            "ok-1.0.0.dist-info/WHEEL",
-            b"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
-                .as_slice(),
-        ),
+        ("ok-1.0.0.dist-info/WHEEL", wheel_metadata.as_bytes()),
         (
             "ok-1.0.0.dist-info/METADATA",
             b"Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\n".as_slice(),
@@ -1139,11 +1142,25 @@ enum RangeResponse {
 /// The first full GET reaches the streaming fallback, and the second is interrupted. When
 /// supported, that interrupted download can be resumed.
 fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl Drop) {
+    let (server, guard, _) = wheel_server_with_etag(wheel, range_response, Some("\"wheel\""), None);
+    (server, guard)
+}
+
+/// Serve an optional replacement wheel after the interrupted download, honoring `If-Range`.
+/// Return the full GET count so tests can distinguish a fresh download from a continuation.
+fn wheel_server_with_etag(
+    wheel: Vec<u8>,
+    range_response: RangeResponse,
+    etag: Option<&'static str>,
+    replacement: Option<Vec<u8>>,
+) -> (String, impl Drop, Arc<AtomicUsize>) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     listener.set_nonblocking(true).unwrap();
     let server_url = format!("http://{}", listener.local_addr().unwrap());
     let wheel = Bytes::from(wheel);
+    let replacement = replacement.map(Bytes::from);
     let full_get_count = Arc::new(AtomicUsize::new(0));
+    let requests = full_get_count.clone();
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -1157,6 +1174,7 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                     loop {
                         let Ok((stream, _)) = listener.accept().await else { break };
                         let wheel = wheel.clone();
+                        let replacement = replacement.clone();
                         let full_get_count = full_get_count.clone();
                         tokio::spawn(async move {
                             let _ = hyper_util::server::conn::auto::Builder::new(
@@ -1166,11 +1184,23 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                 TokioIo::new(stream),
                                 service_fn(move |request: hyper::Request<hyper::body::Incoming>| {
                                     let wheel = wheel.clone();
+                                    let replacement = replacement.clone();
                                     let full_get_count = full_get_count.clone();
                                     async move {
+                                        let (wheel, etag) = if full_get_count.load(Ordering::Relaxed) >= 2
+                                            && let Some(replacement) = replacement
+                                        {
+                                            (replacement, Some("\"replacement\""))
+                                        } else {
+                                            (wheel, etag)
+                                        };
                                         let size = wheel.len();
+                                        let mut response = hyper::Response::builder();
+                                        if let Some(etag) = etag {
+                                            response = response.header(ETAG, etag);
+                                        }
                                         if request.method() == hyper::Method::HEAD {
-                                            return Ok::<_, Infallible>(hyper::Response::builder()
+                                            return Ok::<_, Infallible>(response
                                                 .header(CONTENT_LENGTH, size.to_string())
                                                 .header(ACCEPT_RANGES, "bytes")
                                                 .body(http_body_util::Empty::new().boxed())
@@ -1178,10 +1208,13 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                         }
 
                                         if let Some(range) = request.headers().get(RANGE) {
-                                            if matches!(range_response, RangeResponse::Ignored)
-                                                && full_get_count.load(Ordering::Relaxed) >= 2
+                                            if full_get_count.load(Ordering::Relaxed) >= 2
+                                                && (matches!(range_response, RangeResponse::Ignored)
+                                                    || request.headers().get(IF_RANGE).is_some_and(|validator| {
+                                                        etag.is_none_or(|etag| validator != etag)
+                                                    }))
                                             {
-                                                return Ok::<_, Infallible>(hyper::Response::builder()
+                                                return Ok::<_, Infallible>(response
                                                     .header(CONTENT_LENGTH, size.to_string())
                                                     .body(http_body_util::Full::new(wheel).boxed())
                                                     .expect("valid wheel response"));
@@ -1231,7 +1264,7 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                                 start
                                             };
                                             let bytes = wheel.slice(start..=end);
-                                            return Ok::<_, Infallible>(hyper::Response::builder()
+                                            return Ok::<_, Infallible>(response
                                                 .status(StatusCode::PARTIAL_CONTENT)
                                                 .header(CONTENT_RANGE, format!("bytes {content_range_start}-{end}/{complete_length}"))
                                                 .header(CONTENT_LENGTH, bytes.len().to_string())
@@ -1240,7 +1273,7 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                         }
 
                                         if full_get_count.fetch_add(1, Ordering::Relaxed) != 1 {
-                                            return Ok::<_, Infallible>(hyper::Response::builder()
+                                            return Ok::<_, Infallible>(response
                                                 .header(CONTENT_LENGTH, size.to_string())
                                                 .body(http_body_util::Full::new(wheel).boxed())
                                                 .unwrap());
@@ -1253,8 +1286,7 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                                 .await;
                                             tokio::time::sleep(Duration::from_mins(1)).await;
                                         });
-                                        let mut response = hyper::Response::builder()
-                                            .header(CONTENT_LENGTH, size.to_string());
+                                        response = response.header(CONTENT_LENGTH, size.to_string());
                                         if matches!(
                                             range_response,
                                             RangeResponse::Supported
@@ -1279,7 +1311,7 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
             }
         });
     });
-    (server_url, shutdown_tx)
+    (server_url, shutdown_tx, requests)
 }
 
 /// A resumed download hashes the complete wheel without consuming a retry.
@@ -1465,4 +1497,196 @@ async fn direct_url_invalid_range_does_not_bypass_retry() {
       ├─▶ Failed to write to the distribution cache
       ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
     ");
+}
+
+/// A changed wheel is downloaded afresh instead of combining two representations.
+#[tokio::test]
+async fn direct_url_range_validator_changed() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let replacement = wheel_requiring_download_with_generator("next").await;
+    let hash = hex::encode(Sha256::digest(&replacement));
+    let (server, _guard, full_get_count) = wheel_server_with_etag(
+        wheel,
+        RangeResponse::Supported,
+        Some("\"wheel\""),
+        Some(replacement),
+    );
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    // The fresh full response supplies both the wheel and its HTTP cache metadata.
+    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
+
+    Ok(())
+}
+
+/// A full replacement response must be cached with its own response metadata.
+#[tokio::test]
+async fn direct_url_range_validator_changed_full_response() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let replacement = wheel_requiring_download_with_generator("next").await;
+    let hash = hex::encode(Sha256::digest(&replacement));
+    let (server, _guard, full_get_count) = wheel_server_with_etag(
+        wheel,
+        RangeResponse::Ignored,
+        Some("\"wheel\""),
+        Some(replacement),
+    );
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    // The fresh full response supplies both the wheel and its HTTP cache metadata.
+    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
+
+    Ok(())
+}
+
+/// An interrupted response without a validator uses a full download retry.
+#[tokio::test]
+async fn direct_url_range_validator_missing() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let hash = hex::encode(Sha256::digest(&wheel));
+    let (server, _guard, full_get_count) =
+        wheel_server_with_etag(wheel, RangeResponse::Supported, None, None);
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
+
+    Ok(())
+}
+
+/// A weak `ETag` cannot validate the bytes of a resumed download.
+#[tokio::test]
+async fn direct_url_range_validator_weak() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let hash = hex::encode(Sha256::digest(&wheel));
+    let (server, _guard, full_get_count) =
+        wheel_server_with_etag(wheel, RangeResponse::Supported, Some("W/\"wheel\""), None);
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
+
+    Ok(())
+}
+
+/// An invalid `ETag` cannot validate the bytes of a resumed download.
+#[tokio::test]
+async fn direct_url_range_validator_invalid() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let hash = hex::encode(Sha256::digest(&wheel));
+    let (server, _guard, full_get_count) =
+        wheel_server_with_etag(wheel, RangeResponse::Supported, Some("unquoted"), None);
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
+
+    Ok(())
 }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1301,9 +1301,9 @@ async fn direct_url_no_range_resume() {
     ");
 }
 
-/// An invalid continuation response is discarded before restarting the download.
+/// An invalid continuation response does not bypass regular retry handling.
 #[tokio::test]
-async fn direct_url_invalid_range_resume() {
+async fn direct_url_invalid_range_does_not_bypass_retry() {
     let context = uv_test::test_context!("3.12");
 
     let wheel = wheel_requiring_download().await;
@@ -1317,16 +1317,16 @@ async fn direct_url_invalid_range_resume() {
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
         .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
         .env(EnvVars::RUST_LOG, "warn"), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Resolved 1 package in [TIME]
     WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    WARN Invalid range request response from server that declares HTTP range request support, restarting download: http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    WARN Invalid range request response from server that declares HTTP range request support, abandoning resumed download: http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl
+      × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
+      ├─▶ Failed to write to the distribution cache
+      ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
     ");
 }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -7,8 +7,6 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild};
-use async_zip::base::write::ZipFileWriter;
-use async_zip::{Compression, ZipEntryBuilder};
 use bytes::Bytes;
 use http::StatusCode;
 use http::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_RANGE, ETAG, IF_RANGE, RANGE};
@@ -1105,29 +1103,6 @@ async fn retry_read_timeout_stream() {
     ");
 }
 
-/// A wheel that supports both streaming and on-disk extraction.
-async fn test_wheel(generator: &str) -> Result<Bytes> {
-    let wheel_metadata = format!(
-        "Wheel-Version: 1.0\nGenerator: {generator}\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
-    );
-    let mut writer = ZipFileWriter::new(Vec::new());
-    for (path, contents) in [
-        ("ok-1.0.0.dist-info/WHEEL", wheel_metadata.as_bytes()),
-        (
-            "ok-1.0.0.dist-info/METADATA",
-            b"Metadata-Version: 2.1\nName: ok\nVersion: 1.0.0\n".as_slice(),
-        ),
-        (
-            "ok-1.0.0.dist-info/RECORD",
-            b"ok-1.0.0.dist-info/RECORD,,\n".as_slice(),
-        ),
-    ] {
-        let entry = ZipEntryBuilder::new(path.to_string().into(), Compression::Deflate);
-        writer.write_entry_whole(entry, contents).await?;
-    }
-    Ok(writer.close().await?.into())
-}
-
 #[derive(Clone, Copy, Default)]
 enum RangeResponse {
     #[default]
@@ -1262,10 +1237,19 @@ fn wheel_response(
     ))
 }
 
-async fn wheel_server(case: DownloadCase) -> Result<(String, impl Drop, Arc<AtomicUsize>, String)> {
-    let wheel = test_wheel("test").await?;
+fn wheel_server(
+    context: &TestContext,
+    case: DownloadCase,
+) -> Result<(String, impl Drop, Arc<AtomicUsize>, String)> {
+    let fixtures = context.workspace_root.join("test/links");
+    let wheel = Bytes::from(fs_err::read(
+        fixtures.join("build_tag-1.0.0-1-py2.py3-none-any.whl"),
+    )?);
+    // These builds have the same package version and length, but different contents.
     let replacement = if case.replace {
-        Some(test_wheel("next").await?)
+        Some(Bytes::from(fs_err::read(
+            fixtures.join("build_tag-1.0.0-3-py2.py3-none-any.whl"),
+        )?))
     } else {
         None
     };
@@ -1284,12 +1268,12 @@ async fn wheel_server(case: DownloadCase) -> Result<(String, impl Drop, Arc<Atom
     Ok((server, guard, requests, hash))
 }
 
-async fn assert_wheel_download(case: DownloadCase) -> Result<()> {
+fn assert_wheel_download(case: DownloadCase) -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let (server, _guard, full_get_count, hash) = wheel_server(case).await?;
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let (server, _guard, full_get_count, hash) = wheel_server(&context, case)?;
+    let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
     let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    requirements.write_str(&format!("build-tag @ {wheel_url} --hash=sha256:{hash}\n"))?;
     allow_duplicates! {
         uv_snapshot!(context.filters(), context
             .pip_install()
@@ -1303,10 +1287,10 @@ async fn assert_wheel_download(case: DownloadCase) -> Result<()> {
         exit_code: 0 (success)
         ----- stderr -----
         Resolved 1 package in [TIME]
-        WARN Streaming failed for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
+        WARN Streaming failed for build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
         Prepared 1 package in [TIME]
         Installed 1 package in [TIME]
-         + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+         + build-tag==1.0.0 (from http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl)
         ");
     }
     // Both streaming and the download fallback use their configured full-request retry budgets.
@@ -1317,116 +1301,109 @@ async fn assert_wheel_download(case: DownloadCase) -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn direct_url_range_resume() -> Result<()> {
-    assert_wheel_download(DownloadCase::default()).await
+#[test]
+fn direct_url_range_resume() -> Result<()> {
+    assert_wheel_download(DownloadCase::default())
 }
 
-#[tokio::test]
-async fn direct_url_partial_range_resume() -> Result<()> {
+#[test]
+fn direct_url_partial_range_resume() -> Result<()> {
     assert_wheel_download(DownloadCase {
         range: RangeResponse::Limited { known_length: true },
         ..DownloadCase::default()
     })
-    .await
 }
 
-#[tokio::test]
-async fn direct_url_partial_range_resume_unknown_length() -> Result<()> {
+#[test]
+fn direct_url_partial_range_resume_unknown_length() -> Result<()> {
     assert_wheel_download(DownloadCase {
         range: RangeResponse::Limited {
             known_length: false,
         },
         ..DownloadCase::default()
     })
-    .await
 }
 
-#[tokio::test]
-async fn direct_url_ignored_range_resume() -> Result<()> {
+#[test]
+fn direct_url_ignored_range_resume() -> Result<()> {
     assert_wheel_download(DownloadCase {
         range: RangeResponse::Ignored,
         ..DownloadCase::default()
     })
-    .await
 }
 
-#[tokio::test]
-async fn direct_url_no_range_resume() -> Result<()> {
+#[test]
+fn direct_url_no_range_resume() -> Result<()> {
     assert_wheel_download(DownloadCase {
         range: RangeResponse::NotAdvertised,
         full_retries: 1,
         ..DownloadCase::default()
     })
-    .await
 }
 
-#[tokio::test]
-async fn direct_url_range_validator_changed() -> Result<()> {
+#[test]
+fn direct_url_range_validator_changed() -> Result<()> {
     assert_wheel_download(DownloadCase {
         replace: true,
         full_retries: 1,
         ..DownloadCase::default()
     })
-    .await
 }
 
-#[tokio::test]
-async fn direct_url_range_validator_changed_full_response() -> Result<()> {
+#[test]
+fn direct_url_range_validator_changed_full_response() -> Result<()> {
     assert_wheel_download(DownloadCase {
         range: RangeResponse::Ignored,
         replace: true,
         full_retries: 1,
         ..DownloadCase::default()
     })
-    .await
 }
 
-#[tokio::test]
-async fn direct_url_range_validator_missing() -> Result<()> {
+#[test]
+fn direct_url_range_validator_missing() -> Result<()> {
     assert_wheel_download(DownloadCase {
         etag: None,
         full_retries: 1,
         ..DownloadCase::default()
     })
-    .await
 }
 
-#[tokio::test]
-async fn direct_url_range_validator_weak() -> Result<()> {
+#[test]
+fn direct_url_range_validator_weak() -> Result<()> {
     assert_wheel_download(DownloadCase {
         etag: Some("W/\"wheel\""),
         full_retries: 1,
         ..DownloadCase::default()
     })
-    .await
 }
 
-#[tokio::test]
-async fn direct_url_range_validator_invalid() -> Result<()> {
+#[test]
+fn direct_url_range_validator_invalid() -> Result<()> {
     assert_wheel_download(DownloadCase {
         etag: Some("unquoted"),
         full_retries: 1,
         ..DownloadCase::default()
     })
-    .await
 }
 
 /// An invalid continuation response does not bypass regular retry handling.
-#[tokio::test]
-async fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
+#[test]
+fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
-    let (server, _guard, _, _) = wheel_server(DownloadCase {
-        range: RangeResponse::InvalidContentRange,
-        ..DownloadCase::default()
-    })
-    .await?;
+    let (server, _guard, _, _) = wheel_server(
+        &context,
+        DownloadCase {
+            range: RangeResponse::InvalidContentRange,
+            ..DownloadCase::default()
+        },
+    )?;
 
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
     uv_snapshot!(context.filters(), context
         .pip_install()
-        .arg(format!("ok @ {wheel_url}"))
+        .arg(format!("build-tag @ {wheel_url}"))
         .env(EnvVars::UV_HTTP_RETRIES, "0")
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
         .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
@@ -1434,9 +1411,9 @@ async fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     Resolved 1 package in [TIME]
-    WARN Streaming failed for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
-    WARN Invalid range request response from server that declares HTTP range request support, abandoning resumed download: http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl
-      × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
+    WARN Streaming failed for build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
+    WARN Invalid range request response from server that declares HTTP range request support, abandoning resumed download: http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl
+      × Failed to download `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`
       ├─▶ Failed to write to the distribution cache
       ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
     ");

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::future::ready;
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -17,6 +18,7 @@ use http_body_util::{BodyExt, StreamBody};
 use hyper::body::Frame;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
+use insta::allow_duplicates;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use tokio_stream::wrappers::ReceiverStream;
@@ -187,51 +189,59 @@ async fn mixed_error_server() -> (MockServer, String) {
     (server, mock_server_uri)
 }
 
-async fn time_out_response(
-    _req: hyper::Request<hyper::body::Incoming>,
-) -> Result<hyper::Response<BoxBody<Bytes, Infallible>>, Infallible> {
+type StreamingResponse = hyper::Response<BoxBody<Bytes, Infallible>>;
+
+/// Emit some bytes and then stall until the client times out.
+fn stalled_body(bytes: Bytes) -> BoxBody<Bytes, Infallible> {
     let (tx, rx) = tokio::sync::mpsc::channel(1);
     tokio::spawn(async move {
-        let _ = tx.send(Ok(Frame::data(Bytes::new()))).await;
+        let _ = tx.send(Ok(Frame::data(bytes))).await;
         tokio::time::sleep(Duration::from_mins(1)).await;
     });
-    let body = StreamBody::new(ReceiverStream::new(rx)).boxed();
-    Ok(hyper::Response::builder()
-        .header("Content-Type", "text/html")
-        .body(body)
-        .unwrap())
+    StreamBody::new(ReceiverStream::new(rx)).boxed()
 }
 
-/// Returns the server URL and a drop guard that shuts down the server.
-///
-/// The server runs in a thread with its own tokio runtime, so it
-/// won't be starved by the subprocess blocking the test thread. Dropping the
-/// guard shuts down the runtime and all tasks running in it.
-fn read_timeout_server() -> (String, impl Drop) {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.set_nonblocking(true).unwrap();
-    let server = format!("http://{}", listener.local_addr().unwrap());
+fn time_out_response(
+    _request: hyper::Request<hyper::body::Incoming>,
+) -> Result<StreamingResponse, http::Error> {
+    hyper::Response::builder()
+        .header("Content-Type", "text/html")
+        .body(stalled_body(Bytes::new()))
+}
 
+/// Run a streaming HTTP server on its own runtime so test subprocesses cannot starve it.
+/// Dropping the guard shuts down the runtime and all connection tasks.
+fn streaming_server(
+    handler: impl Fn(hyper::Request<hyper::body::Incoming>) -> Result<StreamingResponse, http::Error>
+    + Send
+    + Sync
+    + 'static,
+) -> (String, impl Drop) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test server");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking listener");
+    let server = format!("http://{}", listener.local_addr().expect("server address"));
+    let handler = Arc::new(handler);
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .unwrap();
+            .expect("test server runtime");
         runtime.block_on(async move {
-            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+            let listener = tokio::net::TcpListener::from_std(listener).expect("async listener");
             tokio::select! {
-                _ = async {
-                    loop {
-                        let (stream, _) = listener.accept().await.unwrap();
-                        let io = TokioIo::new(stream);
-
+                () = async {
+                    while let Ok((stream, _)) = listener.accept().await {
+                        let handler = handler.clone();
                         tokio::spawn(async move {
-                           let _ = hyper_util::server::conn::auto::Builder::new(
+                            let _ = hyper_util::server::conn::auto::Builder::new(
                                 hyper_util::rt::TokioExecutor::new(),
                             )
-                            .serve_connection(io, service_fn(time_out_response))
+                            .serve_connection(TokioIo::new(stream), service_fn(move |request| {
+                                ready(handler(request))
+                            }))
                             .await;
                         });
                     }
@@ -240,7 +250,6 @@ fn read_timeout_server() -> (String, impl Drop) {
             }
         });
     });
-
     (server, shutdown_tx)
 }
 
@@ -1038,7 +1047,7 @@ fn connect_timeout_stream() {
 async fn retry_read_timeout_index() {
     let context = uv_test::test_context!("3.12").with_fast_http_retry();
 
-    let (server, _guard) = read_timeout_server();
+    let (server, _guard) = streaming_server(time_out_response);
 
     uv_snapshot!(context.filters(), context
         .pip_install()
@@ -1059,7 +1068,7 @@ async fn retry_read_timeout_index() {
 async fn retry_read_timeout_python_downloads_json() {
     let context = uv_test::test_context!("3.12").with_fast_http_retry();
 
-    let (server, _guard) = read_timeout_server();
+    let (server, _guard) = streaming_server(time_out_response);
 
     uv_snapshot!(context.filters(), context
         .python_list()
@@ -1081,7 +1090,7 @@ async fn retry_read_timeout_python_downloads_json() {
 async fn retry_read_timeout_stream() {
     let context = uv_test::test_context!("3.12").with_fast_http_retry();
 
-    let (server, _guard) = read_timeout_server();
+    let (server, _guard) = streaming_server(time_out_response);
 
     uv_snapshot!(context.filters(), context
         .pip_install()
@@ -1097,12 +1106,8 @@ async fn retry_read_timeout_stream() {
     ");
 }
 
-/// A valid wheel whose data descriptors require the on-disk extraction fallback.
-async fn wheel_requiring_download() -> Vec<u8> {
-    wheel_requiring_download_with_generator("test").await
-}
-
-async fn wheel_requiring_download_with_generator(generator: &str) -> Vec<u8> {
+/// A valid wheel whose stored entries and data descriptors require on-disk extraction.
+async fn wheel_requiring_download(generator: &str) -> Result<Bytes> {
     let wheel_metadata = format!(
         "Wheel-Version: 1.0\nGenerator: {generator}\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
     );
@@ -1119,366 +1124,294 @@ async fn wheel_requiring_download_with_generator(generator: &str) -> Vec<u8> {
         ),
     ] {
         let entry = ZipEntryBuilder::new(path.to_string().into(), Compression::Stored);
-        let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
-        entry_writer.write_all(contents).await.unwrap();
-        entry_writer.close().await.unwrap();
+        let mut entry_writer = writer.write_entry_stream(entry).await?;
+        entry_writer.write_all(contents).await?;
+        entry_writer.close().await?;
     }
-    writer.close().await.unwrap()
+    Ok(writer.close().await?.into())
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 enum RangeResponse {
+    #[default]
     Supported,
-    Limited,
-    LimitedUnknownLength,
+    Limited {
+        known_length: bool,
+    },
     Ignored,
     NotAdvertised,
     InvalidContentRange,
 }
 
-/// Returns a server URL and a drop guard that serves a wheel with mid-stream interruption.
-///
-/// HEAD and range requests complete normally so metadata reads do not affect the download count.
-/// The first full GET reaches the streaming fallback, and the second is interrupted. When
-/// supported, that interrupted download can be resumed.
-fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl Drop) {
-    let (server, guard, _) = wheel_server_with_etag(wheel, range_response, Some("\"wheel\""), None);
-    (server, guard)
+#[derive(Clone, Copy)]
+struct DownloadCase {
+    range: RangeResponse,
+    etag: Option<&'static str>,
+    replace: bool,
+    /// Number of full download retries expected and allowed.
+    full_retries: usize,
 }
 
-/// Serve an optional replacement wheel after the interrupted download, honoring `If-Range`.
-/// Return the full GET count so tests can distinguish a fresh download from a continuation.
-fn wheel_server_with_etag(
-    wheel: Vec<u8>,
-    range_response: RangeResponse,
-    etag: Option<&'static str>,
-    replacement: Option<Vec<u8>>,
-) -> (String, impl Drop, Arc<AtomicUsize>) {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.set_nonblocking(true).unwrap();
-    let server_url = format!("http://{}", listener.local_addr().unwrap());
-    let wheel = Bytes::from(wheel);
-    let replacement = replacement.map(Bytes::from);
+impl Default for DownloadCase {
+    fn default() -> Self {
+        Self {
+            range: RangeResponse::Supported,
+            etag: Some("\"wheel\""),
+            replace: false,
+            full_retries: 0,
+        }
+    }
+}
+
+/// Serve metadata normally, then interrupt the second full GET after streaming extraction fails.
+/// Subsequent requests exercise the configured continuation or full-download fallback.
+fn wheel_response(
+    request: &hyper::Request<hyper::body::Incoming>,
+    wheel: &Bytes,
+    replacement: Option<&Bytes>,
+    case: DownloadCase,
+    full_get_count: &AtomicUsize,
+) -> Result<StreamingResponse, http::Error> {
+    let resuming = full_get_count.load(Ordering::Relaxed) >= 2;
+    let (wheel, etag) = if resuming && let Some(replacement) = replacement {
+        (replacement, Some("\"replacement\""))
+    } else {
+        (wheel, case.etag)
+    };
+    let size = wheel.len();
+    let mut response = hyper::Response::builder();
+    if let Some(etag) = etag {
+        response = response.header(ETAG, etag);
+    }
+    if request.method() == hyper::Method::HEAD {
+        return response
+            .header(CONTENT_LENGTH, size)
+            .header(ACCEPT_RANGES, "bytes")
+            .body(http_body_util::Empty::new().boxed());
+    }
+    if let Some(range) = request.headers().get(RANGE) {
+        if resuming
+            && request
+                .headers()
+                .get(IF_RANGE)
+                .is_some_and(|validator| etag.is_none_or(|etag| validator != etag))
+        {
+            return response
+                .header(CONTENT_LENGTH, size)
+                .body(http_body_util::Full::new(wheel.clone()).boxed());
+        }
+        let (start, end) = range
+            .to_str()
+            .expect("ASCII range")
+            .strip_prefix("bytes=")
+            .expect("byte range")
+            .split_once('-')
+            .expect("range bounds");
+        let start: usize = start.parse().expect("range start");
+        let mut end = if end.is_empty() {
+            size - 1
+        } else {
+            end.parse().expect("range end")
+        };
+        let mut content_range_start = start;
+        let mut complete_length = size.to_string();
+        if resuming {
+            match case.range {
+                RangeResponse::Supported | RangeResponse::NotAdvertised => {}
+                RangeResponse::Ignored => {
+                    return response
+                        .header(CONTENT_LENGTH, size)
+                        .body(http_body_util::Full::new(wheel.clone()).boxed());
+                }
+                RangeResponse::Limited { known_length } => {
+                    end = end.min(start + size / 4 - 1);
+                    if !known_length {
+                        complete_length = "*".to_string();
+                    }
+                }
+                RangeResponse::InvalidContentRange => content_range_start = 0,
+            }
+        }
+        let bytes = wheel.slice(start..=end);
+        return response
+            .status(StatusCode::PARTIAL_CONTENT)
+            .header(
+                CONTENT_RANGE,
+                format!("bytes {content_range_start}-{end}/{complete_length}"),
+            )
+            .header(CONTENT_LENGTH, bytes.len())
+            .body(http_body_util::Full::new(bytes).boxed());
+    }
+    response = response.header(CONTENT_LENGTH, size);
+    if full_get_count.fetch_add(1, Ordering::Relaxed) != 1 {
+        return response.body(http_body_util::Full::new(wheel.clone()).boxed());
+    }
+    if !matches!(case.range, RangeResponse::NotAdvertised) {
+        response = response.header(ACCEPT_RANGES, "bytes");
+    }
+    response.body(stalled_body(wheel.slice(..size / 2)))
+}
+
+async fn wheel_server(case: DownloadCase) -> Result<(String, impl Drop, Arc<AtomicUsize>, String)> {
+    let wheel = wheel_requiring_download("test").await?;
+    let replacement = if case.replace {
+        Some(wheel_requiring_download("next").await?)
+    } else {
+        None
+    };
+    let hash = hex::encode(Sha256::digest(replacement.as_ref().unwrap_or(&wheel)));
     let full_get_count = Arc::new(AtomicUsize::new(0));
     let requests = full_get_count.clone();
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        runtime.block_on(async move {
-            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
-            tokio::select! {
-                () = async {
-                    loop {
-                        let Ok((stream, _)) = listener.accept().await else { break };
-                        let wheel = wheel.clone();
-                        let replacement = replacement.clone();
-                        let full_get_count = full_get_count.clone();
-                        tokio::spawn(async move {
-                            let _ = hyper_util::server::conn::auto::Builder::new(
-                                hyper_util::rt::TokioExecutor::new(),
-                            )
-                            .serve_connection(
-                                TokioIo::new(stream),
-                                service_fn(move |request: hyper::Request<hyper::body::Incoming>| {
-                                    let wheel = wheel.clone();
-                                    let replacement = replacement.clone();
-                                    let full_get_count = full_get_count.clone();
-                                    async move {
-                                        let (wheel, etag) = if full_get_count.load(Ordering::Relaxed) >= 2
-                                            && let Some(replacement) = replacement
-                                        {
-                                            (replacement, Some("\"replacement\""))
-                                        } else {
-                                            (wheel, etag)
-                                        };
-                                        let size = wheel.len();
-                                        let mut response = hyper::Response::builder();
-                                        if let Some(etag) = etag {
-                                            response = response.header(ETAG, etag);
-                                        }
-                                        if request.method() == hyper::Method::HEAD {
-                                            return Ok::<_, Infallible>(response
-                                                .header(CONTENT_LENGTH, size.to_string())
-                                                .header(ACCEPT_RANGES, "bytes")
-                                                .body(http_body_util::Empty::new().boxed())
-                                                .unwrap());
-                                        }
-
-                                        if let Some(range) = request.headers().get(RANGE) {
-                                            if full_get_count.load(Ordering::Relaxed) >= 2
-                                                && (matches!(range_response, RangeResponse::Ignored)
-                                                    || request.headers().get(IF_RANGE).is_some_and(|validator| {
-                                                        etag.is_none_or(|etag| validator != etag)
-                                                    }))
-                                            {
-                                                return Ok::<_, Infallible>(response
-                                                    .header(CONTENT_LENGTH, size.to_string())
-                                                    .body(http_body_util::Full::new(wheel).boxed())
-                                                    .expect("valid wheel response"));
-                                            }
-                                            let (start, end) = range
-                                                .to_str()
-                                                .unwrap()
-                                                .trim_start_matches("bytes=")
-                                                .split_once('-')
-                                                .map(|(start, end)| {
-                                                    (
-                                                        start.parse().unwrap(),
-                                                        end.parse().unwrap_or(size - 1),
-                                                    )
-                                                })
-                                                .unwrap();
-                                            let end = match range_response {
-                                                RangeResponse::Limited | RangeResponse::LimitedUnknownLength
-                                                    if full_get_count.load(Ordering::Relaxed) >= 2 =>
-                                                {
-                                                    end.min(start + size / 4 - 1)
-                                                }
-                                                RangeResponse::Supported
-                                                | RangeResponse::Limited
-                                                | RangeResponse::LimitedUnknownLength
-                                                | RangeResponse::Ignored
-                                                | RangeResponse::NotAdvertised
-                                                | RangeResponse::InvalidContentRange => end,
-                                            };
-                                            let complete_length = match range_response {
-                                                RangeResponse::LimitedUnknownLength
-                                                    if full_get_count.load(Ordering::Relaxed) >= 2 => "*".to_string(),
-                                                RangeResponse::Supported
-                                                | RangeResponse::Limited
-                                                | RangeResponse::LimitedUnknownLength
-                                                | RangeResponse::Ignored
-                                                | RangeResponse::NotAdvertised
-                                                | RangeResponse::InvalidContentRange => size.to_string(),
-                                            };
-                                            let content_range_start = if matches!(
-                                                range_response,
-                                                RangeResponse::InvalidContentRange
-                                            ) && full_get_count.load(Ordering::Relaxed) >= 2
-                                            {
-                                                0
-                                            } else {
-                                                start
-                                            };
-                                            let bytes = wheel.slice(start..=end);
-                                            return Ok::<_, Infallible>(response
-                                                .status(StatusCode::PARTIAL_CONTENT)
-                                                .header(CONTENT_RANGE, format!("bytes {content_range_start}-{end}/{complete_length}"))
-                                                .header(CONTENT_LENGTH, bytes.len().to_string())
-                                                .body(http_body_util::Full::new(bytes).boxed())
-                                                .unwrap());
-                                        }
-
-                                        if full_get_count.fetch_add(1, Ordering::Relaxed) != 1 {
-                                            return Ok::<_, Infallible>(response
-                                                .header(CONTENT_LENGTH, size.to_string())
-                                                .body(http_body_util::Full::new(wheel).boxed())
-                                                .unwrap());
-                                        }
-
-                                        let (tx, rx) = tokio::sync::mpsc::channel(1);
-                                        tokio::spawn(async move {
-                                            let _ = tx
-                                                .send(Ok(Frame::data(wheel.slice(..size / 2))))
-                                                .await;
-                                            tokio::time::sleep(Duration::from_mins(1)).await;
-                                        });
-                                        response = response.header(CONTENT_LENGTH, size.to_string());
-                                        if matches!(
-                                            range_response,
-                                            RangeResponse::Supported
-                                                | RangeResponse::Limited
-                                                | RangeResponse::LimitedUnknownLength
-                                                | RangeResponse::Ignored
-                                                | RangeResponse::InvalidContentRange
-                                        ) {
-                                            response = response.header(ACCEPT_RANGES, "bytes");
-                                        }
-                                        Ok::<_, Infallible>(response
-                                            .body(StreamBody::new(ReceiverStream::new(rx)).boxed())
-                                            .unwrap())
-                                    }
-                                }),
-                            )
-                            .await;
-                        });
-                    }
-                } => {}
-                _ = shutdown_rx => {}
-            }
-        });
+    let (server, guard) = streaming_server(move |request| {
+        wheel_response(
+            &request,
+            &wheel,
+            replacement.as_ref(),
+            case,
+            &full_get_count,
+        )
     });
-    (server_url, shutdown_tx, requests)
+    Ok((server, guard, requests, hash))
 }
 
-/// A resumed download hashes the complete wheel without consuming a retry.
+async fn assert_wheel_download(case: DownloadCase) -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let (server, _guard, full_get_count, hash) = wheel_server(case).await?;
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    allow_duplicates! {
+        uv_snapshot!(context.filters(), context
+            .pip_install()
+            .arg("-r")
+            .arg(requirements.path())
+            .arg("--require-hashes")
+            .env(EnvVars::UV_HTTP_RETRIES, case.full_retries.to_string())
+            .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+            .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+            .env(EnvVars::RUST_LOG, "warn"), @"
+        exit_code: 0 (success)
+        ----- stderr -----
+        Resolved 1 package in [TIME]
+        WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+        Prepared 1 package in [TIME]
+        Installed 1 package in [TIME]
+         + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+        ");
+    }
+    // The first full GET reaches the extraction fallback; the second is interrupted.
+    assert_eq!(
+        full_get_count.load(Ordering::Relaxed),
+        2 + case.full_retries
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn direct_url_range_resume() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let hash = hex::encode(Sha256::digest(&wheel));
-    let (server, _guard) = wheel_server(wheel, RangeResponse::Supported);
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "0")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    Ok(())
+    assert_wheel_download(DownloadCase::default()).await
 }
 
-/// Complete the wheel when each range response supplies only part of the remaining bytes.
 #[tokio::test]
 async fn direct_url_partial_range_resume() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let hash = hex::encode(Sha256::digest(&wheel));
-    let (server, _guard) = wheel_server(wheel, RangeResponse::Limited);
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "0")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    Ok(())
+    assert_wheel_download(DownloadCase {
+        range: RangeResponse::Limited { known_length: true },
+        ..DownloadCase::default()
+    })
+    .await
 }
 
-/// Use the original content length when partial responses omit the complete length.
 #[tokio::test]
 async fn direct_url_partial_range_resume_unknown_length() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let hash = hex::encode(Sha256::digest(&wheel));
-    let (server, _guard) = wheel_server(wheel, RangeResponse::LimitedUnknownLength);
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "0")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    Ok(())
+    assert_wheel_download(DownloadCase {
+        range: RangeResponse::Limited {
+            known_length: false,
+        },
+        ..DownloadCase::default()
+    })
+    .await
 }
 
-/// A full response to a range request resets the wheel hash along with the partial file.
 #[tokio::test]
 async fn direct_url_ignored_range_resume() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let hash = hex::encode(Sha256::digest(&wheel));
-    let (server, _guard) = wheel_server(wheel, RangeResponse::Ignored);
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "0")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    Ok(())
+    assert_wheel_download(DownloadCase {
+        range: RangeResponse::Ignored,
+        ..DownloadCase::default()
+    })
+    .await
 }
 
-/// Without advertised range support, a mid-stream interruption uses a regular retry.
 #[tokio::test]
-async fn direct_url_no_range_resume() {
-    let context = uv_test::test_context!("3.12");
+async fn direct_url_no_range_resume() -> Result<()> {
+    assert_wheel_download(DownloadCase {
+        range: RangeResponse::NotAdvertised,
+        full_retries: 1,
+        ..DownloadCase::default()
+    })
+    .await
+}
 
-    let wheel = wheel_requiring_download().await;
-    let (server, _guard) = wheel_server(wheel, RangeResponse::NotAdvertised);
+#[tokio::test]
+async fn direct_url_range_validator_changed() -> Result<()> {
+    assert_wheel_download(DownloadCase {
+        replace: true,
+        full_retries: 1,
+        ..DownloadCase::default()
+    })
+    .await
+}
 
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg(format!("ok @ {wheel_url}"))
-        .env(EnvVars::UV_HTTP_RETRIES, "1")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
+#[tokio::test]
+async fn direct_url_range_validator_changed_full_response() -> Result<()> {
+    assert_wheel_download(DownloadCase {
+        range: RangeResponse::Ignored,
+        replace: true,
+        full_retries: 1,
+        ..DownloadCase::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn direct_url_range_validator_missing() -> Result<()> {
+    assert_wheel_download(DownloadCase {
+        etag: None,
+        full_retries: 1,
+        ..DownloadCase::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn direct_url_range_validator_weak() -> Result<()> {
+    assert_wheel_download(DownloadCase {
+        etag: Some("W/\"wheel\""),
+        full_retries: 1,
+        ..DownloadCase::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn direct_url_range_validator_invalid() -> Result<()> {
+    assert_wheel_download(DownloadCase {
+        etag: Some("unquoted"),
+        full_retries: 1,
+        ..DownloadCase::default()
+    })
+    .await
 }
 
 /// An invalid continuation response does not bypass regular retry handling.
 #[tokio::test]
-async fn direct_url_invalid_range_does_not_bypass_retry() {
+async fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
-    let wheel = wheel_requiring_download().await;
-    let (server, _guard) = wheel_server(wheel, RangeResponse::InvalidContentRange);
+    let (server, _guard, _, _) = wheel_server(DownloadCase {
+        range: RangeResponse::InvalidContentRange,
+        ..DownloadCase::default()
+    })
+    .await?;
 
     let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
     uv_snapshot!(context.filters(), context
@@ -1497,196 +1430,5 @@ async fn direct_url_invalid_range_does_not_bypass_retry() {
       ├─▶ Failed to write to the distribution cache
       ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
     ");
-}
-
-/// A changed wheel is downloaded afresh instead of combining two representations.
-#[tokio::test]
-async fn direct_url_range_validator_changed() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let replacement = wheel_requiring_download_with_generator("next").await;
-    let hash = hex::encode(Sha256::digest(&replacement));
-    let (server, _guard, full_get_count) = wheel_server_with_etag(
-        wheel,
-        RangeResponse::Supported,
-        Some("\"wheel\""),
-        Some(replacement),
-    );
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "1")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    // The fresh full response supplies both the wheel and its HTTP cache metadata.
-    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
-
-    Ok(())
-}
-
-/// A full replacement response must be cached with its own response metadata.
-#[tokio::test]
-async fn direct_url_range_validator_changed_full_response() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let replacement = wheel_requiring_download_with_generator("next").await;
-    let hash = hex::encode(Sha256::digest(&replacement));
-    let (server, _guard, full_get_count) = wheel_server_with_etag(
-        wheel,
-        RangeResponse::Ignored,
-        Some("\"wheel\""),
-        Some(replacement),
-    );
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "1")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    // The fresh full response supplies both the wheel and its HTTP cache metadata.
-    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
-
-    Ok(())
-}
-
-/// An interrupted response without a validator uses a full download retry.
-#[tokio::test]
-async fn direct_url_range_validator_missing() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let hash = hex::encode(Sha256::digest(&wheel));
-    let (server, _guard, full_get_count) =
-        wheel_server_with_etag(wheel, RangeResponse::Supported, None, None);
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "1")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
-
-    Ok(())
-}
-
-/// A weak `ETag` cannot validate the bytes of a resumed download.
-#[tokio::test]
-async fn direct_url_range_validator_weak() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let hash = hex::encode(Sha256::digest(&wheel));
-    let (server, _guard, full_get_count) =
-        wheel_server_with_etag(wheel, RangeResponse::Supported, Some("W/\"wheel\""), None);
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "1")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
-
-    Ok(())
-}
-
-/// An invalid `ETag` cannot validate the bytes of a resumed download.
-#[tokio::test]
-async fn direct_url_range_validator_invalid() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-
-    let wheel = wheel_requiring_download().await;
-    let hash = hex::encode(Sha256::digest(&wheel));
-    let (server, _guard, full_get_count) =
-        wheel_server_with_etag(wheel, RangeResponse::Supported, Some("unquoted"), None);
-
-    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
-    let requirements = context.temp_dir.child("requirements.txt");
-    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg("-r")
-        .arg(requirements.path())
-        .arg("--require-hashes")
-        .env(EnvVars::UV_HTTP_RETRIES, "1")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
-    ");
-
-    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
-
     Ok(())
 }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
+use anyhow::Result;
 use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild};
 use async_zip::base::write::ZipFileWriter;
 use async_zip::{Compression, ZipEntryBuilder};
@@ -17,6 +18,7 @@ use hyper::body::Frame;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use tokio_stream::wrappers::ReceiverStream;
 use wiremock::matchers::{any, method};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
@@ -1124,6 +1126,7 @@ async fn wheel_requiring_download() -> Vec<u8> {
 #[derive(Clone, Copy)]
 enum RangeResponse {
     Supported,
+    Ignored,
     NotAdvertised,
     InvalidContentRange,
 }
@@ -1173,6 +1176,14 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                         }
 
                                         if let Some(range) = request.headers().get(RANGE) {
+                                            if matches!(range_response, RangeResponse::Ignored)
+                                                && full_get_count.load(Ordering::Relaxed) >= 2
+                                            {
+                                                return Ok::<_, Infallible>(hyper::Response::builder()
+                                                    .header(CONTENT_LENGTH, size.to_string())
+                                                    .body(http_body_util::Full::new(wheel).boxed())
+                                                    .expect("valid wheel response"));
+                                            }
                                             let (start, end) = range
                                                 .to_str()
                                                 .unwrap()
@@ -1222,6 +1233,7 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
                                         if matches!(
                                             range_response,
                                             RangeResponse::Supported
+                                                | RangeResponse::Ignored
                                                 | RangeResponse::InvalidContentRange
                                         ) {
                                             response = response.header(ACCEPT_RANGES, "bytes");
@@ -1243,26 +1255,28 @@ fn wheel_server(wheel: Vec<u8>, range_response: RangeResponse) -> (String, impl 
     (server_url, shutdown_tx)
 }
 
-/// A mid-stream interruption is transparently resumed via HTTP range without consuming a retry.
+/// A resumed download hashes the complete wheel without consuming a retry.
 #[tokio::test]
-async fn direct_url_range_resume() {
+async fn direct_url_range_resume() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
     let wheel = wheel_requiring_download().await;
+    let hash = hex::encode(Sha256::digest(&wheel));
     let (server, _guard) = wheel_server(wheel, RangeResponse::Supported);
 
     let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
     uv_snapshot!(context.filters(), context
         .pip_install()
-        .arg(format!("ok @ {wheel_url}"))
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
         .env(EnvVars::UV_HTTP_RETRIES, "0")
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
         .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
         .env(EnvVars::RUST_LOG, "warn"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
+    exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
     WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
@@ -1270,6 +1284,41 @@ async fn direct_url_range_resume() {
     Installed 1 package in [TIME]
      + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
     ");
+
+    Ok(())
+}
+
+/// A full response to a range request resets the wheel hash along with the partial file.
+#[tokio::test]
+async fn direct_url_ignored_range_resume() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let wheel = wheel_requiring_download().await;
+    let hash = hex::encode(Sha256::digest(&wheel));
+    let (server, _guard) = wheel_server(wheel, RangeResponse::Ignored);
+
+    let wheel_url = format!("{server}/ok-1.0.0-py3-none-any.whl");
+    let requirements = context.temp_dir.child("requirements.txt");
+    requirements.write_str(&format!("ok @ {wheel_url} --hash=sha256:{hash}\n"))?;
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("-r")
+        .arg(requirements.path())
+        .arg("--require-hashes")
+        .env(EnvVars::UV_HTTP_RETRIES, "0")
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env(EnvVars::RUST_LOG, "warn"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    Ok(())
 }
 
 /// Without advertised range support, a mid-stream interruption uses a regular retry.
@@ -1288,10 +1337,7 @@ async fn direct_url_no_range_resume() {
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
         .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
         .env(EnvVars::RUST_LOG, "warn"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
+    exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
     WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)
@@ -1317,10 +1363,7 @@ async fn direct_url_invalid_range_does_not_bypass_retry() {
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
         .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
         .env(EnvVars::RUST_LOG, "warn"), @"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-
+    exit_code: 1 (failure)
     ----- stderr -----
     Resolved 1 package in [TIME]
     WARN Streaming unsupported for ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl; downloading wheel to disk (Invalid zip file structure)

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1103,13 +1103,12 @@ async fn retry_read_timeout_stream() {
     ");
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 enum RangeResponse {
-    #[default]
     Supported,
-    Limited {
-        known_length: bool,
-    },
+    Limited { known_length: bool },
+    Interrupted,
+    LimitedThenInterrupted,
     Ignored,
     NotAdvertised,
     InvalidContentRange,
@@ -1117,11 +1116,10 @@ enum RangeResponse {
     Unsatisfiable,
 }
 
-#[derive(Clone, Copy, Default)]
-struct DownloadCase {
-    range: RangeResponse,
-    /// Retry limit for both paths, and the number of retries expected after falling back.
-    full_retries: usize,
+#[derive(Default)]
+struct DownloadRequests {
+    full: AtomicUsize,
+    resumed: AtomicUsize,
 }
 
 /// Serve metadata normally, then truncate full responses until streaming retries are exhausted.
@@ -1130,11 +1128,12 @@ struct DownloadCase {
 fn wheel_response(
     request: &hyper::Request<hyper::body::Incoming>,
     wheel: &Bytes,
-    case: DownloadCase,
-    full_get_count: &AtomicUsize,
+    range_response: RangeResponse,
+    retries: usize,
+    requests: &DownloadRequests,
 ) -> Result<StreamingResponse, http::Error> {
-    let streaming_attempts = 1 + case.full_retries;
-    let resuming = full_get_count.load(Ordering::Relaxed) > streaming_attempts;
+    let streaming_attempts = 1 + retries;
+    let resuming = requests.full.load(Ordering::Relaxed) > streaming_attempts;
     let size = wheel.len();
     let mut response = hyper::Response::builder();
     if request.method() == hyper::Method::HEAD {
@@ -1161,7 +1160,8 @@ fn wheel_response(
         let mut complete_length = size.to_string();
         let mut body_end = None;
         if resuming {
-            match case.range {
+            let resumed_request = requests.resumed.fetch_add(1, Ordering::Relaxed);
+            match range_response {
                 RangeResponse::Supported | RangeResponse::NotAdvertised => {}
                 RangeResponse::Ignored => {
                     return response
@@ -1172,6 +1172,22 @@ fn wheel_response(
                     end = end.min(start + size / 4 - 1);
                     if !known_length {
                         complete_length = "*".to_string();
+                    }
+                }
+                RangeResponse::Interrupted | RangeResponse::LimitedThenInterrupted => {
+                    if let RangeResponse::LimitedThenInterrupted = range_response
+                        && resumed_request == 0
+                    {
+                        end = start + size / 8 - 1;
+                    } else {
+                        return response
+                            .status(StatusCode::PARTIAL_CONTENT)
+                            .header(CONTENT_RANGE, format!("bytes {start}-{end}/{size}"))
+                            .header(CONTENT_LENGTH, end - start + 1)
+                            .body(delayed_body(
+                                wheel.slice(start..start + (end - start).div_ceil(2)),
+                                Duration::from_mins(1),
+                            ));
                     }
                 }
                 RangeResponse::InvalidContentRange => content_range_start = 0,
@@ -1195,7 +1211,7 @@ fn wheel_response(
             .header(CONTENT_LENGTH, bytes.len())
             .body(http_body_util::Full::new(bytes).boxed());
     }
-    let full_get = full_get_count.fetch_add(1, Ordering::Relaxed);
+    let full_get = requests.full.fetch_add(1, Ordering::Relaxed);
     if full_get < streaming_attempts {
         // Give Hyper time to flush the partial body before closing short of Content-Length.
         return response.header(CONTENT_LENGTH, size).body(delayed_body(
@@ -1208,10 +1224,10 @@ fn wheel_response(
             .header(CONTENT_LENGTH, size)
             .body(http_body_util::Full::new(wheel.clone()).boxed());
     }
-    if !matches!(case.range, RangeResponse::NotAdvertised) {
+    if !matches!(range_response, RangeResponse::NotAdvertised) {
         response = response.header(ACCEPT_RANGES, "bytes");
     }
-    if let RangeResponse::Unsatisfiable = case.range {
+    if let RangeResponse::Unsatisfiable = range_response {
         // Send all wheel bytes, but stall before terminating the chunked response.
         return response.body(delayed_body(wheel.clone(), Duration::from_mins(1)));
     }
@@ -1223,30 +1239,37 @@ fn wheel_response(
 
 fn wheel_server(
     context: &TestContext,
-    case: DownloadCase,
-) -> Result<(String, impl Drop, Arc<AtomicUsize>, String)> {
+    range_response: RangeResponse,
+    retries: usize,
+) -> Result<(String, impl Drop, Arc<DownloadRequests>, String)> {
     let fixtures = context.workspace_root.join("test/links");
     let wheel = Bytes::from(fs_err::read(
         fixtures.join("build_tag-1.0.0-1-py2.py3-none-any.whl"),
     )?);
     let hash = hex::encode(Sha256::digest(&wheel));
-    let full_get_count = Arc::new(AtomicUsize::new(0));
-    let requests = full_get_count.clone();
-    let (server, guard) =
-        streaming_server(move |request| wheel_response(&request, &wheel, case, &full_get_count));
+    let requests = Arc::new(DownloadRequests::default());
+    let server_requests = requests.clone();
+    let (server, guard) = streaming_server(move |request| {
+        wheel_response(&request, &wheel, range_response, retries, &server_requests)
+    });
     Ok((server, guard, requests, hash))
 }
 
-fn assert_wheel_download(case: DownloadCase) -> Result<()> {
+fn assert_wheel_download(
+    range_response: RangeResponse,
+    retries: usize,
+    full_requests: usize,
+    resumed_requests: usize,
+) -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let (server, _guard, full_get_count, hash) = wheel_server(&context, case)?;
+    let (server, _guard, requests, hash) = wheel_server(&context, range_response, retries)?;
     write_wheel_lockfile(&context, &server, 932, &hash)?;
     allow_duplicates! {
         uv_snapshot!(context.filters(), context
             .pip_sync()
             .arg("--preview")
             .arg("pylock.toml")
-            .env(EnvVars::UV_HTTP_RETRIES, case.full_retries.to_string())
+            .env(EnvVars::UV_HTTP_RETRIES, retries.to_string())
             .env(EnvVars::UV_HTTP_TIMEOUT, "1")
             .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
             .env(EnvVars::RUST_LOG, "warn"), @"
@@ -1258,11 +1281,8 @@ fn assert_wheel_download(case: DownloadCase) -> Result<()> {
          + build-tag==1.0.0 (from http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl)
         ");
     }
-    // Both streaming and the download fallback use their configured full-request retry budgets.
-    assert_eq!(
-        full_get_count.load(Ordering::Relaxed),
-        2 * (1 + case.full_retries)
-    );
+    assert_eq!(requests.full.load(Ordering::Relaxed), full_requests);
+    assert_eq!(requests.resumed.load(Ordering::Relaxed), resumed_requests);
 
     let site_packages = context.site_packages();
     assert_eq!(
@@ -1289,6 +1309,38 @@ fn assert_wheel_download(case: DownloadCase) -> Result<()> {
     Ok(())
 }
 
+fn assert_wheel_download_timeout(
+    range_response: RangeResponse,
+    retries: usize,
+    full_requests: usize,
+    resumed_requests: usize,
+) -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let (server, _guard, requests, _) = wheel_server(&context, range_response, retries)?;
+
+    let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
+    allow_duplicates! {
+        uv_snapshot!(context.filters(), context
+            .pip_install()
+            .arg(format!("build-tag @ {wheel_url}"))
+            .env(EnvVars::UV_HTTP_RETRIES, retries.to_string())
+            .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+            .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+            .env(EnvVars::RUST_LOG, "warn"), @"
+        exit_code: 1 (failure)
+        ----- stderr -----
+        Resolved 1 package in [TIME]
+        WARN Streaming failed for build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
+          × Failed to download `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`
+          ├─▶ Failed to write to the distribution cache
+          ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
+        ");
+    }
+    assert_eq!(requests.full.load(Ordering::Relaxed), full_requests);
+    assert_eq!(requests.resumed.load(Ordering::Relaxed), resumed_requests);
+    Ok(())
+}
+
 fn write_wheel_lockfile(context: &TestContext, server: &str, size: u64, hash: &str) -> Result<()> {
     context.temp_dir.child("pylock.toml").write_str(&formatdoc! {
         r#"
@@ -1307,13 +1359,7 @@ fn write_wheel_lockfile(context: &TestContext, server: &str, size: u64, hash: &s
 #[test]
 fn direct_url_content_length_mismatch() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let (server, _guard, full_get_count, hash) = wheel_server(
-        &context,
-        DownloadCase {
-            range: RangeResponse::NotAdvertised,
-            full_retries: 1,
-        },
-    )?;
+    let (server, _guard, requests, hash) = wheel_server(&context, RangeResponse::NotAdvertised, 1)?;
     write_wheel_lockfile(&context, &server, 1, &hash)?;
 
     uv_snapshot!(context.filters(), context
@@ -1331,86 +1377,50 @@ fn direct_url_content_length_mismatch() -> Result<()> {
       ╰─▶ Content-Length mismatch for `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`: expected 1 bytes, but the server advertised 932 bytes
     ");
     // The first fallback response fails on its headers without consuming a full-download retry.
-    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
+    assert_eq!(requests.full.load(Ordering::Relaxed), 3);
     Ok(())
 }
 
 #[test]
 fn direct_url_range_resume() -> Result<()> {
-    assert_wheel_download(DownloadCase::default())
+    assert_wheel_download(RangeResponse::Supported, 1, 3, 1)
 }
 
 #[test]
 fn direct_url_partial_range_resume() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        range: RangeResponse::Limited { known_length: true },
-        ..DownloadCase::default()
-    })
+    assert_wheel_download(RangeResponse::Limited { known_length: true }, 1, 3, 2)
 }
 
 #[test]
 fn direct_url_partial_range_resume_unknown_length() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        range: RangeResponse::Limited {
+    assert_wheel_download(
+        RangeResponse::Limited {
             known_length: false,
         },
-        ..DownloadCase::default()
-    })
+        1,
+        3,
+        2,
+    )
 }
 
 #[test]
 fn direct_url_ignored_range_resume() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        range: RangeResponse::Ignored,
-        ..DownloadCase::default()
-    })
+    assert_wheel_download(RangeResponse::Ignored, 1, 3, 1)
 }
 
 #[test]
 fn direct_url_no_range_resume() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        range: RangeResponse::NotAdvertised,
-        full_retries: 1,
-    })
+    assert_wheel_download(RangeResponse::NotAdvertised, 1, 4, 0)
 }
 
 #[test]
 fn direct_url_unsatisfiable_range_retries_in_full() -> Result<()> {
-    assert_wheel_download(DownloadCase {
-        range: RangeResponse::Unsatisfiable,
-        full_retries: 1,
-    })
+    assert_wheel_download(RangeResponse::Unsatisfiable, 2, 5, 1)
 }
 
 #[test]
 fn direct_url_unsatisfiable_range_does_not_bypass_retry() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let (server, _guard, full_get_count, _) = wheel_server(
-        &context,
-        DownloadCase {
-            range: RangeResponse::Unsatisfiable,
-            ..DownloadCase::default()
-        },
-    )?;
-
-    let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
-    uv_snapshot!(context.filters(), context
-        .pip_install()
-        .arg(format!("build-tag @ {wheel_url}"))
-        .env(EnvVars::UV_HTTP_RETRIES, "0")
-        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
-        .env(EnvVars::RUST_LOG, "warn"), @"
-    exit_code: 1 (failure)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    WARN Streaming failed for build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl; downloading wheel to disk (I/O operation failed during extraction)
-      × Failed to download `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`
-      ├─▶ Failed to write to the distribution cache
-      ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
-    ");
-    assert_eq!(full_get_count.load(Ordering::Relaxed), 2);
-    Ok(())
+    assert_wheel_download_timeout(RangeResponse::Unsatisfiable, 1, 3, 1)
 }
 
 /// An invalid continuation response does not bypass regular retry handling.
@@ -1418,19 +1428,14 @@ fn direct_url_unsatisfiable_range_does_not_bypass_retry() -> Result<()> {
 fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
-    let (server, _guard, _, _) = wheel_server(
-        &context,
-        DownloadCase {
-            range: RangeResponse::InvalidContentRange,
-            ..DownloadCase::default()
-        },
-    )?;
+    let (server, _guard, requests, _) =
+        wheel_server(&context, RangeResponse::InvalidContentRange, 1)?;
 
     let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
     uv_snapshot!(context.filters(), context
         .pip_install()
         .arg(format!("build-tag @ {wheel_url}"))
-        .env(EnvVars::UV_HTTP_RETRIES, "0")
+        .env(EnvVars::UV_HTTP_RETRIES, "1")
         .env(EnvVars::UV_HTTP_TIMEOUT, "1")
         .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
         .env(EnvVars::RUST_LOG, "warn"), @"
@@ -1443,6 +1448,8 @@ fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
       ├─▶ Failed to write to the distribution cache
       ╰─▶ Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
     ");
+    assert_eq!(requests.full.load(Ordering::Relaxed), 3);
+    assert_eq!(requests.resumed.load(Ordering::Relaxed), 1);
     Ok(())
 }
 
@@ -1450,13 +1457,7 @@ fn direct_url_invalid_range_does_not_bypass_retry() -> Result<()> {
 #[test]
 fn direct_url_range_size_mismatch() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let (server, _guard, full_get_count, _) = wheel_server(
-        &context,
-        DownloadCase {
-            range: RangeResponse::ShortBody,
-            full_retries: 1,
-        },
-    )?;
+    let (server, _guard, requests, _) = wheel_server(&context, RangeResponse::ShortBody, 1)?;
 
     let wheel_url = format!("{server}/build_tag-1.0.0-1-py2.py3-none-any.whl");
     uv_snapshot!(context.filters(), context
@@ -1474,6 +1475,21 @@ fn direct_url_range_size_mismatch() -> Result<()> {
       ╰─▶ Range response size mismatch for `build-tag @ http://[LOCALHOST]/build_tag-1.0.0-1-py2.py3-none-any.whl`: expected 466 bytes from Content-Range, but received 465 bytes
     ");
     // Two streaming attempts precede the download fallback; the range mismatch ends the attempt.
-    assert_eq!(full_get_count.load(Ordering::Relaxed), 3);
+    assert_eq!(requests.full.load(Ordering::Relaxed), 3);
     Ok(())
+}
+
+#[test]
+fn direct_url_range_resume_disabled() -> Result<()> {
+    assert_wheel_download_timeout(RangeResponse::Supported, 0, 2, 0)
+}
+
+#[test]
+fn direct_url_range_resume_retry_limit() -> Result<()> {
+    assert_wheel_download_timeout(RangeResponse::Interrupted, 2, 4, 2)
+}
+
+#[test]
+fn direct_url_range_resume_success_does_not_reset_retries() -> Result<()> {
+    assert_wheel_download_timeout(RangeResponse::LimitedThenInterrupted, 1, 3, 2)
 }


### PR DESCRIPTION
## Summary

This is a rebased version of #19075. Supersedes/closes #19075.

TL;DR: this adapts the `download_wheel` process (which we fallback to when wheel streaming encounters a non-terminal error) so that partial downloads are handled gracefully. In particular, if the origin supports range requests, we use them to attempt resumption rather than kicking back immediately to the normal retry logic. This should be helpful to some users with flaky network connections, i.e. where large downloads fail consistently even across retries.

## Test Plan

Adds tests.

<!-- How was it tested? -->


---

<details>
<summary>Original PR body</summary>

Summary
For whatever reason, pypi resets the connection a lot, and we run out of retries. pip does not have this problem because it retries with http Range requests, and does not have to redownload the whole file.

I have been plagued with this issue for about a year, and it has made uv near-unusable for me, unless I am using an index other than official pypi. When I use uv I usually have to use the Tsinghua mirror, because pypi is flaky and uv cannot handle it.

I've gotten so frustrated with uv recently that I decided to take matters into my own hands.

It looks like someone else tried to address this in https://github.com/astral-sh/uv/pull/17656, but that PR was rejected for being complicated, and the author never followed up. There have been other attempts too, if I recall.

Fixes https://github.com/astral-sh/uv/issues/16934
Fixes https://github.com/astral-sh/uv/issues/13359
Fixes https://github.com/astral-sh/uv/issues/18642
Fixes https://github.com/astral-sh/uv/issues/18538

Testing
Passed all tests in:

cargo insta test --accept --test-runner nextest
Except for python_upgrade::python_upgrade_implementation, which appears to be broken on main.
</details>