### PR TITLE
Add explicit ordering to diagnostic hints

### DIFF
--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -261,7 +261,7 @@ impl TestClient {
             let mut rendered = String::new();
             write_error_chain_with_options(
                 &error,
-                error.hints(),
+                &error.hints(),
                 ErrorOptions::default().with_stream(&mut rendered),
             )
             .unwrap();

--- a/crates/uv-dev/src/main.rs
+++ b/crates/uv-dev/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> ExitCode {
     if let Err(err) = result {
         trace!("Error trace: {err:?}");
         let err = err.context("uv-dev failed");
-        uv_errors::write_error_chain(err.as_ref(), uv_errors::Hints::none())
+        uv_errors::write_error_chain(err.as_ref(), &uv_errors::Hints::none())
             .expect("writing to stderr should not fail");
         ExitCode::FAILURE
     } else {

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -44,7 +44,7 @@ impl<'a> HintMessage<'a> {
     pub fn new(message: impl Into<Cow<'a, str>>) -> Self {
         Self {
             message: message.into(),
-            ordering: HintOrdering::Any,
+            ordering: HintOrdering::default(),
         }
     }
 

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -281,7 +281,7 @@ impl<'a, C, W> ErrorOptions<'a, C, W> {
 
 /// Format an error chain and explicitly supplied hints to standard error using the default level
 /// and color.
-pub fn write_error_chain(err: &dyn Error, hints: Hints<'_>) -> fmt::Result {
+pub fn write_error_chain(err: &dyn Error, hints: &Hints<'_>) -> fmt::Result {
     write_error_chain_with_options(err, hints, ErrorOptions::default())
 }
 
@@ -309,7 +309,7 @@ impl fmt::Display for DebugErrorChain<'_> {
 /// Each hint is rendered on its own line, prefixed with the styled `hint:` label.
 pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
     err: &dyn Error,
-    hints: Hints<'_>,
+    hints: &Hints<'_>,
     options: ErrorOptions<'_, C, W>,
 ) -> fmt::Result {
     let ErrorOptions {
@@ -492,7 +492,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default()
                 .with_width_override(80)
                 .with_stream(&mut output),
@@ -525,7 +525,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default().with_stream(&mut output),
         )
         .unwrap();
@@ -569,7 +569,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             error.as_ref(),
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default()
                 .with_level("warning")
                 .with_color(AnsiColors::Yellow)
@@ -594,7 +594,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default()
                 .with_width_override(50)
                 .with_stream(&mut output),
@@ -619,7 +619,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default()
                 .with_width_override(40)
                 .with_stream(&mut output),
@@ -659,7 +659,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default()
                 .with_width_override(60)
                 .with_stream(&mut output),
@@ -685,7 +685,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default()
                 .with_width_override(50)
                 .with_stream(&mut output),
@@ -712,7 +712,7 @@ mod tests {
         let mut output = String::new();
         write_error_chain_with_options(
             &error,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default()
                 .with_width_override(50)
                 .with_stream(&mut output),
@@ -739,7 +739,7 @@ mod tests {
         let mut rendered = String::new();
         write_error_chain_with_options(
             err.as_ref(),
-            hints,
+            &hints,
             ErrorOptions::default().with_stream(&mut rendered),
         )
         .unwrap();
@@ -768,7 +768,7 @@ mod tests {
         let mut rendered = String::new();
         write_error_chain_with_options(
             err.as_ref(),
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default().with_stream(&mut rendered),
         )
         .unwrap();

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -113,15 +113,13 @@ impl<'a> Hints<'a> {
     }
 
     /// Iterate over hint messages in display order.
-    pub fn iter(&self) -> impl Iterator<Item = &str> {
-        [HintOrdering::First, HintOrdering::Any, HintOrdering::Last]
-            .into_iter()
-            .flat_map(|ordering| {
-                self.0
-                    .iter()
-                    .filter(move |hint| hint.ordering == ordering)
-                    .map(|hint| hint.message.as_ref())
-            })
+    pub fn iter(&self) -> HintsIter<'_, 'a> {
+        HintsIter {
+            hints: &self.0,
+            current: self.0.iter(),
+            ordering: HintOrdering::First,
+            remaining: [HintOrdering::Any, HintOrdering::Last].into_iter(),
+        }
     }
 
     /// Extend with another set of hints, converting borrowed hints to owned.
@@ -139,6 +137,48 @@ impl<'a> Hints<'a> {
                 self.0.push(hint.into_owned());
             }
         }
+    }
+}
+
+/// A borrowed iterator over hint messages in display order.
+pub struct HintsIter<'h, 'a> {
+    hints: &'h [HintMessage<'a>],
+    current: std::slice::Iter<'h, HintMessage<'a>>,
+    ordering: HintOrdering,
+    remaining: std::array::IntoIter<HintOrdering, 2>,
+}
+
+impl<'h> Iterator for HintsIter<'h, '_> {
+    type Item = &'h str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(hint) = self.current.find(|hint| hint.ordering == self.ordering) {
+                return Some(hint.message.as_ref());
+            }
+            self.ordering = self.remaining.next()?;
+            self.current = self.hints.iter();
+        }
+    }
+}
+
+impl<'h, 'a> IntoIterator for &'h Hints<'a> {
+    type Item = &'h str;
+    type IntoIter = HintsIter<'h, 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for Hints<'a> {
+    type Item = Cow<'a, str>;
+    type IntoIter =
+        std::iter::Map<std::vec::IntoIter<HintMessage<'a>>, fn(HintMessage<'a>) -> Cow<'a, str>>;
+
+    fn into_iter(mut self) -> Self::IntoIter {
+        self.0.sort_by_key(|hint| hint.ordering);
+        self.0.into_iter().map(|hint| hint.message)
     }
 }
 
@@ -195,7 +235,7 @@ impl<'a, T: Into<HintMessage<'a>>> FromIterator<T> for Hints<'a> {
 
 impl fmt::Display for Hints<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for hint in self.iter() {
+        for hint in self {
             write!(f, "\n{HintPrefix} {hint}")?;
         }
         Ok(())
@@ -359,7 +399,7 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
         }
     }
 
-    for hint in hints.iter() {
+    for hint in hints {
         writeln!(&mut stream, "\n{HintPrefix} {hint}")?;
     }
 
@@ -410,7 +450,17 @@ mod tests {
         hint: last 1
         hint: last 2
         ");
-        assert_debug_snapshot!(hints.iter().collect::<Vec<_>>(), @r#"
+        assert_debug_snapshot!((&hints).into_iter().collect::<Vec<_>>(), @r#"
+        [
+            "first 1",
+            "first 2",
+            "any 1",
+            "any 2",
+            "last 1",
+            "last 2",
+        ]
+        "#);
+        assert_debug_snapshot!(hints.into_iter().collect::<Vec<_>>(), @r#"
         [
             "first 1",
             "first 2",

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -34,12 +34,12 @@ pub enum HintOrdering {
 }
 
 /// A user-facing hint and its preferred display order.
-pub struct HintMessage<'a> {
+pub struct Hint<'a> {
     message: Cow<'a, str>,
     ordering: HintOrdering,
 }
 
-impl<'a> HintMessage<'a> {
+impl<'a> Hint<'a> {
     /// Create a hint with no preferred placement.
     pub fn new(message: impl Into<Cow<'a, str>>) -> Self {
         Self {
@@ -56,21 +56,21 @@ impl<'a> HintMessage<'a> {
     }
 
     /// Convert a borrowed hint to owned, extending its lifetime to `'static`.
-    fn into_owned(self) -> HintMessage<'static> {
-        HintMessage {
+    fn into_owned(self) -> Hint<'static> {
+        Hint {
             message: Cow::Owned(self.message.into_owned()),
             ordering: self.ordering,
         }
     }
 }
 
-impl<'a> From<&'a str> for HintMessage<'a> {
+impl<'a> From<&'a str> for Hint<'a> {
     fn from(message: &'a str) -> Self {
         Self::new(message)
     }
 }
 
-impl From<String> for HintMessage<'_> {
+impl From<String> for Hint<'_> {
     fn from(message: String) -> Self {
         Self::new(message)
     }
@@ -80,7 +80,7 @@ impl From<String> for HintMessage<'_> {
 ///
 /// Each hint is rendered on its own line, prefixed with the styled `hint:` label.
 /// Hints are grouped by [`HintOrdering`], retaining insertion order within each group.
-pub struct Hints<'a>(Vec<HintMessage<'a>>);
+pub struct Hints<'a>(Vec<Hint<'a>>);
 
 impl<'a> Hints<'a> {
     /// No hints.
@@ -89,7 +89,7 @@ impl<'a> Hints<'a> {
     }
 
     /// Add a single hint.
-    pub fn push(&mut self, hint: impl Into<HintMessage<'a>>) {
+    pub fn push(&mut self, hint: impl Into<Hint<'a>>) {
         self.0.push(hint.into());
     }
 
@@ -104,7 +104,7 @@ impl<'a> Hints<'a> {
 
     /// Convert all borrowed hints to owned, extending the lifetime to `'static`.
     pub fn into_owned(self) -> Hints<'static> {
-        Hints(self.0.into_iter().map(HintMessage::into_owned).collect())
+        Hints(self.0.into_iter().map(Hint::into_owned).collect())
     }
 
     /// Whether the collection is empty.
@@ -142,8 +142,8 @@ impl<'a> Hints<'a> {
 
 /// A borrowed iterator over hint messages in display order.
 pub struct HintsIter<'h, 'a> {
-    hints: &'h [HintMessage<'a>],
-    current: std::slice::Iter<'h, HintMessage<'a>>,
+    hints: &'h [Hint<'a>],
+    current: std::slice::Iter<'h, Hint<'a>>,
     ordering: HintOrdering,
     remaining: std::array::IntoIter<HintOrdering, 2>,
 }
@@ -173,8 +173,7 @@ impl<'h, 'a> IntoIterator for &'h Hints<'a> {
 
 impl<'a> IntoIterator for Hints<'a> {
     type Item = Cow<'a, str>;
-    type IntoIter =
-        std::iter::Map<std::vec::IntoIter<HintMessage<'a>>, fn(HintMessage<'a>) -> Cow<'a, str>>;
+    type IntoIter = std::iter::Map<std::vec::IntoIter<Hint<'a>>, fn(Hint<'a>) -> Cow<'a, str>>;
 
     fn into_iter(mut self) -> Self::IntoIter {
         self.0.sort_by_key(|hint| hint.ordering);
@@ -211,23 +210,23 @@ impl<E: fmt::Display> fmt::Display for ErrorWithHints<'_, E> {
 
 impl<'a> From<&'a str> for Hints<'a> {
     fn from(hint: &'a str) -> Self {
-        Self::from(HintMessage::from(hint))
+        Self::from(Hint::from(hint))
     }
 }
 
 impl From<String> for Hints<'_> {
     fn from(hint: String) -> Self {
-        Self::from(HintMessage::from(hint))
+        Self::from(Hint::from(hint))
     }
 }
 
-impl<'a> From<HintMessage<'a>> for Hints<'a> {
-    fn from(hint: HintMessage<'a>) -> Self {
+impl<'a> From<Hint<'a>> for Hints<'a> {
+    fn from(hint: Hint<'a>) -> Self {
         Self(vec![hint])
     }
 }
 
-impl<'a, T: Into<HintMessage<'a>>> FromIterator<T> for Hints<'a> {
+impl<'a, T: Into<Hint<'a>>> FromIterator<T> for Hints<'a> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         Self(iter.into_iter().map(Into::into).collect())
     }
@@ -414,7 +413,7 @@ mod tests {
     use owo_colors::AnsiColors;
 
     use super::{
-        ErrorOptions, ErrorWithHints, HintMessage, HintOrdering, Hints, debug_error_chain,
+        ErrorOptions, ErrorWithHints, Hint, HintOrdering, Hints, debug_error_chain,
         write_error_chain_with_options,
     };
 
@@ -436,8 +435,8 @@ mod tests {
     #[test]
     fn hint_ordering_retains_insertion_order() {
         let mut hints = Hints::from("any 1");
-        hints.push(HintMessage::new("last 1").with_ordering(HintOrdering::Last));
-        hints.push(HintMessage::new("first 1").with_ordering(HintOrdering::First));
+        hints.push(Hint::new("last 1").with_ordering(HintOrdering::Last));
+        hints.push(Hint::new("first 1").with_ordering(HintOrdering::First));
         hints.push("any 2".to_string());
         hints.extend(Hints::from("last 2").with_ordering(HintOrdering::Last));
         hints.extend(Hints::from("first 2").with_ordering(HintOrdering::First));
@@ -475,9 +474,9 @@ mod tests {
     #[test]
     fn changing_ordering_retains_insertion_order() {
         let hints = [
-            HintMessage::new("last").with_ordering(HintOrdering::Last),
-            HintMessage::new("first").with_ordering(HintOrdering::First),
-            HintMessage::new("any"),
+            Hint::new("last").with_ordering(HintOrdering::Last),
+            Hint::new("first").with_ordering(HintOrdering::First),
+            Hint::new("any"),
         ]
         .into_iter()
         .collect::<Hints<'_>>()

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -33,17 +33,46 @@ pub enum HintOrdering {
     Last,
 }
 
-struct HintMessage<'a> {
+/// A user-facing hint and its preferred display order.
+pub struct HintMessage<'a> {
     message: Cow<'a, str>,
     ordering: HintOrdering,
 }
 
-impl HintMessage<'_> {
-    fn into_owned(self) -> HintMessage<'static> {
+impl<'a> HintMessage<'a> {
+    /// Create a hint with no preferred placement.
+    pub fn new(message: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            message: message.into(),
+            ordering: HintOrdering::Any,
+        }
+    }
+
+    /// Set the preferred display order of this hint.
+    #[must_use]
+    pub fn with_ordering(mut self, ordering: HintOrdering) -> Self {
+        self.ordering = ordering;
+        self
+    }
+
+    /// Convert a borrowed hint to owned, extending its lifetime to `'static`.
+    pub fn into_owned(self) -> HintMessage<'static> {
         HintMessage {
             message: Cow::Owned(self.message.into_owned()),
             ordering: self.ordering,
         }
+    }
+}
+
+impl<'a> From<&'a str> for HintMessage<'a> {
+    fn from(message: &'a str) -> Self {
+        Self::new(message)
+    }
+}
+
+impl From<String> for HintMessage<'_> {
+    fn from(message: String) -> Self {
+        Self::new(message)
     }
 }
 
@@ -53,18 +82,15 @@ impl HintMessage<'_> {
 /// Hints are grouped by [`HintOrdering`], retaining insertion order within each group.
 pub struct Hints<'a>(Vec<HintMessage<'a>>);
 
-impl Hints<'_> {
+impl<'a> Hints<'a> {
     /// No hints.
     pub fn none() -> Self {
         Self(Vec::new())
     }
 
-    /// Add a single owned hint.
-    pub fn push(&mut self, hint: String) {
-        self.0.push(HintMessage {
-            message: Cow::Owned(hint),
-            ordering: HintOrdering::Any,
-        });
+    /// Add a single hint.
+    pub fn push(&mut self, hint: impl Into<HintMessage<'a>>) {
+        self.0.push(hint.into());
     }
 
     /// Set the display order of every hint in this collection.
@@ -84,6 +110,18 @@ impl Hints<'_> {
     /// Whether the collection is empty.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    /// Iterate over hint messages in display order.
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        [HintOrdering::First, HintOrdering::Any, HintOrdering::Last]
+            .into_iter()
+            .flat_map(|ordering| {
+                self.0
+                    .iter()
+                    .filter(move |hint| hint.ordering == ordering)
+                    .map(|hint| hint.message.as_ref())
+            })
     }
 
     /// Extend with another set of hints, converting borrowed hints to owned.
@@ -133,57 +171,34 @@ impl<E: fmt::Display> fmt::Display for ErrorWithHints<'_, E> {
 
 impl<'a> From<&'a str> for Hints<'a> {
     fn from(hint: &'a str) -> Self {
-        Self(vec![HintMessage {
-            message: Cow::Borrowed(hint),
-            ordering: HintOrdering::Any,
-        }])
+        Self::from(HintMessage::from(hint))
     }
 }
 
 impl From<String> for Hints<'_> {
     fn from(hint: String) -> Self {
-        Self(vec![HintMessage {
-            message: Cow::Owned(hint),
-            ordering: HintOrdering::Any,
-        }])
+        Self::from(HintMessage::from(hint))
     }
 }
 
-impl FromIterator<String> for Hints<'_> {
-    fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
-        Self(
-            iter.into_iter()
-                .map(|message| HintMessage {
-                    message: Cow::Owned(message),
-                    ordering: HintOrdering::Any,
-                })
-                .collect(),
-        )
+impl<'a> From<HintMessage<'a>> for Hints<'a> {
+    fn from(hint: HintMessage<'a>) -> Self {
+        Self(vec![hint])
+    }
+}
+
+impl<'a, T: Into<HintMessage<'a>>> FromIterator<T> for Hints<'a> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().map(Into::into).collect())
     }
 }
 
 impl fmt::Display for Hints<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut hints = self.0.iter().collect::<Vec<_>>();
-        hints.sort_by_key(|hint| hint.ordering);
-        for hint in hints {
-            write!(f, "\n{HintPrefix} {}", hint.message)?;
+        for hint in self.iter() {
+            write!(f, "\n{HintPrefix} {hint}")?;
         }
         Ok(())
-    }
-}
-
-impl<'a> IntoIterator for Hints<'a> {
-    type Item = Cow<'a, str>;
-    type IntoIter = std::vec::IntoIter<Cow<'a, str>>;
-
-    fn into_iter(mut self) -> Self::IntoIter {
-        self.0.sort_by_key(|hint| hint.ordering);
-        self.0
-            .into_iter()
-            .map(|hint| hint.message)
-            .collect::<Vec<_>>()
-            .into_iter()
     }
 }
 
@@ -344,7 +359,7 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
         }
     }
 
-    for hint in hints {
+    for hint in hints.iter() {
         writeln!(&mut stream, "\n{HintPrefix} {hint}")?;
     }
 
@@ -359,7 +374,7 @@ mod tests {
     use owo_colors::AnsiColors;
 
     use super::{
-        ErrorOptions, ErrorWithHints, HintOrdering, Hints, debug_error_chain,
+        ErrorOptions, ErrorWithHints, HintMessage, HintOrdering, Hints, debug_error_chain,
         write_error_chain_with_options,
     };
 
@@ -369,10 +384,7 @@ mod tests {
         hints.extend(Hints::from("same"));
         hints.extend(Hints::from("other"));
 
-        let hints = hints
-            .into_iter()
-            .map(std::borrow::Cow::into_owned)
-            .collect::<Vec<_>>();
+        let hints = hints.iter().collect::<Vec<_>>();
         assert_debug_snapshot!(hints, @r#"
         [
             "same",
@@ -384,8 +396,8 @@ mod tests {
     #[test]
     fn hint_ordering_retains_insertion_order() {
         let mut hints = Hints::from("any 1");
-        hints.extend(Hints::from("last 1").with_ordering(HintOrdering::Last));
-        hints.extend(Hints::from("first 1").with_ordering(HintOrdering::First));
+        hints.push(HintMessage::new("last 1").with_ordering(HintOrdering::Last));
+        hints.push(HintMessage::new("first 1").with_ordering(HintOrdering::First));
         hints.push("any 2".to_string());
         hints.extend(Hints::from("last 2").with_ordering(HintOrdering::Last));
         hints.extend(Hints::from("first 2").with_ordering(HintOrdering::First));
@@ -398,7 +410,7 @@ mod tests {
         hint: last 1
         hint: last 2
         ");
-        assert_debug_snapshot!(hints.into_iter().collect::<Vec<_>>(), @r#"
+        assert_debug_snapshot!(hints.iter().collect::<Vec<_>>(), @r#"
         [
             "first 1",
             "first 2",
@@ -406,6 +418,26 @@ mod tests {
             "any 2",
             "last 1",
             "last 2",
+        ]
+        "#);
+    }
+
+    #[test]
+    fn changing_ordering_retains_insertion_order() {
+        let hints = [
+            HintMessage::new("last").with_ordering(HintOrdering::Last),
+            HintMessage::new("first").with_ordering(HintOrdering::First),
+            HintMessage::new("any"),
+        ]
+        .into_iter()
+        .collect::<Hints<'_>>()
+        .with_ordering(HintOrdering::Any);
+
+        assert_debug_snapshot!(hints.iter().collect::<Vec<_>>(), @r#"
+        [
+            "last",
+            "first",
+            "any",
         ]
         "#);
     }

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -56,7 +56,7 @@ impl<'a> HintMessage<'a> {
     }
 
     /// Convert a borrowed hint to owned, extending its lifetime to `'static`.
-    pub fn into_owned(self) -> HintMessage<'static> {
+    fn into_owned(self) -> HintMessage<'static> {
         HintMessage {
             message: Cow::Owned(self.message.into_owned()),
             ordering: self.ordering,

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -21,10 +21,37 @@ pub trait Hinted {
     }
 }
 
+/// The display order of a user-facing hint.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum HintOrdering {
+    /// Advice that should be shown before other hints.
+    First,
+    /// Advice with no preferred placement.
+    #[default]
+    Any,
+    /// General advice that should follow more specific hints.
+    Last,
+}
+
+struct HintMessage<'a> {
+    message: Cow<'a, str>,
+    ordering: HintOrdering,
+}
+
+impl HintMessage<'_> {
+    fn into_owned(self) -> HintMessage<'static> {
+        HintMessage {
+            message: Cow::Owned(self.message.into_owned()),
+            ordering: self.ordering,
+        }
+    }
+}
+
 /// A collection of user-facing hint messages.
 ///
 /// Each hint is rendered on its own line, prefixed with the styled `hint:` label.
-pub struct Hints<'a>(Vec<Cow<'a, str>>);
+/// Hints are grouped by [`HintOrdering`], retaining insertion order within each group.
+pub struct Hints<'a>(Vec<HintMessage<'a>>);
 
 impl Hints<'_> {
     /// No hints.
@@ -34,17 +61,24 @@ impl Hints<'_> {
 
     /// Add a single owned hint.
     pub fn push(&mut self, hint: String) {
-        self.0.push(Cow::Owned(hint));
+        self.0.push(HintMessage {
+            message: Cow::Owned(hint),
+            ordering: HintOrdering::Any,
+        });
+    }
+
+    /// Set the display order of every hint in this collection.
+    #[must_use]
+    pub fn with_ordering(mut self, ordering: HintOrdering) -> Self {
+        for hint in &mut self.0 {
+            hint.ordering = ordering;
+        }
+        self
     }
 
     /// Convert all borrowed hints to owned, extending the lifetime to `'static`.
     pub fn into_owned(self) -> Hints<'static> {
-        Hints(
-            self.0
-                .into_iter()
-                .map(|cow| Cow::Owned(cow.into_owned()))
-                .collect(),
-        )
+        Hints(self.0.into_iter().map(HintMessage::into_owned).collect())
     }
 
     /// Whether the collection is empty.
@@ -53,14 +87,18 @@ impl Hints<'_> {
     }
 
     /// Extend with another set of hints, converting borrowed hints to owned.
-    pub fn extend<T>(&mut self, other: impl IntoIterator<Item = T>)
-    where
-        T: Into<String>,
-    {
-        for hint in other {
-            let hint = Cow::Owned(hint.into());
-            if !self.0.iter().any(|existing| existing == &hint) {
-                self.0.push(hint);
+    ///
+    /// Duplicate messages retain their first insertion position and earliest ordering.
+    pub fn extend(&mut self, other: Hints<'_>) {
+        for hint in other.0 {
+            if let Some(existing) = self
+                .0
+                .iter_mut()
+                .find(|existing| existing.message == hint.message)
+            {
+                existing.ordering = existing.ordering.min(hint.ordering);
+            } else {
+                self.0.push(hint.into_owned());
             }
         }
     }
@@ -95,26 +133,41 @@ impl<E: fmt::Display> fmt::Display for ErrorWithHints<'_, E> {
 
 impl<'a> From<&'a str> for Hints<'a> {
     fn from(hint: &'a str) -> Self {
-        Self(vec![Cow::Borrowed(hint)])
+        Self(vec![HintMessage {
+            message: Cow::Borrowed(hint),
+            ordering: HintOrdering::Any,
+        }])
     }
 }
 
 impl From<String> for Hints<'_> {
     fn from(hint: String) -> Self {
-        Self(vec![Cow::Owned(hint)])
+        Self(vec![HintMessage {
+            message: Cow::Owned(hint),
+            ordering: HintOrdering::Any,
+        }])
     }
 }
 
 impl FromIterator<String> for Hints<'_> {
     fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
-        Self(iter.into_iter().map(Cow::Owned).collect())
+        Self(
+            iter.into_iter()
+                .map(|message| HintMessage {
+                    message: Cow::Owned(message),
+                    ordering: HintOrdering::Any,
+                })
+                .collect(),
+        )
     }
 }
 
 impl fmt::Display for Hints<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for hint in &self.0 {
-            write!(f, "\n{HintPrefix} {hint}")?;
+        let mut hints = self.0.iter().collect::<Vec<_>>();
+        hints.sort_by_key(|hint| hint.ordering);
+        for hint in hints {
+            write!(f, "\n{HintPrefix} {}", hint.message)?;
         }
         Ok(())
     }
@@ -124,8 +177,13 @@ impl<'a> IntoIterator for Hints<'a> {
     type Item = Cow<'a, str>;
     type IntoIter = std::vec::IntoIter<Cow<'a, str>>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+    fn into_iter(mut self) -> Self::IntoIter {
+        self.0.sort_by_key(|hint| hint.ordering);
+        self.0
+            .into_iter()
+            .map(|hint| hint.message)
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }
 
@@ -297,11 +355,11 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
 mod tests {
     use anyhow::anyhow;
     use indoc::indoc;
-    use insta::assert_snapshot;
+    use insta::{assert_debug_snapshot, assert_snapshot};
     use owo_colors::AnsiColors;
 
     use super::{
-        ErrorOptions, ErrorWithHints, HintPrefix, Hints, debug_error_chain,
+        ErrorOptions, ErrorWithHints, HintOrdering, Hints, debug_error_chain,
         write_error_chain_with_options,
     };
 
@@ -315,19 +373,72 @@ mod tests {
             .into_iter()
             .map(std::borrow::Cow::into_owned)
             .collect::<Vec<_>>();
-        assert_eq!(hints, vec!["same".to_string(), "other".to_string()]);
+        assert_debug_snapshot!(hints, @r#"
+        [
+            "same",
+            "other",
+        ]
+        "#);
+    }
+
+    #[test]
+    fn hint_ordering_retains_insertion_order() {
+        let mut hints = Hints::from("any 1");
+        hints.extend(Hints::from("last 1").with_ordering(HintOrdering::Last));
+        hints.extend(Hints::from("first 1").with_ordering(HintOrdering::First));
+        hints.push("any 2".to_string());
+        hints.extend(Hints::from("last 2").with_ordering(HintOrdering::Last));
+        hints.extend(Hints::from("first 2").with_ordering(HintOrdering::First));
+
+        assert_snapshot!(anstream::adapter::strip_str(&hints.to_string()), @"
+        hint: first 1
+        hint: first 2
+        hint: any 1
+        hint: any 2
+        hint: last 1
+        hint: last 2
+        ");
+        assert_debug_snapshot!(hints.into_iter().collect::<Vec<_>>(), @r#"
+        [
+            "first 1",
+            "first 2",
+            "any 1",
+            "any 2",
+            "last 1",
+            "last 2",
+        ]
+        "#);
+    }
+
+    #[test]
+    fn duplicate_hints_retain_the_earliest_ordering() {
+        let message = String::from("shared");
+        let mut hints = Hints::from(message.as_str())
+            .with_ordering(HintOrdering::Last)
+            .into_owned();
+        drop(message);
+
+        hints.extend(Hints::from("first").with_ordering(HintOrdering::First));
+        hints.extend(Hints::from("shared").with_ordering(HintOrdering::First));
+        hints.extend(Hints::from("shared").with_ordering(HintOrdering::Last));
+        hints.extend(Hints::from("any"));
+
+        assert_snapshot!(anstream::adapter::strip_str(&hints.to_string()), @"
+        hint: shared
+        hint: first
+        hint: any
+        ");
     }
 
     #[test]
     fn error_with_hints_separates_hints_from_error() {
-        assert_eq!(
-            ErrorWithHints::new("error", Hints::from("fix it")).to_string(),
-            format!("error\n\n{HintPrefix} fix it")
-        );
-        assert_eq!(
-            ErrorWithHints::new("error", Hints::none()).to_string(),
-            "error"
-        );
+        let output = ErrorWithHints::new("error", Hints::from("fix it")).to_string();
+        assert_snapshot!(anstream::adapter::strip_str(&output), @"
+        error
+
+        hint: fix it
+        ");
+        assert_snapshot!(ErrorWithHints::new("error", Hints::none()), @"error");
     }
 
     #[test]

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -2246,7 +2246,7 @@ mod tests {
         let mut capture = String::new();
         write_error_chain_with_options(
             &err,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default().with_stream(&mut capture),
         )
         .unwrap();
@@ -2280,7 +2280,7 @@ mod tests {
         let mut capture = String::new();
         write_error_chain_with_options(
             &err,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default().with_stream(&mut capture),
         )
         .unwrap();
@@ -2319,7 +2319,7 @@ mod tests {
         let mut capture = String::new();
         write_error_chain_with_options(
             &err,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default().with_stream(&mut capture),
         )
         .unwrap();
@@ -2361,7 +2361,7 @@ mod tests {
         let mut capture = String::new();
         write_error_chain_with_options(
             &err,
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default().with_stream(&mut capture),
         )
         .unwrap();

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1387,7 +1387,7 @@ pub fn find_all_python_installations(
             Ok(Err(_)) => {}
             Err(err @ Error::Query(..)) => {
                 if uv_warnings::ENABLED.load(Ordering::Relaxed) {
-                    write_warning_chain(&err, Hints::none())
+                    write_warning_chain(&err, &Hints::none())
                         .expect("writing to stderr should not fail");
                 }
             }
@@ -1677,7 +1677,7 @@ pub(crate) async fn find_best_python_installation(
                 let error = anyhow::Error::from(error).context(format!(
                     "A managed Python download is available for {request}, but an error occurred when attempting to download it."
                 ));
-                write_warning_chain(error.as_ref(), Hints::none())
+                write_warning_chain(error.as_ref(), &Hints::none())
                     .expect("writing to stderr should not fail");
                 previous_fetch_failed = true;
             }

--- a/crates/uv-warnings/src/lib.rs
+++ b/crates/uv-warnings/src/lib.rs
@@ -25,13 +25,13 @@ pub fn disable() {
 }
 
 /// Format a warning chain to standard error.
-pub fn write_warning_chain(err: &dyn Error, hints: Hints<'_>) -> fmt::Result {
+pub fn write_warning_chain(err: &dyn Error, hints: &Hints<'_>) -> fmt::Result {
     write_warning_chain_with_options(err, hints, ErrorOptions::default())
 }
 
 fn write_warning_chain_with_options<C, W: fmt::Write>(
     err: &dyn Error,
-    hints: Hints<'_>,
+    hints: &Hints<'_>,
     options: ErrorOptions<'_, C, W>,
 ) -> fmt::Result {
     write_error_chain_with_options(
@@ -93,7 +93,7 @@ mod tests {
         let mut output = String::new();
         write_warning_chain_with_options(
             error.as_ref(),
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default().with_stream(&mut output),
         )
         .unwrap();

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -521,7 +521,7 @@ async fn build_impl(
                 let hints = crate::commands::diagnostics::hints_for_error(&err);
                 write_error_chain_with_options(
                     err.as_ref(),
-                    hints,
+                    &hints,
                     ErrorOptions::default().with_stream(printer.stderr_important()),
                 )?;
 

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -8,7 +8,7 @@ use version_ranges::Ranges;
 use uv_distribution_types::{
     DerivationChain, DerivationStep, Dist, DistErrorKind, Name, RequestedDist,
 };
-use uv_errors::{Hinted, Hints};
+use uv_errors::{HintOrdering, Hinted, Hints};
 use uv_normalize::PackageName;
 use uv_pep440::{Version, strip_local_version_sentinels};
 
@@ -110,7 +110,12 @@ impl OperationDiagnostic {
         };
 
         // Render all hints after the error output.
-        hints.extend(self.hints);
+        hints.extend(
+            self.hints
+                .into_iter()
+                .collect::<Hints<'_>>()
+                .with_ordering(HintOrdering::Last),
+        );
         if !hints.is_empty() {
             anstream::eprintln!("{hints}");
         }

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -223,7 +223,7 @@ fn no_solution(
 pub(crate) fn write_error_chain(err: &anyhow::Error, printer: Printer) -> std::fmt::Result {
     uv_errors::write_error_chain_with_options(
         err.as_ref(),
-        hints_for_error(err),
+        &hints_for_error(err),
         uv_errors::ErrorOptions::default().with_stream(printer.stderr_important()),
     )
 }
@@ -422,7 +422,7 @@ fn format_chain(name: &PackageName, version: Option<&Version>, chain: &Derivatio
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
+    use insta::assert_debug_snapshot;
 
     use uv_workspace::pyproject::{PyprojectTomlError, SourceError};
 
@@ -436,14 +436,11 @@ mod tests {
             "python_version != '3.12'".to_string(),
         )));
 
-        let hints = hints_for_error(&err)
-            .into_iter()
-            .map(Cow::into_owned)
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            hints,
-            vec!["replace `python_version == '3.12'` with `python_version != '3.12'`".to_string()]
-        );
+        let hints = hints_for_error(&err);
+        assert_debug_snapshot!(hints.iter().collect::<Vec<_>>(), @r#"
+        [
+            "replace `python_version == '3.12'` with `python_version != '3.12'`",
+        ]
+        "#);
     }
 }

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -109,7 +109,8 @@ impl OperationDiagnostic {
             err => return Some(err),
         };
 
-        // Render all hints after the error output.
+        // Caller-provided advice describes how to adjust the command, so show the underlying
+        // failure's more specific hints first.
         hints.extend(
             self.hints
                 .into_iter()

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -198,7 +198,7 @@ async fn publish_files(
                 }
                 write_error_chain_with_options(
                     err.as_ref(),
-                    Hints::none(),
+                    &Hints::none(),
                     ErrorOptions::default().with_stream(printer.stderr()),
                 )?;
                 error_count += 1;
@@ -394,7 +394,7 @@ async fn gather_credentials(
             anyhow::Error::from(err)
                 .context("Trusted publishing failed")
                 .as_ref(),
-            Hints::none(),
+            &Hints::none(),
             ErrorOptions::default().with_stream(printer.stderr()),
         )?;
     }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -917,7 +917,7 @@ async fn perform_install(
                 InstallErrorKind::DownloadUnpack => {
                     write_error_chain_with_options(
                         err.context(format!("Failed to install {key}")).as_ref(),
-                        Hints::none(),
+                        &Hints::none(),
                         ErrorOptions::default().with_stream(printer.stderr()),
                     )?;
                 }
@@ -931,7 +931,7 @@ async fn perform_install(
                     write_error_chain_with_options(
                         err.context(format!("Failed to install executable for {key}"))
                             .as_ref(),
-                        Hints::none(),
+                        &Hints::none(),
                         ErrorOptions::default()
                             .with_level(level)
                             .with_color(color)
@@ -949,7 +949,7 @@ async fn perform_install(
                     write_error_chain_with_options(
                         err.context(format!("Failed to create registry entry for {key}"))
                             .as_ref(),
-                        Hints::none(),
+                        &Hints::none(),
                         ErrorOptions::default()
                             .with_level(level)
                             .with_color(color)

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -1269,7 +1269,7 @@ impl uv_errors::Hinted for ToolRunScriptError {
             ),
         };
         uv_errors::Hints::from(
-            uv_errors::HintMessage::new(message).with_ordering(uv_errors::HintOrdering::Last),
+            uv_errors::Hint::new(message).with_ordering(uv_errors::HintOrdering::Last),
         )
     }
 }

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -1244,7 +1244,7 @@ pub(crate) enum ToolRunScriptError {
 
 impl uv_errors::Hinted for ToolRunScriptError {
     fn hints(&self) -> uv_errors::Hints<'_> {
-        uv_errors::Hints::from(match self {
+        let message = match self {
             Self::FromScript {
                 package_name,
                 target,
@@ -1267,6 +1267,9 @@ impl uv_errors::Hinted for ToolRunScriptError {
                 package_name.cyan(),
                 format!("{invocation} --from {package_name} {target}").green(),
             ),
-        })
+        };
+        uv_errors::Hints::from(
+            uv_errors::HintMessage::new(message).with_ordering(uv_errors::HintOrdering::Last),
+        )
     }
 }

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -182,7 +182,7 @@ pub(crate) async fn upgrade(
             write_error_chain_with_options(
                 err.context(format!("Failed to upgrade {}", name.green()))
                     .as_ref(),
-                Hints::none(),
+                &Hints::none(),
                 ErrorOptions::default().with_stream(printer.stderr()),
             )?;
         }


### PR DESCRIPTION
Hint ordering currently depends on error-chain traversal and manually appending caller-provided advice. Add `HintOrdering::{First, Any, Last}` to individual `Hint` values and `Hints` collections so error types can specify where their guidance belongs. Borrowed iteration visits the three groups without sorting or allocating; owned iteration sorts the existing vector. Both retain insertion order within each group. Error and warning renderers borrow the collection. Unannotated hints use `Any`, and merging duplicate messages retains the earliest ordering. The operation reporter's caller-provided hints and tool script usage advice use `Last`.

Prior work:

- #18090 introduced the `Hint` and `Hints` APIs.
- #20155 made hints explicit in error-chain rendering.
- #21584 renamed the hint-producing trait to `Hinted`.

This provides the ordering primitive for #17110 without requiring the command-layer collector to special-case error types.
