### PR TITLE
Add instructions on how to integrate autocomplete on nushell

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -198,7 +198,13 @@ To enable shell autocompletion for uv commands, run one of the following:
     ```bash
     echo 'eval (uv generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
     ```
+    
+=== "Nushell"
 
+    ```nu
+    "\nmkdir ($nu.data-dir | path join "vendor/autoload")\nuv generate-shell-completion nushell | save -f ($nu.data-dir | path join "vendor/autoload/uv.nu")" | save --append $nu.config-path
+    ```
+    
 === "PowerShell / pwsh"
 
     ```powershell
@@ -233,7 +239,12 @@ To enable shell autocompletion for uvx, run one of the following:
     ```bash
     echo 'eval (uvx --generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
     ```
+=== "Nushell"
 
+    ```nu
+    "\nmkdir ($nu.data-dir | path join "vendor/autoload")\nuvx --generate-shell-completion nushell | save -f ($nu.data-dir | path join "vendor/autoload/uvx.nu")" | save --append $nu.config-path
+    ```
+    
 === "PowerShell / pwsh"
 
     ```powershell

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -198,13 +198,13 @@ To enable shell autocompletion for uv commands, run one of the following:
     ```bash
     echo 'eval (uv generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
     ```
-    
+
 === "Nushell"
 
     ```nu
     "\nmkdir ($nu.data-dir | path join "vendor/autoload")\nuv generate-shell-completion nushell | save -f ($nu.data-dir | path join "vendor/autoload/uv.nu")" | save --append $nu.config-path
     ```
-    
+
 === "PowerShell / pwsh"
 
     ```powershell
@@ -239,12 +239,13 @@ To enable shell autocompletion for uvx, run one of the following:
     ```bash
     echo 'eval (uvx --generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
     ```
+
 === "Nushell"
 
     ```nu
     "\nmkdir ($nu.data-dir | path join "vendor/autoload")\nuvx --generate-shell-completion nushell | save -f ($nu.data-dir | path join "vendor/autoload/uvx.nu")" | save --append $nu.config-path
     ```
-    
+
 === "PowerShell / pwsh"
 
     ```powershell


### PR DESCRIPTION
Add tutorial to add autocompletion on nushell

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add an instruction on how to add shell autocompletion to nushell

## Test Plan

i tested this by manually run the command and observing the autocompletion showing up when i press tab or seeing 2 new lines added per command on `config.nu` file also the existence of `uv.nu` and/or `uvx.nu` on `vendor\autoload`
