### PR TITLE
Rename the hint-producing trait to Hinted

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -95,10 +95,10 @@ pub enum Error {
     GzipWrite(PathBuf, #[source] io::Error),
 }
 
-impl uv_errors::Hint for Error {
+impl uv_errors::Hinted for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
-            Self::PortableGlob { source, .. } => uv_errors::Hint::hints(source),
+            Self::PortableGlob { source, .. } => uv_errors::Hinted::hints(source),
             _ => uv_errors::Hints::none(),
         }
     }
@@ -493,7 +493,7 @@ mod tests {
     use tar_codec::{Archive as _, TarArchive, extract::ExtractPolicy};
     use tempfile::TempDir;
     use uv_distribution_filename::{SourceDistFilename, WheelFilename};
-    use uv_errors::{ErrorWithHints, Hint};
+    use uv_errors::{ErrorWithHints, Hinted};
     use uv_fs::{copy_dir_all, relative_to};
     use uv_preview::PreviewFeature;
 

--- a/crates/uv-build-frontend/src/error.rs
+++ b/crates/uv-build-frontend/src/error.rs
@@ -10,7 +10,7 @@ use regex::regex;
 use thiserror::Error;
 use uv_configuration::BuildOutput;
 use uv_distribution_types::IsBuildBackendError;
-use uv_errors::{Hint, Hints};
+use uv_errors::{Hinted, Hints};
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
@@ -80,7 +80,7 @@ impl IsBuildBackendError for Error {
     }
 }
 
-impl Hint for Error {
+impl Hinted for Error {
     fn hints(&self) -> Hints<'_> {
         match self {
             Self::BuildBackend(_) => Hints::from(
@@ -450,7 +450,7 @@ mod test {
     use std::process::ExitStatus;
     use std::str::FromStr;
     use uv_configuration::BuildOutput;
-    use uv_errors::{ErrorWithHints, Hint};
+    use uv_errors::{ErrorWithHints, Hinted};
     use uv_normalize::PackageName;
     use uv_pep440::Version;
 

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -16,7 +16,7 @@ use crate::{FlatIndexError, html};
 use uv_cache::Error as CacheError;
 use uv_distribution_filename::{WheelFilename, WheelFilenameError};
 use uv_distribution_types::IndexUrl;
-use uv_errors::{Hint, Hints};
+use uv_errors::{Hinted, Hints};
 use uv_git::GitError;
 use uv_normalize::PackageName;
 use uv_pypi_types::HashDigest;
@@ -376,7 +376,7 @@ impl Error {
     }
 }
 
-impl Hint for Error {
+impl Hinted for Error {
     fn hints(&self) -> Hints<'_> {
         if self.suggests_system_certs() {
             Hints::from(format!(

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -15,7 +15,7 @@ use url::Url;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Certificates, RegistryClientBuilder};
 use uv_distribution_types::IndexUrl;
-use uv_errors::{ErrorOptions, Hint, write_error_chain_with_options};
+use uv_errors::{ErrorOptions, Hinted, write_error_chain_with_options};
 use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -68,7 +68,7 @@ pub enum BuildDispatchError {
     Lookahead(#[from] uv_requirements::Error),
 }
 
-impl uv_errors::Hint for BuildDispatchError {
+impl uv_errors::Hinted for BuildDispatchError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::BuildFrontend(err) => err.hints(),

--- a/crates/uv-distribution-types/src/dist_error.rs
+++ b/crates/uv-distribution-types/src/dist_error.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 
 /// Inspect whether an error type is a build error.
-pub trait IsBuildBackendError: uv_errors::Hint + std::error::Error + Send + Sync + 'static {
+pub trait IsBuildBackendError:
+    uv_errors::Hinted + std::error::Error + Send + Sync + 'static
+{
     /// Returns whether the build backend failed to build the package, so it's not a uv error.
     fn is_build_backend_error(&self) -> bool;
 }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -230,11 +230,11 @@ impl From<reqwest_middleware::Error> for Error {
     }
 }
 
-impl uv_errors::Hint for Error {
+impl uv_errors::Hinted for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::Build(err) => err.hints(),
-            Self::Client(err) => uv_errors::Hint::hints(err),
+            Self::Client(err) => uv_errors::Hinted::hints(err),
             Self::MetadataLowering(err) => err.hints(),
             _ => uv_errors::Hints::none(),
         }

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -619,7 +619,7 @@ pub enum LoweringError {
     RelativeTo(io::Error),
 }
 
-impl uv_errors::Hint for LoweringError {
+impl uv_errors::Hinted for LoweringError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::MissingIndex {

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -54,7 +54,7 @@ pub enum MetadataError {
     IncompleteSourceGroup(PackageName, GroupName),
 }
 
-impl uv_errors::Hint for MetadataError {
+impl uv_errors::Hinted for MetadataError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::LoweringError(_, err) | Self::GroupLoweringError(_, _, err) => err.hints(),

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -14,7 +14,7 @@ use line_wrap::{get_wrap_width, wrap_text};
 /// Implement this on error types that want to surface contextual suggestions
 /// (e.g., "try `--prerelease=allow`") to the diagnostics layer. Hints are
 /// rendered after the error output, each prefixed with `hint:`.
-pub trait Hint {
+pub trait Hinted {
     /// Return any hints associated with this error.
     fn hints(&self) -> Hints<'_> {
         Hints::none()

--- a/crates/uv-globfilter/src/portable_glob.rs
+++ b/crates/uv-globfilter/src/portable_glob.rs
@@ -45,7 +45,7 @@ pub enum PortableGlobError {
     TrailingEscape { glob: String, pos: usize },
 }
 
-impl uv_errors::Hint for PortableGlobError {
+impl uv_errors::Hinted for PortableGlobError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::InvalidCharacterUv { .. } => {
@@ -223,7 +223,7 @@ impl PortableGlobParser {
 mod tests {
     use super::*;
     use insta::assert_snapshot;
-    use uv_errors::{ErrorWithHints, Hint};
+    use uv_errors::{ErrorWithHints, Hinted};
 
     #[test]
     fn test_error() {

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -221,7 +221,7 @@ impl fmt::Display for IncompatibleWheelError {
 
 impl std::error::Error for IncompatibleWheelError {}
 
-impl uv_errors::Hint for IncompatibleWheelError {
+impl uv_errors::Hinted for IncompatibleWheelError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         if let Some(hint) = &self.compatibility_hint {
             uv_errors::Hints::from(hint.to_string())

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -311,7 +311,7 @@ pub enum Error {
     BuildVersion(#[from] crate::python_version::BuildVersionError),
 }
 
-impl uv_errors::Hint for Error {
+impl uv_errors::Hinted for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::Query(err, _, _) => err.hints(),

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -865,7 +865,7 @@ pub enum Error {
     Encode(#[from] rmp_serde::encode::Error),
 }
 
-impl uv_errors::Hint for Error {
+impl uv_errors::Hinted for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::BrokenLink(err) => err.hints(),
@@ -902,7 +902,7 @@ impl Display for BrokenLink {
     }
 }
 
-impl uv_errors::Hint for BrokenLink {
+impl uv_errors::Hinted for BrokenLink {
     fn hints(&self) -> uv_errors::Hints<'_> {
         if self.venv {
             uv_errors::Hints::from(format!(

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -174,7 +174,7 @@ impl std::fmt::Display for MissingPythonHint {
     }
 }
 
-impl uv_errors::Hint for Error {
+impl uv_errors::Hinted for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::MissingPython(_, Some(hint)) => uv_errors::Hints::from(hint.to_string()),

--- a/crates/uv-requirements-txt/src/requirement.rs
+++ b/crates/uv-requirements-txt/src/requirement.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::path::Path;
 
-use uv_errors::{Hint, Hints};
+use uv_errors::{Hinted, Hints};
 use uv_pep508::{
     Pep508Error, Pep508ErrorSource, RequirementOrigin, TracingReporter, UnnamedRequirement,
     VersionOrUrl,
@@ -17,7 +17,7 @@ pub enum MakeEditableError {
     Url(#[from] uv_pypi_types::MakeEditableError),
 }
 
-impl Hint for MakeEditableError {
+impl Hinted for MakeEditableError {
     fn hints(&self) -> Hints<'_> {
         Hints::from("Editable requirements must refer to a local directory")
     }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -150,13 +150,13 @@ pub enum ResolveError {
     },
 }
 
-impl uv_errors::Hint for ResolveError {
+impl uv_errors::Hinted for ResolveError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
-            Self::NoSolution(no_solution) => uv_errors::Hint::hints(no_solution.as_ref()),
-            Self::Client(error) => uv_errors::Hint::hints(error),
-            Self::Distribution(error) => uv_errors::Hint::hints(error),
-            Self::Dependencies(error, ..) => uv_errors::Hint::hints(error.as_ref()),
+            Self::NoSolution(no_solution) => uv_errors::Hinted::hints(no_solution.as_ref()),
+            Self::Client(error) => uv_errors::Hinted::hints(error),
+            Self::Distribution(error) => uv_errors::Hinted::hints(error),
+            Self::Dependencies(error, ..) => uv_errors::Hinted::hints(error.as_ref()),
             _ => uv_errors::Hints::none(),
         }
     }
@@ -892,7 +892,7 @@ impl std::fmt::Debug for NoSolutionError {
 
 impl std::error::Error for NoSolutionError {}
 
-impl uv_errors::Hint for NoSolutionError {
+impl uv_errors::Hinted for NoSolutionError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         self.pubgrub_hints()
             .iter()
@@ -901,7 +901,7 @@ impl uv_errors::Hint for NoSolutionError {
     }
 }
 
-impl uv_errors::Hint for Box<NoSolutionError> {
+impl uv_errors::Hinted for Box<NoSolutionError> {
     fn hints(&self) -> uv_errors::Hints<'_> {
         self.as_ref().hints()
     }

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -213,7 +213,7 @@ impl std::fmt::Display for PylockTomlError {
     }
 }
 
-impl uv_errors::Hint for PylockTomlError {
+impl uv_errors::Hinted for PylockTomlError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         if let Some(hint) = &self.hint {
             uv_errors::Hints::from(hint.to_string())

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -6928,7 +6928,7 @@ impl std::error::Error for LockError {
     }
 }
 
-impl uv_errors::Hint for LockError {
+impl uv_errors::Hinted for LockError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         if let Some(hint) = &self.hint {
             uv_errors::Hints::from(hint.to_string())

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -303,7 +303,7 @@ impl std::error::Error for AnyErrorBuild {
     }
 }
 
-impl uv_errors::Hint for AnyErrorBuild {
+impl uv_errors::Hinted for AnyErrorBuild {
     fn hints(&self) -> uv_errors::Hints<'_> {
         self.0.hints()
     }

--- a/crates/uv-virtualenv/src/lib.rs
+++ b/crates/uv-virtualenv/src/lib.rs
@@ -39,7 +39,7 @@ pub enum Error {
     },
 }
 
-impl uv_errors::Hint for Error {
+impl uv_errors::Hinted for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::Exists { name, .. } => uv_errors::Hints::from(format!(

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1646,7 +1646,7 @@ pub enum SourceError {
     EmptySources,
 }
 
-impl uv_errors::Hint for SourceError {
+impl uv_errors::Hinted for SourceError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::OverlappingMarkers(_, rhs, replacement) => {

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -26,7 +26,7 @@ use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations,
     PackageConfigSettings, Requirement, SourceDist,
 };
-use uv_errors::{ErrorOptions, Hint, Hints, write_error_chain_with_options};
+use uv_errors::{ErrorOptions, Hinted, Hints, write_error_chain_with_options};
 use uv_fs::{Simplified, normalize_path, relative_to};
 use uv_install_wheel::LinkMode;
 use uv_normalize::PackageName;
@@ -108,7 +108,7 @@ impl From<ProjectError> for Error {
     }
 }
 
-impl Hint for Error {
+impl Hinted for Error {
     fn hints(&self) -> Hints<'_> {
         match self {
             Self::BuildBackend(err) => err.hints(),

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -8,7 +8,7 @@ use version_ranges::Ranges;
 use uv_distribution_types::{
     DerivationChain, DerivationStep, Dist, DistErrorKind, Name, RequestedDist,
 };
-use uv_errors::{Hint, Hints};
+use uv_errors::{Hinted, Hints};
 use uv_normalize::PackageName;
 use uv_pep440::{Version, strip_local_version_sentinels};
 
@@ -227,7 +227,7 @@ pub(crate) fn write_error_chain(err: &anyhow::Error, printer: Printer) -> std::f
 ///
 /// This is the central "hint for error" function. It walks the full error chain
 /// (via `anyhow::Error::chain`) and tries to downcast each error to known types
-/// that implement [`Hint`]. All hint rendering logic should be consolidated here.
+/// that implement [`Hinted`]. All hint rendering logic should be consolidated here.
 pub(crate) fn hints_for_error(err: &anyhow::Error) -> Hints<'static> {
     let mut hints = Hints::none();
     for cause in err.chain() {
@@ -265,7 +265,7 @@ pub(crate) fn hints_for_error(err: &anyhow::Error) -> Hints<'static> {
 }
 
 /// If `cause` can be downcast to `T`, collect its hints.
-fn collect_hint<T: Hint + std::error::Error + 'static>(
+fn collect_hint<T: Hinted + std::error::Error + 'static>(
     cause: &(dyn std::error::Error + 'static),
     hints: &mut Hints<'static>,
 ) {

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -6,7 +6,7 @@ use owo_colors::OwoColorize;
 use thiserror::Error;
 use tracing::{Level, debug, enabled, warn};
 
-use uv_errors::{Hint, Hints};
+use uv_errors::{Hinted, Hints};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -64,7 +64,7 @@ pub(crate) struct ExternallyManagedError {
     system: bool,
 }
 
-impl Hint for ExternallyManagedError {
+impl Hinted for ExternallyManagedError {
     fn hints(&self) -> Hints<'_> {
         if self.system {
             Hints::from("Virtual environments were not considered due to the `--system` flag")

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -1398,14 +1398,14 @@ pub(crate) enum Error {
     OutdatedEnvironment(Box<Changelog>),
 }
 
-impl uv_errors::Hint for Error {
+impl uv_errors::Hinted for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::Resolve(resolve_err) => resolve_err.hints(),
             Self::Anyhow(err) => {
                 for cause in err.chain() {
                     if let Some(extra_err) = cause.downcast_ref::<ExtrasWithoutSourceError>() {
-                        return uv_errors::Hint::hints(extra_err);
+                        return uv_errors::Hinted::hints(extra_err);
                     }
                 }
                 uv_errors::Hints::none()
@@ -1424,7 +1424,7 @@ pub(crate) struct ExtrasWithoutSourceError {
     has_editable: bool,
 }
 
-impl uv_errors::Hint for ExtrasWithoutSourceError {
+impl uv_errors::Hinted for ExtrasWithoutSourceError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         uv_errors::Hints::from(if self.has_editable {
             "Use `<dir>[extra]` syntax or `-r <file>` instead"

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -401,7 +401,7 @@ impl std::fmt::Display for MalwareFindings {
     }
 }
 
-impl uv_errors::Hint for ProjectError {
+impl uv_errors::Hinted for ProjectError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
             Self::LockMismatch(..) | Self::LockWorkspaceMismatch(..) => {
@@ -416,7 +416,7 @@ impl uv_errors::Hint for ProjectError {
             Self::Lock(err) => err.hints(),
             Self::Python(err) => err.hints(),
             Self::Operation(err) => err.hints(),
-            Self::Client(err) => uv_errors::Hint::hints(err),
+            Self::Client(err) => uv_errors::Hinted::hints(err),
             _ => uv_errors::Hints::none(),
         }
     }

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -474,7 +474,7 @@ pub(crate) struct DependencyNotFoundError {
     found_in: Vec<DependencyType>,
 }
 
-impl uv_errors::Hint for DependencyNotFoundError {
+impl uv_errors::Hinted for DependencyNotFoundError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         self.found_in
             .iter()

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -2166,7 +2166,7 @@ pub(crate) struct RecursionLimitError {
     max: u32,
 }
 
-impl uv_errors::Hint for RecursionLimitError {
+impl uv_errors::Hinted for RecursionLimitError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         uv_errors::Hints::from(format!(
             "If you are running a script with `{}` in the shebang, you may need to include the `{}` flag",

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -380,7 +380,7 @@ pub(crate) struct MissingProjectVersionError {
     err: WorkspaceError,
 }
 
-impl uv_errors::Hint for MissingProjectVersionError {
+impl uv_errors::Hinted for MissingProjectVersionError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         uv_errors::Hints::from(format!(
             "If you meant to view uv's version, use `{}` instead",

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -167,7 +167,7 @@ pub(crate) async fn find_script(
             writeln!(
                 printer.stderr(),
                 "{}",
-                ErrorWithHints::new(&error, uv_errors::Hint::hints(&error))
+                ErrorWithHints::new(&error, uv_errors::Hinted::hints(&error))
             )?;
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -25,7 +25,7 @@ use uv_distribution_types::{
     DependencyMetadata, HashCollection, Index, IndexLocations, InstalledDist, Name, Requirement,
     RequiresPython, Resolution, UnresolvedRequirement,
 };
-use uv_errors::{ErrorWithHints, Hint, Hints};
+use uv_errors::{ErrorWithHints, Hinted, Hints};
 #[cfg(unix)]
 use uv_fs::replace_symlink;
 use uv_fs::{CWD, Simplified};
@@ -68,7 +68,7 @@ pub(crate) enum NoExecutablesError {
     },
 }
 
-impl Hint for NoExecutablesError {
+impl Hinted for NoExecutablesError {
     fn hints(&self) -> Hints<'_> {
         let mut hints = Hints::none();
         let (package, matching_dependency_packages) = match self {

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -1242,7 +1242,7 @@ pub(crate) enum ToolRunScriptError {
     },
 }
 
-impl uv_errors::Hint for ToolRunScriptError {
+impl uv_errors::Hinted for ToolRunScriptError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         uv_errors::Hints::from(match self {
             Self::FromScript {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -117,7 +117,7 @@ struct ExternallyInstalledError {
 }
 
 #[cfg(not(feature = "self-update"))]
-impl uv_errors::Hint for ExternallyInstalledError {
+impl uv_errors::Hinted for ExternallyInstalledError {
     fn hints(&self) -> uv_errors::Hints<'_> {
         if let Some(source) = &self.install_source {
             uv_errors::Hints::from(format!(


### PR DESCRIPTION
Rename `uv_errors::Hint` to `Hinted`. The trait describes an error's ability to provide a collection of contextual hints, while `Hint` is a clearer name for an individual hint value. Update the implementations, trait bounds, and callers without changing diagnostic output or error classification.

Prior work:

- #18090 introduced the hint-producing trait and `Hints` collection.
- #20155 made hints explicit in error-chain rendering.

This prepares the concrete `Hint` type in #21577.
