### PR TITLE
Separate registry response context from publish failures

### DIFF
--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::path::PathBuf;
@@ -98,6 +99,16 @@ impl ProblemDetails {
                 warn!("Failed to read response body for problem details: {err}");
                 None
             }
+        }
+    }
+
+    /// The server's description without a diagnostic label.
+    pub fn message(&self) -> Option<Cow<'_, str>> {
+        match (self.title.as_deref(), self.detail.as_deref(), self.status) {
+            (Some(title), Some(detail), _) => Some(Cow::Owned(format!("{title}, {detail}"))),
+            (Some(message), None, _) | (None, Some(message), _) => Some(Cow::Borrowed(message)),
+            (None, None, Some(status)) => Some(Cow::Owned(format!("HTTP error {status}"))),
+            (None, None, None) => None,
         }
     }
 
@@ -879,6 +890,38 @@ mod tests {
         let problem_details: ProblemDetails =
             serde_json::from_slice(json_minimal.as_bytes()).unwrap();
         assert_eq!(problem_details.description().unwrap(), "HTTP error 400");
+    }
+
+    #[test]
+    fn test_problem_details_message() {
+        let messages = [
+            r#"{"title":"Bad Request","detail":"Missing name","status":400}"#,
+            r#"{"title":"Bad Request"}"#,
+            r#"{"detail":"Missing name"}"#,
+            r#"{"status":400}"#,
+            "{}",
+        ]
+        .map(|json| {
+            let problem: ProblemDetails = serde_json::from_str(json).unwrap();
+            problem.message().map(Cow::into_owned)
+        });
+        insta::assert_debug_snapshot!(messages, @r#"
+        [
+            Some(
+                "Bad Request, Missing name",
+            ),
+            Some(
+                "Bad Request",
+            ),
+            Some(
+                "Missing name",
+            ),
+            Some(
+                "HTTP error 400",
+            ),
+            None,
+        ]
+        "#);
     }
 
     #[test]

--- a/crates/uv-errors/src/diagnostic.rs
+++ b/crates/uv-errors/src/diagnostic.rs
@@ -31,9 +31,8 @@ impl<'a> Diagnostic<'a> {
     }
 
     /// Attach additional context to this error.
-    #[cfg(test)]
     #[must_use]
-    pub(super) fn with_info(mut self, info: Info<'a>) -> Self {
+    pub fn with_info(mut self, info: Info<'a>) -> Self {
         self.info.push(info);
         self
     }
@@ -56,15 +55,14 @@ impl<'a> Diagnostic<'a> {
 }
 
 /// Additional context, rather than a cause or an actionable hint.
-pub(super) struct Info<'a> {
+pub struct Info<'a> {
     message: Cow<'a, str>,
     details: Option<Cow<'a, str>>,
 }
 
-#[cfg(test)]
 impl<'a> Info<'a> {
     /// Create an informational statement.
-    pub(super) fn new(message: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(message: impl Into<Cow<'a, str>>) -> Self {
         Self {
             message: message.into(),
             details: None,
@@ -74,7 +72,7 @@ impl<'a> Info<'a> {
     /// Attach a block of text, retaining its authored line breaks and indentation.
     /// Terminal control characters are escaped when the block is rendered.
     #[must_use]
-    pub(super) fn with_details(mut self, details: impl Into<Cow<'a, str>>) -> Self {
+    pub fn with_details(mut self, details: impl Into<Cow<'a, str>>) -> Self {
         self.details = Some(details.into());
         self
     }

--- a/crates/uv-errors/src/lib.rs
+++ b/crates/uv-errors/src/lib.rs
@@ -9,10 +9,8 @@ use std::iter;
 
 use owo_colors::{AnsiColors, DynColor, OwoColorize};
 
-#[cfg(test)]
-use diagnostic::Info;
 use diagnostic::write_info;
-pub use diagnostic::{Diagnostic, DiagnosticFn};
+pub use diagnostic::{Diagnostic, DiagnosticFn, Info};
 use line_wrap::{get_wrap_width, wrap_text};
 use source::write_snippets;
 pub use source::{SourceFile, SourceSnippet};

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -2,6 +2,7 @@ mod trusted_publishing;
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::error::Error as StdError;
 use std::fmt::Display;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -38,6 +39,7 @@ use uv_client::{
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
 use uv_distribution_filename::{DistFilename, SourceDistExtension, SourceDistFilename};
 use uv_distribution_types::{IndexCapabilities, IndexUrl};
+use uv_errors::{Diagnostic, Info};
 use uv_extract::hash::Hasher;
 use uv_fs::{ProgressReader, Simplified};
 use uv_metadata::read_metadata_async_seek;
@@ -133,8 +135,8 @@ pub enum PublishSendError {
     StatusNoBody(StatusCode, #[source] reqwest::Error),
     #[error("Server returned status code {0}. Server says: {1}")]
     Status(StatusCode, String),
-    #[error("Server returned status code {0}. {1}")]
-    StatusProblemDetails(StatusCode, String),
+    #[error("Server returned status code {0}. {description}", description = .1.description().unwrap_or_default())]
+    StatusProblemDetails(StatusCode, ProblemDetails),
     #[error(
         "POST requests are not supported by the endpoint, are you using the simple index URL instead of the upload URL?"
     )]
@@ -156,6 +158,18 @@ pub enum PublishSendError {
     RedirectLocationInvalidStr(#[source] ToStrError),
     #[error("Request was redirected, but location header is not a URL")]
     RedirectInvalidLocation(#[source] DisplaySafeUrlError),
+}
+
+/// Resolve user-facing context for a publishing error in a source chain.
+pub fn diagnostic_for_error<'a>(error: &'a (dyn StdError + 'static)) -> Option<Diagnostic<'a>> {
+    error
+        .downcast_ref::<PublishSendError>()
+        .or_else(|| {
+            error
+                .downcast_ref::<Box<PublishSendError>>()
+                .map(AsRef::as_ref)
+        })?
+        .diagnostic()
 }
 
 pub trait Reporter: Send + Sync + 'static {
@@ -325,6 +339,44 @@ pub struct PublishSession<'a> {
 }
 
 impl PublishSendError {
+    /// Separate the server's response from the transport failure.
+    fn diagnostic(&self) -> Option<Diagnostic<'_>> {
+        let (message, details) = match self {
+            Self::Status(status, body) => (
+                format!("Server returned status code {status}"),
+                Cow::Borrowed(body.as_str()),
+            ),
+            Self::StatusProblemDetails(status, problem) => (
+                format!("Server returned status code {status}"),
+                problem.message()?,
+            ),
+            Self::MethodNotAllowed(body) => (
+                Self::MethodNotAllowedNoBody.to_string(),
+                Cow::Borrowed(body.as_str()),
+            ),
+            Self::PermissionDenied(status, body) => (
+                format!("Permission denied (status code {status})"),
+                Cow::Borrowed(body.as_str()),
+            ),
+            Self::ReqwestMiddleware(_)
+            | Self::StatusNoBody(..)
+            | Self::MethodNotAllowedNoBody
+            | Self::TooManyRedirects(_)
+            | Self::RedirectRealmMismatch(_)
+            | Self::RedirectNoLocation
+            | Self::RedirectLocationInvalidStr(_)
+            | Self::RedirectInvalidLocation(_) => return None,
+        };
+        let diagnostic = Diagnostic::new(message);
+        if details.trim().is_empty() {
+            Some(diagnostic)
+        } else {
+            Some(diagnostic.with_info(
+                Info::new("The server included the following context:").with_details(details),
+            ))
+        }
+    }
+
     /// Extract `code` from the PyPI json error response, if any.
     ///
     /// The error response from PyPI contains crucial context, such as the difference between
@@ -393,13 +445,16 @@ impl PublishSendError {
     ///            Access was denied to this resource.<br/><br/>
     /// ```
     ///
-    /// In comparison, we now show (line-wrapped for readability):
+    /// The user-facing diagnostic separates the status from this context (line-wrapped here):
     ///
     /// ```text
     /// error: Failed to publish `dist/astral_test_1-0.1.0-py3-none-any.whl` to `https://test.pypi.org/legacy/`
-    ///   └── Incorrect credentials (status code 403 Forbidden): 403 Username/Password
-    ///       authentication is no longer supported. Migrate to API Tokens or Trusted Publishers
-    ///       instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+    ///   cause: Server returned status code 403 Forbidden
+    ///   info: The server included the following context:
+    ///     |
+    ///     | 403 Username/Password authentication is no longer supported. Migrate to API Tokens
+    ///     | or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and
+    ///     | https://test.pypi.org/help/#trusted-publishers
     /// ```
     fn extract_error_message(body: String, content_type: Option<&str>) -> String {
         if content_type == Some("application/json") {
@@ -1402,12 +1457,9 @@ impl PublishSession<'_> {
         // Try to parse as RFC 9457 Problem Details.
         if content_type.as_deref() == Some(ProblemDetails::CONTENT_TYPE)
             && let Some(problem) = ProblemDetails::try_from_response_body(upload_error.as_bytes())
-            && let Some(description) = problem.description()
+            && problem.message().is_some()
         {
-            return Err(PublishSendError::StatusProblemDetails(
-                status_code,
-                description,
-            ));
+            return Err(PublishSendError::StatusProblemDetails(status_code, problem));
         }
 
         // Raced uploads of the same file are handled by the caller.
@@ -1442,7 +1494,8 @@ mod tests {
 
     use crate::{
         FormMetadata, PublishError, PublishOutcome, PublishPrepareError, PublishSession,
-        PublishingCredentials, Reporter, UploadOutcome, group_files, source_dist_pkg_info,
+        PublishingCredentials, Reporter, UploadOutcome, diagnostic_for_error, group_files,
+        source_dist_pkg_info,
     };
     use uv_errors::{ErrorOptions, Hints, write_error_chain_with_options};
     use wiremock::matchers::{method, path};
@@ -2247,7 +2300,9 @@ mod tests {
         write_error_chain_with_options(
             &err,
             &Hints::none(),
-            ErrorOptions::default().with_stream(&mut capture),
+            ErrorOptions::default()
+                .with_diagnostic(diagnostic_for_error)
+                .with_stream(&mut capture),
         )
         .unwrap();
 
@@ -2281,7 +2336,9 @@ mod tests {
         write_error_chain_with_options(
             &err,
             &Hints::none(),
-            ErrorOptions::default().with_stream(&mut capture),
+            ErrorOptions::default()
+                .with_diagnostic(diagnostic_for_error)
+                .with_stream(&mut capture),
         )
         .unwrap();
 
@@ -2320,7 +2377,9 @@ mod tests {
         write_error_chain_with_options(
             &err,
             &Hints::none(),
-            ErrorOptions::default().with_stream(&mut capture),
+            ErrorOptions::default()
+                .with_diagnostic(diagnostic_for_error)
+                .with_stream(&mut capture),
         )
         .unwrap();
 
@@ -2331,7 +2390,10 @@ mod tests {
             &capture,
             @"
         error: Failed to publish `../../test/links/tqdm-4.66.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl` to [SERVER]/final
-          cause: Server returned status code 400 Bad Request. Server says: 400 Error: Use 'source' as Python version for an sdist.
+          cause: Server returned status code 400 Bad Request
+          info: The server included the following context:
+            |
+            | 400 Error: Use 'source' as Python version for an sdist.
         "
         );
     }
@@ -2362,7 +2424,9 @@ mod tests {
         write_error_chain_with_options(
             &err,
             &Hints::none(),
-            ErrorOptions::default().with_stream(&mut capture),
+            ErrorOptions::default()
+                .with_diagnostic(diagnostic_for_error)
+                .with_stream(&mut capture),
         )
         .unwrap();
 
@@ -2373,7 +2437,10 @@ mod tests {
             &capture,
             @"
         error: Failed to publish `../../test/links/tqdm-4.66.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl` to [SERVER]/final
-          cause: Server returned status code 400 Bad Request. Server message: Bad Request, Missing required field `name`
+          cause: Server returned status code 400 Bad Request
+          info: The server included the following context:
+            |
+            | Bad Request, Missing required field `name`
         "
         );
     }

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -455,6 +455,7 @@ impl PublishSendError {
     ///     | 403 Username/Password authentication is no longer supported. Migrate to API Tokens
     ///     | or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and
     ///     | https://test.pypi.org/help/#trusted-publishers
+    ///     |
     /// ```
     fn extract_error_message(body: String, content_type: Option<&str>) -> String {
         if content_type == Some("application/json") {
@@ -2394,6 +2395,7 @@ mod tests {
           info: The server included the following context:
             |
             | 400 Error: Use 'source' as Python version for an sdist.
+            |
         "
         );
     }
@@ -2441,6 +2443,7 @@ mod tests {
           info: The server included the following context:
             |
             | Bad Request, Missing required field `name`
+            |
         "
         );
     }

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -54,6 +54,7 @@ pub(crate) fn diagnostic_for_error<'a>(error: &'a (dyn Error + 'static)) -> Opti
     uv_settings::diagnostic_for_error(error)
         .or_else(|| uv_workspace::pyproject::diagnostic_for_error(error))
         .or_else(|| uv_pypi_types::diagnostic_for_error(error))
+        .or_else(|| uv_publish::diagnostic_for_error(error))
 }
 
 /// Walk an error chain and collect hint strings from all known error types.

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -89,7 +89,10 @@ fn username_password_no_longer_supported() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/
-      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden
+      info: The server included the following context:
+        |
+        | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 }
@@ -112,7 +115,10 @@ fn invalid_token() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/
-      cause: Server returned status code 403 Forbidden. Server says: 403 Invalid or non-existent authentication information. See https://test.pypi.org/help/#invalid-auth for more information.
+      cause: Server returned status code 403 Forbidden
+      info: The server included the following context:
+        |
+        | 403 Invalid or non-existent authentication information. See https://test.pypi.org/help/#invalid-auth for more information.
     "
     );
 }
@@ -319,7 +325,10 @@ fn check_keyring_behaviours() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
-      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden
+      info: The server included the following context:
+        |
+        | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 
@@ -342,7 +351,10 @@ fn check_keyring_behaviours() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
-      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden
+      info: The server included the following context:
+        |
+        | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 
@@ -370,7 +382,10 @@ fn check_keyring_behaviours() {
     Keyring request for dummy@https://test.pypi.org/legacy/?ok
     Keyring request for dummy@test.pypi.org
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
-      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden
+      info: The server included the following context:
+        |
+        | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 
@@ -393,7 +408,10 @@ fn check_keyring_behaviours() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
-      cause: Server returned status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+      cause: Server returned status code 403 Forbidden
+      info: The server included the following context:
+        |
+        | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "
     );
 }
@@ -863,7 +881,10 @@ async fn trusted_publishing_burn_failure() {
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     warning: Failed to invalidate trusted publishing token. It will expire naturally. Cause: Failed to fetch: `http://[LOCALHOST]/_/oidc/burn-token`
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
-      cause: Server returned status code 400 Bad Request. Server says: Upload failed
+      cause: Server returned status code 400 Bad Request
+      info: The server included the following context:
+        |
+        | Upload failed
     "
     );
 }
@@ -1186,7 +1207,10 @@ async fn upload_error_pypi_json() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
-      cause: Server returned status code 400 Bad Request. Server says: 400 Use 'source' as Python version for an sdist.
+      cause: Server returned status code 400 Bad Request
+      info: The server included the following context:
+        |
+        | 400 Use 'source' as Python version for an sdist.
     "
     );
 }
@@ -1220,9 +1244,50 @@ async fn upload_error_problem_details() {
     Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
     error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
-      cause: Server returned status code 400 Bad Request. Server message: Bad Request, Missing required field `name`
+      cause: Server returned status code 400 Bad Request
+      info: The server included the following context:
+        |
+        | Bad Request, Missing required field `name`
     "
     );
+}
+
+/// A plain-text server response remains readable when it contains multiple paragraphs.
+#[tokio::test]
+async fn upload_error_method_not_allowed() {
+    let context = uv_test::test_context!("3.12").with_filtered_sizes();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .respond_with(ResponseTemplate::new(405).set_body_raw(
+            "This endpoint accepts GET requests only.\n\nUse /legacy/ to upload packages.",
+            "text/plain",
+        ))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("-u")
+        .arg("dummy")
+        .arg("-p")
+        .arg("dummy")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(dummy_wheel()), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Hashing ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE]B)
+    error: Failed to publish `[WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl` to http://[LOCALHOST]/upload
+      cause: POST requests are not supported by the endpoint, are you using the simple index URL instead of the upload URL?
+      info: The server included the following context:
+        |
+        | This endpoint accepts GET requests only.
+        |
+        | Use /legacy/ to upload packages.
+    ");
 }
 
 /// A dry run checks valid distribution metadata without uploading the file.

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -93,6 +93,7 @@ fn username_password_no_longer_supported() {
       info: The server included the following context:
         |
         | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+        |
     "
     );
 }
@@ -119,6 +120,7 @@ fn invalid_token() {
       info: The server included the following context:
         |
         | 403 Invalid or non-existent authentication information. See https://test.pypi.org/help/#invalid-auth for more information.
+        |
     "
     );
 }
@@ -329,6 +331,7 @@ fn check_keyring_behaviours() {
       info: The server included the following context:
         |
         | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+        |
     "
     );
 
@@ -355,6 +358,7 @@ fn check_keyring_behaviours() {
       info: The server included the following context:
         |
         | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+        |
     "
     );
 
@@ -386,6 +390,7 @@ fn check_keyring_behaviours() {
       info: The server included the following context:
         |
         | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+        |
     "
     );
 
@@ -412,6 +417,7 @@ fn check_keyring_behaviours() {
       info: The server included the following context:
         |
         | 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+        |
     "
     );
 }
@@ -885,6 +891,7 @@ async fn trusted_publishing_burn_failure() {
       info: The server included the following context:
         |
         | Upload failed
+        |
     "
     );
 }
@@ -1211,6 +1218,7 @@ async fn upload_error_pypi_json() {
       info: The server included the following context:
         |
         | 400 Use 'source' as Python version for an sdist.
+        |
     "
     );
 }
@@ -1248,6 +1256,7 @@ async fn upload_error_problem_details() {
       info: The server included the following context:
         |
         | Bad Request, Missing required field `name`
+        |
     "
     );
 }
@@ -1287,6 +1296,7 @@ async fn upload_error_method_not_allowed() {
         | This endpoint accepts GET requests only.
         |
         | Use /legacy/ to upload packages.
+        |
     ");
 }
 


### PR DESCRIPTION
Registry upload failures currently mix the HTTP status and server response into one cause, making multiline responses hard to distinguish from uv's own explanation. Use the typed presentation API to keep the status or endpoint failure as the cause while rendering the server's response in a separate `info:` block. PyPI JSON errors, RFC 9457 problem details, and plain-text responses retain their useful context without changing upload behavior or exit statuses.

Prior work:

- #21603 renders source errors with `cause:` labels.
- #21604 adds typed per-error information, source excerpts, and guttered context blocks.
