### PR TITLE
Use shared Depot Docker actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -182,8 +182,6 @@ jobs:
           username: astralshbot
           password: ${{ secrets.DOCKERHUB_TOKEN_RO }}
 
-      - uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
-
       - name: Check tag consistency
         if: ${{ needs.docker-plan.outputs.push-version == 'true' }}
         env:
@@ -198,59 +196,22 @@ jobs:
           fi
           echo "Releasing ${version}"
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+      - name: Build and save image
+        id: build
+        uses: astral-sh/github-actions/docker-build@29736b0ef051c49097a9b4adca75e0f3e0c973dd
         with:
+          name: uv
+          project: ${{ env.DEPOT_PROJECT_ID }}
           images: |
             ${{ env.UV_GHCR_IMAGE }}
             ${{ env.UV_DOCKERHUB_IMAGE }}
-          # Set `org.opencontainers.image.version` to the release version,
-          # rather than the branch name.
+          save: ${{ needs.docker-plan.outputs.save }}
+          # Set the OCI version label to the release version.
           tags: |
             type=raw,value=dry-run,enable=${{ needs.docker-plan.outputs.push == 'false' }}
             type=pep440,pattern={{ version }},value=${{ needs.docker-plan.outputs.tag }},enable=${{ needs.docker-plan.outputs.push-version == 'true' }}
             type=pep440,pattern={{ major }}.{{ minor }},value=${{ needs.docker-plan.outputs.tag }},enable=${{ needs.docker-plan.outputs.push-version == 'true' }}
             type=sha,enable=${{ inputs.push-dev }}
-
-      - name: Build and save image
-        id: build
-        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
-        with:
-          project: ${{ env.DEPOT_PROJECT_ID }}
-          context: .
-          platforms: linux/amd64,linux/arm64
-          save: ${{ needs.docker-plan.outputs.save }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: mode=max
-          sbom: true
-
-      - name: Record image
-        if: ${{ needs.docker-plan.outputs.save == 'true' }}
-        env:
-          BUILD_ID: ${{ steps.build.outputs.build-id }}
-          DIGEST: ${{ steps.build.outputs.digest }}
-          TAGS: ${{ steps.meta.outputs.tags }}
-          ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
-        run: |
-          jq -en \
-            --arg name uv \
-            --arg build_id "$BUILD_ID" \
-            --arg digest "$DIGEST" \
-            --arg tags "$TAGS" \
-            --arg annotations "$ANNOTATIONS" \
-            '{name: $name, build_id: $build_id, digest: $digest,
-              tags: ($tags | split("\n")), annotations: ($annotations | split("\n"))}
-              | select(.build_id != "" and (.digest | test("^sha256:[0-9a-f]{64}$")))' > uv.json
-
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: ${{ needs.docker-plan.outputs.save == 'true' }}
-        with:
-          name: docker-image-uv
-          path: uv.json
-          overwrite: true
 
   docker-build-extra:
     name: build ${{ matrix.image-mapping }}
@@ -281,119 +242,32 @@ jobs:
           username: astralshbot
           password: ${{ secrets.DOCKERHUB_TOKEN_RO }}
 
-      - uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
-
-      - name: Authenticate to Depot Registry
-        if: ${{ needs.docker-plan.outputs.save == 'true' }}
-        env:
-          BUILD_ID: ${{ needs.docker-build-base.outputs.build-id }}
-        run: |
-          token="$(depot pull-token --project "$DEPOT_PROJECT_ID" "$BUILD_ID")"
-          echo "::add-mask::$token"
-          printf '%s' "$token" | docker login registry.depot.dev --username x-token --password-stdin
-
       - name: Generate Dockerfile and tags
-        id: dockerfile
-        env:
-          VERSION: ${{ needs.docker-plan.outputs.tag }}
-          PUSH_DEV: ${{ inputs.push-dev }}
-          # When the new base image is not saved, use the registry's `latest` tag.
-          UV_BASE_IMAGE: ${{ needs.docker-plan.outputs.save == 'true' && format('registry.depot.dev/{0}@{1}', env.DEPOT_PROJECT_ID, needs.docker-build-base.outputs.image-digest) || format('{0}:latest', env.UV_GHCR_IMAGE) }}
-          IMAGE_MAPPING: ${{ matrix.image-mapping }}
-        run: |
-          set -euo pipefail
-
-          # Extract the image and tags from the matrix variable.
-          IFS=',' read -r BASE_IMAGE BASE_TAGS <<< "${IMAGE_MAPPING}"
-          # The first image alias is the name of its manifest artifact.
-          echo "name=${BASE_TAGS%%,*}" >> "$GITHUB_OUTPUT"
-
-          # Generate the Dockerfile for this base image.
-          cat <<EOF > Dockerfile
-          FROM ${BASE_IMAGE}
-          COPY --from=${UV_BASE_IMAGE} /uv /uvx /usr/local/bin/
-          ENV UV_TOOL_BIN_DIR="/usr/local/bin"
-          ENTRYPOINT []
-          CMD ["/usr/local/bin/uv"]
-          EOF
-
-          # Collect Docker metadata patterns for every image alias.
-          TAG_PATTERNS=""
-
-          # For releases, the first tag includes the patch version and image suffix.
-          # Docker metadata uses it for `org.opencontainers.image.version`.
-          IFS=','; for TAG in ${BASE_TAGS}; do
-            if [ "${PUSH_DEV}" == "true" ]; then
-              TAG_PATTERNS="${TAG_PATTERNS}type=sha,suffix=-${TAG}\n"
-            else
-              TAG_PATTERNS="${TAG_PATTERNS}type=pep440,pattern={{ version }},suffix=-${TAG},value=${VERSION}\n"
-              TAG_PATTERNS="${TAG_PATTERNS}type=pep440,pattern={{ major }}.{{ minor }},suffix=-${TAG},value=${VERSION}\n"
-              TAG_PATTERNS="${TAG_PATTERNS}type=raw,value=${TAG}\n"
-            fi
-          done
-
-          # Remove the trailing escaped newline from the pattern list.
-          TAG_PATTERNS="${TAG_PATTERNS%\\n}"
-
-          # Export the patterns using GitHub Actions' multiline environment syntax.
-          {
-            echo "TAG_PATTERNS<<EOF"
-            echo -e "${TAG_PATTERNS}"
-            echo EOF
-          } >> "$GITHUB_ENV"
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        # GHCR uses index-level annotations for image metadata.
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+        id: variant
+        uses: astral-sh/github-actions/docker-variant@29736b0ef051c49097a9b4adca75e0f3e0c973dd
         with:
+          image-mapping: ${{ matrix.image-mapping }}
+          # Unsaved PR builds use the published base image.
+          source-image: ${{ needs.docker-plan.outputs.save == 'true' && format('registry.depot.dev/{0}@{1}', env.DEPOT_PROJECT_ID, needs.docker-build-base.outputs.image-digest) || format('{0}:latest', env.UV_GHCR_IMAGE) }}
+          binaries: uv uvx
+          command: uv
+          dockerfile-lines: ENV UV_TOOL_BIN_DIR="/usr/local/bin"
+          version: ${{ needs.docker-plan.outputs.tag }}
+          push-dev: ${{ inputs.push-dev }}
+
+      - name: Build and save image
+        uses: astral-sh/github-actions/docker-build@29736b0ef051c49097a9b4adca75e0f3e0c973dd
+        with:
+          name: ${{ steps.variant.outputs.name }}
+          project: ${{ env.DEPOT_PROJECT_ID }}
+          pull-build-id: ${{ needs.docker-plan.outputs.save == 'true' && needs.docker-build-base.outputs.build-id || '' }}
+          file: ${{ steps.variant.outputs.file }}
           images: |
             ${{ env.UV_GHCR_IMAGE }}
             ${{ env.UV_DOCKERHUB_IMAGE }}
-          flavor: |
-            latest=false
-          tags: |
-            ${{ env.TAG_PATTERNS }}
-
-      - name: Build and save image
-        id: build
-        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
-        with:
-          context: .
-          project: ${{ env.DEPOT_PROJECT_ID }}
-          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.variant.outputs.tags }}
+          flavor: latest=false
           save: ${{ needs.docker-plan.outputs.save }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: mode=max
-          sbom: true
-
-      - name: Record image
-        if: ${{ needs.docker-plan.outputs.save == 'true' }}
-        env:
-          NAME: ${{ steps.dockerfile.outputs.name }}
-          BUILD_ID: ${{ steps.build.outputs.build-id }}
-          DIGEST: ${{ steps.build.outputs.digest }}
-          TAGS: ${{ steps.meta.outputs.tags }}
-          ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
-        run: |
-          jq -en \
-            --arg name "$NAME" \
-            --arg build_id "$BUILD_ID" \
-            --arg digest "$DIGEST" \
-            --arg tags "$TAGS" \
-            --arg annotations "$ANNOTATIONS" \
-            '{name: $name, build_id: $build_id, digest: $digest,
-              tags: ($tags | split("\n")), annotations: ($annotations | split("\n"))}
-              | select(.build_id != "" and (.digest | test("^sha256:[0-9a-f]{64}$")))' > "$NAME.json"
-
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: ${{ needs.docker-plan.outputs.save == 'true' }}
-        with:
-          name: docker-image-${{ steps.dockerfile.outputs.name }}
-          path: ${{ steps.dockerfile.outputs.name }}.json
-          overwrite: true
 
   docker-manifest:
     name: collect image manifest
@@ -405,34 +279,10 @@ jobs:
     runs-on: ${{ github.repository_owner == 'astral-sh' && 'github-ubuntu-24.04-x86_64-4' || 'ubuntu-latest' }}
     timeout-minutes: 2
     outputs:
-      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+      artifact-id: ${{ steps.manifest.outputs.artifact-id }}
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: astral-sh/github-actions/docker-manifest@29736b0ef051c49097a9b4adca75e0f3e0c973dd
+        id: manifest
         with:
-          pattern: docker-image-*
-          path: images
-          merge-multiple: true
-
-      - name: Assemble image manifest
-        env:
-          EXTRA_IMAGES: ${{ needs.docker-plan.outputs.extra-images }}
-        run: |
-          # Load the per-image records and require one base image plus the
-          # expected number of distinct variants. Split the result into
-          # base and extra images so the publisher can publish the base last.
-          jq -se --argjson expected "$EXTRA_IMAGES" '
-            if length != (1 + ($expected["image-mapping"] | length))
-              or (map(.name) | unique | length) != length
-              or (map(select(.name == "uv")) | length) != 1
-            then error("incomplete Docker image manifest")
-            else {base: map(select(.name == "uv"))[0],
-                  extra: map(select(.name != "uv"))}
-            end
-          ' images/*.json > docker-manifest.json
-
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        id: upload
-        with:
-          name: docker-manifest
-          path: docker-manifest.json
-          overwrite: true
+          base-name: uv
+          image-mappings: ${{ toJson(fromJson(needs.docker-plan.outputs.extra-images).image-mapping) }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -71,15 +71,6 @@ jobs:
           echo "GHCR destination: $UV_GHCR_IMAGE"
           echo "Docker Hub destination: ${UV_DOCKERHUB_IMAGE:-none}"
 
-      - uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
-
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          # Install a version that supports `imagetools create --metadata-file`
-          # (https://github.com/docker/buildx/issues/2407).
-          version: v0.33.0
-          cache-binary: false
-
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         if: ${{ !inputs.push-dev }}
         with:
@@ -92,84 +83,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Copy saved image and publish tags
-        id: publish
-        env:
-          IMAGE_JSON: ${{ inputs.image }}
-          IMAGES: "${{ env.UV_GHCR_IMAGE }} ${{ env.UV_DOCKERHUB_IMAGE }}"
-        run: |
-          set -euo pipefail
-          build_id=$(jq -er '.build_id | select(test("^[a-zA-Z0-9]+$"))' <<< "$IMAGE_JSON")
-          digest=$(jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<< "$IMAGE_JSON")
-
-          # Verify that the Depot build ID resolves to the recorded index digest.
-          token="$(depot pull-token --project "$DEPOT_PROJECT_ID" "$build_id")"
-          echo "::add-mask::$token"
-          printf '%s' "$token" | docker login registry.depot.dev --username x-token --password-stdin
-          saved_digest=$(docker buildx imagetools inspect \
-            "registry.depot.dev/${DEPOT_PROJECT_ID}:$build_id" --format '{{.Manifest.Digest}}')
-          if [ "$saved_digest" != "$digest" ]; then
-            echo "The saved Depot image does not match the build manifest" >&2
-            exit 1
-          fi
-
-          # Keep annotation values containing spaces or shell-special characters
-          # together as individual command arguments.
-          annotations=()
-          while IFS= read -r annotation; do
-            annotations+=(--annotation "$annotation")
-          done < <(jq -r '.annotations[]' <<< "$IMAGE_JSON")
-
-          # Only accept tag references for the destination repositories selected
-          # by this workflow.
-          for image in $IMAGES; do
-            readarray -t image_tags < <(
-              jq -r --arg prefix "$image:" '.tags[] | select(startswith($prefix))' <<< "$IMAGE_JSON"
-            )
-            if [ "${#image_tags[@]}" -eq 0 ]; then
-              echo "Missing tags for $image" >&2
-              exit 1
-            fi
-
-            # Copy the complete index instead of loading and re-pushing it through
-            # the local Docker image store, which can drop platforms or change
-            # the manifest format (astral-sh/uv#14165).
-            depot push --project "$DEPOT_PROJECT_ID" --tag "${image_tags[0]}" "$build_id"
-            copied_digest=$(docker buildx imagetools inspect \
-              "${image_tags[0]}" --format '{{.Manifest.Digest}}')
-            if [ "$copied_digest" != "$digest" ]; then
-              echo "The copied image digest does not match the build manifest" >&2
-              exit 1
-            fi
-
-            tags=()
-            for tag in "${image_tags[@]}"; do
-              tags+=(-t "$tag")
-            done
-            # Apply index metadata during publication so the final digest covers
-            # both the complete multi-platform image and its annotations.
-            docker buildx imagetools create \
-              "${annotations[@]}" \
-              "${tags[@]}" \
-              --metadata-file "$RUNNER_TEMP/docker-publish-metadata.json" \
-              "$image@$digest"
-
-            # Adding index annotations changes the digest. Read the new digest
-            # from `imagetools` so the attestation cannot race a mutable tag.
-            if [ "$image" == "$UV_GHCR_IMAGE" ]; then
-              final_digest=$(jq -er '."containerimage.descriptor".digest' "$RUNNER_TEMP/docker-publish-metadata.json")
-              echo "digest=$final_digest" >> "$GITHUB_OUTPUT"
-            fi
-          done
-
-      - name: Attest original image
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      - name: Publish saved image
+        uses: astral-sh/github-actions/docker-publish@29736b0ef051c49097a9b4adca75e0f3e0c973dd
         with:
-          subject-name: ${{ env.UV_GHCR_IMAGE }}
-          subject-digest: ${{ fromJson(inputs.image).digest }}
-
-      - name: Attest published image
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        with:
-          subject-name: ${{ env.UV_GHCR_IMAGE }}
-          subject-digest: ${{ steps.publish.outputs.digest }}
+          project: ${{ env.DEPOT_PROJECT_ID }}
+          image: ${{ inputs.image }}
+          images: |
+            ${{ env.UV_GHCR_IMAGE }}
+            ${{ env.UV_DOCKERHUB_IMAGE }}
+          attestation-image: ${{ env.UV_GHCR_IMAGE }}


### PR DESCRIPTION
Use the shared Depot Docker actions from astral-sh/github-actions#4 for image builds, variant Dockerfiles, manifest assembly, and publication. Keep uv's Depot project selection, image matrix, release gates, registry credentials, and development-publication restrictions in its workflows.
