### PR TITLE
Remove redundant Homebrew Python system job on macOS

### DIFF
--- a/.github/workflows/test-system.yml
+++ b/.github/workflows/test-system.yml
@@ -401,29 +401,6 @@ jobs:
       - name: "Validate global Python install"
         run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
 
-  system-test-macos-aarch64:
-    timeout-minutes: 10
-    name: "python on macos aarch64"
-    runs-on: macos-14 # github-macos-14-aarch64-3
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: "Download binary"
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: uv-macos-aarch64-${{ inputs.sha }}
-
-      - name: "Prepare binary"
-        run: chmod +x ./uv
-
-      - name: "Print Python path"
-        run: echo $(which python3)
-
-      - name: "Validate global Python install"
-        run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
-
   system-test-macos-aarch64-homebrew:
     timeout-minutes: 10
     name: "homebrew python on macos aarch64"

--- a/.github/workflows/test-system.yml
+++ b/.github/workflows/test-system.yml
@@ -401,17 +401,14 @@ jobs:
       - name: "Validate global Python install"
         run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
 
-  system-test-macos-aarch64-homebrew:
+  system-test-macos-aarch64:
     timeout-minutes: 10
-    name: "homebrew python on macos aarch64"
+    name: "python on macos aarch64"
     runs-on: macos-14 # github-macos-14-aarch64-3
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: "Install Python"
-        run: brew install python3
 
       - name: "Download binary"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Remove the Homebrew-specific macOS ARM system job. Both [the default job](https://github.com/astral-sh/uv/actions/runs/34663282841/job/103470876350) and [the Homebrew job](https://github.com/astral-sh/uv/actions/runs/34663282841/job/103470876326) use `/opt/homebrew/bin/python3` (CPython 3.14.7), and `brew install python3` is a no-op.

We keep the default Python job and save one macOS job per run. This means we won't separately test Homebrew if GitHub switches to a different default.
