### PR TITLE
Add per-error informational diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6657,6 +6657,7 @@ dependencies = [
  "terminal_size",
  "textwrap",
  "thiserror",
+ "unicode-width 0.2.2",
  "uv-static",
 ]
 
@@ -7144,12 +7145,14 @@ dependencies = [
  "url",
  "uv-cache-key",
  "uv-distribution-filename",
+ "uv-errors",
  "uv-git-types",
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
  "uv-redacted",
  "uv-small-str",
+ "uv-toml",
 ]
 
 [[package]]
@@ -7402,7 +7405,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde-untagged",
- "textwrap",
  "thiserror",
  "toml",
  "tracing",
@@ -7412,6 +7414,7 @@ dependencies = [
  "uv-configuration",
  "uv-dirs",
  "uv-distribution-types",
+ "uv-errors",
  "uv-flags",
  "uv-fs",
  "uv-install-wheel",
@@ -7426,6 +7429,7 @@ dependencies = [
  "uv-redacted",
  "uv-resolver",
  "uv-static",
+ "uv-toml",
  "uv-torch",
  "uv-version",
  "uv-warnings",
@@ -7526,7 +7530,10 @@ dependencies = [
 name = "uv-toml"
 version = "0.0.80"
 dependencies = [
+ "insta",
  "serde",
+ "toml",
+ "uv-errors",
 ]
 
 [[package]]

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -2661,7 +2661,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         let pyproject_toml = match PyProjectToml::from_toml(&content, source) {
             Ok(metadata) => metadata,
             Err(
-                uv_pypi_types::MetadataError::InvalidPyprojectTomlSyntax(..)
+                uv_pypi_types::MetadataError::InvalidPyprojectTomlSyntax { .. }
                 | uv_pypi_types::MetadataError::InvalidPyprojectTomlSchema(..),
             ) => {
                 debug!("Failed to read `pyproject.toml` from GitHub API for: {url}");
@@ -3626,7 +3626,7 @@ async fn read_pyproject_toml(
         Err(err) => return Err(Error::CacheRead(err)),
     };
 
-    let pyproject_toml = PyProjectToml::from_toml(&content, pyproject_toml.simplified_display())?;
+    let pyproject_toml = PyProjectToml::from_toml(&content, pyproject_toml.user_display())?;
 
     Ok(pyproject_toml)
 }

--- a/crates/uv-errors/Cargo.toml
+++ b/crates/uv-errors/Cargo.toml
@@ -14,6 +14,7 @@ anstream = { workspace = true }
 owo-colors = { workspace = true }
 terminal_size = { workspace = true }
 textwrap = { workspace = true }
+unicode-width = { workspace = true }
 uv-static = { workspace = true }
 
 [dev-dependencies]

--- a/crates/uv-errors/src/diagnostic.rs
+++ b/crates/uv-errors/src/diagnostic.rs
@@ -5,45 +5,64 @@ use std::fmt::{self, Write};
 use owo_colors::OwoColorize;
 
 use crate::line_wrap::wrap_text;
+use crate::source::SourceSnippet;
 
 /// User-facing presentation data for one error in a source chain.
 ///
 /// This does not replace the error or its sources. Unrecognized error types continue to use
 /// their [`fmt::Display`] implementation.
 #[derive(Default)]
-pub(super) struct Diagnostic<'a> {
-    pub(super) message: Option<Cow<'a, str>>,
-    pub(super) info: Vec<Info<'a>>,
+pub struct Diagnostic<'a> {
+    pub(crate) message: Option<Cow<'a, str>>,
+    pub(crate) snippets: Vec<SourceSnippet>,
+    pub(crate) info: Vec<Info<'a>>,
+    pub(crate) source: Option<Box<Self>>,
 }
 
-#[cfg(test)]
 impl<'a> Diagnostic<'a> {
     /// Override the displayed message for this error.
-    pub(super) fn new(message: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(message: impl Into<Cow<'a, str>>) -> Self {
         Self {
             message: Some(message.into()),
+            snippets: Vec::new(),
             info: Vec::new(),
+            source: None,
         }
     }
 
     /// Attach additional context to this error.
     #[must_use]
-    pub(super) fn with_info(mut self, info: Info<'a>) -> Self {
+    pub fn with_info(mut self, info: Info<'a>) -> Self {
         self.info.push(info);
+        self
+    }
+
+    /// Attach a source location to this error.
+    #[must_use]
+    pub fn with_snippet(mut self, snippet: SourceSnippet) -> Self {
+        self.snippets.push(snippet);
+        self
+    }
+
+    /// Supply presentation data for the next actual [`Error::source`] node.
+    ///
+    /// This does not add, replace, or remove an error from the source chain.
+    #[must_use]
+    pub fn with_source(mut self, source: Self) -> Self {
+        self.source = Some(Box::new(source));
         self
     }
 }
 
 /// Additional context, rather than a cause or an actionable hint.
-pub(super) struct Info<'a> {
+pub struct Info<'a> {
     message: Cow<'a, str>,
     details: Option<Cow<'a, str>>,
 }
 
-#[cfg(test)]
 impl<'a> Info<'a> {
     /// Create an informational statement.
-    pub(super) fn new(message: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(message: impl Into<Cow<'a, str>>) -> Self {
         Self {
             message: message.into(),
             details: None,
@@ -53,14 +72,14 @@ impl<'a> Info<'a> {
     /// Attach a block of text, retaining its authored line breaks and indentation.
     /// Terminal control characters are escaped when the block is rendered.
     #[must_use]
-    pub(super) fn with_details(mut self, details: impl Into<Cow<'a, str>>) -> Self {
+    pub fn with_details(mut self, details: impl Into<Cow<'a, str>>) -> Self {
         self.details = Some(details.into());
         self
     }
 }
 
 /// Resolve presentation data for a concrete error type.
-pub(super) type DiagnosticFn = for<'a> fn(&'a (dyn Error + 'static)) -> Option<Diagnostic<'a>>;
+pub type DiagnosticFn = for<'a> fn(&'a (dyn Error + 'static)) -> Option<Diagnostic<'a>>;
 
 pub(crate) fn write_info(
     stream: &mut impl Write,
@@ -118,7 +137,7 @@ pub(crate) fn write_info(
 }
 
 /// Keep untrusted text inside its diagnostic gutter, including on ANSI-capable terminals.
-fn normalize_details(details: &str) -> Cow<'_, str> {
+pub(crate) fn normalize_details(details: &str) -> Cow<'_, str> {
     if !details.chars().any(|character| {
         (character.is_control() && character != '\n') || is_layout_control(character)
     }) {
@@ -145,7 +164,7 @@ fn normalize_details(details: &str) -> Cow<'_, str> {
     Cow::Owned(normalized)
 }
 
-fn is_layout_control(character: char) -> bool {
+pub(crate) fn is_layout_control(character: char) -> bool {
     matches!(
         character,
         '\u{061c}'

--- a/crates/uv-errors/src/diagnostic.rs
+++ b/crates/uv-errors/src/diagnostic.rs
@@ -31,8 +31,9 @@ impl<'a> Diagnostic<'a> {
     }
 
     /// Attach additional context to this error.
+    #[cfg(test)]
     #[must_use]
-    pub fn with_info(mut self, info: Info<'a>) -> Self {
+    pub(super) fn with_info(mut self, info: Info<'a>) -> Self {
         self.info.push(info);
         self
     }
@@ -55,14 +56,15 @@ impl<'a> Diagnostic<'a> {
 }
 
 /// Additional context, rather than a cause or an actionable hint.
-pub struct Info<'a> {
+pub(super) struct Info<'a> {
     message: Cow<'a, str>,
     details: Option<Cow<'a, str>>,
 }
 
+#[cfg(test)]
 impl<'a> Info<'a> {
     /// Create an informational statement.
-    pub fn new(message: impl Into<Cow<'a, str>>) -> Self {
+    pub(super) fn new(message: impl Into<Cow<'a, str>>) -> Self {
         Self {
             message: message.into(),
             details: None,
@@ -72,7 +74,7 @@ impl<'a> Info<'a> {
     /// Attach a block of text, retaining its authored line breaks and indentation.
     /// Terminal control characters are escaped when the block is rendered.
     #[must_use]
-    pub fn with_details(mut self, details: impl Into<Cow<'a, str>>) -> Self {
+    pub(super) fn with_details(mut self, details: impl Into<Cow<'a, str>>) -> Self {
         self.details = Some(details.into());
         self
     }

--- a/crates/uv-errors/src/diagnostic.rs
+++ b/crates/uv-errors/src/diagnostic.rs
@@ -111,6 +111,7 @@ pub(crate) fn write_info(
                     writeln!(stream, "    {} {line}", "|".cyan().bold())?;
                 }
             }
+            writeln!(stream, "    {}", "|".cyan().bold())?;
         }
     }
     Ok(())

--- a/crates/uv-errors/src/diagnostic.rs
+++ b/crates/uv-errors/src/diagnostic.rs
@@ -1,0 +1,155 @@
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::{self, Write};
+
+use owo_colors::OwoColorize;
+
+use crate::line_wrap::wrap_text;
+
+/// User-facing presentation data for one error in a source chain.
+///
+/// This does not replace the error or its sources. Unrecognized error types continue to use
+/// their [`fmt::Display`] implementation.
+#[derive(Default)]
+pub(super) struct Diagnostic<'a> {
+    pub(super) message: Option<Cow<'a, str>>,
+    pub(super) info: Vec<Info<'a>>,
+}
+
+#[cfg(test)]
+impl<'a> Diagnostic<'a> {
+    /// Override the displayed message for this error.
+    pub(super) fn new(message: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            message: Some(message.into()),
+            info: Vec::new(),
+        }
+    }
+
+    /// Attach additional context to this error.
+    #[must_use]
+    pub(super) fn with_info(mut self, info: Info<'a>) -> Self {
+        self.info.push(info);
+        self
+    }
+}
+
+/// Additional context, rather than a cause or an actionable hint.
+pub(super) struct Info<'a> {
+    message: Cow<'a, str>,
+    details: Option<Cow<'a, str>>,
+}
+
+#[cfg(test)]
+impl<'a> Info<'a> {
+    /// Create an informational statement.
+    pub(super) fn new(message: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    /// Attach a block of text, retaining its authored line breaks and indentation.
+    /// Terminal control characters are escaped when the block is rendered.
+    #[must_use]
+    pub(super) fn with_details(mut self, details: impl Into<Cow<'a, str>>) -> Self {
+        self.details = Some(details.into());
+        self
+    }
+}
+
+/// Resolve presentation data for a concrete error type.
+pub(super) type DiagnosticFn = for<'a> fn(&'a (dyn Error + 'static)) -> Option<Diagnostic<'a>>;
+
+pub(crate) fn write_info(
+    stream: &mut impl Write,
+    info: &[Info<'_>],
+    width: Option<usize>,
+) -> fmt::Result {
+    for info in info {
+        let message = wrap_text(
+            &info.message,
+            width.map(|width| width.saturating_sub(8)),
+            "",
+            "",
+            "",
+        );
+        let mut lines = message.lines();
+        writeln!(
+            stream,
+            "  {}{} {}",
+            "info".cyan().bold(),
+            ":".bold(),
+            lines.next().unwrap_or_default().trim(),
+        )?;
+        for line in lines {
+            if line.trim().is_empty() {
+                writeln!(stream)?;
+            } else {
+                writeln!(stream, "        {line}")?;
+            }
+        }
+        if let Some(details) = info
+            .details
+            .as_deref()
+            .filter(|details| !details.is_empty())
+        {
+            let details = normalize_details(details);
+            let details = wrap_text(
+                &details,
+                width.map(|width| width.saturating_sub(6)),
+                "",
+                "",
+                "",
+            );
+            writeln!(stream, "    {}", "|".cyan().bold())?;
+            for line in details.lines() {
+                if line.trim().is_empty() {
+                    writeln!(stream, "    {}", "|".cyan().bold())?;
+                } else {
+                    writeln!(stream, "    {} {line}", "|".cyan().bold())?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Keep untrusted text inside its diagnostic gutter, including on ANSI-capable terminals.
+fn normalize_details(details: &str) -> Cow<'_, str> {
+    if !details.chars().any(|character| {
+        (character.is_control() && character != '\n') || is_layout_control(character)
+    }) {
+        return Cow::Borrowed(details);
+    }
+
+    let mut normalized = String::with_capacity(details.len());
+    let mut characters = details.chars().peekable();
+    while let Some(character) = characters.next() {
+        match character {
+            '\r' if characters.peek() == Some(&'\n') => {
+                characters.next();
+                normalized.push('\n');
+            }
+            '\n' => normalized.push('\n'),
+            '\t' => normalized.push_str("    "),
+            character if character.is_control() => normalized.extend(character.escape_debug()),
+            character if is_layout_control(character) => {
+                normalized.extend(character.escape_unicode());
+            }
+            character => normalized.push(character),
+        }
+    }
+    Cow::Owned(normalized)
+}
+
+fn is_layout_control(character: char) -> bool {
+    matches!(
+        character,
+        '\u{061c}'
+            | '\u{200e}'..='\u{200f}'
+            | '\u{2028}'..='\u{202e}'
+            | '\u{2066}'..='\u{2069}'
+    )
+}

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -1,5 +1,6 @@
 mod diagnostic;
 mod line_wrap;
+mod source;
 
 use std::borrow::Cow;
 use std::error::Error;
@@ -8,10 +9,11 @@ use std::iter;
 
 use owo_colors::{AnsiColors, DynColor, OwoColorize};
 
-#[cfg(test)]
-use diagnostic::{Diagnostic, Info};
-use diagnostic::{DiagnosticFn, write_info};
+use diagnostic::write_info;
+pub use diagnostic::{Diagnostic, DiagnosticFn, Info};
 use line_wrap::{get_wrap_width, wrap_text};
+use source::write_snippets;
+pub use source::{SourceFile, SourceSnippet};
 
 /// An error that may carry user-facing hints.
 ///
@@ -326,8 +328,7 @@ impl<'a, C, W> ErrorOptions<'a, C, W> {
     }
 
     /// Resolve presentation data for each error in the chain.
-    #[cfg(test)]
-    fn with_diagnostic(mut self, diagnostic: DiagnosticFn) -> Self {
+    pub fn with_diagnostic(mut self, diagnostic: DiagnosticFn) -> Self {
         self.diagnostic = Some(diagnostic);
         self
     }
@@ -390,11 +391,16 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
         wrapped_main.trim()
     )?;
     if let Some(diagnostic) = &main_diagnostic {
+        write_snippets(&mut stream, &diagnostic.snippets, color)?;
         write_info(&mut stream, &diagnostic.info, width)?;
     }
 
+    let mut source_override = main_diagnostic.and_then(|diagnostic| diagnostic.source);
     for source in iter::successors(err.source(), |&err| err.source()) {
-        let source_diagnostic = diagnostic.and_then(|diagnostic| diagnostic(source));
+        let source_diagnostic = source_override
+            .take()
+            .map(|diagnostic| *diagnostic)
+            .or_else(|| diagnostic.and_then(|diagnostic| diagnostic(source)));
         let msg = source_diagnostic
             .as_ref()
             .and_then(|diagnostic| diagnostic.message.as_deref())
@@ -421,8 +427,10 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
             }
         }
         if let Some(diagnostic) = &source_diagnostic {
+            write_snippets(&mut stream, &diagnostic.snippets, color)?;
             write_info(&mut stream, &diagnostic.info, width)?;
         }
+        source_override = source_diagnostic.and_then(|diagnostic| diagnostic.source);
     }
 
     for hint in hints {
@@ -442,8 +450,8 @@ mod tests {
     use owo_colors::AnsiColors;
 
     use super::{
-        Diagnostic, ErrorOptions, ErrorWithHints, Hint, HintOrdering, Hints, Info,
-        debug_error_chain, write_error_chain_with_options,
+        Diagnostic, ErrorOptions, ErrorWithHints, Hint, HintOrdering, Hints, Info, SourceFile,
+        SourceSnippet, debug_error_chain, write_error_chain_with_options,
     };
 
     #[test]
@@ -1026,6 +1034,62 @@ mod tests {
             | \u{1b}[31mred\u{1b}[0m
             | \u{1b}]8;;https://example.com\u{7}link\u{85}\u{202e}text\u{2029}\rrewritten
             |
+        ");
+    }
+
+    #[test]
+    fn source_presentation_keeps_the_real_chain_and_trailing_hints() {
+        #[derive(Debug, thiserror::Error)]
+        #[error("Failed to parse `pyproject.toml`")]
+        struct Outer(#[source] Inner);
+
+        #[derive(Debug, thiserror::Error)]
+        #[error("Original parser display")]
+        struct Inner(#[source] Last);
+
+        #[derive(Debug, thiserror::Error)]
+        #[error("Additional cause")]
+        struct Last;
+
+        let error = Outer(Inner(Last));
+        let mut output = String::new();
+        write_error_chain_with_options(
+            &error,
+            &Hints::from("Update the version."),
+            ErrorOptions::default()
+                .with_diagnostic(|error| {
+                    error.is::<Outer>().then(|| {
+                        Diagnostic::default().with_source(
+                            Diagnostic::new("invalid type: integer `42`, expected a string")
+                                .with_snippet(
+                                    SourceSnippet::new(
+                                        SourceFile::new("pyproject.toml", "version = 42"),
+                                        10..12,
+                                    )
+                                    .expect("valid source span in test input"),
+                                ),
+                        )
+                    })
+                })
+                .with_stream(&mut output),
+        )
+        .expect("writing to a string should not fail");
+        assert!(
+            error
+                .source()
+                .expect("original parser source remains present")
+                .is::<Inner>()
+        );
+        assert_snapshot!(anstream::adapter::strip_str(&output), @"
+        error: Failed to parse `pyproject.toml`
+          cause: invalid type: integer `42`, expected a string
+           --> pyproject.toml:1:11
+            |
+          1 | version = 42
+            |           ^^
+          cause: Additional cause
+
+        hint: Update the version.
         ");
     }
 }

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -9,8 +9,10 @@ use std::iter;
 
 use owo_colors::{AnsiColors, DynColor, OwoColorize};
 
+#[cfg(test)]
+use diagnostic::Info;
 use diagnostic::write_info;
-pub use diagnostic::{Diagnostic, DiagnosticFn, Info};
+pub use diagnostic::{Diagnostic, DiagnosticFn};
 use line_wrap::{get_wrap_width, wrap_text};
 use source::write_snippets;
 pub use source::{SourceFile, SourceSnippet};

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -1,3 +1,4 @@
+mod diagnostic;
 mod line_wrap;
 
 use std::borrow::Cow;
@@ -7,6 +8,9 @@ use std::iter;
 
 use owo_colors::{AnsiColors, DynColor, OwoColorize};
 
+#[cfg(test)]
+use diagnostic::{Diagnostic, Info};
+use diagnostic::{DiagnosticFn, write_info};
 use line_wrap::{get_wrap_width, wrap_text};
 
 /// An error that may carry user-facing hints.
@@ -257,6 +261,7 @@ pub struct ErrorOptions<'a, C = AnsiColors, W = Stderr> {
     color: C,
     width_override: Option<usize>,
     stream: W,
+    diagnostic: Option<DiagnosticFn>,
 }
 
 /// A standard-error writer for formatted error chains.
@@ -277,6 +282,7 @@ impl Default for ErrorOptions<'_, AnsiColors, Stderr> {
             color: AnsiColors::Red,
             width_override: None,
             stream: Stderr,
+            diagnostic: None,
         }
     }
 }
@@ -295,6 +301,7 @@ impl<'a, C, W> ErrorOptions<'a, C, W> {
             color,
             width_override: self.width_override,
             stream: self.stream,
+            diagnostic: self.diagnostic,
         }
     }
 
@@ -314,13 +321,21 @@ impl<'a, C, W> ErrorOptions<'a, C, W> {
             color: self.color,
             width_override: self.width_override,
             stream,
+            diagnostic: self.diagnostic,
         }
+    }
+
+    /// Resolve presentation data for each error in the chain.
+    #[cfg(test)]
+    fn with_diagnostic(mut self, diagnostic: DiagnosticFn) -> Self {
+        self.diagnostic = Some(diagnostic);
+        self
     }
 }
 
 /// Format an error chain and explicitly supplied hints to standard error using the default level
 /// and color.
-pub fn write_error_chain(err: &dyn Error, hints: &Hints<'_>) -> fmt::Result {
+pub fn write_error_chain(err: &(dyn Error + 'static), hints: &Hints<'_>) -> fmt::Result {
     write_error_chain_with_options(err, hints, ErrorOptions::default())
 }
 
@@ -347,7 +362,7 @@ impl fmt::Display for DebugErrorChain<'_> {
 ///
 /// Each hint is rendered on its own line, prefixed with the styled `hint:` label.
 pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
-    err: &dyn Error,
+    err: &(dyn Error + 'static),
     hints: &Hints<'_>,
     options: ErrorOptions<'_, C, W>,
 ) -> fmt::Result {
@@ -356,10 +371,15 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
         color,
         width_override,
         mut stream,
+        diagnostic,
     } = options;
     let width = get_wrap_width(width_override);
 
-    let main_msg = err.to_string();
+    let main_diagnostic = diagnostic.and_then(|diagnostic| diagnostic(err));
+    let main_msg = main_diagnostic
+        .as_ref()
+        .and_then(|diagnostic| diagnostic.message.as_deref())
+        .map_or_else(|| Cow::Owned(err.to_string()), Cow::Borrowed);
     let main_padding = " ".repeat(level.len() + 2);
     let wrapped_main = wrap_text(&main_msg, width, &main_padding, &main_padding, "");
     writeln!(
@@ -369,9 +389,16 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
         ":".bold(),
         wrapped_main.trim()
     )?;
+    if let Some(diagnostic) = &main_diagnostic {
+        write_info(&mut stream, &diagnostic.info, width)?;
+    }
 
     for source in iter::successors(err.source(), |&err| err.source()) {
-        let msg = source.to_string();
+        let source_diagnostic = diagnostic.and_then(|diagnostic| diagnostic(source));
+        let msg = source_diagnostic
+            .as_ref()
+            .and_then(|diagnostic| diagnostic.message.as_deref())
+            .map_or_else(|| Cow::Owned(source.to_string()), Cow::Borrowed);
         // Reserve the display width of the prefix before wrapping the message. Authored lines
         // retain their own indentation beneath it.
         let wrapped = wrap_text(&msg, width.map(|width| width.saturating_sub(9)), "", "", "");
@@ -393,6 +420,9 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
                 }
             }
         }
+        if let Some(diagnostic) = &source_diagnostic {
+            write_info(&mut stream, &diagnostic.info, width)?;
+        }
     }
 
     for hint in hints {
@@ -404,14 +434,16 @@ pub fn write_error_chain_with_options<C: DynColor + Copy, W: fmt::Write>(
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
+
     use anyhow::anyhow;
     use indoc::indoc;
     use insta::{assert_debug_snapshot, assert_snapshot};
     use owo_colors::AnsiColors;
 
     use super::{
-        ErrorOptions, ErrorWithHints, Hint, HintOrdering, Hints, debug_error_chain,
-        write_error_chain_with_options,
+        Diagnostic, ErrorOptions, ErrorWithHints, Hint, HintOrdering, Hints, Info,
+        debug_error_chain, write_error_chain_with_options,
     };
 
     #[test]
@@ -851,6 +883,146 @@ mod tests {
 
                  For downloads, please refer to https://example.com/download/python3.13.tar.zst
           cause: Caused By: HTTP Error 400
+        ");
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("HTTP error 400 Bad Request")]
+    struct HttpError;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("Failed to fetch {url}. Server says: {body}")]
+    struct FetchError {
+        url: String,
+        body: String,
+        #[source]
+        source: HttpError,
+    }
+
+    fn fetch_diagnostic<'a>(error: &'a (dyn Error + 'static)) -> Option<Diagnostic<'a>> {
+        let error = error.downcast_ref::<FetchError>()?;
+        Some(
+            Diagnostic::new(format!("Failed to fetch {}", error.url)).with_info(
+                Info::new("The server included the following context:")
+                    .with_details(error.body.as_str()),
+            ),
+        )
+    }
+
+    #[test]
+    fn format_info_between_causes() {
+        let error = anyhow!(FetchError {
+            url: "https://example.com/python.tar.zst".to_string(),
+            body: "This endpoint accepts POST requests only.\n\nUse /download/ instead."
+                .to_string(),
+            source: HttpError,
+        })
+        .context("Failed to download Python 3.13");
+        let mut output = String::new();
+        write_error_chain_with_options(
+            error.as_ref(),
+            &Hints::from("Check the download URL"),
+            ErrorOptions::default()
+                .with_diagnostic(fetch_diagnostic)
+                .with_stream(&mut output),
+        )
+        .unwrap();
+        assert_snapshot!(anstream::adapter::strip_str(&output), @"
+        error: Failed to download Python 3.13
+          cause: Failed to fetch https://example.com/python.tar.zst
+          info: The server included the following context:
+            |
+            | This endpoint accepts POST requests only.
+            |
+            | Use /download/ instead.
+          cause: HTTP error 400 Bad Request
+
+        hint: Check the download URL
+        ");
+    }
+
+    #[test]
+    fn format_info_on_root() {
+        let mut output = String::new();
+        write_error_chain_with_options(
+            &HttpError,
+            &Hints::none(),
+            ErrorOptions::default()
+                .with_diagnostic(|error| {
+                    error.downcast_ref::<HttpError>().map(|_| {
+                        Diagnostic::default()
+                            .with_info(Info::new("First detail"))
+                            .with_info(Info::new("Second detail").with_details(""))
+                    })
+                })
+                .with_stream(&mut output),
+        )
+        .unwrap();
+        assert_snapshot!(anstream::adapter::strip_str(&output), @"
+        error: HTTP error 400 Bad Request
+          info: First detail
+          info: Second detail
+        ");
+    }
+
+    #[test]
+    fn format_info_wrapping() {
+        let error = FetchError {
+            url: "https://example.com".to_string(),
+            body: "First paragraph has several words.\n\n  Indented second paragraph.".to_string(),
+            source: HttpError,
+        };
+        let mut output = String::new();
+        write_error_chain_with_options(
+            &error,
+            &Hints::none(),
+            ErrorOptions::default()
+                .with_level("warning")
+                .with_color(AnsiColors::Yellow)
+                .with_width_override(30)
+                .with_diagnostic(fetch_diagnostic)
+                .with_stream(&mut output),
+        )
+        .unwrap();
+        assert_snapshot!(anstream::adapter::strip_str(&output), @"
+        warning: Failed to fetch
+                 https://example.com
+          info: The server included
+                the following context:
+            |
+            | First paragraph has
+            | several words.
+            |
+            |   Indented second
+            | paragraph.
+          cause: HTTP error 400 Bad
+                 Request
+        ");
+    }
+
+    #[test]
+    fn format_untrusted_info_details() {
+        let mut output = String::new();
+        write_error_chain_with_options(
+            &HttpError,
+            &Hints::none(),
+            ErrorOptions::default()
+                .with_diagnostic(|_| {
+                    Some(Diagnostic::default().with_info(Info::new("Server response:").with_details(
+                        "café 👩‍💻\r\n\tindented\n\u{1b}[31mred\u{1b}[0m\n\u{1b}]8;;https://example.com\u{7}link\u{85}\u{202e}text\u{2029}\rrewritten",
+                    )))
+                })
+                .with_stream(&mut output),
+        )
+        .unwrap();
+        assert_snapshot!(anstream::adapter::strip_str(&output), @r"
+        error: HTTP error 400 Bad Request
+          info: Server response:
+            |
+            | café 👩‍💻
+            |     indented
+            | \u{1b}[31mred\u{1b}[0m
+            | \u{1b}]8;;https://example.com\u{7}link\u{85}\u{202e}text\u{2029}\rrewritten
         ");
     }
 }

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -935,6 +935,7 @@ mod tests {
             | This endpoint accepts POST requests only.
             |
             | Use /download/ instead.
+            |
           cause: HTTP error 400 Bad Request
 
         hint: Check the download URL
@@ -995,6 +996,7 @@ mod tests {
             |
             |   Indented second
             | paragraph.
+            |
           cause: HTTP error 400 Bad
                  Request
         ");
@@ -1023,6 +1025,7 @@ mod tests {
             |     indented
             | \u{1b}[31mred\u{1b}[0m
             | \u{1b}]8;;https://example.com\u{7}link\u{85}\u{202e}text\u{2029}\rrewritten
+            |
         ");
     }
 }

--- a/crates/uv-errors/src/source.rs
+++ b/crates/uv-errors/src/source.rs
@@ -34,12 +34,12 @@ impl SourceFile {
     }
 
     /// The user-facing name of this source.
-    pub fn name(&self) -> &str {
+    fn name(&self) -> &str {
         &self.inner.name
     }
 
     /// The exact decoded text used by the parser.
-    pub fn text(&self) -> &str {
+    fn text(&self) -> &str {
         &self.inner.text
     }
 }

--- a/crates/uv-errors/src/source.rs
+++ b/crates/uv-errors/src/source.rs
@@ -1,0 +1,250 @@
+use std::fmt::{self, Write};
+use std::ops::Range;
+use std::sync::Arc;
+
+use owo_colors::{DynColor, OwoColorize};
+use unicode_width::UnicodeWidthStr;
+
+use crate::diagnostic::{is_layout_control, normalize_details};
+
+/// An immutable source snapshot captured when an error is produced.
+///
+/// Spans refer to UTF-8 byte offsets in the decoded text. The renderer never reopens the file.
+#[derive(Clone)]
+pub struct SourceFile {
+    inner: Arc<SourceFileInner>,
+}
+
+struct SourceFileInner {
+    name: Arc<str>,
+    text: Arc<str>,
+}
+
+impl SourceFile {
+    /// Retain the display name and decoded source text.
+    ///
+    /// The name must be safe to show, for example a local path or a redacted URL.
+    pub fn new(name: impl Into<Arc<str>>, text: impl Into<Arc<str>>) -> Self {
+        Self {
+            inner: Arc::new(SourceFileInner {
+                name: name.into(),
+                text: text.into(),
+            }),
+        }
+    }
+
+    /// The user-facing name of this source.
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    /// The exact decoded text used by the parser.
+    pub fn text(&self) -> &str {
+        &self.inner.text
+    }
+}
+
+impl fmt::Debug for SourceFile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Configuration files can contain credentials; debug output must not dump the snapshot.
+        formatter
+            .debug_struct("SourceFile")
+            .field("name", &self.name())
+            .field("len", &self.text().len())
+            .finish()
+    }
+}
+
+/// The first physical source line touched by a parser's byte span.
+///
+/// Only that line is shown, since surrounding configuration may contain credentials. This does
+/// not redact values on the selected line. Multiline spans are clipped to its visible text.
+#[derive(Clone, Debug)]
+pub struct SourceSnippet {
+    source: SourceFile,
+    line: Range<usize>,
+    annotation: Range<usize>,
+    line_number: usize,
+    column: usize,
+}
+
+impl SourceSnippet {
+    /// Select a source line, or return `None` for an invalid UTF-8 byte span.
+    pub fn new(source: SourceFile, span: Range<usize>) -> Option<Self> {
+        let text = source.text();
+        text.get(span.clone())?;
+        let before = text.get(..span.start)?;
+        let after = text.get(span.start..)?;
+        let start = before.rfind('\n').map_or(0, |index| index + 1);
+        let newline = after.find('\n').map(|index| span.start + index);
+        let mut end = newline.unwrap_or(text.len());
+        if newline.is_some() && text.get(start..end)?.ends_with('\r') {
+            end -= 1;
+        }
+        let annotation_start = span.start.min(end) - start;
+        let annotation_end = span.end.min(end) - start;
+        let line_number = before.bytes().filter(|byte| *byte == b'\n').count() + 1;
+        let column = text.get(start..span.start.min(end))?.chars().count() + 1;
+        Some(Self {
+            source,
+            line: start..end,
+            annotation: annotation_start..annotation_end,
+            line_number,
+            column,
+        })
+    }
+}
+
+pub(crate) fn write_snippets<C: DynColor + Copy>(
+    stream: &mut impl Write,
+    snippets: &[SourceSnippet],
+    color: C,
+) -> fmt::Result {
+    for snippet in snippets {
+        let line = &snippet.source.text()[snippet.line.clone()];
+        let prefix = normalize_details(&line[..snippet.annotation.start]);
+        let through_annotation = normalize_details(&line[..snippet.annotation.end]);
+        let offset = UnicodeWidthStr::width(prefix.as_ref());
+        let length = UnicodeWidthStr::width(through_annotation.as_ref())
+            .saturating_sub(offset)
+            .max(1);
+        let line = normalize_details(line);
+        let name = normalize_name(snippet.source.name());
+        let line_number = snippet.line_number.to_string();
+        let gutter = " ".repeat(line_number.len() + 3);
+        writeln!(
+            stream,
+            "{}{} {name}:{}:{}",
+            " ".repeat(line_number.len() + 2),
+            "-->".cyan().bold(),
+            snippet.line_number,
+            snippet.column,
+        )?;
+        writeln!(stream, "{gutter}{}", "|".cyan().bold())?;
+        if line.is_empty() {
+            writeln!(
+                stream,
+                "  {} {}",
+                line_number.cyan().bold(),
+                "|".cyan().bold()
+            )?;
+        } else {
+            writeln!(
+                stream,
+                "  {} {} {line}",
+                line_number.cyan().bold(),
+                "|".cyan().bold(),
+            )?;
+        }
+        writeln!(
+            stream,
+            "{gutter}{} {}{}",
+            "|".cyan().bold(),
+            " ".repeat(offset),
+            "^".repeat(length).color(color).bold(),
+        )?;
+    }
+    Ok(())
+}
+
+/// Keep a source name on one terminal line without obscuring control characters.
+fn normalize_name(name: &str) -> String {
+    let mut normalized = String::with_capacity(name.len());
+    for character in name.chars() {
+        if character.is_control() {
+            normalized.extend(character.escape_debug());
+        } else if is_layout_control(character) {
+            normalized.extend(character.escape_unicode());
+        } else {
+            normalized.push(character);
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::{assert_debug_snapshot, assert_snapshot};
+    use owo_colors::AnsiColors;
+
+    use super::{SourceFile, SourceSnippet, write_snippets};
+
+    fn render(source: &str, span: std::ops::Range<usize>) -> String {
+        let snippet = SourceSnippet::new(SourceFile::new("pyproject.toml", source), span)
+            .expect("valid source span in test input");
+        let mut output = String::new();
+        write_snippets(&mut output, &[snippet], AnsiColors::Red)
+            .expect("writing to a string should not fail");
+        anstream::adapter::strip_str(&output).to_string()
+    }
+
+    #[test]
+    fn single_source_line() {
+        let source = "token = 'first-secret'\r\nversion = 42\r\nother = 'second-secret'\r\n";
+        let start = source.find("42").expect("invalid version in test input");
+        assert_snapshot!(render(source, start..start + 2), @"
+           --> pyproject.toml:2:11
+            |
+          2 | version = 42
+            |           ^^
+        ");
+    }
+
+    #[test]
+    fn multiline_and_eof_spans() {
+        let source = "items = [\n  'first',\n]\n";
+        assert_snapshot!(render(source, 8..source.len()), @"
+           --> pyproject.toml:1:9
+            |
+          1 | items = [
+            |         ^
+        ");
+        assert_snapshot!(render(source, source.len()..source.len()), @"
+           --> pyproject.toml:4:1
+            |
+          4 |
+            | ^
+        ");
+    }
+
+    #[test]
+    fn untrusted_source_text() {
+        let source = "\tname = 'café 界'\u{1b}[31m\u{202e}value";
+        let start = source.find("value").expect("highlight in test input");
+        assert_snapshot!(render(source, start..source.len()), @r"
+         --> pyproject.toml:1:23
+          |
+        1 |     name = 'café 界'\u{1b}[31m\u{202e}value
+          |                                       ^^^^^
+        ");
+    }
+
+    #[test]
+    fn invalid_source_spans() {
+        let source = SourceFile::new("pyproject.toml", "café");
+        assert!(SourceSnippet::new(source.clone(), 3..4).is_none());
+        assert!(SourceSnippet::new(source.clone(), 4..5).is_none());
+        assert!(SourceSnippet::new(source, std::ops::Range { start: 2, end: 1 }).is_none());
+    }
+
+    #[test]
+    fn source_names_and_debug_output_are_safe() {
+        let source = SourceFile::new("uv\n\u{1b}[31m\u{202e}.toml", "token = 'secret'");
+        assert_debug_snapshot!(source, @r#"
+        SourceFile {
+            name: "uv\n\u{1b}[31m\u{202e}.toml",
+            len: 16,
+        }
+        "#);
+        let snippet = SourceSnippet::new(source, 8..16).expect("valid source span in test input");
+        let mut output = String::new();
+        write_snippets(&mut output, &[snippet], AnsiColors::Red)
+            .expect("writing to a string should not fail");
+        assert_snapshot!(anstream::adapter::strip_str(&output), @r"
+           --> uv\n\u{1b}[31m\u{202e}.toml:1:9
+            |
+          1 | token = 'secret'
+            |         ^^^^^^^^
+        ");
+    }
+}

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -18,12 +18,14 @@ workspace = true
 [dependencies]
 uv-cache-key = { workspace = true }
 uv-distribution-filename = { workspace = true }
+uv-errors = { workspace = true }
 uv-git-types = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true, features = ["rkyv"] }
 uv-redacted = { workspace = true }
 uv-small-str = { workspace = true }
+uv-toml = { workspace = true }
 
 hashbrown = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }

--- a/crates/uv-pypi-types/src/metadata/mod.rs
+++ b/crates/uv-pypi-types/src/metadata/mod.rs
@@ -5,14 +5,17 @@ mod metadata_resolver;
 mod pyproject_toml;
 mod requires_dist;
 
+use std::error::Error as StdError;
 use std::str::Utf8Error;
 
 use mailparse::{MailHeaderMap, MailParseError};
 use thiserror::Error;
 
+use uv_errors::{Diagnostic, SourceFile};
 use uv_normalize::InvalidNameError;
 use uv_pep440::{VersionParseError, VersionSpecifiersParseError};
 use uv_pep508::Pep508Error;
+use uv_toml::{ParseError, diagnostic_for_span};
 
 use crate::VerbatimParsedUrl;
 
@@ -31,9 +34,13 @@ pub enum MetadataError {
     #[error(transparent)]
     MailParse(#[from] MailParseError),
     #[error("Invalid `pyproject.toml`")]
-    InvalidPyprojectTomlSyntax(#[source] toml_edit::TomlError),
+    InvalidPyprojectTomlSyntax {
+        #[source]
+        source: toml_edit::TomlError,
+        document: SourceFile,
+    },
     #[error(transparent)]
-    InvalidPyprojectTomlSchema(toml_edit::de::Error),
+    InvalidPyprojectTomlSchema(ParseError<toml_edit::de::Error>),
     #[error(
         "`pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set"
     )]
@@ -64,6 +71,25 @@ pub enum MetadataError {
     RequiresTxtContents(#[from] std::io::Error),
     #[error("The description is not valid utf-8")]
     DescriptionEncoding(#[source] Utf8Error),
+}
+
+/// Resolve retained `pyproject.toml` source context without replacing parser causes.
+pub fn diagnostic_for_error<'a>(error: &'a (dyn StdError + 'static)) -> Option<Diagnostic<'a>> {
+    let error = error
+        .downcast_ref::<MetadataError>()
+        .or_else(|| error.downcast_ref::<Box<MetadataError>>().map(Box::as_ref))?;
+    match error {
+        MetadataError::InvalidPyprojectTomlSyntax { source, document } => {
+            diagnostic_for_span(source.message(), source.span(), document)
+                .map(|source| Diagnostic::default().with_source(source))
+        }
+        MetadataError::InvalidPyprojectTomlSchema(error) => diagnostic_for_span(
+            error.original().message(),
+            error.original().span(),
+            error.document()?,
+        ),
+        _ => None,
+    }
 }
 
 impl From<Pep508Error<VerbatimParsedUrl>> for MetadataError {

--- a/crates/uv-pypi-types/src/metadata/pyproject_toml.rs
+++ b/crates/uv-pypi-types/src/metadata/pyproject_toml.rs
@@ -6,8 +6,10 @@ use serde::Deserialize;
 use serde::de::IntoDeserializer;
 use tracing::instrument;
 
+use uv_errors::SourceFile;
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
+use uv_toml::ParseError;
 
 use crate::{LenientVersionSpecifiers, MetadataError};
 
@@ -20,12 +22,22 @@ pub struct PyProjectToml {
 }
 
 impl PyProjectToml {
-    #[instrument(name = "toml::from_str uv pypi types", skip_all, fields(source = % _source))]
-    pub fn from_toml(toml: &str, _source: impl Display) -> Result<Self, MetadataError> {
-        let pyproject_toml = toml_edit::Document::from_str(toml)
-            .map_err(MetadataError::InvalidPyprojectTomlSyntax)?;
-        let pyproject_toml = Self::deserialize(pyproject_toml.into_deserializer())
-            .map_err(MetadataError::InvalidPyprojectTomlSchema)?;
+    /// Parse metadata while retaining its caller-provided, display-safe source name.
+    #[instrument(name = "toml::from_str uv pypi types", skip_all, fields(source = %source))]
+    pub fn from_toml(toml: &str, source: impl Display) -> Result<Self, MetadataError> {
+        let pyproject_toml = toml_edit::Document::from_str(toml).map_err(|error| {
+            MetadataError::InvalidPyprojectTomlSyntax {
+                source: error,
+                document: SourceFile::new(source.to_string(), toml),
+            }
+        })?;
+        let pyproject_toml =
+            Self::deserialize(pyproject_toml.into_deserializer()).map_err(|error| {
+                MetadataError::InvalidPyprojectTomlSchema(ParseError::new(
+                    error,
+                    SourceFile::new(source.to_string(), toml),
+                ))
+            })?;
         Ok(pyproject_toml)
     }
 
@@ -124,8 +136,29 @@ pub struct ToolPoetry {
 mod tests {
     use std::assert_matches;
 
+    use insta::assert_snapshot;
+    use uv_errors::SourceFile;
+    use uv_toml::ParseError;
+
     use super::PyProjectToml;
     use crate::MetadataError;
+
+    #[test]
+    fn spanless_schema_error_retains_the_key_path() {
+        let mut original =
+            <toml_edit::de::Error as serde::de::Error>::custom("invalid project metadata");
+        original.add_key("name".to_owned());
+        original.add_key("project".to_owned());
+        let error = MetadataError::InvalidPyprojectTomlSchema(ParseError::new(
+            original,
+            SourceFile::new("pyproject.toml", "[project]\nname = 42\n"),
+        ));
+        assert!(crate::diagnostic_for_error(&error).is_none());
+        assert_snapshot!(error, @"
+        invalid project metadata
+        in `project.name`
+        ");
+    }
 
     #[test]
     fn requires_python_allows_unrelated_dynamic_metadata() {

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -22,6 +22,7 @@ uv-client = { workspace = true }
 uv-configuration = { workspace = true, features = ["clap"] }
 uv-dirs = { workspace = true }
 uv-distribution-types = { workspace = true }
+uv-errors = { workspace = true }
 uv-flags = { workspace = true }
 uv-fs = { workspace = true }
 uv-install-wheel = { workspace = true, features = ["clap"] }
@@ -36,6 +37,7 @@ uv-python = { workspace = true, features = ["clap"] }
 uv-redacted = { workspace = true }
 uv-resolver = { workspace = true, features = ["clap"] }
 uv-static = { workspace = true }
+uv-toml = { workspace = true }
 uv-torch = { workspace = true, features = ["clap"] }
 uv-version = { workspace = true }
 uv-warnings = { workspace = true }
@@ -46,7 +48,6 @@ fs-err = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde-untagged = { workspace = true }
-textwrap = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -1,3 +1,4 @@
+use std::error::Error as StdError;
 use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -8,14 +9,16 @@ use uv_client::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_READ_TIME
 use uv_configuration::RequiredVersion;
 use uv_dirs::{system_config_file, user_config_dir};
 use uv_distribution_types::{IndexUrlError, Origin};
+use uv_errors::{Diagnostic, ErrorOptions, Hints, SourceFile};
 use uv_flags::EnvironmentFlags;
 use uv_fs::Simplified;
 use uv_normalize::{GroupName, PackageName};
 use uv_pep440::Version;
 use uv_redacted::DisplaySafeUrl;
 use uv_static::{EnvVars, InvalidEnvironmentVariable, parse_boolish_environment_variable};
+use uv_toml::diagnostic_for_span;
 use uv_torch::AmdGpuArchitecture;
-use uv_warnings::warn_user;
+use uv_warnings::{warn_user, warn_user_with_chain};
 
 pub use crate::combine::*;
 pub use crate::settings::*;
@@ -105,12 +108,12 @@ impl FilesystemOptions {
                 Ok(None) => {
                     // Continue traversing the directory tree.
                 }
-                Err(Error::PyprojectToml(path, err)) => {
+                Err(error @ Error::PyprojectToml { .. }) => {
                     // If we see an invalid `pyproject.toml`, warn but continue.
-                    warn_user!(
-                        "Failed to parse `{}` during settings discovery:\n{}",
-                        path.user_display().cyan(),
-                        textwrap::indent(&err.to_string(), "  ")
+                    warn_user_with_chain!(
+                        &error,
+                        Hints::none(),
+                        ErrorOptions::default().with_diagnostic(discovery_diagnostic_for_error),
                     );
                 }
                 Err(err) => {
@@ -132,13 +135,7 @@ impl FilesystemOptions {
                 let options =
                     info_span!("toml::from_str filesystem options uv.toml", path = %path.display())
                         .in_scope(|| toml::from_str::<Options>(&content))
-                        .map_err(|err| {
-                            check_uv_toml_required_version(
-                                &path,
-                                &content,
-                                Error::UvToml(path.clone(), Box::new(err)),
-                            )
-                        })?
+                        .map_err(|err| check_uv_toml_required_version(&path, &content, err))?
                         .relative_to(&std::path::absolute(dir)?)?;
 
                 // If the directory also contains a `[tool.uv]` table in a `pyproject.toml` file,
@@ -222,13 +219,7 @@ fn read_file(path: &Path) -> Result<Options, Error> {
     let content = fs_err::read_to_string(path)?;
     let options = info_span!("toml::from_str filesystem options uv.toml", path = %path.display())
         .in_scope(|| toml::from_str::<Options>(&content))
-        .map_err(|err| {
-            check_uv_toml_required_version(
-                path,
-                &content,
-                Error::UvToml(path.to_path_buf(), Box::new(err)),
-            )
-        })?;
+        .map_err(|err| check_uv_toml_required_version(path, &content, err))?;
     let options = if let Some(parent) = std::path::absolute(path)?.parent() {
         options.relative_to(parent)?
     } else {
@@ -256,7 +247,11 @@ fn required_version_mismatch(required_version: Option<RequiredVersion>) -> Optio
 /// On a `pyproject.toml` settings parse error, check whether `tool.uv.required-version` should
 /// take precedence over that error.
 fn check_pyproject_required_version(path: &Path, content: &str, source: toml::de::Error) -> Error {
-    let fallback = || Error::PyprojectToml(path.to_path_buf(), Box::new(source));
+    let fallback = || Error::PyprojectToml {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+        document: SourceFile::new(path.user_display().to_string(), content),
+    };
     let Ok(pyproject) = info_span!(
         "toml::from_str filesystem required-version pyproject.toml",
         path = %path.display()
@@ -274,15 +269,20 @@ fn check_pyproject_required_version(path: &Path, content: &str, source: toml::de
 
 /// On a `uv.toml` settings parse or schema error, check whether top-level `required-version`
 /// should take precedence over that error.
-fn check_uv_toml_required_version(path: &Path, content: &str, source: Error) -> Error {
+fn check_uv_toml_required_version(path: &Path, content: &str, source: toml::de::Error) -> Error {
+    let fallback = || Error::UvToml {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+        document: SourceFile::new(path.user_display().to_string(), content),
+    };
     let Ok(uv_toml) = info_span!(
         "toml::from_str filesystem required-version uv.toml",
         path = %path.display()
     )
     .in_scope(|| toml::from_str::<UvRequiredVersionToml>(content)) else {
-        return source;
+        return fallback();
     };
-    required_version_mismatch(uv_toml.required_version).unwrap_or(source)
+    required_version_mismatch(uv_toml.required_version).unwrap_or_else(fallback)
 }
 
 /// Validate that an [`Options`] schema is compatible with `uv.toml`.
@@ -671,11 +671,21 @@ pub enum Error {
     #[error(transparent)]
     Index(#[from] uv_distribution_types::IndexUrlError),
 
-    #[error("Failed to parse: `{}`", _0.user_display())]
-    PyprojectToml(PathBuf, #[source] Box<toml::de::Error>),
+    #[error("Failed to parse: `{}`", path.user_display())]
+    PyprojectToml {
+        path: PathBuf,
+        #[source]
+        source: Box<toml::de::Error>,
+        document: SourceFile,
+    },
 
-    #[error("Failed to parse: `{}`", _0.user_display())]
-    UvToml(PathBuf, #[source] Box<toml::de::Error>),
+    #[error("Failed to parse: `{}`", path.user_display())]
+    UvToml {
+        path: PathBuf,
+        #[source]
+        source: Box<toml::de::Error>,
+        document: SourceFile,
+    },
 
     #[error("Failed to parse: `{}`. The `{}` field is not allowed in a `uv.toml` file. `{}` is only applicable in the context of a project, and should be placed in a `pyproject.toml` file instead.", _0.user_display(), _1, _1
     )]
@@ -691,6 +701,52 @@ pub enum Error {
 
     #[error(transparent)]
     InvalidEnvironmentVariable(#[from] InvalidEnvironmentVariable),
+}
+
+/// Resolve source presentation for settings errors without replacing their TOML causes.
+pub fn diagnostic_for_error<'a>(error: &'a (dyn StdError + 'static)) -> Option<Diagnostic<'a>> {
+    let error = error
+        .downcast_ref::<Error>()
+        .or_else(|| error.downcast_ref::<Box<Error>>().map(Box::as_ref))?;
+    match error {
+        Error::PyprojectToml {
+            source, document, ..
+        }
+        | Error::UvToml {
+            source, document, ..
+        } => diagnostic_for_span(source.message(), source.span(), document)
+            .map(|source| Diagnostic::default().with_source(source)),
+        Error::Io(_)
+        | Error::Index(_)
+        | Error::PyprojectOnlyField(_, _)
+        | Error::RequiredVersion { .. }
+        | Error::InvalidEnvironmentVariable(_) => None,
+    }
+}
+
+/// Settings discovery can recover from an invalid project configuration.
+fn discovery_diagnostic_for_error<'a>(
+    error: &'a (dyn StdError + 'static),
+) -> Option<Diagnostic<'a>> {
+    let Error::PyprojectToml {
+        path,
+        source,
+        document,
+    } = error.downcast_ref::<Error>()?
+    else {
+        return diagnostic_for_error(error);
+    };
+    let diagnostic = Diagnostic::new(format!(
+        "Failed to parse `{}` during settings discovery",
+        path.user_display(),
+    ));
+    Some(
+        if let Some(source) = diagnostic_for_span(source.message(), source.span(), document) {
+            diagnostic.with_source(source)
+        } else {
+            diagnostic
+        },
+    )
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/crates/uv-toml/Cargo.toml
+++ b/crates/uv-toml/Cargo.toml
@@ -17,3 +17,8 @@ workspace = true
 
 [dependencies]
 serde = { workspace = true }
+uv-errors = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }
+toml = { workspace = true }

--- a/crates/uv-toml/src/diagnostic.rs
+++ b/crates/uv-toml/src/diagnostic.rs
@@ -1,0 +1,159 @@
+use std::error::Error;
+use std::fmt;
+use std::ops::Range;
+
+use uv_errors::{Diagnostic, SourceFile, SourceSnippet};
+
+/// A transparently displayed parser error with optional retained input.
+///
+/// The original error is not rewritten, and its source chain is unchanged. Callers that already
+/// expose the original error as a source can instead retain a [`SourceFile`] beside that source.
+#[derive(Debug)]
+pub struct ParseError<E> {
+    error: E,
+    document: Option<SourceFile>,
+}
+
+impl<E> ParseError<E> {
+    /// Retain the exact decoded document passed to the parser.
+    pub fn new(error: E, document: SourceFile) -> Self {
+        Self {
+            error,
+            document: Some(document),
+        }
+    }
+
+    /// The original parser error.
+    pub fn original(&self) -> &E {
+        &self.error
+    }
+
+    /// The source snapshot retained by the parse boundary, if available.
+    pub fn document(&self) -> Option<&SourceFile> {
+        self.document.as_ref()
+    }
+}
+
+impl<E> From<E> for ParseError<E> {
+    fn from(error: E) -> Self {
+        Self {
+            error,
+            document: None,
+        }
+    }
+}
+
+impl<E: fmt::Display> fmt::Display for ParseError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(formatter)
+    }
+}
+
+impl<E: Error + 'static> Error for ParseError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.error.source()
+    }
+}
+
+/// Describe a TOML parser message using its typed span and retained input.
+///
+/// An unavailable or invalid span leaves the original parser display in use, including any
+/// deserialization key path. Only the first physical line touched by the span is displayed.
+pub fn diagnostic_for_span<'a>(
+    message: &'a str,
+    span: Option<Range<usize>>,
+    document: &SourceFile,
+) -> Option<Diagnostic<'a>> {
+    let snippet = SourceSnippet::new(document.clone(), span?)?;
+    Some(Diagnostic::new(message).with_snippet(snippet))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use insta::assert_snapshot;
+    use serde::Deserialize;
+    use uv_errors::SourceFile;
+
+    use super::{ParseError, diagnostic_for_span};
+
+    #[test]
+    fn retains_the_original_parser_error() {
+        #[derive(Deserialize)]
+        struct Settings {
+            #[serde(rename = "count")]
+            _count: usize,
+        }
+
+        let input = "count = 'invalid'";
+        let original = toml::from_str::<Settings>(input)
+            .err()
+            .expect("invalid integer in test input");
+        let error = ParseError::new(original, SourceFile::new("uv.toml", input));
+        assert!(error.source().is_none());
+        assert!(
+            diagnostic_for_span(
+                error.original().message(),
+                error.original().span(),
+                error.document().expect("retained source"),
+            )
+            .is_some()
+        );
+        assert_snapshot!(error, @r#"
+        TOML parse error at line 1, column 9
+          |
+        1 | count = 'invalid'
+          |         ^^^^^^^^^
+        invalid type: string "invalid", expected usize
+        "#);
+
+        let original = <toml::de::Error as serde::de::Error>::custom("invalid settings");
+        let error = ParseError::from(original);
+        assert!(error.document().is_none());
+        assert!(
+            diagnostic_for_span(
+                error.original().message(),
+                error.original().span(),
+                &SourceFile::new("uv.toml", input),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn spanless_deserialization_retains_the_key_path() {
+        #[derive(Deserialize)]
+        struct Settings {
+            #[serde(rename = "outer")]
+            _outer: Nested,
+        }
+
+        #[derive(Deserialize)]
+        struct Nested {
+            #[serde(rename = "count")]
+            _count: usize,
+        }
+
+        let input = "[outer]\ncount = 'invalid'";
+        let value = toml::from_str::<toml::Value>(input).expect("valid TOML in test input");
+        let original = value
+            .try_into::<Settings>()
+            .err()
+            .expect("invalid integer in test input");
+        assert!(original.span().is_none());
+        let error = ParseError::new(original, SourceFile::new("uv.toml", input));
+        assert!(
+            diagnostic_for_span(
+                error.original().message(),
+                error.original().span(),
+                error.document().expect("retained source"),
+            )
+            .is_none()
+        );
+        assert_snapshot!(error, @r#"
+        invalid type: string "invalid", expected usize
+        in `outer.count`
+        "#);
+    }
+}

--- a/crates/uv-toml/src/lib.rs
+++ b/crates/uv-toml/src/lib.rs
@@ -2,6 +2,10 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Deserializer};
 
+pub use diagnostic::{ParseError, diagnostic_for_span};
+
+mod diagnostic;
+
 /// Deserialize a map while ensuring all keys are unique.
 pub fn deserialize_unique_map<'de, D, K, V, F>(
     deserializer: D,

--- a/crates/uv-warnings/src/lib.rs
+++ b/crates/uv-warnings/src/lib.rs
@@ -27,7 +27,7 @@ pub fn disable() {
 }
 
 /// Format a warning chain to standard error.
-pub fn write_warning_chain(err: &dyn Error, hints: &Hints<'_>) -> fmt::Result {
+pub fn write_warning_chain(err: &(dyn Error + 'static), hints: &Hints<'_>) -> fmt::Result {
     write_warning_chain_with_options(err, hints, ErrorOptions::default())
 }
 
@@ -57,7 +57,7 @@ fn write_warning_chain_once_with_writer(
 }
 
 fn write_warning_chain_with_options<C, W: fmt::Write>(
-    err: &dyn Error,
+    err: &(dyn Error + 'static),
     hints: &Hints<'_>,
     options: ErrorOptions<'_, C, W>,
 ) -> fmt::Result {

--- a/crates/uv-warnings/src/lib.rs
+++ b/crates/uv-warnings/src/lib.rs
@@ -32,22 +32,28 @@ pub fn write_warning_chain(err: &(dyn Error + 'static), hints: &Hints<'_>) -> fm
 }
 
 /// Format a warning chain to standard error once, deduplicating the complete rendered chain and hints.
-pub fn write_warning_chain_once(err: &dyn Error, hints: &Hints<'_>) -> fmt::Result {
-    write_warning_chain_once_with_writer(err, hints, &WARNINGS, Stderr)
+pub fn write_warning_chain_once(err: &(dyn Error + 'static), hints: &Hints<'_>) -> fmt::Result {
+    write_warning_chain_once_with_options(err, hints, ErrorOptions::default())
 }
 
-fn write_warning_chain_once_with_writer(
-    err: &dyn Error,
+/// Format a warning chain once using custom presentation options.
+pub fn write_warning_chain_once_with_options<C>(
+    err: &(dyn Error + 'static),
+    hints: &Hints<'_>,
+    options: ErrorOptions<'_, C>,
+) -> fmt::Result {
+    write_warning_chain_once_with_writer(err, hints, &WARNINGS, options, Stderr)
+}
+
+fn write_warning_chain_once_with_writer<C>(
+    err: &(dyn Error + 'static),
     hints: &Hints<'_>,
     warnings: &Mutex<FxHashSet<String>>,
+    options: ErrorOptions<'_, C>,
     mut writer: impl fmt::Write,
 ) -> fmt::Result {
     let mut message = String::new();
-    write_warning_chain_with_options(
-        err,
-        hints,
-        ErrorOptions::default().with_stream(&mut message),
-    )?;
+    write_warning_chain_with_options(err, hints, options.with_stream(&mut message))?;
     if let Ok(mut warnings) = warnings.lock()
         && warnings.insert(message.clone())
     {
@@ -56,7 +62,8 @@ fn write_warning_chain_once_with_writer(
     Ok(())
 }
 
-fn write_warning_chain_with_options<C, W: fmt::Write>(
+/// Format a warning chain using custom presentation and output options.
+pub fn write_warning_chain_with_options<C, W: fmt::Write>(
     err: &(dyn Error + 'static),
     hints: &Hints<'_>,
     options: ErrorOptions<'_, C, W>,
@@ -88,8 +95,9 @@ macro_rules! warn_user {
 /// Warn a user with an error and its cause chain, if warnings are enabled.
 ///
 /// The error must be passed as a reference to a type implementing [`Error`], or as a
-/// `&dyn Error`. Optional [`Hints`] are rendered after the cause chain. Arguments are
-/// only evaluated when warnings are enabled.
+/// `&(dyn Error + 'static)`. Optional [`Hints`] are rendered after the cause chain. A third
+/// [`ErrorOptions`] argument can customize presentation. Arguments are only evaluated when
+/// warnings are enabled.
 ///
 /// Attach context to the error to include a warning-specific message without losing its causes:
 ///
@@ -109,6 +117,12 @@ macro_rules! warn_user_with_chain {
     ($err:expr, $hints:expr $(,)?) => {{
         if $crate::ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
             $crate::write_warning_chain($err, &$hints).expect("writing to stderr should not fail");
+        }
+    }};
+    ($err:expr, $hints:expr, $options:expr $(,)?) => {{
+        if $crate::ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
+            $crate::write_warning_chain_with_options($err, &$hints, $options)
+                .expect("writing to stderr should not fail");
         }
     }};
 }
@@ -146,6 +160,12 @@ macro_rules! warn_user_once_with_chain {
     ($err:expr, $hints:expr $(,)?) => {{
         if $crate::ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
             $crate::write_warning_chain_once($err, &$hints)
+                .expect("writing to stderr should not fail");
+        }
+    }};
+    ($err:expr, $hints:expr, $options:expr $(,)?) => {{
+        if $crate::ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
+            $crate::write_warning_chain_once_with_options($err, &$hints, $options)
                 .expect("writing to stderr should not fail");
         }
     }};
@@ -218,6 +238,7 @@ mod tests {
                 error.as_ref(),
                 &Hints::from(hint),
                 &warnings,
+                ErrorOptions::default(),
                 &mut output,
             )?;
         }
@@ -259,6 +280,20 @@ mod tests {
                 Hints::none()
             },
         );
+        warn_user_with_chain!(
+            {
+                evaluations += 1;
+                error.as_ref()
+            },
+            {
+                evaluations += 1;
+                Hints::none()
+            },
+            {
+                evaluations += 1;
+                ErrorOptions::default()
+            },
+        );
         warn_user_once_with_chain!({
             evaluations += 1;
             error.as_ref()
@@ -271,6 +306,20 @@ mod tests {
             {
                 evaluations += 1;
                 Hints::none()
+            },
+        );
+        warn_user_once_with_chain!(
+            {
+                evaluations += 1;
+                error.as_ref()
+            },
+            {
+                evaluations += 1;
+                Hints::none()
+            },
+            {
+                evaluations += 1;
+                ErrorOptions::default()
             },
         );
 

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -8,6 +8,7 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::error::Error as StdError;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -22,7 +23,8 @@ use tracing::instrument;
 use uv_build_backend::BuildBackendSettings;
 use uv_configuration::{ExcludeDependency, GitLfsSetting, Override};
 use uv_distribution_types::{Index, IndexName, RequirementSource};
-use uv_fs::{PortablePathBuf, try_relative_to_if};
+use uv_errors::{Diagnostic, SourceFile};
+use uv_fs::{PortablePathBuf, Simplified, try_relative_to_if};
 use uv_git_types::GitReference;
 use uv_macros::OptionsMetadata;
 use uv_normalize::{DefaultGroups, ExtraName, GroupName, PackageName};
@@ -34,12 +36,12 @@ use uv_pypi_types::{
     VerbatimParsedUrl,
 };
 use uv_redacted::DisplaySafeUrl;
-use uv_toml::deserialize_unique_map;
+use uv_toml::{ParseError, deserialize_unique_map, diagnostic_for_span};
 
 #[derive(Error, Debug)]
 pub enum PyprojectTomlError {
     #[error(transparent)]
-    Toml(#[from] toml::de::Error),
+    Toml(#[from] ParseError<toml::de::Error>),
     #[error("Failed to parse `tool.uv.sources`")]
     Source(
         #[from]
@@ -54,6 +56,31 @@ pub enum PyprojectTomlError {
         "`pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list"
     )]
     MissingVersion,
+}
+
+impl From<toml::de::Error> for PyprojectTomlError {
+    fn from(error: toml::de::Error) -> Self {
+        Self::Toml(error.into())
+    }
+}
+
+/// Resolve source presentation for a parsed `pyproject.toml` error.
+pub fn diagnostic_for_error<'a>(error: &'a (dyn StdError + 'static)) -> Option<Diagnostic<'a>> {
+    let error = error.downcast_ref::<PyprojectTomlError>().or_else(|| {
+        error
+            .downcast_ref::<Box<PyprojectTomlError>>()
+            .map(Box::as_ref)
+    })?;
+    match error {
+        PyprojectTomlError::Toml(error) => diagnostic_for_span(
+            error.original().message(),
+            error.original().span(),
+            error.document()?,
+        ),
+        PyprojectTomlError::Source(_)
+        | PyprojectTomlError::MissingName
+        | PyprojectTomlError::MissingVersion => None,
+    }
 }
 
 fn deserialize_optional_dependencies<'de, D, V>(
@@ -91,21 +118,25 @@ pub struct PyProjectToml {
 
 impl PyProjectToml {
     /// Parse a `PyProjectToml` from a raw TOML string.
-    #[instrument("toml::from_str workspace", skip_all, fields(path = %_path.as_ref().display()))]
-    pub fn from_string(raw: String, _path: impl AsRef<Path>) -> Result<Self, PyprojectTomlError> {
+    #[instrument("toml::from_str workspace", skip_all, fields(path = %path.as_ref().display()))]
+    pub fn from_string(raw: String, path: impl AsRef<Path>) -> Result<Self, PyprojectTomlError> {
         let pyproject: Self = match toml::from_str(&raw) {
             Ok(pyproject) => pyproject,
             Err(error) => {
+                let document =
+                    SourceFile::new(path.as_ref().user_display().to_string(), raw.clone());
                 // Preserve the more specific source error if both parses would fail.
                 let sources = toml::from_str::<PyProjectTomlSourcesWire>(&raw)
-                    .map_err(PyprojectTomlError::Toml)?
+                    .map_err(|error| {
+                        PyprojectTomlError::Toml(ParseError::new(error, document.clone()))
+                    })?
                     .tool
                     .and_then(|tool| tool.uv)
                     .and_then(|uv| uv.sources);
                 if let Some(sources) = sources {
                     ToolUvSources::try_from(sources)?;
                 }
-                return Err(PyprojectTomlError::Toml(error));
+                return Err(PyprojectTomlError::Toml(ParseError::new(error, document)));
             }
         };
 

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
@@ -6,7 +7,7 @@ use rustc_hash::FxHashMap;
 use version_ranges::Ranges;
 
 use uv_distribution_types::{DerivationChain, DerivationStep};
-use uv_errors::{Hinted, Hints};
+use uv_errors::{Diagnostic, Hinted, Hints};
 use uv_normalize::PackageName;
 use uv_pep440::{Version, strip_local_version_sentinels};
 
@@ -42,8 +43,17 @@ pub(crate) fn write_error_chain(err: &anyhow::Error, printer: Printer) -> std::f
     uv_errors::write_error_chain_with_options(
         err.as_ref(),
         &hints_for_error(err),
-        uv_errors::ErrorOptions::default().with_stream(printer.stderr_important()),
+        uv_errors::ErrorOptions::default()
+            .with_diagnostic(diagnostic_for_error)
+            .with_stream(printer.stderr_important()),
     )
+}
+
+/// Resolve presentation data without changing an error or its source chain.
+pub(crate) fn diagnostic_for_error<'a>(error: &'a (dyn Error + 'static)) -> Option<Diagnostic<'a>> {
+    uv_settings::diagnostic_for_error(error)
+        .or_else(|| uv_workspace::pyproject::diagnostic_for_error(error))
+        .or_else(|| uv_pypi_types::diagnostic_for_error(error))
 }
 
 /// Walk an error chain and collect hint strings from all known error types.
@@ -243,11 +253,85 @@ fn format_chain(name: &PackageName, version: Option<&Version>, chain: &Derivatio
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_debug_snapshot;
+    use std::error::Error;
 
-    use uv_workspace::pyproject::{PyprojectTomlError, SourceError};
+    use assert_fs::prelude::*;
+    use insta::{assert_debug_snapshot, assert_snapshot};
 
-    use super::hints_for_error;
+    use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
+    use uv_fs::Simplified;
+    use uv_settings::FilesystemOptions;
+    use uv_workspace::pyproject::{PyProjectToml, PyprojectTomlError, SourceError};
+
+    use super::{diagnostic_for_error, hints_for_error};
+
+    #[test]
+    fn settings_parse_error_retains_source() -> anyhow::Result<()> {
+        let file = assert_fs::NamedTempFile::new("uv.toml")?;
+        file.write_str(indoc::indoc! {r#"
+            index-url = "https://user:first-secret@example.com/simple"
+            preview-features = 123
+            publish-url = "https://user:second-secret@example.com/legacy/"
+        "#})?;
+        let error = FilesystemOptions::from_file(file.path())
+            .expect_err("invalid preview setting in test input");
+        assert!(
+            error
+                .source()
+                .expect("settings retain the original TOML cause")
+                .is::<Box<toml::de::Error>>()
+        );
+
+        file.write_str("preview-features = []\n")?;
+        let mut output = String::new();
+        write_error_chain_with_options(
+            &error,
+            &Hints::none(),
+            ErrorOptions::default()
+                .with_diagnostic(diagnostic_for_error)
+                .with_stream(&mut output),
+        )?;
+        let output = anstream::adapter::strip_str(&output);
+        let display_path = regex::escape(&file.path().user_display().to_string());
+        let filters = [(display_path.as_str(), "[CONFIG]")];
+        insta::with_settings!({ filters => filters }, {
+            assert_snapshot!(output, @"
+            error: Failed to parse: `[CONFIG]`
+              cause: invalid type: integer `123`, expected a boolean or a list of preview feature names
+               --> [CONFIG]:2:20
+                |
+              2 | preview-features = 123
+                |                    ^^^
+            ");
+        });
+        Ok(())
+    }
+
+    #[test]
+    fn pyproject_diagnostics_retain_parser_sources() {
+        let error = uv_pypi_types::PyProjectToml::from_toml("123 - 456", "pyproject.toml")
+            .expect_err("invalid TOML in test input");
+        assert!(
+            error
+                .source()
+                .expect("metadata retains the original syntax error")
+                .is::<toml_edit::TomlError>()
+        );
+        assert!(diagnostic_for_error(&error).is_some());
+        assert!(diagnostic_for_error(&Box::new(error)).is_some());
+
+        let error =
+            uv_pypi_types::PyProjectToml::from_toml("[project]\nname = 42\n", "pyproject.toml")
+                .expect_err("invalid project name in test input");
+        assert!(error.source().is_none());
+        assert!(diagnostic_for_error(&error).is_some());
+
+        let error = PyProjectToml::from_string("[project]\n".to_owned(), "pyproject.toml")
+            .expect_err("missing project name in test input");
+        assert!(error.source().is_none());
+        assert!(diagnostic_for_error(&error).is_some());
+        assert!(diagnostic_for_error(&Box::new(error)).is_some());
+    }
 
     #[test]
     fn collects_source_hints_through_pyproject_errors() {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -21,6 +21,7 @@ use uv_distribution_types::{
     DependencyMetadata, HashCollection, Index, IndexLocations, NameRequirementSpecification,
     Requirement, RequiresPython, UnresolvedRequirementSpecification,
 };
+use uv_errors::{ErrorOptions, Hints};
 use uv_git::ResolvedRepositoryReference;
 use uv_git_types::GitOid;
 use uv_normalize::{GroupName, PackageName};
@@ -46,6 +47,7 @@ use uv_workspace::{
     DiscoveryOptions, Editability, VirtualProject, WorkspaceCache, WorkspaceMember,
 };
 
+use crate::commands::diagnostics::diagnostic_for_error;
 use crate::commands::pip::loggers::{DefaultResolveLogger, ResolveLogger, SummaryResolveLogger};
 use crate::commands::project::lock_target::{LockTarget, find_lock_format_error};
 use crate::commands::project::{
@@ -974,7 +976,9 @@ async fn do_lock(
                 warn_user_with_chain!(
                     anyhow::Error::from(err)
                         .context("Failed to validate existing lockfile")
-                        .as_ref()
+                        .as_ref(),
+                    Hints::none(),
+                    ErrorOptions::default().with_diagnostic(diagnostic_for_error),
                 );
                 None
             }

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -13,6 +13,7 @@ use uv_configuration::{
 };
 use uv_distribution::{ArchiveMetadata, Metadata};
 use uv_distribution_types::{Identifier, RequiresPython};
+use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_pep440::{Operator, Version, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{MarkerTree, Pep508ErrorSource, Requirement, VerbatimUrl, VersionOrUrl};
@@ -336,7 +337,7 @@ pub(crate) async fn upgrade(
     let pyproject = pyproject.to_string();
     let pyproject = PyProjectToml::from_toml(
         &pyproject,
-        project.project_root().join("pyproject.toml").display(),
+        project.project_root().join("pyproject.toml").user_display(),
     )?;
     if pyproject
         .project

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{ActiveEnvironment, DependencyGroupsWithDefaults};
-use uv_errors::ErrorWithHints;
+use uv_errors::{ErrorOptions, ErrorWithHints, Hints};
 use uv_fs::Simplified;
 use uv_python::{
     ConfigDiscovery, EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference,
@@ -16,6 +16,7 @@ use uv_settings::PythonInstallMirrors;
 use uv_warnings::{warn_user, warn_user_once_with_chain};
 use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceErrorKind};
 
+use crate::commands::diagnostics::diagnostic_for_error;
 use crate::commands::{
     ExitStatus,
     project::{ScriptInterpreter, WorkspacePython, validate_project_requires_python},
@@ -65,7 +66,11 @@ pub(crate) async fn find(
                         | WorkspaceErrorKind::MissingPyprojectToml
                         | WorkspaceErrorKind::NonWorkspace(_)
                 ) {
-                    warn_user_once_with_chain!(&err);
+                    warn_user_once_with_chain!(
+                        &err,
+                        Hints::none(),
+                        ErrorOptions::default().with_diagnostic(diagnostic_for_error),
+                    );
                 }
                 None
             }

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -17,6 +17,7 @@ use uv_distribution_types::{
     ExtraBuildRequires, IndexCapabilities, NameRequirementSpecification, Requirement,
     RequirementSource, UnresolvedRequirementSpecification,
 };
+use uv_errors::{ErrorOptions, Hints};
 use uv_installer::{InstallationStrategy, Planner, SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
 use uv_pep440::{VersionSpecifier, VersionSpecifiers};
@@ -34,6 +35,7 @@ use uv_warnings::{warn_user, warn_user_once, warn_user_with_chain};
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::ExitStatus;
+use crate::commands::diagnostics::diagnostic_for_error;
 use crate::commands::pip::latest::LatestClient;
 use crate::commands::pip::loggers::{
     DefaultInstallLogger, DefaultResolveLogger, SummaryResolveLogger,
@@ -554,7 +556,9 @@ pub(crate) async fn install(
                     warn_user_with_chain!(
                         anyhow::Error::from(err)
                             .context("Failed to validate existing tool lock")
-                            .as_ref()
+                            .as_ref(),
+                        Hints::none(),
+                        ErrorOptions::default().with_diagnostic(diagnostic_for_error),
                     );
                     None
                 }

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -1,3 +1,4 @@
+use std::error::Error as StdError;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -19,6 +20,7 @@ use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildRequires, Index, IndexLocations,
     PackageConfigSettings, Requirement,
 };
+use uv_errors::{Diagnostic, ErrorOptions, Hints};
 use uv_fs::Simplified;
 use uv_install_wheel::LinkMode;
 use uv_normalize::DefaultGroups;
@@ -34,10 +36,13 @@ use uv_types::{
     AnyErrorBuild, BuildContext, BuildIsolation, BuildStack, HashStrategy, SourceTreeEditablePolicy,
 };
 use uv_virtualenv::{OnExisting, RemovalReason, Seed};
-use uv_warnings::warn_user;
-use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceErrorKind};
+use uv_warnings::{warn_user, warn_user_with_chain};
+use uv_workspace::{
+    DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceError, WorkspaceErrorKind,
+};
 
 use crate::commands::ExitStatus;
+use crate::commands::diagnostics::diagnostic_for_error;
 use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
 use crate::commands::pip::operations::{Changelog, report_interpreter};
 use crate::commands::project::{
@@ -60,6 +65,21 @@ enum VenvError {
 
     #[error("Failed to resolve `--find-links` entry")]
     FlatIndex(#[source] uv_client::FlatIndexError),
+}
+
+fn discovery_diagnostic_for_error<'a>(
+    error: &'a (dyn StdError + 'static),
+) -> Option<Diagnostic<'a>> {
+    if let Some(error) = error.downcast_ref::<WorkspaceError>()
+        && let WorkspaceErrorKind::Toml(path, _) = error.as_ref()
+    {
+        Some(Diagnostic::new(format!(
+            "Failed to parse `{}` during environment creation",
+            path.user_display(),
+        )))
+    } else {
+        diagnostic_for_error(error)
+    }
 }
 
 /// Create a virtual environment.
@@ -107,11 +127,11 @@ pub(crate) async fn venv(
                     WorkspaceErrorKind::MissingProject(_)
                     | WorkspaceErrorKind::MissingPyprojectToml
                     | WorkspaceErrorKind::NonWorkspace(_) => {}
-                    WorkspaceErrorKind::Toml(path, err) => {
-                        warn_user!(
-                            "Failed to parse `{}` during environment creation:\n{}",
-                            path.user_display().cyan(),
-                            textwrap::indent(&err.to_string(), "  ")
+                    WorkspaceErrorKind::Toml(..) => {
+                        warn_user_with_chain!(
+                            &err,
+                            Hints::none(),
+                            ErrorOptions::default().with_diagnostic(discovery_diagnostic_for_error),
                         );
                     }
                     _ => warn_user!("{err}"),

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -752,11 +752,11 @@ async fn proxy_invalid_url_in_uv_toml() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      cause: TOML parse error at line 1, column 14
-               |
-             1 | http-proxy = "ftp://proxy.example.com:8080"
-               |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             invalid proxy URL scheme `ftp` in `ftp://proxy.example.com:8080/`: expected http, https, socks5, or socks5h
+      cause: invalid proxy URL scheme `ftp` in `ftp://proxy.example.com:8080/`: expected http, https, socks5, or socks5h
+       --> uv.toml:1:14
+        |
+      1 | http-proxy = "ftp://proxy.example.com:8080"
+        |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "#);
 }
 
@@ -780,11 +780,11 @@ async fn proxy_invalid_url_not_a_url_in_uv_toml() {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      cause: TOML parse error at line 1, column 14
-               |
-             1 | http-proxy = "not a valid url"
-               |              ^^^^^^^^^^^^^^^^^
-             invalid proxy URL: invalid international domain name
+      cause: invalid proxy URL: invalid international domain name
+       --> uv.toml:1:14
+        |
+      1 | http-proxy = "not a valid url"
+        |              ^^^^^^^^^^^^^^^^^
     "#);
 }
 

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -70,18 +70,18 @@ fn lock_validation_warning_chain() -> Result<()> {
     ----- stderr -----
     warning: Failed to validate existing lockfile
       cause: Failed to parse `[TEMP_DIR]/child/pyproject.toml`
-      cause: TOML parse error at line 3, column 11
-               |
-             3 | version = 42
-               |           ^^
-             invalid type: integer `42`, expected a string
+      cause: invalid type: integer `42`, expected a string
+       --> child/pyproject.toml:3:11
+        |
+      3 | version = 42
+        |           ^^
     error: Failed to build `child @ file://[TEMP_DIR]/child`
       cause: Failed to parse metadata from built wheel
-      cause: TOML parse error at line 3, column 11
-               |
-             3 | version = 42
-               |           ^^
-             invalid type: integer `42`, expected a string
+      cause: invalid type: integer `42`, expected a string
+       --> child/pyproject.toml:3:11
+        |
+      3 | version = 42
+        |           ^^
     ");
     Ok(())
 }
@@ -24978,19 +24978,18 @@ fn lock_invalid_index() -> Result<()> {
     uv_snapshot!(context.filters(), context.lock(), @r#"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 12, column 16
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
+        --> pyproject.toml:12:16
          |
       12 |         name = "internal proxy"
          |                ^^^^^^^^^^^^^^^^
-      Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
-
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 9, column 31
-               |
-             9 |         iniconfig = { index = "internal proxy" }
-               |                               ^^^^^^^^^^^^^^^^
-             Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
+      cause: Index names may only contain letters, digits, hyphens, underscores, and periods, but found unsupported character (` `) in: `internal proxy`
+       --> pyproject.toml:9:31
+        |
+      9 |         iniconfig = { index = "internal proxy" }
+        |                               ^^^^^^^^^^^^^^^^
     "#);
 
     Ok(())
@@ -25283,19 +25282,18 @@ fn lock_unnamed_explicit_index() -> Result<()> {
     uv_snapshot!(context.filters(), context.lock(), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 8, column 9
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
+       --> pyproject.toml:8:9
         |
       8 |         [[tool.uv.index]]
         |         ^^^^^^^^^^^^^^^^^
-      An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
-
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 8, column 9
-               |
-             8 |         [[tool.uv.index]]
-               |         ^^^^^^^^^^^^^^^^^
-             An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
+      cause: An index with `explicit = true` requires a `name`: https://test.pypi.org/simple
+       --> pyproject.toml:8:9
+        |
+      8 |         [[tool.uv.index]]
+        |         ^^^^^^^^^^^^^^^^^
     ");
 
     Ok(())
@@ -25328,19 +25326,18 @@ fn lock_invalid_index_cache_control() -> Result<()> {
     uv_snapshot!(context.filters(), context.lock(), @r#"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 11, column 9
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: `cache-control.api` must be a valid HTTP header value
+        --> pyproject.toml:11:9
          |
       11 |         cache-control.api = """
          |         ^^^^^^^^^^^^^
-      `cache-control.api` must be a valid HTTP header value
-
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 11, column 9
-                |
-             11 |         cache-control.api = """
-                |         ^^^^^^^^^^^^^
-             `cache-control.api` must be a valid HTTP header value
+      cause: `cache-control.api` must be a valid HTTP header value
+        --> pyproject.toml:11:9
+         |
+      11 |         cache-control.api = """
+         |         ^^^^^^^^^^^^^
     "#);
 
     Ok(())
@@ -25763,11 +25760,11 @@ fn lock_repeat_named_index() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 8, column 9
-               |
-             8 |         [[tool.uv.index]]
-               |         ^^^^^^^^^^^^^^^^^
-             duplicate index name `pytorch`
+      cause: duplicate index name `pytorch`
+       --> pyproject.toml:8:9
+        |
+      8 |         [[tool.uv.index]]
+        |         ^^^^^^^^^^^^^^^^^
     ");
 
     Ok(())
@@ -25804,11 +25801,11 @@ fn lock_multiple_default_indexes() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 8, column 9
-               |
-             8 |         [[tool.uv.index]]
-               |         ^^^^^^^^^^^^^^^^^
-             found multiple indexes with `default = true`; only one index may be marked as default
+      cause: found multiple indexes with `default = true`; only one index may be marked as default
+       --> pyproject.toml:8:9
+        |
+      8 |         [[tool.uv.index]]
+        |         ^^^^^^^^^^^^^^^^^
     ");
 
     Ok(())
@@ -27864,13 +27861,12 @@ fn lock_dependency_metadata() -> Result<()> {
     uv_snapshot!(context.filters(), context.lock(), @r#"
     exit_code: 0 (success)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 11, column 9
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: unknown field `requires_dist`, expected one of `name`, `version`, `requires-dist`, `requires-python`, `provides-extra`, `provides-extras`
+        --> pyproject.toml:11:9
          |
       11 |         requires_dist = ["typing-extensions"]
          |         ^^^^^^^^^^^^^
-      unknown field `requires_dist`, expected one of `name`, `version`, `requires-dist`, `requires-python`, `provides-extra`, `provides-extras`
-
     Resolved 4 packages in [TIME]
     Added idna v3.6
     Removed iniconfig v2.0.0
@@ -28159,19 +28155,18 @@ fn lock_duplicate_sources() -> Result<()> {
     uv_snapshot!(context.filters(), context.lock(), @r#"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 9, column 9
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: duplicate key
+       --> pyproject.toml:9:9
         |
       9 |         python-multipart = { url = "https://files.pythonhosted.org/packages/c0/3e/9fbfd74e7f5b54f653f7ca99d44ceb56e718846920162165061c4c22b71a/python_multipart-0.0.8-py3-none-any.whl" }
         |         ^^^^^^^^^^^^^^^^
-      duplicate key
-
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 9, column 9
-               |
-             9 |         python-multipart = { url = "https://files.pythonhosted.org/packages/c0/3e/9fbfd74e7f5b54f653f7ca99d44ceb56e718846920162165061c4c22b71a/python_multipart-0.0.8-py3-none-any.whl" }
-               |         ^^^^^^^^^^^^^^^^
-             duplicate key
+      cause: duplicate key
+       --> pyproject.toml:9:9
+        |
+      9 |         python-multipart = { url = "https://files.pythonhosted.org/packages/c0/3e/9fbfd74e7f5b54f653f7ca99d44ceb56e718846920162165061c4c22b71a/python_multipart-0.0.8-py3-none-any.whl" }
+        |         ^^^^^^^^^^^^^^^^
     "#);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -28192,11 +28187,11 @@ fn lock_duplicate_sources() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 7, column 9
-               |
-             7 |         [tool.uv.sources]
-               |         ^^^^^^^^^^^^^^^^^
-             duplicate sources for package `python-multipart`
+      cause: duplicate sources for package `python-multipart`
+       --> pyproject.toml:7:9
+        |
+      7 |         [tool.uv.sources]
+        |         ^^^^^^^^^^^^^^^^^
     ");
 
     Ok(())
@@ -28235,11 +28230,11 @@ fn lock_invalid_project_table() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     error: Failed to build `b @ file://[TEMP_DIR]/b`
       cause: Failed to parse metadata from built wheel
-      cause: TOML parse error at line 2, column 10
-               |
-             2 |         [project.urls]
-               |          ^^^^^^^
-             `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+      cause: `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+       --> [TEMP_DIR]/b/pyproject.toml:2:10
+        |
+      2 |         [project.urls]
+        |          ^^^^^^^
     ");
 
     Ok(())
@@ -28264,11 +28259,11 @@ fn lock_missing_name() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 1, column 1
-               |
-             1 | [project]
-               | ^^^^^^^^^
-             `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+      cause: `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+       --> pyproject.toml:1:1
+        |
+      1 | [project]
+        | ^^^^^^^^^
     ");
 
     Ok(())
@@ -28293,11 +28288,11 @@ fn lock_missing_version() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 1, column 1
-               |
-             1 | [project]
-               | ^^^^^^^^^
-             `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list
+      cause: `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list
+       --> pyproject.toml:1:1
+        |
+      1 | [project]
+        | ^^^^^^^^^
     ");
 
     Ok(())
@@ -31152,11 +31147,11 @@ fn lock_group_invalid_entry_group_name() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 9, column 16
-               |
-             9 |         foo = [{include-group = "invalid!"}]
-               |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             Not a valid package or extra name: "invalid!". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+      cause: Not a valid package or extra name: "invalid!". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+       --> pyproject.toml:9:16
+        |
+      9 |         foo = [{include-group = "invalid!"}]
+        |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "#);
 
     Ok(())
@@ -31186,11 +31181,11 @@ fn lock_group_invalid_duplicate_group_name() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 8, column 9
-               |
-             8 |         [dependency-groups]
-               |         ^^^^^^^^^^^^^^^^^^^
-             duplicate dependency group: `foo-bar`
+      cause: duplicate dependency group: `foo-bar`
+       --> pyproject.toml:8:9
+        |
+      8 |         [dependency-groups]
+        |         ^^^^^^^^^^^^^^^^^^^
     ");
 
     Ok(())
@@ -31278,11 +31273,11 @@ fn lock_group_invalid_entry_type() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 9, column 33
-               |
-             9 |         foo = [{include-group = true}]
-               |                                 ^^^^
-             invalid type: boolean `true`, expected a string
+      cause: invalid type: boolean `true`, expected a string
+       --> pyproject.toml:9:33
+        |
+      9 |         foo = [{include-group = true}]
+        |                                 ^^^^
     ");
 
     Ok(())
@@ -31311,11 +31306,11 @@ fn lock_group_empty_entry_table() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 9, column 16
-               |
-             9 |         foo = [{}]
-               |                ^^
-             missing field `include-group`
+      cause: missing field `include-group`
+       --> pyproject.toml:9:16
+        |
+      9 |         foo = [{}]
+        |                ^^
     ");
 
     Ok(())
@@ -41216,11 +41211,11 @@ async fn lock_check_multiple_default_indexes_explicit_assignment_dependency_grou
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 13, column 9
-                |
-             13 |         [[tool.uv.index]]
-                |         ^^^^^^^^^^^^^^^^^
-             found multiple indexes with `default = true`; only one index may be marked as default
+      cause: found multiple indexes with `default = true`; only one index may be marked as default
+        --> pyproject.toml:13:9
+         |
+      13 |         [[tool.uv.index]]
+         |         ^^^^^^^^^^^^^^^^^
     ");
 
     Ok(())

--- a/crates/uv/tests/lock_scenarios/lock_conflict.rs
+++ b/crates/uv/tests/lock_scenarios/lock_conflict.rs
@@ -10625,11 +10625,11 @@ fn conflict_item_unknown_field() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 10, column 17
-                |
-             10 |               { name = "foo", extra = "extra1" },
-                |                 ^^^^
-             unknown field `name`, expected one of `package`, `extra`, `group`
+      cause: unknown field `name`, expected one of `package`, `extra`, `group`
+        --> pyproject.toml:10:17
+         |
+      10 |               { name = "foo", extra = "extra1" },
+         |                 ^^^^
     "#);
 
     Ok(())

--- a/crates/uv/tests/lock_scenarios/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/lock_scenarios/lock_exclude_newer_relative.rs
@@ -1304,13 +1304,12 @@ fn lock_exclude_newer_relative_values_pyproject() -> Result<()> {
         .lock(), @r#"
     exit_code: 0 (success)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 9, column 25
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: `invalid span` could not be parsed as a valid exclude-newer value (expected a date like `2024-01-01`, a timestamp like `2024-01-01T00:00:00Z`, or a duration like `3 days` or `P3D`)
+       --> pyproject.toml:9:25
         |
       9 |         exclude-newer = "invalid span"
         |                         ^^^^^^^^^^^^^^
-      `invalid span` could not be parsed as a valid exclude-newer value (expected a date like `2024-01-01`, a timestamp like `2024-01-01T00:00:00Z`, or a duration like `3 days` or `P3D`)
-
     Resolved 2 packages in [TIME]
     "#);
 
@@ -1331,13 +1330,12 @@ fn lock_exclude_newer_relative_values_pyproject() -> Result<()> {
         .lock(), @r#"
     exit_code: 0 (success)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 9, column 25
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: `2 foos` could not be parsed as a duration: failed to parse input in the "friendly" duration format: expected to find unit designator suffix (e.g., `years` or `secs`) after parsing integer
+       --> pyproject.toml:9:25
         |
       9 |         exclude-newer = "2 foos"
         |                         ^^^^^^^^
-      `2 foos` could not be parsed as a duration: failed to parse input in the "friendly" duration format: expected to find unit designator suffix (e.g., `years` or `secs`) after parsing integer
-
     Resolved 2 packages in [TIME]
     "#);
 
@@ -1358,13 +1356,12 @@ fn lock_exclude_newer_relative_values_pyproject() -> Result<()> {
         .lock(), @r#"
     exit_code: 0 (success)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 9, column 25
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: `P4Z` could not be parsed as an ISO 8601 duration: expected to find date unit designator suffix (`Y`, `M`, `W` or `D`), but found `Z` instead
+       --> pyproject.toml:9:25
         |
       9 |         exclude-newer = "P4Z"
         |                         ^^^^^
-      `P4Z` could not be parsed as an ISO 8601 duration: expected to find date unit designator suffix (`Y`, `M`, `W` or `D`), but found `Z` instead
-
     Resolved 2 packages in [TIME]
     "#);
 
@@ -1385,13 +1382,12 @@ fn lock_exclude_newer_relative_values_pyproject() -> Result<()> {
         .lock(), @r#"
     exit_code: 0 (success)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 9, column 25
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: `10` could not be parsed as a valid exclude-newer value (expected a date like `2024-01-01`, a timestamp like `2024-01-01T00:00:00Z`, or a duration like `3 days` or `P3D`)
+       --> pyproject.toml:9:25
         |
       9 |         exclude-newer = "10"
         |                         ^^^^
-      `10` could not be parsed as a valid exclude-newer value (expected a date like `2024-01-01`, a timestamp like `2024-01-01T00:00:00Z`, or a duration like `3 days` or `P3D`)
-
     Resolved 2 packages in [TIME]
     "#);
 

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -1020,11 +1020,11 @@ build-backend = "poetry.core.masonry.api"
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 13, column 1
-                |
-             13 | [project.dependencies]
-                | ^^^^^^^^^^^^^^^^^^^^^^
-             invalid type: map, expected a sequence
+      cause: invalid type: map, expected a sequence
+        --> pyproject.toml:13:1
+         |
+      13 | [project.dependencies]
+         | ^^^^^^^^^^^^^^^^^^^^^^
     "
     );
 
@@ -1222,11 +1222,11 @@ dependencies = [
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 6, column 8
-               |
-             6 | name = "!project"
-               |        ^^^^^^^^^^
-             Not a valid package or extra name: "!project". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+      cause: Not a valid package or extra name: "!project". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+       --> pyproject.toml:6:8
+        |
+      6 | name = "!project"
+        |        ^^^^^^^^^^
     "#
     );
 
@@ -4420,23 +4420,22 @@ fn override_dependency_from_workspace_invalid_syntax() -> Result<()> {
             .arg("pyproject.toml"), @r#"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 10, column 7
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: no such comparison operator "=", must be one of ~= == != <= >= < > ===
+             werkzeug=2.3.0
+                     ^^^^^^
+        --> pyproject.toml:10:7
          |
       10 |       "werkzeug=2.3.0"
          |       ^^^^^^^^^^^^^^^^
-      no such comparison operator "=", must be one of ~= == != <= >= < > ===
-      werkzeug=2.3.0
-              ^^^^^^
-
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 10, column 7
-                |
-             10 |       "werkzeug=2.3.0"
-                |       ^^^^^^^^^^^^^^^^
-             no such comparison operator "=", must be one of ~= == != <= >= < > ===
+      cause: no such comparison operator "=", must be one of ~= == != <= >= < > ===
              werkzeug=2.3.0
                      ^^^^^^
+        --> pyproject.toml:10:7
+         |
+      10 |       "werkzeug=2.3.0"
+         |       ^^^^^^^^^^^^^^^^
     "#
     );
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -488,20 +488,19 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
         .arg("pyproject.toml"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 1, column 5
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: key with no value, expected `=`
+       --> pyproject.toml:1:5
         |
       1 | 123 - 456
         |     ^
-      key with no value, expected `=`
-
     error: Failed to parse: `pyproject.toml`
       cause: Invalid `pyproject.toml`
-      cause: TOML parse error at line 1, column 5
-               |
-             1 | 123 - 456
-               |     ^
-             key with no value, expected `=`
+      cause: key with no value, expected `=`
+       --> pyproject.toml:1:5
+        |
+      1 | 123 - 456
+        |     ^
     "
     );
 
@@ -520,11 +519,11 @@ fn invalid_pyproject_toml_project_schema() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 1, column 1
-               |
-             1 | [project]
-               | ^^^^^^^^^
-             `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+      cause: `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+       --> pyproject.toml:1:1
+        |
+      1 | [project]
+        | ^^^^^^^^^
     "
     );
 
@@ -544,13 +543,12 @@ fn invalid_pyproject_toml_option_schema() -> Result<()> {
         .arg("iniconfig"), @"
     exit_code: 0 (success)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 2, column 13
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: invalid type: boolean `true`, expected a string
+       --> pyproject.toml:2:13
         |
       2 | index-url = true
         |             ^^^^
-      invalid type: boolean `true`, expected a string
-
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -582,13 +580,12 @@ fn invalid_pyproject_toml_option_unknown_field() -> Result<()> {
         .arg("pyproject.toml"), @r#"
     exit_code: 0 (success)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 2, column 1
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: unknown field `unknown`, expected one of `required-version`, `system-certs`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `preview-features`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `http-proxy`, `https-proxy`, `no-proxy`, `allow-insecure-host`, `resolution`, `prerelease`, `prerelease-package`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `no-sources-package`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `torch-backend`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `audit`, `pip`, `cache-keys`, `override-dependencies`, `exclude-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`
+       --> pyproject.toml:2:1
         |
       2 | unknown = "field"
         | ^^^^^^^
-      unknown field `unknown`, expected one of `required-version`, `system-certs`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `preview-features`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `http-proxy`, `https-proxy`, `no-proxy`, `allow-insecure-host`, `resolution`, `prerelease`, `prerelease-package`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `no-sources-package`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `torch-backend`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `audit`, `pip`, `cache-keys`, `override-dependencies`, `exclude-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`
-
     Resolved in [TIME]
     Checked in [TIME]
     "#
@@ -5081,13 +5078,12 @@ fn prerelease_package_rejected_in_pip_configuration() -> Result<()> {
         .arg("a>0.1.0"), @r#"
     exit_code: 1 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 2, column 1
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: unknown field `prerelease-package`, expected one of [...]
+       --> pyproject.toml:2:1
         |
       2 | prerelease-package = { a = "allow" }
         | ^^^^^^^^^^^^^^^^^^
-      unknown field `prerelease-package`, expected one of [...]
-
     error: No solution found when resolving dependencies
       cause: Because only a<=0.1.0 is available and you require a>0.1.0, we can conclude that your requirements are unsatisfiable.
 

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -13612,19 +13612,18 @@ async fn add_invalid_ignore_error_code() -> Result<()> {
     uv_snapshot!(context.filters(), context.add().arg("anyio"), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 9, column 22
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: 1234 is not a valid HTTP status code
+       --> pyproject.toml:9:22
         |
       9 | ignore-error-codes = [401, 403, 1234]
         |                      ^^^^^^^^^^^^^^^^
-      1234 is not a valid HTTP status code
-
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 9, column 22
-               |
-             9 | ignore-error-codes = [401, 403, 1234]
-               |                      ^^^^^^^^^^^^^^^^
-             1234 is not a valid HTTP status code
+      cause: 1234 is not a valid HTTP status code
+       --> pyproject.toml:9:22
+        |
+      9 | ignore-error-codes = [401, 403, 1234]
+        |                      ^^^^^^^^^^^^^^^^
     "
     );
 
@@ -13651,13 +13650,13 @@ fn add_invalid_requires_python() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 4, column 19
-               |
-             4 | requires-python = "3.12"
-               |                   ^^^^^^
-             Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
+      cause: Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
              3.12
              ^^^^
+       --> pyproject.toml:4:19
+        |
+      4 | requires-python = "3.12"
+        |                   ^^^^^^
     "#);
 
     Ok(())

--- a/crates/uv/tests/project/format.rs
+++ b/crates/uv/tests/project/format.rs
@@ -346,20 +346,19 @@ fn format_fails_malformed_pyproject() -> Result<()> {
     uv_snapshot!(context.filters(), context.format(), @"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 1, column 11
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: key with no value, expected `=`
+       --> pyproject.toml:1:11
         |
       1 | malformed pyproject.toml
         |           ^
-      key with no value, expected `=`
-
     warning: `uv format` is experimental and may change without warning. Pass `--preview-features format-command` to disable this warning.
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 1, column 11
-               |
-             1 | malformed pyproject.toml
-               |           ^
-             key with no value, expected `=`
+      cause: key with no value, expected `=`
+       --> pyproject.toml:1:11
+        |
+      1 | malformed pyproject.toml
+        |           ^
     ");
 
     // Check that the file is not formatted

--- a/crates/uv/tests/project/run.rs
+++ b/crates/uv/tests/project/run.rs
@@ -4080,11 +4080,11 @@ fn run_invalid_project_table() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 1, column 2
-               |
-             1 | [project.urls]
-               |  ^^^^^^^
-             `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+      cause: `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
+       --> pyproject.toml:1:2
+        |
+      1 | [project.urls]
+        |  ^^^^^^^
     ");
 
     Ok(())

--- a/crates/uv/tests/python/python_find.rs
+++ b/crates/uv/tests/python/python_find.rs
@@ -30,11 +30,11 @@ fn python_find_warning_chain() -> Result<()> {
 
     ----- stderr -----
     warning: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 2, column 8
-               |
-             2 | name = 42
-               |        ^^
-             invalid type: integer `42`, expected a string
+      cause: invalid type: integer `42`, expected a string
+       --> pyproject.toml:2:8
+        |
+      2 | name = 42
+        |        ^^
     ");
     uv_snapshot!(context.filters(), context.python_find().arg("--no-config").arg("--quiet"), @"exit_code: 0 (success)");
     Ok(())

--- a/crates/uv/tests/python/venv.rs
+++ b/crates/uv/tests/python/venv.rs
@@ -1163,20 +1163,18 @@ fn create_venv_warns_user_on_requires_python_discovery_error() -> Result<()> {
     uv_snapshot!(context.filters(), context.venv(), @"
     exit_code: 0 (success)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 1, column 9
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: key with no value, expected `=`
+       --> pyproject.toml:1:9
         |
       1 | invalid toml
         |         ^
-      key with no value, expected `=`
-
-    warning: Failed to parse `pyproject.toml` during environment creation:
-      TOML parse error at line 1, column 9
+    warning: Failed to parse `pyproject.toml` during environment creation
+      cause: key with no value, expected `=`
+       --> pyproject.toml:1:9
         |
       1 | invalid toml
         |         ^
-      key with no value, expected `=`
-
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     Activate with: source .venv/[BIN]/activate

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -2458,11 +2458,11 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 7, column 13
-               |
-             7 | conflicts = [
-               |             ^
-             Each set of conflicts must have at least two entries, but found only one
+      cause: Each set of conflicts must have at least two entries, but found only one
+       --> pyproject.toml:7:13
+        |
+      7 | conflicts = [
+        |             ^
     "
     );
 
@@ -2482,11 +2482,11 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 7, column 13
-               |
-             7 | conflicts = [[]]
-               |             ^^^^
-             Each set of conflicts must have at least two entries, but found none
+      cause: Each set of conflicts must have at least two entries, but found none
+       --> pyproject.toml:7:13
+        |
+      7 | conflicts = [[]]
+        |             ^^^^
     "
     );
 
@@ -2508,11 +2508,11 @@ fn invalid_conflicts() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 7, column 13
-               |
-             7 | conflicts = [
-               |             ^
-             Each set of conflicts must have at least two entries, but found only one
+      cause: Each set of conflicts must have at least two entries, but found only one
+       --> pyproject.toml:7:13
+        |
+      7 | conflicts = [
+        |             ^
     "
     );
 
@@ -2698,11 +2698,11 @@ fn resolve_config_file() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `[CACHE_DIR]/uv.toml`
-      cause: TOML parse error at line 1, column 2
-               |
-             1 | [project]
-               |  ^^^^^^^
-             unknown field `project`, expected one of `required-version`, `system-certs`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `preview-features`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `http-proxy`, `https-proxy`, `no-proxy`, `allow-insecure-host`, `resolution`, `prerelease`, `prerelease-package`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `no-sources-package`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `torch-backend`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `audit`, `pip`, `cache-keys`, `override-dependencies`, `exclude-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`
+      cause: unknown field `project`, expected one of `required-version`, `system-certs`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `preview-features`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `http-proxy`, `https-proxy`, `no-proxy`, `allow-insecure-host`, `resolution`, `prerelease`, `prerelease-package`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `no-sources-package`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `torch-backend`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `audit`, `pip`, `cache-keys`, `override-dependencies`, `exclude-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`
+       --> [CACHE_DIR]/uv.toml:1:2
+        |
+      1 | [project]
+        |  ^^^^^^^
     "
     );
 
@@ -2730,11 +2730,11 @@ fn resolve_config_file() -> anyhow::Result<()> {
     ----- stderr -----
     warning: The `--config-file` argument expects to receive a `uv.toml` file, not a `pyproject.toml`. If you're trying to run a command from another project, use the `--project` argument instead.
     error: Failed to parse: `[CACHE_DIR]/pyproject.toml`
-      cause: TOML parse error at line 9, column 3
-               |
-             9 | ""
-               |   ^
-             key with no value, expected `=`
+      cause: key with no value, expected `=`
+       --> [CACHE_DIR]/pyproject.toml:9:3
+        |
+      9 | ""
+        |   ^
     "#
     );
 
@@ -4318,11 +4318,11 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      cause: TOML parse error at line 1, column 20
-               |
-             1 | preview-features = ["  "]
-               |                    ^^^^^^
-             preview feature name cannot be empty
+      cause: preview feature name cannot be empty
+       --> uv.toml:1:20
+        |
+      1 | preview-features = ["  "]
+        |                    ^^^^^^
     "#);
 
     config.write_str("preview-features = 123")?;
@@ -4332,11 +4332,11 @@ fn preview_features_uv_toml() -> anyhow::Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `uv.toml`
-      cause: TOML parse error at line 1, column 20
-               |
-             1 | preview-features = 123
-               |                    ^^^
-             invalid type: integer `123`, expected a boolean or a list of preview feature names
+      cause: invalid type: integer `123`, expected a boolean or a list of preview feature names
+       --> uv.toml:1:20
+        |
+      1 | preview-features = 123
+        |                    ^^^
     ");
 
     Ok(())
@@ -4404,13 +4404,12 @@ fn preview_features_pyproject_toml() -> anyhow::Result<()> {
      }
     +
     +----- stderr -----
-    +warning: Failed to parse `pyproject.toml` during settings discovery:
-    +  TOML parse error at line 1, column 1
+    +warning: Failed to parse `pyproject.toml` during settings discovery
+    +  cause: cannot specify both `preview` and `preview-features`
+    +   --> pyproject.toml:1:1
     +    |
     +  1 | [tool.uv]
     +    | ^^^^^^^^^
-    +  cannot specify both `preview` and `preview-features`
-    +
     ...
     "
     );
@@ -4433,13 +4432,12 @@ fn preview_features_pyproject_toml() -> anyhow::Result<()> {
      }
     +
     +----- stderr -----
-    +warning: Failed to parse `pyproject.toml` during settings discovery:
-    +  TOML parse error at line 2, column 20
+    +warning: Failed to parse `pyproject.toml` during settings discovery
+    +  cause: invalid type: integer `123`, expected a boolean or a list of preview feature names
+    +   --> pyproject.toml:2:20
     +    |
     +  2 | preview-features = 123
     +    |                    ^^^
-    +  invalid type: integer `123`, expected a boolean or a list of preview feature names
-    +
     ...
     "
     );

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -4545,11 +4545,11 @@ fn sync_default_groups_gibberish() -> Result<()> {
     exit_code: 2 (failure)
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 14, column 26
-                |
-             14 |         default-groups = "gibberish"
-                |                          ^^^^^^^^^^^
-             default-groups must be "all" or a ["list", "of", "groups"]
+      cause: default-groups must be "all" or a ["list", "of", "groups"]
+        --> pyproject.toml:14:26
+         |
+      14 |         default-groups = "gibberish"
+         |                          ^^^^^^^^^^^
     "#);
 
     Ok(())
@@ -16128,19 +16128,18 @@ fn sync_fails_ambiguous_url() -> Result<()> {
     uv_snapshot!(context.filters(), context.sync(), @r#"
     exit_code: 2 (failure)
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery:
-      TOML parse error at line 10, column 15
+    warning: Failed to parse `pyproject.toml` during settings discovery
+      cause: ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
+        --> pyproject.toml:10:15
          |
       10 |         url = "https://user/name:password@domain/a/b/c"
          |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
-
     error: Failed to parse: `pyproject.toml`
-      cause: TOML parse error at line 10, column 15
-                |
-             10 |         url = "https://user/name:password@domain/a/b/c"
-                |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
+      cause: ambiguous user/pass authority in URL (not percent-encoded?): https:***@domain/a/b/c
+        --> pyproject.toml:10:15
+         |
+      10 |         url = "https://user/name:password@domain/a/b/c"
+         |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     "#);
 
     Ok(())

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -6017,18 +6017,18 @@ fn tool_install_lock_refreshes_local_directory_constraint() -> Result<()> {
     ----- stderr -----
     warning: Failed to validate existing tool lock
       cause: Failed to parse `[TEMP_DIR]/simple-launcher/pyproject.toml`
-      cause: TOML parse error at line 3, column 11
-               |
-             3 | version = 42
-               |           ^^
-             invalid type: integer `42`, expected a string
+      cause: invalid type: integer `42`, expected a string
+       --> simple-launcher/pyproject.toml:3:11
+        |
+      3 | version = 42
+        |           ^^
     error: Failed to build `simple-launcher @ file://[TEMP_DIR]/simple-launcher`
       cause: Failed to parse metadata from built wheel
-      cause: TOML parse error at line 3, column 11
-               |
-             3 | version = 42
-               |           ^^
-             invalid type: integer `42`, expected a string
+      cause: invalid type: integer `42`, expected a string
+       --> simple-launcher/pyproject.toml:3:11
+        |
+      3 | version = 42
+        |           ^^
     ");
 
     Ok(())


### PR DESCRIPTION
TOML failures currently place the parser's complete multiline display inside a cause, including a redundant heading and its own source gutter. Add typed presentation data for individual errors so the shared renderer can show the specific parser message, a source location, and a numbered excerpt when a valid span is available. Settings, workspace, and package-metadata errors retain the original parser error and the exact input used to produce it; recoverable warnings use the same presentation as fatal errors.

The presentation API also supports inline `info:` statements and guttered detail blocks. Detail blocks retain paragraphs and visibly escape terminal control characters. Errors without presentation data still use `Display`, and the underlying source chains, hints, and exit-status classification are unchanged.

Prior work:

- #17110 routes command failures through the shared error renderer.
- #21603 gives source errors a compact `cause:` label.
- #21565 renders warning source chains through the shared formatter.
