### PR TITLE
Skip retry delays when testing rejected source archives

### DIFF
--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -2579,6 +2579,7 @@ async fn lock_sdist_url_rejected_archive_not_cached() -> Result<()> {
     uv_snapshot!(context.filters(), context.lock()
         .arg("--locked")
         .arg("--refresh")
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
         .env("UV_LOCK_TEST_SENTINEL", sentinel.path()), @"
     exit_code: 1 (failure)
     ----- stderr -----


### PR DESCRIPTION
Skip retry delays in the test for rejected source archives. We still make the same retry attempts and check that the archive isn't cached.

In one Linux CI comparison, the test went from [12.4s](https://github.com/astral-sh/uv/actions/runs/34663282841) to [0.35s](https://github.com/astral-sh/uv/actions/runs/34667360319).
