### PR TITLE
Reuse direct URL wheels across hash fragments

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -242,6 +242,7 @@ impl CachedClient {
     >(
         &self,
         req: Request,
+        cache_read_entry: &CacheEntry,
         cache_entry: &CacheEntry,
         cache_control: CacheControl,
         response_callback: Callback,
@@ -250,7 +251,7 @@ impl CachedClient {
 
         if matches!(cache_control, CacheControl::AllowStale) {
             let (req, cached) = self
-                .read_and_decode_stale_cache::<Payload>(req, cache_entry)
+                .read_and_decode_stale_cache::<Payload>(req, cache_read_entry)
                 .await;
             match cached {
                 Ok(Some(payload)) => return Ok(payload),
@@ -259,14 +260,17 @@ impl CachedClient {
                     DisplaySafeUrl::from_url(req.url().clone())
                 ),
                 Err(err) if err.is_file_not_exists() => {
-                    trace!("No cache entry exists for {}", cache_entry.path().display());
+                    trace!(
+                        "No cache entry exists for {}",
+                        cache_read_entry.path().display()
+                    );
                 }
                 Err(err) => {
                     warn!(
                         "Broken cache entry at {}, removing: {err}",
-                        cache_entry.path().display()
+                        cache_read_entry.path().display()
                     );
-                    let _ = fs_err::tokio::remove_file(&cache_entry.path()).await;
+                    let _ = fs_err::tokio::remove_file(cache_read_entry.path()).await;
                 }
             }
 
@@ -283,7 +287,7 @@ impl CachedClient {
         }
 
         let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
-        let cached_response = if let Some(cached) = self.read_cache(cache_entry).await {
+        let cached_response = if let Some(cached) = self.read_cache(cache_read_entry).await {
             self.send_cached(req, cache_control.clone(), cached)
                 .boxed_local()
                 .await?
@@ -327,6 +331,9 @@ impl CachedClient {
                 async {
                     let data_with_cache_policy_bytes =
                         DataWithCachePolicy::serialize(&new_policy, &cached.data)?;
+                    fs_err::tokio::create_dir_all(cache_entry.dir())
+                        .await
+                        .map_err(ErrorKind::CacheWrite)?;
                     write_atomic(cache_entry.path(), data_with_cache_policy_bytes)
                         .await
                         .map_err(ErrorKind::CacheWrite)?;
@@ -713,11 +720,42 @@ impl CachedClient {
         cache_control: CacheControl,
         response_callback: Callback,
     ) -> Result<Payload, CachedClientError<CallBackError>> {
+        self.get_serde_with_retry_from(
+            req,
+            cache_entry,
+            cache_entry,
+            cache_control,
+            response_callback,
+        )
+        .await
+    }
+
+    /// Make a cached request, reading from one entry and writing new or revalidated responses to
+    /// another. This allows callers to reuse an older cache key without continuing to populate it.
+    #[instrument(skip_all)]
+    pub async fn get_serde_with_retry_from<
+        Payload: Serialize + DeserializeOwned + Send + 'static,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+    >(
+        &self,
+        req: Request,
+        cache_read_entry: &CacheEntry,
+        cache_entry: &CacheEntry,
+        cache_control: CacheControl,
+        response_callback: Callback,
+    ) -> Result<Payload, CachedClientError<CallBackError>> {
         let payload = self
-            .get_cacheable_with_retry(req, cache_entry, cache_control, async |resp| {
-                let payload = response_callback(resp).await?;
-                Ok(SerdeCacheable { inner: payload })
-            })
+            .get_cacheable_with_retry_from(
+                req,
+                cache_read_entry,
+                cache_entry,
+                cache_control,
+                async |resp| {
+                    let payload = response_callback(resp).await?;
+                    Ok(SerdeCacheable { inner: payload })
+                },
+            )
             .await?;
         Ok(payload)
     }
@@ -737,12 +775,36 @@ impl CachedClient {
         cache_control: CacheControl,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
+        self.get_cacheable_with_retry_from(
+            req,
+            cache_entry,
+            cache_entry,
+            cache_control,
+            response_callback,
+        )
+        .boxed_local()
+        .await
+    }
+
+    async fn get_cacheable_with_retry_from<
+        Payload: Cacheable + 'static,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+    >(
+        &self,
+        req: Request,
+        cache_read_entry: &CacheEntry,
+        cache_entry: &CacheEntry,
+        cache_control: CacheControl,
+        response_callback: Callback,
+    ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let mut retry_state = RetryState::start(self.uncached().retry_policy(), req.url().clone());
         loop {
             let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
             let result = self
                 .get_cacheable(
                     fresh_req,
+                    cache_read_entry,
                     cache_entry,
                     cache_control.clone(),
                     &response_callback,

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -245,6 +245,7 @@ impl CachedClient {
         cache_read_entry: &CacheEntry,
         cache_entry: &CacheEntry,
         cache_control: CacheControl,
+        cache_validator: impl Fn(&Payload::Target) -> Result<bool, CallBackError>,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let start = Instant::now();
@@ -254,7 +255,19 @@ impl CachedClient {
                 .read_and_decode_stale_cache::<Payload>(req, cache_read_entry)
                 .await;
             match cached {
-                Ok(Some(payload)) => return Ok(payload),
+                Ok(Some(payload)) => {
+                    if cache_validator(&payload).map_err(|err| CachedClientError::Callback {
+                        retries: 0,
+                        err,
+                        duration: start.elapsed(),
+                    })? {
+                        return Ok(payload);
+                    }
+                    debug!(
+                        "Cached response rejected: {}",
+                        cache_read_entry.path().display()
+                    );
+                }
                 Ok(None) => warn!(
                     "Cached response doesn't match current request for: {}",
                     DisplaySafeUrl::from_url(req.url().clone())
@@ -302,29 +315,8 @@ impl CachedClient {
                 cache_policy,
             }
         };
-        match cached_response {
-            CachedResponse::FreshCache(cached) => match self
-                .0
-                .cache_read_runtime()
-                .spawn_blocking(move || Payload::from_aligned_bytes(cached.data))
-                .await
-                .expect("cache payload decoding task panicked")
-            {
-                Ok(payload) => Ok(payload),
-                Err(err) => {
-                    warn!(
-                        "Broken fresh cache entry (for payload) at {}, removing: {err}",
-                        cache_entry.path().display()
-                    );
-                    self.resend_and_heal_cache(
-                        fresh_req,
-                        cache_entry,
-                        cache_control.clone(),
-                        response_callback,
-                    )
-                    .await
-                }
-            },
+        let cached = match cached_response {
+            CachedResponse::FreshCache(cached) => cached,
             CachedResponse::NotModified { cached, new_policy } => {
                 let refresh_cache =
                     info_span!("refresh_cache", file = %cache_entry.path().display());
@@ -337,63 +329,68 @@ impl CachedClient {
                     write_atomic(cache_entry.path(), data_with_cache_policy_bytes)
                         .await
                         .map_err(ErrorKind::CacheWrite)?;
-                    match self
-                        .0
-                        .cache_read_runtime()
-                        .spawn_blocking(move || Payload::from_aligned_bytes(cached.data))
-                        .await
-                        .expect("cache payload decoding task panicked")
-                    {
-                        Ok(payload) => Ok(payload),
-                        Err(err) => {
-                            warn!(
-                                "Broken fresh cache entry after revalidation \
-                                 (for payload) at {}, removing: {err}",
-                                cache_entry.path().display()
-                            );
-                            self.resend_and_heal_cache(
-                                fresh_req,
-                                cache_entry,
-                                cache_control.clone(),
-                                response_callback,
-                            )
-                            .await
-                        }
-                    }
+                    Ok::<_, Error>(cached)
                 }
                 .instrument(refresh_cache)
-                .await
+                .await?
             }
             CachedResponse::ModifiedOrNew {
                 response,
                 cache_policy,
             } => {
-                // If we got a modified response, but it's a 304, then a validator failed (e.g., the
-                // ETag didn't match). We need to make a fresh request.
+                // An unusable 304 requires a fresh request instead of the response callback.
                 if response.status() == http::StatusCode::NOT_MODIFIED {
                     warn!(
                         "Server returned unusable 304 for: {}",
                         DisplaySafeUrl::from_url(fresh_req.url().clone())
                     );
-                    self.resend_and_heal_cache(
-                        fresh_req,
-                        cache_entry,
-                        cache_control,
-                        response_callback,
-                    )
-                    .await
                 } else {
-                    self.run_response_callback(
-                        cache_entry,
-                        cache_policy,
-                        start,
-                        response,
-                        response_callback,
-                    )
-                    .await
+                    return self
+                        .run_response_callback(
+                            cache_entry,
+                            cache_policy,
+                            start,
+                            response,
+                            response_callback,
+                        )
+                        .await;
                 }
+                let _ = fs_err::tokio::remove_file(cache_entry.path()).await;
+                return self
+                    .fetch_and_cache(fresh_req, cache_entry, cache_control, response_callback)
+                    .await;
+            }
+        };
+        match self
+            .0
+            .cache_read_runtime()
+            .spawn_blocking(move || Payload::from_aligned_bytes(cached.data))
+            .await
+            .expect("cache payload decoding task panicked")
+        {
+            Ok(payload) => {
+                if cache_validator(&payload).map_err(|err| CachedClientError::Callback {
+                    retries: 0,
+                    err,
+                    duration: start.elapsed(),
+                })? {
+                    return Ok(payload);
+                }
+                debug!(
+                    "Cached response rejected: {}",
+                    cache_read_entry.path().display()
+                );
+            }
+            Err(err) => {
+                warn!(
+                    "Broken cache entry (for payload) at {}, removing: {err}",
+                    cache_read_entry.path().display()
+                );
+                let _ = fs_err::tokio::remove_file(cache_read_entry.path()).await;
             }
         }
+        self.fetch_and_cache(fresh_req, cache_entry, cache_control, response_callback)
+            .await
     }
 
     /// Make a request without checking whether the cache is fresh.
@@ -421,7 +418,7 @@ impl CachedClient {
         Ok(payload)
     }
 
-    async fn resend_and_heal_cache<
+    async fn fetch_and_cache<
         Payload: Cacheable,
         CallBackError: std::error::Error + 'static,
         Callback: AsyncFnOnce(Response) -> Result<Payload, CallBackError>,
@@ -432,7 +429,6 @@ impl CachedClient {
         cache_control: CacheControl,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
-        let _ = fs_err::tokio::remove_file(&cache_entry.path()).await;
         let start = Instant::now();
         let (response, cache_policy) = self.fresh_request(req, cache_control).await?;
         self.run_response_callback(
@@ -725,6 +721,7 @@ impl CachedClient {
             cache_entry,
             cache_entry,
             cache_control,
+            |_| Ok(true),
             response_callback,
         )
         .await
@@ -732,6 +729,9 @@ impl CachedClient {
 
     /// Make a cached request, reading from one entry and writing new or revalidated responses to
     /// another. This allows callers to reuse an older cache key without continuing to populate it.
+    /// The `cache_validator` returns `Ok(true)` to reuse a cached value, `Ok(false)` to fetch it
+    /// again, or an error to stop the request. Fresh responses are passed to `response_callback`
+    /// without applying the cache validator.
     #[instrument(skip_all)]
     pub async fn get_serde_with_retry_from<
         Payload: Serialize + DeserializeOwned + Send + 'static,
@@ -743,6 +743,7 @@ impl CachedClient {
         cache_read_entry: &CacheEntry,
         cache_entry: &CacheEntry,
         cache_control: CacheControl,
+        cache_validator: impl Fn(&Payload) -> Result<bool, CallBackError>,
         response_callback: Callback,
     ) -> Result<Payload, CachedClientError<CallBackError>> {
         let payload = self
@@ -751,6 +752,7 @@ impl CachedClient {
                 cache_read_entry,
                 cache_entry,
                 cache_control,
+                cache_validator,
                 async |resp| {
                     let payload = response_callback(resp).await?;
                     Ok(SerdeCacheable { inner: payload })
@@ -780,6 +782,7 @@ impl CachedClient {
             cache_entry,
             cache_entry,
             cache_control,
+            |_| Ok(true),
             response_callback,
         )
         .boxed_local()
@@ -796,6 +799,7 @@ impl CachedClient {
         cache_read_entry: &CacheEntry,
         cache_entry: &CacheEntry,
         cache_control: CacheControl,
+        cache_validator: impl Fn(&Payload::Target) -> Result<bool, CallBackError>,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let mut retry_state = RetryState::start(self.uncached().retry_policy(), req.url().clone());
@@ -807,6 +811,7 @@ impl CachedClient {
                     cache_read_entry,
                     cache_entry,
                     cache_control.clone(),
+                    &cache_validator,
                     &response_callback,
                 )
                 .await;

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -283,8 +283,13 @@ impl ArchivedCachePolicy {
     /// checks because those produce [`BeforeRequest::Stale`], which an allow-stale caller accepts.
     pub(crate) fn matches_stale_request(&self, request: &reqwest::Request) -> bool {
         self.is_storable()
-            && self.request.uri == request.url().as_str()
+            && self.matches_uri(request)
             && (request.method() == http::Method::GET || request.method() == http::Method::HEAD)
+    }
+
+    /// Fragments are not part of the HTTP request target. Older cache entries may include them.
+    fn matches_uri(&self, request: &reqwest::Request) -> bool {
+        self.request.uri.split('#').next() == request.url().as_str().split('#').next()
     }
 
     /// Determines what caching behavior is correct given an existing
@@ -329,7 +334,7 @@ impl ArchivedCachePolicy {
         //
         // "the presented target URI and that of the stored response match,
         // and..."
-        if self.request.uri != request.url().as_str() {
+        if !self.matches_uri(request) {
             tracing::trace!(
                 "Request {} does not match cache URL of {}",
                 request.url(),

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -274,7 +274,7 @@ pub struct DirectUrlBuiltDist {
     /// We require that wheel urls end in the full wheel filename, e.g.
     /// `https://example.org/packages/flask-3.0.0-py3-none-any.whl`
     pub filename: WheelFilename,
-    /// The URL without the subdirectory fragment.
+    /// The URL without fragments (which are not used in comparisons)
     pub location: Box<DisplaySafeUrl>,
     /// The URL as it was provided by the user.
     pub url: VerbatimUrl,

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -274,7 +274,7 @@ pub struct DirectUrlBuiltDist {
     /// We require that wheel urls end in the full wheel filename, e.g.
     /// `https://example.org/packages/flask-3.0.0-py3-none-any.whl`
     pub filename: WheelFilename,
-    /// The URL without fragments (which are not used in comparisons)
+    /// The URL without fragments.
     pub location: Box<DisplaySafeUrl>,
     /// The URL as it was provided by the user.
     pub url: VerbatimUrl,

--- a/crates/uv-distribution/src/archive.rs
+++ b/crates/uv-distribution/src/archive.rs
@@ -1,8 +1,10 @@
 use serde::ser::SerializeMap;
 use uv_cache::{ARCHIVE_VERSION, ArchiveId, Cache};
 use uv_distribution_filename::WheelFilename;
-use uv_distribution_types::Hashed;
+use uv_distribution_types::{ArchiveHashPolicy, DirectUrlBuiltDist, Hashed};
 use uv_pypi_types::{HashDigest, HashDigests};
+
+use crate::hash::url_hashes_for_cache;
 
 /// An archive (unzipped wheel) that exists in the local cache.
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -52,6 +54,23 @@ impl Archive {
             version: ARCHIVE_VERSION,
             size,
         }
+    }
+
+    /// Whether this cached archive can satisfy the direct URL request.
+    pub(crate) fn matches_direct_url(
+        &self,
+        cache: &Cache,
+        wheel: &DirectUrlBuiltDist,
+        hashes: ArchiveHashPolicy<'_>,
+    ) -> bool {
+        let url_hashes = url_hashes_for_cache(&wheel.url, hashes);
+        let cache_hashes = url_hashes
+            .as_ref()
+            .map_or(hashes, |hashes| ArchiveHashPolicy::All(hashes.as_slice()));
+        self.satisfies(cache_hashes)
+            && self.has_digests(hashes)
+            && wheel.size.is_none_or(|size| self.size == Some(size))
+            && self.exists(cache)
     }
 
     /// Returns `true` if the archive exists in the cache.

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -5,7 +5,6 @@ use std::iter::once;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
@@ -44,7 +43,7 @@ use uv_types::{BuildContext, BuildStack};
 use crate::archive::Archive;
 use crate::error::PythonVersion;
 use crate::extracted_wheel::{ExtractedWheel, HashedWheel, WheelExtractor};
-use crate::hash::{http_wheel_hash_algorithms, url_hashes_for_generation};
+use crate::hash::http_wheel_hash_algorithms;
 use crate::metadata::{ArchiveMetadata, Metadata};
 use crate::source::SourceDistributionBuilder;
 use crate::{Error, LocalWheel, Reporter, RequiresDist};
@@ -609,36 +608,15 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             return Ok(ArchiveMetadata::from_metadata23(metadata));
         }
 
-        // A shared archive can be replaced through another URL fragment while the metadata
-        // cache still describes the old wheel. Read its metadata through the archive's HTTP
-        // cache, so we also honor expiration and refresh mismatched hashes before resolution.
+        // Cached archives determine both installed contents and metadata. Resolve through the
+        // same HTTP cache so changed hashes and expired responses are refreshed together.
         if let BuiltDist::DirectUrl(wheel) = dist
-            && once(wheel.location.as_ref())
-                .chain((wheel.location.as_ref() != wheel.url.raw()).then_some(wheel.url.raw()))
-                .any(|location| {
-                    self.build_context
-                        .cache()
-                        .entry(
-                            CacheBucket::Wheels,
-                            WheelCache::Url(location).wheel_dir(wheel.name().as_ref()),
-                            format!("{}.http", wheel.filename.cache_key()),
-                        )
-                        .path()
-                        .exists()
-                })
+            && HttpArchivePointer::read_entries(self.build_context.cache(), wheel)
+                .next()
+                .is_some()
         {
-            let url_hashes = parse_url_hashes(&wheel.url);
-            let cache_hashes = if hash_policy.is_none() {
-                url_hashes.as_ref().map_or(hash_policy, |hashes| {
-                    ArchiveHashPolicy::All(hashes.as_slice())
-                })
-            } else {
-                hash_policy
-            };
-            let wheel = self.get_wheel(dist, cache_hashes).await?;
-            if wheel.satisfies(cache_hashes) {
-                return Ok(ArchiveMetadata::from_metadata23(wheel.metadata()?));
-            }
+            let wheel = self.get_wheel(dist, hash_policy).await?;
+            return Ok(ArchiveMetadata::from_metadata23(wheel.metadata()?));
         }
 
         let result = self
@@ -766,8 +744,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             BuiltDist::DirectUrl(_) => size,
             _ => None,
         };
-        let is_online_direct_url = self.client.unmanaged.connectivity().is_online()
-            && matches!(dist, BuiltDist::DirectUrl(_));
 
         // Acquire an advisory lock, to guard against concurrent writes.
         let _lock = Self::lock_wheel(wheel_entry, filename).await?;
@@ -775,8 +751,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
         let cache_read_entry = self.wheel_cache_read_entry(dist, hashes, &http_entry);
-        let url_hashes = url_hashes_for_generation(dist, hashes);
-        let downloaded = AtomicBool::new(false);
 
         let download = |response: reqwest::Response| {
             async {
@@ -845,7 +819,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
-                downloaded.store(true, Ordering::Relaxed);
                 Ok(Archive::new(
                     id,
                     hashers.into_iter().map(HashDigest::from).collect(),
@@ -886,7 +859,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     req,
                     &cache_read_entry,
                     &http_entry,
-                    cache_control.clone(),
+                    cache_control,
+                    |archive| self.validate_cached_wheel(archive, dist, hashes, expected_size),
                     download,
                 )
             })
@@ -898,7 +872,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
-            && !is_online_direct_url
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
@@ -906,52 +879,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 actual,
             });
         }
-
-        // A direct URL's contents can change even while its HTTP response is fresh. Online,
-        // refresh if the cached hashes or size do not match. Offline, preserve mismatch errors.
-        // Also refresh if the archive is missing required hashes or size, or has been removed.
-        let archive = Some(archive)
-            .filter(|archive| {
-                let downloaded = downloaded.load(Ordering::Relaxed);
-                // Another process may have replaced the shared pointer since the initial lookup.
-                if !downloaded
-                    && cache_read_entry.path() == http_entry.path()
-                    && let Some(url_hashes) = &url_hashes
-                    && !archive.satisfies(ArchiveHashPolicy::All(url_hashes.as_slice()))
-                {
-                    return false;
-                }
-                if is_online_direct_url && !downloaded {
-                    archive.satisfies(hashes)
-                        && expected_size.is_none_or(|expected| archive.size == Some(expected))
-                } else {
-                    archive.has_digests(hashes)
-                }
-            })
-            .filter(|archive| archive.exists(self.build_context.cache()))
-            .filter(|archive| expected_size.is_none() || archive.size.is_some());
-
-        let archive = if let Some(archive) = archive {
-            archive
-        } else {
-            self.client
-                .managed(async |client| {
-                    client
-                        .cached_client()
-                        .skip_cache_with_retry(
-                            self.request(url)?,
-                            &http_entry,
-                            cache_control,
-                            download,
-                        )
-                        .await
-                        .map_err(|err| match err {
-                            CachedClientError::Callback { err, .. } => err,
-                            CachedClientError::Client(err) => Error::Client(err),
-                        })
-                })
-                .await?
-        };
 
         Ok(archive)
     }
@@ -972,8 +899,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             BuiltDist::DirectUrl(_) => size,
             _ => None,
         };
-        let is_online_direct_url = self.client.unmanaged.connectivity().is_online()
-            && matches!(dist, BuiltDist::DirectUrl(_));
 
         let content_addressed_cache = self.content_addressed_cache;
 
@@ -983,8 +908,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
         let cache_read_entry = self.wheel_cache_read_entry(dist, hashes, &http_entry);
-        let url_hashes = url_hashes_for_generation(dist, hashes);
-        let downloaded = AtomicBool::new(false);
 
         let download = |response: reqwest::Response| {
             async {
@@ -1071,7 +994,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
-                downloaded.store(true, Ordering::Relaxed);
                 Ok(Archive::new(
                     id,
                     hashes,
@@ -1112,7 +1034,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     req,
                     &cache_read_entry,
                     &http_entry,
-                    cache_control.clone(),
+                    cache_control,
+                    |archive| self.validate_cached_wheel(archive, dist, hashes, expected_size),
                     download,
                 )
             })
@@ -1124,7 +1047,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
-            && !is_online_direct_url
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
@@ -1132,52 +1054,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 actual,
             });
         }
-
-        // A direct URL's contents can change even while its HTTP response is fresh. Online,
-        // refresh if the cached hashes or size do not match. Offline, preserve mismatch errors.
-        // Also refresh if the archive is missing required hashes or size, or has been removed.
-        let archive = Some(archive)
-            .filter(|archive| {
-                let downloaded = downloaded.load(Ordering::Relaxed);
-                // Another process may have replaced the shared pointer since the initial lookup.
-                if !downloaded
-                    && cache_read_entry.path() == http_entry.path()
-                    && let Some(url_hashes) = &url_hashes
-                    && !archive.satisfies(ArchiveHashPolicy::All(url_hashes.as_slice()))
-                {
-                    return false;
-                }
-                if is_online_direct_url && !downloaded {
-                    archive.satisfies(hashes)
-                        && expected_size.is_none_or(|expected| archive.size == Some(expected))
-                } else {
-                    archive.has_digests(hashes)
-                }
-            })
-            .filter(|archive| archive.exists(self.build_context.cache()))
-            .filter(|archive| expected_size.is_none() || archive.size.is_some());
-
-        let archive = if let Some(archive) = archive {
-            archive
-        } else {
-            self.client
-                .managed(async |client| {
-                    client
-                        .cached_client()
-                        .skip_cache_with_retry(
-                            self.request(url)?,
-                            &http_entry,
-                            cache_control,
-                            download,
-                        )
-                        .await
-                        .map_err(|err| match err {
-                            CachedClientError::Callback { err, .. } => err,
-                            CachedClientError::Client(err) => Error::Client(err),
-                        })
-                })
-                .await?
-        };
 
         Ok(archive)
     }
@@ -1376,6 +1252,47 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .map_err(Error::CacheWrite)
     }
 
+    /// Check whether a cached wheel can satisfy the request before reusing it.
+    fn validate_cached_wheel(
+        &self,
+        archive: &Archive,
+        dist: &BuiltDist,
+        hashes: ArchiveHashPolicy<'_>,
+        expected_size: Option<u64>,
+    ) -> Result<bool, Error> {
+        match dist {
+            BuiltDist::DirectUrl(wheel) => {
+                // Offline, report known mismatches because a replacement cannot be downloaded.
+                if self.client.unmanaged.connectivity().is_offline() {
+                    if let (Some(expected), Some(actual)) = (expected_size, archive.size)
+                        && expected != actual
+                    {
+                        return Err(Error::MismatchedSize {
+                            distribution: dist.to_string(),
+                            expected,
+                            actual,
+                        });
+                    }
+                    if hashes.requires_validation()
+                        && archive.has_digests(hashes)
+                        && !archive.satisfies(hashes)
+                    {
+                        return Err(Error::hash_mismatch(
+                            dist.to_string(),
+                            hashes.digests(),
+                            archive.hashes(),
+                        ));
+                    }
+                }
+                Ok(archive.matches_direct_url(self.build_context.cache(), wheel, hashes))
+            }
+            BuiltDist::Registry(_) | BuiltDist::Path(_) | BuiltDist::GitPath(_) => Ok(archive
+                .exists(self.build_context.cache())
+                && archive.has_digests(hashes)
+                && (expected_size.is_none() || archive.size.is_some())),
+        }
+    }
+
     /// Find the cached response to read, while keeping new downloads under the canonical key.
     fn wheel_cache_read_entry(
         &self,
@@ -1386,28 +1303,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         let BuiltDist::DirectUrl(wheel) = dist else {
             return http_entry.clone();
         };
-        let cache = self.build_context.cache();
-        let url_hashes = url_hashes_for_generation(dist, hashes);
-        let cache_hashes = url_hashes
-            .as_ref()
-            .map_or(hashes, |hashes| ArchiveHashPolicy::All(hashes.as_slice()));
-        if let Some((entry, pointer)) =
-            HttpArchivePointer::read_from_direct_url(cache, wheel, cache_hashes)
-            && pointer.archive.has_digests(hashes)
-        {
-            return entry;
-        }
-
-        // Generation does not validate fresh downloads. If the shared entry does not match the
-        // explicit URL hash, retain the old verbatim-key lookup instead of returning other bytes.
-        if url_hashes.is_some() {
-            return cache.entry(
-                CacheBucket::Wheels,
-                WheelCache::Url(wheel.url.raw()).wheel_dir(wheel.name().as_ref()),
-                format!("{}.http", wheel.filename.cache_key()),
-            );
-        }
-        http_entry.clone()
+        HttpArchivePointer::read_from_direct_url(self.build_context.cache(), wheel, hashes)
+            .map_or_else(|| http_entry.clone(), |(entry, _)| entry)
     }
 
     /// Returns a GET [`reqwest::Request`] for the given URL.
@@ -1607,28 +1504,33 @@ impl HttpArchivePointer {
         wheel: &DirectUrlBuiltDist,
         hashes: ArchiveHashPolicy<'_>,
     ) -> Option<(CacheEntry, Self)> {
+        Self::read_entries(cache, wheel).find_map(|(entry, pointer)| {
+            pointer
+                .ok()
+                .filter(|pointer| pointer.archive.matches_direct_url(cache, wheel, hashes))
+                .map(|pointer| (entry, pointer))
+        })
+    }
+
+    /// Read canonical and legacy URL entries, retaining corrupt entries so callers can heal them.
+    fn read_entries(
+        cache: &Cache,
+        wheel: &DirectUrlBuiltDist,
+    ) -> impl Iterator<Item = (CacheEntry, Result<Self, Error>)> {
         once(wheel.location.as_ref())
             .chain((wheel.location.as_ref() != wheel.url.raw()).then_some(wheel.url.raw()))
-            .find_map(|location| {
+            .filter_map(move |location| {
                 let entry = cache.entry(
                     CacheBucket::Wheels,
                     WheelCache::Url(location).wheel_dir(wheel.name().as_ref()),
                     format!("{}.http", wheel.filename.cache_key()),
                 );
                 match Self::read_from(&entry) {
-                    Ok(Some(pointer))
-                        if pointer.archive.satisfies(hashes)
-                            && wheel
-                                .size
-                                .is_none_or(|size| pointer.archive.size == Some(size))
-                            && pointer.archive.exists(cache) =>
-                    {
-                        Some((entry, pointer))
-                    }
-                    Ok(_) => None,
+                    Ok(Some(pointer)) => Some((entry, Ok(pointer))),
+                    Ok(None) => None,
                     Err(err) => {
                         debug!("Failed to deserialize cached URL wheel for {wheel}: {err}");
-                        None
+                        Some((entry, Err(err)))
                     }
                 }
             })

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1,9 +1,11 @@
 use std::cmp::Reverse;
 use std::future::Future;
 use std::io;
+use std::iter::once;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
@@ -13,7 +15,7 @@ use rustc_hash::FxHashMap;
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
 use tokio::sync::Semaphore;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
-use tracing::{Instrument, info_span, instrument, warn};
+use tracing::{Instrument, debug, info_span, instrument, warn};
 use url::Url;
 
 use uv_cache::{ArchiveFileId, ArchiveId, Cache, CacheBucket, CacheEntry, WheelCache};
@@ -24,9 +26,9 @@ use uv_client::{
 use uv_configuration::initialize_rayon_once;
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
-    ArchiveHashPolicy, BuildInfo, BuildableSource, BuiltDist, Dist, DistRef, HashCollection,
-    HashValidation, Hashed, IndexUrl, InstalledDist, MetadataHashPolicy, Name, SourceDist,
-    SourceUrl, parse_url_hashes,
+    ArchiveHashPolicy, BuildInfo, BuildableSource, BuiltDist, DirectUrlBuiltDist, Dist, DistRef,
+    HashCollection, HashValidation, Hashed, IndexUrl, InstalledDist, MetadataHashPolicy, Name,
+    SourceDist, SourceUrl, parse_url_hashes,
 };
 use uv_extract::dirhash::{DirectoryDigest, HashedFile};
 use uv_extract::hash::Hasher;
@@ -34,7 +36,7 @@ use uv_fs::{LockedFile, write_atomic};
 use uv_git::{GIT_LFS, GitError};
 use uv_platform_tags::Tags;
 use uv_preview::PreviewFeature;
-use uv_pypi_types::{HashDigest, HashDigests, PyProjectToml};
+use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, PyProjectToml};
 use uv_python::PythonVariant;
 use uv_redacted::DisplaySafeUrl;
 use uv_types::{BuildContext, BuildStack};
@@ -42,7 +44,7 @@ use uv_types::{BuildContext, BuildStack};
 use crate::archive::Archive;
 use crate::error::PythonVersion;
 use crate::extracted_wheel::{ExtractedWheel, HashedWheel, WheelExtractor};
-use crate::hash::http_hash_algorithms;
+use crate::hash::{http_wheel_hash_algorithms, url_hashes_for_generation};
 use crate::metadata::{ArchiveMetadata, Metadata};
 use crate::source::SourceDistributionBuilder;
 use crate::{Error, LocalWheel, Reporter, RequiresDist};
@@ -311,17 +313,18 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             }
 
             BuiltDist::DirectUrl(wheel) => {
-                // Create a cache entry for the wheel.
+                // Key the wheel by its location, so a hash fragment does not prevent reuse
+                // when the same wheel is read from a lockfile. Hashes are checked separately.
                 let wheel_entry = self.build_context.cache().entry(
                     CacheBucket::Wheels,
-                    WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
+                    WheelCache::Url(&wheel.location).wheel_dir(wheel.name().as_ref()),
                     wheel.filename.cache_key(),
                 );
 
                 // Download and unzip.
                 match self
                     .stream_wheel(
-                        wheel.url.raw().clone(),
+                        (*wheel.location).clone(),
                         None,
                         &wheel.filename,
                         wheel.size,
@@ -358,7 +361,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         // download the wheel directly.
                         let archive = self
                             .download_wheel(
-                                wheel.url.raw().clone(),
+                                (*wheel.location).clone(),
                                 None,
                                 &wheel.filename,
                                 wheel.size,
@@ -581,7 +584,16 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             } else {
                 wheel.metadata()?
             };
-            let hashes = wheel.hashes;
+            // Other URL digests are retained in the cache for reuse, not generated output.
+            let hashes = if matches!(dist, BuiltDist::DirectUrl(_)) {
+                wheel
+                    .hashes
+                    .into_iter()
+                    .filter(|digest| digest.algorithm() == HashAlgorithm::Sha256)
+                    .collect()
+            } else {
+                wheel.hashes
+            };
             return Ok(ArchiveMetadata {
                 metadata: Metadata::from_metadata23(metadata),
                 hashes,
@@ -719,12 +731,17 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             BuiltDist::DirectUrl(_) => size,
             _ => None,
         };
+        let is_online_direct_url = self.client.unmanaged.connectivity().is_online()
+            && matches!(dist, BuiltDist::DirectUrl(_));
 
         // Acquire an advisory lock, to guard against concurrent writes.
         let _lock = Self::lock_wheel(wheel_entry, filename).await?;
 
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
+        let cache_read_entry = self.wheel_cache_read_entry(dist, hashes, &http_entry);
+        let url_hashes = url_hashes_for_generation(dist, hashes);
+        let downloaded = AtomicBool::new(false);
 
         let download = |response: reqwest::Response| {
             async {
@@ -743,7 +760,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .into_async_read();
 
                 // Create a hasher for each hash algorithm.
-                let algorithms = http_hash_algorithms(hashes);
+                let algorithms = http_wheel_hash_algorithms(dist, hashes);
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
@@ -793,6 +810,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
+                downloaded.store(true, Ordering::Relaxed);
                 Ok(Archive::new(
                     id,
                     hashers.into_iter().map(HashDigest::from).collect(),
@@ -820,7 +838,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             Connectivity::Online => CacheControl::from(
                 self.build_context
                     .cache()
-                    .freshness(&http_entry, Some(&filename.name), None)
+                    .freshness(&cache_read_entry, Some(&filename.name), None)
                     .map_err(Error::CacheRead)?,
             ),
             Connectivity::Offline => CacheControl::AllowStale,
@@ -829,8 +847,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         let archive = self
             .client
             .managed(|client| {
-                client.cached_client().get_serde_with_retry(
+                client.cached_client().get_serde_with_retry_from(
                     req,
+                    &cache_read_entry,
                     &http_entry,
                     cache_control.clone(),
                     download,
@@ -844,6 +863,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
+            && !is_online_direct_url
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
@@ -852,9 +872,27 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             });
         }
 
-        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
+        // A direct URL's contents can change even while its HTTP response is fresh. Online,
+        // refresh if the cached hashes or size do not match. Offline, preserve mismatch errors.
+        // Also refresh if the archive is missing required hashes or size, or has been removed.
         let archive = Some(archive)
-            .filter(|archive| archive.has_digests(hashes))
+            .filter(|archive| {
+                let downloaded = downloaded.load(Ordering::Relaxed);
+                // Another process may have replaced the shared pointer since the initial lookup.
+                if !downloaded
+                    && cache_read_entry.path() == http_entry.path()
+                    && let Some(url_hashes) = &url_hashes
+                    && !archive.satisfies(ArchiveHashPolicy::All(url_hashes.as_slice()))
+                {
+                    return false;
+                }
+                if is_online_direct_url && !downloaded {
+                    archive.satisfies(hashes)
+                        && expected_size.is_none_or(|expected| archive.size == Some(expected))
+                } else {
+                    archive.has_digests(hashes)
+                }
+            })
             .filter(|archive| archive.exists(self.build_context.cache()))
             .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
@@ -899,6 +937,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             BuiltDist::DirectUrl(_) => size,
             _ => None,
         };
+        let is_online_direct_url = self.client.unmanaged.connectivity().is_online()
+            && matches!(dist, BuiltDist::DirectUrl(_));
 
         let content_addressed_cache = self.content_addressed_cache;
 
@@ -907,6 +947,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // Create an entry for the HTTP cache.
         let http_entry = wheel_entry.with_file(format!("{}.http", filename.cache_key()));
+        let cache_read_entry = self.wheel_cache_read_entry(dist, hashes, &http_entry);
+        let url_hashes = url_hashes_for_generation(dist, hashes);
+        let downloaded = AtomicBool::new(false);
 
         let download = |response: reqwest::Response| {
             async {
@@ -923,7 +966,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .bytes_stream()
                     .map_err(|err| self.handle_response_errors(err))
                     .into_async_read();
-                let algorithms = http_hash_algorithms(hashes);
+                let algorithms = http_wheel_hash_algorithms(dist, hashes);
                 let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                 let mut hasher = uv_extract::hash::HashReader::new(reader.compat(), &mut hashers);
 
@@ -993,6 +1036,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     reporter.on_download_complete(dist.name(), progress);
                 }
 
+                downloaded.store(true, Ordering::Relaxed);
                 Ok(Archive::new(
                     id,
                     hashes,
@@ -1020,7 +1064,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             Connectivity::Online => CacheControl::from(
                 self.build_context
                     .cache()
-                    .freshness(&http_entry, Some(&filename.name), None)
+                    .freshness(&cache_read_entry, Some(&filename.name), None)
                     .map_err(Error::CacheRead)?,
             ),
             Connectivity::Offline => CacheControl::AllowStale,
@@ -1029,8 +1073,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         let archive = self
             .client
             .managed(|client| {
-                client.cached_client().get_serde_with_retry(
+                client.cached_client().get_serde_with_retry_from(
                     req,
+                    &cache_read_entry,
                     &http_entry,
                     cache_control.clone(),
                     download,
@@ -1044,6 +1089,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         if let (Some(expected), Some(actual)) = (expected_size, archive.size)
             && expected != actual
+            && !is_online_direct_url
         {
             return Err(Error::MismatchedSize {
                 distribution: dist.to_string(),
@@ -1052,9 +1098,27 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             });
         }
 
-        // If the archive is missing the required hashes or size, or has since been removed, force a refresh.
+        // A direct URL's contents can change even while its HTTP response is fresh. Online,
+        // refresh if the cached hashes or size do not match. Offline, preserve mismatch errors.
+        // Also refresh if the archive is missing required hashes or size, or has been removed.
         let archive = Some(archive)
-            .filter(|archive| archive.has_digests(hashes))
+            .filter(|archive| {
+                let downloaded = downloaded.load(Ordering::Relaxed);
+                // Another process may have replaced the shared pointer since the initial lookup.
+                if !downloaded
+                    && cache_read_entry.path() == http_entry.path()
+                    && let Some(url_hashes) = &url_hashes
+                    && !archive.satisfies(ArchiveHashPolicy::All(url_hashes.as_slice()))
+                {
+                    return false;
+                }
+                if is_online_direct_url && !downloaded {
+                    archive.satisfies(hashes)
+                        && expected_size.is_none_or(|expected| archive.size == Some(expected))
+                } else {
+                    archive.has_digests(hashes)
+                }
+            })
             .filter(|archive| archive.exists(self.build_context.cache()))
             .filter(|archive| expected_size.is_none() || archive.size.is_some());
 
@@ -1277,6 +1341,40 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             .map_err(Error::CacheWrite)
     }
 
+    /// Find the cached response to read, while keeping new downloads under the canonical key.
+    fn wheel_cache_read_entry(
+        &self,
+        dist: &BuiltDist,
+        hashes: ArchiveHashPolicy<'_>,
+        http_entry: &CacheEntry,
+    ) -> CacheEntry {
+        let BuiltDist::DirectUrl(wheel) = dist else {
+            return http_entry.clone();
+        };
+        let cache = self.build_context.cache();
+        let url_hashes = url_hashes_for_generation(dist, hashes);
+        let cache_hashes = url_hashes
+            .as_ref()
+            .map_or(hashes, |hashes| ArchiveHashPolicy::All(hashes.as_slice()));
+        if let Some((entry, pointer)) =
+            HttpArchivePointer::read_from_direct_url(cache, wheel, cache_hashes)
+            && pointer.archive.has_digests(hashes)
+        {
+            return entry;
+        }
+
+        // Generation does not validate fresh downloads. If the shared entry does not match the
+        // explicit URL hash, retain the old verbatim-key lookup instead of returning other bytes.
+        if url_hashes.is_some() {
+            return cache.entry(
+                CacheBucket::Wheels,
+                WheelCache::Url(wheel.url.raw()).wheel_dir(wheel.name().as_ref()),
+                format!("{}.http", wheel.filename.cache_key()),
+            );
+        }
+        http_entry.clone()
+    }
+
     /// Returns a GET [`reqwest::Request`] for the given URL.
     fn request(&self, url: DisplaySafeUrl) -> Result<reqwest::Request, reqwest::Error> {
         self.client
@@ -1465,8 +1563,44 @@ pub struct HttpArchivePointer {
 }
 
 impl HttpArchivePointer {
+    /// Find a cached direct wheel with matching hashes and size, and an existing archive.
+    ///
+    /// Prefer its fragment-free location, then try the verbatim URL used by older versions of uv.
+    /// Return the matching entry so downloads can apply its HTTP cache policy in either mode.
+    pub fn read_from_direct_url(
+        cache: &Cache,
+        wheel: &DirectUrlBuiltDist,
+        hashes: ArchiveHashPolicy<'_>,
+    ) -> Option<(CacheEntry, Self)> {
+        once(wheel.location.as_ref())
+            .chain((wheel.location.as_ref() != wheel.url.raw()).then_some(wheel.url.raw()))
+            .find_map(|location| {
+                let entry = cache.entry(
+                    CacheBucket::Wheels,
+                    WheelCache::Url(location).wheel_dir(wheel.name().as_ref()),
+                    format!("{}.http", wheel.filename.cache_key()),
+                );
+                match Self::read_from(&entry) {
+                    Ok(Some(pointer))
+                        if pointer.archive.satisfies(hashes)
+                            && wheel
+                                .size
+                                .is_none_or(|size| pointer.archive.size == Some(size))
+                            && pointer.archive.exists(cache) =>
+                    {
+                        Some((entry, pointer))
+                    }
+                    Ok(_) => None,
+                    Err(err) => {
+                        debug!("Failed to deserialize cached URL wheel for {wheel}: {err}");
+                        None
+                    }
+                }
+            })
+    }
+
     /// Read an [`HttpArchivePointer`] from the cache.
-    pub fn read_from(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
+    pub(crate) fn read_from(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
         match fs_err::File::open(path.as_ref()) {
             Ok(file) => {
                 let data = DataWithCachePolicy::from_reader(file)?.data;

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -609,6 +609,38 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             return Ok(ArchiveMetadata::from_metadata23(metadata));
         }
 
+        // A shared archive can be replaced through another URL fragment while the metadata
+        // cache still describes the old wheel. Read its metadata through the archive's HTTP
+        // cache, so we also honor expiration and refresh mismatched hashes before resolution.
+        if let BuiltDist::DirectUrl(wheel) = dist
+            && once(wheel.location.as_ref())
+                .chain((wheel.location.as_ref() != wheel.url.raw()).then_some(wheel.url.raw()))
+                .any(|location| {
+                    self.build_context
+                        .cache()
+                        .entry(
+                            CacheBucket::Wheels,
+                            WheelCache::Url(location).wheel_dir(wheel.name().as_ref()),
+                            format!("{}.http", wheel.filename.cache_key()),
+                        )
+                        .path()
+                        .exists()
+                })
+        {
+            let url_hashes = parse_url_hashes(&wheel.url);
+            let cache_hashes = if hash_policy.is_none() {
+                url_hashes.as_ref().map_or(hash_policy, |hashes| {
+                    ArchiveHashPolicy::All(hashes.as_slice())
+                })
+            } else {
+                hash_policy
+            };
+            let wheel = self.get_wheel(dist, cache_hashes).await?;
+            if wheel.satisfies(cache_hashes) {
+                return Ok(ArchiveMetadata::from_metadata23(wheel.metadata()?));
+            }
+        }
+
         let result = self
             .client
             .managed(|client| {
@@ -637,7 +669,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 // downloading the wheel directly, try that.
                 let wheel = self.get_wheel(dist, hash_policy).await?;
                 let metadata = wheel.metadata()?;
-                let hashes = wheel.hashes;
+                let hashes = match hashes.collection {
+                    HashCollection::None => HashDigests::empty(),
+                    HashCollection::Url | HashCollection::All => wheel.hashes,
+                };
                 Ok(ArchiveMetadata {
                     metadata: Metadata::from_metadata23(metadata),
                     hashes,

--- a/crates/uv-distribution/src/hash.rs
+++ b/crates/uv-distribution/src/hash.rs
@@ -1,5 +1,6 @@
 use uv_distribution_types::{ArchiveHashPolicy, BuiltDist};
 use uv_pypi_types::{HashAlgorithm, HashDigests, Hashes};
+use uv_redacted::DisplaySafeUrl;
 
 /// Return the algorithms to compute for an HTTP distribution.
 fn http_hash_algorithms(hashes: ArchiveHashPolicy<'_>) -> Vec<HashAlgorithm> {
@@ -10,31 +11,30 @@ fn http_hash_algorithms(hashes: ArchiveHashPolicy<'_>) -> Vec<HashAlgorithm> {
     algorithms
 }
 
-/// Return the URL hash that must match before reusing a shared wheel cache entry during generation.
-pub(crate) fn url_hashes_for_generation(
-    dist: &BuiltDist,
+/// Use a URL hash to select cached contents unless explicit hash requirements take precedence.
+pub(crate) fn url_hashes_for_cache(
+    url: &DisplaySafeUrl,
     hashes: ArchiveHashPolicy<'_>,
 ) -> Option<HashDigests> {
-    if hashes != ArchiveHashPolicy::Generate {
-        return None;
+    match hashes {
+        ArchiveHashPolicy::None | ArchiveHashPolicy::Generate => {}
+        ArchiveHashPolicy::Any(_) | ArchiveHashPolicy::All(_) => return None,
     }
-    let BuiltDist::DirectUrl(wheel) = dist else {
-        return None;
-    };
-    wheel
-        .url
-        .fragment()?
+    url.fragment()?
         .split('&')
         .find_map(|fragment| Hashes::parse_fragment(fragment).ok())
         .map(HashDigests::from)
 }
 
-/// Include the URL's hash algorithm so subsequent generation can reuse the canonical wheel entry.
+/// Compute URL digests needed to recognize the same wheel in subsequent cache lookups.
 pub(crate) fn http_wheel_hash_algorithms(
     dist: &BuiltDist,
     hashes: ArchiveHashPolicy<'_>,
 ) -> Vec<HashAlgorithm> {
-    let url_hashes = url_hashes_for_generation(dist, hashes);
+    let url_hashes = match dist {
+        BuiltDist::DirectUrl(wheel) => url_hashes_for_cache(&wheel.url, hashes),
+        BuiltDist::Registry(_) | BuiltDist::Path(_) | BuiltDist::GitPath(_) => None,
+    };
     http_hash_algorithms(
         url_hashes
             .as_ref()

--- a/crates/uv-distribution/src/hash.rs
+++ b/crates/uv-distribution/src/hash.rs
@@ -2,7 +2,7 @@ use uv_distribution_types::{ArchiveHashPolicy, BuiltDist};
 use uv_pypi_types::{HashAlgorithm, HashDigests, Hashes};
 
 /// Return the algorithms to compute for an HTTP distribution.
-pub(crate) fn http_hash_algorithms(hashes: ArchiveHashPolicy<'_>) -> Vec<HashAlgorithm> {
+fn http_hash_algorithms(hashes: ArchiveHashPolicy<'_>) -> Vec<HashAlgorithm> {
     let mut algorithms = hashes.algorithms();
     algorithms.push(HashAlgorithm::Sha256);
     algorithms.sort();

--- a/crates/uv-distribution/src/hash.rs
+++ b/crates/uv-distribution/src/hash.rs
@@ -1,5 +1,5 @@
-use uv_distribution_types::ArchiveHashPolicy;
-use uv_pypi_types::HashAlgorithm;
+use uv_distribution_types::{ArchiveHashPolicy, BuiltDist};
+use uv_pypi_types::{HashAlgorithm, HashDigests, Hashes};
 
 /// Return the algorithms to compute for an HTTP distribution.
 pub(crate) fn http_hash_algorithms(hashes: ArchiveHashPolicy<'_>) -> Vec<HashAlgorithm> {
@@ -8,4 +8,36 @@ pub(crate) fn http_hash_algorithms(hashes: ArchiveHashPolicy<'_>) -> Vec<HashAlg
     algorithms.sort();
     algorithms.dedup();
     algorithms
+}
+
+/// Return the URL hash that must match before reusing a shared wheel cache entry during generation.
+pub(crate) fn url_hashes_for_generation(
+    dist: &BuiltDist,
+    hashes: ArchiveHashPolicy<'_>,
+) -> Option<HashDigests> {
+    if hashes != ArchiveHashPolicy::Generate {
+        return None;
+    }
+    let BuiltDist::DirectUrl(wheel) = dist else {
+        return None;
+    };
+    wheel
+        .url
+        .fragment()?
+        .split('&')
+        .find_map(|fragment| Hashes::parse_fragment(fragment).ok())
+        .map(HashDigests::from)
+}
+
+/// Include the URL's hash algorithm so subsequent generation can reuse the canonical wheel entry.
+pub(crate) fn http_wheel_hash_algorithms(
+    dist: &BuiltDist,
+    hashes: ArchiveHashPolicy<'_>,
+) -> Vec<HashAlgorithm> {
+    let url_hashes = url_hashes_for_generation(dist, hashes);
+    http_hash_algorithms(
+        url_hashes
+            .as_ref()
+            .map_or(hashes, |hashes| ArchiveHashPolicy::All(hashes.as_slice())),
+    )
 }

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -426,46 +426,29 @@ impl<'a> Planner<'a> {
 
                     // Find the exact wheel from the cache, since we know the filename in
                     // advance.
-                    let cache_entry = cache
-                        .shard(
-                            CacheBucket::Wheels,
-                            WheelCache::Url(&wheel.url).wheel_dir(wheel.name().as_ref()),
-                        )
-                        .entry(format!("{}.http", wheel.filename.cache_key()));
+                    if let Some((_, pointer)) = HttpArchivePointer::read_from_direct_url(
+                        cache,
+                        wheel,
+                        hasher.archive_policy(dist.as_ref()),
+                    ) {
+                        let cache_info = pointer.to_cache_info();
+                        let build_info = pointer.to_build_info();
+                        let archive = pointer.into_archive();
+                        let cached_dist = CachedDirectUrlDist {
+                            filename: wheel.filename.clone(),
+                            url: VerbatimParsedUrl {
+                                parsed_url: wheel.to_parsed_url(),
+                                verbatim: wheel.url.clone(),
+                            },
+                            hashes: archive.hashes,
+                            cache_info,
+                            build_info,
+                            path: cache.archive(&archive.id).into_boxed_path(),
+                        };
 
-                    // Read the HTTP pointer.
-                    match HttpArchivePointer::read_from(&cache_entry) {
-                        Ok(Some(pointer)) => {
-                            let cache_info = pointer.to_cache_info();
-                            let build_info = pointer.to_build_info();
-                            let archive = pointer.into_archive();
-                            if archive.satisfies(hasher.archive_policy(dist.as_ref())) {
-                                let cached_dist = CachedDirectUrlDist {
-                                    filename: wheel.filename.clone(),
-                                    url: VerbatimParsedUrl {
-                                        parsed_url: wheel.to_parsed_url(),
-                                        verbatim: wheel.url.clone(),
-                                    },
-                                    hashes: archive.hashes,
-                                    cache_info,
-                                    build_info,
-                                    path: cache.archive(&archive.id).into_boxed_path(),
-                                };
-
-                                debug!("URL wheel requirement already cached: {cached_dist}");
-                                cached.push(CachedDist::Url(cached_dist));
-                                continue;
-                            }
-                            debug!(
-                                "Cached URL wheel requirement does not match expected hash policy for: {wheel}"
-                            );
-                        }
-                        Ok(None) => {}
-                        Err(err) => {
-                            debug!(
-                                "Failed to deserialize cached URL wheel requirement for: {wheel} ({err})"
-                            );
-                        }
+                        debug!("URL wheel requirement already cached: {cached_dist}");
+                        cached.push(CachedDist::Url(cached_dist));
+                        continue;
                     }
                 }
                 Dist::Built(BuiltDist::Path(wheel)) => {

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1946,9 +1946,11 @@ impl PylockTomlArchive {
             match ext {
                 DistExtension::Wheel => {
                     let filename = WheelFilename::from_str(&filename)?;
+                    let mut location = url.clone();
+                    location.set_fragment(None);
                     Ok(Dist::Built(BuiltDist::DirectUrl(DirectUrlBuiltDist {
                         filename,
-                        location: Box::new(url.clone()),
+                        location: Box::new(location),
                         url: VerbatimUrl::from_url(url.clone()),
                         size: self.size,
                     })))

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1266,6 +1266,7 @@ fn lock_wheel_git_archive_missing_lfs() -> Result<()> {
 }
 
 /// A downloaded fragment-bearing URL can be installed from the lockfile offline.
+#[cfg(feature = "test-universal")]
 #[tokio::test]
 async fn lock_wheel_url_fragment_download() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -1265,6 +1265,50 @@ fn lock_wheel_git_archive_missing_lfs() -> Result<()> {
     Ok(())
 }
 
+/// A downloaded fragment-bearing URL can be installed from the lockfile offline.
+#[tokio::test]
+async fn lock_wheel_url_fragment_download() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let server = MockServer::start().await;
+    let filename = "ok-1.0.0-py3-none-any.whl";
+    let wheel = fs_err::read(context.workspace_root.join("test/links").join(filename))?;
+    Mock::given(method("GET"))
+        .and(path(format!("/{filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_bytes(wheel),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // MD5 cannot be reused for hash generation, so locking must download the wheel to compute
+    // SHA-256. Stronger URL hashes can avoid downloading the archive altogether.
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["ok @ {}/{filename}#md5=88d6d524262f256596aa7f663c88038b"]
+    "#, server.uri()})?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    Ok(())
+}
+
 /// Lock a requirement from a direct URL to a wheel.
 #[cfg(feature = "test-universal")]
 #[test]

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -1,12 +1,13 @@
 use std::env::consts::EXE_SUFFIX;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use fs_err as fs;
 use indoc::{formatdoc, indoc};
 use predicates::Predicate;
+use sha2::{Digest, Sha256};
 use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -4877,6 +4878,91 @@ fn require_hashes_url() -> Result<()> {
      + iniconfig==2.0.0 (from https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl#sha256=b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374)
     "
     );
+
+    Ok(())
+}
+
+/// Changed hashes must refresh a direct wheel even when its HTTP cache is still fresh.
+#[tokio::test]
+async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel_filename = "ok-1.0.0-py3-none-any.whl";
+    let wheel = fs::read(
+        context
+            .workspace_root
+            .join("test/links")
+            .join(wheel_filename),
+    )?;
+    // Give the valid fixture a ZIP comment, changing its hash without changing its contents.
+    let Some(prefix) = wheel.strip_suffix(&[0, 0]) else {
+        bail!("expected a wheel fixture without a ZIP comment");
+    };
+    let comment = b"replacement archive";
+    let mut replacement = prefix.to_vec();
+    replacement.extend_from_slice(&u16::try_from(comment.len())?.to_le_bytes());
+    replacement.extend_from_slice(comment);
+    let original_hash = hex::encode(Sha256::digest(&wheel));
+    let replacement_hash = hex::encode(Sha256::digest(&replacement));
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([
+            (original_hash.as_str(), "[ORIGINAL_HASH]"),
+            (replacement_hash.as_str(), "[REPLACEMENT_HASH]"),
+        ])
+        .collect::<Vec<_>>();
+
+    let server = MockServer::start().await;
+    let response = |wheel| {
+        ResponseTemplate::new(200)
+            .insert_header("Cache-Control", "max-age=3600")
+            .set_body_bytes(wheel)
+    };
+    Mock::given(path(format!("/{wheel_filename}")))
+        .respond_with(response(wheel))
+        .mount(&server)
+        .await;
+    let wheel_url = format!("{}/{wheel_filename}", server.uri());
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str(&format!("ok @ {wheel_url} --hash=sha256:{original_hash}\n"))?;
+
+    uv_snapshot!(filters.clone(), context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+    ");
+
+    // Require another install without `--reinstall`, which also refreshes the cache.
+    context.pip_uninstall().arg("ok").assert().success();
+    server.reset().await;
+    Mock::given(path(format!("/{wheel_filename}")))
+        .respond_with(response(replacement))
+        .mount(&server)
+        .await;
+    requirements_txt.write_str(&format!(
+        "ok @ {wheel_url} --hash=sha256:{replacement_hash}\n"
+    ))?;
+
+    uv_snapshot!(filters, context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+      × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
+      ╰─▶ Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
+
+          Expected:
+            sha256:[REPLACEMENT_HASH]
+
+          Computed:
+            sha256:[ORIGINAL_HASH]
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -1,18 +1,24 @@
 use std::env::consts::EXE_SUFFIX;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use fs_err as fs;
 use indoc::{formatdoc, indoc};
 use predicates::Predicate;
+use reqwest::{Method, Request};
 use sha2::{Digest, Sha256};
 use url::Url;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+use uv_cache::{Cache, CacheBucket, WheelCache};
+use uv_client::{BaseClientBuilder, CacheControl, CachedClient, Error as ClientError};
+use uv_distribution::HttpArchivePointer;
+use uv_distribution_types::{DirectUrlBuiltDist, HashPolicy};
 use uv_fs::{Simplified, copy_dir_all};
+use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 use uv_test::find_links::FindLinksServer;
 use uv_test::packse::PackseServer;
@@ -4882,51 +4888,114 @@ fn require_hashes_url() -> Result<()> {
     Ok(())
 }
 
-/// Changed hashes must refresh a direct wheel even when its HTTP cache is still fresh.
+/// Direct-wheel cache reuse must respect changed hashes and sizes across input formats.
 #[tokio::test]
 async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let wheel_filename = "ok-1.0.0-py3-none-any.whl";
-    let wheel = fs::read(
+    let original = fs::read(
         context
             .workspace_root
             .join("test/links")
             .join(wheel_filename),
     )?;
-    // Give the valid fixture a ZIP comment, changing its hash without changing its contents.
-    let Some(prefix) = wheel.strip_suffix(&[0, 0]) else {
+    // A ZIP comment changes the archive's hash and size without changing its contents.
+    let Some(prefix) = original.strip_suffix(&[0, 0]) else {
         bail!("expected a wheel fixture without a ZIP comment");
     };
     let comment = b"replacement archive";
     let mut replacement = prefix.to_vec();
     replacement.extend_from_slice(&u16::try_from(comment.len())?.to_le_bytes());
     replacement.extend_from_slice(comment);
-    let original_hash = hex::encode(Sha256::digest(&wheel));
+    let original_size = original.len();
+    let replacement_size = replacement.len();
+    let original_hash = hex::encode(Sha256::digest(&original));
     let replacement_hash = hex::encode(Sha256::digest(&replacement));
-    let filters = context
-        .filters()
-        .into_iter()
-        .chain([
-            (original_hash.as_str(), "[ORIGINAL_HASH]"),
-            (replacement_hash.as_str(), "[REPLACEMENT_HASH]"),
-        ])
-        .collect::<Vec<_>>();
+    let context = context
+        .with_filter((original_hash.as_str(), "[ORIGINAL_HASH]"))
+        .with_filter((replacement_hash.as_str(), "[REPLACEMENT_HASH]"));
 
     let server = MockServer::start().await;
-    let response = |wheel| {
+    let response = |contents: &[u8]| {
         ResponseTemplate::new(200)
             .insert_header("Cache-Control", "max-age=3600")
-            .set_body_bytes(wheel)
+            .set_body_bytes(contents)
     };
+    let wheel_url = format!("{}/{wheel_filename}", server.uri());
+    let generation_url = format!("{wheel_url}?generate");
+    let size_url = format!("{wheel_url}?size");
+    let lockfile = |url: &str, size: usize, hash: &str| {
+        formatdoc! {
+            r#"
+        lock-version = "1.0"
+        created-by = "uv"
+
+        [[packages]]
+        name = "ok"
+        version = "1.0.0"
+        archive = {{ url = "{url}", size = {size}, hashes = {{ sha256 = "{hash}" }} }}
+        "#,
+        }
+    };
+    let requirements_in = context.temp_dir.child("requirements.in");
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+
     Mock::given(path(format!("/{wheel_filename}")))
-        .respond_with(response(wheel))
+        .respond_with(response(&original))
         .mount(&server)
         .await;
-    let wheel_url = format!("{}/{wheel_filename}", server.uri());
-    let requirements_txt = context.temp_dir.child("requirements.txt");
+    // Seed independent entries so generation cannot mask a stale validation entry.
+    requirements_in.write_str(&format!("ok @ {generation_url}#sha256={original_hash}\n"))?;
+    context
+        .pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes")
+        .assert()
+        .success();
     requirements_txt.write_str(&format!("ok @ {wheel_url} --hash=sha256:{original_hash}\n"))?;
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .assert()
+        .success();
+    context.pip_uninstall().arg("ok").assert().success();
 
-    uv_snapshot!(filters.clone(), context.pip_sync()
+    server.reset().await;
+    Mock::given(path(format!("/{wheel_filename}")))
+        .respond_with(response(&replacement))
+        .mount(&server)
+        .await;
+    requirements_in.write_str(&format!(
+        "ok @ {generation_url}#sha256={replacement_hash}\n"
+    ))?;
+    uv_snapshot!(context.filters(), context.pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes"), @r"
+    exit_code: 0 (success)
+    ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv pip compile --cache-dir [CACHE_DIR] requirements.in --generate-hashes
+    ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl?generate#sha256=[REPLACEMENT_HASH] \
+        --hash=sha256:[REPLACEMENT_HASH]
+        # via -r requirements.in
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    requirements_txt.write_str(&format!(
+        "ok @ {wheel_url} --hash=sha256:{replacement_hash}\n"
+    ))?;
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .arg("--offline")
+        .assert()
+        .failure();
+    uv_snapshot!(context.filters(), context.pip_sync()
         .arg("requirements.txt")
         .arg("--require-hashes"), @"
     exit_code: 0 (success)
@@ -4937,25 +5006,71 @@ async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
      + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
     ");
 
-    // Require another install without `--reinstall`, which also refreshes the cache.
+    // Seed another entry for a size-only refresh, with hash checking disabled below.
+    requirements_in.write_str(&format!("ok @ {size_url}\n"))?;
+    context
+        .pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes")
+        .assert()
+        .success();
     context.pip_uninstall().arg("ok").assert().success();
+
+    // Both pylock URL forms must reuse the requirements cache offline.
+    for url in [
+        generation_url.clone(),
+        format!("{generation_url}#sha256={replacement_hash}"),
+    ] {
+        pylock_toml.write_str(&lockfile(&url, replacement_size, &replacement_hash))?;
+        context
+            .pip_sync()
+            .arg("--preview")
+            .arg("--offline")
+            .arg("pylock.toml")
+            .assert()
+            .success();
+        context.pip_uninstall().arg("ok").assert().success();
+    }
+
     server.reset().await;
     Mock::given(path(format!("/{wheel_filename}")))
-        .respond_with(response(replacement))
+        .respond_with(response(&original))
         .mount(&server)
         .await;
-    requirements_txt.write_str(&format!(
-        "ok @ {wheel_url} --hash=sha256:{replacement_hash}\n"
-    ))?;
+    pylock_toml.write_str(&lockfile(&size_url, original_size, &original_hash))?;
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("--no-verify-hashes")
+        .arg("pylock.toml"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl?size)
+    ");
+    context.pip_uninstall().arg("ok").assert().success();
 
-    uv_snapshot!(filters, context.pip_sync()
-        .arg("requirements.txt")
-        .arg("--require-hashes"), @"
+    // A genuinely cold mismatch must preserve the integrity error after one full GET.
+    server.reset().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/{wheel_filename}")))
+        .respond_with(response(&original))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    pylock_toml.write_str(&lockfile(
+        &format!("{wheel_url}?cold"),
+        original_size,
+        &replacement_hash,
+    ))?;
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml"), @"
     exit_code: 1 (failure)
     ----- stderr -----
-    Resolved 1 package in [TIME]
-      × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
-      ╰─▶ Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl`
+      × Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl?cold`
+      ╰─▶ Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl?cold`
 
           Expected:
             sha256:[REPLACEMENT_HASH]
@@ -4963,7 +5078,124 @@ async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
           Computed:
             sha256:[ORIGINAL_HASH]
     ");
+    server.verify().await;
+    Ok(())
+}
 
+/// Legacy fragment-bearing entries remain usable offline and revalidate into the canonical key.
+#[tokio::test]
+async fn require_hashes_url_legacy_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let wheel_filename = "ok-1.0.0-py3-none-any.whl";
+    let contents = fs::read(
+        context
+            .workspace_root
+            .join("test/links")
+            .join(wheel_filename),
+    )?;
+    let hash = hex::encode(Sha256::digest(&contents));
+    let context = context.with_filter((hash.as_str(), "[HASH]"));
+    let server = MockServer::start().await;
+    Mock::given(path(format!("/{wheel_filename}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Cache-Control", "max-age=3600")
+                .insert_header("ETag", "\"original\"")
+                .set_body_bytes(contents),
+        )
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/{wheel_filename}", server.uri());
+    let wheel = DirectUrlBuiltDist {
+        filename: wheel_filename.parse()?,
+        location: Box::new(DisplaySafeUrl::parse(&url)?),
+        url: format!("{url}#sha256={hash}").parse()?,
+        size: None,
+    };
+    context
+        .temp_dir
+        .child("requirements.txt")
+        .write_str(&format!("ok @ {}\n", wheel.url))?;
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .assert()
+        .success();
+
+    // Re-create the old layout, including the fragment in the stored HTTP request URI.
+    let cache = Cache::from_path(context.cache_dir.path());
+    let (canonical, pointer) =
+        HttpArchivePointer::read_from_direct_url(&cache, &wheel, HashPolicy::None)
+            .context("expected the downloaded wheel in the cache")?;
+    let archive = pointer.into_archive();
+    let legacy = cache.entry(
+        CacheBucket::Wheels,
+        WheelCache::Url(wheel.url.raw()).wheel_dir("ok"),
+        format!("{}.http", wheel.filename.cache_key()),
+    );
+    CachedClient::new(BaseClientBuilder::default().build()?)
+        .get_serde_with_retry(
+            Request::new(Method::GET, Url::from(wheel.url.raw().clone())),
+            &legacy,
+            CacheControl::None,
+            async |_| Ok::<_, ClientError>(archive.clone()),
+        )
+        .await
+        .map_err(ClientError::from)?;
+    fs::rename(
+        canonical.with_file(wheel.filename.cache_key()),
+        legacy.with_file(wheel.filename.cache_key()),
+    )?;
+    fs::remove_file(canonical.path())?;
+    let legacy_bytes = fs::read(legacy.path())?;
+    server.reset().await;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .arg("--reinstall")
+        .arg("--offline"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
+     + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha256=[HASH])
+    ");
+    assert!(!canonical.path().exists());
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
+
+    // Revalidate using the legacy ETag; a 304 must create the canonical entry.
+    for request_method in ["HEAD", "GET"] {
+        Mock::given(method(request_method))
+            .and(path(format!("/{wheel_filename}")))
+            .and(header("if-none-match", "\"original\""))
+            .respond_with(
+                ResponseTemplate::new(304)
+                    .insert_header("Cache-Control", "max-age=3600")
+                    .insert_header("ETag", "\"original\""),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+    }
+    context
+        .pip_sync()
+        .arg("requirements.txt")
+        .arg("--require-hashes")
+        .arg("--reinstall")
+        .assert()
+        .success();
+    assert!(canonical.path().exists());
+    assert_eq!(fs::read(legacy.path())?, legacy_bytes);
+    server.verify().await;
     Ok(())
 }
 

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -4978,6 +4978,31 @@ async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
         .arg("--offline")
         .assert()
         .failure();
+    // A failed refresh must leave the original archive usable for requests that still match it.
+    Mock::given(method("GET"))
+        .and(path(format!("/{wheel_filename}")))
+        .respond_with(ResponseTemplate::new(404))
+        .with_priority(1)
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    context
+        .pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes")
+        .assert()
+        .failure();
+    requirements_in.write_str(&format!("ok @ {generation_url}\n"))?;
+    context
+        .pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes")
+        .arg("--offline")
+        .assert()
+        .success();
+    requirements_in.write_str(&format!(
+        "ok @ {generation_url}#sha256={replacement_hash}\n"
+    ))?;
     uv_snapshot!(context.filters(), context.pip_compile()
         .arg("requirements.in")
         .arg("--generate-hashes"), @r"

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -16,7 +16,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use uv_cache::{Cache, CacheBucket, WheelCache};
 use uv_client::{BaseClientBuilder, CacheControl, CachedClient, Error as ClientError};
 use uv_distribution::HttpArchivePointer;
-use uv_distribution_types::{DirectUrlBuiltDist, HashPolicy};
+use uv_distribution_types::{ArchiveHashPolicy, DirectUrlBuiltDist};
 use uv_fs::{Simplified, copy_dir_all};
 use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
@@ -4946,7 +4946,7 @@ async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
         .mount(&server)
         .await;
     // Seed independent entries so generation cannot mask a stale validation entry.
-    requirements_in.write_str(&format!("ok @ {generation_url}#sha256={original_hash}\n"))?;
+    requirements_in.write_str(&format!("ok @ {generation_url}\n"))?;
     context
         .pip_compile()
         .arg("requirements.in")
@@ -4970,6 +4970,14 @@ async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
     requirements_in.write_str(&format!(
         "ok @ {generation_url}#sha256={replacement_hash}\n"
     ))?;
+    // The shared archive has a different hash and cannot supply metadata for this URL offline.
+    context
+        .pip_compile()
+        .arg("requirements.in")
+        .arg("--generate-hashes")
+        .arg("--offline")
+        .assert()
+        .failure();
     uv_snapshot!(context.filters(), context.pip_compile()
         .arg("requirements.in")
         .arg("--generate-hashes"), @r"
@@ -5001,7 +5009,6 @@ async fn direct_url_wheel_cache_tracks_content() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + ok==1.0.0 (from http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl)
     ");
@@ -5127,7 +5134,7 @@ async fn require_hashes_url_legacy_cache() -> Result<()> {
     // Re-create the old layout, including the fragment in the stored HTTP request URI.
     let cache = Cache::from_path(context.cache_dir.path());
     let (canonical, pointer) =
-        HttpArchivePointer::read_from_direct_url(&cache, &wheel, HashPolicy::None)
+        HttpArchivePointer::read_from_direct_url(&cache, &wheel, ArchiveHashPolicy::None)
             .context("expected the downloaded wheel in the cache")?;
     let archive = pointer.into_archive();
     let legacy = cache.entry(
@@ -5173,19 +5180,17 @@ async fn require_hashes_url_legacy_cache() -> Result<()> {
     );
 
     // Revalidate using the legacy ETag; a 304 must create the canonical entry.
-    for request_method in ["HEAD", "GET"] {
-        Mock::given(method(request_method))
-            .and(path(format!("/{wheel_filename}")))
-            .and(header("if-none-match", "\"original\""))
-            .respond_with(
-                ResponseTemplate::new(304)
-                    .insert_header("Cache-Control", "max-age=3600")
-                    .insert_header("ETag", "\"original\""),
-            )
-            .expect(1)
-            .mount(&server)
-            .await;
-    }
+    Mock::given(method("GET"))
+        .and(path(format!("/{wheel_filename}")))
+        .and(header("if-none-match", "\"original\""))
+        .respond_with(
+            ResponseTemplate::new(304)
+                .insert_header("Cache-Control", "max-age=3600")
+                .insert_header("ETag", "\"original\""),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
     context
         .pip_sync()
         .arg("requirements.txt")

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -16998,3 +16998,135 @@ fn compile_bytecode_excludes_stdlib() -> Result<()> {
 
     Ok(())
 }
+
+/// Cached URL metadata must describe the archive selected for installation.
+#[tokio::test]
+async fn direct_url_wheel_cache_metadata() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix();
+    let server = MockServer::start().await;
+    let filename = "ok-1.0.0-py3-none-any.whl";
+    let url = format!("{}/{filename}", server.uri());
+    let original = fs_err::read(context.workspace_root.join("test/links").join(filename))?;
+    let serve = |wheel, cache_control| {
+        Mock::given(method("GET"))
+            .and(path(format!("/{filename}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("cache-control", cache_control)
+                    .set_body_bytes(wheel),
+            )
+    };
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(405))
+        .mount(&server)
+        .await;
+    serve(original, "max-age=0, must-revalidate")
+        .mount(&server)
+        .await;
+    context
+        .pip_install()
+        .arg("--target")
+        .arg("original")
+        .arg(&url)
+        .assert()
+        .success();
+
+    server.reset().await;
+
+    // Publish different metadata at the same wheel URL, selected by a new hash.
+    let wheel_with_dependency = |dependency: &str| -> Result<Vec<u8>> {
+        let (_, wheel) = generate_wheel(
+            &"ok".parse()?,
+            &"1.0.0".parse()?,
+            &[dependency.parse()?],
+            &BTreeMap::new(),
+            None,
+            "py3-none-any",
+        );
+        Ok(wheel)
+    };
+    let changed = wheel_with_dependency("cache-missing-dependency==1.0")?;
+    let hash = hex::encode(Sha256::digest(&changed));
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(405))
+        .mount(&server)
+        .await;
+    serve(changed, "max-age=0, must-revalidate")
+        .mount(&server)
+        .await;
+    context
+        .pip_install()
+        .arg("--target")
+        .arg("changed")
+        .arg("--no-deps")
+        .arg(format!("{url}#sha256={hash}"))
+        .assert()
+        .success();
+
+    // The fragment-free URL must resolve dependencies from the wheel it will install.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("changed-offline")
+        .arg("--offline").arg(&url), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because cache-missing-dependency was not found in the cache and ok==1.0.0 depends on cache-missing-dependency==1.0, we can conclude that ok==1.0.0 cannot be used.
+          And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
+
+    hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
+    ");
+
+    server.reset().await;
+    serve(
+        wheel_with_dependency("cache-missing-dependency==2.0")?,
+        "max-age=3600",
+    )
+    .expect(1)
+    .mount(&server)
+    .await;
+    // An expired URL without an expected hash must revalidate before resolving dependencies.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("unpinned")
+        .arg("--no-index").arg(&url), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because cache-missing-dependency was not found in the provided package locations and ok==1.0.0 depends on cache-missing-dependency==2.0, we can conclude that ok==1.0.0 cannot be used.
+          And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
+
+    hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
+    ");
+
+    // A new expected hash must refresh the archive before resolving dependencies.
+    let refreshed = wheel_with_dependency("cache-missing-dependency==3.0")?;
+    let hash = hex::encode(Sha256::digest(&refreshed));
+    server.reset().await;
+    serve(refreshed, "max-age=3600")
+        .expect(1)
+        .mount(&server)
+        .await;
+    context
+        .temp_dir
+        .child("requirements.txt")
+        .write_str(&format!("ok @ {url} --hash=sha256:{hash}"))?;
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--target").arg("refreshed")
+        .arg("--no-index").arg("--require-hashes")
+        .arg("-r").arg("requirements.txt"), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: .venv/[BIN]/[PYTHON]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because cache-missing-dependency was not found in the provided package locations and ok==1.0.0 depends on cache-missing-dependency==3.0, we can conclude that ok==1.0.0 cannot be used.
+          And because only ok==1.0.0 is available and you require ok, we can conclude that your requirements are unsatisfiable.
+
+    hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

We cache direct URL wheels by their fragment-free location, so a wheel downloaded from a URL with a hash fragment can be reused offline from a lockfile that stores the URL without its fragment. We retain fallback reads for older cache entries.

We validate cached archives before reuse and refresh them when their expected hashes or sizes change. Offline requests retain specific mismatch errors. Metadata uses the archive's HTTP cache so resolution describes the wheel we install and still honors expiration. Regression coverage includes offline lockfile reuse, legacy cache entries, changed hashes and sizes, metadata refresh, and failed replacement downloads.

Based on #21210 by @konstin.
