### PR TITLE
Read Python version files with BOM sniffing

### DIFF
--- a/crates/uv-python/src/version_files.rs
+++ b/crates/uv-python/src/version_files.rs
@@ -185,7 +185,9 @@ impl PythonVersionFile {
     ///
     /// If the file does not exist, `Ok(None)` is returned.
     async fn try_from_path(path: PathBuf) -> Result<Option<Self>, std::io::Error> {
-        match fs::tokio::read_to_string(&path).await {
+        // Version files are often written by editors and shells that emit a byte-order mark, so
+        // read them with BOM sniffing, as we do for requirements files.
+        match uv_fs::read_to_string_transcode(&path).await {
             Ok(content) => {
                 debug!(
                     "Reading Python requests from version file at `{}`",

--- a/crates/uv/tests/python/python_find.rs
+++ b/crates/uv/tests/python/python_find.rs
@@ -1,6 +1,9 @@
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::{FileTouch, PathChild};
-use assert_fs::{fixture::FileWriteStr, prelude::PathCreateDir};
+use assert_fs::{
+    fixture::{FileWriteBin, FileWriteStr},
+    prelude::PathCreateDir,
+};
 use indoc::indoc;
 
 use uv_platform::{Arch, Os};
@@ -282,6 +285,45 @@ fn python_find_pin_arbitrary_name() {
 
     ----- stderr -----
     warning: Ignoring unsupported Python request `foo` in version file: [TEMP_DIR]/foo/.python-version
+    ");
+}
+
+/// Version files are frequently written by editors and shells that prepend a byte-order mark; on
+/// Windows, `Set-Content -Encoding UTF8` writes a UTF-8 BOM and `>` writes UTF-16LE.
+#[test]
+fn python_find_pin_byte_order_mark() {
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
+
+    // UTF-8 with a byte-order mark.
+    let mut utf8 = vec![0xEF, 0xBB, 0xBF];
+    utf8.extend_from_slice(b"3.12");
+    context
+        .temp_dir
+        .child(".python-version")
+        .write_binary(&utf8)
+        .unwrap();
+
+    uv_snapshot!(context.filters(), context.python_find(), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [PYTHON-3.12]
+    ");
+
+    // UTF-16LE with a byte-order mark.
+    let mut utf16 = vec![0xFF, 0xFE];
+    for unit in "3.12".encode_utf16() {
+        utf16.extend_from_slice(&unit.to_le_bytes());
+    }
+    context
+        .temp_dir
+        .child(".python-version")
+        .write_binary(&utf16)
+        .unwrap();
+
+    uv_snapshot!(context.filters(), context.python_find(), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [PYTHON-3.12]
     ");
 }
 


### PR DESCRIPTION
## Summary

On Windows, `.python-version` files often end up with a byte-order mark, because that's what the shell writes. Windows PowerShell 5.1 writes UTF-16LE for `>` redirection, and a UTF-8 BOM for `Set-Content -Encoding UTF8`. uv handles neither.

With a UTF-8 BOM, the mark stays on the front of the first request, so `3.12` is parsed as an executable name and filtered out. The warning prints the mark, which is invisible, so it reads as if a plain `3.12` were unsupported — and the pin is silently ignored:

```console
PS> Set-Content -Encoding UTF8 -Path .python-version -Value 3.12
PS> uv python find
warning: Ignoring unsupported Python request `3.12` in version file: C:\...\.python-version
C:\Users\...\Programs\Python\Python311\python.exe
```

With UTF-16LE, the read fails outright:

```console
PS> echo 3.12 > .python-version
PS> uv python find
error: failed to read from file `C:\...\.python-version`: stream did not contain valid UTF-8
```

`uv_fs::read_to_string_transcode` already does BOM sniffing and is what backs requirements file reads (#2283). Use it in `PythonVersionFile::try_from_path` too.

After, both files resolve as written:

```console
PS> uv python find
C:\...\Programs\Python\Python312\python.exe
```

## Test Plan

New `python_find_pin_byte_order_mark` writes `.python-version` twice, once as UTF-8 with a BOM and once as UTF-16LE with a BOM, and expects `uv python find` to report 3.12 both times.

Against `main` it fails on the first snapshot:

```
    1     1 │ exit_code: 0 (success)
    2     2 │ ----- stdout -----
    3       │-[PYTHON-3.12]
          3 │+[PYTHON-3.11]
          4 │+
          5 │+----- stderr -----
          6 │+warning: Ignoring unsupported Python request `3.12` in version file: [TEMP_DIR]/.python-version
```

(the `+` line contains the BOM before `3.12`.)

With the change:

```console
$ cargo test -p uv --test python -- python_find::python_find_pin_byte_order_mark --exact
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 175 filtered out
```

Existing coverage in the same area still passes:

```console
$ cargo test -p uv --test python -- python_find:: python_pin::
test result: FAILED. 35 passed; 1 failed
```

The one failure is `python_find_path`, and it fails on this machine before the change too: `with_filtered_not_executable` matches the English wording of `os error 193`, and this is a non-English Windows install, so the localized message doesn't get filtered.

`cargo fmt --all --check` and `cargo clippy -p uv-python -p uv --all-targets --locked -- -D warnings` are clean.
