### PR TITLE
Separate operation context from exit-status classification

### DIFF
--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -151,43 +151,6 @@ impl UvError {
         Self::Unexpected(error)
     }
 
-    /// Classify an operation error with command-specific resolution context.
-    fn from_operation_with_context(error: pip::operations::Error, context: &'static str) -> Self {
-        Self::from_operation(error, Some(context))
-    }
-
-    fn from_operation(error: pip::operations::Error, context: Option<&'static str>) -> Self {
-        let is_user_failure = error.is_user_failure();
-        let error = match error {
-            pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(cause)) => {
-                let header = uv_resolver::NoSolutionHeader::new(cause.environment().clone());
-                let header = if let Some(context) = context {
-                    header.with_context(context)
-                } else {
-                    header
-                };
-                anyhow::Error::new(pip::operations::Error::Resolve(
-                    uv_resolver::ResolveError::NoSolution(cause),
-                ))
-                .context(header)
-            }
-            pip::operations::Error::Requirements(error) => {
-                let error = anyhow::Error::new(pip::operations::Error::Requirements(error));
-                if let Some(context) = context {
-                    error.context(format!("Failed to resolve {context} requirement"))
-                } else {
-                    error
-                }
-            }
-            error => anyhow::Error::new(error),
-        };
-        if is_user_failure {
-            Self::user(error)
-        } else {
-            Self::unexpected(error)
-        }
-    }
-
     /// Add command-specific context to a user error without changing unexpected errors.
     fn map_user(self, context: impl FnOnce(anyhow::Error) -> anyhow::Error) -> Self {
         match self {
@@ -216,7 +179,12 @@ impl From<project::ProjectError> for UvError {
 
 impl From<pip::operations::Error> for UvError {
     fn from(error: pip::operations::Error) -> Self {
-        Self::from_operation(error, None)
+        let error = error.with_default_resolution_context();
+        if error.is_user_failure() {
+            Self::user(error)
+        } else {
+            Self::unexpected(error.into())
+        }
     }
 }
 
@@ -224,12 +192,13 @@ impl From<pip::operations::Error> for UvError {
 mod error_tests {
     use std::io::{Error, ErrorKind};
 
+    use anyhow::bail;
     use insta::{allow_duplicates, assert_snapshot};
 
     use super::{UvError, pip, project};
 
     #[test]
-    fn contextual_operations_keep_their_classification_and_cause() {
+    fn contextual_operations_keep_their_classification_and_cause() -> anyhow::Result<()> {
         for (kind, user_failure) in [
             (ErrorKind::NotFound, true),
             (ErrorKind::PermissionDenied, false),
@@ -237,17 +206,37 @@ mod error_tests {
             let error = pip::operations::Error::Requirements(uv_requirements::Error::Io(
                 Error::new(kind, "requirements failure"),
             ));
-            let error = UvError::from_operation_with_context(error, "tool");
+            let error = UvError::from(
+                error
+                    .with_resolution_context("script")
+                    .with_resolution_context("tool"),
+            );
             let ((UvError::User(error), true) | (UvError::Unexpected(error), false)) =
                 (error, user_failure)
             else {
-                panic!("operation classification changed with context");
+                bail!("operation classification changed with context");
             };
             allow_duplicates! {
-                assert_snapshot!(error, @"Failed to resolve tool requirement");
+                assert_snapshot!(format!("{error:#}"), @"Failed to resolve tool requirement: requirements failure");
             }
             assert!(error.downcast_ref::<pip::operations::Error>().is_some());
         }
+        Ok(())
+    }
+
+    #[test]
+    fn resolution_context_leaves_other_errors_unchanged() -> anyhow::Result<()> {
+        let error = pip::operations::Error::Io(Error::new(
+            ErrorKind::PermissionDenied,
+            "cache write failed",
+        ));
+        let UvError::Unexpected(error) = UvError::from(error.with_resolution_context("tool"))
+        else {
+            bail!("operation classification changed with context");
+        };
+        assert_snapshot!(format!("{error:#}"), @"cache write failed");
+        assert!(error.downcast_ref::<pip::operations::Error>().is_some());
+        Ok(())
     }
 
     #[test]

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -44,8 +44,9 @@ use uv_requirements::{
     RequirementsSpecification, SourceTree, SourceTreeResolution, SourceTreeResolver,
 };
 use uv_resolver::{
-    DependencyMode, Exclusions, FlatIndex, InMemoryIndex, Manifest, Options, Preference,
-    Preferences, PythonRequirement, Resolver, ResolverEnvironment, ResolverOutput, UpgradePackages,
+    DependencyMode, Exclusions, FlatIndex, InMemoryIndex, Manifest, NoSolutionError,
+    NoSolutionHeader, Options, Preference, Preferences, PythonRequirement, ResolveError, Resolver,
+    ResolverEnvironment, ResolverOutput, UpgradePackages,
 };
 use uv_tool::InstalledTools;
 use uv_types::{BuildContext, HashStrategy, InFlight, InstalledPackagesProvider};
@@ -1386,8 +1387,15 @@ pub(crate) enum Error {
     #[error(transparent)]
     Prepare(#[from] uv_installer::PrepareError),
 
+    #[error("{header}")]
+    NoSolution {
+        header: NoSolutionHeader,
+        #[source]
+        source: Box<NoSolutionError>,
+    },
+
     #[error(transparent)]
-    Resolve(#[from] uv_resolver::ResolveError),
+    Resolve(#[from] ResolveError),
 
     #[error(transparent)]
     Uninstall(#[from] uv_installer::UninstallError),
@@ -1404,6 +1412,13 @@ pub(crate) enum Error {
     #[error(transparent)]
     Requirements(#[from] uv_requirements::Error),
 
+    #[error("Failed to resolve {context} requirement")]
+    RequirementsWithContext {
+        context: &'static str,
+        #[source]
+        source: uv_requirements::Error,
+    },
+
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
 
@@ -1412,13 +1427,62 @@ pub(crate) enum Error {
 }
 
 impl Error {
+    /// Add the default heading when this operation is the final command error.
+    ///
+    /// Nested operation errors may already have a more specific heading from their caller.
+    #[must_use]
+    pub(crate) fn with_default_resolution_context(self) -> Self {
+        match self {
+            Self::Resolve(ResolveError::NoSolution(source)) => Self::NoSolution {
+                header: NoSolutionHeader::new(source.environment().clone()),
+                source,
+            },
+            error @ (Self::Prepare(_)
+            | Self::NoSolution { .. }
+            | Self::Resolve(_)
+            | Self::Uninstall(_)
+            | Self::Hash(_)
+            | Self::Io(_)
+            | Self::Fmt(_)
+            | Self::Requirements(_)
+            | Self::RequirementsWithContext { .. }
+            | Self::Anyhow(_)
+            | Self::OutdatedEnvironment(_)) => error,
+        }
+    }
+
+    /// Set the command-specific context for a resolution failure.
+    #[must_use]
+    pub(crate) fn with_resolution_context(self, context: &'static str) -> Self {
+        match self.with_default_resolution_context() {
+            Self::NoSolution { header, source } => Self::NoSolution {
+                header: header.with_context(context),
+                source,
+            },
+            Self::Requirements(source) | Self::RequirementsWithContext { source, .. } => {
+                Self::RequirementsWithContext { context, source }
+            }
+            error @ (Self::Prepare(_)
+            | Self::Resolve(_)
+            | Self::Uninstall(_)
+            | Self::Hash(_)
+            | Self::Io(_)
+            | Self::Fmt(_)
+            | Self::Anyhow(_)
+            | Self::OutdatedEnvironment(_)) => error,
+        }
+    }
+
     /// Return whether this operation failure is an expected user-facing failure.
     pub(crate) fn is_user_failure(&self) -> bool {
         match self {
             Self::Prepare(error) => error.is_user_failure(),
+            Self::NoSolution { .. } => true,
             Self::Resolve(error) => error.is_user_failure(),
             Self::Hash(_) | Self::OutdatedEnvironment(_) => true,
-            Self::Requirements(error) => error.is_user_failure(),
+            Self::Requirements(error) | Self::RequirementsWithContext { source: error, .. } => {
+                error.is_user_failure()
+            }
             Self::Uninstall(_) | Self::Io(_) | Self::Fmt(_) | Self::Anyhow(_) => false,
         }
     }
@@ -1427,6 +1491,7 @@ impl Error {
 impl uv_errors::Hinted for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
+            Self::NoSolution { source, .. } => source.hints(),
             Self::Resolve(uv_resolver::ResolveError::Dist(_, dist, chain, error)) => {
                 crate::commands::diagnostics::dist_hints(
                     dist.name(),
@@ -1439,14 +1504,16 @@ impl uv_errors::Hinted for Error {
                 crate::commands::diagnostics::dist_hints(name, Some(version), chain, error.hints())
             }
             Self::Resolve(error) => error.hints(),
-            Self::Requirements(uv_requirements::Error::Dist(_, dist, error)) => {
-                crate::commands::diagnostics::dist_hints(
-                    dist.name(),
-                    dist.version(),
-                    &DerivationChain::default(),
-                    error.hints(),
-                )
-            }
+            Self::Requirements(uv_requirements::Error::Dist(_, dist, error))
+            | Self::RequirementsWithContext {
+                source: uv_requirements::Error::Dist(_, dist, error),
+                ..
+            } => crate::commands::diagnostics::dist_hints(
+                dist.name(),
+                dist.version(),
+                &DerivationChain::default(),
+                error.hints(),
+            ),
             Self::Prepare(uv_installer::PrepareError::Dist(_, dist, chain, error)) => {
                 crate::commands::diagnostics::dist_hints(
                     dist.name(),
@@ -1463,7 +1530,14 @@ impl uv_errors::Hinted for Error {
                 }
                 uv_errors::Hints::none()
             }
-            _ => uv_errors::Hints::none(),
+            Self::Prepare(_)
+            | Self::Uninstall(_)
+            | Self::Hash(_)
+            | Self::Io(_)
+            | Self::Fmt(_)
+            | Self::Requirements(_)
+            | Self::RequirementsWithContext { .. }
+            | Self::OutdatedEnvironment(_) => uv_errors::Hints::none(),
         }
     }
 }

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -265,7 +265,7 @@ pub(crate) async fn run(
             {
                 Ok(result) => result.into_lock(),
                 Err(ProjectError::Operation(err)) => {
-                    return Err(UvError::from_operation_with_context(err, "script").into());
+                    return Err(UvError::from(err.with_resolution_context("script")).into());
                 }
                 Err(err) => return Err(UvError::from(err).into()),
             };
@@ -308,7 +308,7 @@ pub(crate) async fn run(
             {
                 Ok(_) => {}
                 Err(ProjectError::Operation(err)) => {
-                    return Err(UvError::from_operation_with_context(err, "script").into());
+                    return Err(UvError::from(err.with_resolution_context("script")).into());
                 }
                 Err(err) => return Err(UvError::from(err).into()),
             }
@@ -449,7 +449,7 @@ pub(crate) async fn run(
                 {
                     Ok(update) => Some(update.into_environment().into_interpreter()),
                     Err(ProjectError::Operation(err)) => {
-                        return Err(UvError::from_operation_with_context(err, "script").into());
+                        return Err(UvError::from(err.with_resolution_context("script")).into());
                     }
                     Err(err) => return Err(UvError::from(err).into()),
                 }
@@ -1001,7 +1001,7 @@ pub(crate) async fn run(
             let environment = match result {
                 Ok(resolution) => resolution,
                 Err(ProjectError::Operation(err)) => {
-                    return Err(UvError::from_operation_with_context(err, "`--with`").into());
+                    return Err(UvError::from(err.with_resolution_context("`--with`")).into());
                 }
                 Err(err) => return Err(UvError::from(err).into()),
             };

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -335,7 +335,7 @@ pub(crate) async fn run(
             // If the user ran `uvx run ...`, the `run` is likely a mistake. Show a dedicated hint.
             if from.is_none() && invocation_source == ToolRunCommand::Uvx && target == "run" {
                 let rest = args.iter().map(|s| s.to_string_lossy()).join(" ");
-                return Err(UvError::from_operation_with_context(err, "tool")
+                return Err(UvError::from(err.with_resolution_context("tool"))
                     .map_user(|cause| {
                         ToolRunUsageError {
                             cause,
@@ -362,13 +362,12 @@ pub(crate) async fn run(
                     .into());
             }
 
-            return Err(UvError::from_operation_with_context(err, "tool").into());
+            return Err(UvError::from(err.with_resolution_context("tool")).into());
         }
 
         Err(ProjectError::Requirements(err)) => {
-            return Err(UvError::from_operation_with_context(
-                operations::Error::Requirements(err),
-                "`--with`",
+            return Err(UvError::from(
+                operations::Error::Requirements(err).with_resolution_context("`--with`"),
             )
             .into());
         }


### PR DESCRIPTION
Resolution headings are assembled inside `UvError::from_operation`, mixing operation-specific formatting with exit-status selection. Store no-solution and contextual-requirement headings as typed `operations::Error` variants, and attach command context before converting to `UvError`. Add the default no-solution heading only at the final command-error boundary so errors nested under higher-level build or tool messages do not gain redundant headings. The original sources and hints remain available, and diagnostic output and exit-status policy are unchanged.

Prior work:

- #20188 introduced the explicit `UvError` model.
- #17110 routes operation errors through the standard diagnostic path.
- #21566 uses that path for batched tool-upgrade failures.
