### PR TITLE
Render error sources with cause labels

### DIFF
--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -370,34 +370,26 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
         wrapped_main.trim()
     )?;
 
-    let mut sources = iter::successors(err.source(), |&err| err.source()).peekable();
-    while let Some(source) = sources.next() {
+    for source in iter::successors(err.source(), |&err| err.source()) {
         let msg = source.to_string();
-        let has_more = sources.peek().is_some();
-        let connector = if has_more { "├──" } else { "└──" };
-        // Reserve the display width of the gutter before wrapping the message. Authored lines
-        // retain their own indentation within the gutter.
-        let wrapped = wrap_text(&msg, width.map(|width| width.saturating_sub(6)), "", "", "");
+        // Reserve the display width of the prefix before wrapping the message. Authored lines
+        // retain their own indentation beneath it.
+        let wrapped = wrap_text(&msg, width.map(|width| width.saturating_sub(9)), "", "", "");
 
         let mut lines = wrapped.lines();
         if let Some(first) = lines.next() {
             writeln!(
                 &mut stream,
-                "  {} {}",
-                connector.color(color).bold(),
+                "  {}{} {}",
+                "cause".color(color).bold(),
+                ":".bold(),
                 first.trim()
             )?;
             for line in lines {
                 if line.trim().is_empty() {
-                    if has_more {
-                        writeln!(&mut stream, "  {}", "│".color(color).bold())?;
-                    } else {
-                        writeln!(&mut stream)?;
-                    }
-                } else if has_more {
-                    writeln!(&mut stream, "  {}   {line}", "│".color(color).bold())?;
+                    writeln!(&mut stream)?;
                 } else {
-                    writeln!(&mut stream, "      {line}")?;
+                    writeln!(&mut stream, "         {line}")?;
                 }
             }
         }
@@ -556,9 +548,9 @@ mod tests {
 
         assert_snapshot!(output, @"
         error: No solution found when resolving dependencies
-          └── Because fiasobfhuasbf was not found in the package registry and you
-              require fiasobfhuasbf, we can conclude that your requirements are
-              unsatisfiable.
+          cause: Because fiasobfhuasbf was not found in the package registry and you
+                 require fiasobfhuasbf, we can conclude that your requirements are
+                 unsatisfiable.
         ");
     }
 
@@ -583,12 +575,12 @@ mod tests {
             ErrorOptions::default().with_stream(&mut output),
         )
         .unwrap();
-        assert_snapshot!(format!("{output:?}"), @r#""\u{1b}[1m\u{1b}[31merror\u{1b}[39m\u{1b}[0m\u{1b}[1m:\u{1b}[0m Failed to write file\n  \u{1b}[1m\u{1b}[31m└──\u{1b}[39m\u{1b}[0m Permission denied\n""#);
+        assert_snapshot!(format!("{output:?}"), @r#""\u{1b}[1m\u{1b}[31merror\u{1b}[39m\u{1b}[0m\u{1b}[1m:\u{1b}[0m Failed to write file\n  \u{1b}[1m\u{1b}[31mcause\u{1b}[39m\u{1b}[0m\u{1b}[1m:\u{1b}[0m Permission denied\n""#);
         let output = anstream::adapter::strip_str(&output);
 
         assert_snapshot!(output, @"
         error: Failed to write file
-          └── Permission denied
+          cause: Permission denied
         ");
     }
 
@@ -723,10 +715,10 @@ mod tests {
         assert_snapshot!(output, @"
         error: Unable to resolve package
                dependencies
-          ├── Failed to fetch package metadata
-          │   from registry
-          └── Network connection timeout after
-              multiple retry attempts
+          cause: Failed to fetch package
+                 metadata from registry
+          cause: Network connection timeout
+                 after multiple retry attempts
         ");
     }
 
@@ -746,8 +738,8 @@ mod tests {
 
         assert_snapshot!(output, @"
         error: root
-          └── one
-              two
+          cause: one
+                 two
         ");
     }
 
@@ -825,7 +817,7 @@ mod tests {
 
         assert_snapshot!(rendered, @"
         error: Failed to fetch package
-          └── Permission denied
+          cause: Permission denied
 
         hint: Try running with `--verbose` for more information.
 
@@ -854,11 +846,11 @@ mod tests {
 
         assert_snapshot!(rendered, @"
         error: Failed to download Python 3.12
-          ├── Failed to fetch https://example.com/upload/python3.13.tar.zst
-          │   Server says: This endpoint only support POST requests.
-          │
-          │   For downloads, please refer to https://example.com/download/python3.13.tar.zst
-          └── Caused By: HTTP Error 400
+          cause: Failed to fetch https://example.com/upload/python3.13.tar.zst
+                 Server says: This endpoint only support POST requests.
+
+                 For downloads, please refer to https://example.com/download/python3.13.tar.zst
+          cause: Caused By: HTTP Error 400
         ");
     }
 }

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -2258,7 +2258,7 @@ mod tests {
             &capture,
             @"
         error: Failed to publish `../../test/links/tqdm-4.66.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl` to [SERVER]/final
-          └── Too many redirects, only 10 redirects are allowed
+          cause: Too many redirects, only 10 redirects are allowed
         "
         );
     }
@@ -2292,7 +2292,7 @@ mod tests {
             &capture,
             @"
         error: Failed to publish `../../test/links/tqdm-4.66.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl` to https://different.auth.tld/final/
-          └── Redirected URL is not in the same realm. Redirected to: https://different.auth.tld/final/
+          cause: Redirected URL is not in the same realm. Redirected to: https://different.auth.tld/final/
         "
         );
     }
@@ -2331,7 +2331,7 @@ mod tests {
             &capture,
             @"
         error: Failed to publish `../../test/links/tqdm-4.66.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl` to [SERVER]/final
-          └── Server returned status code 400 Bad Request. Server says: 400 Error: Use 'source' as Python version for an sdist.
+          cause: Server returned status code 400 Bad Request. Server says: 400 Error: Use 'source' as Python version for an sdist.
         "
         );
     }
@@ -2373,7 +2373,7 @@ mod tests {
             &capture,
             @"
         error: Failed to publish `../../test/links/tqdm-4.66.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl` to [SERVER]/final
-          └── Server returned status code 400 Bad Request. Server message: Bad Request, Missing required field `name`
+          cause: Server returned status code 400 Bad Request. Server message: Bad Request, Missing required field `name`
         "
         );
     }

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -338,14 +338,14 @@ impl TestContext {
         // The exact message string depends on the system language, so we remove it.
         // Keep the severity or cause prefix while removing the operating system's message.
         self.filters.push((
-            r"[^:\n─]* \(os error 2\)".to_string(),
+            r"[^:\n]* \(os error 2\)".to_string(),
             " [OS ERROR 2]".to_string(),
         ));
         // Replace the Windows "The system cannot find the path specified. (os error 3)"
         // with the Unix "No such file or directory (os error 2)"
         // and mask the language-dependent message.
         self.filters.push((
-            r"[^:\n─]* \(os error 3\)".to_string(),
+            r"[^:\n]* \(os error 3\)".to_string(),
             " [OS ERROR 2]".to_string(),
         ));
         self

--- a/crates/uv-warnings/src/lib.rs
+++ b/crates/uv-warnings/src/lib.rs
@@ -116,13 +116,13 @@ mod tests {
             ErrorOptions::default().with_stream(&mut output),
         )
         .unwrap();
-        assert_snapshot!(format!("{output:?}"), @r#""\u{1b}[1m\u{1b}[33mwarning\u{1b}[39m\u{1b}[0m\u{1b}[1m:\u{1b}[0m Failed to install Python\n  \u{1b}[1m\u{1b}[33m├──\u{1b}[39m\u{1b}[0m Failed to write registry entry\n  \u{1b}[1m\u{1b}[33m└──\u{1b}[39m\u{1b}[0m Permission denied\n\n\u{1b}[36m\u{1b}[1mhint\u{1b}[0m\u{1b}[39m\u{1b}[1m:\u{1b}[0m Check the registry permissions.\n""#);
+        assert_snapshot!(format!("{output:?}"), @r#""\u{1b}[1m\u{1b}[33mwarning\u{1b}[39m\u{1b}[0m\u{1b}[1m:\u{1b}[0m Failed to install Python\n  \u{1b}[1m\u{1b}[33mcause\u{1b}[39m\u{1b}[0m\u{1b}[1m:\u{1b}[0m Failed to write registry entry\n  \u{1b}[1m\u{1b}[33mcause\u{1b}[39m\u{1b}[0m\u{1b}[1m:\u{1b}[0m Permission denied\n\n\u{1b}[36m\u{1b}[1mhint\u{1b}[0m\u{1b}[39m\u{1b}[1m:\u{1b}[0m Check the registry permissions.\n""#);
         let output = anstream::adapter::strip_str(&output);
 
         assert_snapshot!(output, @"
         warning: Failed to install Python
-          ├── Failed to write registry entry
-          └── Permission denied
+          cause: Failed to write registry entry
+          cause: Permission denied
 
         hint: Check the registry permissions.
         ");

--- a/crates/uv/tests/build/audit.rs
+++ b/crates/uv/tests/build/audit.rs
@@ -393,8 +393,8 @@ async fn audit_malformed_vulnerability_record() {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: OSV returned a malformed vulnerability record for `PYSEC-2023-0001`
-      ├── error decoding response body for url (http://[LOCALHOST]/v1/vulns/PYSEC-2023-0001)
-      └── expected value at line 1 column 56
+      cause: error decoding response body for url (http://[LOCALHOST]/v1/vulns/PYSEC-2023-0001)
+      cause: expected value at line 1 column 56
     ");
 }
 

--- a/crates/uv/tests/build/build.rs
+++ b/crates/uv/tests/build/build.rs
@@ -106,7 +106,7 @@ fn build_basic() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/`
-      └── [TEMP_DIR]/ does not appear to be a Python project, as neither `pyproject.toml` nor `setup.py` are present in the directory
+      cause: [TEMP_DIR]/ does not appear to be a Python project, as neither `pyproject.toml` nor `setup.py` are present in the directory
     ");
 
     // Build to a specified path, even if builds are disabled for the project by name.
@@ -239,7 +239,7 @@ fn build_sdist_missing_backend_path() -> Result<()> {
     Building source distribution...
     Building wheel from source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      └── `backend-path` entry `backend_dir` does not exist or is not a directory
+      cause: `backend-path` entry `backend_dir` does not exist or is not a directory
     ");
 
     Ok(())
@@ -272,7 +272,7 @@ fn build_backend_path_outside_source_tree() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/project`
-      └── `backend-path` entry `../backend` must be a relative path within the source tree
+      cause: `backend-path` entry `../backend` must be a relative path within the source tree
     ");
 
     Ok(())
@@ -306,7 +306,7 @@ fn build_backend_path_absolute_inside_source_tree() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/project`
-      └── `backend-path` entry `[TEMP_DIR]/project/backend` must be a relative path within the source tree
+      cause: `backend-path` entry `[TEMP_DIR]/project/backend` must be a relative path within the source tree
     ");
 
     Ok(())
@@ -341,7 +341,7 @@ fn build_backend_path_symlink_outside_source_tree() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/project`
-      └── `backend-path` entry `backend` must be a relative path within the source tree
+      cause: `backend-path` entry `backend` must be a relative path within the source tree
     ");
 
     Ok(())
@@ -543,7 +543,7 @@ fn build_wheel_from_sdist() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to build `[TEMP_DIR]/project/dist/project-0.1.0.tar.gz`
-      └── Pass `--wheel` explicitly to build a wheel from a source distribution
+      cause: Pass `--wheel` explicitly to build a wheel from a source distribution
     ");
 
     // Error if `--sdist` is specified.
@@ -551,7 +551,7 @@ fn build_wheel_from_sdist() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to build `[TEMP_DIR]/project/dist/project-0.1.0.tar.gz`
-      └── Building an `--sdist` from a source distribution is not supported
+      cause: Building an `--sdist` from a source distribution is not supported
     ");
 
     // Explicit wheel builds from an sdist are allowed even when dependency builds are disabled.
@@ -576,7 +576,7 @@ fn build_wheel_from_sdist() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to build `[TEMP_DIR]/project/dist/project-0.1.0-py3-none-any.whl`
-      └── `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`.
+      cause: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`.
     ");
 
     Ok(())
@@ -641,8 +641,8 @@ fn build_fail() -> Result<()> {
         from setuptools import setup
     IndentationError: unexpected indent
     error: Failed to build `[TEMP_DIR]/project`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
 
     hint: Build failures usually indicate a problem with the package or the build environment
     "#);
@@ -807,7 +807,7 @@ fn build_workspace() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: `--package` was provided, but no workspace was found
-      └── No `pyproject.toml` found in current directory or any parent directory
+      cause: No `pyproject.toml` found in current directory or any parent directory
     ");
 
     // Fail when `--all` is provided without a workspace.
@@ -815,7 +815,7 @@ fn build_workspace() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: `--all-packages` was provided, but no workspace was found
-      └── No `pyproject.toml` found in current directory or any parent directory
+      cause: No `pyproject.toml` found in current directory or any parent directory
     ");
 
     // Fail when `--package` is a non-existent member without a workspace.
@@ -936,8 +936,8 @@ fn build_all_with_failure() -> Result<()> {
     Successfully built dist/member_a-0.1.0.tar.gz
     Successfully built dist/member_a-0.1.0-py3-none-any.whl
     error: Failed to build `member-b @ [TEMP_DIR]/project/packages/member_b`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
 
     hint: Build failures usually indicate a problem with the package or the build environment
     Successfully built dist/project-0.1.0.tar.gz
@@ -1002,9 +1002,9 @@ fn build_constraints() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      ├── Failed to resolve requirements from `build-system.requires`
-      ├── No solution found when resolving: `hatchling>=1.0`
-      └── Because you require hatchling>=1.0 and hatchling==0.1.0, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `build-system.requires`
+      cause: No solution found when resolving: `hatchling>=1.0`
+      cause: Because you require hatchling>=1.0 and hatchling==0.1.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     project
@@ -1379,16 +1379,16 @@ fn build_sha() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      ├── Failed to install requirements from `build-system.requires`
-      ├── Failed to download `hatchling==1.22.4`
-      └── Hash mismatch for `hatchling==1.22.4`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Failed to download `hatchling==1.22.4`
+      cause: Hash mismatch for `hatchling==1.22.4`
 
-          Expected:
-            sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
-            sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+             Expected:
+               sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
+               sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
 
-          Computed:
-            sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+             Computed:
+               sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
     ");
 
     project
@@ -1408,16 +1408,16 @@ fn build_sha() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      ├── Failed to install requirements from `build-system.requires`
-      ├── Failed to download `hatchling==1.22.4`
-      └── Hash mismatch for `hatchling==1.22.4`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Failed to download `hatchling==1.22.4`
+      cause: Hash mismatch for `hatchling==1.22.4`
 
-          Expected:
-            sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
-            sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+             Expected:
+               sha256:a248cb506794bececcddeddb1678bc722f9cfcacf02f98f7c0af6b9ed893caf2
+               sha256:e16da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
 
-          Computed:
-            sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
+             Computed:
+               sha256:f56da5bfc396af7b29daa3164851dd04991c994083f56cb054b5003675caecdc
     ");
 
     project
@@ -1440,9 +1440,9 @@ fn build_sha() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      ├── Failed to resolve requirements from `build-system.requires`
-      ├── No solution found when resolving: `hatchling`
-      └── In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `hatchling`
+      cause: Failed to resolve requirements from `build-system.requires`
+      cause: No solution found when resolving: `hatchling`
+      cause: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `hatchling`
     ");
 
     project
@@ -1754,8 +1754,8 @@ fn build_hide_build_output_on_failure() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.build_sdist` failed (exit status: 1)
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -1836,8 +1836,8 @@ fn build_tool_uv_sources() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      ├── Failed to install requirements from `build-system.requires`
-      └── Building source distributions is disabled, but attempted to build `backend`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Building source distributions is disabled, but attempted to build `backend`
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--no-build-package").arg("backend").current_dir(project.path()), @"
@@ -1845,8 +1845,8 @@ fn build_tool_uv_sources() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      ├── Failed to install requirements from `build-system.requires`
-      └── Building source distributions is disabled, but attempted to build `backend`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Building source distributions is disabled, but attempted to build `backend`
     ");
 
     project
@@ -1914,8 +1914,8 @@ fn build_named_index_config_file_hint() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      ├── Failed to parse entry: `hatchling`
-      └── Package `hatchling` references an undeclared index: `privindex`
+      cause: Failed to parse entry: `hatchling`
+      cause: Package `hatchling` references an undeclared index: `privindex`
 
     hint: Index `privindex` was found in a project-level `uv.toml`, but indexes referenced via `tool.uv.sources` must be defined in the project's `pyproject.toml`
     ");
@@ -2274,8 +2274,8 @@ fn build_unsafe_script_entry_point_name() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/`
-      ├── Invalid project metadata
-      └── Script entry point name `../script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+      cause: Invalid project metadata
+      cause: Script entry point name `../script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())
@@ -2315,8 +2315,8 @@ fn build_dot_script_entry_point_name() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/`
-      ├── Invalid project metadata
-      └── Script entry point name `.` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+      cause: Invalid project metadata
+      cause: Script entry point name `.` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())
@@ -2356,8 +2356,8 @@ fn build_nested_script_entry_point_name() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/`
-      ├── Invalid project metadata
-      └── Script entry point name `nested/script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+      cause: Invalid project metadata
+      cause: Script entry point name `nested/script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())
@@ -2519,7 +2519,7 @@ fn build_list_files_errors() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to build `[WORKSPACE]/test/packages/anyio_local`
-      └── Can only use `--list` with a compatible uv build backend, but `[WORKSPACE]/test/packages/anyio_local` is not compatible because `build_system.build-backend` is not `uv_build`, but `flit_core.buildapi`
+      cause: Can only use `--list` with a compatible uv build backend, but `[WORKSPACE]/test/packages/anyio_local` is not compatible because `build_system.build-backend` is not `uv_build`, but `flit_core.buildapi`
     ");
     Ok(())
 }
@@ -2550,7 +2550,7 @@ fn build_version_mismatch() -> Result<()> {
     ----- stderr -----
     Building wheel from source distribution...
     error: Failed to build `[TEMP_DIR]/anyio-1.2.3.tar.gz`
-      └── The source distribution declares version 1.2.3, but the wheel declares version 4.3.0+foo
+      cause: The source distribution declares version 1.2.3, but the wheel declares version 4.3.0+foo
     ");
     Ok(())
 }
@@ -2586,7 +2586,7 @@ fn build_name_mismatch() -> Result<()> {
     Building source distribution...
     Building wheel...
     error: Failed to build `[TEMP_DIR]/project`
-      └── The source distribution declares name alpha, but the wheel declares name beta
+      cause: The source distribution declares name alpha, but the wheel declares name beta
     ");
 
     Ok(())
@@ -2686,7 +2686,7 @@ fn build_workspace_virtual_root() -> Result<()> {
     warning: `[TEMP_DIR]/` appears to be a workspace root without a Python project; consider using `uv sync` to install the workspace, or add a `[build-system]` table to `pyproject.toml`
     Building wheel from source distribution...
     error: Failed to build `[TEMP_DIR]/`
-      └── The source distribution declares name cache, but the wheel declares name unknown
+      cause: The source distribution declares name cache, but the wheel declares name unknown
     ");
     Ok(())
 }
@@ -2712,7 +2712,7 @@ fn build_pyproject_toml_not_a_project() -> Result<()> {
     warning: `[TEMP_DIR]/` does not appear to be a Python project, as the `pyproject.toml` does not include a `[build-system]` table, and neither `setup.py` nor `setup.cfg` are present in the directory
     Building wheel from source distribution...
     error: Failed to build `[TEMP_DIR]/`
-      └── The source distribution declares name cache, but the wheel declares name unknown
+      cause: The source distribution declares name cache, but the wheel declares name unknown
     ");
     Ok(())
 }
@@ -2796,7 +2796,7 @@ fn force_pep517() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/`
-      └── Expected a Python module at: src/does_not_exist/__init__.py
+      cause: Expected a Python module at: src/does_not_exist/__init__.py
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--force-pep517").env(EnvVars::RUST_BACKTRACE, "0"), @"
@@ -2805,8 +2805,8 @@ fn force_pep517() -> Result<()> {
     Building source distribution...
     Error: Missing module directory for `does_not_exist` in `src`. Found: `temp`
     error: Failed to build `[TEMP_DIR]/`
-      ├── The build backend returned an error
-      └── Call to `uv_build.build_sdist` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `uv_build.build_sdist` failed (exit status: 1)
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -2862,9 +2862,9 @@ fn venv_included_in_sdist() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/`
-      ├── Invalid tar file
-      ├── failed to unpack `[CACHE_DIR]/sdists-v9/[TMP]/project-0.1.0/.venv/bin/python`
-      └── symlink path `[PYTHON-3.12]` is absolute, but external symlinks are not allowed
+      cause: Invalid tar file
+      cause: failed to unpack `[CACHE_DIR]/sdists-v9/[TMP]/project-0.1.0/.venv/bin/python`
+      cause: symlink path `[PYTHON-3.12]` is absolute, but external symlinks are not allowed
 
     hint: The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.
     ");
@@ -2885,8 +2885,8 @@ fn venv_included_in_sdist() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/`
-      ├── Invalid tar file
-      └── at byte [OFFSET]: unsafe symbolic-link target "[PYTHON-3.12]": is absolute
+      cause: Invalid tar file
+      cause: at byte [OFFSET]: unsafe symbolic-link target "[PYTHON-3.12]": is absolute
 
     hint: The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.
     "#);
@@ -2895,9 +2895,9 @@ fn venv_included_in_sdist() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to build `[TEMP_DIR]/`
-      ├── Invalid tar file
-      ├── failed to unpack `[CACHE_DIR]/sdists-v9/[TMP]/project-0.1.0/.venv/bin/python`
-      └── symlink path `[PYTHON-3.12]` is absolute, but external symlinks are not allowed
+      cause: Invalid tar file
+      cause: failed to unpack `[CACHE_DIR]/sdists-v9/[TMP]/project-0.1.0/.venv/bin/python`
+      cause: symlink path `[PYTHON-3.12]` is absolute, but external symlinks are not allowed
 
     hint: The source distribution includes a virtual environment. Virtual environments must be excluded from source distributions.
     ");

--- a/crates/uv/tests/build/build_backend.rs
+++ b/crates/uv/tests/build/build_backend.rs
@@ -859,7 +859,7 @@ fn license_glob_without_matches_errors() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Invalid project metadata
-      └── `project.license-files` glob `abc` did not match any files
+      cause: `project.license-files` glob `abc` did not match any files
     ");
 
     Ok(())
@@ -899,7 +899,7 @@ fn license_file_must_be_utf8() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Invalid project metadata
-      └── License file `LICENSE.bin` must be UTF-8 encoded
+      cause: License file `LICENSE.bin` must be UTF-8 encoded
     ");
 
     Ok(())
@@ -1046,7 +1046,7 @@ fn error_on_relative_module_root_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/`
-      └── Module root must be inside the project: ..
+      cause: Module root must be inside the project: ..
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--wheel"), @"
@@ -1054,7 +1054,7 @@ fn error_on_relative_module_root_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/`
-      └── Module root must be inside the project: ..
+      cause: Module root must be inside the project: ..
     ");
 
     Ok(())
@@ -1095,7 +1095,7 @@ fn error_on_relative_data_dir_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/project`
-      └── The path for the data directory headers must be inside the project: ../header
+      cause: The path for the data directory headers must be inside the project: ../header
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("project").arg("--wheel"), @"
@@ -1103,7 +1103,7 @@ fn error_on_relative_data_dir_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/project`
-      └── The path for the data directory headers must be inside the project: ../header
+      cause: The path for the data directory headers must be inside the project: ../header
     ");
 
     pyproject_toml.write_str(indoc! {r#"
@@ -1130,7 +1130,7 @@ fn error_on_relative_data_dir_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/project`
-      └── The path for the data directory headers must be inside the project: ../outside
+      cause: The path for the data directory headers must be inside the project: ../outside
     ");
 
     Ok(())
@@ -1221,7 +1221,7 @@ fn wheel_data_symlink_containment() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to build `[TEMP_DIR]/project`
-      └── The path for the data directory data must be inside the project: external-assets
+      cause: The path for the data directory data must be inside the project: external-assets
     ");
 
     project.child("assets/public.txt").touch()?;
@@ -1283,7 +1283,7 @@ fn venv_in_source_tree() {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/`
-      └── Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: src/foo/.venv
+      cause: Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: src/foo/.venv
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--wheel"), @"
@@ -1291,7 +1291,7 @@ fn venv_in_source_tree() {
     ----- stderr -----
     Building wheel...
     error: Failed to build `[TEMP_DIR]/`
-      └── Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: src/foo/.venv
+      cause: Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: src/foo/.venv
     ");
 }
 
@@ -1380,12 +1380,12 @@ fn invalid_pyproject_toml() -> Result<()> {
     ----- stderr -----
     Building source distribution...
     error: Failed to build `[TEMP_DIR]/child`
-      ├── Invalid metadata format in: child/pyproject.toml
-      └── TOML parse error at line 2, column 8
-            |
-          2 | name = 1
-            |        ^
-          invalid type: integer `1`, expected a string
+      cause: Invalid metadata format in: child/pyproject.toml
+      cause: TOML parse error at line 2, column 8
+               |
+             2 | name = 1
+               |        ^
+             invalid type: integer `1`, expected a string
     ");
 
     Ok(())

--- a/crates/uv/tests/build/cache.rs
+++ b/crates/uv/tests/build/cache.rs
@@ -353,7 +353,7 @@ fn cache_init_failure() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to initialize cache at `cache_parent/cache`
-      └── failed to create directory `[CACHE_DIR]/`: Permission denied (os error 13)
+      cause: failed to create directory `[CACHE_DIR]/`: Permission denied (os error 13)
     ");
 
     Ok(())

--- a/crates/uv/tests/build/cache_prune.rs
+++ b/crates/uv/tests/build/cache_prune.rs
@@ -362,7 +362,7 @@ fn prune_unzipped() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of iniconfig need to be downloaded from a registry and you require iniconfig, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of iniconfig need to be downloaded from a registry and you require iniconfig, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     ");

--- a/crates/uv/tests/it/auth.rs
+++ b/crates/uv/tests/it/auth.rs
@@ -28,8 +28,8 @@ async fn invalid_cloud_endpoint_urls() {
             exit_code: 2 (failure)
             ----- stderr -----
             error: Failed to fetch: `http://[LOCALHOST]/basic-auth/simple/iniconfig/`
-              ├── Invalid `UV_[CLOUD]_ENDPOINT_URL`
-              └── relative URL without a base
+              cause: Invalid `UV_[CLOUD]_ENDPOINT_URL`
+              cause: relative URL without a base
             ");
         }
     }
@@ -66,8 +66,8 @@ async fn add_package_native_auth_realm() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 
@@ -122,8 +122,8 @@ async fn add_package_native_auth_realm() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 
@@ -166,8 +166,8 @@ async fn add_package_native_auth() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 
@@ -222,8 +222,8 @@ async fn add_package_native_auth() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 
@@ -664,7 +664,7 @@ async fn logout_native_auth() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unable to remove credentials for http://[LOCALHOST]/basic-auth
-      └── No matching entry found in secure storage
+      cause: No matching entry found in secure storage
     ");
 
     // Logout before logging in (with a username)
@@ -676,7 +676,7 @@ async fn logout_native_auth() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unable to remove credentials for public@http://[LOCALHOST]/basic-auth
-      └── No matching entry found in secure storage
+      cause: No matching entry found in secure storage
     ");
 
     // Login with a username
@@ -701,7 +701,7 @@ async fn logout_native_auth() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unable to remove credentials for http://[LOCALHOST]/basic-auth
-      └── No matching entry found in secure storage
+      cause: No matching entry found in secure storage
     ");
 
     // Logout with a username
@@ -1811,7 +1811,7 @@ fn bazel_helper_invalid_bearer_token() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Invalid authorization header
-      └── failed to parse header value
+      cause: failed to parse header value
     "
     );
 
@@ -1851,7 +1851,7 @@ fn bazel_helper_invalid_json() {
     ----- stderr -----
     warning: The `uv auth helper` command is experimental and may change without warning. Pass `--preview-features auth-helper` to disable this warning
     error: Failed to parse credential request as JSON
-      └── expected ident at line 1 column 2
+      cause: expected ident at line 1 column 2
     "
     );
 }
@@ -1870,7 +1870,7 @@ fn bazel_helper_invalid_uri() {
     ----- stderr -----
     warning: The `uv auth helper` command is experimental and may change without warning. Pass `--preview-features auth-helper` to disable this warning
     error: Failed to parse credential request as JSON
-      └── relative URL without a base: "not a url" at line 1 column 18
+      cause: relative URL without a base: "not a url" at line 1 column 18
     "#
     );
 }

--- a/crates/uv/tests/it/branching_urls.rs
+++ b/crates/uv/tests/it/branching_urls.rs
@@ -60,9 +60,9 @@ fn branching_urls_overlapping() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve dependencies for package `a==0.1.0`
-      └── Requirements contain conflicting URLs for package `iniconfig` in split `python_full_version == '3.11.*'`:
-          - https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl
-          - https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
+      cause: Requirements contain conflicting URLs for package `iniconfig` in split `python_full_version == '3.11.*'`:
+             - https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl
+             - https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
     "
     );
 
@@ -125,9 +125,9 @@ fn root_package_splits_but_transitive_conflict() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve dependencies for package `b2==0.1.0`
-      └── Requirements contain conflicting URLs for package `iniconfig` in split `python_full_version >= '3.12'`:
-          - https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl
-          - https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
+      cause: Requirements contain conflicting URLs for package `iniconfig` in split `python_full_version >= '3.12'`:
+             - https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl
+             - https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
 
     hint: `b2` (v0.1.0) was included because `a` (v0.1.0) depends on `b` (v0.1.0) which depends on `b2`
     "
@@ -712,9 +712,9 @@ fn branching_urls_of_different_sources_conflict() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve dependencies for package `a==0.1.0`
-      └── Requirements contain conflicting URLs for package `iniconfig` in split `python_full_version == '3.11.*'`:
-          - git+https://github.com/pytest-dev/iniconfig@93f5930e668c0d1ddf4597e38dd0dea4e2665e7a
-          - https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl
+      cause: Requirements contain conflicting URLs for package `iniconfig` in split `python_full_version == '3.11.*'`:
+             - git+https://github.com/pytest-dev/iniconfig@93f5930e668c0d1ddf4597e38dd0dea4e2665e7a
+             - https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl
     "
     );
 

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -254,8 +254,8 @@ async fn invalid_ssl_cert_file_warns_default_roots_are_disabled() {
     ----- stderr -----
     warning: Invalid `SSL_CERT_FILE`. Path does not exist: [TEMP_DIR]/missing.pem. No default certificates will be trusted.
     error: Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/tqdm/`
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/tqdm/)
+      cause: Failed to fetch: `http://[LOCALHOST]/tqdm/`
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/tqdm/)
     ");
 }
 
@@ -277,8 +277,8 @@ async fn invalid_ssl_cert_dir_warns_default_roots_are_disabled() {
     ----- stderr -----
     warning: Invalid `SSL_CERT_DIR`. The directory does not exist: [TEMP_DIR]/missing-certs. No default certificates will be trusted.
     error: Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/tqdm/`
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/tqdm/)
+      cause: Failed to fetch: `http://[LOCALHOST]/tqdm/`
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/tqdm/)
     ");
 }
 
@@ -298,8 +298,8 @@ async fn simple_http_500() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/tqdm/`
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/tqdm/)
+      cause: Failed to fetch: `http://[LOCALHOST]/tqdm/`
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/tqdm/)
     ");
 }
 
@@ -319,10 +319,10 @@ async fn simple_io_err() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/tqdm/`
-      ├── error sending request for url (http://[LOCALHOST]/tqdm/)
-      ├── client error (SendRequest)
-      └── connection closed before message completed
+      cause: Failed to fetch: `http://[LOCALHOST]/tqdm/`
+      cause: error sending request for url (http://[LOCALHOST]/tqdm/)
+      cause: client error (SendRequest)
+      cause: connection closed before message completed
     ");
 }
 
@@ -343,9 +343,9 @@ async fn find_links_http_500() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read `--find-links` URL: http://[LOCALHOST]/
-      ├── Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/`
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/)
+      cause: Request failed after 3 retries in [TIME]
+      cause: Failed to fetch: `http://[LOCALHOST]/`
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/)
     ");
 }
 
@@ -366,11 +366,11 @@ async fn find_links_io_error() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read `--find-links` URL: http://[LOCALHOST]/
-      ├── Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/`
-      ├── error sending request for url (http://[LOCALHOST]/)
-      ├── client error (SendRequest)
-      └── connection closed before message completed
+      cause: Request failed after 3 retries in [TIME]
+      cause: Failed to fetch: `http://[LOCALHOST]/`
+      cause: error sending request for url (http://[LOCALHOST]/)
+      cause: client error (SendRequest)
+      cause: connection closed before message completed
     ");
 }
 
@@ -392,9 +392,9 @@ async fn find_links_mixed_error() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read `--find-links` URL: http://[LOCALHOST]/
-      ├── Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/`
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/)
+      cause: Request failed after 3 retries in [TIME]
+      cause: Failed to fetch: `http://[LOCALHOST]/`
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/)
     ");
 }
 
@@ -416,8 +416,8 @@ async fn direct_url_http_404() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `tqdm @ http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl`
-      ├── Failed to fetch: `http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl`
-      └── HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl)
+      cause: Failed to fetch: `http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl`
+      cause: HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl)
     ");
 
     uv_snapshot!(context.filters(), context
@@ -427,8 +427,8 @@ async fn direct_url_http_404() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `tqdm @ http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl`
-      ├── Failed to fetch: `http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl`
-      └── HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl)
+      cause: Failed to fetch: `http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl`
+      cause: HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/tqdm-4.67.1-py3-none-any.whl)
     ");
 
     uv_snapshot!(context.filters(), context
@@ -458,9 +458,9 @@ async fn direct_url_http_500() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to download `tqdm @ http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
-      ├── Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl)
+      cause: Request failed after 3 retries in [TIME]
+      cause: Failed to fetch: `http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl)
     ");
 }
 
@@ -481,11 +481,11 @@ async fn direct_url_io_error() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to download `tqdm @ http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
-      ├── Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
-      ├── error sending request for url (http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl)
-      ├── client error (SendRequest)
-      └── connection closed before message completed
+      cause: Request failed after 3 retries in [TIME]
+      cause: Failed to fetch: `http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
+      cause: error sending request for url (http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl)
+      cause: client error (SendRequest)
+      cause: connection closed before message completed
     ");
 }
 
@@ -507,9 +507,9 @@ async fn direct_url_mixed_error() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to download `tqdm @ http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
-      ├── Request failed after 3 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl)
+      cause: Request failed after 3 retries in [TIME]
+      cause: Failed to fetch: `http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl)
     ");
 }
 
@@ -561,9 +561,9 @@ async fn python_install_http_500() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to install cpython-3.10.0-[PLATFORM]
-      ├── Request failed after 3 retries in [TIME]
-      ├── Failed to download http://[LOCALHOST]/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-[PLATFORM]-pgo%2Blto-20211017T1616.tar.zst
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-[PLATFORM]-pgo%2Blto-20211017T1616.tar.zst)
+      cause: Request failed after 3 retries in [TIME]
+      cause: Failed to download http://[LOCALHOST]/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-[PLATFORM]-pgo%2Blto-20211017T1616.tar.zst
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-[PLATFORM]-pgo%2Blto-20211017T1616.tar.zst)
     ");
 }
 
@@ -588,11 +588,11 @@ async fn python_install_io_error() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to install cpython-3.10.0-[PLATFORM]
-      ├── Request failed after 3 retries in [TIME]
-      ├── Failed to download http://[LOCALHOST]/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-[PLATFORM]-pgo%2Blto-20211017T1616.tar.zst
-      ├── error sending request for url (http://[LOCALHOST]/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-[PLATFORM]-pgo%2Blto-20211017T1616.tar.zst)
-      ├── client error (SendRequest)
-      └── connection closed before message completed
+      cause: Request failed after 3 retries in [TIME]
+      cause: Failed to download http://[LOCALHOST]/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-[PLATFORM]-pgo%2Blto-20211017T1616.tar.zst
+      cause: error sending request for url (http://[LOCALHOST]/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-[PLATFORM]-pgo%2Blto-20211017T1616.tar.zst)
+      cause: client error (SendRequest)
+      cause: connection closed before message completed
     ");
 }
 
@@ -651,8 +651,8 @@ async fn install_http_retries() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Request failed after 5 retries in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/anyio/`
-      └── HTTP status server error (503 Service Unavailable) for url (http://[LOCALHOST]/anyio/)
+      cause: Failed to fetch: `http://[LOCALHOST]/anyio/`
+      cause: HTTP status server error (503 Service Unavailable) for url (http://[LOCALHOST]/anyio/)
     "
     );
 }
@@ -680,10 +680,10 @@ async fn install_http_retry_low_level() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Request failed after 1 retry in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/anyio/`
-      ├── error sending request for url (http://[LOCALHOST]/anyio/)
-      ├── client error (SendRequest)
-      └── connection closed before message completed
+      cause: Failed to fetch: `http://[LOCALHOST]/anyio/`
+      cause: error sending request for url (http://[LOCALHOST]/anyio/)
+      cause: client error (SendRequest)
+      cause: connection closed before message completed
     "
     );
 }
@@ -726,9 +726,9 @@ async fn rfc9457_problem_details_license_violation() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to download `tqdm @ http://[LOCALHOST]/packages/tqdm-4.67.1-py3-none-any.whl`
-      ├── Failed to fetch: `http://[LOCALHOST]/packages/tqdm-4.67.1-py3-none-any.whl`
-      ├── Server message: License Compliance Issue, This package version has a license that violates organizational policy.
-      └── HTTP status client error (403 Forbidden) for url (http://[LOCALHOST]/packages/tqdm-4.67.1-py3-none-any.whl)
+      cause: Failed to fetch: `http://[LOCALHOST]/packages/tqdm-4.67.1-py3-none-any.whl`
+      cause: Server message: License Compliance Issue, This package version has a license that violates organizational policy.
+      cause: HTTP status client error (403 Forbidden) for url (http://[LOCALHOST]/packages/tqdm-4.67.1-py3-none-any.whl)
     ");
 }
 
@@ -752,11 +752,11 @@ async fn proxy_invalid_url_in_uv_toml() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      └── TOML parse error at line 1, column 14
-            |
-          1 | http-proxy = "ftp://proxy.example.com:8080"
-            |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          invalid proxy URL scheme `ftp` in `ftp://proxy.example.com:8080/`: expected http, https, socks5, or socks5h
+      cause: TOML parse error at line 1, column 14
+               |
+             1 | http-proxy = "ftp://proxy.example.com:8080"
+               |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             invalid proxy URL scheme `ftp` in `ftp://proxy.example.com:8080/`: expected http, https, socks5, or socks5h
     "#);
 }
 
@@ -780,11 +780,11 @@ async fn proxy_invalid_url_not_a_url_in_uv_toml() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      └── TOML parse error at line 1, column 14
-            |
-          1 | http-proxy = "not a valid url"
-            |              ^^^^^^^^^^^^^^^^^
-          invalid proxy URL: invalid international domain name
+      cause: TOML parse error at line 1, column 14
+               |
+             1 | http-proxy = "not a valid url"
+               |              ^^^^^^^^^^^^^^^^^
+             invalid proxy URL: invalid international domain name
     "#);
 }
 
@@ -1024,9 +1024,9 @@ fn connect_timeout_index() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to fetch: `https://[LOCALHOST]/tqdm/`
-      ├── error sending request for url (https://[LOCALHOST]/tqdm/)
-      ├── client error (Connect)
-      └── operation timed out
+      cause: error sending request for url (https://[LOCALHOST]/tqdm/)
+      cause: client error (Connect)
+      cause: operation timed out
     ");
 
     // Assumption: There's less than 2s overhead for this test and startup.
@@ -1054,10 +1054,10 @@ fn connect_timeout_stream() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to download `tqdm @ https://[LOCALHOST]/tqdm-0.1-py3-none-any.whl`
-      ├── Failed to fetch: `https://[LOCALHOST]/tqdm-0.1-py3-none-any.whl`
-      ├── error sending request for url (https://[LOCALHOST]/tqdm-0.1-py3-none-any.whl)
-      ├── client error (Connect)
-      └── operation timed out
+      cause: Failed to fetch: `https://[LOCALHOST]/tqdm-0.1-py3-none-any.whl`
+      cause: error sending request for url (https://[LOCALHOST]/tqdm-0.1-py3-none-any.whl)
+      cause: client error (Connect)
+      cause: operation timed out
     ");
 
     // Assumption: There's less than 2s overhead for this test and startup.
@@ -1082,10 +1082,10 @@ async fn retry_read_timeout_index() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Request failed after 1 retry in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/tqdm/`
-      ├── error decoding response body for url (http://[LOCALHOST]/tqdm/)
-      ├── request or response body error
-      └── operation timed out
+      cause: Failed to fetch: `http://[LOCALHOST]/tqdm/`
+      cause: error decoding response body for url (http://[LOCALHOST]/tqdm/)
+      cause: request or response body error
+      cause: operation timed out
     ");
 }
 
@@ -1103,11 +1103,11 @@ async fn retry_read_timeout_python_downloads_json() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Error while fetching remote python downloads json from 'http://[LOCALHOST]/'
-      ├── Request failed after 1 retry in [TIME]
-      ├── Failed to download http://[LOCALHOST]/
-      ├── error decoding response body for url (http://[LOCALHOST]/)
-      ├── request or response body error
-      └── operation timed out
+      cause: Request failed after 1 retry in [TIME]
+      cause: Failed to download http://[LOCALHOST]/
+      cause: error decoding response body for url (http://[LOCALHOST]/)
+      cause: request or response body error
+      cause: operation timed out
     ");
 }
 
@@ -1123,10 +1123,10 @@ async fn retry_read_timeout_stream() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `tqdm @ http://[LOCALHOST]/tqdm-0.1-py3-none-any.whl`
-      ├── Request failed after 1 retry in [TIME]
-      ├── Failed to read metadata: `http://[LOCALHOST]/tqdm-0.1-py3-none-any.whl`
-      ├── Failed to read from zip file
-      ├── an upstream reader returned an error: Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
-      └── Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
+      cause: Request failed after 1 retry in [TIME]
+      cause: Failed to read metadata: `http://[LOCALHOST]/tqdm-0.1-py3-none-any.whl`
+      cause: Failed to read from zip file
+      cause: an upstream reader returned an error: Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
+      cause: Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: [TIME]).
     ");
 }

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -89,7 +89,7 @@ fn username_password_no_longer_supported() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/
-      └── Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 }
@@ -112,7 +112,7 @@ fn invalid_token() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/
-      └── Server returned status code 403 Forbidden. Server says: 403 Invalid or non-existent authentication information. See https://test.pypi.org/help/#invalid-auth for more information.
+      cause: Server returned status code 403 Forbidden. Server says: 403 Invalid or non-existent authentication information. See https://test.pypi.org/help/#invalid-auth for more information.
     "
     );
 }
@@ -159,9 +159,9 @@ fn missing_trusted_publishing_permission() {
     ----- stderr -----
     Publishing 1 file to https://test.pypi.org/legacy/
     error: Failed to obtain token for trusted publishing
-      ├── Failed to obtain OIDC token: is the `id-token: write` permission missing?
-      ├── GitHub Actions detection error
-      └── insufficient permissions: missing ACTIONS_ID_TOKEN_REQUEST_URL
+      cause: Failed to obtain OIDC token: is the `id-token: write` permission missing?
+      cause: GitHub Actions detection error
+      cause: insufficient permissions: missing ACTIONS_ID_TOKEN_REQUEST_URL
     "
     );
 }
@@ -183,14 +183,14 @@ fn no_credentials() {
     Publishing 1 file to https://test.pypi.org/legacy/
     Note: Neither credentials nor keyring are configured, and there was an error fetching the trusted publishing token. If you don't want to use trusted publishing, you can ignore this error, but you need to provide credentials.
     error: Trusted publishing failed
-      ├── Failed to obtain OIDC token: is the `id-token: write` permission missing?
-      ├── GitHub Actions detection error
-      └── insufficient permissions: missing ACTIONS_ID_TOKEN_REQUEST_URL
+      cause: Failed to obtain OIDC token: is the `id-token: write` permission missing?
+      cause: GitHub Actions detection error
+      cause: insufficient permissions: missing ACTIONS_ID_TOKEN_REQUEST_URL
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/
-      ├── Failed to send POST request
-      └── Missing credentials for https://test.pypi.org/legacy/
+      cause: Failed to send POST request
+      cause: Missing credentials for https://test.pypi.org/legacy/
     "
     );
 }
@@ -319,7 +319,7 @@ fn check_keyring_behaviours() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
-      └── Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 
@@ -342,7 +342,7 @@ fn check_keyring_behaviours() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
-      └── Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 
@@ -370,7 +370,7 @@ fn check_keyring_behaviours() {
     Keyring request for dummy@https://test.pypi.org/legacy/?ok
     Keyring request for dummy@test.pypi.org
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
-      └── Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 
@@ -393,7 +393,7 @@ fn check_keyring_behaviours() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
-      └── Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 }
@@ -535,8 +535,8 @@ async fn read_index_credential_env_vars_for_check_url() {
     Hashing astral_test_private-0.1.0-py3-none-any.whl ([SIZE]KiB)
     Uploading astral_test_private-0.1.0-py3-none-any.whl ([SIZE]KiB)
     error: Failed to publish `dist/astral_test_private-0.1.0-py3-none-any.whl` to http://[LOCALHOST]/upload
-      ├── Failed to send POST request
-      └── Missing credentials for http://[LOCALHOST]/upload
+      cause: Failed to send POST request
+      cause: Missing credentials for http://[LOCALHOST]/upload
     "
     );
     // Test that it works with credentials
@@ -863,7 +863,7 @@ async fn trusted_publishing_burn_failure() {
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     warning: Failed to invalidate trusted publishing token. It will expire naturally. Cause: Failed to fetch: `http://[LOCALHOST]/_/oidc/burn-token`
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
-      └── Server returned status code 400 Bad Request. Server says: Upload failed
+      cause: Server returned status code 400 Bad Request. Server says: Upload failed
     "
     );
 }
@@ -916,9 +916,9 @@ async fn trusted_publishing_burn_after_prepare_failure() {
     Publishing 1 file to http://[LOCALHOST]/upload
     Hashing a-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish: `a-1.0.0-py3-none-any.whl`
-      ├── Failed to read metadata
-      ├── Failed to read from zip file
-      └── unable to locate the end of central directory record
+      cause: Failed to read metadata
+      cause: Failed to read from zip file
+      cause: unable to locate the end of central directory record
     "
     );
 
@@ -941,9 +941,9 @@ async fn trusted_publishing_burn_after_prepare_failure() {
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Hashing z-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish: `z-1.0.0-py3-none-any.whl`
-      ├── Failed to read metadata
-      ├── Failed to read from zip file
-      └── unable to locate the end of central directory record
+      cause: Failed to read metadata
+      cause: Failed to read from zip file
+      cause: unable to locate the end of central directory record
     "
     );
 
@@ -1013,9 +1013,9 @@ async fn trusted_publishing_dry_run() {
     Checking 1 file against http://[LOCALHOST]/upload
     Checking a-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish: `a-1.0.0-py3-none-any.whl`
-      ├── Failed to read metadata
-      ├── Failed to read from zip file
-      └── unable to locate the end of central directory record
+      cause: Failed to read metadata
+      cause: Failed to read from zip file
+      cause: unable to locate the end of central directory record
     Found issues with 1 file
     "
     );
@@ -1186,7 +1186,7 @@ async fn upload_error_pypi_json() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
-      └── Server returned status code 400 Bad Request. Server says: 400 Use 'source' as Python version for an sdist.
+      cause: Server returned status code 400 Bad Request. Server says: 400 Use 'source' as Python version for an sdist.
     "
     );
 }
@@ -1220,7 +1220,7 @@ async fn upload_error_problem_details() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
-      └── Server returned status code 400 Bad Request. Server message: Bad Request, Missing required field `name`
+      cause: Server returned status code 400 Bad Request. Server message: Bad Request, Missing required field `name`
     "
     );
 }
@@ -1277,14 +1277,14 @@ fn dry_run_reports_all_errors() {
     Checking 2 files against https://test.pypi.org/legacy/
     Checking a-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish: `a-1.0.0-py3-none-any.whl`
-      ├── Failed to read metadata
-      ├── Failed to read from zip file
-      └── unable to locate the end of central directory record
+      cause: Failed to read metadata
+      cause: Failed to read from zip file
+      cause: unable to locate the end of central directory record
     Checking b-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish: `b-1.0.0-py3-none-any.whl`
-      ├── Failed to read metadata
-      ├── Failed to read from zip file
-      └── unable to locate the end of central directory record
+      cause: Failed to read metadata
+      cause: Failed to read from zip file
+      cause: unable to locate the end of central directory record
     Found issues with 2 files
     "
     );
@@ -1328,8 +1328,8 @@ async fn publish_invalid_attestations() {
     Publishing 1 file to http://[LOCALHOST]/upload
     Hashing basic_app-0.1.0-py3-none-any.whl ([SIZE]KiB)
     error: Failed to publish: `[WORKSPACE]/test/links/basic_app-0.1.0-py3-none-any.whl`
-      ├── Invalid PEP 740 attestation (not JSON): `[TEMP_DIR]/basic_app-0.1.0-py3-none-any.whl.publish.attestation`
-      └── EOF while parsing an object at line 1 column 1
+      cause: Invalid PEP 740 attestation (not JSON): `[TEMP_DIR]/basic_app-0.1.0-py3-none-any.whl.publish.attestation`
+      cause: EOF while parsing an object at line 1 column 1
     ");
 
     uv_snapshot!(context.filters(), context.publish()
@@ -1347,12 +1347,12 @@ async fn publish_invalid_attestations() {
     Checking 2 files against http://[LOCALHOST]/upload
     Checking basic_app-0.1.0-py3-none-any.whl ([SIZE]KiB)
     error: Failed to publish: `[WORKSPACE]/test/links/basic_app-0.1.0-py3-none-any.whl`
-      ├── Invalid PEP 740 attestation (not JSON): `[TEMP_DIR]/basic_app-0.1.0-py3-none-any.whl.publish.attestation`
-      └── EOF while parsing an object at line 1 column 1
+      cause: Invalid PEP 740 attestation (not JSON): `[TEMP_DIR]/basic_app-0.1.0-py3-none-any.whl.publish.attestation`
+      cause: EOF while parsing an object at line 1 column 1
     Checking ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish: `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl`
-      ├── Invalid PEP 740 attestation (not JSON): `[TEMP_DIR]/ok-1.0.0-py3-none-any.whl.publish.attestation`
-      └── EOF while parsing an object at line 1 column 1
+      cause: Invalid PEP 740 attestation (not JSON): `[TEMP_DIR]/ok-1.0.0-py3-none-any.whl.publish.attestation`
+      cause: EOF while parsing an object at line 1 column 1
     Found issues with 2 files
     ");
 

--- a/crates/uv/tests/it/resource_limits.rs
+++ b/crates/uv/tests/it/resource_limits.rs
@@ -96,6 +96,6 @@ fn run_open_file_limit_override_exceeds_hard_limit() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to apply `UV_RUN_RLIMIT_NOFILE` value `256`
-      └── requested open file limit (256) exceeds the hard limit (128)
+      cause: requested open file limit (256) exceeds the hard limit (128)
     ");
 }

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -524,7 +524,7 @@ fn upgrade_reports_no_solution_without_mutation() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: No solution found when resolving dependencies
-      └── Because there is no version of idna==9999 and your project depends on idna==9999, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because there is no version of idna==9999 and your project depends on idna==9999, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     assert_project_unchanged(&context, pyproject_toml)
@@ -1375,8 +1375,8 @@ fn upgrade_preserves_hard_constraint_no_solution_failure() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: No solution found when resolving dependencies for split (markers: sys_platform != 'linux')
-      └── Because all versions of foo depend on bar{sys_platform != 'linux'}==2 and your project depends on bar<2, we can conclude that your project and all versions of foo are incompatible.
-          And because your project depends on foo==1.0.0, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because all versions of foo depend on bar{sys_platform != 'linux'}==2 and your project depends on bar<2, we can conclude that your project and all versions of foo are incompatible.
+             And because your project depends on foo==1.0.0, we can conclude that your project's requirements are unsatisfiable.
     "
     );
 

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -2555,7 +2555,7 @@ fn version_get_frozen_workspace_without_python() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to initialize cache at `cache-file`
-      └── failed to create directory `[CACHE_DIR]`: [ERROR]
+      cause: failed to create directory `[CACHE_DIR]`: [ERROR]
     ");
 
     Ok(())

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -2490,8 +2490,8 @@ fn version_get_frozen_workspace_without_python() -> Result<()> {
     let context = uv_test::test_context!("3.12")
         .with_cache_dir("cache-file")
         .with_filter((
-            r"└── failed to create directory `[^`]+`: .*",
-            "└── failed to create directory `[CACHE_DIR]`: [ERROR]",
+            r"cause: failed to create directory `[^`]+`: .*",
+            "cause: failed to create directory `[CACHE_DIR]`: [ERROR]",
         ));
 
     context

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -326,11 +326,11 @@ fn lock_rejects_mismatched_exact_git_revision() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse `uv.lock`
-      └── TOML parse error at line 5, column 1
-            |
-          5 | [[package]]
-            | ^^^^^^^^^^^
-          Exact Git revision `0dacfd662c64cb4ceb16e6cf65a157a8b715b979` does not match precise commit `b270df1a2fb5d012294e9aaf05e7e0bab1e6a389` for `https://git:****@example.com/pkg.git`
+      cause: TOML parse error at line 5, column 1
+               |
+             5 | [[package]]
+               | ^^^^^^^^^^^
+             Exact Git revision `0dacfd662c64cb4ceb16e6cf65a157a8b715b979` does not match precise commit `b270df1a2fb5d012294e9aaf05e7e0bab1e6a389` for `https://git:****@example.com/pkg.git`
     ");
 
     Ok(())
@@ -1114,8 +1114,8 @@ fn lock_sdist_git_archive_missing_lfs() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `iniconfig @ git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0.tar.gz`
-      ├── The source distribution `git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0.tar.gz` is missing Git LFS artifacts.
-      └── Git LFS extension not found. Ensure that Git LFS is installed and available.
+      cause: The source distribution `git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0.tar.gz` is missing Git LFS artifacts.
+      cause: Git LFS extension not found. Ensure that Git LFS is installed and available.
     "###
     );
 
@@ -1257,8 +1257,8 @@ fn lock_wheel_git_archive_missing_lfs() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `iniconfig @ git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0-py3-none-any.whl`
-      ├── The wheel `git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0-py3-none-any.whl` is missing Git LFS artifacts.
-      └── Git LFS extension not found. Ensure that Git LFS is installed and available.
+      cause: The wheel `git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0-py3-none-any.whl` is missing Git LFS artifacts.
+      cause: Git LFS extension not found. Ensure that Git LFS is installed and available.
     "###
     );
 
@@ -1807,15 +1807,15 @@ async fn lock_sdist_url_locked_build_dependency_hash_mismatch() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to generate package metadata for `demo-pkg==1.0.0 @ direct+http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      ├── Failed to install requirements from `build-system.requires`
-      ├── Failed to download `review-dep==1.0.0`
-      └── Hash mismatch for `review-dep==1.0.0`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Failed to download `review-dep==1.0.0`
+      cause: Hash mismatch for `review-dep==1.0.0`
 
-          Expected:
-            sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
+             Expected:
+               sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
 
-          Computed:
-            sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
+             Computed:
+               sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
     ");
     assert!(
         !sentinel.exists(),
@@ -1827,15 +1827,15 @@ async fn lock_sdist_url_locked_build_dependency_hash_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      ├── Failed to install requirements from `build-system.requires`
-      ├── Failed to download `review-dep==1.0.0`
-      └── Hash mismatch for `review-dep==1.0.0`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Failed to download `review-dep==1.0.0`
+      cause: Hash mismatch for `review-dep==1.0.0`
 
-          Expected:
-            sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
+             Expected:
+               sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
 
-          Computed:
-            sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
+             Computed:
+               sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
     ");
     assert!(
         !sentinel.exists(),
@@ -1847,15 +1847,15 @@ async fn lock_sdist_url_locked_build_dependency_hash_mismatch() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to generate package metadata for `demo-pkg==1.0.0 @ direct+http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      ├── Failed to install requirements from `build-system.requires`
-      ├── Failed to download `review-dep==1.0.0`
-      └── Hash mismatch for `review-dep==1.0.0`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Failed to download `review-dep==1.0.0`
+      cause: Hash mismatch for `review-dep==1.0.0`
 
-          Expected:
-            sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
+             Expected:
+               sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
 
-          Computed:
-            sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
+             Computed:
+               sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
     ");
     assert!(
         !sentinel.exists(),
@@ -1869,15 +1869,15 @@ async fn lock_sdist_url_locked_build_dependency_hash_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      ├── Failed to install requirements from `build-system.requires`
-      ├── Failed to download `review-dep==1.0.0`
-      └── Hash mismatch for `review-dep==1.0.0`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Failed to download `review-dep==1.0.0`
+      cause: Hash mismatch for `review-dep==1.0.0`
 
-          Expected:
-            sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
+             Expected:
+               sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
 
-          Computed:
-            sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
+             Computed:
+               sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
 
     hint: `demo-pkg` was included because `project` (v0.1.0) depends on `demo-pkg`
     ");
@@ -1910,15 +1910,15 @@ async fn lock_sdist_url_locked_build_dependency_hash_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      ├── Failed to install requirements from `build-system.requires`
-      ├── Failed to download `review-dep==1.0.0`
-      └── Hash mismatch for `review-dep==1.0.0`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Failed to download `review-dep==1.0.0`
+      cause: Hash mismatch for `review-dep==1.0.0`
 
-          Expected:
-            sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
+             Expected:
+               sha256:53a42340ae36747fb1471f9b4b7958be1f6e2e5fc234f931aafa3e454fd31dfb
 
-          Computed:
-            sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
+             Computed:
+               sha256:1aa0f7263e4991934282ab8912e95fdd34f24459d7c4f8b845c2281a04c89807
 
     hint: `demo-pkg` was included because `project` (v0.1.0) depends on `demo-pkg`
     ");
@@ -2040,13 +2040,13 @@ async fn lock_sdist_url_locked_hash_mismatch() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to generate package metadata for `demo-pkg==1.0.0 @ direct+http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      └── Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
+      cause: Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
     ");
     assert!(!sentinel.exists(), "the locked build backend was executed");
 
@@ -2058,13 +2058,13 @@ async fn lock_sdist_url_locked_hash_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      └── Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
+      cause: Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
     ");
     assert!(
         !sentinel.exists(),
@@ -2080,13 +2080,13 @@ async fn lock_sdist_url_locked_hash_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      └── Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
+      cause: Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
     ");
     assert!(
         !sentinel.exists(),
@@ -2099,13 +2099,13 @@ async fn lock_sdist_url_locked_hash_mismatch() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to generate package metadata for `demo-pkg==1.0.0 @ direct+http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      └── Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
+      cause: Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
     ");
     assert!(
         !sentinel.exists(),
@@ -2245,13 +2245,13 @@ async fn lock_sdist_registry_changed_index_locked_hash_mismatch() -> Result<()> 
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg==1.0.0`
-      └── Hash mismatch for `demo-pkg==1.0.0`
+      cause: Hash mismatch for `demo-pkg==1.0.0`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
 
     hint: `demo-pkg` (v1.0.0) was included because `project` (v0.1.0) depends on `demo-pkg==1.0.0`
     ");
@@ -2348,13 +2348,13 @@ async fn lock_sdist_registry_missing_index_locked_hash_mismatch() -> Result<()> 
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg==1.0.0`
-      └── Hash mismatch for `demo-pkg==1.0.0`
+      cause: Hash mismatch for `demo-pkg==1.0.0`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
 
     hint: `demo-pkg` (v1.0.0) was included because `project` (v0.1.0) depends on `demo-pkg==1.0.0`
     ");
@@ -2418,13 +2418,13 @@ async fn lock_sdist_url_root_subdirectory_locked_hash_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz#subdirectory=.`
-      └── Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz#subdirectory=.`
+      cause: Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz#subdirectory=.`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
     ");
     assert!(
         !sentinel.exists(),
@@ -2487,13 +2487,13 @@ async fn lock_sdist_url_rejected_archive_not_cached() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      └── Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
+      cause: Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
     ");
     assert!(
         !sentinel.exists(),
@@ -2529,9 +2529,9 @@ async fn lock_sdist_url_rejected_archive_not_cached() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      ├── Failed to extract archive: demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz
-      ├── I/O operation failed during extraction
-      └── Invalid gzip header
+      cause: Failed to extract archive: demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz
+      cause: I/O operation failed during extraction
+      cause: Invalid gzip header
     ");
     assert!(
         !sentinel.exists(),
@@ -2613,13 +2613,13 @@ async fn lock_sdist_url_equivalent_subdirectory_locked_hash_mismatch() -> Result
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz#subdirectory=nested/../nested`
-      └── Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz#subdirectory=nested/../nested`
+      cause: Hash mismatch for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz#subdirectory=nested/../nested`
 
-          Expected:
-            sha256:09c631b3e8d48a04c4d7e3bc64d61dbc10a6b89131dffadd885eccb3ffa5e455
+             Expected:
+               sha256:09c631b3e8d48a04c4d7e3bc64d61dbc10a6b89131dffadd885eccb3ffa5e455
 
-          Computed:
-            sha256:4d8741dcbddac394ac2680d99589d36c9d8fd7b3b19665531de9cc02550ec5eb
+             Computed:
+               sha256:4d8741dcbddac394ac2680d99589d36c9d8fd7b3b19665531de9cc02550ec5eb
     ");
     assert!(
         !sentinel.exists(),
@@ -2670,13 +2670,13 @@ fn lock_sdist_path_locked_hash_mismatch() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to generate package metadata for `demo-pkg==1.0.0 @ path+demo_pkg-1.0.0.tar.gz`
-      └── Hash mismatch for `demo-pkg @ file://[TEMP_DIR]/demo_pkg-1.0.0.tar.gz`
+      cause: Hash mismatch for `demo-pkg @ file://[TEMP_DIR]/demo_pkg-1.0.0.tar.gz`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
     ");
     assert!(!sentinel.exists(), "the locked backend was executed");
 
@@ -2685,13 +2685,13 @@ fn lock_sdist_path_locked_hash_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `demo-pkg @ file://[TEMP_DIR]/demo_pkg-1.0.0.tar.gz`
-      └── Hash mismatch for `demo-pkg @ file://[TEMP_DIR]/demo_pkg-1.0.0.tar.gz`
+      cause: Hash mismatch for `demo-pkg @ file://[TEMP_DIR]/demo_pkg-1.0.0.tar.gz`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
     ");
     assert!(!sentinel.exists(), "the refreshed backend was executed");
 
@@ -2749,13 +2749,13 @@ fn lock_sdist_path_rejected_archive_not_cached() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `demo-pkg @ file://[TEMP_DIR]/demo_pkg-1.0.0.tar.gz`
-      └── Hash mismatch for `demo-pkg @ file://[TEMP_DIR]/demo_pkg-1.0.0.tar.gz`
+      cause: Hash mismatch for `demo-pkg @ file://[TEMP_DIR]/demo_pkg-1.0.0.tar.gz`
 
-          Expected:
-            sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
+             Expected:
+               sha256:93703857ad8ea956f6661f1d78d445be4340afa15f8b87bf1f3a79621068847f
 
-          Computed:
-            sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
+             Computed:
+               sha256:883b65920e21bce11c2697819dab77eb70e18d810b2746f49e46155d6ca527bc
 
     hint: `demo-pkg` was included because `project` (v0.1.0) depends on `demo-pkg`
     ");
@@ -2839,7 +2839,7 @@ async fn lock_sdist_url_cache_heal_hash_mismatch() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download and build `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`
-      └── Attempted to re-extract the source distribution for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`, but the sha256 hash didn't match. Run `uv cache clean` to clear the cache.
+      cause: Attempted to re-extract the source distribution for `demo-pkg @ http://[LOCALHOST]/files/demo_pkg-1.0.0.tar.gz`, but the sha256 hash didn't match. Run `uv cache clean` to clear the cache.
     ");
     assert!(
         !sentinel.exists(),
@@ -3418,8 +3418,8 @@ fn lock_project_with_scoped_overrides() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because anyio==3.7.0 depends on idna==3.2 and your project depends on anyio==3.7.0, we can conclude that your project depends on idna==3.2.
-          And because your project depends on idna==3.6, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because anyio==3.7.0 depends on idna==3.2 and your project depends on anyio==3.7.0, we can conclude that your project depends on idna==3.2.
+             And because your project depends on idna==3.6, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // A version-gated override is ignored for other versions of the parent package.
@@ -3485,8 +3485,8 @@ fn lock_project_with_conflicting_scoped_overrides() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because anyio==3.7.0 depends on idna==3.2 and idna==3.3, we can conclude that anyio==3.7.0 cannot be used.
-          And because your project depends on anyio==3.7.0, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because anyio==3.7.0 depends on idna==3.2 and idna==3.3, we can conclude that anyio==3.7.0 cannot be used.
+             And because your project depends on anyio==3.7.0, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -4077,9 +4077,9 @@ fn lock_project_with_build_constraints() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
 
     hint: `requests` (v1.2.0) was included because `project` (v0.1.0) depends on `requests==1.2`
     ");
@@ -4819,8 +4819,8 @@ fn lock_conflicting_project_basic1() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because your project depends on sortedcontainers==2.3.0 and project:foo depends on sortedcontainers==2.4.0, we can conclude that your project and project:foo are incompatible.
-          And because your project requires your project and project:foo, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on sortedcontainers==2.3.0 and project:foo depends on sortedcontainers==2.4.0, we can conclude that your project and project:foo are incompatible.
+             And because your project requires your project and project:foo, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // And now with the same group configuration, we tell uv about the
@@ -5233,8 +5233,8 @@ fn lock_conflicting_workspace_members_depends_direct() -> Result<()> {
     ----- stderr -----
     warning: Declaring conflicts for packages (`package = ...`) is experimental and may change without warning. Pass `--preview-features package-conflicts` to disable this warning.
     error: No solution found when resolving dependencies for split (included: example; excluded: subexample)
-      └── Because subexample depends on sortedcontainers==2.4.0 and example depends on sortedcontainers==2.3.0, we can conclude that example and subexample are incompatible.
-          And because example depends on subexample and your workspace requires example, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because subexample depends on sortedcontainers==2.4.0 and example depends on sortedcontainers==2.3.0, we can conclude that example and subexample are incompatible.
+             And because example depends on subexample and your workspace requires example, we can conclude that your workspace's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -5530,9 +5530,9 @@ fn lock_conflicting_workspace_members_depends_transitive() -> Result<()> {
     ----- stderr -----
     warning: Declaring conflicts for packages (`package = ...`) is experimental and may change without warning. Pass `--preview-features package-conflicts` to disable this warning.
     error: No solution found when resolving dependencies for split (included: example; excluded: subexample)
-      └── Because subexample depends on sortedcontainers==2.4.0 and indirection depends on subexample, we can conclude that indirection depends on sortedcontainers==2.4.0.
-          And because example depends on sortedcontainers==2.3.0, we can conclude that example and indirection are incompatible.
-          And because your workspace requires example and indirection, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because subexample depends on sortedcontainers==2.4.0 and indirection depends on subexample, we can conclude that indirection depends on sortedcontainers==2.4.0.
+             And because example depends on sortedcontainers==2.3.0, we can conclude that example and indirection are incompatible.
+             And because your workspace requires example and indirection, we can conclude that your workspace's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -5973,8 +5973,8 @@ fn lock_conflicting_mixed() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project:project1 depends on sortedcontainers==2.3.0 and project[project2] depends on sortedcontainers==2.4.0, we can conclude that project:project1 and project[project2] are incompatible.
-          And because your project requires project[project2] and project:project1, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project:project1 depends on sortedcontainers==2.3.0 and project[project2] depends on sortedcontainers==2.4.0, we can conclude that project:project1 and project[project2] are incompatible.
+             And because your project requires project[project2] and project:project1, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // And now with the same extra/group configuration, we tell uv
@@ -7284,16 +7284,16 @@ fn lock_requires_python() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: python_full_version >= '3.7' and python_full_version < '3.7.9')
-      └── Because the requested Python version (>=3.7) does not satisfy Python>=3.7.9 and pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4, we can conclude that pygls>=1.1.0,<=1.2.1 cannot be used.
-          And because only the following versions of pygls are available:
-              pygls<=1.2.1
-              pygls>=1.3.0
-          we can conclude that pygls>=1.1.0,<1.3.0 cannot be used. (1)
+      cause: Because the requested Python version (>=3.7) does not satisfy Python>=3.7.9 and pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4, we can conclude that pygls>=1.1.0,<=1.2.1 cannot be used.
+             And because only the following versions of pygls are available:
+                 pygls<=1.2.1
+                 pygls>=1.3.0
+             we can conclude that pygls>=1.1.0,<1.3.0 cannot be used. (1)
 
-          Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls==1.3.0 depends on Python>=3.8, we can conclude that pygls==1.3.0 cannot be used.
-          And because only pygls<=1.3.0 is available, we can conclude that pygls>=1.3.0 cannot be used.
-          And because we know from (1) that pygls>=1.1.0,<1.3.0 cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
-          And because your project depends on pygls>=1.1.0, we can conclude that your project's requirements are unsatisfiable.
+             Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls==1.3.0 depends on Python>=3.8, we can conclude that pygls==1.3.0 cannot be used.
+             And because only pygls<=1.3.0 is available, we can conclude that pygls>=1.3.0 cannot be used.
+             And because we know from (1) that pygls>=1.1.0,<1.3.0 cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
+             And because your project depends on pygls>=1.1.0, we can conclude that your project's requirements are unsatisfiable.
 
     hint: While the active Python version is 3.12, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.
 
@@ -11511,13 +11511,13 @@ fn lock_invalid_hash() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `idna==3.6`
-      └── Hash mismatch for `idna==3.6`
+      cause: Hash mismatch for `idna==3.6`
 
-          Expected:
-            sha256:d05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
+             Expected:
+               sha256:d05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
 
-          Computed:
-            sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
+             Computed:
+               sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
 
     hint: `idna` (v3.6) was included because `project` (v0.1.0) depends on `anyio` (v3.7.0) which depends on `idna`
     ");
@@ -12392,7 +12392,7 @@ fn lock_requires_python_no_wheels() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because dearpygui==1.9.1 has no wheels with a matching Python version tag (e.g., `cp312`) and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because dearpygui==1.9.1 has no wheels with a matching Python version tag (e.g., `cp312`) and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
 
     hint: Wheels are available for `dearpygui` (v1.9.1) with the following Python ABI tags: `cp37m`, `cp38`, `cp39`, `cp310`, `cp311`
     ");
@@ -12803,8 +12803,8 @@ fn lock_relative_lock_deserialization() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: Failed to generate package metadata for `child==0.1.0 @ editable+.`
-      ├── Failed to parse entry: `member`
-      └── `member` references a workspace in `tool.uv.sources` (e.g., `member = { workspace = true }`), but is not a workspace member
+      cause: Failed to parse entry: `member`
+      cause: `member` references a workspace in `tool.uv.sources` (e.g., `member = { workspace = true }`), but is not a workspace member
     ");
 
     Ok(())
@@ -12855,8 +12855,8 @@ fn lock_non_workspace_source() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `child`
-      └── `child` is included as a workspace member, but references a path in `tool.uv.sources`. Workspace members must be declared as workspace sources (e.g., `child = { workspace = true }`).
+      cause: Failed to parse entry: `child`
+      cause: `child` is included as a workspace member, but references a path in `tool.uv.sources`. Workspace members must be declared as workspace sources (e.g., `child = { workspace = true }`).
     ");
 
     Ok(())
@@ -12904,8 +12904,8 @@ fn lock_no_workspace_source() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `child`
-      └── `child` is included as a workspace member, but is missing an entry in `tool.uv.sources` (e.g., `child = { workspace = true }`)
+      cause: Failed to parse entry: `child`
+      cause: `child` is included as a workspace member, but is missing an entry in `tool.uv.sources` (e.g., `child = { workspace = true }`)
     ");
 
     Ok(())
@@ -13123,8 +13123,8 @@ fn lock_external_workspace_source() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: Failed to build `project @ file://[TEMP_DIR]/project`
-      ├── Failed to parse entry: `pkg-b`
-      └── Workspace source path `[TEMP_DIR]/external-workspace/packages/pkg-b` must point to a workspace root (found workspace at `[TEMP_DIR]/external-workspace`)
+      cause: Failed to parse entry: `pkg-b`
+      cause: Workspace source path `[TEMP_DIR]/external-workspace/packages/pkg-b` must point to a workspace root (found workspace at `[TEMP_DIR]/external-workspace`)
     ");
 
     Ok(())
@@ -13197,8 +13197,8 @@ fn lock_workspace_member_with_external_workspace_source() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `child`
-      └── `child` is included as a workspace member, but does not use `workspace = true` in `tool.uv.sources`
+      cause: Failed to parse entry: `child`
+      cause: `child` is included as a workspace member, but does not use `workspace = true` in `tool.uv.sources`
     ");
 
     Ok(())
@@ -13440,8 +13440,8 @@ async fn lock_index_workspace_member() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because iniconfig was not found in the package registry and child depends on iniconfig>=2, we can conclude that child's requirements are unsatisfiable.
-          And because your workspace requires child, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because iniconfig was not found in the package registry and child depends on iniconfig>=2, we can conclude that child's requirements are unsatisfiable.
+             And because your workspace requires child, we can conclude that your workspace's requirements are unsatisfiable.
     ");
 
     uv_snapshot!(context.filters(), context.lock()
@@ -13779,8 +13779,8 @@ async fn lock_redact_http() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to download `iniconfig==2.0.0`
-      ├── Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
-      └── HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
+      cause: Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
+      cause: HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
 
     hint: `iniconfig` (v2.0.0) was included because `foo` (v0.1.0) depends on `iniconfig`
     ");
@@ -13790,8 +13790,8 @@ async fn lock_redact_http() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to download `iniconfig==2.0.0`
-      ├── Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
-      └── HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
+      cause: Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
+      cause: HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
 
     hint: `iniconfig` (v2.0.0) was included because `foo` (v0.1.0) depends on `iniconfig`
     ");
@@ -13820,8 +13820,8 @@ async fn lock_redact_http() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to download `iniconfig==2.0.0`
-      ├── Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
-      └── HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
+      cause: Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
+      cause: HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
 
     hint: `iniconfig` (v2.0.0) was included because `foo` (v0.1.0) depends on `iniconfig`
     ");
@@ -14361,7 +14361,7 @@ async fn lock_env_credentials() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
     ");
@@ -17254,9 +17254,9 @@ fn lock_editable() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve dependencies for package `workspace==0.1.0`
-      └── Requirements contain conflicting URLs for package `library` in all marker environments:
-          - file://[TEMP_DIR]/library
-          - file://[TEMP_DIR]/library (editable)
+      cause: Requirements contain conflicting URLs for package `library` in all marker environments:
+             - file://[TEMP_DIR]/library
+             - file://[TEMP_DIR]/library (editable)
     ");
 
     Ok(())
@@ -18292,7 +18292,7 @@ fn unconditional_overlapping_marker_disjoint_version_constraints() -> Result<()>
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because your project depends on datasets<2.19 and datasets>=2.19, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on datasets<2.19 and datasets>=2.19, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -19342,8 +19342,8 @@ fn lock_add_member_with_build_system() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because anyio was not found in the cache and leaf depends on anyio>3, we can conclude that leaf's requirements are unsatisfiable.
-          And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because anyio was not found in the cache and leaf depends on anyio>3, we can conclude that leaf's requirements are unsatisfiable.
+             And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     ");
@@ -19535,8 +19535,8 @@ fn lock_add_member_without_build_system() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because anyio was not found in the cache and leaf depends on anyio>3, we can conclude that leaf's requirements are unsatisfiable.
-          And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because anyio was not found in the cache and leaf depends on anyio>3, we can conclude that leaf's requirements are unsatisfiable.
+             And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     ");
@@ -20878,8 +20878,8 @@ fn lock_regenerates_dependencies_without_metadata() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: python_full_version >= '3.12' and sys_platform != 'win32')
-      └── Because only tqdm{sys_platform != 'win32'}==4.0.0 is available and your project depends on tqdm{sys_platform != 'win32'}>4, we can conclude that your project's requirements are unsatisfiable.
-          And because your project requires project[empty], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because only tqdm{sys_platform != 'win32'}==4.0.0 is available and your project depends on tqdm{sys_platform != 'win32'}>4, we can conclude that your project's requirements are unsatisfiable.
+             And because your project requires project[empty], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // Requested target extras are part of their optional dependency edges.
@@ -20986,7 +20986,7 @@ fn lock_regenerates_incompatible_self_requirement() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because your project depends on itself at an incompatible version (project>=2.0.0), we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on itself at an incompatible version (project>=2.0.0), we can conclude that your project's requirements are unsatisfiable.
 
     hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
     ");
@@ -21005,7 +21005,7 @@ fn lock_regenerates_incompatible_self_requirement() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[feature] depends on itself at an incompatible version (project>=2.0.0) and your project requires project[feature], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[feature] depends on itself at an incompatible version (project>=2.0.0) and your project requires project[feature], we can conclude that your project's requirements are unsatisfiable.
 
     hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
     ");
@@ -24110,8 +24110,8 @@ fn lock_non_project_member_conflicts() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because member-a depends on sortedcontainers==2.3.0 and member-b depends on sortedcontainers==2.4.0, we can conclude that member-a and member-b are incompatible.
-          And because your workspace requires member-a and member-b, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because member-a depends on sortedcontainers==2.3.0 and member-b depends on sortedcontainers==2.4.0, we can conclude that member-a and member-b are incompatible.
+             And because your workspace requires member-a and member-b, we can conclude that your workspace's requirements are unsatisfiable.
     ");
 
     pyproject_toml.write_str(
@@ -24932,11 +24932,11 @@ fn lock_invalid_index() -> Result<()> {
       Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
 
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 9, column 31
-            |
-          9 |         iniconfig = { index = "internal proxy" }
-            |                               ^^^^^^^^^^^^^^^^
-          Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
+      cause: TOML parse error at line 9, column 31
+               |
+             9 |         iniconfig = { index = "internal proxy" }
+               |                               ^^^^^^^^^^^^^^^^
+             Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
     "#);
 
     Ok(())
@@ -25162,7 +25162,7 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG Searching for a compatible version of project @ file://[TEMP_DIR]/ (<0.1.0 | >0.1.0)
     DEBUG No compatible version found for: project
     error: No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
     "#);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
@@ -25237,11 +25237,11 @@ fn lock_unnamed_explicit_index() -> Result<()> {
       An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
 
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 8, column 9
-            |
-          8 |         [[tool.uv.index]]
-            |         ^^^^^^^^^^^^^^^^^
-          An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
+      cause: TOML parse error at line 8, column 9
+               |
+             8 |         [[tool.uv.index]]
+               |         ^^^^^^^^^^^^^^^^^
+             An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
     ");
 
     Ok(())
@@ -25282,11 +25282,11 @@ fn lock_invalid_index_cache_control() -> Result<()> {
       `cache-control.api` must be a valid HTTP header value
 
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 11, column 9
-             |
-          11 |         cache-control.api = """
-             |         ^^^^^^^^^^^^^
-          `cache-control.api` must be a valid HTTP header value
+      cause: TOML parse error at line 11, column 9
+                |
+             11 |         cache-control.api = """
+                |         ^^^^^^^^^^^^^
+             `cache-control.api` must be a valid HTTP header value
     "#);
 
     Ok(())
@@ -25453,7 +25453,7 @@ fn lock_default_index() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
@@ -25520,8 +25520,8 @@ fn lock_named_index_cli() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `jinja2`
-      └── Package `jinja2` references an undeclared index: `pytorch`
+      cause: Failed to parse entry: `jinja2`
+      cause: Package `jinja2` references an undeclared index: `pytorch`
     ");
 
     // But it's fine if it comes from the CLI.
@@ -25617,8 +25617,8 @@ fn lock_named_index_config_file_hint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `jinja2`
-      └── Package `jinja2` references an undeclared index: `pytorch`
+      cause: Failed to parse entry: `jinja2`
+      cause: Package `jinja2` references an undeclared index: `pytorch`
 
     hint: Index `pytorch` was found in a project-level `uv.toml`, but indexes referenced via `tool.uv.sources` must be defined in the project's `pyproject.toml`
     ");
@@ -25671,8 +25671,8 @@ fn lock_named_index_user_config_file_hint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `jinja2`
-      └── Package `jinja2` references an undeclared index: `pytorch`
+      cause: Failed to parse entry: `jinja2`
+      cause: Package `jinja2` references an undeclared index: `pytorch`
 
     hint: Index `pytorch` was found in a user-level `uv.toml`, but indexes referenced via `tool.uv.sources` must be defined in the project's `pyproject.toml`
     ");
@@ -25709,11 +25709,11 @@ fn lock_repeat_named_index() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 8, column 9
-            |
-          8 |         [[tool.uv.index]]
-            |         ^^^^^^^^^^^^^^^^^
-          duplicate index name `pytorch`
+      cause: TOML parse error at line 8, column 9
+               |
+             8 |         [[tool.uv.index]]
+               |         ^^^^^^^^^^^^^^^^^
+             duplicate index name `pytorch`
     ");
 
     Ok(())
@@ -25750,11 +25750,11 @@ fn lock_multiple_default_indexes() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 8, column 9
-            |
-          8 |         [[tool.uv.index]]
-            |         ^^^^^^^^^^^^^^^^^
-          found multiple indexes with `default = true`; only one index may be marked as default
+      cause: TOML parse error at line 8, column 9
+               |
+             8 |         [[tool.uv.index]]
+               |         ^^^^^^^^^^^^^^^^^
+             found multiple indexes with `default = true`; only one index may be marked as default
     ");
 
     Ok(())
@@ -28113,11 +28113,11 @@ fn lock_duplicate_sources() -> Result<()> {
       duplicate key
 
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 9, column 9
-            |
-          9 |         python-multipart = { url = "https://files.pythonhosted.org/packages/c0/3e/9fbfd74e7f5b54f653f7ca99d44ceb56e718846920162165061c4c22b71a/python_multipart-0.0.8-py3-none-any.whl" }
-            |         ^^^^^^^^^^^^^^^^
-          duplicate key
+      cause: TOML parse error at line 9, column 9
+               |
+             9 |         python-multipart = { url = "https://files.pythonhosted.org/packages/c0/3e/9fbfd74e7f5b54f653f7ca99d44ceb56e718846920162165061c4c22b71a/python_multipart-0.0.8-py3-none-any.whl" }
+               |         ^^^^^^^^^^^^^^^^
+             duplicate key
     "#);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -28138,11 +28138,11 @@ fn lock_duplicate_sources() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 7, column 9
-            |
-          7 |         [tool.uv.sources]
-            |         ^^^^^^^^^^^^^^^^^
-          duplicate sources for package `python-multipart`
+      cause: TOML parse error at line 7, column 9
+               |
+             7 |         [tool.uv.sources]
+               |         ^^^^^^^^^^^^^^^^^
+             duplicate sources for package `python-multipart`
     ");
 
     Ok(())
@@ -28180,12 +28180,12 @@ fn lock_invalid_project_table() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: Failed to build `b @ file://[TEMP_DIR]/b`
-      ├── Failed to parse metadata from built wheel
-      └── TOML parse error at line 2, column 10
-            |
-          2 |         [project.urls]
-            |          ^^^^^^^
-          `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+      cause: Failed to parse metadata from built wheel
+      cause: TOML parse error at line 2, column 10
+               |
+             2 |         [project.urls]
+               |          ^^^^^^^
+             `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     ");
 
     Ok(())
@@ -28210,11 +28210,11 @@ fn lock_missing_name() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 1, column 1
-            |
-          1 | [project]
-            | ^^^^^^^^^
-          `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+      cause: TOML parse error at line 1, column 1
+               |
+             1 | [project]
+               | ^^^^^^^^^
+             `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     ");
 
     Ok(())
@@ -28239,11 +28239,11 @@ fn lock_missing_version() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 1, column 1
-            |
-          1 | [project]
-            | ^^^^^^^^^
-          `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list
+      cause: TOML parse error at line 1, column 1
+               |
+             1 | [project]
+               | ^^^^^^^^^
+             `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list
     ");
 
     Ok(())
@@ -28328,7 +28328,7 @@ fn lock_unsupported_version() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse `uv.lock`, which uses an unsupported schema version (v2, but only v1 is supported). Downgrade to a compatible uv version, or remove the `uv.lock` prior to running `uv lock` or `uv sync`.
-      └── Dependency `iniconfig` has missing `source` field but has more than one matching package
+      cause: Dependency `iniconfig` has missing `source` field but has more than one matching package
     ");
 
     Ok(())
@@ -28715,7 +28715,7 @@ async fn lock_keyring_explicit_always() -> Result<()> {
     Keyring request for http://[LOCALHOST]/basic-auth/simple
     Keyring request for [LOCALHOST]
     error: No solution found when resolving dependencies
-      └── Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
     ");
@@ -28890,7 +28890,7 @@ async fn lock_keyring_credentials_always_authenticate_unsupported_mode() -> Resu
     ----- stderr -----
     warning: Attempted to fetch credentials using the `keyring` command, but it does not support `--mode creds`; upgrade to `keyring>=v25.2.1` or provide a username
     error: Failed to fetch: `http://[LOCALHOST]/basic-auth/simple/iniconfig/`
-      └── Missing credentials for http://[LOCALHOST]/basic-auth/simple/iniconfig/
+      cause: Missing credentials for http://[LOCALHOST]/basic-auth/simple/iniconfig/
     ");
 
     Ok(())
@@ -29016,8 +29016,8 @@ fn lock_multiple_sources_conflict() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      ├── Failed to parse `tool.uv.sources`
-      └── Source markers must be disjoint, but the following markers overlap: `python_full_version == '3.12.*' and sys_platform == 'win32'` and `sys_platform == 'win32'`.
+      cause: Failed to parse `tool.uv.sources`
+      cause: Source markers must be disjoint, but the following markers overlap: `python_full_version == '3.12.*' and sys_platform == 'win32'` and `sys_platform == 'win32'`.
 
     hint: replace `sys_platform == 'win32'` with `python_full_version != '3.12.*' and sys_platform == 'win32'`
     ");
@@ -29051,8 +29051,8 @@ fn lock_multiple_sources_no_marker() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      ├── Failed to parse `tool.uv.sources`
-      └── When multiple sources are provided, each source must include a platform marker (e.g., `marker = "sys_platform == 'linux'"`)
+      cause: Failed to parse `tool.uv.sources`
+      cause: When multiple sources are provided, each source must include a platform marker (e.g., `marker = "sys_platform == 'linux'"`)
     "#);
 
     Ok(())
@@ -29982,9 +29982,9 @@ fn lock_multiple_sources_index_overlapping_extras() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve dependencies for package `project==0.1.0`
-      └── Requirements contain conflicting indexes for package `jinja2` in all marker environments:
-          - https://astral-sh.github.io/pytorch-mirror/whl/cu118
-          - https://astral-sh.github.io/pytorch-mirror/whl/cu124
+      cause: Requirements contain conflicting indexes for package `jinja2` in all marker environments:
+             - https://astral-sh.github.io/pytorch-mirror/whl/cu118
+             - https://astral-sh.github.io/pytorch-mirror/whl/cu124
     ");
 
     Ok(())
@@ -30021,7 +30021,7 @@ fn lock_multiple_index_with_missing_extra() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      └── Source entry for `jinja2` only applies to extra `cu118`, but the `cu118` extra does not exist. When an extra is present on a source (e.g., `extra = "cu118"`), the relevant package must be included in the `project.optional-dependencies` section for that extra (e.g., `project.optional-dependencies = { "cu118" = ["jinja2"] }`).
+      cause: Source entry for `jinja2` only applies to extra `cu118`, but the `cu118` extra does not exist. When an extra is present on a source (e.g., `extra = "cu118"`), the relevant package must be included in the `project.optional-dependencies` section for that extra (e.g., `project.optional-dependencies = { "cu118" = ["jinja2"] }`).
     "#);
 
     Ok(())
@@ -30062,7 +30062,7 @@ fn lock_multiple_index_with_absent_extra() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      └── Source entry for `jinja2` only applies to extra `cu118`, but `jinja2` was not found under the `project.optional-dependencies` section for that extra. When an extra is present on a source (e.g., `extra = "cu118"`), the relevant package must be included in the `project.optional-dependencies` section for that extra (e.g., `project.optional-dependencies = { "cu118" = ["jinja2"] }`).
+      cause: Source entry for `jinja2` only applies to extra `cu118`, but `jinja2` was not found under the `project.optional-dependencies` section for that extra. When an extra is present on a source (e.g., `extra = "cu118"`), the relevant package must be included in the `project.optional-dependencies` section for that extra (e.g., `project.optional-dependencies = { "cu118" = ["jinja2"] }`).
     "#);
 
     Ok(())
@@ -30099,7 +30099,7 @@ fn lock_multiple_index_with_missing_group() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      └── Source entry for `jinja2` only applies to dependency group `cu118`, but the `cu118` group does not exist. When a group is present on a source (e.g., `group = "cu118"`), the relevant package must be included in the `dependency-groups` section for that extra (e.g., `dependency-groups = { "cu118" = ["jinja2"] }`).
+      cause: Source entry for `jinja2` only applies to dependency group `cu118`, but the `cu118` group does not exist. When a group is present on a source (e.g., `group = "cu118"`), the relevant package must be included in the `dependency-groups` section for that extra (e.g., `dependency-groups = { "cu118" = ["jinja2"] }`).
     "#);
 
     Ok(())
@@ -30140,7 +30140,7 @@ fn lock_multiple_index_with_absent_group() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      └── Source entry for `jinja2` only applies to dependency group `cu118`, but `jinja2` was not found under the `dependency-groups` section for that group. When a group is present on a source (e.g., `group = "cu118"`), the relevant package must be included in the `dependency-groups` section for that extra (e.g., `dependency-groups = { "cu118" = ["jinja2"] }`).
+      cause: Source entry for `jinja2` only applies to dependency group `cu118`, but `jinja2` was not found under the `dependency-groups` section for that group. When a group is present on a source (e.g., `group = "cu118"`), the relevant package must be included in the `dependency-groups` section for that extra (e.g., `dependency-groups = { "cu118" = ["jinja2"] }`).
     "#);
 
     Ok(())
@@ -30781,7 +30781,7 @@ fn lock_group_requires_undefined_group() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `myproject` has malformed dependency groups
-      └── Failed to find group `foo` specified in `[tool.uv.dependency-groups]`
+      cause: Failed to find group `foo` specified in `[tool.uv.dependency-groups]`
     ");
     Ok(())
 }
@@ -30814,7 +30814,7 @@ fn lock_group_requires_dev_dep() -> Result<()> {
     ----- stderr -----
     warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
     error: Project `myproject` has malformed dependency groups
-      └── `[tool.uv.dependency-groups]` specifies the `dev` group, but only `tool.uv.dev-dependencies` was found. To reference the `dev` group, remove the `tool.uv.dev-dependencies` section and add any development dependencies to the `dev` entry in the `[dependency-groups]` table instead.
+      cause: `[tool.uv.dependency-groups]` specifies the `dev` group, but only `tool.uv.dev-dependencies` was found. To reference the `dev` group, remove the `tool.uv.dev-dependencies` section and add any development dependencies to the `dev` entry in the `[dependency-groups]` table instead.
     ");
     Ok(())
 }
@@ -30965,7 +30965,7 @@ fn lock_group_include_cycle() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `project` has malformed dependency groups
-      └── Detected a cycle in `dependency-groups`: `bar` -> `foobar` -> `foo` -> `bar`
+      cause: Detected a cycle in `dependency-groups`: `bar` -> `foobar` -> `foo` -> `bar`
     ");
 
     Ok(())
@@ -30998,7 +30998,7 @@ fn lock_group_include_dev() -> Result<()> {
     ----- stderr -----
     warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
     error: Project `project` has malformed dependency groups
-      └── Group `foo` includes the `dev` group (`include = "dev"`), but only `tool.uv.dev-dependencies` was found. To reference the `dev` group via an `include`, remove the `tool.uv.dev-dependencies` section and add any development dependencies to the `dev` entry in the `[dependency-groups]` table instead.
+      cause: Group `foo` includes the `dev` group (`include = "dev"`), but only `tool.uv.dev-dependencies` was found. To reference the `dev` group via an `include`, remove the `tool.uv.dev-dependencies` section and add any development dependencies to the `dev` entry in the `[dependency-groups]` table instead.
     "#);
 
     Ok(())
@@ -31027,7 +31027,7 @@ fn lock_group_include_missing() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `project` has malformed dependency groups
-      └── Failed to find group `bar` included by `foo`
+      cause: Failed to find group `bar` included by `foo`
     ");
 
     Ok(())
@@ -31056,20 +31056,20 @@ fn lock_group_invalid_entry_package() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `project` has malformed dependency groups
-      ├── Failed to parse entry in group `foo`: `invalid!`
-      └── no such comparison operator "!", must be one of ~= == != <= >= < > ===
-          invalid!
-                 ^
+      cause: Failed to parse entry in group `foo`: `invalid!`
+      cause: no such comparison operator "!", must be one of ~= == != <= >= < > ===
+             invalid!
+                    ^
     "#);
 
     uv_snapshot!(context.filters(), context.sync().arg("--group").arg("foo"), @r#"
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `project` has malformed dependency groups
-      ├── Failed to parse entry in group `foo`: `invalid!`
-      └── no such comparison operator "!", must be one of ~= == != <= >= < > ===
-          invalid!
-                 ^
+      cause: Failed to parse entry in group `foo`: `invalid!`
+      cause: no such comparison operator "!", must be one of ~= == != <= >= < > ===
+             invalid!
+                    ^
     "#);
 
     Ok(())
@@ -31098,11 +31098,11 @@ fn lock_group_invalid_entry_group_name() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 9, column 16
-            |
-          9 |         foo = [{include-group = "invalid!"}]
-            |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          Not a valid package or extra name: "invalid!". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+      cause: TOML parse error at line 9, column 16
+               |
+             9 |         foo = [{include-group = "invalid!"}]
+               |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             Not a valid package or extra name: "invalid!". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     "#);
 
     Ok(())
@@ -31132,11 +31132,11 @@ fn lock_group_invalid_duplicate_group_name() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 8, column 9
-            |
-          8 |         [dependency-groups]
-            |         ^^^^^^^^^^^^^^^^^^^
-          duplicate dependency group: `foo-bar`
+      cause: TOML parse error at line 8, column 9
+               |
+             8 |         [dependency-groups]
+               |         ^^^^^^^^^^^^^^^^^^^
+             duplicate dependency group: `foo-bar`
     ");
 
     Ok(())
@@ -31165,7 +31165,7 @@ fn lock_group_invalid_entry_table() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `project` has malformed dependency groups
-      └── Group `foo` contains an unknown dependency object specifier: {"bar": "unknown"}
+      cause: Group `foo` contains an unknown dependency object specifier: {"bar": "unknown"}
     "#);
 
     Ok(())
@@ -31195,7 +31195,7 @@ fn lock_group_include_with_extra_key() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `project` has malformed dependency groups
-      └── Group `foo` contains an unknown dependency object specifier: {"include-group": "bar", "unknown": "value"}
+      cause: Group `foo` contains an unknown dependency object specifier: {"include-group": "bar", "unknown": "value"}
     "#);
 
     Ok(())
@@ -31224,11 +31224,11 @@ fn lock_group_invalid_entry_type() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 9, column 33
-            |
-          9 |         foo = [{include-group = true}]
-            |                                 ^^^^
-          invalid type: boolean `true`, expected a string
+      cause: TOML parse error at line 9, column 33
+               |
+             9 |         foo = [{include-group = true}]
+               |                                 ^^^^
+             invalid type: boolean `true`, expected a string
     ");
 
     Ok(())
@@ -31257,11 +31257,11 @@ fn lock_group_empty_entry_table() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 9, column 16
-            |
-          9 |         foo = [{}]
-            |                ^^
-          missing field `include-group`
+      cause: TOML parse error at line 9, column 16
+               |
+             9 |         foo = [{}]
+               |                ^^
+             missing field `include-group`
     ");
 
     Ok(())
@@ -33362,26 +33362,26 @@ fn lock_derivation_chain_prod() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `project` (v0.1.0) depends on `wsgiref==0.1.2`
 
@@ -33412,26 +33412,26 @@ fn lock_derivation_chain_extra() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `project[wsgi]` (v0.1.0) depends on `wsgiref>=0.1`
 
@@ -33464,26 +33464,26 @@ fn lock_derivation_chain_group() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `project:wsgi` (v0.1.0) depends on `wsgiref`
 
@@ -33527,26 +33527,26 @@ fn lock_derivation_chain_extended() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `project` (v0.1.0) depends on `child` (v0.1.0) which depends on `wsgiref>=0.1, <0.2`
 
@@ -33583,7 +33583,7 @@ fn mismatched_name_self_editable() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to build `foo @ file://[TEMP_DIR]/`
-      └── Package metadata name `project` does not match given name `foo`
+      cause: Package metadata name `project` does not match given name `foo`
 
     hint: `foo` was included because `project` (v0.1.0) depends on `foo`
     ");
@@ -33865,7 +33865,7 @@ fn lock_no_build_invalid_dependency_virtual_project() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      └── Building source distributions for `project` is disabled
+      cause: Building source distributions for `project` is disabled
     ");
 
     Ok(())
@@ -33977,7 +33977,7 @@ fn lock_no_build_dynamic_metadata() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `dummy @ file://[TEMP_DIR]/`
-      └── Building source distributions for `dummy` is disabled
+      cause: Building source distributions for `dummy` is disabled
     ");
 
     Ok(())
@@ -34181,7 +34181,7 @@ fn lock_self_incompatible() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because your project depends on itself at an incompatible version (project==0.2.0), we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on itself at an incompatible version (project==0.2.0), we can conclude that your project's requirements are unsatisfiable.
 
     hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
     ");
@@ -34305,7 +34305,7 @@ fn lock_self_extra_to_same_extra_incompatible() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[foo] depends on itself at an incompatible version (project==0.2.0) and your project requires project[foo], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[foo] depends on itself at an incompatible version (project==0.2.0) and your project requires project[foo], we can conclude that your project's requirements are unsatisfiable.
 
     hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
     ");
@@ -34337,7 +34337,7 @@ fn lock_self_extra_to_other_extra_incompatible() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[foo] depends on itself at an incompatible version (project==0.2.0) and your project requires project[foo], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[foo] depends on itself at an incompatible version (project==0.2.0) and your project requires project[foo], we can conclude that your project's requirements are unsatisfiable.
 
     hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
     ");
@@ -34461,7 +34461,7 @@ fn lock_self_extra_incompatible() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[foo] depends on itself at an incompatible version (project==0.2.0) and your project requires project[foo], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[foo] depends on itself at an incompatible version (project==0.2.0) and your project requires project[foo], we can conclude that your project's requirements are unsatisfiable.
 
     hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
     ");
@@ -34578,7 +34578,7 @@ fn lock_self_marker_incompatible() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because your project depends on itself at an incompatible version (project{sys_platform == 'win32'}>0.1), we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on itself at an incompatible version (project{sys_platform == 'win32'}>0.1), we can conclude that your project's requirements are unsatisfiable.
 
     hint: The project `project` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `project`, consider renaming the project `project` to avoid creating a conflict.
     ");
@@ -34700,8 +34700,8 @@ fn lock_missing_git_prefix() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `workspace-in-root-test`
-      └── `workspace-in-root-test` is associated with a URL source, but references a Git repository. Consider using a Git source instead (e.g., `workspace-in-root-test = { git = "https://github.com/astral-sh/workspace-in-root-test" }`)
+      cause: Failed to parse entry: `workspace-in-root-test`
+      cause: `workspace-in-root-test` is associated with a URL source, but references a Git repository. Consider using a Git source instead (e.g., `workspace-in-root-test = { git = "https://github.com/astral-sh/workspace-in-root-test" }`)
     "#);
 
     Ok(())
@@ -37966,8 +37966,8 @@ fn lock_conflict_for_disjoint_python_version() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: python_full_version >= '3.11')
-      └── Because pandas==1.5.3 depends on numpy{python_full_version >= '3.10'}>=1.21.0 and your project depends on numpy==1.20.3, we can conclude that your project and pandas==1.5.3 are incompatible.
-          And because your project depends on pandas==1.5.3, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because pandas==1.5.3 depends on numpy{python_full_version >= '3.10'}>=1.21.0 and your project depends on numpy==1.20.3, we can conclude that your project and pandas==1.5.3 are incompatible.
+             And because your project depends on pandas==1.5.3, we can conclude that your project's requirements are unsatisfiable.
 
     hint: While the active Python version is 3.9, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.
     ");
@@ -38177,7 +38177,7 @@ fn lock_conflict_for_disjoint_platform() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: sys_platform == 'exotic')
-      └── Because your project depends on numpy{sys_platform == 'exotic'}>=1.24,<1.26 and numpy>=1.26, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on numpy{sys_platform == 'exotic'}>=1.24,<1.26 and numpy>=1.26, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The resolution failed for an environment that is not the current one, consider limiting the environments with `tool.uv.environments`.
     ");
@@ -38771,7 +38771,7 @@ fn lock_prefix_match() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only anyio<=4.3.0 is available and your project depends on anyio==5.4.*, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because only anyio<=4.3.0 is available and your project depends on anyio==5.4.*, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -39415,7 +39415,7 @@ fn lock_exclude_newer_hint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there are no versions of iniconfig and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because there are no versions of iniconfig and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2000-01-01T00:00:00Z. The latest version satisfying the requirement is v2.0.0, published at 2023-01-07T11:08:09.864Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     ");
@@ -39463,7 +39463,7 @@ async fn lock_exclude_newer_index_disable() -> Result<()> {
     warning: iniconfig-2.0.0.tar.gz is missing an upload date, but user provided: 2024-03-25T00:00:00Z
     warning: iniconfig-2.0.0-py3-none-any.whl is missing an upload date, but user provided: 2024-03-25T00:00:00Z
     error: No solution found when resolving dependencies
-      └── Because there are no versions of iniconfig and your project depends on iniconfig>=2, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because there are no versions of iniconfig and your project depends on iniconfig>=2, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2024-03-25T00:00:00Z. The latest version satisfying the requirement is v2.0.0. Consider using `exclude-newer-package` to override the cutoff for this package.
     ");
@@ -39542,7 +39542,7 @@ async fn lock_exclude_newer_index_value() -> Result<()> {
     warning: iniconfig-2.0.0.tar.gz is missing an upload date, but user provided: 2025-01-01T00:00:00Z
     warning: iniconfig-2.0.0-py3-none-any.whl is missing an upload date, but user provided: 2025-01-01T00:00:00Z
     error: No solution found when resolving dependencies
-      └── Because there are no versions of iniconfig and your project depends on iniconfig>=2, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because there are no versions of iniconfig and your project depends on iniconfig>=2, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `iniconfig` was filtered by the index-specific `exclude-newer` setting to only include packages uploaded before 2025-01-01T00:00:00Z. The latest version satisfying the requirement is v2.0.0. Consider updating that index's cutoff, setting it to `false`, or using `exclude-newer-package` to override the cutoff for this package.
     ");
@@ -39556,7 +39556,7 @@ async fn lock_exclude_newer_index_value() -> Result<()> {
     warning: iniconfig-2.0.0.tar.gz is missing an upload date, but user provided: 2025-01-01T00:00:00Z
     warning: iniconfig-2.0.0-py3-none-any.whl is missing an upload date, but user provided: 2025-01-01T00:00:00Z
     error: No solution found when resolving dependencies
-      └── Because there are no versions of iniconfig and your project depends on iniconfig>=2, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because there are no versions of iniconfig and your project depends on iniconfig>=2, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `iniconfig` was filtered by the index-specific `exclude-newer` setting to only include packages uploaded before 2025-01-01T00:00:00Z. The latest version satisfying the requirement is v2.0.0. Consider updating that index's cutoff, setting it to `false`, or using `exclude-newer-package` to override the cutoff for this package.
     ");
@@ -39622,7 +39622,7 @@ fn lock_exclude_newer_hint_pinned_version() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of iniconfig==2.0.0 and your project depends on iniconfig==2.0.0, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because there is no version of iniconfig==2.0.0 and your project depends on iniconfig==2.0.0, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2022-01-01T00:00:00Z. The requested version, v2.0.0, was published at 2023-01-07T11:08:09.864Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     ");
@@ -39659,7 +39659,7 @@ fn lock_exclude_newer_hint_compatible_release() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only iniconfig<=1.1.1 is available and your project depends on iniconfig>=2.0,<3.dev0, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because only iniconfig<=1.1.1 is available and your project depends on iniconfig>=2.0,<3.dev0, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2022-01-01T00:00:00Z. The latest version satisfying the requirement is v2.0.0, published at 2023-01-07T11:08:09.864Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     ");
@@ -40745,7 +40745,7 @@ fn collapsed_error_with_marker_packages() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: python_full_version < '3.14' and sys_platform == 'other')
-      └── Because your project depends on anyio{sys_platform == 'other'} and anyio{python_full_version < '3.14'}>=4.4.0, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on anyio{sys_platform == 'other'} and anyio{python_full_version < '3.14'}>=4.4.0, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The resolution failed for an environment that is not the current one, consider limiting the environments with `tool.uv.environments`.
     ");
@@ -40802,8 +40802,8 @@ fn lock_unsupported_wheel_url_requires_python() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only numpy==2.3.5 is available and numpy==2.3.5 has no wheels with a matching Python version tag (e.g., `cp312`), we can conclude that all versions of numpy cannot be used.
-          And because your project depends on numpy, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because only numpy==2.3.5 is available and numpy==2.3.5 has no wheels with a matching Python version tag (e.g., `cp312`), we can conclude that all versions of numpy cannot be used.
+             And because your project depends on numpy, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -40842,8 +40842,8 @@ fn lock_unsupported_wheel_url_supported_platform() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: sys_platform == 'win32')
-      └── Because only numpy==2.3.5 is available and numpy==2.3.5 has no Windows-compatible wheels, we can conclude that all versions of numpy cannot be used.
-          And because your project depends on numpy, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because only numpy==2.3.5 is available and numpy==2.3.5 has no Windows-compatible wheels, we can conclude that all versions of numpy cannot be used.
+             And because your project depends on numpy, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -40872,8 +40872,8 @@ fn lock_unsupported_wheel_url_required_platform() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only numpy==2.3.5 is available and numpy==2.3.5 has no Windows-compatible wheels, we can conclude that all versions of numpy cannot be used.
-          And because your project depends on numpy, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because only numpy==2.3.5 is available and numpy==2.3.5 has no Windows-compatible wheels, we can conclude that all versions of numpy cannot be used.
+             And because your project depends on numpy, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -40957,8 +40957,8 @@ fn lock_required_environment_cycle_reports_resolution_error() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: platform_machine == 'arm64')
-      └── Because a==1.0.0 has no `platform_machine == 'arm64'`-compatible wheels and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because pkg-a depends on a and your workspace requires pkg-a, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because a==1.0.0 has no `platform_machine == 'arm64'`-compatible wheels and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
+             And because pkg-a depends on a and your workspace requires pkg-a, we can conclude that your workspace's requirements are unsatisfiable.
     "
     );
 
@@ -40998,11 +40998,11 @@ fn lock_supported_environment_wheel_only_package_requires_compatible_wheels() ->
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: sys_platform == 'linux')
-      └── Because pywin32<=305 has no wheels with a matching Python version tag (e.g., `cp312`) and only the following versions of pywin32 are available:
-              pywin32<=305
-              pywin32>=306
-          we can conclude that pywin32<306 cannot be used.
-          And because pywin32>=306 has no Linux-compatible wheels and your project depends on pywin32, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because pywin32<=305 has no wheels with a matching Python version tag (e.g., `cp312`) and only the following versions of pywin32 are available:
+                 pywin32<=305
+                 pywin32>=306
+             we can conclude that pywin32<306 cannot be used.
+             And because pywin32>=306 has no Linux-compatible wheels and your project depends on pywin32, we can conclude that your project's requirements are unsatisfiable.
 
     hint: Wheels are available for `pywin32` (v305) with the following Python ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`, `cp310`, `cp311`
     ");
@@ -41162,11 +41162,11 @@ async fn lock_check_multiple_default_indexes_explicit_assignment_dependency_grou
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 13, column 9
-             |
-          13 |         [[tool.uv.index]]
-             |         ^^^^^^^^^^^^^^^^^
-          found multiple indexes with `default = true`; only one index may be marked as default
+      cause: TOML parse error at line 13, column 9
+                |
+             13 |         [[tool.uv.index]]
+                |         ^^^^^^^^^^^^^^^^^
+             found multiple indexes with `default = true`; only one index may be marked as default
     ");
 
     Ok(())
@@ -41191,10 +41191,10 @@ fn lock_tilde_equal_version_u64_max_rejected() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `foo @ file://[TEMP_DIR]/`
-      ├── Failed to parse metadata from built wheel
-      └── expected number less than or equal to 18446744073709551614, but number found in "18446744073709551615" exceeds it
-          bar ~=18446744073709551615.0
-              ^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Failed to parse metadata from built wheel
+      cause: expected number less than or equal to 18446744073709551614, but number found in "18446744073709551615" exceeds it
+             bar ~=18446744073709551615.0
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
     "#);
 
     Ok(())

--- a/crates/uv/tests/lock_scenarios/lock_conflict.rs
+++ b/crates/uv/tests/lock_scenarios/lock_conflict.rs
@@ -135,8 +135,8 @@ fn extra_basic() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
-          And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
+             And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // And now with the same extra configuration, we tell uv about
@@ -303,8 +303,8 @@ fn extra_basic_three_extras() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[extra2] depends on sortedcontainers==2.3.0 and project[extra1] depends on sortedcontainers==2.2.0, we can conclude that project[extra1] and project[extra2] are incompatible.
-          And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[extra2] depends on sortedcontainers==2.3.0 and project[extra1] depends on sortedcontainers==2.2.0, we can conclude that project[extra1] and project[extra2] are incompatible.
+             And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // And now with the same extra configuration, we tell uv about
@@ -549,8 +549,8 @@ fn extra_multiple_not_conflicting2() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
-          And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
+             And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // If we define extra1/extra2 as conflicting and project3/project4
@@ -586,8 +586,8 @@ fn extra_multiple_not_conflicting2() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (included: project[extra2], project[project3]; excluded: project[extra1], project[project4])
-      └── Because project[project3] depends on sortedcontainers==2.3.0 and project[extra2] depends on sortedcontainers==2.4.0, we can conclude that project[extra2] and project[project3] are incompatible.
-          And because your project requires project[extra2] and project[project3], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[project3] depends on sortedcontainers==2.3.0 and project[extra2] depends on sortedcontainers==2.4.0, we can conclude that project[extra2] and project[project3] are incompatible.
+             And because your project requires project[extra2] and project[project3], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // One could try to declare all pairs of conflicting extras as
@@ -698,8 +698,8 @@ fn extra_multiple_independent() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
-          And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
+             And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // OK, responding to the error, we declare our anyio extras
@@ -731,8 +731,8 @@ fn extra_multiple_independent() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (included: project[project4]; excluded: project[project3])
-      └── Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
-          And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
+             And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // Once we declare ALL our conflicting extras, resolution succeeds.
@@ -1003,8 +1003,8 @@ fn extra_config_change_ignore_lockfile() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
-          And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
+             And because your project requires project[extra1] and project[extra2], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -1519,12 +1519,12 @@ fn extra_nested_across_workspace() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (included: dummy[extra2], dummysub[extra1]; excluded: dummy[extra1], dummysub[extra2])
-      └── Because dummy[extra2] depends on proxy1[extra2] and only proxy1[extra2]==0.1.0 is available, we can conclude that dummy[extra2] depends on proxy1[extra2]==0.1.0. (1)
+      cause: Because dummy[extra2] depends on proxy1[extra2] and only proxy1[extra2]==0.1.0 is available, we can conclude that dummy[extra2] depends on proxy1[extra2]==0.1.0. (1)
 
-          Because proxy1[extra1]==0.1.0 depends on anyio==4.1.0 and proxy1[extra2]==0.1.0 depends on anyio==4.2.0, we can conclude that proxy1[extra1]==0.1.0 and proxy1[extra2]==0.1.0 are incompatible.
-          And because we know from (1) that dummy[extra2] depends on proxy1[extra2]==0.1.0, we can conclude that dummy[extra2] and proxy1[extra1]==0.1.0 are incompatible.
-          And because only proxy1[extra1]==0.1.0 is available and dummysub[extra1] depends on proxy1[extra1], we can conclude that dummysub[extra1] and dummy[extra2] are incompatible.
-          And because your workspace requires dummy[extra2] and dummysub[extra1], we can conclude that your workspace's requirements are unsatisfiable.
+             Because proxy1[extra1]==0.1.0 depends on anyio==4.1.0 and proxy1[extra2]==0.1.0 depends on anyio==4.2.0, we can conclude that proxy1[extra1]==0.1.0 and proxy1[extra2]==0.1.0 are incompatible.
+             And because we know from (1) that dummy[extra2] depends on proxy1[extra2]==0.1.0, we can conclude that dummy[extra2] and proxy1[extra1]==0.1.0 are incompatible.
+             And because only proxy1[extra1]==0.1.0 is available and dummysub[extra1] depends on proxy1[extra1], we can conclude that dummysub[extra1] and dummy[extra2] are incompatible.
+             And because your workspace requires dummy[extra2] and dummysub[extra1], we can conclude that your workspace's requirements are unsatisfiable.
     ");
 
     // Now let's write out the full set of conflicts, taking
@@ -1652,8 +1652,8 @@ fn extra_depends_on_conflicting_extra() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (included: example[foo]; excluded: example[bar])
-      └── Because example[foo] depends on sortedcontainers==2.3.0 and sortedcontainers==2.4.0, we can conclude that example[foo]'s requirements are unsatisfiable.
-          And because your project requires example[foo], we can conclude that your project's requirements are unsatisfiable.
+      cause: Because example[foo] depends on sortedcontainers==2.3.0 and sortedcontainers==2.4.0, we can conclude that example[foo]'s requirements are unsatisfiable.
+             And because your project requires example[foo], we can conclude that your project's requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -1865,8 +1865,8 @@ fn group_basic() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project:group2 depends on sortedcontainers==2.4.0 and project:group1 depends on sortedcontainers==2.3.0, we can conclude that project:group1 and project:group2 are incompatible.
-          And because your project requires project:group1 and project:group2, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project:group2 depends on sortedcontainers==2.4.0 and project:group1 depends on sortedcontainers==2.3.0, we can conclude that project:group1 and project:group2 are incompatible.
+             And because your project requires project:group1 and project:group2, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // And now with the same group configuration, we tell uv about
@@ -2182,7 +2182,7 @@ fn group_virtual() -> Result<()> {
     ----- stderr -----
     warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
     error: No solution found when resolving dependencies
-      └── Because you require sortedcontainers==2.3.0 and sortedcontainers==2.4.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require sortedcontainers==2.3.0 and sortedcontainers==2.4.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     // And now with the same group configuration, we tell uv about
@@ -2529,8 +2529,8 @@ fn mixed() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because project:group1 depends on sortedcontainers==2.3.0 and project[extra1] depends on sortedcontainers==2.4.0, we can conclude that project:group1 and project[extra1] are incompatible.
-          And because your project requires project[extra1] and project:group1, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because project:group1 depends on sortedcontainers==2.3.0 and project[extra1] depends on sortedcontainers==2.4.0, we can conclude that project:group1 and project[extra1] are incompatible.
+             And because your project requires project[extra1] and project:group1, we can conclude that your project's requirements are unsatisfiable.
     ");
 
     // And now with the same extra/group configuration, we tell uv
@@ -10625,11 +10625,11 @@ fn conflict_item_unknown_field() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 10, column 17
-             |
-          10 |               { name = "foo", extra = "extra1" },
-             |                 ^^^^
-          unknown field `name`, expected one of `package`, `extra`, `group`
+      cause: TOML parse error at line 10, column 17
+                |
+             10 |               { name = "foo", extra = "extra1" },
+                |                 ^^^^
+             unknown field `name`, expected one of `package`, `extra`, `group`
     "#);
 
     Ok(())

--- a/crates/uv/tests/lock_scenarios/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/lock_scenarios/lock_exclude_newer_relative.rs
@@ -1036,8 +1036,8 @@ fn lock_exclude_newer_relative_values() -> Result<()> {
     ----- stderr -----
     Resolving despite existing lockfile due to removal of exclude newer span
     error: No solution found when resolving dependencies
-      └── Because there are no versions of iniconfig and iniconfig==2.0.0 was published after the exclude newer time, we can conclude that all versions of iniconfig cannot be used.
-          And because your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because there are no versions of iniconfig and iniconfig==2.0.0 was published after the exclude newer time, we can conclude that all versions of iniconfig cannot be used.
+             And because your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2006-12-02T02:07:43Z. The latest version satisfying the requirement is v2.0.0, published at 2023-01-07T11:08:09.864Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     ");
@@ -1272,11 +1272,11 @@ fn lock_exclude_newer_package_relative_no_timestamp_in_lockfile() -> Result<()> 
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse `uv.lock`
-      └── TOML parse error at line 5, column 1
-            |
-          5 | [options]
-            | ^^^^^^^^^
-          data did not match any variant of untagged enum Helper
+      cause: TOML parse error at line 5, column 1
+               |
+             5 | [options]
+               | ^^^^^^^^^
+             data did not match any variant of untagged enum Helper
     ");
 
     Ok(())

--- a/crates/uv/tests/lock_scenarios/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios/lock_scenarios.rs
@@ -751,9 +751,9 @@ fn conflict_in_fork() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: sys_platform == 'os2')
-      └── Because all versions of c depend on d==2 and all versions of b depend on d==1, we can conclude that all versions of b and all versions of c are incompatible.
-          And because a<=1.0.0 depends on b, we can conclude that a<=1.0.0 and all versions of c are incompatible.
-          And because a<=1.0.0 depends on c and your project depends on a{sys_platform == 'os2'}<2, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because all versions of c depend on d==2 and all versions of b depend on d==1, we can conclude that all versions of b and all versions of c are incompatible.
+             And because a<=1.0.0 depends on b, we can conclude that a<=1.0.0 and all versions of c are incompatible.
+             And because a<=1.0.0 depends on c and your project depends on a{sys_platform == 'os2'}<2, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The resolution failed for an environment that is not the current one, consider limiting the environments with `tool.uv.environments`.
     "
@@ -814,7 +814,7 @@ fn fork_conflict_unsatisfiable() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because your project depends on a>=2 and a<2, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on a>=2 and a<2, we can conclude that your project's requirements are unsatisfiable.
     "
     );
 
@@ -1470,7 +1470,7 @@ fn fork_marker_disjoint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because your project depends on a{sys_platform == 'linux'}>=2 and a{sys_platform == 'linux'}<2, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because your project depends on a{sys_platform == 'linux'}>=2 and a{sys_platform == 'linux'}<2, we can conclude that your project's requirements are unsatisfiable.
     "
     );
 
@@ -3065,8 +3065,8 @@ fn fork_non_local_fork_marker_direct() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of b depend on c>=2.0.0 and all versions of a depend on c<2.0.0, we can conclude that all versions of a and all versions of b are incompatible.
-          And because your project depends on a{sys_platform == 'linux'}==1.0.0 and b{sys_platform == 'darwin'}==1.0.0, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because all versions of b depend on c>=2.0.0 and all versions of a depend on c<2.0.0, we can conclude that all versions of a and all versions of b are incompatible.
+             And because your project depends on a{sys_platform == 'linux'}==1.0.0 and b{sys_platform == 'darwin'}==1.0.0, we can conclude that your project's requirements are unsatisfiable.
     "
     );
 
@@ -3134,8 +3134,8 @@ fn fork_non_local_fork_marker_transitive() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of b depend on c{sys_platform == 'darwin'}>=2.0.0 and all versions of a depend on c{sys_platform == 'linux'}<2.0.0, we can conclude that all versions of a and all versions of b are incompatible.
-          And because your project depends on a==1.0.0 and b==1.0.0, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because all versions of b depend on c{sys_platform == 'darwin'}>=2.0.0 and all versions of a depend on c{sys_platform == 'linux'}<2.0.0, we can conclude that all versions of a and all versions of b are incompatible.
+             And because your project depends on a==1.0.0 and b==1.0.0, we can conclude that your project's requirements are unsatisfiable.
     "
     );
 

--- a/crates/uv/tests/pip/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip/pip_compile_scenarios.rs
@@ -366,8 +366,8 @@ fn compatible_python_incompatible_override() -> Result<()> {
     ----- stderr -----
     warning: The requested Python version 3.9 is not available; 3.11.[X] will be used to build dependencies instead.
     error: No solution found when resolving dependencies
-      └── Because the requested Python version (>=3.9) does not satisfy Python>=3.10 and a==1.0.0 depends on Python>=3.10, we can conclude that a==1.0.0 cannot be used.
-          And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because the requested Python version (>=3.9) does not satisfy Python>=3.10 and a==1.0.0 depends on Python>=3.10, we can conclude that a==1.0.0 cannot be used.
+             And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
 
     hint: The `--python-version` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., a==1.0.0 only supports >=3.10). Consider using a higher `--python-version` value.
     "
@@ -644,8 +644,8 @@ fn python_patch_override_no_patch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the requested Python version (>=3.9) does not satisfy Python>=3.9.4 and a==1.0.0 depends on Python>=3.9.4, we can conclude that a==1.0.0 cannot be used.
-          And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because the requested Python version (>=3.9) does not satisfy Python>=3.9.4 and a==1.0.0 depends on Python>=3.9.4, we can conclude that a==1.0.0 cannot be used.
+             And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
 
     hint: The `--python-version` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., a==1.0.0 only supports >=3.9.4). Consider using a higher `--python-version` value.
     "

--- a/crates/uv/tests/pip/pip_freeze.rs
+++ b/crates/uv/tests/pip/pip_freeze.rs
@@ -208,13 +208,13 @@ fn freeze_direct_archive_hash_roundtrip() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to read `ok @ file://[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl#subdirectory=src&sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
-      └── Hash mismatch for `ok @ file://[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl#subdirectory=src&sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+      cause: Hash mismatch for `ok @ file://[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl#subdirectory=src&sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
 
-          Expected:
-            sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             Expected:
+               sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
-          Computed:
-            sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
+             Computed:
+               sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
     ");
 
     Ok(())

--- a/crates/uv/tests/pip/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip/pip_install_scenarios.rs
@@ -63,8 +63,8 @@ fn backtrack_to_missing_package() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because c was not found in the package registry and a<=1.0.0 depends on c, we can conclude that a<=1.0.0 cannot be used.
-          And because all versions of b depend on a==1.0.0 and you require b, we can conclude that your requirements are unsatisfiable.
+      cause: Because c was not found in the package registry and a<=1.0.0 depends on c, we can conclude that a<=1.0.0 cannot be used.
+             And because all versions of b depend on a==1.0.0 and you require b, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -143,7 +143,7 @@ fn requires_exact_version_does_not_exist() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of a==2.0.0 and you require a==2.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of a==2.0.0 and you require a==2.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -173,7 +173,7 @@ fn requires_greater_version_does_not_exist() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a<=1.0.0 is available and you require a>1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a<=1.0.0 is available and you require a>1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -204,7 +204,7 @@ fn requires_less_version_does_not_exist() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a>=2.0.0 is available and you require a<2.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a>=2.0.0 is available and you require a<2.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -231,7 +231,7 @@ fn requires_package_does_not_exist() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a was not found in the package registry and you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because a was not found in the package registry and you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -263,8 +263,8 @@ fn transitive_requires_package_does_not_exist() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because b was not found in the package registry and all versions of a depend on b, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because b was not found in the package registry and all versions of a depend on b, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -343,12 +343,12 @@ fn dependency_excludes_non_contiguous_range_of_compatible_versions() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a<=1.0.0 depends on b==1.0.0 and c<=1.0.0 depends on a<2.0.0, we can conclude that c<=1.0.0 depends on b==1.0.0.
-          And because c>=2.0.0 depends on a>=3.0.0 and a>=3.0.0 depends on b==3.0.0, we can conclude that all versions of c depend on one of:
-              b<=1.0.0
-              b>=3.0.0
+      cause: Because a<=1.0.0 depends on b==1.0.0 and c<=1.0.0 depends on a<2.0.0, we can conclude that c<=1.0.0 depends on b==1.0.0.
+             And because c>=2.0.0 depends on a>=3.0.0 and a>=3.0.0 depends on b==3.0.0, we can conclude that all versions of c depend on one of:
+                 b<=1.0.0
+                 b>=3.0.0
 
-          And because you require b>=2.0.0,<3.0.0 and c, we can conclude that your requirements are unsatisfiable.
+             And because you require b>=2.0.0,<3.0.0 and c, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Only the `2.x` versions of `a` are available since `a==1.0.0` and `a==3.0.0` require incompatible versions of `b`, but all available versions of `c` exclude that range of `a` so resolution fails.
@@ -421,12 +421,12 @@ fn dependency_excludes_range_of_compatible_versions() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a<=1.0.0 depends on b==1.0.0 and c<=1.0.0 depends on a<2.0.0, we can conclude that c<=1.0.0 depends on b==1.0.0.
-          And because c>=2.0.0 depends on a>=3.0.0 and a>=3.0.0 depends on b==3.0.0, we can conclude that all versions of c depend on one of:
-              b<=1.0.0
-              b>=3.0.0
+      cause: Because a<=1.0.0 depends on b==1.0.0 and c<=1.0.0 depends on a<2.0.0, we can conclude that c<=1.0.0 depends on b==1.0.0.
+             And because c>=2.0.0 depends on a>=3.0.0 and a>=3.0.0 depends on b==3.0.0, we can conclude that all versions of c depend on one of:
+                 b<=1.0.0
+                 b>=3.0.0
 
-          And because you require b>=2.0.0,<3.0.0 and c, we can conclude that your requirements are unsatisfiable.
+             And because you require b>=2.0.0,<3.0.0 and c, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Only the `2.x` versions of `a` are available since `a==1.0.0` and `a==3.0.0` require incompatible versions of `b`, but all available versions of `c` exclude that range of `a` so resolution fails.
@@ -474,17 +474,17 @@ fn excluded_only_compatible_version() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a<=1.0.0 depends on b==1.0.0 and a>=3.0.0 depends on b==3.0.0, we can conclude that all of:
-              a<=1.0.0
-              a>=3.0.0
-          depend on one of:
-              b==1.0.0
-              b==3.0.0
+      cause: Because a<=1.0.0 depends on b==1.0.0 and a>=3.0.0 depends on b==3.0.0, we can conclude that all of:
+                 a<=1.0.0
+                 a>=3.0.0
+             depend on one of:
+                 b==1.0.0
+                 b==3.0.0
 
-          And because you require one of:
-              a<2.0.0
-              a>2.0.0
-          and b>=2.0.0,<3.0.0, we can conclude that your requirements are unsatisfiable.
+             And because you require one of:
+                 a<2.0.0
+                 a>2.0.0
+             and b>=2.0.0,<3.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Only `a==1.2.0` is available since `a==1.0.0` and `a==3.0.0` require incompatible versions of `b`. The user has excluded that version of `a` so resolution fails.
@@ -515,10 +515,10 @@ fn excluded_only_version() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a==1.0.0 is available and you require one of:
-              a<1.0.0
-              a>1.0.0
-          we can conclude that your requirements are unsatisfiable.
+      cause: Because only a==1.0.0 is available and you require one of:
+                 a<1.0.0
+                 a>1.0.0
+             we can conclude that your requirements are unsatisfiable.
     ");
 
     // Only `a==1.0.0` is available but the user excluded it.
@@ -706,8 +706,8 @@ fn extra_incompatible_with_extra() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of a[extra-c] depend on b==2.0.0 and all versions of a[extra-b] depend on b==1.0.0, we can conclude that all versions of a[extra-b] and all versions of a[extra-c] are incompatible.
-          And because you require a[extra-b] and a[extra-c], we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of a[extra-c] depend on b==2.0.0 and all versions of a[extra-b] depend on b==1.0.0, we can conclude that all versions of a[extra-b] and all versions of a[extra-c] are incompatible.
+             And because you require a[extra-b] and a[extra-c], we can conclude that your requirements are unsatisfiable.
     ");
 
     // Because both `extra_b` and `extra_c` are requested and they require incompatible versions of `b`, `a` cannot be installed.
@@ -747,8 +747,8 @@ fn extra_incompatible_with_root() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of a[extra] depend on b==1.0.0 and you require a[extra], we can conclude that you require b==1.0.0.
-          And because you require b==2.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of a[extra] depend on b==1.0.0 and you require a[extra], we can conclude that you require b==1.0.0.
+             And because you require b==2.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Because the user requested `b==2.0.0` but the requested extra requires `b==1.0.0`, the dependencies cannot be satisfied.
@@ -902,7 +902,7 @@ fn direct_incompatible_versions() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because you require a==1.0.0 and a==2.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require a==1.0.0 and a==2.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -936,8 +936,8 @@ fn transitive_incompatible_versions() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of a depend on b==2.0.0 and b==1.0.0, we can conclude that all versions of a cannot be used.
-          And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of a depend on b==2.0.0 and b==1.0.0, we can conclude that all versions of a cannot be used.
+             And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -975,8 +975,8 @@ fn transitive_incompatible_with_root_version() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of a depend on b==2.0.0 and you require a, we can conclude that you require b==2.0.0.
-          And because you require b==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of a depend on b==2.0.0 and you require a, we can conclude that you require b==2.0.0.
+             And because you require b==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1019,8 +1019,8 @@ fn transitive_incompatible_with_transitive() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of b depend on c==2.0.0 and all versions of a depend on c==1.0.0, we can conclude that all versions of a and all versions of b are incompatible.
-          And because you require a and b, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of b depend on c==2.0.0 and all versions of a depend on c==1.0.0, we can conclude that all versions of a and all versions of b are incompatible.
+             And because you require a and b, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1084,7 +1084,7 @@ fn local_greater_than() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a==1.2.3+foo is available and you require a>1.2.3, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a==1.2.3+foo is available and you require a>1.2.3, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1147,7 +1147,7 @@ fn local_less_than() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a==1.2.3+foo is available and you require a<1.2.3, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a==1.2.3+foo is available and you require a<1.2.3, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1334,8 +1334,8 @@ fn local_transitive_conflicting() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of a depend on b==2.0.0+bar and you require a, we can conclude that you require b==2.0.0+bar.
-          And because you require b==2.0.0+foo, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of a depend on b==2.0.0+bar and you require a, we can conclude that you require b==2.0.0+bar.
+             And because you require b==2.0.0+foo, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1458,8 +1458,8 @@ fn local_transitive_greater_than() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of a depend on b>2.0.0 and you require a, we can conclude that you require b>2.0.0.
-          And because you require b==2.0.0+foo, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of a depend on b>2.0.0 and you require a, we can conclude that you require b>2.0.0.
+             And because you require b==2.0.0+foo, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1540,8 +1540,8 @@ fn local_transitive_less_than() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of a depend on b<2.0.0 and you require a, we can conclude that you require b<2.0.0.
-          And because you require b==2.0.0+foo, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of a depend on b<2.0.0 and you require a, we can conclude that you require b<2.0.0.
+             And because you require b==2.0.0+foo, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1682,7 +1682,7 @@ fn post_equal_not_available() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of a==1.2.3.post0 and you require a==1.2.3.post0, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of a==1.2.3.post0 and you require a==1.2.3.post0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1779,7 +1779,7 @@ fn post_greater_than_post_not_available() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a<=1.2.3.post1 is available and you require a>1.2.3.post2, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a<=1.2.3.post1 is available and you require a>1.2.3.post2, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1875,7 +1875,7 @@ fn post_greater_than() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a==1.2.3.post1 is available and you require a>1.2.3, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a==1.2.3.post1 is available and you require a>1.2.3, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1904,7 +1904,7 @@ fn post_less_than_or_equal() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a==1.2.3.post1 is available and you require a<=1.2.3, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a==1.2.3.post1 is available and you require a<=1.2.3, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1966,7 +1966,7 @@ fn post_less_than() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a==1.2.3.post1 is available and you require a<1.2.3, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a==1.2.3.post1 is available and you require a<1.2.3, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -1996,7 +1996,7 @@ fn post_local_greater_than_post() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a<=1.2.3.post1 is available and you require a>1.2.3.post1, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a<=1.2.3.post1 is available and you require a>1.2.3.post1, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -2026,7 +2026,7 @@ fn post_local_greater_than() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a<=1.2.3.post1+local is available and you require a>1.2.3, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a<=1.2.3.post1+local is available and you require a>1.2.3, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -2055,7 +2055,7 @@ fn post_simple() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of a==1.2.3 and you require a==1.2.3, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of a==1.2.3 and you require a==1.2.3, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -4110,23 +4110,23 @@ fn python_greater_than_current_excluded() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==2.0.0 depends on Python>=3.10, we can conclude that a==2.0.0 cannot be used.
-          And because only the following versions of a are available:
-              a<=2.0.0
-              a>=3.0.0
-          we can conclude that a>=2.0.0,<3.0.0 cannot be used. (1)
+      cause: Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==2.0.0 depends on Python>=3.10, we can conclude that a==2.0.0 cannot be used.
+             And because only the following versions of a are available:
+                 a<=2.0.0
+                 a>=3.0.0
+             we can conclude that a>=2.0.0,<3.0.0 cannot be used. (1)
 
-          Because the current Python version (3.9.[X]) does not satisfy Python>=3.11 and a==3.0.0 depends on Python>=3.11, we can conclude that a==3.0.0 cannot be used.
-          And because we know from (1) that a>=2.0.0,<3.0.0 cannot be used, we can conclude that a>=2.0.0,<=3.0.0 cannot be used.
-          And because only the following versions of a are available:
-              a<=3.0.0
-              a>=4.0.0
-          we can conclude that a>=2.0.0,<4.0.0 cannot be used. (2)
+             Because the current Python version (3.9.[X]) does not satisfy Python>=3.11 and a==3.0.0 depends on Python>=3.11, we can conclude that a==3.0.0 cannot be used.
+             And because we know from (1) that a>=2.0.0,<3.0.0 cannot be used, we can conclude that a>=2.0.0,<=3.0.0 cannot be used.
+             And because only the following versions of a are available:
+                 a<=3.0.0
+                 a>=4.0.0
+             we can conclude that a>=2.0.0,<4.0.0 cannot be used. (2)
 
-          Because the current Python version (3.9.[X]) does not satisfy Python>=3.12 and a==4.0.0 depends on Python>=3.12, we can conclude that a==4.0.0 cannot be used.
-          And because only a<=4.0.0 is available, we can conclude that a>=4.0.0 cannot be used.
-          And because we know from (2) that a>=2.0.0,<4.0.0 cannot be used, we can conclude that a>=2.0.0 cannot be used.
-          And because you require a>=2.0.0, we can conclude that your requirements are unsatisfiable.
+             Because the current Python version (3.9.[X]) does not satisfy Python>=3.12 and a==4.0.0 depends on Python>=3.12, we can conclude that a==4.0.0 cannot be used.
+             And because only a<=4.0.0 is available, we can conclude that a>=4.0.0 cannot be used.
+             And because we know from (2) that a>=2.0.0,<4.0.0 cannot be used, we can conclude that a>=2.0.0 cannot be used.
+             And because you require a>=2.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -4178,7 +4178,7 @@ fn python_greater_than_current_many() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of a==1.0.0 and you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of a==1.0.0 and you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -4209,8 +4209,8 @@ fn python_greater_than_current_patch() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.13) does not satisfy Python>=3.13.2 and a==1.0.0 depends on Python>=3.13.2, we can conclude that a==1.0.0 cannot be used.
-          And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.13) does not satisfy Python>=3.13.2 and a==1.0.0 depends on Python>=3.13.2, we can conclude that a==1.0.0 cannot be used.
+             And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -4240,8 +4240,8 @@ fn python_greater_than_current() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==1.0.0 depends on Python>=3.10, we can conclude that a==1.0.0 cannot be used.
-          And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.9.[X]) does not satisfy Python>=3.10 and a==1.0.0 depends on Python>=3.10, we can conclude that a==1.0.0 cannot be used.
+             And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -4303,8 +4303,8 @@ fn python_version_does_not_exist() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.12.[X]) does not satisfy Python>=3.30 and a==1.0.0 depends on Python>=3.30, we can conclude that a==1.0.0 cannot be used.
-          And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.12.[X]) does not satisfy Python>=3.30 and a==1.0.0 depends on Python>=3.30, we can conclude that a==1.0.0 cannot be used.
+             And because you require a==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     context.assert_not_installed("a");
@@ -4419,7 +4419,7 @@ fn canonical_empty_requirement() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── you require a<0.dev0, which does not allow any versions
+      cause: you require a<0.dev0, which does not allow any versions
     ");
 
     context.assert_not_installed("a");
@@ -4460,8 +4460,8 @@ fn equivalent_dependency_ranges() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of a depend on c<=1.0 and you require a, we can conclude that you require c<=1.0.
-          And because you require c>=2.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of a depend on c<=1.0 and you require a, we can conclude that you require c<=1.0.
+             And because you require c>=2.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Both versions of `a` require the same logical range of `c`, which conflicts with the root requirement.
@@ -4559,8 +4559,8 @@ fn no_sdist_no_wheels_with_matching_abi() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a==1.0.0 has no wheels with a matching Python ABI tag (e.g., `cp312`) and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because a==1.0.0 has no wheels with a matching Python ABI tag (e.g., `cp312`) and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: You require CPython 3.12 (`cp312`), but we only found wheels for `a` (v1.0.0) with the following Python ABI tag: `graalpy240_310_native`
     ");
@@ -4592,8 +4592,8 @@ fn no_sdist_no_wheels_with_matching_platform() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a==1.0.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because a==1.0.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are available for `a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
     ");
@@ -4625,8 +4625,8 @@ fn no_sdist_no_wheels_with_matching_python() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a==1.0.0 has no wheels with a matching Python implementation tag (e.g., `cp312`) and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because a==1.0.0 has no wheels with a matching Python implementation tag (e.g., `cp312`) and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: You require CPython 3.12 (`cp312`), but we only found wheels for `a` (v1.0.0) with the following Python implementation tag: `graalpy310`
     ");
@@ -4659,8 +4659,8 @@ fn no_wheels_no_build() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a==1.0.0 has no usable wheels and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because a==1.0.0 has no usable wheels and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are required for `a` because building from source is disabled for `a` (i.e., with `--no-build-package a`)
     ");
@@ -4751,8 +4751,8 @@ fn only_wheels_no_binary() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a==1.0.0 has no source distribution and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because a==1.0.0 has no source distribution and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: A source distribution is required for `a` because using pre-built wheels is disabled for `a` (i.e., with `--no-binary-package a`)
     ");
@@ -4842,11 +4842,11 @@ fn package_only_yanked_in_range() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a==1.0.0 was yanked and only the following versions of a are available:
-              a<=0.1.0
-              a==1.0.0
-          we can conclude that a>0.1.0 cannot be used.
-          And because you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because a==1.0.0 was yanked and only the following versions of a are available:
+                 a<=0.1.0
+                 a==1.0.0
+             we can conclude that a>0.1.0 cannot be used.
+             And because you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Since there are other versions of `a` available, yanked versions should not be selected without explicit opt-in.
@@ -4876,8 +4876,8 @@ fn package_only_yanked() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because a==1.0.0 was yanked and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because a==1.0.0 was yanked and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Yanked versions should not be installed, even if they are the only one available.
@@ -5024,11 +5024,11 @@ fn transitive_package_only_yanked_in_range() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because b==1.0.0 was yanked and only the following versions of b are available:
-              b<=0.1
-              b==1.0.0
-          we can conclude that b>0.1 cannot be used.
-          And because all versions of a depend on b>0.1 and you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because b==1.0.0 was yanked and only the following versions of b are available:
+                 b<=0.1
+                 b==1.0.0
+             we can conclude that b>0.1 cannot be used.
+             And because all versions of a depend on b>0.1 and you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Yanked versions should not be installed, even if they are the only valid version in a range.
@@ -5062,8 +5062,8 @@ fn transitive_package_only_yanked() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because b==1.0.0 was yanked and only b==1.0.0 is available, we can conclude that all versions of b cannot be used.
-          And because all versions of a depend on b and you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because b==1.0.0 was yanked and only b==1.0.0 is available, we can conclude that all versions of b cannot be used.
+             And because all versions of a depend on b and you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Yanked versions should not be installed, even if they are the only one available.
@@ -5157,8 +5157,8 @@ fn transitive_yanked_and_unyanked_dependency() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because c==2.0.0 was yanked and all versions of a depend on c==2.0.0, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because c==2.0.0 was yanked and all versions of a depend on c==2.0.0, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Since the user did not explicitly select the yanked version, it cannot be used.

--- a/crates/uv/tests/pip/pip_list.rs
+++ b/crates/uv/tests/pip/pip_list.rs
@@ -657,7 +657,7 @@ Version: 0.1-bulbasaur
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read metadata from: `[SITE_PACKAGES]/paramiko.egg-link`
-     └── after parsing `0.1-b`, found `ulbasaur`, which is not part of a valid version
+     cause: after parsing `0.1-b`, found `ulbasaur`, which is not part of a valid version
     "
     );
 

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -48,7 +48,7 @@ fn cert() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read certificate file `ca-bundle.pem`
-      └── [OS ERROR 2]
+      cause: [OS ERROR 2]
     ");
 
     Ok(())
@@ -68,7 +68,7 @@ fn missing_venv() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from active virtual environment at `.venv/[BIN]/[PYTHON]`
-      └── Python interpreter not found at `[VENV]/[BIN]/[PYTHON]`
+      cause: Python interpreter not found at `[VENV]/[BIN]/[PYTHON]`
     ");
 
     assert!(predicates::path::missing().eval(&context.venv));
@@ -981,7 +981,7 @@ fn install_no_index() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because iniconfig was not found in the provided package locations and you require iniconfig==2.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because iniconfig was not found in the provided package locations and you require iniconfig==2.0.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     "
@@ -1024,7 +1024,7 @@ fn install_no_index_cached() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because iniconfig was not found in the provided package locations and you require iniconfig==2.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because iniconfig was not found in the provided package locations and you require iniconfig==2.0.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     "
@@ -1274,7 +1274,7 @@ fn mismatched_version() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: tomli-3.7.2-py3-none-any.whl (tomli==3.7.2 (from file://[TEMP_DIR]/tomli-3.7.2-py3-none-any.whl))
-      └── Wheel version does not match filename (2.0.1 != 3.7.2), which indicates a malformed wheel. If this is intentional, set `UV_SKIP_WHEEL_FILENAME_CHECK=1`.
+      cause: Wheel version does not match filename (2.0.1 != 3.7.2), which indicates a malformed wheel. If this is intentional, set `UV_SKIP_WHEEL_FILENAME_CHECK=1`.
     "
     );
 
@@ -1317,7 +1317,7 @@ fn mismatched_name() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because foo has an invalid package format and you require foo, we can conclude that your requirements are unsatisfiable.
+      cause: Because foo has an invalid package format and you require foo, we can conclude that your requirements are unsatisfiable.
 
     hint: The structure of `foo` was invalid
       Caused by: The .dist-info directory tomli-2.0.1 does not start with the normalized package name: foo
@@ -1895,7 +1895,7 @@ fn duplicate_package_overlap() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because you require markupsafe==2.1.3 and markupsafe==2.1.2, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require markupsafe==2.1.3 and markupsafe==2.1.2, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -2495,7 +2495,7 @@ fn incompatible_wheel() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because foo has an invalid package format and you require foo, we can conclude that your requirements are unsatisfiable.
+      cause: Because foo has an invalid package format and you require foo, we can conclude that your requirements are unsatisfiable.
 
     hint: The structure of `foo` was invalid
       Caused by: Failed to read from zip file
@@ -2633,7 +2633,7 @@ fn find_links_offline_no_match() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because numpy was not found in the cache and you require numpy, we can conclude that your requirements are unsatisfiable.
+      cause: Because numpy was not found in the cache and you require numpy, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     "
@@ -2743,7 +2743,7 @@ fn offline() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because black was not found in the cache and you require black==23.10.1, we can conclude that your requirements are unsatisfiable.
+      cause: Because black was not found in the cache and you require black==23.10.1, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     "
@@ -2822,7 +2822,7 @@ fn incompatible_constraint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because you require anyio==3.7.0 and anyio==3.6.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require anyio==3.7.0 and anyio==3.6.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -2907,7 +2907,7 @@ fn repeat_requirement_incompatible() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because you require anyio<4.0.0 and anyio==4.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require anyio<4.0.0 and anyio==4.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -3178,8 +3178,8 @@ requires-python = ">=3.13"
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
-          And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
+             And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -3215,8 +3215,8 @@ requires-python = ">=3.13"
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
-          And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
+             And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -3402,13 +3402,13 @@ fn require_hashes_wheel_no_binary() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download and build `anyio==4.0.0`
-      └── Hash mismatch for `anyio==4.0.0`
+      cause: Hash mismatch for `anyio==4.0.0`
 
-          Expected:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Expected:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
 
-          Computed:
-            sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
+             Computed:
+               sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
     "
     );
 
@@ -3488,13 +3488,13 @@ fn require_hashes_source_only_binary() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `anyio==4.0.0`
-      └── Hash mismatch for `anyio==4.0.0`
+      cause: Hash mismatch for `anyio==4.0.0`
 
-          Expected:
-            sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
+             Expected:
+               sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
     "
     );
 
@@ -3517,13 +3517,13 @@ fn require_hashes_wrong_digest() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `anyio==4.0.0`
-      └── Hash mismatch for `anyio==4.0.0`
+      cause: Hash mismatch for `anyio==4.0.0`
 
-          Expected:
-            sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Expected:
+               sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
     "
     );
 
@@ -3546,14 +3546,14 @@ fn require_hashes_wrong_algorithm() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `anyio==4.0.0`
-      └── Hash mismatch for `anyio==4.0.0`
+      cause: Hash mismatch for `anyio==4.0.0`
 
-          Expected:
-            sha512:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Expected:
+               sha512:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
-            sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+               sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
     "
     );
 
@@ -3608,13 +3608,13 @@ fn require_hashes_source_url() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
-      └── Hash mismatch for `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
+      cause: Hash mismatch for `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
 
-          Expected:
-            sha256:a7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
+             Expected:
+               sha256:a7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
 
-          Computed:
-            sha256:1f83ed7498336c7f2ab9b002cf22583d91115ebc624053dc4eb3a45694490106
+             Computed:
+               sha256:1f83ed7498336c7f2ab9b002cf22583d91115ebc624053dc4eb3a45694490106
     "
     );
 
@@ -3636,13 +3636,13 @@ fn require_hashes_source_url_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
-      └── Hash mismatch for `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
+      cause: Hash mismatch for `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
 
-          Expected:
-            sha256:a7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
+             Expected:
+               sha256:a7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
 
-          Computed:
-            sha256:1f83ed7498336c7f2ab9b002cf22583d91115ebc624053dc4eb3a45694490106
+             Computed:
+               sha256:1f83ed7498336c7f2ab9b002cf22583d91115ebc624053dc4eb3a45694490106
     "
     );
 
@@ -3698,13 +3698,13 @@ fn require_hashes_wheel_url() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
-      └── Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
+      cause: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
 
-          Expected:
-            sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Expected:
+               sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
     "
     );
 
@@ -3746,13 +3746,13 @@ fn require_hashes_wheel_url_mismatch() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
-      └── Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
+      cause: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
 
-          Expected:
-            sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Expected:
+               sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
     "
     );
 
@@ -3775,7 +3775,7 @@ fn require_hashes_git() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `anyio @ git+https://github.com/agronholm/anyio@4a23745badf5bf5ef7928f1e346e9986bd696d82`
-      └── Hash-checking is not supported for Git repositories: `anyio @ git+https://github.com/agronholm/anyio@4a23745badf5bf5ef7928f1e346e9986bd696d82`
+      cause: Hash-checking is not supported for Git repositories: `anyio @ git+https://github.com/agronholm/anyio@4a23745badf5bf5ef7928f1e346e9986bd696d82`
     "
     );
 
@@ -3802,7 +3802,7 @@ fn require_hashes_source_tree() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `black @ file://[WORKSPACE]/test/packages/black_editable`
-      └── Hash-checking is not supported for local directories: `black @ file://[WORKSPACE]/test/packages/black_editable`
+      cause: Hash-checking is not supported for local directories: `black @ file://[WORKSPACE]/test/packages/black_editable`
     "
     );
 
@@ -3842,13 +3842,13 @@ fn require_hashes_re_download() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `anyio==4.0.0`
-      └── Hash mismatch for `anyio==4.0.0`
+      cause: Hash mismatch for `anyio==4.0.0`
 
-          Expected:
-            sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Expected:
+               sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
     "
     );
 
@@ -3953,13 +3953,13 @@ fn require_hashes_wheel_path_blake2b_mismatch() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to read `tqdm @ file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl`
-      └── Hash mismatch for `tqdm @ file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl`
+      cause: Hash mismatch for `tqdm @ file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl`
 
-          Expected:
-            blake2b:ad611597f5e771ac942d300426f16a38f1579ab572bf4bca968a53709db0a292
+             Expected:
+               blake2b:ad611597f5e771ac942d300426f16a38f1579ab572bf4bca968a53709db0a292
 
-          Computed:
-            blake2b:fd611597f5e771ac942d300426f16a38f1579ab572bf4bca968a53709db0a292
+             Computed:
+               blake2b:fd611597f5e771ac942d300426f16a38f1579ab572bf4bca968a53709db0a292
     "
     );
 
@@ -3987,13 +3987,13 @@ fn require_hashes_wheel_path_mismatch() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to read `tqdm @ file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl`
-      └── Hash mismatch for `tqdm @ file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl`
+      cause: Hash mismatch for `tqdm @ file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl`
 
-          Expected:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Expected:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
 
-          Computed:
-            sha256:a34996d4bd5abb2336e14ff0a2d22b92cfd0f0ed344e6883041ce01953276a13
+             Computed:
+               sha256:a34996d4bd5abb2336e14ff0a2d22b92cfd0f0ed344e6883041ce01953276a13
     "
     );
 
@@ -4049,13 +4049,13 @@ fn require_hashes_source_path_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `tqdm @ file://[WORKSPACE]/test/links/tqdm-999.0.0.tar.gz`
-      └── Hash mismatch for `tqdm @ file://[WORKSPACE]/test/links/tqdm-999.0.0.tar.gz`
+      cause: Hash mismatch for `tqdm @ file://[WORKSPACE]/test/links/tqdm-999.0.0.tar.gz`
 
-          Expected:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Expected:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
 
-          Computed:
-            sha256:89fa05cffa7f457658373b85de302d24d0c205ceda2819a8739e324b75e9430b
+             Computed:
+               sha256:89fa05cffa7f457658373b85de302d24d0c205ceda2819a8739e324b75e9430b
     "
     );
 
@@ -4212,15 +4212,15 @@ fn require_hashes_repeated_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
-      └── Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
+      cause: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
 
-          Expected:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
-            sha512:e30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
+             Expected:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+               sha512:e30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
-            sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+               sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
     "
     );
 
@@ -4241,15 +4241,15 @@ fn require_hashes_repeated_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
-      └── Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
+      cause: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
 
-          Expected:
-            sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
-            sha512:e30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
+             Expected:
+               sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
+               sha512:e30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
-            sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+               sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
     "
     );
 
@@ -4448,13 +4448,13 @@ fn require_hashes_find_links_no_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `basic-package==0.1.0`
-      └── Hash mismatch for `basic-package==0.1.0`
+      cause: Hash mismatch for `basic-package==0.1.0`
 
-          Expected:
-            sha256:123
+             Expected:
+               sha256:123
 
-          Computed:
-            sha256:7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82
+             Computed:
+               sha256:7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82
     "
     );
 
@@ -4477,13 +4477,13 @@ fn require_hashes_find_links_no_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `basic-package==0.1.0`
-      └── Hash mismatch for `basic-package==0.1.0`
+      cause: Hash mismatch for `basic-package==0.1.0`
 
-          Expected:
-            sha256:af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4
+             Expected:
+               sha256:af478ff91ec60856c99a540b8df13d756513bebb65bc301fb27e0d1f974532b4
 
-          Computed:
-            sha256:7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82
+             Computed:
+               sha256:7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82
     "
     );
 
@@ -4507,9 +4507,9 @@ fn require_hashes_find_links_no_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download and build `basic-package==0.1.0`
-      ├── Failed to resolve requirements from `build-system.requires`
-      ├── No solution found when resolving: `uv-build>=0.8.3, <0.9.0`
-      └── Because uv-build was not found in the package registry and you require uv-build>=0.8.3,<0.9.0, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `build-system.requires`
+      cause: No solution found when resolving: `uv-build>=0.8.3, <0.9.0`
+      cause: Because uv-build was not found in the package registry and you require uv-build>=0.8.3,<0.9.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -4561,13 +4561,13 @@ fn require_hashes_find_links_invalid_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `example-a-961b4c22==1.0.0`
-      └── Hash mismatch for `example-a-961b4c22==1.0.0`
+      cause: Hash mismatch for `example-a-961b4c22==1.0.0`
 
-          Expected:
-            sha256:123
+             Expected:
+               sha256:123
 
-          Computed:
-            sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
+             Computed:
+               sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
     "
     );
 
@@ -4586,13 +4586,13 @@ fn require_hashes_find_links_invalid_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `example-a-961b4c22==1.0.0`
-      └── Hash mismatch for `example-a-961b4c22==1.0.0`
+      cause: Hash mismatch for `example-a-961b4c22==1.0.0`
 
-          Expected:
-            sha256:8838f9d005ff0432b258ba648d9cabb1cbdf06ac29d14f788b02edae544032ea
+             Expected:
+               sha256:8838f9d005ff0432b258ba648d9cabb1cbdf06ac29d14f788b02edae544032ea
 
-          Computed:
-            sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
+             Computed:
+               sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
     "
     );
 
@@ -4657,14 +4657,14 @@ fn require_hashes_find_links_invalid_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download and build `example-a-961b4c22==1.0.0`
-      └── Hash mismatch for `example-a-961b4c22==1.0.0`
+      cause: Hash mismatch for `example-a-961b4c22==1.0.0`
 
-          Expected:
-            sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
-            sha256:a3cf07a05aac526131a2e8b6e4375ee6c6eaac8add05b88035e960ac6cd999ee
+             Expected:
+               sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
+               sha256:a3cf07a05aac526131a2e8b6e4375ee6c6eaac8add05b88035e960ac6cd999ee
 
-          Computed:
-            sha256:294e788dbe500fdc39e8b88e82652ab67409a1dc9dd06543d0fe0ae31b713eb3
+             Computed:
+               sha256:294e788dbe500fdc39e8b88e82652ab67409a1dc9dd06543d0fe0ae31b713eb3
     "
     );
 
@@ -4716,7 +4716,7 @@ fn require_hashes_registry_valid_hash() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because example-a-961b4c22 was not found in the package registry and you require example-a-961b4c22==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because example-a-961b4c22 was not found in the package registry and you require example-a-961b4c22==1.0.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -4743,13 +4743,13 @@ fn require_hashes_registry_invalid_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `example-a-961b4c22==1.0.0`
-      └── Hash mismatch for `example-a-961b4c22==1.0.0`
+      cause: Hash mismatch for `example-a-961b4c22==1.0.0`
 
-          Expected:
-            sha256:123
+             Expected:
+               sha256:123
 
-          Computed:
-            sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
+             Computed:
+               sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
     "
     );
 
@@ -4769,13 +4769,13 @@ fn require_hashes_registry_invalid_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `example-a-961b4c22==1.0.0`
-      └── Hash mismatch for `example-a-961b4c22==1.0.0`
+      cause: Hash mismatch for `example-a-961b4c22==1.0.0`
 
-          Expected:
-            sha256:8838f9d005ff0432b258ba648d9cabb1cbdf06ac29d14f788b02edae544032ea
+             Expected:
+               sha256:8838f9d005ff0432b258ba648d9cabb1cbdf06ac29d14f788b02edae544032ea
 
-          Computed:
-            sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
+             Computed:
+               sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
     "
     );
 
@@ -4843,14 +4843,14 @@ fn require_hashes_registry_invalid_hash() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download and build `example-a-961b4c22==1.0.0`
-      └── Hash mismatch for `example-a-961b4c22==1.0.0`
+      cause: Hash mismatch for `example-a-961b4c22==1.0.0`
 
-          Expected:
-            sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
-            sha256:a3cf07a05aac526131a2e8b6e4375ee6c6eaac8add05b88035e960ac6cd999ee
+             Expected:
+               sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
+               sha256:a3cf07a05aac526131a2e8b6e4375ee6c6eaac8add05b88035e960ac6cd999ee
 
-          Computed:
-            sha256:294e788dbe500fdc39e8b88e82652ab67409a1dc9dd06543d0fe0ae31b713eb3
+             Computed:
+               sha256:294e788dbe500fdc39e8b88e82652ab67409a1dc9dd06543d0fe0ae31b713eb3
     "
     );
 
@@ -4918,13 +4918,13 @@ fn require_hashes_url_invalid() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl#sha256=c6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374`
-      └── Hash mismatch for `iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl#sha256=c6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374`
+      cause: Hash mismatch for `iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl#sha256=c6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374`
 
-          Expected:
-            sha256:c6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
+             Expected:
+               sha256:c6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
 
-          Computed:
-            sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
+             Computed:
+               sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     "
     );
 
@@ -5313,9 +5313,9 @@ fn incompatible_build_constraint() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -5472,9 +5472,9 @@ fn semicolon_no_space() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.txt` at position 0
-      └── Expected direct URL (`https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl;python_version%20%3E%20'3.10'`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-          iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl;python_version > '3.10'
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Expected direct URL (`https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl;python_version%20%3E%20'3.10'`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
+             iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl;python_version > '3.10'
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 
@@ -5610,11 +5610,11 @@ fn pep_751_requires_packages() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Not a valid `pylock.toml` file: pylock.toml
-      └── TOML parse error at line 1, column 1
-            |
-          1 |
-            | ^
-          missing field `packages`
+      cause: TOML parse error at line 1, column 1
+               |
+             1 |
+               | ^
+             missing field `packages`
     "#);
 
     Ok(())
@@ -5723,7 +5723,7 @@ fn pep_751_validates_remote_archive_size() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`
-      └── Size mismatch for `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`: expected 1 bytes, but downloaded 921 bytes
+      cause: Size mismatch for `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`: expected 1 bytes, but downloaded 921 bytes
     ");
 
     context.temp_dir.child("pylock.toml").write_str(&formatdoc! {
@@ -5745,7 +5745,7 @@ fn pep_751_validates_remote_archive_size() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `a==1.0.0`
-      └── Size mismatch for `a==1.0.0`: expected 1 bytes, but downloaded 921 bytes
+      cause: Size mismatch for `a==1.0.0`: expected 1 bytes, but downloaded 921 bytes
     ");
 
     context.temp_dir.child("pylock.toml").write_str(&formatdoc! {
@@ -5767,7 +5767,7 @@ fn pep_751_validates_remote_archive_size() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `a==1.0.0`
-      └── Size mismatch for `a==1.0.0`: expected 1 bytes, but downloaded 607 bytes
+      cause: Size mismatch for `a==1.0.0`: expected 1 bytes, but downloaded 607 bytes
     ");
 
     Ok(())
@@ -5805,7 +5805,7 @@ fn pep_751_validates_cached_remote_archive_size() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`
-      └── Size mismatch for `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`: expected 1 bytes, but downloaded 921 bytes
+      cause: Size mismatch for `a @ http://[LOCALHOST]/files/a-1.0.0-py3-none-any.whl`: expected 1 bytes, but downloaded 921 bytes
     ");
 
     Ok(())
@@ -6136,7 +6136,7 @@ fn pep_751_direct_url_tags() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to determine installation plan
-      └── A URL (https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl) dependency is incompatible with the current platform
+      cause: A URL (https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl) dependency is incompatible with the current platform
 
     hint: The wheel is compatible with macOS (`macosx_11_0_arm64`), but you're on Linux (`manylinux_2_28_x86_64`)
     "
@@ -6172,7 +6172,7 @@ fn incompatible_python_version_direct_url() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to determine installation plan
-      └── A URL (https://files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl) dependency is incompatible with the current platform
+      cause: A URL (https://files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl) dependency is incompatible with the current platform
 
     hint: The wheel is compatible with CPython 3.13 (`cp313`), but you're using CPython 3.12 (`cp312`)
     "
@@ -6196,7 +6196,7 @@ fn incompatible_direct_url_redacts_credentials() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to determine installation plan
-      └── A URL (https://user:****@files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl?X-Amz-Signature=****) dependency is incompatible with the current platform
+      cause: A URL (https://user:****@files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl?X-Amz-Signature=****) dependency is incompatible with the current platform
 
     hint: The wheel is compatible with CPython 3.13 (`cp313`), but you're using CPython 3.12 (`cp312`)
     "
@@ -6220,7 +6220,7 @@ fn incompatible_platform_direct_url() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to determine installation plan
-      └── A URL (https://files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl) dependency is incompatible with the current platform
+      cause: A URL (https://files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl) dependency is incompatible with the current platform
 
     hint: The wheel is compatible with Windows (`win32`), but you're on Linux (`manylinux_2_28_x86_64`)
     "

--- a/crates/uv/tests/pip/pip_uninstall.rs
+++ b/crates/uv/tests/pip/pip_uninstall.rs
@@ -34,9 +34,9 @@ fn invalid_requirement() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `flask==1.0.x`
-      └── after parsing `1.0`, found `.x`, which is not part of a valid version
-          flask==1.0.x
-               ^^^^^^^
+      cause: after parsing `1.0`, found `.x`, which is not part of a valid version
+             flask==1.0.x
+                  ^^^^^^^
     ");
 }
 
@@ -67,9 +67,9 @@ fn invalid_requirements_txt_requirement() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.txt` at position 0
-      └── after parsing `1.0`, found `.x`, which is not part of a valid version
-          flask==1.0.x
-               ^^^^^^^
+      cause: after parsing `1.0`, found `.x`, which is not part of a valid version
+             flask==1.0.x
+                  ^^^^^^^
     ");
 
     Ok(())

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -414,8 +414,8 @@ fn compile_constraints_many_versions() -> Result<()> {
 
     let mut filters = context.filters();
     filters.push((
-        r"(?s)  └── Because package<=1\.0\.0.*requirements are unsatisfiable\.",
-        "  └── [LONG DERIVATION]",
+        r"(?s)  cause: Because package<=1\.0\.0.*requirements are unsatisfiable\.",
+        "  cause: [LONG DERIVATION]",
     ));
 
     uv_snapshot!(filters, context.pip_compile()

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -327,7 +327,7 @@ fn compile_pyproject_toml_eager_validation() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse entry: `anyio`
-      └── `anyio` references a workspace in `tool.uv.sources` (e.g., `anyio = { workspace = true }`), but is not a workspace member
+      cause: `anyio` references a workspace in `tool.uv.sources` (e.g., `anyio = { workspace = true }`), but is not a workspace member
     ");
 
     Ok(())
@@ -428,7 +428,7 @@ fn compile_constraints_many_versions() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── [LONG DERIVATION]
+      cause: [LONG DERIVATION]
     ");
 
     Ok(())
@@ -1020,11 +1020,11 @@ build-backend = "poetry.core.masonry.api"
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 13, column 1
-             |
-          13 | [project.dependencies]
-             | ^^^^^^^^^^^^^^^^^^^^^^
-          invalid type: map, expected a sequence
+      cause: TOML parse error at line 13, column 1
+                |
+             13 | [project.dependencies]
+                | ^^^^^^^^^^^^^^^^^^^^^^
+             invalid type: map, expected a sequence
     "
     );
 
@@ -1222,11 +1222,11 @@ dependencies = [
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 6, column 8
-            |
-          6 | name = "!project"
-            |        ^^^^^^^^^^
-          Not a valid package or extra name: "!project". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+      cause: TOML parse error at line 6, column 8
+               |
+             6 | name = "!project"
+               |        ^^^^^^^^^^
+             Not a valid package or extra name: "!project". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     "#
     );
 
@@ -1994,8 +1994,8 @@ fn compile_python_37() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and black==23.10.1 depends on Python>=3.8, we can conclude that black==23.10.1 cannot be used.
-          And because you require black==23.10.1, we can conclude that your requirements are unsatisfiable.
+      cause: Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and black==23.10.1 depends on Python>=3.8, we can conclude that black==23.10.1 cannot be used.
+             And because you require black==23.10.1, we can conclude that your requirements are unsatisfiable.
 
     hint: The `--python-version` value (>=3.7) includes Python versions that are not supported by your dependencies (e.g., black==23.10.1 only supports >=3.8). Consider using a higher `--python-version` value.
     ");
@@ -2509,7 +2509,7 @@ fn compile_git_mismatched_name() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `dask @ git+https://github.com/pallets/flask.git@3.0.0`
-      └── Package metadata name `flask` does not match given name `dask`
+      cause: Package metadata name `flask` does not match given name `dask`
     "
     );
 
@@ -2675,7 +2675,7 @@ fn conflicting_direct_url_dependency() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of werkzeug==3.0.0 and you require werkzeug==3.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of werkzeug==3.0.0 and you require werkzeug==3.0.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -2790,8 +2790,8 @@ fn conflicting_transitive_url_dependency() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only werkzeug<3.0.0 is available and flask==3.0.0 depends on werkzeug>=3.0.0, we can conclude that flask==3.0.0 cannot be used.
-          And because you require flask==3.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because only werkzeug<3.0.0 is available and flask==3.0.0 depends on werkzeug>=3.0.0, we can conclude that flask==3.0.0 cannot be used.
+             And because you require flask==3.0.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -3126,7 +3126,7 @@ fn requirement_constraint_override_url() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of anyio==3.7.0 and you require anyio==3.7.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of anyio==3.7.0 and you require anyio==3.7.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -3343,7 +3343,7 @@ dependencies = ["anyio==3.7.0", "anyio==4.0.0"]
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because my-project depends on anyio==3.7.0 and anyio==4.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because my-project depends on anyio==3.7.0 and anyio==4.0.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -3373,7 +3373,7 @@ dependencies = ["anyio==300.1.4"]
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of anyio==300.1.4 and my-project depends on anyio==300.1.4, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of anyio==300.1.4 and my-project depends on anyio==300.1.4, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -3959,12 +3959,12 @@ fn compile_yanked_version_indirect() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because attrs==21.1.0 was yanked (reason: Installable but not importable on Python 3.4) and only the following versions of attrs are available:
-              attrs<=20.3.0
-              attrs==21.1.0
-              attrs>=21.2.0
-          we can conclude that attrs>20.3.0,<21.2.0 cannot be used.
-          And because you require attrs>20.3.0,<21.2.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because attrs==21.1.0 was yanked (reason: Installable but not importable on Python 3.4) and only the following versions of attrs are available:
+                 attrs<=20.3.0
+                 attrs==21.1.0
+                 attrs>=21.2.0
+             we can conclude that attrs>20.3.0,<21.2.0 cannot be used.
+             And because you require attrs>20.3.0,<21.2.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -4430,13 +4430,13 @@ fn override_dependency_from_workspace_invalid_syntax() -> Result<()> {
               ^^^^^^
 
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 10, column 7
-             |
-          10 |       "werkzeug=2.3.0"
-             |       ^^^^^^^^^^^^^^^^
-          no such comparison operator "=", must be one of ~= == != <= >= < > ===
-          werkzeug=2.3.0
-                  ^^^^^^
+      cause: TOML parse error at line 10, column 7
+                |
+             10 |       "werkzeug=2.3.0"
+                |       ^^^^^^^^^^^^^^^^
+             no such comparison operator "=", must be one of ~= == != <= >= < > ===
+             werkzeug=2.3.0
+                     ^^^^^^
     "#
     );
 
@@ -4784,9 +4784,9 @@ fn error_missing_unnamed_env_var() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.in` at position 0
-      └── Expected package name starting with an alphanumeric character, found `$`
-          ${URL}
-          ^
+      cause: Expected package name starting with an alphanumeric character, found `$`
+             ${URL}
+             ^
     "
     );
 
@@ -5569,14 +5569,14 @@ async fn generate_hashes_url_fragment() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
-      └── Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
+      cause: Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
 
-          Expected:
-            sha512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+             Expected:
+               sha512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
-          Computed:
-            sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
-            sha512:34d2da25dff510a575ddfacf1c54928d04a28fac96a457c2b079d9a773b8dd5cd3a33f763def112d75298a1a0f10d939c8ddfe41fa50b26c9206f59c1b284557
+             Computed:
+               sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
+               sha512:34d2da25dff510a575ddfacf1c54928d04a28fac96a457c2b079d9a773b8dd5cd3a33f763def112d75298a1a0f10d939c8ddfe41fa50b26c9206f59c1b284557
     ");
 
     Ok(())
@@ -5641,13 +5641,13 @@ async fn generate_hashes_url_fragment_no_range_requests() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha256=0000000000000000000000000000000000000000000000000000000000000000`
-      └── Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha256=0000000000000000000000000000000000000000000000000000000000000000`
+      cause: Hash mismatch for `ok @ http://[LOCALHOST]/ok-1.0.0-py3-none-any.whl#sha256=0000000000000000000000000000000000000000000000000000000000000000`
 
-          Expected:
-            sha256:0000000000000000000000000000000000000000000000000000000000000000
+             Expected:
+               sha256:0000000000000000000000000000000000000000000000000000000000000000
 
-          Computed:
-            sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
+             Computed:
+               sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
     ");
 
     Ok(())
@@ -5782,14 +5782,14 @@ async fn generate_hashes_url_fragment_source_subdirectory() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `source-package @ http://[LOCALHOST]/source.tar.gz#subdirectory=src&sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
-      └── Hash mismatch for `source-package @ http://[LOCALHOST]/source.tar.gz#subdirectory=src&sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
+      cause: Hash mismatch for `source-package @ http://[LOCALHOST]/source.tar.gz#subdirectory=src&sha512=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
 
-          Expected:
-            sha512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+             Expected:
+               sha512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
-          Computed:
-            sha256:cf89b679b25281c8f68b2bbefe0d90b7a5bf57d8c9fbe6c6fe909a713748c008
-            sha512:3dcc75e1a1047c21a9f84282b5cf93ef54d8dc471bd043223b6d50ebbbc9a1c06715991409f01fdaa965b991ff77c5b6d29c932269301c1e5ef6a1ad685cc46e
+             Computed:
+               sha256:cf89b679b25281c8f68b2bbefe0d90b7a5bf57d8c9fbe6c6fe909a713748c008
+               sha512:3dcc75e1a1047c21a9f84282b5cf93ef54d8dc471bd043223b6d50ebbbc9a1c06715991409f01fdaa965b991ff77c5b6d29c932269301c1e5ef6a1ad685cc46e
     ");
 
     Ok(())
@@ -5854,13 +5854,13 @@ async fn generate_hashes_url_fragment_source_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `source-package @ http://[LOCALHOST]/source.tar.gz#sha256=0000000000000000000000000000000000000000000000000000000000000000`
-      └── Hash mismatch for `source-package @ http://[LOCALHOST]/source.tar.gz#sha256=0000000000000000000000000000000000000000000000000000000000000000`
+      cause: Hash mismatch for `source-package @ http://[LOCALHOST]/source.tar.gz#sha256=0000000000000000000000000000000000000000000000000000000000000000`
 
-          Expected:
-            sha256:0000000000000000000000000000000000000000000000000000000000000000
+             Expected:
+               sha256:0000000000000000000000000000000000000000000000000000000000000000
 
-          Computed:
-            sha256:0278d222c8f122de338efc402d719a27f81cb59a73dc2980460f310da098e35c
+             Computed:
+               sha256:0278d222c8f122de338efc402d719a27f81cb59a73dc2980460f310da098e35c
     ");
     assert!(!sentinel.exists(), "the build backend was executed");
 
@@ -6747,7 +6747,7 @@ fn missing_editable_file() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unsupported editable requirement in `requirements.in` at line 1: `file://[TEMP_DIR]/foo/anyio-3.7.0.tar.gz`
-      └── Local archives cannot be editable
+      cause: Local archives cannot be editable
 
     hint: Editable requirements must refer to a local directory
     ");
@@ -7015,7 +7015,7 @@ fn cert() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read certificate file `ca-bundle.pem`
-      └── [OS ERROR 2]
+      cause: [OS ERROR 2]
     "
     );
 
@@ -7508,7 +7508,7 @@ fn no_index_requirements_txt() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because tqdm was not found in the provided package locations and you require tqdm, we can conclude that your requirements are unsatisfiable.
+      cause: Because tqdm was not found in the provided package locations and you require tqdm, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     "
@@ -7610,7 +7610,7 @@ fn offline_registry() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because black was not found in the cache and you require black==23.10.1, we can conclude that your requirements are unsatisfiable.
+      cause: Because black was not found in the cache and you require black==23.10.1, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     "
@@ -7683,7 +7683,7 @@ fn offline_registry_prerelease() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because flask was not found in the cache and you require flask==2.0.0rc1, we can conclude that your requirements are unsatisfiable.
+      cause: Because flask was not found in the cache and you require flask==2.0.0rc1, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     ");
@@ -7755,7 +7755,7 @@ fn offline_find_links() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because tqdm was not found in the cache and you require tqdm, we can conclude that your requirements are unsatisfiable.
+      cause: Because tqdm was not found in the cache and you require tqdm, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     "
@@ -7771,7 +7771,7 @@ fn offline_find_links() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because tqdm was not found in the cache and you require tqdm, we can conclude that your requirements are unsatisfiable.
+      cause: Because tqdm was not found in the cache and you require tqdm, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     "
@@ -7794,7 +7794,7 @@ fn offline_direct_url() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
-      └── Network connectivity is disabled, but the requested data wasn't found in the cache for: `https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
+      cause: Network connectivity is disabled, but the requested data wasn't found in the cache for: `https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
     "
     );
 
@@ -7849,7 +7849,7 @@ fn invalid_metadata_requires_python() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because validation==2.0.0 has invalid metadata and you require validation==2.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because validation==2.0.0 has invalid metadata and you require validation==2.0.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Metadata for `validation` (v2.0.0) could not be parsed:
       Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==12`?:
@@ -7877,7 +7877,7 @@ fn invalid_metadata_multiple_dist_info() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because validation==3.0.0 has an invalid package format and you require validation==3.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because validation==3.0.0 has an invalid package format and you require validation==3.0.0, we can conclude that your requirements are unsatisfiable.
 
     hint: The structure of `validation` (v3.0.0) was invalid:
       Multiple .dist-info directories found: validation-2.0.0, validation-3.0.0
@@ -8160,7 +8160,7 @@ fn compile_constraints_incompatible_url() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only anyio>=4 is available and you require anyio<4, we can conclude that your requirements are unsatisfiable.
+      cause: Because only anyio>=4 is available and you require anyio<4, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -8181,7 +8181,7 @@ fn index_url_in_requirements() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and you require anyio<4, we can conclude that your requirements are unsatisfiable.
+      cause: Because anyio was not found in the package registry and you require anyio<4, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -8233,9 +8233,9 @@ fn unsupported_scheme() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.in` at position 0
-      └── Unsupported URL prefix `bzr` in URL: `bzr+https://example.com/anyio` (Bazaar is not supported)
-          anyio @ bzr+https://example.com/anyio
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Unsupported URL prefix `bzr` in URL: `bzr+https://example.com/anyio` (Bazaar is not supported)
+             anyio @ bzr+https://example.com/anyio
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 
@@ -10916,7 +10916,7 @@ fn compile_constraints_incompatible_version() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because you require filelock==1.0.0 and filelock==3.8.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require filelock==1.0.0 and filelock==3.8.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -10941,7 +10941,7 @@ fn conflicting_url_markers() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because you require filelock==1.0.0 and filelock==3.8.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require filelock==1.0.0 and filelock==3.8.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -11089,7 +11089,7 @@ fn override_with_incompatible_constraint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because you require anyio>=3.0.0 and anyio<3.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require anyio>=3.0.0 and anyio<3.0.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -11511,7 +11511,7 @@ fn compile_pyproject_toml_recursive_extra_self_constraint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because recursive-demo depends on recursive-demo{sys_platform == 'darwin'}>=2 and recursive-demo{sys_platform == 'darwin'}==1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because recursive-demo depends on recursive-demo{sys_platform == 'darwin'}>=2 and recursive-demo{sys_platform == 'darwin'}==1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Resolving the package itself expands recursive extras inside the resolver instead.
@@ -11524,8 +11524,8 @@ fn compile_pyproject_toml_recursive_extra_self_constraint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only recursive-demo[outer]==1.0.0 is available and recursive-demo[outer]==1.0.0 depends on recursive-demo{sys_platform == 'darwin'}>=2, we can conclude that all versions of recursive-demo[outer] cannot be used.
-          And because you require recursive-demo[outer], we can conclude that your requirements are unsatisfiable.
+      cause: Because only recursive-demo[outer]==1.0.0 is available and recursive-demo[outer]==1.0.0 depends on recursive-demo{sys_platform == 'darwin'}>=2, we can conclude that all versions of recursive-demo[outer] cannot be used.
+             And because you require recursive-demo[outer], we can conclude that your requirements are unsatisfiable.
     ");
 
     // Both recursive edges intersect Python >=3.12, but their conjunction only applies below
@@ -12272,8 +12272,8 @@ requires-python = ">=3.13"
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
-          And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
+             And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -12311,8 +12311,8 @@ requires-python = ">=3.13"
     ----- stderr -----
     warning: The requested Python version 3.11 is not available; 3.12.[X] will be used to build dependencies instead.
     error: No solution found when resolving dependencies
-      └── Because the requested Python version (>=3.11) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
-          And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
+      cause: Because the requested Python version (>=3.11) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
+             And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
 
     hint: The `--python-version` value (>=3.11) includes Python versions that are not supported by your dependencies (e.g., example==0.0.0 only supports >=3.13). Consider using a higher `--python-version` value.
     "
@@ -12507,8 +12507,8 @@ fn not_found_direct_url() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `iniconfig @ https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl`
-      ├── Failed to fetch: `https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl`
-      └── HTTP status client error (404 Not Found) for url (https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl)
+      cause: Failed to fetch: `https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl`
+      cause: HTTP status client error (404 Not Found) for url (https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl)
     "
     );
 
@@ -12544,8 +12544,8 @@ requires-python = ">=3.13"
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
-          And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
+             And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -13636,9 +13636,9 @@ requires-python = ">3.8"
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of anyio==0.0.0 and lib==0.0.0 depends on anyio==0.0.0, we can conclude that lib==0.0.0 cannot be used.
-          And because only lib==0.0.0 is available and example==0.0.0 depends on lib, we can conclude that example==0.0.0 cannot be used.
-          And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of anyio==0.0.0 and lib==0.0.0 depends on anyio==0.0.0, we can conclude that lib==0.0.0 cannot be used.
+             And because only lib==0.0.0 is available and example==0.0.0 depends on lib, we can conclude that example==0.0.0 cannot be used.
+             And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -13803,7 +13803,7 @@ fn compile_index_url_first_match_base() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of jinja2==3.1.0 and you require jinja2==3.1.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of jinja2==3.1.0 and you require jinja2==3.1.0, we can conclude that your requirements are unsatisfiable.
 
     hint: `jinja2` was found on https://astral-sh.github.io/pytorch-mirror/whl/cpu, but not at the requested version (jinja2==3.1.0). A compatible version may be available on a subsequent index (e.g., https://pypi.org/simple). By default, uv will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `--index-strategy unsafe-best-match` to consider all versions from all indexes, regardless of the order in which they were defined.
     "
@@ -13835,7 +13835,7 @@ fn compile_index_url_first_match_marker() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of jinja2{sys_platform == 'linux'}==3.1.0 and you require jinja2{sys_platform == 'linux'}==3.1.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of jinja2{sys_platform == 'linux'}==3.1.0 and you require jinja2{sys_platform == 'linux'}==3.1.0, we can conclude that your requirements are unsatisfiable.
 
     hint: `jinja2` was found on https://astral-sh.github.io/pytorch-mirror/whl/cpu, but not at the requested version (jinja2==3.1.0). A compatible version may be available on a subsequent index (e.g., https://pypi.org/simple). By default, uv will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `--index-strategy unsafe-best-match` to consider all versions from all indexes, regardless of the order in which they were defined.
     "
@@ -13865,7 +13865,7 @@ fn compile_index_url_first_match_all_versions() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there are no versions of pandas and you require pandas, we can conclude that your requirements are unsatisfiable.
+      cause: Because there are no versions of pandas and you require pandas, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -14238,7 +14238,7 @@ fn no_version_for_direct_dependency() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── you require pypyp==1 and pypyp>=1.2, which are incompatible
+      cause: you require pypyp==1 and pypyp>=1.2, which are incompatible
     "
     );
 
@@ -14556,12 +14556,12 @@ fn git_source_missing_tag() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@missing`
-      ├── Git operation failed
-      ├── failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
-      ├── failed to fetch tag `missing`
-      └── process didn't exit successfully: `git fetch --force --update-head-ok 'https://github.com/astral-test/uv-public-pypackage' '+refs/tags/missing:refs/remotes/origin/tags/missing'` (exit status: 128)
-          --- stderr
-          fatal: couldn't find remote ref refs/tags/missing
+      cause: Git operation failed
+      cause: failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
+      cause: failed to fetch tag `missing`
+      cause: process didn't exit successfully: `git fetch --force --update-head-ok 'https://github.com/astral-test/uv-public-pypackage' '+refs/tags/missing:refs/remotes/origin/tags/missing'` (exit status: 128)
+             --- stderr
+             fatal: couldn't find remote ref refs/tags/missing
     ");
 
     Ok(())
@@ -14744,9 +14744,9 @@ fn invalid_tool_uv_sources() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse metadata from built wheel
-      └── Expected direct URL (`https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-          urllib3 @ https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Expected direct URL (`https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
+             urllib3 @ https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 
@@ -14769,7 +14769,7 @@ fn invalid_tool_uv_sources() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse entry: `urllib3`
-      └── Expected direct URL (`https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
+      cause: Expected direct URL (`https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.tar.baz`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
     "
     );
 
@@ -14847,8 +14847,8 @@ fn no_binary_only_binary() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because source-distribution==0.0.1 has no usable wheels and only source-distribution>=0.0.1 is available, we can conclude that source-distribution<=0.0.1 cannot be used.
-          And because you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
+      cause: Because source-distribution==0.0.1 has no usable wheels and only source-distribution>=0.0.1 is available, we can conclude that source-distribution<=0.0.1 cannot be used.
+             And because you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are required for `source-distribution` because building from source is disabled for all packages (i.e., with `--no-build`)
     "
@@ -14927,9 +14927,9 @@ fn incompatible_build_constraint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -14993,9 +14993,9 @@ build-constraint-dependencies = [
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -15077,9 +15077,9 @@ build-constraint-dependencies = [
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -15113,9 +15113,9 @@ build-constraint-dependencies = [
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools==1 and setuptools>=40, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools==1 and setuptools>=40, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -15254,9 +15254,9 @@ fn invalid_extra() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.in` at position 0
-      └── Expected an alphanumeric character starting the extra name, found `_`
-          .[_anyio]
-            ^
+      cause: Expected an alphanumeric character starting the extra name, found `_`
+             .[_anyio]
+               ^
     ");
 
     // Sync the `anyio` extra. We should reject it.
@@ -15421,8 +15421,8 @@ fn universal_required_environment() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: platform_machine == 'arm64')
-      └── Because a==1.0.0 has no `platform_machine == 'arm64'`-compatible wheels and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
-          And because project depends on a, we can conclude that your requirements are unsatisfiable.
+      cause: Because a==1.0.0 has no `platform_machine == 'arm64'`-compatible wheels and only a==1.0.0 is available, we can conclude that all versions of a cannot be used.
+             And because project depends on a, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -15441,8 +15441,8 @@ fn compile_enumerate_no_versions() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.10.[X]) does not satisfy Python>=3.11,<4.0 and all versions of rooster-blue depend on Python>=3.11,<4.0, we can conclude that all versions of rooster-blue cannot be used.
-          And because you require rooster-blue, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.10.[X]) does not satisfy Python>=3.11,<4.0 and all versions of rooster-blue depend on Python>=3.11,<4.0, we can conclude that all versions of rooster-blue cannot be used.
+             And because you require rooster-blue, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -15885,7 +15885,7 @@ fn unsupported_requires_python_dynamic_metadata() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: python_full_version >= '3.10')
-      └── Because source-distribution==0.0.3 requires Python >=3.10 and you require source-distribution{python_full_version >= '3.10'}==0.0.3, we can conclude that your requirements are unsatisfiable.
+      cause: Because source-distribution==0.0.3 requires Python >=3.10 and you require source-distribution{python_full_version >= '3.10'}==0.0.3, we can conclude that your requirements are unsatisfiable.
 
     hint: While the active Python version is 3.8, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.
 
@@ -15999,26 +15999,26 @@ fn compile_derivation_chain() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `child` (v0.1.0) depends on `wsgiref`
 
@@ -16044,11 +16044,11 @@ fn invalid_platform() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`) and only the following versions of open3d are available:
-              open3d<=0.15.2
-              open3d>=0.16.0
-          we can conclude that open3d<0.16.0 cannot be used.
-          And because open3d>=0.16.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require open3d, we can conclude that your requirements are unsatisfiable.
+      cause: Because open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`) and only the following versions of open3d are available:
+                 open3d<=0.15.2
+                 open3d>=0.16.0
+             we can conclude that open3d<0.16.0 cannot be used.
+             And because open3d>=0.16.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require open3d, we can conclude that your requirements are unsatisfiable.
 
     hint: You require CPython 3.10 (`cp310`), but we only found wheels for `open3d` (v0.15.2) with the following Python ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`
 
@@ -16159,9 +16159,9 @@ fn universal_conflicting_override_urls() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve dependencies for package `anyio==4.3.0`
-      └── Requirements contain conflicting URLs for package `sniffio` in split `sys_platform == 'win32'`:
-          - https://files.pythonhosted.org/packages/c3/a0/5dba8ed157b0136607c7f2151db695885606968d1fae123dc3391e0cfdbf/sniffio-1.3.0-py3-none-any.whl
-          - https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
+      cause: Requirements contain conflicting URLs for package `sniffio` in split `sys_platform == 'win32'`:
+             - https://files.pythonhosted.org/packages/c3/a0/5dba8ed157b0136607c7f2151db695885606968d1fae123dc3391e0cfdbf/sniffio-1.3.0-py3-none-any.whl
+             - https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
     "
     );
 
@@ -17336,7 +17336,7 @@ fn group_target_does_not_exist() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read dependency groups from: does/not/exist/pyproject.toml
-      └── No pyproject.toml found at: does/not/exist/pyproject.toml
+      cause: No pyproject.toml found at: does/not/exist/pyproject.toml
     ");
 
     Ok(())
@@ -18901,8 +18901,8 @@ fn incompatible_cuda() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because torchvision==0.17.1+cu118 depends on system:cuda==11.8 and torch>=2.2.1+cu121 depends on system:cuda==12.1, we can conclude that torch>=2.2.1+cu121 and torchvision==0.17.1+cu118 are incompatible.
-          And because you require torch==2.2.1+cu121 and torchvision==0.17.1+cu118, we can conclude that your requirements are unsatisfiable.
+      cause: Because torchvision==0.17.1+cu118 depends on system:cuda==11.8 and torch>=2.2.1+cu121 depends on system:cuda==12.1, we can conclude that torch>=2.2.1+cu121 and torchvision==0.17.1+cu118 are incompatible.
+             And because you require torch==2.2.1+cu121 and torchvision==0.17.1+cu118, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -18937,7 +18937,7 @@ fn compile_broken_active_venv() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python`
-      └── Broken symlink at `.venv/bin/python`, was the underlying Python interpreter removed?
+      cause: Broken symlink at `.venv/bin/python`, was the underlying Python interpreter removed?
 
     hint: Consider recreating the environment (e.g., with `uv venv`)
     ");
@@ -19148,7 +19148,7 @@ async fn credentials_from_subdirectory() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because iniconfig was not found in the package registry and foo depends on iniconfig, we can conclude that your requirements are unsatisfiable.
+      cause: Because iniconfig was not found in the package registry and foo depends on iniconfig, we can conclude that your requirements are unsatisfiable.
     ");
 
     uv_snapshot!(context.filters(), context
@@ -19519,15 +19519,15 @@ async fn compile_missing_python_download_error_warning() {
     exit_code: 2 (failure)
     ----- stderr -----
     warning: A managed Python download is available for Python 3.10, but an error occurred when attempting to download it.
-      ├── Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
-      ├── error sending request for url (https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
-      ├── client error (Connect)
-      └── tunnel error: unsuccessful
+      cause: Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
+      cause: error sending request for url (https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
+      cause: client error (Connect)
+      cause: tunnel error: unsuccessful
     warning: The requested Python version 3.10 is not available; 3.12.[X] will be used to build dependencies instead.
     error: Failed to fetch: `https://pypi.org/simple/anyio/`
-      ├── error sending request for url (https://pypi.org/simple/anyio/)
-      ├── client error (Connect)
-      └── tunnel error: unsuccessful
+      cause: error sending request for url (https://pypi.org/simple/anyio/)
+      cause: client error (Connect)
+      cause: tunnel error: unsuccessful
     ");
 
     // Also check for the patch fallback
@@ -19541,15 +19541,15 @@ async fn compile_missing_python_download_error_warning() {
     exit_code: 2 (failure)
     ----- stderr -----
     warning: A managed Python download is available for Python 3.10, but an error occurred when attempting to download it.
-      ├── Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
-      ├── error sending request for url (https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
-      ├── client error (Connect)
-      └── tunnel error: unsuccessful
+      cause: Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
+      cause: error sending request for url (https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
+      cause: client error (Connect)
+      cause: tunnel error: unsuccessful
     warning: The requested Python version 3.10.99 is not available; 3.12.[X] will be used to build dependencies instead.
     error: Failed to fetch: `https://pypi.org/simple/anyio/`
-      ├── error sending request for url (https://pypi.org/simple/anyio/)
-      ├── client error (Connect)
-      └── tunnel error: unsuccessful
+      cause: error sending request for url (https://pypi.org/simple/anyio/)
+      cause: client error (Connect)
+      cause: tunnel error: unsuccessful
     ");
 
     // Check that looking up a valid patch version only warns once
@@ -19563,14 +19563,14 @@ async fn compile_missing_python_download_error_warning() {
     exit_code: 2 (failure)
     ----- stderr -----
     warning: A managed Python download is available for Python 3.10.19, but an error occurred when attempting to download it.
-      ├── Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
-      ├── error sending request for url (https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
-      ├── client error (Connect)
-      └── tunnel error: unsuccessful
+      cause: Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
+      cause: error sending request for url (https://github.com/astral-sh/python-build-standalone/releases/download/[FILE-PATH]
+      cause: client error (Connect)
+      cause: tunnel error: unsuccessful
     warning: The requested Python version 3.10.19 is not available; 3.12.[X] will be used to build dependencies instead.
     error: Failed to fetch: `https://pypi.org/simple/anyio/`
-      ├── error sending request for url (https://pypi.org/simple/anyio/)
-      ├── client error (Connect)
-      └── tunnel error: unsuccessful
+      cause: error sending request for url (https://pypi.org/simple/anyio/)
+      cause: client error (Connect)
+      cause: tunnel error: unsuccessful
     ");
 }

--- a/crates/uv/tests/pip_install/direct_url_hashes.rs
+++ b/crates/uv/tests/pip_install/direct_url_hashes.rs
@@ -177,7 +177,7 @@ async fn require_hashes_rejects_direct_url_hash_discovered_in_wheel_metadata() -
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `ok @ file://[TEMP_DIR]/ok-1.0.0.tar.gz#sha256=[SOURCE_HASH]`
-      └── Hash-checking is enabled, but no hashes were provided or computed for: `ok @ file://[TEMP_DIR]/ok-1.0.0.tar.gz#sha256=[SOURCE_HASH]`
+      cause: Hash-checking is enabled, but no hashes were provided or computed for: `ok @ file://[TEMP_DIR]/ok-1.0.0.tar.gz#sha256=[SOURCE_HASH]`
     ");
 
     context.assert_backend_did_not_run();

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -14227,7 +14227,7 @@ fn reject_symlinked_wheel_package_directory() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo/dist/foo-0.1.0-py3-none-any.whl))
-      └── The wheel is invalid: Cannot install into symlinked directory: [SITE_PACKAGES]/foo
+      cause: The wheel is invalid: Cannot install into symlinked directory: [SITE_PACKAGES]/foo
     ");
 
     external
@@ -14274,7 +14274,7 @@ fn reject_symlinked_wheel_nested_package_directory() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo/dist/foo-0.1.0-py3-none-any.whl))
-      └── The wheel is invalid: Cannot install into symlinked directory: [SITE_PACKAGES]/foo/existing/nested
+      cause: The wheel is invalid: Cannot install into symlinked directory: [SITE_PACKAGES]/foo/existing/nested
     ");
 
     external.child("sentinel.txt").assert("keep me");
@@ -14344,7 +14344,7 @@ fn reject_symlinked_wheel_data_package_directory() -> Result<()> {
         Resolved 1 package in [TIME]
         Prepared 1 package in [TIME]
         error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-          └── The wheel is invalid: Cannot install into symlinked directory: [SITE_PACKAGES]/foo
+          cause: The wheel is invalid: Cannot install into symlinked directory: [SITE_PACKAGES]/foo
             ");
 
             external
@@ -14409,7 +14409,7 @@ fn reject_symlinked_wheel_headers_destination() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── The wheel is invalid: Cannot install into symlinked directory: [VENV]/include/site/python3.12/foo
+      cause: The wheel is invalid: Cannot install into symlinked directory: [VENV]/include/site/python3.12/foo
     ");
 
     external

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -444,7 +444,7 @@ fn missing_find_links() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read `--find-links` directory: [TEMP_DIR]/missing
-      └── [OS ERROR 2]
+      cause: [OS ERROR 2]
     "
     );
 
@@ -470,7 +470,7 @@ fn missing_find_links_from_requirements_file() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Invalid URL in `requirements/requirements.txt` at position 0: `./missing`
-      └── relative URL without a base
+      cause: relative URL without a base
     "
     );
 
@@ -496,12 +496,12 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
       key with no value, expected `=`
 
     error: Failed to parse: `pyproject.toml`
-      ├── Invalid `pyproject.toml`
-      └── TOML parse error at line 1, column 5
-            |
-          1 | 123 - 456
-            |     ^
-          key with no value, expected `=`
+      cause: Invalid `pyproject.toml`
+      cause: TOML parse error at line 1, column 5
+               |
+             1 | 123 - 456
+               |     ^
+             key with no value, expected `=`
     "
     );
 
@@ -520,11 +520,11 @@ fn invalid_pyproject_toml_project_schema() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 1, column 1
-            |
-          1 | [project]
-            | ^^^^^^^^^
-          `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+      cause: TOML parse error at line 1, column 1
+               |
+             1 | [project]
+               | ^^^^^^^^^
+             `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     "
     );
 
@@ -809,59 +809,59 @@ dependencies = ["flask==1.0.x"]
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/path_dep`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stdout]
-          configuration error: `project.dependencies[0]` must be pep508
-          DESCRIPTION:
-              Project dependency specification according to PEP 508
+             [stdout]
+             configuration error: `project.dependencies[0]` must be pep508
+             DESCRIPTION:
+                 Project dependency specification according to PEP 508
 
-          GIVEN VALUE:
-              "flask==1.0.x"
+             GIVEN VALUE:
+                 "flask==1.0.x"
 
-          OFFENDING RULE: 'format'
+             OFFENDING RULE: 'format'
 
-          DEFINITION:
-              {
-                  "$id": "#/definitions/dependency",
-                  "title": "Dependency",
-                  "type": "string",
-                  "format": "pep508"
-              }
+             DEFINITION:
+                 {
+                     "$id": "#/definitions/dependency",
+                     "title": "Dependency",
+                     "type": "string",
+                     "format": "pep508"
+                 }
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 1, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/__init__.py", line 104, in setup
-              return distutils.core.setup(**attrs)
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/_distutils/core.py", line 159, in setup
-              dist.parse_config_files()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/_virtualenv.py", line 21, in parse_config_files
-              result = old_parse_config_files(self, *args, **kwargs)
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/dist.py", line 631, in parse_config_files
-              pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/config/pyprojecttoml.py", line 68, in apply_configuration
-              config = read_configuration(filepath, True, ignore_option_errors, dist)
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/config/pyprojecttoml.py", line 129, in read_configuration
-              validate(subset, filepath)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/config/pyprojecttoml.py", line 57, in validate
-              raise ValueError(f"{error}/n{summary}") from None
-          ValueError: invalid pyproject.toml config: `project.dependencies[0]`.
-          configuration error: `project.dependencies[0]` must be pep508
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 1, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/__init__.py", line 104, in setup
+                 return distutils.core.setup(**attrs)
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/_distutils/core.py", line 159, in setup
+                 dist.parse_config_files()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/_virtualenv.py", line 21, in parse_config_files
+                 result = old_parse_config_files(self, *args, **kwargs)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/dist.py", line 631, in parse_config_files
+                 pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/config/pyprojecttoml.py", line 68, in apply_configuration
+                 config = read_configuration(filepath, True, ignore_option_errors, dist)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/config/pyprojecttoml.py", line 129, in read_configuration
+                 validate(subset, filepath)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/config/pyprojecttoml.py", line 57, in validate
+                 raise ValueError(f"{error}/n{summary}") from None
+             ValueError: invalid pyproject.toml config: `project.dependencies[0]`.
+             configuration error: `project.dependencies[0]` must be pep508
 
     hint: Build failures usually indicate a problem with the package or the build environment
     "##
@@ -913,8 +913,8 @@ fn no_solution() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because flask>=3.0.2 depends on werkzeug>=3.0.0 and you require flask>=3.0.2, we can conclude that you require werkzeug>=3.0.0.
-          And because you require werkzeug<1.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because flask>=3.0.2 depends on werkzeug>=3.0.0 and you require flask>=3.0.2, we can conclude that you require werkzeug>=3.0.0.
+             And because you require werkzeug<1.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 }
 
@@ -1260,8 +1260,8 @@ werkzeug==3.0.1
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because flask>=3.0.2 depends on click>=8.1.3 and you require click==7.0.0, we can conclude that your requirements and flask>=3.0.2 are incompatible.
-          And because you require flask==3.0.2, we can conclude that your requirements are unsatisfiable.
+      cause: Because flask>=3.0.2 depends on click>=8.1.3 and you require click==7.0.0, we can conclude that your requirements and flask>=3.0.2 are incompatible.
+             And because you require flask==3.0.2, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -2109,7 +2109,7 @@ fn install_editable_incompatible_constraint_version() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only black<=0.1.0 is available and you require black>0.1.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because only black<=0.1.0 is available and you require black>0.1.0, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -2329,7 +2329,7 @@ fn invalid_editable_no_url() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unsupported editable requirement in `requirements.txt` at line 1: `black==0.1.0`
-      └── Registry requirements cannot be editable
+      cause: Registry requirements cannot be editable
 
     hint: Editable requirements must refer to a local directory
     "
@@ -2352,7 +2352,7 @@ fn invalid_editable_unnamed_remote_url_requirements_txt() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unsupported editable requirement in `requirements.txt` at line 1: `http://user:****@example.com/black-1.0.0-py3-none-any.whl`
-      └── Remote archives cannot be editable
+      cause: Remote archives cannot be editable
 
     hint: Editable requirements must refer to a local directory
     "
@@ -2371,7 +2371,7 @@ fn invalid_editable_unnamed_remote_url_cli() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unsupported editable requirement: `http://user:****@example.com/black-1.0.0-py3-none-any.whl`
-      └── Remote archives cannot be editable
+      cause: Remote archives cannot be editable
 
     hint: Editable requirements must refer to a local directory
     "
@@ -2395,7 +2395,7 @@ fn invalid_editable_named_https_url() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unsupported editable requirement in `requirements.txt` at line 3: `black @ https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl`
-      └── Remote archives cannot be editable
+      cause: Remote archives cannot be editable
 
     hint: Editable requirements must refer to a local directory
     "
@@ -2453,7 +2453,7 @@ fn install_no_index() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because flask was not found in the provided package locations and you require flask, we can conclude that your requirements are unsatisfiable.
+      cause: Because flask was not found in the provided package locations and you require flask, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     "
@@ -2474,7 +2474,7 @@ fn install_no_index_version() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because flask was not found in the provided package locations and you require flask==3.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because flask was not found in the provided package locations and you require flask==3.0.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     "
@@ -2948,9 +2948,9 @@ fn install_git_unescaped_ref() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `example @ git+https://example.com/repository@pkg@1.2.3`
-      └── Ambiguous Git URL `https://example.com/repository@pkg@1.2.3`: the path contains multiple `@` characters. If the Git revision contains `@`, percent-encode it as `%40`
-          example @ git+https://example.com/repository@pkg@1.2.3
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Ambiguous Git URL `https://example.com/repository@pkg@1.2.3`: the path contains multiple `@` characters. If the Git revision contains `@`, percent-encode it as `%40`
+             example @ git+https://example.com/repository@pkg@1.2.3
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ");
 }
 
@@ -3010,12 +3010,12 @@ fn install_git_public_https_missing_branch_or_tag() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0`
-      ├── Git operation failed
-      ├── failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
-      ├── failed to fetch branch or tag `2.0.0`
-      └── process didn't exit successfully: `git fetch [...]` (exit code: 128)
-          --- stderr
-          fatal: couldn't find remote ref refs/tags/2.0.0
+      cause: Git operation failed
+      cause: failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
+      cause: failed to fetch branch or tag `2.0.0`
+      cause: process didn't exit successfully: `git fetch [...]` (exit code: 128)
+             --- stderr
+             fatal: couldn't find remote ref refs/tags/2.0.0
     ");
 }
 
@@ -3061,8 +3061,8 @@ async fn install_git_public_rejects_mismatched_github_api_commit() -> Result<()>
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979`
-      ├── Git operation failed
-      └── Exact Git revision `0dacfd662c64cb4ceb16e6cf65a157a8b715b979` does not match precise commit `b270df1a2fb5d012294e9aaf05e7e0bab1e6a389` for `https://github.com/astral-test/uv-public-pypackage`
+      cause: Git operation failed
+      cause: Exact Git revision `0dacfd662c64cb4ceb16e6cf65a157a8b715b979` does not match precise commit `b270df1a2fb5d012294e9aaf05e7e0bab1e6a389` for `https://github.com/astral-test/uv-public-pypackage`
     ");
 
     Ok(())
@@ -3142,12 +3142,12 @@ fn install_git_public_https_missing_commit() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@79a935a7a1a0ad6d0bdf72dce0e16cb0a24a1b3b`
-      ├── Git operation failed
-      ├── failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
-      ├── failed to fetch commit `79a935a7a1a0ad6d0bdf72dce0e16cb0a24a1b3b`
-      └── process didn't exit successfully: `git fetch [...]` (exit code: 128)
-          --- stderr
-          fatal: remote error: upload-pack: not our ref 79a935a7a1a0ad6d0bdf72dce0e16cb0a24a1b3b
+      cause: Git operation failed
+      cause: failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
+      cause: failed to fetch commit `79a935a7a1a0ad6d0bdf72dce0e16cb0a24a1b3b`
+      cause: process didn't exit successfully: `git fetch [...]` (exit code: 128)
+             --- stderr
+             fatal: remote error: upload-pack: not our ref 79a935a7a1a0ad6d0bdf72dce0e16cb0a24a1b3b
     ");
 }
 
@@ -3346,12 +3346,12 @@ fn install_git_private_https_pat_not_authorized() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `uv-private-pypackage @ git+https://git:****@github.com/astral-test/uv-private-pypackage`
-      ├── Git operation failed
-      ├── failed to clone into: [CACHE_DIR]/git-v0/db/8401f5508e3e612d
-      └── process didn't exit successfully: `git fetch --force --update-head-ok 'https://git:****@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
-          --- stderr
-          remote: Invalid username or token. Password authentication is not supported for Git operations.
-          fatal: Authentication failed for 'https://github.com/astral-test/uv-private-pypackage/'
+      cause: Git operation failed
+      cause: failed to clone into: [CACHE_DIR]/git-v0/db/8401f5508e3e612d
+      cause: process didn't exit successfully: `git fetch --force --update-head-ok 'https://git:****@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
+             --- stderr
+             remote: Invalid username or token. Password authentication is not supported for Git operations.
+             fatal: Authentication failed for 'https://github.com/astral-test/uv-private-pypackage/'
     ");
 }
 
@@ -3435,11 +3435,11 @@ fn install_git_private_https_interactive() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `uv-private-pypackage @ git+https://github.com/astral-test/uv-private-pypackage`
-      ├── Git operation failed
-      ├── failed to clone into: [CACHE_DIR]/git-v0/db/8401f5508e3e612d
-      └── process didn't exit successfully: `/usr/bin/git fetch --force --update-head-ok 'https://github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
-          --- stderr
-          fatal: could not read Username for 'https://github.com': terminal prompts disabled
+      cause: Git operation failed
+      cause: failed to clone into: [CACHE_DIR]/git-v0/db/8401f5508e3e612d
+      cause: process didn't exit successfully: `/usr/bin/git fetch --force --update-head-ok 'https://github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
+             --- stderr
+             fatal: could not read Username for 'https://github.com': terminal prompts disabled
     ");
 }
 
@@ -3723,7 +3723,7 @@ fn install_only_binary_all_and_no_binary_all() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because all versions of anyio have no usable wheels and you require anyio, we can conclude that your requirements are unsatisfiable.
+      cause: Because all versions of anyio have no usable wheels and you require anyio, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are required for `anyio` because building from source is disabled for all packages (i.e., with `--no-build`)
     "
@@ -3845,7 +3845,7 @@ fn only_binary_requirements_txt() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because django-allauth==0.51.0 has no usable wheels and you require django-allauth==0.51.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because django-allauth==0.51.0 has no usable wheels and you require django-allauth==0.51.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Wheels are required for `django-allauth` because building from source is disabled for `django-allauth` (i.e., with `--no-build-package django-allauth`)
     "
@@ -3953,9 +3953,9 @@ fn no_prerelease_hint_source_builds() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because only setuptools<=40.4.3 is available and you require setuptools>=40.8.0, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because only setuptools<=40.4.3 is available and you require setuptools>=40.8.0, we can conclude that your requirements are unsatisfiable.
 
     hint: `setuptools` was filtered by `exclude-newer` to only include packages uploaded before 2018-10-09T00:00:00Z. The latest version satisfying the requirement is v69.2.0, published at 2024-03-13T11:20:54.103Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     "
@@ -4243,8 +4243,8 @@ fn no_deps_installed() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because child was not found in the provided package locations and parent==1.0.0 depends on child>=2, we can conclude that parent==1.0.0 cannot be used.
-          And because parent was not found in the provided package locations and you require parent, we can conclude that your requirements are unsatisfiable.
+      cause: Because child was not found in the provided package locations and parent==1.0.0 depends on child>=2, we can conclude that parent==1.0.0 cannot be used.
+             And because parent was not found in the provided package locations and you require parent, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     ");
@@ -4285,7 +4285,7 @@ fn no_deps_installed() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because you require parent==1.0.0 and parent==2.0.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because you require parent==1.0.0 and parent==2.0.0, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -4757,9 +4757,9 @@ fn install_git_source_respects_offline_mode() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage`
-      ├── Git operation failed
-      ├── failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
-      └── Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+      cause: Git operation failed
+      cause: failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
+      cause: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
     "
     );
 }
@@ -4817,7 +4817,7 @@ fn explicit_prerelease_does_not_fall_back_if_necessary() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because only a<=0.1.0 is available and you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a<=0.1.0 is available and you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Pre-releases are available for `a` in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)
     ");
@@ -4929,8 +4929,8 @@ fn explicit_prerelease_disallows_transitive_marker() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of c==2.0.0b1 and all versions of a depend on c==2.0.0b1, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of c==2.0.0b1 and all versions of a depend on c==2.0.0b1, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: `c` was requested with a pre-release marker (e.g., c==2.0.0b1), but pre-releases weren't enabled (try: `--prerelease=allow`)
     ");
@@ -4981,8 +4981,8 @@ fn prerelease_package_disallows_transitive_prerelease() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of c==2.0.0b1 and all versions of a depend on c==2.0.0b1, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of c==2.0.0b1 and all versions of a depend on c==2.0.0b1, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: `c` was requested with a pre-release marker (e.g., c==2.0.0b1), but pre-releases weren't enabled (try: `--prerelease-package c=allow`)
     ");
@@ -5089,7 +5089,7 @@ fn prerelease_package_rejected_in_pip_configuration() -> Result<()> {
       unknown field `prerelease-package`, expected one of [...]
 
     error: No solution found when resolving dependencies
-      └── Because only a<=0.1.0 is available and you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because only a<=0.1.0 is available and you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Pre-releases are available for `a` in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)
     "#);
@@ -5178,8 +5178,8 @@ fn disallow_transitive_prerelease() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of c==2.0.0b1 and all versions of a depend on c==2.0.0b1, we can conclude that all versions of a cannot be used.
-          And because you require a, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of c==2.0.0b1 and all versions of a depend on c==2.0.0b1, we can conclude that all versions of a cannot be used.
+             And because you require a, we can conclude that your requirements are unsatisfiable.
 
     hint: `c` was requested with a pre-release marker (e.g., c==2.0.0b1), but pre-releases weren't enabled (try: `--prerelease=allow`)
     ");
@@ -6345,8 +6345,8 @@ requires-python = ">=3.13"
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
-          And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
+             And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -6438,13 +6438,13 @@ fn no_build_isolation() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.prepare_metadata_for_build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.prepare_metadata_for_build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 8, in <module>
-          ModuleNotFoundError: No module named 'setuptools'
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 8, in <module>
+             ModuleNotFoundError: No module named 'setuptools'
 
     hint: This error likely indicates that `anyio` depends on `setuptools`, but doesn't declare it as a build dependency. If `anyio` is a first-party package, consider adding `setuptools` to its `build-system.requires`. Otherwise, either add it to your `pyproject.toml` under:
 
@@ -6502,13 +6502,13 @@ fn respect_no_build_isolation_env_var() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.prepare_metadata_for_build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.prepare_metadata_for_build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 8, in <module>
-          ModuleNotFoundError: No module named 'setuptools'
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 8, in <module>
+             ModuleNotFoundError: No module named 'setuptools'
 
     hint: This error likely indicates that `anyio` depends on `setuptools`, but doesn't declare it as a build dependency. If `anyio` is a first-party package, consider adding `setuptools` to its `build-system.requires`. Otherwise, either add it to your `pyproject.toml` under:
 
@@ -6875,8 +6875,8 @@ requires-python = ">=3.13"
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
-          And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.12.[X]) does not satisfy Python>=3.13 and example==0.0.0 depends on Python>=3.13, we can conclude that example==0.0.0 cannot be used.
+             And because only example==0.0.0 is available and you require example, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -6922,8 +6922,8 @@ fn install_package_basic_auth_invalid_utf8() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse credentials in index URL: https://user:****@example.com/simple
-      ├── URL password contains invalid UTF-8
-      └── invalid utf-8 sequence of 1 bytes from index 0
+      cause: URL password contains invalid UTF-8
+      cause: invalid utf-8 sequence of 1 bytes from index 0
     ");
 }
 
@@ -7132,7 +7132,7 @@ async fn install_package_basic_auth_from_keyring_wrong_password() {
     Keyring request for public@http://[LOCALHOST]/basic-auth/simple
     Keyring request for public@[LOCALHOST]
     error: No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and you require anyio, we can conclude that your requirements are unsatisfiable.
+      cause: Because anyio was not found in the package registry and you require anyio, we can conclude that your requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
     "
@@ -7174,7 +7174,7 @@ async fn install_package_basic_auth_from_keyring_wrong_username() {
     Keyring request for public@[LOCALHOST]
     Keyring request for public@http://[LOCALHOST]
     error: No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and you require anyio, we can conclude that your requirements are unsatisfiable.
+      cause: Because anyio was not found in the package registry and you require anyio, we can conclude that your requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
     "
@@ -7323,7 +7323,7 @@ fn reinstall_no_index() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because anyio was not found in the provided package locations and you require anyio, we can conclude that your requirements are unsatisfiable.
+      cause: Because anyio was not found in the provided package locations and you require anyio, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     "
@@ -7432,8 +7432,8 @@ fn already_installed_dependent_editable() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because first-local was not found in the provided package locations and second-local==0.1.0 depends on first-local, we can conclude that second-local==0.1.0 cannot be used.
-          And because only second-local==0.1.0 is available and you require second-local, we can conclude that your requirements are unsatisfiable.
+      cause: Because first-local was not found in the provided package locations and second-local==0.1.0 depends on first-local, we can conclude that second-local==0.1.0 cannot be used.
+             And because only second-local==0.1.0 is available and you require second-local, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -7534,8 +7534,8 @@ fn already_installed_local_path_dependent() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because first-local was not found in the provided package locations and second-local==0.1.0 depends on first-local, we can conclude that second-local==0.1.0 cannot be used.
-          And because only second-local==0.1.0 is available and you require second-local, we can conclude that your requirements are unsatisfiable.
+      cause: Because first-local was not found in the provided package locations and second-local==0.1.0 depends on first-local, we can conclude that second-local==0.1.0 cannot be used.
+             And because only second-local==0.1.0 is available and you require second-local, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -7638,7 +7638,7 @@ fn already_installed_local_version_of_remote_package() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because anyio was not found in the provided package locations and you require anyio==4.2.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because anyio was not found in the provided package locations and you require anyio==4.2.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     "
@@ -7652,7 +7652,7 @@ fn already_installed_local_version_of_remote_package() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because there is no version of anyio==4.3.0+foo and you require anyio==4.3.0+foo, we can conclude that your requirements are unsatisfiable.
+      cause: Because there is no version of anyio==4.3.0+foo and you require anyio==4.3.0+foo, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -7859,7 +7859,7 @@ fn already_installed_remote_url() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because uv-public-pypackage was not found in the provided package locations and you require uv-public-pypackage, we can conclude that your requirements are unsatisfiable.
+      cause: Because uv-public-pypackage was not found in the provided package locations and you require uv-public-pypackage, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     ");
@@ -7896,7 +7896,7 @@ fn already_installed_remote_url() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because uv-public-pypackage was not found in the provided package locations and you require uv-public-pypackage==0.2.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because uv-public-pypackage was not found in the provided package locations and you require uv-public-pypackage==0.2.0, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
     ");
@@ -8162,7 +8162,7 @@ fn find_links_relative_to_working_directory() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Invalid URL in `requirements/requirements.txt` at position 11: `./links`
-      └── relative URL without a base
+      cause: relative URL without a base
     "
     );
 
@@ -8369,7 +8369,7 @@ async fn reject_wheel_with_multiple_dist_info_directories() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `validation==3.0.0`
-      └── The wheel is invalid: Multiple .dist-info directories found: validation-2.0.0, validation-3.0.0
+      cause: The wheel is invalid: Multiple .dist-info directories found: validation-2.0.0, validation-3.0.0
     "
     );
 
@@ -8527,14 +8527,14 @@ fn require_hashes_mismatch() -> Result<()> {
     ----- stderr -----
     Resolved 3 packages in [TIME]
     error: Failed to download `anyio==4.0.0`
-      └── Hash mismatch for `anyio==4.0.0`
+      cause: Hash mismatch for `anyio==4.0.0`
 
-          Expected:
-            sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
-            sha256:a7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
+             Expected:
+               sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+               sha256:a7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
 
-          Computed:
-            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+             Computed:
+               sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
     "
     );
 
@@ -9148,14 +9148,14 @@ fn verify_hashes_mismatch() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `idna==3.6`
-      └── Hash mismatch for `idna==3.6`
+      cause: Hash mismatch for `idna==3.6`
 
-          Expected:
-            sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2
-            sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
+             Expected:
+               sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2
+               sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
 
-          Computed:
-            sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
+             Computed:
+               sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
     "
     );
 
@@ -9198,13 +9198,13 @@ fn verify_hashes_exact_equal() -> Result<()> {
             ----- stderr -----
             Resolved 1 package in [TIME]
             error: Failed to download `ok==1.0.0`
-              └── Hash mismatch for `ok==1.0.0`
+              cause: Hash mismatch for `ok==1.0.0`
 
-                  Expected:
-                    sha256:0000000000000000000000000000000000000000000000000000000000000000
+                     Expected:
+                       sha256:0000000000000000000000000000000000000000000000000000000000000000
 
-                  Computed:
-                    sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
+                     Computed:
+                       sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f
             ");
         }
     }
@@ -9258,13 +9258,13 @@ fn verify_hashes_public_pin_local_version() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `hash-probe==1.0.0+local`
-      └── Hash mismatch for `hash-probe==1.0.0+local`
+      cause: Hash mismatch for `hash-probe==1.0.0+local`
 
-          Expected:
-            sha256:[PUBLIC_HASH]
+             Expected:
+               sha256:[PUBLIC_HASH]
 
-          Computed:
-            sha256:[LOCAL_HASH]
+             Computed:
+               sha256:[LOCAL_HASH]
     ");
 
     // A hash for `==1.0.0+local` takes precedence over the hash for `==1.0.0`.
@@ -10060,7 +10060,7 @@ fn install_script_with_symlinked_lib() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: black-0.1.0-py3-none-any.whl (black==0.1.0 (from file://[WORKSPACE]/test/packages/black_editable))
-      └── failed to query metadata of file `[VENV]/bin/black`: No such file or directory (os error 2)
+      cause: failed to query metadata of file `[VENV]/bin/black`: No such file or directory (os error 2)
     ");
 
     assert!(!context.venv.join("bin/black").exists());
@@ -10130,10 +10130,10 @@ fn install_incompatible_python_version_interpreter_broken_in_path() -> Result<()
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from first executable in the search path at `[BIN]/python3`
-      └── Querying Python at `[BIN]/python3` failed with exit status exit status: 1
+      cause: Querying Python at `[BIN]/python3` failed with exit status exit status: 1
 
-          [stderr]
-          error: intentionally broken python executable
+             [stderr]
+             error: intentionally broken python executable
     "
     );
 
@@ -10198,9 +10198,9 @@ fn incompatible_build_constraint() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -10224,9 +10224,9 @@ fn incompatible_build_constraint_from_stdin() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -10276,9 +10276,9 @@ build-constraint-dependencies = [
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -10338,9 +10338,9 @@ build-constraint-dependencies = [
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -10363,9 +10363,9 @@ build-constraint-dependencies = [
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools==1 and setuptools>=40, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools==1 and setuptools>=40, we can conclude that your requirements are unsatisfiable.
     "
     );
 
@@ -10429,13 +10429,13 @@ fn install_build_isolation_package() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
-      ├── The build backend returned an error
-      └── Call to `hatchling.build.prepare_metadata_for_build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `hatchling.build.prepare_metadata_for_build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 8, in <module>
-          ModuleNotFoundError: No module named 'hatchling'
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 8, in <module>
+             ModuleNotFoundError: No module named 'hatchling'
 
     hint: This error likely indicates that `iniconfig` depends on `hatchling`, but doesn't declare it as a build dependency. If `iniconfig` is a first-party package, consider adding `hatchling` to its `build-system.requires`. Otherwise, either add it to your `pyproject.toml` under:
 
@@ -10494,9 +10494,9 @@ fn invalid_extension() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz`
-      └── Expected direct URL (`https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-          ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Expected direct URL (`https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
+             ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.baz
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ");
 }
 
@@ -10511,9 +10511,9 @@ fn no_extension() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6`
-      └── Expected direct URL (`https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-          ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Expected direct URL (`https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
+             ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ");
 }
 
@@ -10721,25 +10721,25 @@ fn sklearn() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `sklearn==0.0.post12`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
-          rather than 'sklearn' for pip commands.
+             [stderr]
+             The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
+             rather than 'sklearn' for pip commands.
 
-          Here is how to fix this error in the main use cases:
-          - use 'pip install scikit-learn' rather than 'pip install sklearn'
-          - replace 'sklearn' by 'scikit-learn' in your pip requirements files
-            (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
-          - if the 'sklearn' package is used by one of your dependencies,
-            it would be great if you take some time to track which package uses
-            'sklearn' instead of 'scikit-learn' and report it to their issue tracker
-          - as a last resort, set the environment variable
-            SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
+             Here is how to fix this error in the main use cases:
+             - use 'pip install scikit-learn' rather than 'pip install sklearn'
+             - replace 'sklearn' by 'scikit-learn' in your pip requirements files
+               (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
+             - if the 'sklearn' package is used by one of your dependencies,
+               it would be great if you take some time to track which package uses
+               'sklearn' instead of 'scikit-learn' and report it to their issue tracker
+             - as a last resort, set the environment variable
+               SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
 
-          More information is available at
-          https://github.com/scikit-learn/sklearn-pypi-package
+             More information is available at
+             https://github.com/scikit-learn/sklearn-pypi-package
 
     hint: `sklearn` is often confused for `scikit-learn`. Did you mean to install `scikit-learn` instead?
 
@@ -10768,26 +10768,26 @@ fn resolve_derivation_chain() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `project` (v0.1.0) depends on `wsgiref`
 
@@ -10868,7 +10868,7 @@ fn test_dynamic_version_sdist_wrong_version() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to build `foo @ file://[TEMP_DIR]/foo-1.2.3.tar.gz`
-      └── Package metadata version `10.11.12` does not match given version `1.2.3`
+      cause: Package metadata version `10.11.12` does not match given version `1.2.3`
     "
     );
 
@@ -10915,9 +10915,9 @@ fn missing_git_prefix() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `workspace-in-root-test @ https://github.com/astral-sh/workspace-in-root-test`
-      └── Direct URL (`https://github.com/astral-sh/workspace-in-root-test`) references a Git repository, but is missing the `git+` prefix (e.g., `git+https://github.com/astral-sh/workspace-in-root-test`)
-          workspace-in-root-test @ https://github.com/astral-sh/workspace-in-root-test
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Direct URL (`https://github.com/astral-sh/workspace-in-root-test`) references a Git repository, but is missing the `git+` prefix (e.g., `git+https://github.com/astral-sh/workspace-in-root-test`)
+             workspace-in-root-test @ https://github.com/astral-sh/workspace-in-root-test
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 
@@ -10936,7 +10936,7 @@ fn missing_subdirectory_git() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `workspace-in-root-test @ git+https://github.com/astral-sh/workspace-in-root-test#subdirectory=missing`
-      └── The source distribution `git+https://github.com/astral-sh/workspace-in-root-test#subdirectory=missing` has no subdirectory `missing`
+      cause: The source distribution `git+https://github.com/astral-sh/workspace-in-root-test#subdirectory=missing` has no subdirectory `missing`
     "
     );
 
@@ -10954,7 +10954,7 @@ fn missing_subdirectory_url() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `source-distribution @ https://files.pythonhosted.org/packages/1f/e5/5b016c945d745f8b108e759d428341488a6aee8f51f07c6c4e33498bb91f/source_distribution-0.0.3.tar.gz#subdirectory=missing`
-      └── The source distribution `https://files.pythonhosted.org/packages/1f/e5/5b016c945d745f8b108e759d428341488a6aee8f51f07c6c4e33498bb91f/source_distribution-0.0.3.tar.gz#subdirectory=missing` has no subdirectory `missing`
+      cause: The source distribution `https://files.pythonhosted.org/packages/1f/e5/5b016c945d745f8b108e759d428341488a6aee8f51f07c6c4e33498bb91f/source_distribution-0.0.3.tar.gz#subdirectory=missing` has no subdirectory `missing`
     "
     );
 
@@ -10976,8 +10976,8 @@ fn bad_crc32() -> Result<()> {
     ----- stderr -----
     Resolved 7 packages in [TIME]
     error: Failed to download `osqp @ https://files.pythonhosted.org/packages/00/04/5959347582ab970e9b922f27585d34f7c794ed01125dac26fb4e7dd80205/osqp-1.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`
-      ├── Failed to extract archive: osqp-1.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      └── Bad uncompressed size (got 0007b829, expected 0007b828) for file: osqp/ext_builtin.cpython-311-x86_64-linux-gnu.so
+      cause: Failed to extract archive: osqp-1.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      cause: Bad uncompressed size (got 0007b829, expected 0007b828) for file: osqp/ext_builtin.cpython-311-x86_64-linux-gnu.so
     "
     );
 
@@ -11088,13 +11088,13 @@ fn direct_url_hash_source_tree_dependency() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to download `protobug @ https://files.pythonhosted.org/packages/f2/cc/db26b91cddffbcf0c6df7834fd642578f737fe34197635ae8ea64643a35f/protobug-0.3.0-py3-none-any.whl#sha256=ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520`
-      └── Hash mismatch for `protobug @ https://files.pythonhosted.org/packages/f2/cc/db26b91cddffbcf0c6df7834fd642578f737fe34197635ae8ea64643a35f/protobug-0.3.0-py3-none-any.whl#sha256=ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520`
+      cause: Hash mismatch for `protobug @ https://files.pythonhosted.org/packages/f2/cc/db26b91cddffbcf0c6df7834fd642578f737fe34197635ae8ea64643a35f/protobug-0.3.0-py3-none-any.whl#sha256=ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520`
 
-          Expected:
-            sha256:ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520
+             Expected:
+               sha256:ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520
 
-          Computed:
-            sha256:ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c202652e
+             Computed:
+               sha256:ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c202652e
 
     hint: `protobug` (v0.3.0) was included because `pylock` (v0.1.0) depends on `protobug`
     "
@@ -11250,8 +11250,8 @@ fn cyclic_build_dependency() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download and build `circular-one==0.2.0`
-      ├── Failed to install requirements from `build-system.requires`
-      └── Cyclic build dependency detected for `circular-one`
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Cyclic build dependency detected for `circular-one`
     "
     );
 
@@ -11541,8 +11541,8 @@ fn recursive_dependency_group() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read dependency groups from: [TEMP_DIR]/pyproject.toml
-      ├── Project `myproject` has malformed dependency groups
-      └── Detected a cycle in `dependency-groups`: `test` -> `test`
+      cause: Project `myproject` has malformed dependency groups
+      cause: Detected a cycle in `dependency-groups`: `test` -> `test`
     ");
 
     // Test mutually recursive groups.
@@ -11570,8 +11570,8 @@ fn recursive_dependency_group() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to read dependency groups from: [TEMP_DIR]/pyproject.toml
-      ├── Project `myproject` has malformed dependency groups
-      └── Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
+      cause: Project `myproject` has malformed dependency groups
+      cause: Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
     ");
 
     Ok(())
@@ -12382,9 +12382,9 @@ fn unsupported_git_scheme() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `git+fantasy://foo`
-      └── Unsupported Git URL scheme `fantasy:` in `fantasy://foo` (expected one of `https:`, `ssh:`, or `file:`)
-          git+fantasy://foo
-          ^^^^^^^^^^^^^^^^^
+      cause: Unsupported Git URL scheme `fantasy:` in `fantasy://foo` (expected one of `https:`, `ssh:`, or `file:`)
+             git+fantasy://foo
+             ^^^^^^^^^^^^^^^^^
     "
     );
 }
@@ -13506,11 +13506,11 @@ fn pep_751_missing_hashes() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Not a valid `pylock.toml` file: pylock.toml
-      └── TOML parse error at line 7, column 11
-            |
-          7 | wheels = [{ url = "https://example.com/iniconfig-2.0.0-py3-none-any.whl" }]
-            |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          missing field `hashes`
+      cause: TOML parse error at line 7, column 11
+               |
+             7 | wheels = [{ url = "https://example.com/iniconfig-2.0.0-py3-none-any.whl" }]
+               |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             missing field `hashes`
     "#);
 
     Ok(())
@@ -13639,13 +13639,13 @@ fn pep_751_hash_mismatch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to read `iniconfig @ file://[TEMP_DIR]/iniconfig-2.0.0-py3-none-any.whl`
-      └── Hash mismatch for `iniconfig @ file://[TEMP_DIR]/iniconfig-2.0.0-py3-none-any.whl`
+      cause: Hash mismatch for `iniconfig @ file://[TEMP_DIR]/iniconfig-2.0.0-py3-none-any.whl`
 
-          Expected:
-            sha256:c5185871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
+             Expected:
+               sha256:c5185871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
 
-          Computed:
-            sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
+             Computed:
+               sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     "
     );
 
@@ -13977,11 +13977,11 @@ fn pep_751_lock_version() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Not a valid `pylock.toml` file: pylock.toml
-      └── TOML parse error at line 2, column 24
-            |
-          2 |         lock-version = "2.0"
-            |                        ^^^^^
-          unsupported lock version (`2.0`, but only major version 1 is supported)
+      cause: TOML parse error at line 2, column 24
+               |
+             2 |         lock-version = "2.0"
+               |                        ^^^^^
+             unsupported lock version (`2.0`, but only major version 1 is supported)
     "#
     );
 
@@ -14196,7 +14196,7 @@ fn reserved_script_name() -> Result<()> {
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     error: Failed to install: project-0.1.0-py3-none-any.whl (project==0.1.0 (from file://[TEMP_DIR]/))
-      └── Scripts must not use the reserved name `python`, got: `python`
+      cause: Scripts must not use the reserved name `python`, got: `python`
     "
     );
 
@@ -14479,7 +14479,7 @@ fn reject_reserved_wheel_data_script_name() -> Result<()> {
         Resolved 1 package in [TIME]
         Prepared 1 package in [TIME]
         error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-          └── Scripts must not use the reserved name `python`, got: `python`
+          cause: Scripts must not use the reserved name `python`, got: `python`
             ");
 
             Command::new(venv_bin_path(&context.venv).join(interpreter))
@@ -14561,7 +14561,7 @@ fn reject_wheel_entrypoint_paths() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── The wheel is invalid: Script path must resolve to a file within the scripts directory: `[TEMP_DIR]/escaped-entrypoint`
+      cause: The wheel is invalid: Script path must resolve to a file within the scripts directory: `[TEMP_DIR]/escaped-entrypoint`
     "
     );
 
@@ -14582,7 +14582,7 @@ fn reject_normalized_reserved_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `python`, got: `nested/../python`
+      cause: Scripts must not use the reserved name `python`, got: `nested/../python`
     "
     );
 
@@ -14600,7 +14600,7 @@ fn reject_case_variant_reserved_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `python`, got: `Python`
+      cause: Scripts must not use the reserved name `python`, got: `Python`
     ");
 
     let context = uv_test::test_context!("3.12");
@@ -14612,7 +14612,7 @@ fn reject_case_variant_reserved_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `python`, got: `Python.PY`
+      cause: Scripts must not use the reserved name `python`, got: `Python.PY`
     ");
 
     let context = uv_test::test_context!("3.12");
@@ -14624,7 +14624,7 @@ fn reject_case_variant_reserved_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `python`, got: `python.Py`
+      cause: Scripts must not use the reserved name `python`, got: `python.Py`
     ");
 
     Ok(())
@@ -14642,7 +14642,7 @@ fn reject_normalized_reserved_gui_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `python`, got: `nested/../python`
+      cause: Scripts must not use the reserved name `python`, got: `nested/../python`
     "
     );
 
@@ -14661,7 +14661,7 @@ fn reject_free_threaded_python_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `python3.13t`, got: `python3.13t`
+      cause: Scripts must not use the reserved name `python3.13t`, got: `python3.13t`
     "
     );
 
@@ -14680,7 +14680,7 @@ fn reject_windowed_free_threaded_python_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `pythonw3.13t`, got: `pythonw3.13t`
+      cause: Scripts must not use the reserved name `pythonw3.13t`, got: `pythonw3.13t`
     "
     );
 
@@ -14698,7 +14698,7 @@ fn reject_windows_rewritten_python_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `python`, got: `python.py`
+      cause: Scripts must not use the reserved name `python`, got: `python.py`
     "
     );
 
@@ -14717,7 +14717,7 @@ fn reject_windows_rewritten_free_threaded_python_wheel_entrypoint_name() -> Resu
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `pythonw3.13t`, got: `pythonw3.13t.py`
+      cause: Scripts must not use the reserved name `pythonw3.13t`, got: `pythonw3.13t.py`
     "
     );
 
@@ -14735,7 +14735,7 @@ fn reject_pypy_major_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `pypy3`, got: `pypy3`
+      cause: Scripts must not use the reserved name `pypy3`, got: `pypy3`
     "
     );
 
@@ -14753,7 +14753,7 @@ fn reject_windows_rewritten_pypy_wheel_entrypoint_name() -> Result<()> {
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      └── Scripts must not use the reserved name `pypy`, got: `pypy.py`
+      cause: Scripts must not use the reserved name `pypy`, got: `pypy.py`
     "
     );
 
@@ -15216,8 +15216,8 @@ fn reject_invalid_archive_member_names() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `cbwheeldiff2==0.0.1`
-      ├── Failed to extract archive: cbwheeldiff2-0.0.1-py2.py3-none-any.whl
-      └── Archive contains unacceptable filename: cbwheeldiff2-0.0.1.dist-info/RECORD�
+      cause: Failed to extract archive: cbwheeldiff2-0.0.1-py2.py3-none-any.whl
+      cause: Archive contains unacceptable filename: cbwheeldiff2-0.0.1.dist-info/RECORD�
     "
     );
 }
@@ -15232,8 +15232,8 @@ fn reject_invalid_streaming_zip() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `cbwheelstreamtest==0.0.1`
-      ├── Failed to extract archive: cbwheelstreamtest-0.0.1-py2.py3-none-any.whl
-      └── ZIP file contains multiple entries with different contents for: cbwheelstreamtest/__init__.py
+      cause: Failed to extract archive: cbwheelstreamtest-0.0.1-py2.py3-none-any.whl
+      cause: ZIP file contains multiple entries with different contents for: cbwheelstreamtest/__init__.py
     "
     );
 
@@ -15245,8 +15245,8 @@ fn reject_invalid_streaming_zip() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `cbwheelstreamtest==0.0.1`
-      ├── Failed to extract archive: cbwheelstreamtest-0.0.1-py2.py3-none-any.whl
-      └── ZIP file contains multiple entries for the same output path: cbwheelstreamtest/__init__.py
+      cause: Failed to extract archive: cbwheelstreamtest-0.0.1-py2.py3-none-any.whl
+      cause: ZIP file contains multiple entries for the same output path: cbwheelstreamtest/__init__.py
     "
     );
 }
@@ -15261,8 +15261,8 @@ fn reject_invalid_double_zip() {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to download `cbwheelziptest==0.0.2`
-      ├── Failed to extract archive: cbwheelziptest-0.0.2-py2.py3-none-any.whl
-      └── ZIP file contains trailing contents after the end-of-central-directory record
+      cause: Failed to extract archive: cbwheelziptest-0.0.2-py2.py3-none-any.whl
+      cause: ZIP file contains trailing contents after the end-of-central-directory record
     "
     );
 }
@@ -15277,9 +15277,9 @@ fn reject_invalid_central_directory_offset() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `attrs @ https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/zip1/attrs-25.3.0-py3-none-any.whl`
-      ├── Failed to extract archive: attrs-25.3.0-py3-none-any.whl
-      ├── Invalid zip file structure
-      └── the central directory size (0x8d3) did not match the observed byte span (0x911)
+      cause: Failed to extract archive: attrs-25.3.0-py3-none-any.whl
+      cause: Invalid zip file structure
+      cause: the central directory size (0x8d3) did not match the observed byte span (0x911)
     "
     );
 }
@@ -15294,8 +15294,8 @@ fn reject_invalid_crc32_mismatch() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `attrs @ https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/zip2/attrs-25.3.0-py3-none-any.whl`
-      ├── Failed to extract archive: attrs-25.3.0-py3-none-any.whl
-      └── Bad uncompressed size (got 0000001b, expected 0000000c) for file: sitecustomize.py
+      cause: Failed to extract archive: attrs-25.3.0-py3-none-any.whl
+      cause: Bad uncompressed size (got 0000001b, expected 0000000c) for file: sitecustomize.py
     "
     );
 }
@@ -15310,8 +15310,8 @@ fn reject_invalid_crc32_non_data_descriptor() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `attrs @ https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/zip3/attrs-25.3.0-py3-none-any.whl`
-      ├── Failed to extract archive: attrs-25.3.0-py3-none-any.whl
-      └── Bad uncompressed size (got 0000001b, expected 0000000c) for file: sitecustomize.py
+      cause: Failed to extract archive: attrs-25.3.0-py3-none-any.whl
+      cause: Bad uncompressed size (got 0000001b, expected 0000000c) for file: sitecustomize.py
     "
     );
 }
@@ -15325,8 +15325,8 @@ fn reject_invalid_duplicate_extra_field() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `attrs @ https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/zip4/attrs-25.3.0-py3-none-any.whl`
-      ├── Failed to unzip wheel: attrs-25.3.0-py3-none-any.whl
-      └── an extra field with id 0x7075 was duplicated in the header
+      cause: Failed to unzip wheel: attrs-25.3.0-py3-none-any.whl
+      cause: an extra field with id 0x7075 was duplicated in the header
     "
     );
 }
@@ -15341,8 +15341,8 @@ fn reject_invalid_short_usize() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to download `attrs @ https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/zip5/attrs-25.3.0-py3-none-any.whl`
-      ├── Failed to extract archive: attrs-25.3.0-py3-none-any.whl
-      └── Bad CRC (got 5100f20e, expected de0ffd6e) for file: attr/_make.py
+      cause: Failed to extract archive: attrs-25.3.0-py3-none-any.whl
+      cause: Bad CRC (got 5100f20e, expected de0ffd6e) for file: attr/_make.py
     "
     );
 }
@@ -15356,8 +15356,8 @@ fn reject_invalid_chained_extra_field() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `attrs @ https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/zip6/attrs-25.3.0-py3-none-any.whl`
-      ├── Failed to unzip wheel: attrs-25.3.0-py3-none-any.whl
-      └── an extra field with id 0x7075 was duplicated in the header
+      cause: Failed to unzip wheel: attrs-25.3.0-py3-none-any.whl
+      cause: an extra field with id 0x7075 was duplicated in the header
     "
     );
 }
@@ -15371,8 +15371,8 @@ fn reject_invalid_short_usize_zip64() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `attrs @ https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/zip7/attrs-25.3.0-py3-none-any.whl`
-      ├── Failed to unzip wheel: attrs-25.3.0-py3-none-any.whl
-      └── zip64 extended information field was too long: expected 16 bytes, but 0 bytes were provided
+      cause: Failed to unzip wheel: attrs-25.3.0-py3-none-any.whl
+      cause: zip64 extended information field was too long: expected 16 bytes, but 0 bytes were provided
     "
     );
 }
@@ -15543,11 +15543,11 @@ fn pip_install_build_dependencies_respect_locked_versions() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Expected `a` version 0.1 but got 0.3.0
+             [stderr]
+             Expected `a` version 0.1 but got 0.3.0
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -15603,11 +15603,11 @@ fn pip_install_build_dependencies_respect_locked_versions() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Expected `a` version 0.2 but got 0.1.0
+             [stderr]
+             Expected `a` version 0.2 but got 0.1.0
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -16365,7 +16365,7 @@ fn build_backend_wrong_wheel_platform() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to build `py313 @ file://[TEMP_DIR]/child`
-      └── The built wheel `py313-0.1.0-py313-none-any.whl` is not compatible with the target Python 3.12 on [ARCH] [OS]. Consider using `--no-build` to disable building wheels.
+      cause: The built wheel `py313-0.1.0-py313-none-any.whl` is not compatible with the target Python 3.12 on [ARCH] [OS]. Consider using `--no-build` to disable building wheels.
     ");
 
     // A python 3.12 host with a 3.13 explicit target works.
@@ -16398,7 +16398,7 @@ fn build_backend_wrong_wheel_platform() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to build `py313 @ file://[TEMP_DIR]/child`
-      └── The built wheel `py313-0.1.0-py313-none-any.whl` is not compatible with the target Python 3.12 on [ARCH] [OS]. Consider using `--no-build` to disable building wheels.
+      cause: The built wheel `py313-0.1.0-py313-none-any.whl` is not compatible with the target Python 3.12 on [ARCH] [OS]. Consider using `--no-build` to disable building wheels.
     ");
 
     // Create a project that will resolve to a non-latest version of `anyio`
@@ -16453,9 +16453,9 @@ fn build_backend_wrong_wheel_platform() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to build `parent @ file://[TEMP_DIR]/`
-      ├── Failed to install requirements from `build-system.requires`
-      ├── Failed to build `py313 @ file://[TEMP_DIR]/child`
-      └── The built wheel `py313-0.1.0-py313-none-any.whl` is not compatible with the current Python 3.12 on [ARCH] [OS]
+      cause: Failed to install requirements from `build-system.requires`
+      cause: Failed to build `py313 @ file://[TEMP_DIR]/child`
+      cause: The built wheel `py313-0.1.0-py313-none-any.whl` is not compatible with the current Python 3.12 on [ARCH] [OS]
     ");
 
     Ok(())
@@ -16662,7 +16662,7 @@ fn abi_compatibility_on_freethreaded_python() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to determine installation plan
-      └── A path ([WORKSPACE]/test/links/abi3_package-1.0.0-cp37-abi3-manylinux_2_17_x86_64.whl) dependency is incompatible with the current platform
+      cause: A path ([WORKSPACE]/test/links/abi3_package-1.0.0-cp37-abi3-manylinux_2_17_x86_64.whl) dependency is incompatible with the current platform
 
     hint: You're using free-threaded CPython 3.14 (`cp314t`), but the wheel was built for the stable ABI (`abi3`), which requires a GIL-enabled interpreter
     ");
@@ -16679,7 +16679,7 @@ fn abi_compatibility_on_freethreaded_python() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to determine installation plan
-      └── A path ([WORKSPACE]/test/links/cpython_package-1.0.0-cp314-cp314-manylinux_2_17_x86_64.whl) dependency is incompatible with the current platform
+      cause: A path ([WORKSPACE]/test/links/cpython_package-1.0.0-cp314-cp314-manylinux_2_17_x86_64.whl) dependency is incompatible with the current platform
 
     hint: You're using free-threaded CPython 3.14 (`cp314t`), but the wheel was built for the CPython 3.14 ABI (`cp314`), which requires a GIL-enabled interpreter
     ");
@@ -16818,7 +16818,7 @@ fn abi_compatibility_on_nondebug_python_with_debug_wheel() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to determine installation plan
-      └── A path (cpython_debug_package/dist/cpython_debug_package-1.0.0-cp314-cp314d-manylinux_2_17_x86_64.whl) dependency is incompatible with the current platform
+      cause: A path (cpython_debug_package/dist/cpython_debug_package-1.0.0-cp314-cp314d-manylinux_2_17_x86_64.whl) dependency is incompatible with the current platform
 
     hint: The wheel is compatible with CPython 3.14 (`cp314d`), but you're using CPython 3.14 (`cp314`)
     ");
@@ -16837,8 +16837,8 @@ fn fail_on_bz2_wheel() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `futzed-bz2 @ http://[LOCALHOST]/futzed_bz2-0.1.0-py3-none-any.whl`
-      ├── Failed to read metadata: `http://[LOCALHOST]/futzed_bz2-0.1.0-py3-none-any.whl`
-      └── Archive contains a file with an unsupported compression method; files must be compressed with 'stored', 'DEFLATE', or 'zstd'
+      cause: Failed to read metadata: `http://[LOCALHOST]/futzed_bz2-0.1.0-py3-none-any.whl`
+      cause: Archive contains a file with an unsupported compression method; files must be compressed with 'stored', 'DEFLATE', or 'zstd'
     "
     );
 }
@@ -16856,8 +16856,8 @@ fn fail_on_lzma_wheel() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `futzed-lzma @ http://[LOCALHOST]/futzed_lzma-0.1.0-py3-none-any.whl`
-      ├── Failed to read metadata: `http://[LOCALHOST]/futzed_lzma-0.1.0-py3-none-any.whl`
-      └── Archive contains a file with an unsupported compression method; files must be compressed with 'stored', 'DEFLATE', or 'zstd'
+      cause: Failed to read metadata: `http://[LOCALHOST]/futzed_lzma-0.1.0-py3-none-any.whl`
+      cause: Archive contains a file with an unsupported compression method; files must be compressed with 'stored', 'DEFLATE', or 'zstd'
     "
     );
 }

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -1783,13 +1783,13 @@ fn check_locked_tool_rejects_invalid_hash() -> Result<()> {
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     error: Failed to download `ty==0.0.17`
-      └── Hash mismatch for `ty==0.0.17`
+      cause: Hash mismatch for `ty==0.0.17`
 
-          Expected:
-            sha256:[HASH]
+             Expected:
+               sha256:[HASH]
 
-          Computed:
-            sha256:[HASH]
+             Computed:
+               sha256:[HASH]
     "
     );
 
@@ -2630,11 +2630,11 @@ fn check_no_sync_errors_on_invalid_lockfile() -> Result<()> {
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     error: Failed to parse `uv.lock`
-      └── TOML parse error at line 1, column 8
-            |
-          1 | invalid
-            |        ^
-          key with no value, expected `=`
+      cause: TOML parse error at line 1, column 8
+               |
+             1 | invalid
+               |        ^
+             key with no value, expected `=`
     "
     );
 
@@ -2674,11 +2674,11 @@ fn check_script_no_sync_errors_on_invalid_lockfile() -> Result<()> {
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     error: Failed to parse `uv.lock`
-      └── TOML parse error at line 1, column 8
-            |
-          1 | invalid
-            |        ^
-          key with no value, expected `=`
+      cause: TOML parse error at line 1, column 8
+               |
+             1 | invalid
+               |        ^
+             key with no value, expected `=`
     "
     );
 
@@ -2715,7 +2715,7 @@ fn check_ty_version_no_match() {
     ----- stderr -----
     warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
     error: Failed to find ty version matching: >=999.0.0
-      └── No version of ty found matching `>=999.0.0` for platform `[PLATFORM]`
+      cause: No version of ty found matching `>=999.0.0` for platform `[PLATFORM]`
     "
     );
 }

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -4572,8 +4572,8 @@ fn add_error() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because there are no versions of xyz and your project depends on xyz, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because there are no versions of xyz and your project depends on xyz, we can conclude that your project's requirements are unsatisfiable.
 
     hint: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing
     ");
@@ -4606,8 +4606,8 @@ fn add_standard_library_error() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because pickle was not found in the package registry and your project depends on pickle, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because pickle was not found in the package registry and your project depends on pickle, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The module `pickle` is included in the Python standard library and usually should not be added as a dependency
 
@@ -4635,8 +4635,8 @@ fn add_standard_library_unrelated_resolution_error() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because there are no versions of xyz and your project depends on xyz, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because there are no versions of xyz and your project depends on xyz, we can conclude that your project's requirements are unsatisfiable.
 
     hint: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing
     ");
@@ -8529,22 +8529,22 @@ fn fail_to_add_revert_project() -> Result<()> {
     ----- stderr -----
     Resolved 3 packages in [TIME]
     error: Failed to add dependencies
-      ├── Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
+      cause: Failed to build `child @ file://[TEMP_DIR]/child`
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 1, in <module>
-          ZeroDivisionError: division by zero
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 1, in <module>
+             ZeroDivisionError: division by zero
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -8629,22 +8629,22 @@ fn fail_to_edit_revert_project() -> Result<()> {
     ----- stderr -----
     Resolved 3 packages in [TIME]
     error: Failed to add dependencies
-      ├── Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
+      cause: Failed to build `child @ file://[TEMP_DIR]/child`
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 1, in <module>
-          ZeroDivisionError: division by zero
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 1, in <module>
+             ZeroDivisionError: division by zero
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -8740,25 +8740,25 @@ fn fail_to_add_revert_workspace_root() -> Result<()> {
     Added `broken` to workspace members
     Resolved 3 packages in [TIME]
     error: Failed to add dependencies
-      ├── Failed to build `broken @ file://[TEMP_DIR]/broken`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.build_editable` failed (exit status: 1)
+      cause: Failed to build `broken @ file://[TEMP_DIR]/broken`
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.build_editable` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 448, in get_requires_for_build_editable
-              return self.get_requires_for_build_wheel(config_settings)
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 1, in <module>
-          ZeroDivisionError: division by zero
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 448, in get_requires_for_build_editable
+                 return self.get_requires_for_build_wheel(config_settings)
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 1, in <module>
+             ZeroDivisionError: division by zero
 
     hint: `broken` was included because `parent` (v0.1.0) depends on `broken`
 
@@ -8856,25 +8856,25 @@ fn fail_to_add_revert_workspace_member() -> Result<()> {
     Added `broken` to workspace members
     Resolved 4 packages in [TIME]
     error: Failed to add dependencies
-      ├── Failed to build `broken @ file://[TEMP_DIR]/broken`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.build_editable` failed (exit status: 1)
+      cause: Failed to build `broken @ file://[TEMP_DIR]/broken`
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.build_editable` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 448, in get_requires_for_build_editable
-              return self.get_requires_for_build_wheel(config_settings)
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 1, in <module>
-          ZeroDivisionError: division by zero
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 448, in get_requires_for_build_editable
+                 return self.get_requires_for_build_wheel(config_settings)
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 1, in <module>
+             ZeroDivisionError: division by zero
 
     hint: `broken` was included because `child` (v0.1.0) depends on `broken`
 
@@ -9554,8 +9554,8 @@ fn add_shadowed_name() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because dagster-webserver>=1.6.13 depends on your project and your project depends on dagster-webserver==1.6.13, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because dagster-webserver>=1.6.13 depends on your project and your project depends on dagster-webserver==1.6.13, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The package `dagster-webserver` depends on the package `dagster` but the name is shadowed by your project. Consider changing the name of the project.
 
@@ -9567,9 +9567,9 @@ fn add_shadowed_name() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because dagster-webserver==1.6.11 depends on your project and dagster-webserver==1.6.12 depends on your project, we can conclude that dagster-webserver>=1.6.11,<=1.6.12 depends on your project.
-          And because dagster-webserver>=1.6.13 depends on your project and your project depends on dagster-webserver>=1.6.11, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because dagster-webserver==1.6.11 depends on your project and dagster-webserver==1.6.12 depends on your project, we can conclude that dagster-webserver>=1.6.11,<=1.6.12 depends on your project.
+             And because dagster-webserver>=1.6.13 depends on your project and your project depends on dagster-webserver>=1.6.11, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The package `dagster-webserver` depends on the package `dagster` but the name is shadowed by your project. Consider changing the name of the project.
 
@@ -9663,8 +9663,8 @@ fn add_warn_index_url() -> Result<()> {
     ----- stderr -----
     warning: Indexes specified via `--extra-index-url` will not be persisted to the `pyproject.toml` file; use `--index` instead.
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because only idna==2.7 is available and your project depends on idna>=3.6, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because only idna==2.7 is available and your project depends on idna>=3.6, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `idna` was found on https://test.pypi.org/simple, but not at the requested version (idna>=3.6). A compatible version may be available on a subsequent index (e.g., https://pypi.org/simple). By default, uv will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `--index-strategy unsafe-best-match` to consider all versions from all indexes, regardless of the order in which they were defined.
 
@@ -13151,10 +13151,10 @@ fn add_with_build_constraints() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to download and build `requests==1.2.0`
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
 
     hint: `requests` (v1.2.0) was included because `project` (v0.1.0) depends on `requests==1.2`
 
@@ -13196,9 +13196,9 @@ fn add_unsupported_git_scheme() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `git+fantasy://ferris/dreams/of/urls@7701ffcbae245819b828dc5f885a5201158897ef`
-      └── Unsupported Git URL scheme `fantasy:` in `fantasy://ferris/dreams/of/urls` (expected one of `https:`, `ssh:`, or `file:`)
-          git+fantasy://ferris/dreams/of/urls@7701ffcbae245819b828dc5f885a5201158897ef
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      cause: Unsupported Git URL scheme `fantasy:` in `fantasy://ferris/dreams/of/urls` (expected one of `https:`, `ssh:`, or `file:`)
+             git+fantasy://ferris/dreams/of/urls@7701ffcbae245819b828dc5f885a5201158897ef
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ");
 }
 
@@ -13308,8 +13308,8 @@ async fn add_full_url_in_keyring() -> Result<()> {
     Keyring request for public@[LOCALHOST]
     Keyring request for public@http://[LOCALHOST]
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 
@@ -13345,8 +13345,8 @@ async fn add_stop_index_search_early_on_auth_failure() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 
@@ -13429,8 +13429,8 @@ async fn add_empty_ignore_error_codes() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index (http://[LOCALHOST]/) returned a 403 Forbidden error. Check that the index URL is correct and the credentials are valid.
 
@@ -13507,8 +13507,8 @@ async fn lock_forbidden_index_with_available_package() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because idna was not found in the package registry and all versions of anyio depend on idna>=2.8, we can conclude that all versions of anyio cannot be used.
-          And because your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because idna was not found in the package registry and all versions of anyio depend on idna>=2.8, we can conclude that all versions of anyio cannot be used.
+             And because your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index (http://[LOCALHOST]/) returned a 403 Forbidden error, but uv received a successful response from another request to the index. If the failing package is not present on this index, consider adding `ignore-error-codes = [403]` to the index's `[[tool.uv.index]]` entry to continue searching across indexes.
     ");
@@ -13542,8 +13542,8 @@ fn add_missing_package_on_pytorch() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because fakepkg was not found in the package registry and your project depends on fakepkg, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because fakepkg was not found in the package registry and your project depends on fakepkg, we can conclude that your project's requirements are unsatisfiable.
 
     hint: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing
     "
@@ -13579,8 +13579,8 @@ async fn add_unexpected_error_code() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Request failed after 1 retry in [TIME]
-      ├── Failed to fetch: `http://[LOCALHOST]/anyio/`
-      └── HTTP status server error (503 Service Unavailable) for url (http://[LOCALHOST]/anyio/)
+      cause: Failed to fetch: `http://[LOCALHOST]/anyio/`
+      cause: HTTP status server error (503 Service Unavailable) for url (http://[LOCALHOST]/anyio/)
     "
     );
     Ok(())
@@ -13620,11 +13620,11 @@ async fn add_invalid_ignore_error_code() -> Result<()> {
       1234 is not a valid HTTP status code
 
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 9, column 22
-            |
-          9 | ignore-error-codes = [401, 403, 1234]
-            |                      ^^^^^^^^^^^^^^^^
-          1234 is not a valid HTTP status code
+      cause: TOML parse error at line 9, column 22
+               |
+             9 | ignore-error-codes = [401, 403, 1234]
+               |                      ^^^^^^^^^^^^^^^^
+             1234 is not a valid HTTP status code
     "
     );
 
@@ -13651,13 +13651,13 @@ fn add_invalid_requires_python() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 4, column 19
-            |
-          4 | requires-python = "3.12"
-            |                   ^^^^^^
-          Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
-          3.12
-          ^^^^
+      cause: TOML parse error at line 4, column 19
+               |
+             4 | requires-python = "3.12"
+               |                   ^^^^^^
+             Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
+             3.12
+             ^^^^
     "#);
 
     Ok(())
@@ -13731,7 +13731,7 @@ fn add_auth_policy_always_without_credentials() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to fetch: `https://pypi.org/simple/anyio/`
-      └── Missing credentials for https://pypi.org/simple/anyio/
+      cause: Missing credentials for https://pypi.org/simple/anyio/
     "
     );
 
@@ -13739,7 +13739,7 @@ fn add_auth_policy_always_without_credentials() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to fetch: `https://pypi.org/simple/black/`
-      └── Missing credentials for https://pypi.org/simple/black/
+      cause: Missing credentials for https://pypi.org/simple/black/
     "
     );
     Ok(())
@@ -13771,7 +13771,7 @@ fn add_auth_policy_always_with_username_no_password() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to fetch: `https://pypi.org/simple/anyio/`
-      └── Incomplete credentials for https://pypi.org/simple/anyio/
+      cause: Incomplete credentials for https://pypi.org/simple/anyio/
     "
     );
     Ok(())
@@ -13806,7 +13806,7 @@ async fn add_auth_policy_never_with_url_credentials() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl`
-      └── HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl)
+      cause: HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl)
     "
     );
 
@@ -13843,9 +13843,9 @@ async fn add_auth_policy_never_with_url_credentials_ignored() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio==4.3.0 could not be fetched from the network (`401 Unauthorized`) and only anyio==4.3.0 is available, we can conclude that all versions of anyio cannot be used.
-          And because your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio==4.3.0 could not be fetched from the network (`401 Unauthorized`) and only anyio==4.3.0 is available, we can conclude that all versions of anyio cannot be used.
+             And because your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: Metadata for `anyio` (v4.3.0) could not be fetched; the server returned: `401 Unauthorized`
 
@@ -13887,8 +13887,8 @@ async fn add_auth_policy_never_with_env_var_credentials() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 
@@ -13974,8 +13974,8 @@ async fn add_redirect_cross_origin() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 
@@ -14091,8 +14091,8 @@ async fn add_redirect_with_keyring_cross_origin() -> Result<()> {
     Keyring request for public@[LOCALHOST]
     Keyring request for public@http://[LOCALHOST]
     error: Failed to add dependencies
-      ├── No solution found when resolving dependencies
-      └── Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
 

--- a/crates/uv/tests/project/export.rs
+++ b/crates/uv/tests/project/export.rs
@@ -1290,8 +1290,8 @@ fn requirements_txt_frozen() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `child`
-      └── `child` references a workspace in `tool.uv.sources` (e.g., `child = { workspace = true }`), but is not a workspace member
+      cause: Failed to parse entry: `child`
+      cause: `child` references a workspace in `tool.uv.sources` (e.g., `child = { workspace = true }`), but is not a workspace member
     ");
 
     uv_snapshot!(context.filters(), context.export().arg("--all-packages").arg("--frozen"), @r"
@@ -1659,17 +1659,17 @@ fn requirements_txt_ssh_git_username() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `uv-private-pypackage @ git+ssh://git@github.com/astral-test/uv-private-pypackage.git@d780faf0ac91257d4d5a4f0c5a0e4509608c0071`
-      ├── Git operation failed
-      ├── failed to clone into: [PATH]
-      ├── failed to fetch commit `d780faf0ac91257d4d5a4f0c5a0e4509608c0071`
-      └── process didn't exit successfully: [GIT_COMMAND_ERROR]
-          --- stderr
-          Load key "[TEMP_DIR]/fake_deploy_key": [ERROR]
-          git@github.com: Permission denied (publickey).
-          fatal: Could not read from remote repository.
+      cause: Git operation failed
+      cause: failed to clone into: [PATH]
+      cause: failed to fetch commit `d780faf0ac91257d4d5a4f0c5a0e4509608c0071`
+      cause: process didn't exit successfully: [GIT_COMMAND_ERROR]
+             --- stderr
+             Load key "[TEMP_DIR]/fake_deploy_key": [ERROR]
+             git@github.com: Permission denied (publickey).
+             fatal: Could not read from remote repository.
 
-          Please make sure you have the correct access rights
-          and the repository exists.
+             Please make sure you have the correct access rights
+             and the repository exists.
     "#);
 
     let ssh_deploy_key = context.temp_dir.child("uv_test_key");
@@ -6951,8 +6951,8 @@ fn cyclonedx_export_workspace_frozen() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `project @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `child`
-      └── `child` references a workspace in `tool.uv.sources` (e.g., `child = { workspace = true }`), but is not a workspace member
+      cause: Failed to parse entry: `child`
+      cause: `child` references a workspace in `tool.uv.sources` (e.g., `child = { workspace = true }`), but is not a workspace member
     ");
 
     uv_snapshot!(context.filters(), context.export().arg("--format").arg("cyclonedx1.5").arg("--all-packages").arg("--frozen").arg("--no-hashes"), @r#"

--- a/crates/uv/tests/project/format.rs
+++ b/crates/uv/tests/project/format.rs
@@ -355,11 +355,11 @@ fn format_fails_malformed_pyproject() -> Result<()> {
 
     warning: `uv format` is experimental and may change without warning. Pass `--preview-features format-command` to disable this warning.
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 1, column 11
-            |
-          1 | malformed pyproject.toml
-            |           ^
-          key with no value, expected `=`
+      cause: TOML parse error at line 1, column 11
+               |
+             1 | malformed pyproject.toml
+               |           ^
+             key with no value, expected `=`
     ");
 
     // Check that the file is not formatted
@@ -687,7 +687,7 @@ fn format_no_matching_version() -> Result<()> {
     ----- stderr -----
     warning: `uv format` is experimental and may change without warning. Pass `--preview-features format-command` to disable this warning.
     error: Failed to find ruff version matching: >=999.0.0
-      └── No version of ruff found matching `>=999.0.0` for platform `[PLATFORM]`
+      cause: No version of ruff found matching `>=999.0.0` for platform `[PLATFORM]`
     ");
 
     Ok(())

--- a/crates/uv/tests/project/init.rs
+++ b/crates/uv/tests/project/init.rs
@@ -2750,7 +2750,7 @@ fn init_failure() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to discover parent workspace; use `uv init --no-workspace` to ignore
-      └── No `project` table found in: [TEMP_DIR]/pyproject.toml
+      cause: No `project` table found in: [TEMP_DIR]/pyproject.toml
     ");
 
     uv_snapshot!(context.filters(), context.init().arg("foo").arg("--no-workspace"), @"

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -434,7 +434,7 @@ fn run_pep723_script() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving script dependencies
-      └── Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
+      cause: Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
     ");
 
     // If the script can't be resolved, we should reference the script.
@@ -453,7 +453,7 @@ fn run_pep723_script() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving script dependencies
-      └── Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
+      cause: Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
     ");
 
     // If the script contains an unclosed PEP 723 tag, we should error.
@@ -1054,9 +1054,9 @@ fn run_pep723_script_build_constraints() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Compatible build constraints.
@@ -1493,7 +1493,7 @@ fn run_with() -> Result<()> {
     Resolved 2 packages in [TIME]
     Checked 2 packages in [TIME]
     error: No solution found when resolving `--with` dependencies
-      └── Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
+      cause: Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -1983,9 +1983,9 @@ fn run_with_build_constraints() -> Result<()> {
      + sniffio==1.3.1
      + typing-extensions==4.10.0
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Change the build constraint to be compatible with `requests==1.2`.
@@ -2287,7 +2287,7 @@ fn run_with_editable() -> Result<()> {
     Resolved 3 packages in [TIME]
     Checked 3 packages in [TIME]
     error: Failed to resolve `--with` requirement
-      └── Distribution not found at: file://[TEMP_DIR]/foo
+      cause: Distribution not found at: file://[TEMP_DIR]/foo
     ");
 
     Ok(())
@@ -3285,7 +3285,7 @@ fn run_from_directory() -> Result<()> {
     Installed 1 package in [TIME]
      + foo==1.0.0 (from file://[TEMP_DIR]/project)
     error: Failed to spawn: `./project/main.py`
-      └── [OS ERROR 2]
+      cause: [OS ERROR 2]
     ");
 
     // Even if we write a `.python-version` file in the current directory, we should prefer the
@@ -4080,11 +4080,11 @@ fn run_invalid_project_table() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 1, column 2
-            |
-          1 | [project.urls]
-            |  ^^^^^^^
-          `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+      cause: TOML parse error at line 1, column 2
+               |
+             1 | [project.urls]
+               |  ^^^^^^^
+             `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     ");
 
     Ok(())
@@ -4123,7 +4123,7 @@ fn run_script_without_build_system() -> Result<()> {
     Resolved 1 package in [TIME]
     Checked in [TIME]
     error: Failed to spawn: `entry`
-      └── No such file or directory (os error 2)
+      cause: No such file or directory (os error 2)
     ");
 
     Ok(())
@@ -4781,8 +4781,8 @@ fn run_remote_pep723_script_with_nonexistent_ssl_cert_file() {
     ----- stderr -----
     warning: Invalid `SSL_CERT_FILE`. Path does not exist: [TEMP_DIR]/missing.pem. No default certificates will be trusted.
     error: error sending request for url (https://raw.githubusercontent.com/astral-sh/uv/df45b9ac2584824309ff29a6a09421055ad730f6/scripts/uv-run-remote-script-test.py)
-      ├── client error (Connect)
-      └── invalid peer certificate: UnknownIssuer
+      cause: client error (Connect)
+      cause: invalid peer certificate: UnknownIssuer
     ");
 }
 
@@ -4829,10 +4829,10 @@ fn run_remote_pep723_requirements_fetch_error_does_not_leak_credentials() -> Res
     exit_code: 2 (failure)
     ----- stderr -----
     error: Request failed after 3 retries
-      ├── error sending request for url (http://[LOCALHOST]/requirements.py)
-      ├── client error (Connect)
-      ├── tcp connect error
-      └── [CONNECTION_REFUSED]
+      cause: error sending request for url (http://[LOCALHOST]/requirements.py)
+      cause: client error (Connect)
+      cause: tcp connect error
+      cause: [CONNECTION_REFUSED]
     ");
 
     Ok(())

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -4809,8 +4809,8 @@ fn run_remote_requirements_offline_redacts_credentials() -> Result<()> {
 #[test]
 fn run_remote_pep723_requirements_fetch_error_does_not_leak_credentials() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filter((
-        r"(?m)^  └── .*(Connection refused|No connection could be made).*$",
-        "  └── [CONNECTION_REFUSED]",
+        r"(?m)^  cause: .*(Connection refused|No connection could be made).*$",
+        "  cause: [CONNECTION_REFUSED]",
     ));
 
     let script = context.temp_dir.child("main.py");

--- a/crates/uv/tests/python/python_find.rs
+++ b/crates/uv/tests/python/python_find.rs
@@ -791,7 +791,7 @@ fn python_find_venv_invalid() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from active virtual environment at `.venv/[BIN]/[PYTHON]`
-      └── Python interpreter not found at `[VENV]/[BIN]/[PYTHON]`
+      cause: Python interpreter not found at `[VENV]/[BIN]/[PYTHON]`
     ");
 
     // Unless the virtual environment is not active
@@ -1075,8 +1075,8 @@ fn python_find_path() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from provided path at `bar`
-      ├── Failed to query Python interpreter at `[TEMP_DIR]/bar`
-      └── [PERMISSION DENIED]
+      cause: Failed to query Python interpreter at `[TEMP_DIR]/bar`
+      cause: [PERMISSION DENIED]
     ");
 
     // No interpreter at a file that does not exist

--- a/crates/uv/tests/python/python_install.rs
+++ b/crates/uv/tests/python/python_install.rs
@@ -358,7 +358,7 @@ fn python_install_force() {
     exit_code: 0 (success)
     ----- stderr -----
     warning: Failed to install executable for cpython-3.14.[LATEST]-[PLATFORM]
-      └── Executable already exists at `[BIN]/python3.14` but is not managed by uv; use `--force` to replace it
+      cause: Executable already exists at `[BIN]/python3.14` but is not managed by uv; use `--force` to replace it
     ");
 
     uv_snapshot!(context.filters(), context.python_install().arg("--force").arg("3.14"), @"
@@ -591,7 +591,7 @@ fn python_install_preview() {
     exit_code: 0 (success)
     ----- stderr -----
     warning: Failed to install executable for cpython-3.14.[LATEST]-[PLATFORM]
-      └── Executable already exists at `[BIN]/python3.14` but is not managed by uv; use `--force` to replace it
+      cause: Executable already exists at `[BIN]/python3.14` but is not managed by uv; use `--force` to replace it
     ");
 
     // With `--bin`, this should error instead of warn
@@ -599,13 +599,13 @@ fn python_install_preview() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to install executable for cpython-3.14.[LATEST]-[PLATFORM]
-      └── Executable already exists at `[BIN]/python3.14` but is not managed by uv; use `--force` to replace it
+      cause: Executable already exists at `[BIN]/python3.14` but is not managed by uv; use `--force` to replace it
     ");
     uv_snapshot!(context.filters(), context.python_install().arg("--preview").arg("3.14").env(EnvVars::UV_PYTHON_INSTALL_BIN, "1"), @"
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to install executable for cpython-3.14.[LATEST]-[PLATFORM]
-      └── Executable already exists at `[BIN]/python3.14` but is not managed by uv; use `--force` to replace it
+      cause: Executable already exists at `[BIN]/python3.14` but is not managed by uv; use `--force` to replace it
     ");
 
     // With `--no-bin`, this should be silent
@@ -763,7 +763,7 @@ fn python_install_multiple_unmanaged_executables() {
     exit_code: 0 (success)
     ----- stderr -----
     warning: Failed to install executable for cpython-3.13.[LATEST]-[PLATFORM]
-      └── Executables `python3.13`, `python3`, and `python` already exist in `[BIN]/` but are not managed by uv; use `--force` to replace them
+      cause: Executables `python3.13`, `python3`, and `python` already exist in `[BIN]/` but are not managed by uv; use `--force` to replace them
     ");
 
     // The unmanaged executables should be left untouched (still empty).
@@ -2468,7 +2468,7 @@ fn python_install_cached() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to install cpython-3.12.[LATEST]-[PLATFORM]
-      └── An offline Python installation was requested, but cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz) is missing in python-cache
+      cause: An offline Python installation was requested, but cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz) is missing in python-cache
     ");
 }
 
@@ -2558,8 +2558,8 @@ fn python_install_no_cache() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to install cpython-3.12.[LATEST]-[PLATFORM]
-      ├── Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[DATE]/cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz
-      └── Network connectivity is disabled, but the requested data wasn't found in the cache for: `https://github.com/astral-sh/python-build-standalone/releases/download/[DATE]/cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz`
+      cause: Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[DATE]/cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz
+      cause: Network connectivity is disabled, but the requested data wasn't found in the cache for: `https://github.com/astral-sh/python-build-standalone/releases/download/[DATE]/cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz`
     ");
 }
 
@@ -3169,7 +3169,7 @@ fn uninstall_last_patch() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from active virtual environment at `.venv/[BIN]/python`
-      └── Broken symlink at `.venv/[BIN]/python`, was the underlying Python interpreter removed?
+      cause: Broken symlink at `.venv/[BIN]/python`, was the underlying Python interpreter removed?
 
     hint: Consider recreating the environment (e.g., with `uv venv`)
     "
@@ -3180,7 +3180,7 @@ fn uninstall_last_patch() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from active virtual environment at `.venv/[BIN]/python`
-      └── Python interpreter not found at `[VENV]/[BIN]/python`
+      cause: Python interpreter not found at `[VENV]/[BIN]/python`
     "
     );
 }

--- a/crates/uv/tests/python/python_list.rs
+++ b/crates/uv/tests/python/python_list.rs
@@ -184,8 +184,8 @@ fn python_list_warns_on_non_native_search_path_interpreters() -> Result<()> {
 
     ----- stderr -----
     warning: Failed to inspect Python interpreter from first executable in the search path at `foreign-bin/python`
-     ├── Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
-     └── Bad CPU type in executable (os error 86)
+     cause: Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
+     cause: Bad CPU type in executable (os error 86)
     ");
 
     uv_snapshot!(context.filters(), context.python_list()
@@ -201,8 +201,8 @@ fn python_list_warns_on_non_native_search_path_interpreters() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     warning: Failed to inspect Python interpreter from provided path at `foreign-bin/python`
-     ├── Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
-     └── Bad CPU type in executable (os error 86)
+     cause: Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
+     cause: Bad CPU type in executable (os error 86)
     ");
 
     uv_snapshot!(context.filters(), context.python_find()
@@ -210,8 +210,8 @@ fn python_list_warns_on_non_native_search_path_interpreters() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from first executable in the search path at `foreign-bin/python`
-     ├── Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
-     └── Bad CPU type in executable (os error 86)
+     cause: Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
+     cause: Bad CPU type in executable (os error 86)
     ");
 
     uv_snapshot!(context.filters(), context.python_find()
@@ -219,8 +219,8 @@ fn python_list_warns_on_non_native_search_path_interpreters() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect Python interpreter from provided path at `foreign-bin/python`
-     ├── Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
-     └── Bad CPU type in executable (os error 86)
+     cause: Failed to query Python interpreter at `[TEMP_DIR]/foreign-bin/python`
+     cause: Bad CPU type in executable (os error 86)
     ");
 
     Ok(())

--- a/crates/uv/tests/python/python_list.rs
+++ b/crates/uv/tests/python/python_list.rs
@@ -119,10 +119,10 @@ fn python_list_warns_on_noncritical_explicit_path_errors() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     warning: Failed to inspect Python interpreter from provided path at `python`
-      └── Querying Python at `[TEMP_DIR]/python` failed with exit status exit status: 1
+      cause: Querying Python at `[TEMP_DIR]/python` failed with exit status exit status: 1
 
-          [stderr]
-          error: intentionally broken python executable
+             [stderr]
+             error: intentionally broken python executable
     ");
 
     let environment = context.temp_dir.join("environment");
@@ -137,10 +137,10 @@ fn python_list_warns_on_noncritical_explicit_path_errors() -> Result<()> {
     exit_code: 0 (success)
     ----- stderr -----
     warning: Failed to inspect Python interpreter from provided path at `environment`
-      └── Querying Python at `[TEMP_DIR]/environment/bin/python` failed with exit status exit status: 1
+      cause: Querying Python at `[TEMP_DIR]/environment/bin/python` failed with exit status exit status: 1
 
-          [stderr]
-          error: intentionally broken python executable
+             [stderr]
+             error: intentionally broken python executable
     ");
 
     Ok(())
@@ -638,8 +638,8 @@ async fn python_list_remote_python_downloads_json_url() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Error while fetching remote python downloads json from 'http://[LOCALHOST]/404'
-      ├── Failed to fetch: `http://[LOCALHOST]/404`
-      └── HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/404)
+      cause: Failed to fetch: `http://[LOCALHOST]/404`
+      cause: HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/404)
     ");
 
     // test invalid json
@@ -650,7 +650,7 @@ async fn python_list_remote_python_downloads_json_url() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Unable to parse the JSON Python download list at http://[LOCALHOST]/invalid
-      └── EOF while parsing an object at line 1 column 1
+      cause: EOF while parsing an object at line 1 column 1
     ");
 
     Ok(())

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -47,7 +47,7 @@ fn create_venv() {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── A virtual environment already exists at: .venv
+      cause: A virtual environment already exists at: .venv
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
     "
@@ -419,7 +419,7 @@ fn create_centralized_project_environment() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment `project-cp3.12.[X]-[HASH]`
     error: Failed to create virtual environment
-      └── A virtual environment already exists at: [CACHE_DIR]/environments-v2/project-cp3.12.[X]-[HASH]
+      cause: A virtual environment already exists at: [CACHE_DIR]/environments-v2/project-cp3.12.[X]-[HASH]
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
     "#);
@@ -1390,7 +1390,7 @@ fn file_exists() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── File exists at `.venv`
+      cause: File exists at `.venv`
     "
     );
 
@@ -1414,7 +1414,7 @@ fn non_utf8_path() {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv-�
     error: Failed to create virtual environment
-      └── Virtual environment path is not valid UTF-8: .venv-�
+      cause: Virtual environment path is not valid UTF-8: .venv-�
     "
     );
 
@@ -1462,7 +1462,7 @@ fn non_empty_dir_exists() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── A directory already exists at: .venv
+      cause: A directory already exists at: .venv
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing directory
     ");
@@ -1477,7 +1477,7 @@ fn non_empty_dir_exists() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── uv will not clear a directory that is not a virtual environment
+      cause: uv will not clear a directory that is not a virtual environment
 
     hint: Use the `--force` flag to remove the existing directory anyway
     "
@@ -1534,7 +1534,7 @@ fn non_empty_dir_exists_allow_existing() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── A directory already exists at: .venv
+      cause: A directory already exists at: .venv
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing directory
     "
@@ -1906,7 +1906,7 @@ fn path_with_trailing_space_gives_proper_error() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to initialize cache at `[CACHE_DIR]/ `
-      └── failed to open file `[CACHE_DIR]/ /CACHEDIR.TAG`: The system cannot find the path specified. (os error 3)
+      cause: failed to open file `[CACHE_DIR]/ /CACHEDIR.TAG`: The system cannot find the path specified. (os error 3)
     "###
     );
     // Note the extra trailing `/` in the snapshot is due to the filters, not the actual output.
@@ -2030,7 +2030,7 @@ fn venv_python_preference() {
     Using CPython 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── A virtual environment already exists at: .venv
+      cause: A virtual environment already exists at: .venv
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
     ");
@@ -2049,7 +2049,7 @@ fn venv_python_preference() {
     Using CPython 3.12.[X]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── A virtual environment already exists at: .venv
+      cause: A virtual environment already exists at: .venv
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
     ");
@@ -2291,7 +2291,7 @@ fn create_venv_current_working_directory() {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .
     error: Failed to create virtual environment
-      └── failed to remove directory `[VENV]/`: The process cannot access the file because it is being used by another process. (os error 32)
+      cause: failed to remove directory `[VENV]/`: The process cannot access the file because it is being used by another process. (os error 32)
     "
     );
 }
@@ -2324,7 +2324,7 @@ fn no_clear_with_existing_directory() {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── A virtual environment already exists at: .venv
+      cause: A virtual environment already exists at: .venv
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
     "
@@ -2372,7 +2372,7 @@ fn no_clear_overrides_clear() {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── A directory already exists at: .venv
+      cause: A directory already exists at: .venv
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing directory
     "
@@ -2399,7 +2399,7 @@ fn no_clear_overrides_clear_env_var() {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to create virtual environment
-      └── A directory already exists at: .venv
+      cause: A directory already exists at: .venv
 
     hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing directory
     "

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -2458,11 +2458,11 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 7, column 13
-            |
-          7 | conflicts = [
-            |             ^
-          Each set of conflicts must have at least two entries, but found only one
+      cause: TOML parse error at line 7, column 13
+               |
+             7 | conflicts = [
+               |             ^
+             Each set of conflicts must have at least two entries, but found only one
     "
     );
 
@@ -2482,11 +2482,11 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 7, column 13
-            |
-          7 | conflicts = [[]]
-            |             ^^^^
-          Each set of conflicts must have at least two entries, but found none
+      cause: TOML parse error at line 7, column 13
+               |
+             7 | conflicts = [[]]
+               |             ^^^^
+             Each set of conflicts must have at least two entries, but found none
     "
     );
 
@@ -2508,11 +2508,11 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 7, column 13
-            |
-          7 | conflicts = [
-            |             ^
-          Each set of conflicts must have at least two entries, but found only one
+      cause: TOML parse error at line 7, column 13
+               |
+             7 | conflicts = [
+               |             ^
+             Each set of conflicts must have at least two entries, but found only one
     "
     );
 
@@ -2698,11 +2698,11 @@ fn resolve_config_file() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `[CACHE_DIR]/uv.toml`
-      └── TOML parse error at line 1, column 2
-            |
-          1 | [project]
-            |  ^^^^^^^
-          unknown field `project`, expected one of `required-version`, `system-certs`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `preview-features`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `http-proxy`, `https-proxy`, `no-proxy`, `allow-insecure-host`, `resolution`, `prerelease`, `prerelease-package`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `no-sources-package`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `torch-backend`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `audit`, `pip`, `cache-keys`, `override-dependencies`, `exclude-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`
+      cause: TOML parse error at line 1, column 2
+               |
+             1 | [project]
+               |  ^^^^^^^
+             unknown field `project`, expected one of `required-version`, `system-certs`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `preview-features`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `http-proxy`, `https-proxy`, `no-proxy`, `allow-insecure-host`, `resolution`, `prerelease`, `prerelease-package`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `no-sources-package`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `torch-backend`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `audit`, `pip`, `cache-keys`, `override-dependencies`, `exclude-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`
     "
     );
 
@@ -2730,11 +2730,11 @@ fn resolve_config_file() -> anyhow::Result<()> {
     ----- stderr -----
     warning: The `--config-file` argument expects to receive a `uv.toml` file, not a `pyproject.toml`. If you're trying to run a command from another project, use the `--project` argument instead.
     error: Failed to parse: `[CACHE_DIR]/pyproject.toml`
-      └── TOML parse error at line 9, column 3
-            |
-          9 | ""
-            |   ^
-          key with no value, expected `=`
+      cause: TOML parse error at line 9, column 3
+               |
+             9 | ""
+               |   ^
+             key with no value, expected `=`
     "#
     );
 
@@ -4288,7 +4288,7 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      └── cannot specify both `preview` and `preview-features`
+      cause: cannot specify both `preview` and `preview-features`
     ");
 
     config.write_str(r#"preview-features = ["unknown-preview-feature"]"#)?;
@@ -4318,11 +4318,11 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      └── TOML parse error at line 1, column 20
-            |
-          1 | preview-features = ["  "]
-            |                    ^^^^^^
-          preview feature name cannot be empty
+      cause: TOML parse error at line 1, column 20
+               |
+             1 | preview-features = ["  "]
+               |                    ^^^^^^
+             preview feature name cannot be empty
     "#);
 
     config.write_str("preview-features = 123")?;
@@ -4332,11 +4332,11 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      └── TOML parse error at line 1, column 20
-            |
-          1 | preview-features = 123
-            |                    ^^^
-          invalid type: integer `123`, expected a boolean or a list of preview feature names
+      cause: TOML parse error at line 1, column 20
+               |
+             1 | preview-features = 123
+               |                    ^^^
+             invalid type: integer `123`, expected a boolean or a list of preview feature names
     ");
 
     Ok(())

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -1198,9 +1198,9 @@ fn group_requires_python_useful_defaults() -> Result<()> {
     Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
     Creating virtual environment at: .venv
     error: No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*')
-      └── Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
-          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
-          And because pharaohs-tomp:dev depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:dev, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
+             And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
+             And because pharaohs-tomp:dev depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:dev, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
@@ -1210,9 +1210,9 @@ fn group_requires_python_useful_defaults() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*')
-      └── Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
-          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
-          And because pharaohs-tomp:dev depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:dev, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
+             And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
+             And because pharaohs-tomp:dev depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:dev, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
@@ -1330,9 +1330,9 @@ fn group_requires_python_useful_non_defaults() -> Result<()> {
     Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
     Creating virtual environment at: .venv
     error: No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*')
-      └── Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
-          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
-          And because pharaohs-tomp:mygroup depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:mygroup, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
+             And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
+             And because pharaohs-tomp:mygroup depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:mygroup, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
@@ -1343,9 +1343,9 @@ fn group_requires_python_useful_non_defaults() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*')
-      └── Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
-          And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
-          And because pharaohs-tomp:mygroup depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:mygroup, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and sphinx==7.2.6 depends on Python>=3.9, we can conclude that sphinx==7.2.6 cannot be used.
+             And because only sphinx<=7.2.6 is available, we can conclude that sphinx>=7.2.6 cannot be used.
+             And because pharaohs-tomp:mygroup depends on sphinx>=7.2.6 and your project requires pharaohs-tomp:mygroup, we can conclude that your project's requirements are unsatisfiable.
 
     hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., sphinx==7.2.6 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
     ");
@@ -1974,13 +1974,13 @@ fn sync_build_isolation_package() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to build `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
-      ├── The build backend returned an error
-      └── Call to `hatchling.build.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `hatchling.build.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 8, in <module>
-          ModuleNotFoundError: No module named 'hatchling'
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 8, in <module>
+             ModuleNotFoundError: No module named 'hatchling'
 
     hint: `source-distribution` was included because `project` (v0.1.0) depends on `source-distribution`
 
@@ -2054,13 +2054,13 @@ fn sync_build_isolation_package_order() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to build `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
-      ├── The build backend returned an error
-      └── Call to `hatchling.build.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `hatchling.build.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 8, in <module>
-          ModuleNotFoundError: No module named 'hatchling'
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 8, in <module>
+             ModuleNotFoundError: No module named 'hatchling'
 
     hint: `source-distribution` was included because `project` (v0.1.0) depends on `source-distribution`
 
@@ -2219,13 +2219,13 @@ fn sync_build_isolation_extra() -> Result<()> {
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
     error: Failed to build `source-distribution @ https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz`
-      ├── The build backend returned an error
-      └── Call to `hatchling.build.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `hatchling.build.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 8, in <module>
-          ModuleNotFoundError: No module named 'hatchling'
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 8, in <module>
+             ModuleNotFoundError: No module named 'hatchling'
 
     hint: `source-distribution` was included because `project[compile]` (v0.1.0) depends on `source-distribution`
 
@@ -2350,11 +2350,11 @@ fn sync_extra_build_dependencies() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Missing `anyio` module
+             [stderr]
+             Missing `anyio` module
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -2417,11 +2417,11 @@ fn sync_extra_build_dependencies() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Missing `anyio` module
+             [stderr]
+             Missing `anyio` module
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -2483,11 +2483,11 @@ fn sync_extra_build_dependencies() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `bad-child @ file://[TEMP_DIR]/bad_child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Found `anyio` module
+             [stderr]
+             Found `anyio` module
 
     hint: `bad-child` was included because `parent` (v0.1.0) depends on `bad-child`
 
@@ -2572,11 +2572,11 @@ fn sync_extra_build_dependencies_setuptools_legacy() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Missing `anyio` module
+             [stderr]
+             Missing `anyio` module
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -2671,11 +2671,11 @@ fn sync_extra_build_dependencies_setuptools() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Missing `anyio` module
+             [stderr]
+             Missing `anyio` module
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -2852,11 +2852,11 @@ fn sync_extra_build_dependencies_index() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Expected `anyio` version 3.0 but got 4.3.0
+             [stderr]
+             Expected `anyio` version 3.0 but got 4.3.0
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -2901,11 +2901,11 @@ fn sync_extra_build_dependencies_index() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Expected `anyio` version 4.3 but got 3.5.0
+             [stderr]
+             Expected `anyio` version 4.3 but got 3.5.0
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -2992,11 +2992,11 @@ fn sync_extra_build_dependencies_sources_from_child() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Found system anyio instead of local anyio
+             [stderr]
+             Found system anyio instead of local anyio
 
     hint: `child` was included because `project` (v0.1.0) depends on `child`
 
@@ -3056,15 +3056,15 @@ fn sync_build_dependencies_module_error_hints() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 8, in <module>
-            File "[TEMP_DIR]/child/build_backend.py", line 4, in <module>
-              import a
-          ModuleNotFoundError: No module named 'a'
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 8, in <module>
+               File "[TEMP_DIR]/child/build_backend.py", line 4, in <module>
+                 import a
+             ModuleNotFoundError: No module named 'a'
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -3117,15 +3117,15 @@ fn sync_build_dependencies_module_error_hints() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 8, in <module>
-            File "[TEMP_DIR]/child/build_backend.py", line 5, in <module>
-              import sklearn
-          ModuleNotFoundError: No module named 'sklearn'
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 8, in <module>
+               File "[TEMP_DIR]/child/build_backend.py", line 5, in <module>
+                 import sklearn
+             ModuleNotFoundError: No module named 'sklearn'
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -4545,11 +4545,11 @@ fn sync_default_groups_gibberish() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 14, column 26
-             |
-          14 |         default-groups = "gibberish"
-             |                          ^^^^^^^^^^^
-          default-groups must be "all" or a ["list", "of", "groups"]
+      cause: TOML parse error at line 14, column 26
+                |
+             14 |         default-groups = "gibberish"
+                |                          ^^^^^^^^^^^
+             default-groups must be "all" or a ["list", "of", "groups"]
     "#);
 
     Ok(())
@@ -6225,11 +6225,11 @@ fn sync_extra_build_dependencies_script() -> Result<()> {
     Creating script environment at: [CACHE_DIR]/environments-v2/script-[HASH]
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Missing `anyio` module
+             [stderr]
+             Missing `anyio` module
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -6528,7 +6528,7 @@ fn virtual_no_build_dynamic_no_cache() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to generate package metadata for `project==0.1.0 @ virtual+.`
-      └── Building source distributions for `project` is disabled
+      cause: Building source distributions for `project` is disabled
     ");
 
     Ok(())
@@ -10098,26 +10098,26 @@ fn sync_derivation_chain() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `project` (v0.1.0) depends on `wsgiref`
 
@@ -10153,26 +10153,26 @@ fn sync_derivation_chain_extra() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `project[wsgi]` (v0.1.0) depends on `wsgiref`
 
@@ -10210,26 +10210,26 @@ fn sync_derivation_chain_group() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to build `wsgiref==0.1.2`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Traceback (most recent call last):
-            File "<string>", line 14, in <module>
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
-              return self._get_build_requires(config_settings, requirements=['wheel'])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
-              self.run_setup()
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
-              super().run_setup(setup_script=setup_script)
-            File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
-              exec(code, locals())
-            File "<string>", line 5, in <module>
-            File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
-              print "Setuptools version",version,"or greater has been installed."
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
+             [stderr]
+             Traceback (most recent call last):
+               File "<string>", line 14, in <module>
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+                 return self._get_build_requires(config_settings, requirements=['wheel'])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
+                 self.run_setup()
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 487, in run_setup
+                 super().run_setup(setup_script=setup_script)
+               File "[CACHE_DIR]/builds-v0/[TMP]/[PYTHON-LIB]/site-packages/setuptools/build_meta.py", line 311, in run_setup
+                 exec(code, locals())
+               File "<string>", line 5, in <module>
+               File "[CACHE_DIR]/[TMP]/src/ez_setup/__init__.py", line 170
+                 print "Setuptools version",version,"or greater has been installed."
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
 
     hint: `wsgiref` (v0.1.2) was included because `project:wsgi` (v0.1.0) depends on `wsgiref`
 
@@ -10774,8 +10774,8 @@ fn sync_git_path_archive_missing_lfs() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download `iniconfig @ git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true`
-      ├── The wheel `git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true` is missing Git LFS artifacts.
-      └── Git LFS extension not found. Ensure that Git LFS is installed and available.
+      cause: The wheel `git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true` is missing Git LFS artifacts.
+      cause: Git LFS extension not found. Ensure that Git LFS is installed and available.
 
     hint: `iniconfig` (v2.0.0) was included because `foo` (v0.1.0) depends on `iniconfig`
     "###
@@ -10809,7 +10809,7 @@ fn mismatched_name_self_editable() -> Result<()> {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Failed to build `foo @ file://[TEMP_DIR]/`
-      └── Package metadata name `project` does not match given name `foo`
+      cause: Package metadata name `project` does not match given name `foo`
 
     hint: `foo` was included because `project` (v0.1.0) depends on `foo`
     ");
@@ -10857,7 +10857,7 @@ fn mismatched_name_cached_wheel() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `foo @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
-      └── Package metadata name `iniconfig` does not match given name `foo`
+      cause: Package metadata name `iniconfig` does not match given name `foo`
     ");
 
     Ok(())
@@ -11399,13 +11399,13 @@ fn url_hash_mismatch() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to generate package metadata for `iniconfig==2.0.0 @ direct+https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
-      └── Hash mismatch for `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
+      cause: Hash mismatch for `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
 
-          Expected:
-            sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b4
+             Expected:
+               sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b4
 
-          Computed:
-            sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3
+             Computed:
+               sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3
     ");
 
     Ok(())
@@ -11467,13 +11467,13 @@ fn path_hash_mismatch() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to generate package metadata for `iniconfig==2.0.0 @ path+iniconfig-2.0.0.tar.gz`
-      └── Hash mismatch for `iniconfig @ file://[TEMP_DIR]/iniconfig-2.0.0.tar.gz`
+      cause: Hash mismatch for `iniconfig @ file://[TEMP_DIR]/iniconfig-2.0.0.tar.gz`
 
-          Expected:
-            sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b4
+             Expected:
+               sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b4
 
-          Computed:
-            sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3
+             Computed:
+               sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3
     ");
 
     Ok(())
@@ -12164,9 +12164,9 @@ fn sync_script_with_incompatible_build_constraints() -> Result<()> {
     ----- stderr -----
     Creating script environment at: [CACHE_DIR]/environments-v2/script-[HASH]
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -12196,8 +12196,8 @@ fn unsupported_git_scheme() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     error: Failed to build `foo @ file://[TEMP_DIR]/`
-      ├── Failed to parse entry: `foo`
-      └── Unsupported Git URL scheme `c:` in `c:/home/ferris/projects/foo` (expected one of `https:`, `ssh:`, or `file:`)
+      cause: Failed to parse entry: `foo`
+      cause: Unsupported Git URL scheme `c:` in `c:/home/ferris/projects/foo` (expected one of `https:`, `ssh:`, or `file:`)
     ");
     Ok(())
 }
@@ -12565,35 +12565,35 @@ fn transitive_group_conflicts_cycle() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `example` has malformed dependency groups
-      └── Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
+      cause: Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
     ");
 
     uv_snapshot!(context.filters(), context.sync().arg("--group").arg("dev"), @"
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `example` has malformed dependency groups
-      └── Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
+      cause: Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
     ");
 
     uv_snapshot!(context.filters(), context.sync().arg("--group").arg("dev").arg("--group").arg("test"), @"
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `example` has malformed dependency groups
-      └── Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
+      cause: Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
     ");
 
     uv_snapshot!(context.filters(), context.sync().arg("--group").arg("test").arg("--group").arg("magic"), @"
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `example` has malformed dependency groups
-      └── Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
+      cause: Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
     ");
 
     uv_snapshot!(context.filters(), context.sync().arg("--group").arg("dev").arg("--group").arg("magic"), @"
     exit_code: 2 (failure)
     ----- stderr -----
     error: Project `example` has malformed dependency groups
-      └── Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
+      cause: Detected a cycle in `dependency-groups`: `dev` -> `test` -> `dev`
     ");
 
     Ok(())
@@ -12715,7 +12715,7 @@ fn locked_version_coherence() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse `uv.lock`
-      └── The entry for package `iniconfig` (1.0.0) has wheel `iniconfig-2.0.0-py3-none-any.whl` with inconsistent version (2.0.0), which indicates a malformed wheel. If this is intentional, set `UV_SKIP_WHEEL_FILENAME_CHECK=1`.
+      cause: The entry for package `iniconfig` (1.0.0) has wheel `iniconfig-2.0.0-py3-none-any.whl` with inconsistent version (2.0.0), which indicates a malformed wheel. If this is intentional, set `UV_SKIP_WHEEL_FILENAME_CHECK=1`.
     ");
 
     // Without `--locked`, we could fail or recreate the lockfile, currently, we fail.
@@ -12723,7 +12723,7 @@ fn locked_version_coherence() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse `uv.lock`
-      └── The entry for package `iniconfig` (1.0.0) has wheel `iniconfig-2.0.0-py3-none-any.whl` with inconsistent version (2.0.0), which indicates a malformed wheel. If this is intentional, set `UV_SKIP_WHEEL_FILENAME_CHECK=1`.
+      cause: The entry for package `iniconfig` (1.0.0) has wheel `iniconfig-2.0.0-py3-none-any.whl` with inconsistent version (2.0.0), which indicates a malformed wheel. If this is intentional, set `UV_SKIP_WHEEL_FILENAME_CHECK=1`.
     ");
 
     Ok(())
@@ -14267,11 +14267,11 @@ fn sync_build_dependencies_respect_locked_versions() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Expected `a` version 0.1 but got 0.3.0
+             [stderr]
+             Expected `a` version 0.1 but got 0.3.0
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -14326,11 +14326,11 @@ fn sync_build_dependencies_respect_locked_versions() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_wheel` failed (exit status: 1)
 
-          [stderr]
-          Expected `a` version 0.2 but got 0.1.0
+             [stderr]
+             Expected `a` version 0.2 but got 0.1.0
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
 
@@ -14385,9 +14385,9 @@ fn sync_build_dependencies_respect_locked_versions() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `child @ file://[TEMP_DIR]/child`
-      ├── Failed to resolve requirements from `build-system.requires` and `extra-build-dependencies`
-      ├── No solution found when resolving: `hatchling`, `a<0.3, >0.15`, `a==0.1.0 (index: http://[LOCALHOST]/simple/)`
-      └── you require a<0.3 and a>0.15, which are incompatible
+      cause: Failed to resolve requirements from `build-system.requires` and `extra-build-dependencies`
+      cause: No solution found when resolving: `hatchling`, `a<0.3, >0.15`, `a==0.1.0 (index: http://[LOCALHOST]/simple/)`
+      cause: you require a<0.3 and a>0.15, which are incompatible
 
     hint: `child` was included because `parent` (v0.1.0) depends on `child`
     ");
@@ -14476,11 +14476,11 @@ fn sync_extra_build_variables() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `parent @ file://[TEMP_DIR]/`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_editable` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_editable` failed (exit status: 1)
 
-          [stderr]
-          Expected `anyio` version 3.0 but got 4.3.0
+             [stderr]
+             Expected `anyio` version 3.0 but got 4.3.0
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -14506,11 +14506,11 @@ fn sync_extra_build_variables() -> Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     error: Failed to build `parent @ file://[TEMP_DIR]/`
-      ├── The build backend returned an error
-      └── Call to `build_backend.build_editable` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `build_backend.build_editable` failed (exit status: 1)
 
-          [stderr]
-          Expected `anyio` version 3.0 but got 4.3.0
+             [stderr]
+             Expected `anyio` version 3.0 but got 4.3.0
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -14565,7 +14565,7 @@ fn reject_unmatched_runtime() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `source-distribution==0.0.3`
-      └── Extra build requirement `iniconfig` was declared with `match-runtime = true`, but `source-distribution` does not declare static metadata, making runtime-matching impossible
+      cause: Extra build requirement `iniconfig` was declared with `match-runtime = true`, but `source-distribution` does not declare static metadata, making runtime-matching impossible
 
     hint: `source-distribution` (v0.0.3) was included because `foo` (v0.1.0) depends on `source-distribution`
     ");
@@ -15303,8 +15303,8 @@ async fn sync_non_pep625_sdist() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because basic-package==0.1.0 has a non-PEP 625-compliant source distribution filename and only basic-package==0.1.0 is available, we can conclude that all versions of basic-package cannot be used.
-          And because your project depends on basic-package, we can conclude that your project's requirements are unsatisfiable.
+      cause: Because basic-package==0.1.0 has a non-PEP 625-compliant source distribution filename and only basic-package==0.1.0 is available, we can conclude that all versions of basic-package cannot be used.
+             And because your project depends on basic-package, we can conclude that your project's requirements are unsatisfiable.
 
     hint: `basic-package` was found on http://[LOCALHOST]/simple, but not at the requested version (basic-package==0.1.0). A compatible version may be available on a subsequent index (e.g., https://pypi.org/simple). By default, uv will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `--index-strategy unsafe-best-match` to consider all versions from all indexes, regardless of the order in which they were defined.
     ");
@@ -16136,11 +16136,11 @@ fn sync_fails_ambiguous_url() -> Result<()> {
       ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
 
     error: Failed to parse: `pyproject.toml`
-      └── TOML parse error at line 10, column 15
-             |
-          10 |         url = "https://user/name:password@domain/a/b/c"
-             |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
+      cause: TOML parse error at line 10, column 15
+                |
+             10 |         url = "https://user/name:password@domain/a/b/c"
+                |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
     "#);
 
     Ok(())
@@ -16568,7 +16568,7 @@ async fn sync_malware_check_network_error() {
     ----- stderr -----
     Resolved 2 packages in [TIME]
     error: Malware check failed due to an error from OSV
-      └── HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/v1/querybatch)
+      cause: HTTP status server error (500 Internal Server Error) for url (http://[LOCALHOST]/v1/querybatch)
     ");
 }
 

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -1555,9 +1555,9 @@ fn tool_install_with_incompatible_build_constraints() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==2, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==2, we can conclude that your requirements are unsatisfiable.
     ");
 
     tool_dir
@@ -3127,23 +3127,23 @@ fn tool_install_uninstallable() {
     ----- stderr -----
     Resolved 1 package in [TIME]
     error: Failed to build `pyenv==0.0.1`
-      ├── The build backend returned an error
-      └── Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+      cause: The build backend returned an error
+      cause: Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
 
-          [stdout]
-          running bdist_wheel
-          running build
-          installing to build/bdist.linux-x86_64/wheel
-          running install
+             [stdout]
+             running bdist_wheel
+             running build
+             installing to build/bdist.linux-x86_64/wheel
+             running install
 
-          [stderr]
-          # NOTE #
-          We are sorry, but this package is not installable with pip.
+             [stderr]
+             # NOTE #
+             We are sorry, but this package is not installable with pip.
 
-          Please read the installation instructions at:
+             Please read the installation instructions at:
 
-          https://github.com/pyenv/pyenv#installation
-          #
+             https://github.com/pyenv/pyenv#installation
+             #
 
     hint: Build failures usually indicate a problem with the package or the build environment
     ");
@@ -3366,8 +3366,8 @@ fn tool_install_git_does_not_infer_dynamic_requires_python() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because the current Python version (3.11.[X]) does not satisfy Python>=3.12,<3.13 and dynamic-requires-python-tool==0.1.0 depends on Python>=3.12,<3.13, we can conclude that dynamic-requires-python-tool==0.1.0 cannot be used.
-          And because only dynamic-requires-python-tool==0.1.0 is available and you require dynamic-requires-python-tool, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.11.[X]) does not satisfy Python>=3.12,<3.13 and dynamic-requires-python-tool==0.1.0 depends on Python>=3.12,<3.13, we can conclude that dynamic-requires-python-tool==0.1.0 cannot be used.
+             And because only dynamic-requires-python-tool==0.1.0 is available and you require dynamic-requires-python-tool, we can conclude that your requirements are unsatisfiable.
     ");
 }
 
@@ -4417,8 +4417,8 @@ fn tool_install_preserve_environment() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving dependencies
-      └── Because black==24.1.1 depends on packaging>=22.0 and you require black==24.1.1, we can conclude that you require packaging>=22.0.
-          And because you require packaging==0.0.1, we can conclude that your requirements are unsatisfiable.
+      cause: Because black==24.1.1 depends on packaging>=22.0 and you require black==24.1.1, we can conclude that you require packaging>=22.0.
+             And because you require packaging==0.0.1, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Install `black`. The tool should already be installed, since we didn't remove the environment.
@@ -5416,8 +5416,8 @@ async fn tool_install_default_credentials() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to upgrade executable-application
-      ├── Failed to fetch: `http://[LOCALHOST]/basic-auth/simple/executable-application/`
-      └── Missing credentials for http://[LOCALHOST]/basic-auth/simple/executable-application/
+      cause: Failed to fetch: `http://[LOCALHOST]/basic-auth/simple/executable-application/`
+      cause: Missing credentials for http://[LOCALHOST]/basic-auth/simple/executable-application/
     ");
 
     // Attempt to upgrade.
@@ -5643,8 +5643,8 @@ fn tool_install_find_links() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving tool dependencies
-      └── Because basic-app==0.1 needs to be downloaded from a registry and only basic-app==0.1 is available, we can conclude that all versions of basic-app cannot be used.
-          And because you require basic-app, we can conclude that your requirements are unsatisfiable.
+      cause: Because basic-app==0.1 needs to be downloaded from a registry and only basic-app==0.1 is available, we can conclude that all versions of basic-app cannot be used.
+             And because you require basic-app, we can conclude that your requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     ");
@@ -5905,13 +5905,13 @@ fn tool_install_lock_verifies_hashes() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to read `simple-launcher @ file://[WORKSPACE]/test/links/simple_launcher-0.1.0-py3-none-any.whl`
-      └── Hash mismatch for `simple-launcher @ file://[WORKSPACE]/test/links/simple_launcher-0.1.0-py3-none-any.whl`
+      cause: Hash mismatch for `simple-launcher @ file://[WORKSPACE]/test/links/simple_launcher-0.1.0-py3-none-any.whl`
 
-          Expected:
-            sha256:0000000000000000000000000000000000000000000000000000000000000000
+             Expected:
+               sha256:0000000000000000000000000000000000000000000000000000000000000000
 
-          Computed:
-            sha256:5327e0bb67cdb46800999de6dcf034bf0a5335702883494af0d8b7f6ca48cee4
+             Computed:
+               sha256:5327e0bb67cdb46800999de6dcf034bf0a5335702883494af0d8b7f6ca48cee4
     "#);
 
     Ok(())

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -97,9 +97,9 @@ fn tool_run_at_version() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pytest@`
-      └── Expected URL
-          pytest@
-                 ^
+      cause: Expected URL
+             pytest@
+                    ^
     ");
 
     // Invalid versions are just treated as package and command names
@@ -109,7 +109,7 @@ fn tool_run_at_version() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve tool requirement
-      └── Distribution not found at: file://[TEMP_DIR]/invalid
+      cause: Distribution not found at: file://[TEMP_DIR]/invalid
     ");
 
     let filters = context
@@ -977,8 +977,8 @@ fn tool_run_git_does_not_infer_dynamic_requires_python() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving tool dependencies
-      └── Because the current Python version (3.11.[X]) does not satisfy Python>=3.12,<3.13 and dynamic-requires-python-tool==0.1.0 depends on Python>=3.12,<3.13, we can conclude that dynamic-requires-python-tool==0.1.0 cannot be used.
-          And because only dynamic-requires-python-tool==0.1.0 is available and you require dynamic-requires-python-tool, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.11.[X]) does not satisfy Python>=3.12,<3.13 and dynamic-requires-python-tool==0.1.0 depends on Python>=3.12,<3.13, we can conclude that dynamic-requires-python-tool==0.1.0 cannot be used.
+             And because only dynamic-requires-python-tool==0.1.0 is available and you require dynamic-requires-python-tool, we can conclude that your requirements are unsatisfiable.
     ");
 }
 
@@ -1704,7 +1704,7 @@ fn tool_run_invalid_with() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve `--with` requirement
-      └── Distribution not found at: file://[TEMP_DIR]/foo
+      cause: Distribution not found at: file://[TEMP_DIR]/foo
     ");
 }
 
@@ -1791,7 +1791,7 @@ fn tool_run_resolution_error() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving tool dependencies
-      └── Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
+      cause: Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
     ");
 }
 
@@ -2071,7 +2071,7 @@ fn tool_run_python_at_version() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving tool dependencies
-      └── Because cp311 was not found in the package registry and you require cp311, we can conclude that your requirements are unsatisfiable.
+      cause: Because cp311 was not found in the package registry and you require cp311, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Bare versions don't work either. Again we interpret them as package names.
@@ -2081,7 +2081,7 @@ fn tool_run_python_at_version() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving tool dependencies
-      └── Because 311 was not found in the package registry and you require 311, we can conclude that your requirements are unsatisfiable.
+      cause: Because 311 was not found in the package registry and you require 311, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Request a version via `-p`
@@ -2880,9 +2880,9 @@ fn tool_run_with_url_ending_in_py() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve `--with` requirement
-      ├── Git operation failed
-      ├── failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
-      └── Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+      cause: Git operation failed
+      cause: failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
+      cause: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
     ");
 
     uv_snapshot!(context.filters(), context.tool_run()
@@ -2891,10 +2891,10 @@ fn tool_run_with_url_ending_in_py() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve tool requirement
-      ├── Failed to download and build `easyeda2kicad @ git+https://github.com/uPesy/easyeda2kicad.py`
-      ├── Git operation failed
-      ├── failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
-      └── Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+      cause: Failed to download and build `easyeda2kicad @ git+https://github.com/uPesy/easyeda2kicad.py`
+      cause: Git operation failed
+      cause: failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
+      cause: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
     ");
 }
 
@@ -2912,9 +2912,9 @@ fn tool_run_with_from_url_ending_in_py() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve `--with` requirement
-      ├── Git operation failed
-      ├── failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
-      └── Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+      cause: Git operation failed
+      cause: failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
+      cause: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
     ");
 
     uv_snapshot!(context.filters(), context.tool_run()
@@ -2925,10 +2925,10 @@ fn tool_run_with_from_url_ending_in_py() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to resolve tool requirement
-      ├── Failed to download and build `easyeda2kicad @ git+https://github.com/uPesy/easyeda2kicad.py`
-      ├── Git operation failed
-      ├── failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
-      └── Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
+      cause: Failed to download and build `easyeda2kicad @ git+https://github.com/uPesy/easyeda2kicad.py`
+      cause: Git operation failed
+      cause: failed to fetch into: [CACHE_DIR]/git-v0/db/efbd3507bcbea33c
+      cause: Remote Git fetches are not allowed because network connectivity is disabled (i.e., with `--offline`)
     ");
 }
 
@@ -2947,8 +2947,8 @@ fn tool_run_verbose_hint() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to run tool
-      ├── No solution found when resolving dependencies
-      └── Because nonexistent-package-foo was not found in the package registry and you require nonexistent-package-foo, we can conclude that your requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because nonexistent-package-foo was not found in the package registry and you require nonexistent-package-foo, we can conclude that your requirements are unsatisfiable.
 
     hint: You provided `--verbose` to `nonexistent-package-foo`. Did you mean to provide it to `uv tool run`? e.g., `uv tool run --verbose nonexistent-package-foo`
     ");
@@ -2960,8 +2960,8 @@ fn tool_run_verbose_hint() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to run tool
-      ├── No solution found when resolving dependencies
-      └── Because nonexistent-package-bar was not found in the package registry and you require nonexistent-package-bar, we can conclude that your requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because nonexistent-package-bar was not found in the package registry and you require nonexistent-package-bar, we can conclude that your requirements are unsatisfiable.
 
     hint: You provided `-v` to `nonexistent-package-bar`. Did you mean to provide it to `uv tool run`? e.g., `uv tool run -v nonexistent-package-bar`
     ");
@@ -2973,8 +2973,8 @@ fn tool_run_verbose_hint() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to run tool
-      ├── No solution found when resolving dependencies
-      └── Because nonexistent-package-baz was not found in the package registry and you require nonexistent-package-baz, we can conclude that your requirements are unsatisfiable.
+      cause: No solution found when resolving dependencies
+      cause: Because nonexistent-package-baz was not found in the package registry and you require nonexistent-package-baz, we can conclude that your requirements are unsatisfiable.
 
     hint: You provided `-vv` to `nonexistent-package-baz`. Did you mean to provide it to `uv tool run`? e.g., `uv tool run -vv nonexistent-package-baz`
     ");
@@ -2986,7 +2986,7 @@ fn tool_run_verbose_hint() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving tool dependencies
-      └── Because nonexistent-package-quux was not found in the package registry and you require nonexistent-package-quux, we can conclude that your requirements are unsatisfiable.
+      cause: Because nonexistent-package-quux was not found in the package registry and you require nonexistent-package-quux, we can conclude that your requirements are unsatisfiable.
     ");
 }
 
@@ -3049,9 +3049,9 @@ fn tool_run_with_incompatible_build_constraints() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      ├── Failed to resolve requirements from `setup.py` build
-      ├── No solution found when resolving: `setuptools>=40.8.0`
-      └── Because you require setuptools>=40.8.0 and setuptools==2, we can conclude that your requirements are unsatisfiable.
+      cause: Failed to resolve requirements from `setup.py` build
+      cause: No solution found when resolving: `setuptools>=40.8.0`
+      cause: Because you require setuptools>=40.8.0 and setuptools==2, we can conclude that your requirements are unsatisfiable.
     ");
 
     Ok(())
@@ -3484,8 +3484,8 @@ fn tool_run_reresolve_python() -> anyhow::Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: No solution found when resolving tool dependencies
-      └── Because the current Python version (3.11.[X]) does not satisfy Python>=3.12 and foo==1.0.0 depends on Python>=3.12, we can conclude that foo==1.0.0 cannot be used.
-          And because only foo==1.0.0 is available and you require foo, we can conclude that your requirements are unsatisfiable.
+      cause: Because the current Python version (3.11.[X]) does not satisfy Python>=3.12 and foo==1.0.0 depends on Python>=3.12, we can conclude that foo==1.0.0 cannot be used.
+             And because only foo==1.0.0 is available and you require foo, we can conclude that your requirements are unsatisfiable.
     ");
 
     // Unless the discovered interpreter is compatible with the request

--- a/crates/uv/tests/tool/tool_run.rs
+++ b/crates/uv/tests/tool/tool_run.rs
@@ -117,8 +117,8 @@ fn tool_run_at_version() {
         .into_iter()
         .chain([(
             // The error message is different on Windows
-            "└── program not found",
-            "└── No such file or directory (os error 2)",
+            "cause: program not found",
+            "cause: No such file or directory (os error 2)",
         )])
         .collect::<Vec<_>>();
 

--- a/crates/uv/tests/tool/tool_upgrade.rs
+++ b/crates/uv/tests/tool/tool_upgrade.rs
@@ -113,7 +113,7 @@ fn tool_upgrade_all_unreadable_receipt() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to inspect installed tools in `tools`
-      └── failed to read from file `[TEMP_DIR]/tools/babel/uv-receipt.toml`: stream did not contain valid UTF-8
+      cause: failed to read from file `[TEMP_DIR]/tools/babel/uv-receipt.toml`: stream did not contain valid UTF-8
     ");
 
     Ok(())
@@ -813,7 +813,7 @@ fn tool_upgrade_non_existing_package() {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to upgrade black
-      └── `black` is not installed; run `uv tool install black` to install
+      cause: `black` is not installed; run `uv tool install black` to install
     ");
 
     // Attempt to upgrade all.
@@ -886,7 +886,7 @@ fn tool_upgrade_not_stop_if_upgrade_fails() -> anyhow::Result<()> {
      - pytz==2018.5
     Installed 1 executable: pybabel
     error: Failed to upgrade python-dotenv
-      └── `python-dotenv` is missing a valid receipt; run `uv tool install --force python-dotenv` to reinstall
+      cause: `python-dotenv` is missing a valid receipt; run `uv tool install --force python-dotenv` to reinstall
     ");
 
     Ok(())
@@ -1548,8 +1548,8 @@ async fn tool_upgrade_invalid_auth() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to upgrade executable-application
-      ├── Failed to fetch: `http://[LOCALHOST]/basic-auth/simple/executable-application/`
-      └── Missing credentials for http://[LOCALHOST]/basic-auth/simple/executable-application/
+      cause: Failed to fetch: `http://[LOCALHOST]/basic-auth/simple/executable-application/`
+      cause: Missing credentials for http://[LOCALHOST]/basic-auth/simple/executable-application/
     ");
 
     Ok(())
@@ -1693,7 +1693,7 @@ async fn tool_upgrade_resolution_hints() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to upgrade simple-launcher
-      └── Because simple-launcher was not found in the package registry and you require simple-launcher>0.1.0, we can conclude that your requirements are unsatisfiable.
+      cause: Because simple-launcher was not found in the package registry and you require simple-launcher>0.1.0, we can conclude that your requirements are unsatisfiable.
 
     hint: An index URL (http://[LOCALHOST]/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized)
     ");
@@ -1753,14 +1753,14 @@ async fn tool_upgrade_lock_verifies_hashes() -> Result<()> {
     exit_code: 1 (failure)
     ----- stderr -----
     error: Failed to upgrade simple-launcher
-      ├── Failed to download `simple-launcher==0.1.0`
-      └── Hash mismatch for `simple-launcher==0.1.0`
+      cause: Failed to download `simple-launcher==0.1.0`
+      cause: Hash mismatch for `simple-launcher==0.1.0`
 
-          Expected:
-            sha256:0000000000000000000000000000000000000000000000000000000000000000
+             Expected:
+               sha256:0000000000000000000000000000000000000000000000000000000000000000
 
-          Computed:
-            sha256:5327e0bb67cdb46800999de6dcf034bf0a5335702883494af0d8b7f6ca48cee4
+             Computed:
+               sha256:5327e0bb67cdb46800999de6dcf034bf0a5335702883494af0d8b7f6ca48cee4
     ");
 
     Ok(())

--- a/crates/uv/tests/workspace/workspace.rs
+++ b/crates/uv/tests/workspace/workspace.rs
@@ -1319,8 +1319,8 @@ fn workspace_inherit_sources() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: No solution found when resolving dependencies
-      └── Because library was not found in the cache and leaf depends on library, we can conclude that leaf's requirements are unsatisfiable.
-          And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because library was not found in the cache and leaf depends on library, we can conclude that leaf's requirements are unsatisfiable.
+             And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
 
     hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     "
@@ -1527,8 +1527,8 @@ fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: No solution found when resolving dependencies
-      └── Because only httpx<=0.27.0 is available and leaf depends on httpx>9999, we can conclude that leaf's requirements are unsatisfiable.
-          And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because only httpx<=0.27.0 is available and leaf depends on httpx>9999, we can conclude that leaf's requirements are unsatisfiable.
+             And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
     "
     );
 
@@ -1592,8 +1592,8 @@ fn workspace_unsatisfiable_member_dependencies_conflicting() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: No solution found when resolving dependencies
-      └── Because bar depends on anyio==4.2.0 and foo depends on anyio==4.1.0, we can conclude that bar and foo are incompatible.
-          And because your workspace requires bar and foo, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because bar depends on anyio==4.2.0 and foo depends on anyio==4.1.0, we can conclude that bar and foo are incompatible.
+             And because your workspace requires bar and foo, we can conclude that your workspace's requirements are unsatisfiable.
     "
     );
 
@@ -1672,8 +1672,8 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_threeway() -> Result<
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: No solution found when resolving dependencies
-      └── Because bird depends on anyio==4.3.0 and knot depends on anyio==4.2.0, we can conclude that bird and knot are incompatible.
-          And because your workspace requires bird and knot, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because bird depends on anyio==4.3.0 and knot depends on anyio==4.2.0, we can conclude that bird and knot are incompatible.
+             And because your workspace requires bird and knot, we can conclude that your workspace's requirements are unsatisfiable.
     "
     );
 
@@ -1739,8 +1739,8 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_extra() -> Result<()>
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: No solution found when resolving dependencies
-      └── Because bar[some-extra] depends on anyio==4.2.0 and foo depends on anyio==4.1.0, we can conclude that foo and bar[some-extra] are incompatible.
-          And because your workspace requires bar[some-extra] and foo, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because bar[some-extra] depends on anyio==4.2.0 and foo depends on anyio==4.1.0, we can conclude that foo and bar[some-extra] are incompatible.
+             And because your workspace requires bar[some-extra] and foo, we can conclude that your workspace's requirements are unsatisfiable.
     "
     );
 
@@ -1807,8 +1807,8 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_dev() -> Result<()> {
     warning: The `tool.uv.dev-dependencies` field (used in `packages/bar/pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: No solution found when resolving dependencies
-      └── Because bar:dev depends on anyio==4.2.0 and foo depends on anyio==4.1.0, we can conclude that foo and bar:dev are incompatible.
-          And because your workspace requires bar:dev and foo, we can conclude that your workspace's requirements are unsatisfiable.
+      cause: Because bar:dev depends on anyio==4.2.0 and foo depends on anyio==4.1.0, we can conclude that foo and bar:dev are incompatible.
+             And because your workspace requires bar:dev and foo, we can conclude that your workspace's requirements are unsatisfiable.
     "
     );
 
@@ -1875,8 +1875,8 @@ fn workspace_member_name_shadows_dependencies() -> Result<()> {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: Failed to build `foo @ file://[TEMP_DIR]/workspace/packages/foo`
-      ├── Failed to parse entry: `anyio`
-      └── `anyio` is included as a workspace member, but is missing an entry in `tool.uv.sources` (e.g., `anyio = { workspace = true }`)
+      cause: Failed to parse entry: `anyio`
+      cause: `anyio` is included as a workspace member, but is missing an entry in `tool.uv.sources` (e.g., `anyio = { workspace = true }`)
     "
     );
 

--- a/crates/uv/tests/workspace/workspace_metadata.rs
+++ b/crates/uv/tests/workspace/workspace_metadata.rs
@@ -1408,8 +1408,8 @@ dependencies = [
     ----- stderr -----
     warning: The `uv workspace metadata` command is experimental and may change without warning. Pass `--preview-features workspace-metadata` to disable this warning.
     error: Failed to collect module owners
-      ├── Failed to determine installation plan
-      └── Distribution not found at: file://[TEMP_DIR]/gpu_a-0.1.0-py3-none-any.whl
+      cause: Failed to determine installation plan
+      cause: Distribution not found at: file://[TEMP_DIR]/gpu_a-0.1.0-py3-none-any.whl
     "#);
 
     Ok(())


### PR DESCRIPTION
Render each source error with a compact `cause:` label, keeping the existing `error:` and `warning:` headings. Wrapped and authored continuation lines align beneath the cause text, and hints remain separate from the error chain. This changes presentation only; source ordering and exit statuses are unchanged.

Prior work:

- #17110 removes the direct `miette` dependency and routes command failures through the shared renderer.
- #21587 separates operation context from exit-status classification.
- #21599 introduces compact tree connectors for source chains.
