### PR TITLE
Append the executable extension without a leading dot on Windows

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -5,6 +5,8 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 use same_file::is_same_file;
 use std::borrow::Cow;
 use std::cmp::Reverse;
+#[cfg(windows)]
+use std::env::consts::EXE_EXTENSION;
 use std::env::consts::EXE_SUFFIX;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::atomic::Ordering;
@@ -1992,7 +1994,7 @@ impl PythonRequest {
         // e.g. path/to/python on Windows, where path/to/python.exe is the true path
         #[cfg(windows)]
         if value_as_path.extension().is_none() {
-            let value_as_path = value_as_path.with_extension(EXE_SUFFIX);
+            let value_as_path = value_as_path.with_extension(EXE_EXTENSION);
             if value_as_path.is_file() {
                 return Self::File(value_as_path);
             }

--- a/crates/uv/tests/python/python_find.rs
+++ b/crates/uv/tests/python/python_find.rs
@@ -163,6 +163,21 @@ fn python_find_cached_launcher_override() {
 }
 
 #[test]
+#[cfg(windows)]
+fn python_find_extensionless_path() {
+    let context = uv_test::test_context!("3.12");
+
+    // A path without the `.exe` extension should resolve to the adjacent executable.
+    let requested_python = venv_bin_path(&context.venv).join("python");
+
+    uv_snapshot!(context.filters(), context.python_find().arg(&requested_python), @"
+    exit_code: 0 (success)
+    ----- stdout -----
+    [VENV]/Scripts/python.exe
+    ");
+}
+
+#[test]
 fn python_find_pin() {
     let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
 


### PR DESCRIPTION
## Summary

On Windows, passing an interpreter path without the `.exe` extension fails, even when the executable is sitting right there:

```console
PS> uv venv out --python .venv\Scripts\python
error: No interpreter found at path `.venv\Scripts\python`

PS> uv venv out --python .venv\Scripts\python.exe
Using CPython 3.12.10 interpreter at: .venv\Scripts\python.exe
Creating virtual environment at: out
```

`PythonRequest::parse` has a Windows-only fallback for exactly this — it probes for the adjacent executable when the path has no extension:

```rust
// e.g. path/to/python on Windows, where path/to/python.exe is the true path
#[cfg(windows)]
if value_as_path.extension().is_none() {
    let value_as_path = value_as_path.with_extension(EXE_SUFFIX);
```

But `EXE_SUFFIX` is `.exe`, and `Path::with_extension` inserts its own `.` separator, so the path it actually probes is `python..exe`. It never matches, and the fallback has no effect. The constant that belongs here is `EXE_EXTENSION`, which is `exe` — that's what `RunCommand::as_command` uses for the same job in `crates/uv/src/commands/project/run.rs`.

This matters most for scripts that are shared across platforms, where `--python "$VENV/bin/python"` on Unix becomes `--python .venv\Scripts\python` on Windows.

After:

```console
PS> uv venv out --python .venv\Scripts\python
Using CPython 3.12.10 interpreter at: .venv\Scripts\python.exe
Creating virtual environment at: out
```

Note that this only covers the extensionless case the fallback was written for. A path like `...\python3.13` still isn't resolved, because `extension()` reports `13` and the branch is skipped.

## Test Plan

New `python_find_extensionless_path` (Windows only) asks `uv python find` for `[VENV]/Scripts/python`.

Against `main`:

```
    1       │-exit_code: 0 (success)
    2       │------ stdout -----
    3       │-[VENV]/Scripts/python.exe
          1 │+exit_code: 2 (failure)
          2 │+----- stderr -----
          3 │+error: No interpreter found at path `.venv/Scripts/python`
```

With the change:

```console
$ cargo test -p uv --test python -- python_find::
test result: FAILED. 22 passed; 1 failed
```

The failure is `python_find_path`, and it fails identically before and after: `with_filtered_not_executable` matches the English wording of `os error 193`, and this is a non-English Windows install, so the localized message isn't filtered. The only diff in that snapshot is that message.

```console
$ cargo test -p uv-python --lib
test result: ok. 84 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo fmt --all --check` and `cargo clippy -p uv-python -p uv --all-targets --locked -- -D warnings` are clean.
