### PR TITLE
Include the Docker image name in publish jobs

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   publish:
+    name: publish ${{ fromJson(inputs.image).name }}
     # Development publication cannot select the production repositories.
     # Production publication requires the main-branch release workflow in `astral-sh/uv`.
     if: ${{ inputs.push-dev || (github.repository == 'astral-sh/uv' && github.event_name == 'workflow_dispatch' && github.workflow_ref == 'astral-sh/uv/.github/workflows/release.yml@refs/heads/main') }}


### PR DESCRIPTION
Docker publication jobs appear as `publish` in the reusable workflow's job view, making individual images hard to distinguish. Include the image name from the saved build manifest in the job's display name.
