### PR TITLE
Use the workflow revision for PR security review configuration

### DIFF
--- a/.github/workflows/pull-request-security-review.yml
+++ b/.github/workflows/pull-request-security-review.yml
@@ -21,9 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: "Prepare review configuration"
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_CONFIG: ${{ runner.temp }}/pull-request-review
+        run: |
+          # Keep the review configuration at the workflow revision, even for older PR branches.
+          printf 'REVIEW_CONFIG=%s\n' "$REVIEW_CONFIG" >> "$GITHUB_ENV"
+          mkdir -p "$REVIEW_CONFIG"
+          cp -R agents/. "$REVIEW_CONFIG/"
+          git checkout --detach "$HEAD_SHA"
 
       - name: "Checkout Codex Security plugin"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,7 +52,7 @@ jobs:
           checksum: "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b"
 
       - name: "Install Codex Security plugin"
-        run: ./agents/scripts/install-codex-security.sh
+        run: '"$REVIEW_CONFIG/scripts/install-codex-security.sh" "$REVIEW_CONFIG/codex"'
 
       - name: "Collect pull request context"
         run: |
@@ -93,7 +103,7 @@ jobs:
             printf 'Pull request security review for #%s: %s\n\n' \
               "$(jq -r '.number' .pull-request-review-event.json)" \
               "$(jq -r '.title | gsub("[\r\n]+"; " ")' .pull-request-review-event.json)"
-            cat agents/prompts/pull-request-security-review.md
+            cat "$REVIEW_CONFIG/prompts/pull-request-security-review.md"
           } > "$RUNNER_TEMP/pull-request-security-review-prompt.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -128,13 +138,13 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           codex-version: "0.153.4"
-          codex-home: "agents/codex"
+          codex-home: "${{ env.REVIEW_CONFIG }}/codex"
           effort: xhigh
           permission-profile: "pull-request-review"
           safety-strategy: drop-sudo
           allow-bot-users: "astral-automations-bot[bot],renovate[bot]"
           prompt-file: "${{ runner.temp }}/pull-request-security-review-prompt.md"
-          output-schema-file: "agents/schemas/pull-request-security-review.json"
+          output-schema-file: "${{ env.REVIEW_CONFIG }}/schemas/pull-request-security-review.json"
           output-file: "${{ runner.temp }}/pull-request-review-result.json"
 
       - name: "Check review coverage"
@@ -169,7 +179,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codex-thread-pull-request-security-review-${{ github.run_id }}-${{ github.run_attempt }}
-          path: agents/codex/sessions
+          path: ${{ env.REVIEW_CONFIG }}/codex/sessions
           if-no-files-found: warn
 
   prepare:

--- a/agents/prompts/pull-request-security-review.md
+++ b/agents/prompts/pull-request-security-review.md
@@ -1,9 +1,10 @@
 Use `$codex-security:security-diff-scan` to review the pull request described in
 `.pull-request-review-event.json` and `.pull-request-review.diff` for security regressions. Use
-`agents/references/threat-model.md` for uv's CLI and `agents/references/repository-threat-model.md`
-for repository automation as the authoritative threat models. Resolve the exact pull request diff
-using `.pull-request-review-revisions.json`: its `base` is the merge base to pass to the plugin's
-terminal diff inventory, and `base_tip` is the pull request event's base revision. The complete path
+`$REVIEW_CONFIG/references/threat-model.md` for uv's CLI and
+`$REVIEW_CONFIG/references/repository-threat-model.md` for repository automation as the
+authoritative threat models. Resolve the exact pull request diff using
+`.pull-request-review-revisions.json`: its `base` is the merge base to pass to the plugin's terminal
+diff inventory, and `base_tip` is the pull request event's base revision. The complete path
 inventory is `.pull-request-review-paths.txt`, including deleted, workflow, configuration, build,
 test, and documentation paths. The plugin's terminal inventory generator may exclude some of these
 paths; add omitted regular files and deleted paths to its `in_scope_files.txt` before candidate
@@ -18,8 +19,8 @@ request to validate findings and suggested fixes, but do not commit, push, or ma
 GitHub. Never print, inspect, encode, or expose credentials. Do not include `@mentions` in review
 findings.
 
-Produce only a JSON object matching `agents/schemas/pull-request-security-review.json`. List each
-fully reviewed changed path once in `reviewed_paths`; reconcile this list with
+Produce only a JSON object matching `$REVIEW_CONFIG/schemas/pull-request-security-review.json`. List
+each fully reviewed changed path once in `reviewed_paths`; reconcile this list with
 `.pull-request-review-paths.txt` before returning. Read deleted paths at the base revision. If a
 path cannot be assessed, omit it from `reviewed_paths` so the incomplete review fails. Do not wrap
 the JSON in Markdown or a code fence.

--- a/agents/scripts/install-codex-security.sh
+++ b/agents/scripts/install-codex-security.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+codex_home="${1:?Codex home directory is required}"
+
 mkdir -p "$RUNNER_TEMP/codex-security"
 curl --fail --location --silent --show-error \
   --output "$RUNNER_TEMP/codex.tar.gz" \
@@ -16,7 +18,7 @@ jq '.name = "openai-curated-ci" | .plugins |= map(select(.name == "codex-securit
   "$marketplace" > "$RUNNER_TEMP/marketplace.json"
 mv "$RUNNER_TEMP/marketplace.json" "$marketplace"
 
-CODEX_HOME="$GITHUB_WORKSPACE/agents/codex" "$codex" plugin marketplace add \
+CODEX_HOME="$codex_home" "$codex" plugin marketplace add \
   "$GITHUB_WORKSPACE/.codex-security-plugin"
-CODEX_HOME="$GITHUB_WORKSPACE/agents/codex" "$codex" plugin add \
+CODEX_HOME="$codex_home" "$codex" plugin add \
   codex-security@openai-curated-ci


### PR DESCRIPTION
## Summary

After #21528, older PR branches can run the new security-review workflow with an old prompt and output schema. Codex returns only `findings`, and the new `reviewed_paths` check fails, as it did on #21589.

Save the review configuration from the workflow revision into a temporary place (`$REVIEW_CONFIG`) before checking out the PR head. Use that copy for the prompt, schema, threat models, installer, Codex settings, and session upload. This also means relocating `$CODEX_HOME` into the temporary `$REVIEW_CONFIG`.

## Test plan (on top of CI)

- Replayed the workflow steps with #21589’s original 27 changed files. Confirmed the original failure, successful complete coverage, and rejection of missing coverage.
- Checked that missing and empty installer arguments fail before setup.
