### PR TITLE
Wrap temporary files to handle long Windows paths

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -17,7 +17,6 @@ use std::io::Read;
 use encoding_rs_io::DecodeReaderBytes;
 #[cfg(target_os = "linux")]
 use rustix::fs::{AtFlags, CWD as RUSTIX_CWD, StatxFlags, statx};
-use tempfile::NamedTempFile;
 use tracing::{debug, warn};
 #[cfg(windows)]
 use windows::Win32::Foundation::HANDLE;
@@ -25,6 +24,7 @@ use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle};
 
 pub use crate::locked_file::*;
+pub use crate::named_temp_file::{NamedTempFile, PersistError, tempfile_in};
 pub use crate::path::*;
 pub use crate::read::ValidatedReader;
 pub use crate::space::{PhysicalSpaceError, physical_space, supports_fine_grained_accounting};
@@ -34,6 +34,7 @@ pub mod cachedir;
 mod hardlink_macos;
 pub mod link;
 mod locked_file;
+mod named_temp_file;
 mod path;
 mod read;
 mod space;
@@ -472,24 +473,6 @@ pub fn symlink_or_copy_file(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std
     Ok(())
 }
 
-/// Return a [`NamedTempFile`] in the specified directory.
-///
-/// Sets the permissions of the temporary file to `0o666`, to match the non-temporary file default.
-/// ([`NamedTempfile`] defaults to `0o600`.)
-#[cfg(unix)]
-pub fn tempfile_in(path: &Path) -> std::io::Result<NamedTempFile> {
-    use std::os::unix::fs::PermissionsExt;
-    tempfile::Builder::new()
-        .permissions(std::fs::Permissions::from_mode(0o666))
-        .tempfile_in(path)
-}
-
-/// Return a [`NamedTempFile`] in the specified directory.
-#[cfg(not(unix))]
-pub fn tempfile_in(path: &Path) -> std::io::Result<NamedTempFile> {
-    tempfile::Builder::new().tempfile_in(path)
-}
-
 /// Write `data` to `path` atomically using a temporary file and atomic rename.
 #[cfg(feature = "tokio")]
 pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std::io::Result<()> {
@@ -515,10 +498,7 @@ pub fn write_atomic_sync(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std:
 
 /// Copy `from` to `to` atomically using a temporary file and atomic rename.
 pub fn copy_atomic_sync(from: impl AsRef<Path>, to: impl AsRef<Path>) -> std::io::Result<()> {
-    // `tempfile` uses Win32 APIs directly, so both paths passed to `persist` need the extended-length
-    // prefix when Windows' long-path opt-in is disabled.
-    let to = verbatim_path(to.as_ref());
-    let temp_file = tempfile_in(to.parent().expect("Write path must have a parent"))?;
+    let temp_file = tempfile_in(to.as_ref().parent().expect("Write path must have a parent"))?;
     fs_err::copy(from.as_ref(), &temp_file)?;
     persist_with_retry_sync(temp_file, to.as_ref())
 }

--- a/crates/uv-fs/src/named_temp_file.rs
+++ b/crates/uv-fs/src/named_temp_file.rs
@@ -9,13 +9,14 @@ use crate::verbatim_path;
 
 /// A temporary file that supports long Windows paths without the process's long-path opt-in.
 ///
-/// Both its temporary path and its persist destination use verbatim paths, since `tempfile` passes
-/// them directly to Win32 APIs. The file is removed on drop unless it is persisted.
+/// On Windows, both its temporary path and its persist destination use verbatim paths, since
+/// `tempfile` passes them directly to Win32 APIs. The file is removed on drop unless it is persisted.
 #[derive(Debug)]
 pub struct NamedTempFile(tempfile::NamedTempFile);
 
 /// Return a [`NamedTempFile`] in the specified directory.
 ///
+/// On Windows, stores a verbatim path so later persistence supports long paths.
 /// On Unix, requests `0o666` permissions (subject to the umask), matching non-temporary files.
 pub fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
     #[cfg(unix)]
@@ -37,12 +38,10 @@ impl NamedTempFile {
         self.0.as_file()
     }
 
-    #[expect(clippy::disallowed_types, reason = "tempfile exposes a std::fs::File")]
-    pub fn as_file_mut(&mut self) -> &mut std::fs::File {
-        self.0.as_file_mut()
-    }
-
     /// Persist the temporary file, atomically replacing any existing file at `path`.
+    ///
+    /// The destination must be on the same filesystem. This does not synchronize the file contents
+    /// or the containing directory to disk.
     ///
     /// On failure, the returned [`PersistError`] retains the temporary file so callers can retry.
     #[expect(clippy::disallowed_types, reason = "tempfile exposes a std::fs::File")]
@@ -98,8 +97,6 @@ mod tests {
             .persist(directory.path().join("missing/file"))
             .unwrap_err();
         assert_eq!(error.error.kind(), io::ErrorKind::NotFound);
-        assert_eq!(error.file.path(), temporary_path);
-        assert_eq!(fs_err::read_to_string(&temporary_path)?, "content");
 
         let destination = directory.path().join("file");
         fs_err::write(&destination, "old content")?;

--- a/crates/uv-fs/src/named_temp_file.rs
+++ b/crates/uv-fs/src/named_temp_file.rs
@@ -29,10 +29,6 @@ pub fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
 }
 
 impl NamedTempFile {
-    pub fn path(&self) -> &Path {
-        self.0.path()
-    }
-
     #[expect(clippy::disallowed_types, reason = "tempfile exposes a std::fs::File")]
     pub fn as_file(&self) -> &std::fs::File {
         self.0.as_file()
@@ -57,7 +53,7 @@ impl NamedTempFile {
 
 impl AsRef<Path> for NamedTempFile {
     fn as_ref(&self) -> &Path {
-        self.path()
+        self.0.path()
     }
 }
 

--- a/crates/uv-fs/src/named_temp_file.rs
+++ b/crates/uv-fs/src/named_temp_file.rs
@@ -79,33 +79,3 @@ pub struct PersistError {
     pub error: io::Error,
     pub file: NamedTempFile,
 }
-
-#[cfg(test)]
-mod tests {
-    use std::io::{self, Write};
-
-    use super::tempfile_in;
-
-    #[test]
-    fn persist_after_failure() -> io::Result<()> {
-        let directory = tempfile::tempdir()?;
-        let mut file = tempfile_in(directory.path())?;
-        file.write_all(b"content")?;
-        let temporary_path = file.path().to_owned();
-
-        let error = file
-            .persist(directory.path().join("missing/file"))
-            .unwrap_err();
-        assert_eq!(error.error.kind(), io::ErrorKind::NotFound);
-
-        let destination = directory.path().join("file");
-        fs_err::write(&destination, "old content")?;
-        error
-            .file
-            .persist(&destination)
-            .map_err(|error| error.error)?;
-        assert_eq!(fs_err::read_to_string(destination)?, "content");
-        assert!(!temporary_path.exists());
-        Ok(())
-    }
-}

--- a/crates/uv-fs/src/named_temp_file.rs
+++ b/crates/uv-fs/src/named_temp_file.rs
@@ -1,0 +1,114 @@
+use std::io::{self, Write};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use thiserror::Error;
+
+use crate::verbatim_path;
+
+/// A temporary file that supports long Windows paths without the process's long-path opt-in.
+///
+/// Both its temporary path and its persist destination use verbatim paths, since `tempfile` passes
+/// them directly to Win32 APIs. The file is removed on drop unless it is persisted.
+#[derive(Debug)]
+pub struct NamedTempFile(tempfile::NamedTempFile);
+
+/// Return a [`NamedTempFile`] in the specified directory.
+///
+/// On Unix, requests `0o666` permissions (subject to the umask), matching non-temporary files.
+pub fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
+    #[cfg(unix)]
+    let file = tempfile::Builder::new()
+        .permissions(std::fs::Permissions::from_mode(0o666))
+        .tempfile_in(path)?;
+    #[cfg(not(unix))]
+    let file = tempfile::Builder::new().tempfile_in(verbatim_path(path))?;
+    Ok(NamedTempFile(file))
+}
+
+impl NamedTempFile {
+    pub fn path(&self) -> &Path {
+        self.0.path()
+    }
+
+    #[expect(clippy::disallowed_types, reason = "tempfile exposes a std::fs::File")]
+    pub fn as_file(&self) -> &std::fs::File {
+        self.0.as_file()
+    }
+
+    #[expect(clippy::disallowed_types, reason = "tempfile exposes a std::fs::File")]
+    pub fn as_file_mut(&mut self) -> &mut std::fs::File {
+        self.0.as_file_mut()
+    }
+
+    /// Persist the temporary file, atomically replacing any existing file at `path`.
+    ///
+    /// On failure, the returned [`PersistError`] retains the temporary file so callers can retry.
+    #[expect(clippy::disallowed_types, reason = "tempfile exposes a std::fs::File")]
+    pub fn persist(self, path: impl AsRef<Path>) -> Result<std::fs::File, PersistError> {
+        self.0
+            .persist(verbatim_path(path.as_ref()))
+            .map_err(|error| PersistError {
+                error: error.error,
+                file: Self(error.file),
+            })
+    }
+}
+
+impl AsRef<Path> for NamedTempFile {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
+impl Write for NamedTempFile {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0.write(buffer)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+/// An error persisting a [`NamedTempFile`], retaining the file for another attempt.
+#[derive(Debug, Error)]
+#[error("failed to persist temporary file: {error}")]
+pub struct PersistError {
+    #[source]
+    pub error: io::Error,
+    pub file: NamedTempFile,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+
+    use super::tempfile_in;
+
+    #[test]
+    fn persist_after_failure() -> io::Result<()> {
+        let directory = tempfile::tempdir()?;
+        let mut file = tempfile_in(directory.path())?;
+        file.write_all(b"content")?;
+        let temporary_path = file.path().to_owned();
+
+        let error = file
+            .persist(directory.path().join("missing/file"))
+            .unwrap_err();
+        assert_eq!(error.error.kind(), io::ErrorKind::NotFound);
+        assert_eq!(error.file.path(), temporary_path);
+        assert_eq!(fs_err::read_to_string(&temporary_path)?, "content");
+
+        let destination = directory.path().join("file");
+        fs_err::write(&destination, "old content")?;
+        error
+            .file
+            .persist(&destination)
+            .map_err(|error| error.error)?;
+        assert_eq!(fs_err::read_to_string(destination)?, "content");
+        assert!(!temporary_path.exists());
+        Ok(())
+    }
+}

--- a/crates/uv-test/src/vendor.rs
+++ b/crates/uv-test/src/vendor.rs
@@ -238,7 +238,7 @@ async fn ensure_cached_artifact(artifact: &VendorArtifact, path: &Path) -> Resul
     })?;
     temp.write_all(&bytes)
         .with_context(|| format!("failed to write `{}`", artifact.filename))?;
-    temp.as_file_mut()
+    temp.as_file()
         .sync_all()
         .with_context(|| format!("failed to sync `{}`", artifact.filename))?;
 


### PR DESCRIPTION
## Summary

After #21625, atomic copies handle long Windows paths, but other callers of `uv_fs::tempfile_in` still receive a raw `tempfile::NamedTempFile` and must convert the destination themselves before persisting.

Return a `uv_fs::NamedTempFile` wrapper that converts both the temporary-file path and the persist destination to verbatim Windows paths. Existing callers get the conversion automatically, including atomic writes and build-backend archives, so we can remove the special case in `copy_atomic_sync`. Persist failures retain the wrapped file for retries; Unix permissions and temporary-file cleanup remain unchanged.
