### PR TITLE
Use paid GitHub-hosted runners for Linux

### DIFF
--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -415,7 +415,7 @@ jobs:
   build-binary-freebsd:
     name: "freebsd"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   docker-plan:
     name: plan
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 2
     outputs:
       login: ${{ steps.plan.outputs.login }}
@@ -134,7 +134,7 @@ jobs:
     name: ${{ needs.docker-plan.outputs.action }} uv
     needs:
       - docker-plan
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -231,7 +231,7 @@ jobs:
 
   docker-publish-extra:
     name: ${{ needs.docker-plan.outputs.action }} ${{ matrix.image-mapping }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 5
     environment:
       name: ${{ needs.docker-plan.outputs.push-version == 'true' && 'release' || (needs.docker-plan.outputs.push == 'true' && 'release-test' || '') }}
@@ -402,7 +402,7 @@ jobs:
   # Annotate the base image
   docker-annotate-base:
     name: annotate uv
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 2
     permissions:
       contents: read

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -1356,7 +1356,7 @@ jobs:
 
   check-wheels:
     name: "check wheel contents"
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     needs:
       - macos-x86_64
       - macos-aarch64

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -11,7 +11,7 @@ jobs:
   docs:
     timeout-minutes: 10
     name: "mkdocs"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/check-fmt.yml
+++ b/.github/workflows/check-fmt.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   rust:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -21,7 +21,7 @@ jobs:
 
   prettier:
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -30,7 +30,7 @@ jobs:
 
   python:
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   cargo-dev-generate-all:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     name: "cargo dev generate-all"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   ruff:
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -38,7 +38,7 @@ jobs:
 
   ty:
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -65,7 +65,7 @@ jobs:
 
   shellcheck:
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -81,7 +81,7 @@ jobs:
 
   validate-pyproject:
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -96,7 +96,7 @@ jobs:
 
   readme:
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -110,7 +110,7 @@ jobs:
     name: "clippy on linux"
     timeout-minutes: 10
     if: ${{ inputs.code-changed == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -161,7 +161,7 @@ jobs:
   hawk:
     timeout-minutes: 15
     if: ${{ inputs.code-changed == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -183,9 +183,8 @@ jobs:
   shear:
     name: "cargo shear"
     timeout-minutes: 10
-    # NOTE: `cargo shear` needs `cargo metadata`, so we don't use `ubuntu-slim` here
-    # as it doesn't include the Rust toolchain.
-    runs-on: ubuntu-latest
+    # `cargo shear` needs `cargo metadata` and the Rust toolchain.
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -199,7 +198,7 @@ jobs:
 
   typos:
     name: "check for typos"
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/check-lock.yml
+++ b/.github/workflows/check-lock.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   lock:
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     name: "uv lockfiles"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   dist-plan:
     name: "dist plan"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/check-zizmor.yml
+++ b/.github/workflows/check-zizmor.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   zizmor:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
     needs:
       - plan
       - build-dev-binaries
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     # Only the main repository is a trusted publisher
     if: ${{ github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.fork != true && needs.plan.outputs.test-publish == 'true' }}
     environment:
@@ -287,7 +287,7 @@ jobs:
       - check-generated-files
       - test
       - build-dev-binaries
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     steps:
       - name: "Check required jobs passed"
         run: |

--- a/.github/workflows/diagnose-workflow-failure.yml
+++ b/.github/workflows/diagnose-workflow-failure.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   diagnose:
     if: github.repository == 'astral-sh/uv' || github.repository == 'astral-sh/uv-dev'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 20
     permissions:
@@ -137,7 +137,7 @@ jobs:
     if: >-
       needs.diagnose.outputs.result != '' &&
       fromJSON(needs.diagnose.outputs.result).failure_kind == 'flaky'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 5
     concurrency:
@@ -229,7 +229,7 @@ jobs:
       needs.diagnose.outputs.result != '' &&
       (fromJSON(needs.diagnose.outputs.result).decision == 'create' ||
       fromJSON(needs.diagnose.outputs.result).decision == 'duplicate')
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/fix-bug.yml
+++ b/.github/workflows/fix-bug.yml
@@ -34,7 +34,7 @@ on:
         type: string
       runner:
         description: "The runner to use for bug fixing"
-        default: ubuntu-latest
+        default: github-ubuntu-24.04-x86_64-4
         required: false
         type: string
     outputs:
@@ -450,7 +450,7 @@ jobs:
   publish:
     needs: fix
     if: needs.fix.outputs.publish == 'true'
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     timeout-minutes: 10
     permissions:
@@ -676,7 +676,7 @@ jobs:
       needs.fix.result == 'success' &&
       needs.fix.outputs.result != '' &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   initialize-context:
     if: github.repository == 'astral-sh/uv'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 10
     permissions:
@@ -106,7 +106,7 @@ jobs:
   triage:
     needs: initialize-context
     if: github.repository == 'astral-sh/uv'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 15
     permissions:
@@ -178,7 +178,7 @@ jobs:
   context:
     needs: triage
     if: needs.triage.outputs.result != ''
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 10
     concurrency:
@@ -260,7 +260,7 @@ jobs:
     with:
       issue: ${{ inputs.issue || github.event.issue.number }}
       issue-type: ${{ fromJSON(needs.triage.outputs.result).type }}
-      runner: ubuntu-latest
+      runner: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     secrets: inherit
 
   fix-bug:
@@ -287,5 +287,5 @@ jobs:
       parent-pull-request: ${{ needs.reproduce-bug.outputs.pull-request }}
       parent-head-ref: ${{ needs.reproduce-bug.outputs.head-ref }}
       parent-head-sha: ${{ needs.reproduce-bug.outputs.head-sha }}
-      runner: ubuntu-latest
+      runner: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     secrets: inherit

--- a/.github/workflows/promote-pull-request.yml
+++ b/.github/workflows/promote-pull-request.yml
@@ -28,7 +28,7 @@ jobs:
   prepare:
     name: "Prepare promotion of pull request #${{ inputs.pull_request }}"
     if: github.repository == 'astral-sh/uv-dev' || github.repository == 'astral-sh/uv-security'
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     timeout-minutes: 10
     permissions:
@@ -358,7 +358,7 @@ jobs:
     name: "Promote pull request #${{ inputs.pull_request }}"
     needs: [prepare, update-pull-request-parent]
     if: always() && needs.prepare.result == 'success' && (needs.prepare.outputs.action == 'promote' || needs.update-pull-request-parent.outputs.outcome == 'clean')
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     timeout-minutes: 10
     permissions:
@@ -684,7 +684,7 @@ jobs:
     name: "Recover rejected promotion #${{ inputs.pull_request }}"
     needs: [prepare, update-pull-request-parent, promote]
     if: always() && needs.prepare.outputs.approval_id != '' && (needs.prepare.outputs.rejection_reason != '' || needs.prepare.outputs.changed_head != '' || needs.promote.outputs.rejection_reason != '' || needs.promote.outputs.changed_head != '' || needs.update-pull-request-parent.outputs.rejection_reason != '' || needs.update-pull-request-parent.outputs.outcome == 'conflicts' || needs.update-pull-request-parent.outputs.outcome == 'empty')
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   crates-publish-uv:
     name: Upload uv to crates.io
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     permissions:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,7 +27,7 @@ jobs:
   mkdocs:
     environment:
       name: release
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     env:
       VERSION: ${{ (inputs.plan != '' && fromJson(inputs.plan).announcement_tag) || inputs.ref }}
     steps:

--- a/.github/workflows/publish-mirror.yml
+++ b/.github/workflows/publish-mirror.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   publish-mirror:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     env:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   pypi-publish-uv:
     name: Upload uv to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     permissions:
@@ -54,7 +54,7 @@ jobs:
 
   pypi-publish-uv-build:
     name: Upload uv-build to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     permissions:

--- a/.github/workflows/publish-versions.yml
+++ b/.github/workflows/publish-versions.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   publish-versions:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment:
       name: release
     env:

--- a/.github/workflows/pull-request-conflicts.yml
+++ b/.github/workflows/pull-request-conflicts.yml
@@ -36,7 +36,7 @@ jobs:
   identify:
     name: Identify conflicted pull requests
     if: github.repository == 'astral-sh/uv-dev' || github.repository == 'astral-sh/uv'
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     timeout-minutes: 5
     permissions:
       contents: read
@@ -164,7 +164,7 @@ jobs:
     name: "Remove rebase label from pull request #${{ inputs.pull_request }}"
     needs: rebase-and-push
     if: inputs.pull_request != ''
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/pull-request-labels.yml
+++ b/.github/workflows/pull-request-labels.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   labels:
     if: github.repository == 'astral-sh/uv' || github.repository == 'astral-sh/uv-dev'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 15
     permissions:
@@ -85,7 +85,7 @@ jobs:
   report:
     needs: labels
     if: needs.labels.outputs.result != ''
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     permissions: {}
     steps:
       - name: "Write label recommendations"
@@ -98,7 +98,7 @@ jobs:
     if: >-
       github.repository == 'astral-sh/uv-dev' &&
       needs.labels.outputs.result != ''
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     permissions: {}
     outputs:
       labels: ${{ steps.validate.outputs.labels }}
@@ -136,7 +136,7 @@ jobs:
     if: >-
       needs.validate.outputs.labels != '' &&
       fromJSON(needs.validate.outputs.labels)[0] != null
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/pull-request-security-review.yml
+++ b/.github/workflows/pull-request-security-review.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   review:
     name: "security review"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 30
     permissions:
@@ -104,7 +104,7 @@ jobs:
   prepare:
     needs: review
     if: needs.review.outputs.result != ''
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 5
     permissions:
       contents: read
@@ -137,7 +137,7 @@ jobs:
   report:
     needs: prepare
     if: needs.prepare.outputs.result != '' && fromJSON(needs.prepare.outputs.result).comments[0] != null
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/rebase-conflicted-pull-request.yml
+++ b/.github/workflows/rebase-conflicted-pull-request.yml
@@ -151,7 +151,7 @@ jobs:
   push:
     name: "Push rebased pull request #${{ inputs.number }}"
     needs: rebase
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   prepare-release:
     if: github.repository == 'astral-sh/uv'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
   release-gate:
     # N.B. This name should not change, it is used for downstream checks.
     name: release-gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     # This environment requires a 2-factor approval, i.e., the workflow must be approved by another
     # team member. GitHub fires approval events on every job that deploys to an environment, so we
     # have a dedicated environment for this purpose instead of using the `release` environment.
@@ -346,7 +346,7 @@ jobs:
     # `publish-crates` is intentionally not a dependency: it's not
     # critical to the release and isn't idempotent on retry.
     if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && needs.sign-release-binaries.result == 'success' && (needs.publish-pypi.result == 'skipped' || needs.publish-pypi.result == 'success') }}
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}"
     environment:
       name: release
     permissions:

--- a/.github/workflows/reproduce-bug.yml
+++ b/.github/workflows/reproduce-bug.yml
@@ -15,7 +15,7 @@ on:
         type: string
       runner:
         description: "The runner to use for reproduction"
-        default: ubuntu-latest
+        default: github-ubuntu-24.04-x86_64-4
         required: false
         type: string
     outputs:
@@ -48,11 +48,11 @@ on:
         type: string
       runner:
         description: "The runner to use for reproduction"
-        default: ubuntu-latest
+        default: github-ubuntu-24.04-x86_64-4
         required: true
         type: choice
         options:
-          - ubuntu-latest
+          - github-ubuntu-24.04-x86_64-4
           - macos-latest
 
 permissions: {}
@@ -150,7 +150,7 @@ jobs:
   report:
     needs: reproduce
     if: needs.reproduce.outputs.result != ''
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 10
     concurrency:
@@ -340,7 +340,7 @@ jobs:
   publish-integration-test:
     needs: [reproduce, create-integration-test]
     if: needs.create-integration-test.outputs.created == 'true'
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/sign-release-binaries.yml
+++ b/.github/workflows/sign-release-binaries.yml
@@ -125,7 +125,7 @@ jobs:
     name: "sign and notarize macos binaries"
     needs: prepare
     if: ${{ github.repository == 'astral-sh/uv' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-24.04' }}
     environment: release
     permissions:
       contents: read

--- a/.github/workflows/sync-python-releases.yml
+++ b/.github/workflows/sync-python-releases.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   sync:
     if: github.repository == 'astral-sh/uv'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     permissions:
       contents: read

--- a/.github/workflows/sync-uv-dev.yml
+++ b/.github/workflows/sync-uv-dev.yml
@@ -18,7 +18,7 @@ jobs:
   sync:
     name: Sync uv-dev
     if: github.repository == 'astral-sh/uv'
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     permissions:
       id-token: write # for the credential broker

--- a/.github/workflows/sync-uv-security.yml
+++ b/.github/workflows/sync-uv-security.yml
@@ -18,7 +18,7 @@ jobs:
   sync:
     name: Sync uv-security
     if: github.repository == 'astral-sh/uv' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     environment: automations
     permissions:
       id-token: write # for the credential broker

--- a/.github/workflows/test-ecosystem.yml
+++ b/.github/workflows/test-ecosystem.yml
@@ -15,7 +15,7 @@ jobs:
   ecosystem-test:
     name: "${{ matrix.repo }}"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -21,7 +21,7 @@ jobs:
   integration-test-nushell:
     name: "nushell"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -68,7 +68,7 @@ jobs:
   integration-test-conda:
     name: "conda on linux"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -137,7 +137,7 @@ jobs:
   integration-test-deadsnakes-39-linux:
     name: "deadsnakes python3.9 on ubuntu"
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - name: "Install python3.9"
         run: |
@@ -399,7 +399,7 @@ jobs:
   integration-test-pypy-linux:
     name: "pypy on linux"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -464,7 +464,7 @@ jobs:
   integration-test-python-install-wine:
     name: "python install under wine"
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     env:
       WINEARCH: win64
       WINEDEBUG: -all
@@ -557,7 +557,7 @@ jobs:
   integration-test-graalpy-linux:
     name: "graalpy on linux"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -681,7 +681,7 @@ jobs:
   integration-test-pyodide-linux:
     name: "pyodide on linux"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -775,7 +775,7 @@ jobs:
   integration-test-termux:
     name: "termux on android"
     timeout-minutes: 15
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -800,7 +800,7 @@ jobs:
   integration-test-github-actions:
     name: "github actions"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     env:
       # This job creates and updates test projects without existing lockfiles.
       UV_LOCKED: 0
@@ -860,7 +860,7 @@ jobs:
   integration-test-github-actions-freethreaded:
     name: "free-threaded on github actions"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -958,7 +958,7 @@ jobs:
   integration-test-public-registries:
     name: "public registries"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     env:
       PYTHON_VERSION: 3.12
     steps:
@@ -1001,7 +1001,7 @@ jobs:
   integration-test-registries:
     name: "registries"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     if: ${{ github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.fork != true }}
     environment:
       name: uv-test-registries
@@ -1123,7 +1123,7 @@ jobs:
   integration-uv-build-backend:
     name: "uv_build"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1175,7 +1175,7 @@ jobs:
   cache-test-ubuntu:
     name: "cache on linux"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -20,7 +20,7 @@ jobs:
   smoke-test-linux:
     name: "linux"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -76,7 +76,7 @@ jobs:
   smoke-test-linux-musl:
     name: "linux musl"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test-system.yml
+++ b/.github/workflows/test-system.yml
@@ -16,7 +16,7 @@ jobs:
   system-test-debian:
     timeout-minutes: 10
     name: "python on debian"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: debian:13@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -48,7 +48,7 @@ jobs:
   system-test-fedora:
     timeout-minutes: 10
     name: "python on fedora"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: fedora:45@sha256:0c1f63ed8fb818fad16cf6ae091598c410a21d2e1a9adf183beb93189299bfba
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -75,7 +75,7 @@ jobs:
   system-test-ubuntu:
     timeout-minutes: 10
     name: "python3.12 via setup-python"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -102,7 +102,7 @@ jobs:
   system-test-python-36:
     timeout-minutes: 10
     name: "python3.6 on debian buster"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: python:3.6-buster
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -126,7 +126,7 @@ jobs:
   system-test-python-37:
     timeout-minutes: 10
     name: "python3.7 on debian buster"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: python:3.7-buster
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -186,7 +186,7 @@ jobs:
   system-test-rocky-linux:
     timeout-minutes: 10
     name: "python on rocky linux ${{ matrix.rocky-version }}"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: rockylinux/rockylinux:${{ matrix.rocky-version }}
     strategy:
       fail-fast: false
@@ -245,7 +245,7 @@ jobs:
   system-test-graalpy:
     timeout-minutes: 10
     name: "graalpy on linux"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -272,7 +272,7 @@ jobs:
   system-test-pypy:
     timeout-minutes: 10
     name: "pypy on linux"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -299,7 +299,7 @@ jobs:
   system-test-pyston:
     timeout-minutes: 10
     name: "pyston on linux"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: pyston/pyston:2.3.5@sha256:3e8c851140fb52a183b1d7f478e2a534374275516426acfeda5c2b0a032fc6bb
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -323,7 +323,7 @@ jobs:
   system-test-chainguard-dev:
     timeout-minutes: 10
     name: "python on chainguard-dev"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container:
       image: cgr.dev/chainguard/python:latest-dev@sha256:c3898a57639a93cb4356fce37d6312f8e9ad44ced420f530148dbcbc5f6797ef
       options: --user root --entrypoint /bin/sh
@@ -347,12 +347,12 @@ jobs:
         run: python scripts/check_system_python.py --uv ./uv
 
   # The Chainguard distroless image has no shell, so we can't use `container:`
-  # directly. Instead, we run on ubuntu-latest and use `docker run` to execute
+  # directly. Instead, we run on Ubuntu and use `docker run` to execute
   # inside the image.
   system-test-chainguard:
     timeout-minutes: 10
     name: "python on chainguard"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -377,7 +377,7 @@ jobs:
   system-test-alpine:
     timeout-minutes: 10
     name: "python on alpine"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -655,7 +655,7 @@ jobs:
   system-test-pyenv:
     timeout-minutes: 10
     name: "python3.9 via pyenv"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -697,7 +697,7 @@ jobs:
   system-test-linux-313:
     timeout-minutes: 10
     name: "python3.13 via setup-python"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -735,7 +735,7 @@ jobs:
           - {
               os: "linux",
               target: "linux-libc",
-              runner: "ubuntu-latest",
+              runner: "${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}",
               arch: "x86-64",
             }
           - {
@@ -794,7 +794,7 @@ jobs:
   system-test-amazonlinux:
     timeout-minutes: 10
     name: "python on amazonlinux"
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     container: amazonlinux:2023@sha256:32f61af6a24e178e8142fb7b0079f4af3a5cda6816cd53d2c611a921ef029ca0
     steps:
       - name: "Install base requirements"

--- a/.github/workflows/test-windows-trampolines.yml
+++ b/.github/workflows/test-windows-trampolines.yml
@@ -21,7 +21,7 @@ jobs:
   # Verify windows crate version matches between workspaces
   windows-version-check:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     name: "check windows crate version"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -40,7 +40,7 @@ jobs:
     # otherwise force a trampoline rebuild on every dependency update.
     if: ${{ inputs.trampoline-build == 'true' }}
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     name: "check binary"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/update-issue-context.yml
+++ b/.github/workflows/update-issue-context.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   update:
     if: github.repository == 'astral-sh/uv' && !github.event.issue.pull_request
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 15
     permissions:
@@ -255,7 +255,7 @@ jobs:
   persist:
     needs: update
     if: needs.update.outputs.changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     environment: automations
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/update-pull-request-parent.yml
+++ b/.github/workflows/update-pull-request-parent.yml
@@ -44,7 +44,7 @@ jobs:
   update:
     name: "Update parent of pull request #${{ inputs.number }}"
     if: github.repository == 'astral-sh/uv-dev' || github.repository == 'astral-sh/uv-security'
-    runs-on: ubuntu-slim
+    runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-2' || 'ubuntu-slim' }}
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
The standard Linux jobs share the organization's GitHub-hosted concurrency limit. Route them to the existing four-core GitHub-hosted larger runners, and move `ubuntu-slim` jobs to the two-core pool. Workflows running outside Astral retain the standard-runner fallback; existing larger, third-party, Windows, and macOS runner choices are unchanged.