### PR TITLE
Classify download length mismatch errors

### DIFF
--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -318,6 +318,8 @@ impl Error {
             | Self::RequiresPython(..)
             | Self::MismatchedHashes { .. }
             | Self::MismatchedSize { .. }
+            | Self::MismatchedContentLength { .. }
+            | Self::MismatchedRangeSize { .. }
             | Self::MissingHashes { .. }
             | Self::MissingActualHashes { .. }
             | Self::MissingExpectedHashes { .. }


### PR DESCRIPTION
The download error variants added in #21570 are missing from the exhaustive `Error::is_user_failure` match, leaving `uv-distribution` unable to compile. Classify `MismatchedContentLength` and `MismatchedRangeSize` as expected user-facing failures alongside `MismatchedSize`.
