### PR TITLE
Hash and extract local wheels in one blocking task

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -1152,31 +1152,31 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 build: None,
             })
         } else {
-            // If necessary, compute the hashes of the wheel.
-            let file = fs_err::tokio::File::open(path)
-                .await
-                .map_err(Error::CacheRead)?;
-            let extractor = WheelExtractor::new(
-                self.build_context.cache().root(),
-                self.content_addressed_cache,
-            )
-            .map_err(Error::CacheWrite)?;
-
-            // Create a hasher for each hash algorithm.
+            // Read, hash, and extract the local wheel in one blocking task.
             let algorithms = hashes.algorithms();
-            let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
-            let mut hasher = uv_extract::hash::HashReader::new(file, &mut hashers);
+            let content_addressed_cache = self.content_addressed_cache;
+            let (mut extracted, hashes) = tokio::task::spawn_blocking({
+                let path = path.to_owned();
+                let root = self.build_context.cache().root().to_path_buf();
+                let filename = filename.to_string();
+                move || -> Result<_, Error> {
+                    let file = fs_err::File::open(path).map_err(Error::CacheRead)?;
+                    let extractor = WheelExtractor::new(&root, content_addressed_cache)
+                        .map_err(Error::CacheWrite)?;
+                    let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
+                    let mut hasher = uv_extract::hash::HashReader::new(file, &mut hashers);
+                    let extracted = extractor
+                        .extract_blocking(&mut hasher)
+                        .map_err(|err| Error::Extract(filename, err))?;
 
-            // Unzip the wheel to a temporary directory.
-            let mut extracted = extractor
-                .extract_streaming(&mut hasher)
-                .await
-                .map_err(|err| Error::Extract(filename.to_string(), err))?;
-
-            // Exhaust the reader to compute the hash.
-            hasher.finish().await.map_err(Error::HashExhaustion)?;
-
-            let hashes = hashers.into_iter().map(HashDigest::from).collect();
+                    // Hash the complete file even when ZIP validation is disabled and extraction
+                    // stops before the end of the archive.
+                    io::copy(&mut hasher, &mut io::sink()).map_err(Error::HashExhaustion)?;
+                    let hashes = hashers.into_iter().map(HashDigest::from).collect();
+                    Ok((extracted, hashes))
+                }
+            })
+            .await??;
 
             // Before we make the wheel accessible by persisting it, ensure that the RECORD is
             // valid.

--- a/crates/uv-distribution/src/extracted_wheel.rs
+++ b/crates/uv-distribution/src/extracted_wheel.rs
@@ -71,6 +71,28 @@ impl WheelExtractor {
         }
     }
 
+    /// Extract a wheel in one pass on the current thread, optionally retaining its per-file digests.
+    ///
+    /// Call this from a blocking task. The caller must drain the reader before finalizing archive
+    /// hashes, since extraction can finish early when ZIP validation is disabled.
+    pub(crate) fn extract_blocking<R: io::Read + Unpin>(
+        self,
+        reader: R,
+    ) -> Result<ExtractedWheel, uv_extract::Error> {
+        let files = if self.content_addressed {
+            let (files, tree) =
+                uv_extract::stream::unzip_and_hash_blocking(reader, self.temp_dir.path())?;
+            ExtractedFiles::Hashed(HashedWheel { files, tree })
+        } else {
+            let files = uv_extract::stream::unzip_blocking(reader, self.temp_dir.path())?;
+            ExtractedFiles::Unhashed(files)
+        };
+        Ok(ExtractedWheel {
+            temp_dir: self.temp_dir,
+            files,
+        })
+    }
+
     /// Extract a wheel from a seekable file, optionally retaining its per-file digests.
     pub(crate) fn extract_seekable(
         self,

--- a/crates/uv-extract/src/hash.rs
+++ b/crates/uv-extract/src/hash.rs
@@ -72,10 +72,7 @@ pub struct HashReader<'a, R> {
     bytes_read: u64,
 }
 
-impl<'a, R> HashReader<'a, R>
-where
-    R: tokio::io::AsyncRead + Unpin,
-{
+impl<'a, R> HashReader<'a, R> {
     pub fn new(reader: R, hashers: &'a mut [Hasher]) -> Self {
         HashReader {
             reader,
@@ -88,12 +85,25 @@ where
     pub fn bytes_read(&self) -> u64 {
         self.bytes_read
     }
+}
 
+impl<R: tokio::io::AsyncRead + Unpin> HashReader<'_, R> {
     /// Exhaust the underlying reader.
     pub async fn finish(&mut self) -> Result<(), std::io::Error> {
         while self.read(&mut vec![0; 8192]).await? > 0 {}
 
         Ok(())
+    }
+}
+
+impl<R: std::io::Read> std::io::Read for HashReader<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let read = self.reader.read(buf)?;
+        self.bytes_read += read as u64;
+        for hasher in self.hashers.iter_mut() {
+            hasher.update(&buf[..read]);
+        }
+        Ok(read)
     }
 }
 

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -109,6 +109,47 @@ pub async fn unzip_and_hash<R: tokio::io::AsyncRead + Unpin>(
     Ok((target, files, tree))
 }
 
+/// Extract a non-seekable ZIP reader on the current thread using synchronous filesystem I/O.
+///
+/// Call this from a blocking task. Callers computing archive hashes must drain the reader after
+/// extraction, which can leave unread bytes when ZIP validation is disabled.
+pub fn unzip_blocking<R: io::Read + Unpin>(
+    reader: R,
+    target: &Path,
+) -> Result<Vec<UnhashedFile>, Error> {
+    let UnzipOutput::Unhashed(files) = block_on(Box::pin(unzip_inner(
+        AllowStdIo::new(reader).compat(),
+        target,
+        false,
+    )))?
+    else {
+        return Err(Error::Io(io::Error::other(
+            "streaming ZIP hash tree was unexpectedly computed",
+        )));
+    };
+    Ok(files)
+}
+
+/// Extract a non-seekable ZIP reader and compute its extracted hash tree on the current thread.
+///
+/// See [`unzip_blocking`] for blocking and archive hash requirements.
+pub fn unzip_and_hash_blocking<R: io::Read + Unpin>(
+    reader: R,
+    target: &Path,
+) -> Result<(Vec<HashedFile>, DirhashTree), Error> {
+    let UnzipOutput::Hashed { files, tree } = block_on(Box::pin(unzip_inner(
+        AllowStdIo::new(reader).compat(),
+        target,
+        true,
+    )))?
+    else {
+        return Err(Error::Io(io::Error::other(
+            "streaming ZIP hash tree was not computed",
+        )));
+    };
+    Ok((files, tree))
+}
+
 /// Feed a borrowed archive reader to an extraction worker that owns the temporary directory.
 async fn unzip_streaming_inner<R: tokio::io::AsyncRead + Unpin>(
     mut reader: R,

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -6,7 +6,9 @@ use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use fs_err as fs;
 use indoc::{formatdoc, indoc};
+use insta::allow_duplicates;
 use predicates::Predicate;
+use sha2::{Digest, Sha256};
 use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -3877,26 +3879,80 @@ fn require_hashes_re_download() -> Result<()> {
 /// Include the hash for a built distribution specified as a local path dependency.
 #[test]
 fn require_hashes_wheel_path() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
+    for content_addressed in [false, true] {
+        let context = uv_test::test_context!("3.12");
 
-    let requirements_txt = context.temp_dir.child("requirements.txt");
-    requirements_txt.write_str(&format!(
-        "tqdm @ {} --hash=sha256:a34996d4bd5abb2336e14ff0a2d22b92cfd0f0ed344e6883041ce01953276a13",
-        context
-            .workspace_root
-            .join("test/links/tqdm-1000.0.0-py3-none-any.whl")
-            .display()
-    ))?;
+        let requirements_txt = context.temp_dir.child("requirements.txt");
+        requirements_txt.write_str(&format!(
+            "tqdm @ {} --hash=sha256:a34996d4bd5abb2336e14ff0a2d22b92cfd0f0ed344e6883041ce01953276a13",
+            context
+                .workspace_root
+                .join("test/links/tqdm-1000.0.0-py3-none-any.whl")
+                .display()
+        ))?;
+
+        let mut command = context.pip_sync();
+        command.arg("requirements.txt").arg("--require-hashes");
+        if content_addressed {
+            command.args(["--preview-features", "content-addressed-cache"]);
+        }
+        allow_duplicates! {
+            uv_snapshot!(context.filters(), command, @"
+            exit_code: 0 (success)
+            ----- stderr -----
+            Resolved 1 package in [TIME]
+            Prepared 1 package in [TIME]
+            Installed 1 package in [TIME]
+             + tqdm==1000.0.0 (from file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl)
+            ");
+        }
+        assert_eq!(
+            context.cache_dir.child("files-v0").exists(),
+            content_addressed
+        );
+    }
+
+    Ok(())
+}
+
+/// Hash the complete local wheel even when ZIP validation allows unread trailing bytes.
+#[test]
+fn require_hashes_wheel_path_trailing_bytes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let filename = "ok-1.0.0-py3-none-any.whl";
+    let wheel = context.temp_dir.join(filename);
+    let mut bytes = fs::read(context.workspace_root.join("test/links").join(filename))?;
+
+    // This fixture has a 22-byte end record without a ZIP comment. Repeat its central directory
+    // at the end so seekable metadata lookup succeeds while streaming extraction stops at the
+    // first end record.
+    let mut end_record = bytes[bytes.len() - 22..].to_vec();
+    let directory_offset = u32::from_le_bytes(end_record[16..20].try_into()?) as usize;
+    let directory = bytes[directory_offset..bytes.len() - 22].to_vec();
+
+    // Exceed the extractor's buffer so hashing must continue after extraction finishes.
+    bytes.resize(bytes.len() + 1024 * 1024, b'x');
+    end_record[16..20].copy_from_slice(&u32::try_from(bytes.len())?.to_le_bytes());
+    bytes.extend_from_slice(&directory);
+    bytes.extend_from_slice(&end_record);
+    let hash = hex::encode(Sha256::digest(&bytes));
+    fs::write(&wheel, bytes)?;
+    context
+        .temp_dir
+        .child("requirements.txt")
+        .write_str(&format!("ok @ {} --hash=sha256:{hash}\n", wheel.display()))?;
 
     uv_snapshot!(context.filters(), context.pip_sync()
         .arg("requirements.txt")
-        .arg("--require-hashes"), @"
+        .arg("--no-index")
+        .arg("--require-hashes")
+        .env(EnvVars::UV_INSECURE_NO_ZIP_VALIDATION, "1"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
-     + tqdm==1000.0.0 (from file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl)
+     + ok==1.0.0 (from file://[TEMP_DIR]/ok-1.0.0-py3-none-any.whl)
     "
     );
 

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -6,9 +6,7 @@ use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use fs_err as fs;
 use indoc::{formatdoc, indoc};
-use insta::allow_duplicates;
 use predicates::Predicate;
-use sha2::{Digest, Sha256};
 use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -3879,80 +3877,26 @@ fn require_hashes_re_download() -> Result<()> {
 /// Include the hash for a built distribution specified as a local path dependency.
 #[test]
 fn require_hashes_wheel_path() -> Result<()> {
-    for content_addressed in [false, true] {
-        let context = uv_test::test_context!("3.12");
-
-        let requirements_txt = context.temp_dir.child("requirements.txt");
-        requirements_txt.write_str(&format!(
-            "tqdm @ {} --hash=sha256:a34996d4bd5abb2336e14ff0a2d22b92cfd0f0ed344e6883041ce01953276a13",
-            context
-                .workspace_root
-                .join("test/links/tqdm-1000.0.0-py3-none-any.whl")
-                .display()
-        ))?;
-
-        let mut command = context.pip_sync();
-        command.arg("requirements.txt").arg("--require-hashes");
-        if content_addressed {
-            command.args(["--preview-features", "content-addressed-cache"]);
-        }
-        allow_duplicates! {
-            uv_snapshot!(context.filters(), command, @"
-            exit_code: 0 (success)
-            ----- stderr -----
-            Resolved 1 package in [TIME]
-            Prepared 1 package in [TIME]
-            Installed 1 package in [TIME]
-             + tqdm==1000.0.0 (from file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl)
-            ");
-        }
-        assert_eq!(
-            context.cache_dir.child("files-v0").exists(),
-            content_addressed
-        );
-    }
-
-    Ok(())
-}
-
-/// Hash the complete local wheel even when ZIP validation allows unread trailing bytes.
-#[test]
-fn require_hashes_wheel_path_trailing_bytes() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let filename = "ok-1.0.0-py3-none-any.whl";
-    let wheel = context.temp_dir.join(filename);
-    let mut bytes = fs::read(context.workspace_root.join("test/links").join(filename))?;
 
-    // This fixture has a 22-byte end record without a ZIP comment. Repeat its central directory
-    // at the end so seekable metadata lookup succeeds while streaming extraction stops at the
-    // first end record.
-    let mut end_record = bytes[bytes.len() - 22..].to_vec();
-    let directory_offset = u32::from_le_bytes(end_record[16..20].try_into()?) as usize;
-    let directory = bytes[directory_offset..bytes.len() - 22].to_vec();
-
-    // Exceed the extractor's buffer so hashing must continue after extraction finishes.
-    bytes.resize(bytes.len() + 1024 * 1024, b'x');
-    end_record[16..20].copy_from_slice(&u32::try_from(bytes.len())?.to_le_bytes());
-    bytes.extend_from_slice(&directory);
-    bytes.extend_from_slice(&end_record);
-    let hash = hex::encode(Sha256::digest(&bytes));
-    fs::write(&wheel, bytes)?;
-    context
-        .temp_dir
-        .child("requirements.txt")
-        .write_str(&format!("ok @ {} --hash=sha256:{hash}\n", wheel.display()))?;
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str(&format!(
+        "tqdm @ {} --hash=sha256:a34996d4bd5abb2336e14ff0a2d22b92cfd0f0ed344e6883041ce01953276a13",
+        context
+            .workspace_root
+            .join("test/links/tqdm-1000.0.0-py3-none-any.whl")
+            .display()
+    ))?;
 
     uv_snapshot!(context.filters(), context.pip_sync()
         .arg("requirements.txt")
-        .arg("--no-index")
-        .arg("--require-hashes")
-        .env(EnvVars::UV_INSECURE_NO_ZIP_VALIDATION, "1"), @"
+        .arg("--require-hashes"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
-     + ok==1.0.0 (from file://[TEMP_DIR]/ok-1.0.0-py3-none-any.whl)
+     + tqdm==1000.0.0 (from file://[WORKSPACE]/test/links/tqdm-1000.0.0-py3-none-any.whl)
     "
     );
 


### PR DESCRIPTION
## Summary

We now read, hash, and extract local wheels in one blocking task. This removes the async pipe and repeated Tokio file-read dispatches while keeping concurrency between wheels.

An extraction that has started can finish after cancellation, but its output is not published to the cache.

## Benchmarks

Installing Jupyter 1.1.1 and its 95 dependencies from local wheels with `--require-hashes` uses **26–27% less peak memory**. The wall-time improvement did not repeat across both batches.

| Batch | Median time, before → after | Median peak RSS, before → after |
| --- | ---: | ---: |
| 1 | 1363.3 → 1229.9 ms | 142.8 → 104.5 MiB |
| 2 | 1207.6 → 1222.3 ms | 142.0 → 104.8 MiB |

Two batches of 12 alternating baseline/PR pairs, each using a fresh environment and empty uv cache, with warm OS pages. Linux/AMD EPYC-Milan, 32 available CPUs, CPython 3.12.13, Ohm 1.98.1-1, and identical `profiling` builds without LTO.

[Raw results, controls, exact revisions, and reproducer](https://gist.github.com/charliermarsh/ab2e9008091ab9d5c3cf8f22715de63d).
