### PR TITLE
Share Python download cache by default in integration tests

### DIFF
--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -125,6 +125,7 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
 ///
 /// * Set the current directory to a temporary directory (`temp_dir`).
 /// * Set the cache dir to a different temporary directory (`cache_dir`).
+/// * Share the Python download cache unless explicitly disabled.
 /// * Set a shared test timestamp so snapshots don't change after a new release.
 /// * Set the venv to a fresh `.venv` in `temp_dir`
 pub struct TestContext {
@@ -702,19 +703,11 @@ impl TestContext {
         self
     }
 
-    /// Use a shared global cache for Python downloads.
+    /// Disable the shared Python download cache for tests that require fresh downloads or isolated cache state.
     #[must_use]
-    pub fn with_python_download_cache(mut self) -> Self {
-        self.extra_env.push((
-            EnvVars::UV_PYTHON_CACHE_DIR.into(),
-            // Respect `UV_PYTHON_CACHE_DIR` if set, or use the default cache directory
-            env::var_os(EnvVars::UV_PYTHON_CACHE_DIR).unwrap_or_else(|| {
-                uv_cache::Cache::from_settings(false, None)
-                    .unwrap()
-                    .bucket(CacheBucket::Python)
-                    .into()
-            }),
-        ));
+    pub fn without_python_download_cache(mut self) -> Self {
+        self.extra_env
+            .retain(|(key, _)| key != EnvVars::UV_PYTHON_CACHE_DIR);
         self
     }
 
@@ -1197,7 +1190,16 @@ impl TestContext {
             python_versions,
             uv_bin,
             filters,
-            extra_env: vec![],
+            extra_env: vec![(
+                EnvVars::UV_PYTHON_CACHE_DIR.into(),
+                // Respect `UV_PYTHON_CACHE_DIR` if set, or use the default cache directory.
+                env::var_os(EnvVars::UV_PYTHON_CACHE_DIR).unwrap_or_else(|| {
+                    Cache::from_settings(false, None)
+                        .expect("Failed to determine the shared Python download cache")
+                        .bucket(CacheBucket::Python)
+                        .into()
+                }),
+            )],
             _root: root,
             _extra_tempdirs: vec![],
         }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -558,6 +558,7 @@ fn write_python_downloads_json(context: &TestContext, mock_server_uri: &String) 
 #[tokio::test]
 async fn python_install_http_500() {
     let context = uv_test::test_context!("3.12")
+        .without_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs();
@@ -585,6 +586,7 @@ async fn python_install_http_500() {
 #[tokio::test]
 async fn python_install_io_error() {
     let context = uv_test::test_context!("3.12")
+        .without_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs();

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -6234,9 +6234,7 @@ fn incompatible_platform_direct_url() -> Result<()> {
 #[test]
 fn sync_missing_python_no_target() -> Result<()> {
     // Create a context that only has Python 3.11 available.
-    let context = uv_test::test_context!("3.11")
-        .with_python_download_cache()
-        .with_managed_python_dirs();
+    let context = uv_test::test_context!("3.11").with_managed_python_dirs();
 
     let requirements = context.temp_dir.child("requirements.txt");
     requirements.write_str("anyio")?;
@@ -6258,7 +6256,6 @@ fn sync_missing_python_no_target() -> Result<()> {
 fn sync_with_target_installs_missing_python() -> Result<()> {
     // Create a context that only has Python 3.11 available.
     let context = uv_test::test_context!("3.11")
-        .with_python_download_cache()
         .with_managed_python_dirs()
         .with_filtered_latest_python_versions();
 

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -19325,9 +19325,7 @@ fn compile_with_python_platform_and_built_wheel_for_different_platform() -> Resu
 #[cfg(feature = "test-python-managed")]
 #[test]
 fn compile_missing_python() -> Result<()> {
-    let context = uv_test::test_context!("3.12")
-        .with_python_download_cache()
-        .with_managed_python_dirs();
+    let context = uv_test::test_context!("3.12").with_managed_python_dirs();
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("anyio==3.7.0")?;
@@ -19358,9 +19356,7 @@ fn compile_missing_python() -> Result<()> {
 #[cfg(feature = "test-python-managed")]
 #[test]
 fn compile_missing_python_version() -> Result<()> {
-    let context = uv_test::test_context!("3.12")
-        .with_python_download_cache()
-        .with_managed_python_dirs();
+    let context = uv_test::test_context!("3.12").with_managed_python_dirs();
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("anyio==3.7.0")?;
@@ -19391,7 +19387,6 @@ fn compile_missing_python_version() -> Result<()> {
 #[test]
 fn compile_missing_python_version_patch_fallback() -> Result<()> {
     let context = uv_test::test_context!("3.12")
-        .with_python_download_cache()
         .with_managed_python_dirs()
         // Filter the patch of the version which will get downloaded
         .with_filter((
@@ -19429,7 +19424,6 @@ fn compile_missing_python_version_patch_fallback() -> Result<()> {
 #[test]
 fn compile_missing_python_version_default_fallback() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_managed_python_dirs()
         .with_filtered_latest_python_versions();
 
@@ -19493,6 +19487,7 @@ fn compile_client_certificate_warning_chain() -> Result<()> {
 #[tokio::test]
 async fn compile_missing_python_download_error_warning() {
     let context = uv_test::test_context!("3.12")
+        .without_python_download_cache()
         .with_managed_python_dirs()
         .with_filter((
             r"(https://github\.com/astral-sh/python-build-standalone/releases/download/).*"

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -16264,7 +16264,6 @@ fn pip_install_no_sources_editable_to_registry_switch() -> Result<()> {
 #[test]
 fn install_with_system_interpreter() {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_managed_python_dirs()
         .with_filtered_python_keys()
         .with_filtered_latest_python_versions();
@@ -16292,9 +16291,7 @@ fn install_with_system_interpreter() {
 #[test]
 fn install_missing_python_no_target() {
     // Create a context that only has Python 3.11 available.
-    let context = uv_test::test_context!("3.11")
-        .with_python_download_cache()
-        .with_managed_python_dirs();
+    let context = uv_test::test_context!("3.11").with_managed_python_dirs();
 
     // Request Python 3.12; which should fail
     uv_snapshot!(context.filters(), context.pip_install()
@@ -16313,7 +16310,6 @@ fn install_missing_python_no_target() {
 fn install_missing_python_with_target() {
     // Create a context with no installed python interpreters.
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_managed_python_dirs()
         .with_filtered_latest_python_versions();
 
@@ -16340,7 +16336,6 @@ fn install_missing_python_with_target() {
 fn install_missing_python_version_with_target() {
     // Create a context that only has Python 3.11 available.
     let context = uv_test::test_context!("3.11")
-        .with_python_download_cache()
         .with_managed_python_dirs()
         .with_filtered_latest_python_versions();
 
@@ -16711,7 +16706,6 @@ fn abi_compatibility_on_freethreaded_python() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();
@@ -16835,7 +16829,6 @@ fn abi_compatibility_on_debug_python() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();

--- a/crates/uv/tests/python/python_find.rs
+++ b/crates/uv/tests/python/python_find.rs
@@ -1124,7 +1124,6 @@ fn python_find_freethreaded_313() {
         .with_filtered_python_keys()
         .with_filtered_python_sources()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();
@@ -1158,7 +1157,6 @@ fn python_find_freethreaded_314() {
         .with_filtered_python_keys()
         .with_filtered_python_sources()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();
@@ -1223,7 +1221,6 @@ fn python_find_version_range_installation_key_order() {
         .with_filtered_latest_python_versions()
         .with_filtered_python_sources()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_exe_suffix();
 
@@ -1355,7 +1352,6 @@ fn python_find_prerelease_version_specifiers() {
         .with_filtered_python_keys()
         .with_filtered_python_sources()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();
@@ -1433,7 +1429,6 @@ fn python_find_prerelease_with_patch_request() {
         .with_filtered_python_keys()
         .with_filtered_python_sources()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();

--- a/crates/uv/tests/python/python_install.rs
+++ b/crates/uv/tests/python/python_install.rs
@@ -325,7 +325,8 @@ fn python_install_force() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_python_download_cache();
 
     // Install the latest version
     uv_snapshot!(context.filters(), context.python_install(), @"
@@ -377,7 +378,8 @@ fn python_install_minor() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_python_download_cache();
 
     // Install a minor version
     uv_snapshot!(context.filters(), context.python_install().arg("3.11"), @"
@@ -430,7 +432,8 @@ fn python_install_multiple_patch() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_python_download_cache();
 
     // Install multiple patch versions
     uv_snapshot!(context.filters(), context.python_install().arg("3.12.8").arg("3.12.6"), @"
@@ -1271,7 +1274,8 @@ fn python_install_debug() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_python_download_cache();
 
     // Install the latest version
     uv_snapshot!(context.filters(), context.python_install().arg("--preview").arg("3.13+debug"), @"
@@ -2312,6 +2316,7 @@ fn python_install_prerelease() {
         .with_managed_python_dirs()
         .with_python_download_cache()
         .with_filtered_python_install_bin()
+        .with_filtered_python_names()
         .with_filtered_exe_suffix();
 
     // Install 3.15
@@ -2330,30 +2335,6 @@ fn python_install_prerelease() {
     Installed Python 3.15.0a2 in [TIME]
      + cpython-3.15.0a2-[PLATFORM]
     ");
-
-    // Install a release candidate for a non-zero patch version
-    uv_snapshot!(context.filters(), context.python_install().arg("3.14.5rc1"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Installed Python 3.14.5rc1 in [TIME]
-     + cpython-3.14.5rc1-[PLATFORM] (python3.14)
-    ");
-}
-
-#[test]
-fn python_find_prerelease() {
-    let context = uv_test::test_context_with_versions!(&[])
-        .with_filtered_python_keys()
-        .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache()
-        .with_filtered_python_install_bin()
-        .with_filtered_python_names()
-        .with_filtered_exe_suffix();
-
-    // See [`python_install_prerelease`] coverage of these.
-    context.python_install().arg("3.15").assert().success();
-    context.python_install().arg("3.15.0a2").assert().success();
 
     // We should be able to find this version without opt-in, because there is no stable release
     // installed
@@ -2388,6 +2369,14 @@ fn python_find_prerelease() {
     exit_code: 0 (success)
     ----- stdout -----
     [TEMP_DIR]/managed/cpython-3.13-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+    ");
+
+    // Install a release candidate for a non-zero patch version
+    uv_snapshot!(context.filters(), context.python_install().arg("3.14.5rc1"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Installed Python 3.14.5rc1 in [TIME]
+     + cpython-3.14.5rc1-[PLATFORM] (python3.14)
     ");
 }
 

--- a/crates/uv/tests/python/python_install.rs
+++ b/crates/uv/tests/python/python_install.rs
@@ -26,8 +26,7 @@ fn python_install() {
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
         .with_managed_python_dirs()
-        .with_empty_python_install_mirror()
-        .with_python_download_cache();
+        .with_empty_python_install_mirror();
 
     // Install the latest version
     uv_snapshot!(context.filters(), context.python_install(), @"
@@ -130,8 +129,7 @@ fn python_reinstall() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install a couple versions
     uv_snapshot!(context.filters(), context.python_install().arg("3.12").arg("3.13"), @"
@@ -174,7 +172,6 @@ fn python_reinstall_patch() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     // Install a couple patch versions
@@ -202,8 +199,7 @@ fn python_install_automatic() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_python_sources()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // With downloads disabled, the automatic install should fail
     uv_snapshot!(context.filters(), context.run()
@@ -296,8 +292,7 @@ fn regression_cpython() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_python_sources()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     let init = context.temp_dir.child("mre.py");
     init.write_str(indoc! { r#"
@@ -325,8 +320,7 @@ fn python_install_force() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install the latest version
     uv_snapshot!(context.filters(), context.python_install(), @"
@@ -378,8 +372,7 @@ fn python_install_minor() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install a minor version
     uv_snapshot!(context.filters(), context.python_install().arg("3.11"), @"
@@ -432,8 +425,7 @@ fn python_install_multiple_patch() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install multiple patch versions
     uv_snapshot!(context.filters(), context.python_install().arg("3.12.8").arg("3.12.6"), @"
@@ -508,8 +500,7 @@ fn python_install_preview() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install the latest version
     uv_snapshot!(context.filters(), context.python_install().arg("--preview"), @"
@@ -741,8 +732,7 @@ fn python_install_multiple_unmanaged_executables() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install a version with the default `python`, `python3`, and `python3.13` executables.
     uv_snapshot!(context.filters(), context.python_install().arg("--default").arg("--preview-features").arg("python-install-default").arg("3.13"), @"
@@ -784,8 +774,7 @@ fn python_install_preview_no_bin() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install the latest version
     uv_snapshot!(context.filters(), context.python_install().arg("--preview").arg("--no-bin"), @"
@@ -825,8 +814,7 @@ fn python_install_preview_upgrade() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     let bin_python = context
         .bin_dir
@@ -970,7 +958,6 @@ fn python_install_freethreaded() {
         .with_filtered_python_keys()
         .with_filtered_latest_python_versions()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();
@@ -1129,7 +1116,6 @@ fn python_install_freethreaded_and_gil_list() {
         .with_filtered_python_keys()
         .with_filtered_latest_python_versions()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix()
@@ -1206,7 +1192,6 @@ fn python_install_registry_takes_precedence_over_no_registry() {
         .with_filtered_python_keys()
         .with_filtered_latest_python_versions()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix()
@@ -1274,8 +1259,7 @@ fn python_install_debug() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install the latest version
     uv_snapshot!(context.filters(), context.python_install().arg("--preview").arg("3.13+debug"), @"
@@ -1374,8 +1358,7 @@ fn python_install_debug_freethreaded() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install the latest version
     uv_snapshot!(context.filters(), context.python_install().arg("--preview").arg("3.13td"), @"
@@ -1486,8 +1469,7 @@ fn python_install_invalid_request() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Request something that is not a Python version
     uv_snapshot!(context.filters(), context.python_install().arg("foobar"), @"
@@ -1517,8 +1499,7 @@ fn python_install_default() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     let bin_python_minor_14 = context
         .bin_dir
@@ -1736,8 +1717,7 @@ fn python_install_default_preview() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     let bin_python_minor_14 = context
         .bin_dir
@@ -2096,9 +2076,7 @@ fn read_link(path: &Path) -> String {
 
 #[test]
 fn python_install_unknown() {
-    let context = uv_test::test_context_with_versions!(&[])
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+    let context = uv_test::test_context_with_versions!(&[]).with_managed_python_dirs();
 
     // An unknown request
     uv_snapshot!(context.filters(), context.python_install().arg("foobar"), @"
@@ -2127,7 +2105,6 @@ fn python_install_broken_link() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     let bin_python = context.bin_dir.child("python3.13");
@@ -2162,8 +2139,7 @@ fn python_install_default_prerelease() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install Python 3.15, which currently only exists as a pre-release.
     context
@@ -2199,8 +2175,7 @@ fn python_install_default_from_env() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install the version specified by the `UV_PYTHON` environment variable by default
     uv_snapshot!(context.filters(), context.python_install().env(EnvVars::UV_PYTHON, "3.12"), @"
@@ -2272,8 +2247,7 @@ fn python_install_patch_dylib() {
 
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_managed_python_dirs();
 
     // Install the latest version
     context
@@ -2314,7 +2288,6 @@ fn python_install_prerelease() {
         .with_filtered_python_keys()
         .with_filtered_latest_python_versions()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();
@@ -2392,6 +2365,7 @@ fn python_install_cached() {
     }
 
     let context = uv_test::test_context_with_versions!(&[])
+        .without_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -2471,6 +2445,7 @@ fn python_install_no_cache() {
     }
 
     let context = uv_test::test_context_with_versions!(&[])
+        .without_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -2558,7 +2533,6 @@ fn python_install_emulated_macos() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     let arch_status = Command::new("/usr/bin/arch")
@@ -2627,7 +2601,6 @@ fn python_install_emulated_windows_x86_on_x64() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     // Before installation, `uv python list` should not show the x86_32 download
@@ -2685,7 +2658,6 @@ fn install_managed_venv_allow_existing() {
         .with_filtered_exe_suffix()
         .with_filtered_latest_python_versions()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     // Install a managed Python version.
@@ -2725,7 +2697,6 @@ fn install_transparent_patch_upgrade_uv_venv() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     // Install a lower patch version.
@@ -2814,7 +2785,6 @@ fn install_multiple_patches() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     // Install 3.12 patches in ascending order list
@@ -2887,7 +2857,6 @@ fn uninstall_highest_patch() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     // Install patches in ascending order list
@@ -2946,7 +2915,6 @@ fn install_no_transparent_upgrade_with_venv_patch_specification() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     uv_snapshot!(context.filters(), context.python_install().arg("--preview").arg("3.12.9"), @"
@@ -3001,7 +2969,6 @@ fn install_transparent_patch_upgrade_venv_module() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     let bin_dir = context.temp_dir.child("bin");
@@ -3060,7 +3027,6 @@ fn install_lower_patch_automatically() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     uv_snapshot!(context.filters(), context.python_install().arg("--preview").arg("3.12.11"), @"
@@ -3115,7 +3081,6 @@ fn uninstall_last_patch() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_virtualenv_bin();
 
     uv_snapshot!(context.filters(), context.python_install().arg("--preview").arg("3.10.17"), @"
@@ -3185,7 +3150,6 @@ fn uninstall_last_patch_removes_minor_version_link() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     let managed_dir = context.temp_dir.child("managed");
@@ -3239,7 +3203,6 @@ fn uninstall_highest_patch_updates_minor_version_link() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin();
 
     let managed_dir = context.temp_dir.child("managed");
@@ -3339,7 +3302,6 @@ fn python_install_pyodide() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     uv_snapshot!(context.filters(), context.python_install().arg("cpython-3.13.2-emscripten-wasm32-musl"), @"
@@ -3471,7 +3433,6 @@ fn python_install_build_version() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_sources()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
@@ -3540,7 +3501,6 @@ fn python_install_build_version_pypy() {
         .with_filtered_python_keys()
         .with_filtered_python_sources()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
         .with_filtered_exe_suffix();
@@ -3594,7 +3554,6 @@ fn python_install_build_version_pypy() {
 #[test]
 fn python_install_upgrade() {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -3696,7 +3655,6 @@ fn python_install_upgrade() {
 #[test]
 fn python_install_upgrade_version_file() {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -3738,7 +3696,6 @@ fn python_install_armv7() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_managed_python_dirs()
-        .with_python_download_cache()
         .with_filtered_python_sources()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
@@ -3796,7 +3753,6 @@ fn python_install_compile_bytecode() -> anyhow::Result<()> {
         .with_filtered_compiled_file_count()
         .with_managed_python_dirs()
         .with_empty_python_install_mirror()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     // Install 3.14 and compile its bytecode
@@ -3861,7 +3817,6 @@ fn python_install_compile_bytecode_existing() {
         .with_filtered_compiled_file_count()
         .with_managed_python_dirs()
         .with_empty_python_install_mirror()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     // A fresh install should be able to be compiled later
@@ -3888,7 +3843,6 @@ fn python_install_compile_bytecode_upgrade() {
         .with_filtered_compiled_file_count()
         .with_managed_python_dirs()
         .with_empty_python_install_mirror()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     // An upgrade should also compile bytecode
@@ -3911,7 +3865,6 @@ fn python_install_compile_bytecode_upgrade() {
 #[test]
 fn python_install_upgrade_build_version() {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -3987,7 +3940,6 @@ fn python_install_compile_bytecode_multiple() {
         .with_filtered_compiled_file_count()
         .with_managed_python_dirs()
         .with_empty_python_install_mirror()
-        .with_python_download_cache()
         .with_filtered_latest_python_versions();
 
     // Should handle installing and compiling multiple versions correctly
@@ -4009,8 +3961,7 @@ fn python_install_compile_bytecode_pyodide() {
         .with_filtered_exe_suffix()
         .with_filtered_compiled_file_count()
         .with_managed_python_dirs()
-        .with_empty_python_install_mirror()
-        .with_python_download_cache();
+        .with_empty_python_install_mirror();
 
     // Should warn on explicit pyodide installation
     uv_snapshot!(context.filters(), context.python_install().arg("--compile-bytecode").arg("cpython-3.13.2-emscripten-wasm32-musl"), @"
@@ -4034,8 +3985,7 @@ fn python_install_compile_bytecode_graalpy() {
         .with_filtered_exe_suffix()
         .with_filtered_compiled_file_count()
         .with_managed_python_dirs()
-        .with_empty_python_install_mirror()
-        .with_python_download_cache();
+        .with_empty_python_install_mirror();
 
     // Should work for graalpy
     uv_snapshot!(context.filters(), context.python_install().arg("--compile-bytecode").arg("graalpy-3.12"), @"
@@ -4054,8 +4004,7 @@ fn python_install_compile_bytecode_pypy() {
         .with_filtered_exe_suffix()
         .with_filtered_compiled_file_count()
         .with_managed_python_dirs()
-        .with_empty_python_install_mirror()
-        .with_python_download_cache();
+        .with_empty_python_install_mirror();
 
     // Should work for pypy
     uv_snapshot!(context.filters(), context.python_install().arg("--compile-bytecode").arg("pypy-3.11"), @"

--- a/crates/uv/tests/python/python_upgrade.rs
+++ b/crates/uv/tests/python/python_upgrade.rs
@@ -10,7 +10,6 @@ use uv_test::{LATEST_PYTHON_3_12, uv_snapshot};
 #[test]
 fn python_upgrade() {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -74,7 +73,6 @@ fn python_upgrade() {
 #[test]
 fn python_upgrade_without_version() {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -126,7 +124,6 @@ fn python_upgrade_without_version() {
 #[test]
 fn python_upgrade_transparent_from_venv() {
     let context = uv_test::test_context_with_versions!(&["3.13"])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -204,7 +201,6 @@ fn python_upgrade_transparent_from_venv() {
 #[test]
 fn python_upgrade_ignored_with_python_pin() {
     let context = uv_test::test_context_with_versions!(&["3.13"])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -256,7 +252,6 @@ fn python_upgrade_ignored_with_python_pin() {
 #[test]
 fn python_no_transparent_upgrade_with_venv_patch_specification() {
     let context = uv_test::test_context_with_versions!(&["3.13"])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -308,7 +303,6 @@ fn python_no_transparent_upgrade_with_venv_patch_specification() {
 #[test]
 fn python_transparent_upgrade_venv_venv() {
     let context = uv_test::test_context_with_versions!(&["3.13"])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_virtualenv_bin()
@@ -385,7 +379,6 @@ fn python_transparent_upgrade_venv_venv() {
 #[test]
 fn python_upgrade_transparent_from_venv_module() {
     let context = uv_test::test_context_with_versions!(&["3.13"])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -438,7 +431,6 @@ fn python_upgrade_transparent_from_venv_module() {
 #[test]
 fn python_upgrade_transparent_from_venv_module_in_venv() {
     let context = uv_test::test_context_with_versions!(&["3.13"])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -508,7 +500,6 @@ fn python_upgrade_transparent_from_venv_module_in_venv() {
 #[test]
 fn python_upgrade_force_install() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.13"])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_empty_python_install_mirror()
@@ -543,7 +534,6 @@ fn python_upgrade_force_install() -> Result<()> {
 #[test]
 fn python_upgrade_implementation() {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_empty_python_install_mirror()
@@ -563,7 +553,6 @@ fn python_upgrade_implementation() {
 #[test]
 fn python_upgrade_build_version() {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -635,7 +624,6 @@ fn python_upgrade_build_version() {
 #[test]
 fn python_sync_transparent_patch_upgrade_reuses_environment() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
@@ -701,7 +689,6 @@ fn python_sync_transparent_patch_upgrade_reuses_environment() -> Result<()> {
 #[test]
 fn python_sync_honors_pinned_patch_version() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()

--- a/crates/uv/tests/sync/centralized_project_envs.rs
+++ b/crates/uv/tests/sync/centralized_project_envs.rs
@@ -127,9 +127,7 @@ fn sync_centralized_env_switch_python() -> Result<()> {
 #[test]
 #[cfg(feature = "test-python-managed")]
 fn sync_centralized_env_distinguishes_python_patch() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&[])
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+    let context = uv_test::test_context_with_versions!(&[]).with_managed_python_dirs();
     context
         .python_install()
         .arg("3.12.9")
@@ -169,9 +167,7 @@ fn sync_centralized_env_distinguishes_python_patch() -> Result<()> {
 #[test]
 #[cfg(feature = "test-python-managed")]
 fn sync_centralized_env_survives_python_patch_upgrade() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&[])
-        .with_managed_python_dirs()
-        .with_python_download_cache();
+    let context = uv_test::test_context_with_versions!(&[]).with_managed_python_dirs();
     context.python_install().arg("3.12.9").assert().success();
     write_project(&context, ">=3.12", &[])?;
 

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -7062,9 +7062,7 @@ fn sync_active_project_environment() -> Result<()> {
 #[test]
 #[cfg(feature = "test-python-managed")]
 fn sync_active_project_environment_with_relative_managed_python_dir() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&[])
-        .with_python_download_cache()
-        .with_empty_python_install_mirror();
+    let context = uv_test::test_context_with_versions!(&[]).with_empty_python_install_mirror();
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(


### PR DESCRIPTION
Share downloaded Python archives across integration tests by default, with opt-outs for tests of caching and download failures. Also combine the prerelease installation and discovery tests, avoiding two repeated Python installations.

The prerelease checks dropped from [56s](https://github.com/astral-sh/uv/actions/runs/34663282841) to [37s](https://github.com/astral-sh/uv/actions/runs/34667468275) median across three macOS CI runs per revision. We haven't measured the effect of making the shared cache the default.
