### PR TITLE
Remove duplicate tests and correct copied scenarios

### DIFF
--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -1700,14 +1700,10 @@ requires-python = ">=3.12"
 
     uv_snapshot!(context.filters(), context.version()
         .arg("--bump").arg("major")
-        .arg("--bump").arg("alpha"), @"
-    exit_code: 0 (success)
-    ----- stdout -----
-    myproject 2.3.4 => 3.0.0a1
-
+        .arg("--bump").arg("minor"), @"
+    exit_code: 2 (failure)
     ----- stderr -----
-    Resolved 1 package in [TIME]
-    Checked in [TIME]
+    error: Only one release version component can be provided to `--bump`, got: major, minor
     ");
     Ok(())
 }

--- a/crates/uv/tests/pip_compile/pip_compile.rs
+++ b/crates/uv/tests/pip_compile/pip_compile.rs
@@ -10923,31 +10923,6 @@ fn compile_constraints_incompatible_version() -> Result<()> {
     Ok(())
 }
 
-/// Resolve a package from a `requirements.in` file, with a `constraints.txt` file pinning one of
-/// its direct dependencies to an incompatible version.
-#[test]
-fn conflicting_url_markers() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let requirements_in = context.temp_dir.child("requirements.in");
-    requirements_in.write_str("filelock==1.0.0")?;
-
-    let constraints_txt = context.temp_dir.child("constraints.txt");
-    constraints_txt.write_str("filelock==3.8.0")?;
-
-    uv_snapshot!(context.filters(), context.pip_compile()
-            .arg("requirements.in")
-            .arg("--constraint")
-            .arg("constraints.txt"), @"
-    exit_code: 1 (failure)
-    ----- stderr -----
-    error: No solution found when resolving dependencies
-      cause: Because you require filelock==1.0.0 and filelock==3.8.0, we can conclude that your requirements are unsatisfiable.
-    "
-    );
-
-    Ok(())
-}
-
 /// Override a regular package with an editable. This should resolve to the editable package.
 #[test]
 fn editable_override() -> Result<()> {

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -4201,22 +4201,15 @@ fn add_preserves_indentation_in_pyproject_toml() -> Result<()> {
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = ["anyio==3.7.0"]
+        dependencies = [
+          "anyio==3.7.0",
+        ]
     "#})?;
 
-    uv_snapshot!(context.filters(), context.add().arg("requests==2.31.0"), @"
+    uv_snapshot!(context.filters(), context.add().arg("requests==2.31.0").arg("--no-sync"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Prepared 7 packages in [TIME]
-    Installed 7 packages in [TIME]
-     + anyio==3.7.0
-     + certifi==2024.2.2
-     + charset-normalizer==3.3.2
-     + idna==3.6
-     + requests==2.31.0
-     + sniffio==1.3.1
-     + urllib3==2.2.1
     ");
 
     let pyproject_toml = context.read("pyproject.toml");
@@ -4231,8 +4224,8 @@ fn add_preserves_indentation_in_pyproject_toml() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio==3.7.0",
-            "requests==2.31.0",
+          "anyio==3.7.0",
+          "requests==2.31.0",
         ]
         "#
         );
@@ -4253,19 +4246,10 @@ fn add_puts_default_indentation_in_pyproject_toml_if_not_observed() -> Result<()
         dependencies = ["anyio==3.7.0"]
     "#})?;
 
-    uv_snapshot!(context.filters(), context.add().arg("requests==2.31.0"), @"
+    uv_snapshot!(context.filters(), context.add().arg("requests==2.31.0").arg("--no-sync"), @"
     exit_code: 0 (success)
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Prepared 7 packages in [TIME]
-    Installed 7 packages in [TIME]
-     + anyio==3.7.0
-     + certifi==2024.2.2
-     + charset-normalizer==3.3.2
-     + idna==3.6
-     + requests==2.31.0
-     + sniffio==1.3.1
-     + urllib3==2.2.1
     ");
 
     let pyproject_toml = context.read("pyproject.toml");

--- a/crates/uv/tests/python/python_module.rs
+++ b/crates/uv/tests/python/python_module.rs
@@ -31,40 +31,6 @@ print(uv.find_uv_bin())
 ";
 
 #[test]
-fn find_uv_bin_venv() {
-    let context = uv_test::test_context!("3.12")
-        .with_filtered_python_names()
-        .with_filtered_virtualenv_bin()
-        .with_filtered_exe_suffix()
-        .with_filter(user_scheme_bin_filter())
-        // Target installs always use "bin" on all platforms. On Windows,
-        // `with_filtered_virtualenv_bin` only filters "Scripts", not "bin"
-        .with_filter((r"[\\/]bin".to_string(), "/[BIN]".to_string()));
-
-    // Install in a virtual environment
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg(context.workspace_root.join("test/packages/fake-uv")), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + uv==0.1.0 (from file://[WORKSPACE]/test/packages/fake-uv)
-    "
-    );
-
-    // We should find the binary in the virtual environment
-    uv_snapshot!(context.filters(), context.python_command()
-        .arg("-c")
-        .arg(TEST_SCRIPT), @"
-    exit_code: 0 (success)
-    ----- stdout -----
-    [VENV]/[BIN]/uv
-    "
-    );
-}
-
-#[test]
 fn find_uv_bin_target() {
     let context = uv_test::test_context!("3.12")
         .with_filtered_python_names()

--- a/crates/uv/tests/python/python_upgrade.rs
+++ b/crates/uv/tests/python/python_upgrade.rs
@@ -201,58 +201,6 @@ fn python_upgrade_transparent_from_venv() {
     );
 }
 
-// Installing Python should not prevent virtual environments from transparently
-// upgrading.
-#[test]
-fn python_upgrade_transparent_from_venv_preview() {
-    let context = uv_test::test_context_with_versions!(&["3.13"])
-        .with_python_download_cache()
-        .with_filtered_python_keys()
-        .with_filtered_exe_suffix()
-        .with_managed_python_dirs()
-        .with_filtered_latest_python_versions();
-
-    // Install an earlier patch version
-    uv_snapshot!(context.filters(), context.python_install().arg("3.10.17"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Installed Python 3.10.17 in [TIME]
-     + cpython-3.10.17-[PLATFORM] (python3.10)
-    ");
-
-    // Create a virtual environment
-    uv_snapshot!(context.filters(), context.venv().arg("-p").arg("3.10"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Using CPython 3.10.17
-    Creating virtual environment at: .venv
-    Activate with: source .venv/[BIN]/activate
-    ");
-
-    uv_snapshot!(context.filters(), context.run().arg("python").arg("--version"), @"
-    exit_code: 0 (success)
-    ----- stdout -----
-    Python 3.10.17
-    "
-    );
-
-    // Upgrade patch version
-    uv_snapshot!(context.filters(), context.python_upgrade().arg("3.10"), @"
-    exit_code: 0 (success)
-    ----- stderr -----
-    Installed Python 3.10.[LATEST] in [TIME]
-     + cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
-    ");
-
-    // Virtual environment should reflect upgraded patch
-    uv_snapshot!(context.filters(), context.run().arg("python").arg("--version"), @"
-    exit_code: 0 (success)
-    ----- stdout -----
-    Python 3.10.[LATEST]
-    "
-    );
-}
-
 #[test]
 fn python_upgrade_ignored_with_python_pin() {
     let context = uv_test::test_context_with_versions!(&["3.13"])


### PR DESCRIPTION
Remove three duplicate tests and fix two copied scenarios: the version-bump test now checks conflicting major/minor bumps, and the indentation test starts with a two-space dependency list. The formatting tests also use `--no-sync` to skip package installation.

In one CI comparison, total time across the affected tests dropped from 8.1s to 4.8s on Linux and 20.9s to 12.6s on Windows ([before](https://github.com/astral-sh/uv/actions/runs/34663282841), [after](https://github.com/astral-sh/uv/actions/runs/34667562574)).
