### PR TITLE
Quote the whole assignment in the Command Prompt PATH hint

### DIFF
--- a/crates/uv-shell/src/lib.rs
+++ b/crates/uv-shell/src/lib.rs
@@ -283,10 +283,9 @@ impl Shell {
                 "$env:PATH = \"{};$env:PATH\"",
                 backtick_escape(&path.simplified_display().to_string()),
             )),
-            Self::Cmd => Some(format!(
-                "set PATH=\"{};%PATH%\"",
-                backslash_escape(&path.simplified_display().to_string()),
-            )),
+            // Command Prompt has no escape character, and quoting the value rather than the whole
+            // assignment would make the quotes part of `PATH`.
+            Self::Cmd => Some(format!("set \"PATH={};%PATH%\"", path.simplified_display())),
         }
     }
 }
@@ -457,6 +456,16 @@ mod tests {
                     vec![tmp_zdotdir.path().join(".zshenv")]
                 );
             },
+        );
+    }
+
+    #[test]
+    fn prepend_path_cmd() {
+        assert_eq!(
+            Shell::Cmd
+                .prepend_path(Path::new(r"C:\Users\ferris\.local\bin"))
+                .unwrap(),
+            r#"set "PATH=C:\Users\ferris\.local\bin;%PATH%""#
         );
     }
 }


### PR DESCRIPTION
## Summary

When `~/.local/bin` isn't on `PATH`, uv suggests a command to add it. From Command Prompt, the command it suggests doesn't work:

```
C:\>uv tool install pycowsay
...
Installed 1 executable: pycowsay
warning: `C:\Users\ferris\.local\bin` is not on your PATH. To use installed tools, run `set PATH="C:\\Users\\ferris\\.local\\bin;%PATH%"` or `uv tool update-shell`.
```

Two things are wrong with `set PATH="C:\\Users\\ferris\\.local\\bin;%PATH%"`:

- Command Prompt has no escape character, so the doubled backslashes stay in the value and name a directory that doesn't exist.
- `set NAME="value"` puts the quotes *in* the value. The first `PATH` entry gains a leading `"` and the last one gains a trailing `"`, so both stop resolving. The quotes belong around the whole assignment: `set "NAME=value"`.

Side by side in `cmd.exe`, with a `demotool.cmd` in the directory being added:

```
--- uv suggestion on main ---
'demotool' is not recognized as an internal or external command,
operable program or batch file.
--- uv suggestion with this change ---
demotool ran
```

The PowerShell arm was corrected in #16307; this is the same class of problem in the Command Prompt arm.

`set "NAME=value"` also protects `&`, `^`, `|`, `<`, `>` and spaces, so no escaping is needed inside. `"` can't appear in a Windows path.

## Test Plan

New `prepend_path_cmd` unit test in `uv-shell`. There is no integration coverage of `prepend_path` for any shell, and the crate's other behavior is covered by unit tests in the same module, so this follows those.

Against `main`:

```
---- tests::prepend_path_cmd stdout ----
assertion `left == right` failed
  left: "set PATH=\"C:\\\\Users\\\\ferris\\\\.local\\\\bin;%PATH%\""
 right: "set \"PATH=C:\\Users\\ferris\\.local\\bin;%PATH%\""
```

With the change:

```console
$ cargo test -p uv-shell --lib
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

And from the built binary, with `PROMPT` set so the shell is detected as Command Prompt:

```
warning: `C:\Users\...\bin` is not on your PATH. To use installed tools, run `set "PATH=C:\Users\...\bin;%PATH%"` or `uv tool update-shell`.
```

`cargo fmt --all --check` and `cargo clippy -p uv-shell --all-targets --locked -- -D warnings` are clean.
