### PR TITLE
used fixed sized buffers

### DIFF
--- a/crates/uv-extract/src/dirhash.rs
+++ b/crates/uv-extract/src/dirhash.rs
@@ -110,14 +110,14 @@ where
     R: AsyncRead,
     W: AsyncWrite,
 {
-    blake3_copy_with_buffer(reader, writer, &mut Vec::new()).await
+    blake3_copy_with_buffer(reader, writer, &mut Box::new([0; 1 << 16])).await
 }
 
 /// Copy and hash bytes with a reusable 64 KiB buffer, allocating it on the first call.
 pub(crate) async fn blake3_copy_with_buffer<R, W>(
     reader: R,
     writer: W,
-    buffer: &mut Vec<u8>,
+    buffer: &mut [u8; 1 << 16],
 ) -> io::Result<(u64, blake3::Hash)>
 where
     R: AsyncRead,
@@ -126,7 +126,7 @@ where
     let mut reader = pin!(reader);
     let mut writer = pin!(writer);
     let mut hasher = blake3::Hasher::new();
-    buffer.resize(1 << 16, 0); // 64 KiB
+    buffer.fill(0);
     let mut total = 0u64;
     // BLAKE3 is fastest when hashing power-of-two sized buffers. That maximizes the time we spend
     // in the wide SIMD part of the implementation (which wants between 4 and 16 KiB at a time
@@ -711,7 +711,7 @@ mod tests {
     async fn test_blake3_copy_reuses_buffer() -> io::Result<()> {
         let mut input = vec![0; 64_000 * 3];
         paint_input(&mut input);
-        let mut buffer = Vec::new();
+        let mut buffer = Box::new([0; 1 << 16]);
         for input in [input.as_slice(), b"hello", b""] {
             let mut output = Vec::new();
             let (bytes_read, hash) =

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -178,7 +178,7 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
     let mut hashed_files = Vec::new();
     let mut digest_directories = FxHashSet::default();
     // Reuse the copy buffer across files, whether or not their contents are hashed.
-    let mut copy_buffer = Vec::new();
+    let mut copy_buffer: Box<[[u8; 65536]; 2]> = Box::new([[0; DEFAULT_BUF_SIZE / 2]; 2]);
     let mut offset = 0;
 
     while let Some(mut entry) = zip.next_with_entry().await? {
@@ -281,23 +281,28 @@ async fn unzip_inner<R: tokio::io::AsyncRead + Unpin>(
                     let mut reader = entry.reader_mut().compat();
                     if hash_contents {
                         let (bytes_read, digest) =
-                            blake3_copy_with_buffer(&mut reader, &mut writer, &mut copy_buffer)
+                            blake3_copy_with_buffer(&mut reader, &mut writer, &mut copy_buffer[0])
                                 .await
                                 .map_err(Error::io_or_zip)?;
                         (bytes_read, Some(digest))
                     } else {
                         let mut bytes_read = 0;
-                        copy_buffer.resize(DEFAULT_BUF_SIZE, 0);
                         loop {
-                            let read = tokio::io::AsyncReadExt::read(&mut reader, &mut copy_buffer)
-                                .await
-                                .map_err(Error::io_or_zip)?;
+                            let read = tokio::io::AsyncReadExt::read(
+                                &mut reader,
+                                copy_buffer.as_flattened_mut(),
+                            )
+                            .await
+                            .map_err(Error::io_or_zip)?;
                             if read == 0 {
                                 break;
                             }
-                            tokio::io::AsyncWriteExt::write_all(&mut writer, &copy_buffer[..read])
-                                .await
-                                .map_err(Error::Io)?;
+                            tokio::io::AsyncWriteExt::write_all(
+                                &mut writer,
+                                &copy_buffer.as_flattened()[..read],
+                            )
+                            .await
+                            .map_err(Error::Io)?;
                             bytes_read += read as u64;
                         }
                         tokio::io::AsyncWriteExt::flush(&mut writer)


### PR DESCRIPTION
  The copy bffer was always 128KiB and the buffer for dirhash always 64KiB - as such these can be allocated st these never need to be resized rather than using vec at all



## Summary

Unnecessary nerd sniped microopt tbh - one possible change would also be changing the dirhash to also be 128KiB consistent w the other buffer then don't have the weird flattening hackery. Probably get most the benefit by just initially making a 128KiB vec so there's no subsequent allocs


