### PR TITLE
use new astral-release-bot for release environment sts

### DIFF
--- a/.github/secure-token-service-release.json
+++ b/.github/secure-token-service-release.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "repositories": {
+    "uv": {
+      "name": "astral-sh/uv",
+      "id": 699532645,
+      "oidc_subject": "legacy"
+    }
+  },
+  "rules": [
+    {
+      "caller": "uv",
+      "environment": "release",
+      "caller_ref": "refs/heads/main",
+      "caller_workflow": "release.yml",
+      "on": ["workflow_dispatch"],
+      "permissions": {
+        "contents": "write",
+        "workflows": "write"
+      },
+      "target": "uv"
+    }
+  ]
+}

--- a/.github/secure-token-service.json
+++ b/.github/secure-token-service.json
@@ -33,14 +33,6 @@
     },
     {
       "caller": "uv",
-      "environment": "release",
-      "caller_workflow": "release.yml",
-      "on": ["workflow_dispatch"],
-      "permissions": { "contents": "write", "workflows": "write" },
-      "target": "uv"
-    },
-    {
-      "caller": "uv",
       "environment": "automations",
       "caller_workflow": "release-prepare.yml",
       "on": ["workflow_dispatch"],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,8 +402,8 @@ jobs:
         id: release-token
         uses: open-security-tools/ost-simple-sts@974a63a2daaaa40f7c6dec40d334f3da4421469e
         with:
-          exchange-url: ${{ secrets.STS_API_URL }}/exchange
-          audience: ${{ secrets.STS_API_URL }}
+          exchange-url: ${{ secrets.RELEASES_STS_API_URL }}/exchange
+          audience: ${{ secrets.RELEASES_STS_API_URL }}
           repository: astral-sh/uv
           # Workflow permission is required to create a release tag after `main` advances across workflow changes.
           permissions: |


### PR DESCRIPTION
initial work to separate concern of the astral-automations-bot from access related to release.

a new astral-releases-bot GitHub App has been created and its STS endpoint configured in the relase environment's RELEASES_STS_API_URL secret.